### PR TITLE
security: gate release workflows behind owner-approved environment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Public repo: only run for same-repo PRs from org members/collaborators.
-    # Fork PRs don't receive secrets anyway — this gate skips the job cleanly
-    # instead of letting it fail, and keeps the review bot org-only.
+    # Public repo: only run for same-repo, non-bot PRs. A same-repo head
+    # branch already proves the author has write access, so no association
+    # check is needed (private org membership would report CONTRIBUTOR in
+    # the payload and wrongly skip). Fork PRs don't receive secrets anyway —
+    # this gate skips them cleanly instead of letting the job fail.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      !endsWith(github.event.pull_request.user.login, '[bot]')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,15 +11,40 @@ on:
     types: [submitted]
 
 jobs:
-  claude:
-    # Public repo: '@claude' alone is not enough — the author must be an org
-    # member/collaborator, or anyone could invoke the bot (and the org's API
-    # key) from a drive-by comment or issue.
+  # Public repo: '@claude' alone is not enough — anyone could invoke the bot
+  # (and the org's API key) from a drive-by comment or issue. We can't use
+  # author_association for this: private org membership reports CONTRIBUTOR,
+  # not MEMBER, in webhook payloads. Instead, ask the API whether the actor
+  # has write access (GITHUB_TOKEN's default metadata scope is sufficient).
+  check-write-access:
     if: |
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)))
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+    steps:
+      - name: Check actor repo permission
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERM=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" --jq '.permission' 2>/dev/null || echo "none")
+          echo "actor='${{ github.actor }}' permission='$PERM'"
+          if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ] || [ "$PERM" = "write" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::@claude ignored: ${{ github.actor }} does not have write access"
+          fi
+
+  claude:
+    needs: check-write-access
+    if: needs.check-write-access.outputs.authorized == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -28,6 +28,9 @@ env:
 jobs:
   validate-and-prepare:
     runs-on: ubuntu-latest
+    # Owner-approval gate (mirrors release.yml / BossTerm): both promote jobs
+    # need this one, so the single environment review gates the whole run.
+    environment: release
     outputs:
       prerelease-version: ${{ steps.validate.outputs.prerelease-version }}
       target-version: ${{ steps.validate.outputs.target-version }}

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Owner-approval gate (mirrors release.yml / BossTerm).
+    environment: release
     permissions:
       contents: read
 

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -52,6 +52,9 @@ jobs:
   # ── 1. Bump version in BossConsoleLite ───────────────────────────────────────
   prepare-version:
     runs-on: ubuntu-latest
+    # Owner-approval gate (mirrors release.yml / BossTerm): all jobs flow from
+    # this one, so the single environment review gates the whole run.
+    environment: release
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       is-prerelease: ${{ steps.get-version.outputs.is-prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,10 @@ env:
 jobs:
   prepare-version:
     runs-on: ubuntu-latest
+    # Owner-approval gate: the 'release' environment requires a review before
+    # this job starts, and every other job needs it — one approval gates the
+    # whole run. Mirrors the BossTerm release workflow.
+    environment: release
     outputs:
       version: ${{ steps.get-version.outputs.version }}
       is-prerelease: ${{ steps.get-version.outputs.is-prerelease }}


### PR DESCRIPTION
## Why

Now that the repo is public, anyone with write access (and automation) can reach the release entry points. This adds the same protection the **BossTerm** release workflow uses: a `release` environment that requires owner approval before any release run proceeds.

## What changed

`environment: release` added to the single entry job of each release-capable workflow — every other job `needs` it, so one approval gates the whole run:

| Workflow | Gated job |
|---|---|
| `release.yml` | `prepare-version` |
| `release-lite.yml` | `prepare-version` |
| `promote-release.yml` | `validate-and-prepare` |
| `publish-maven-central.yml` | `publish` |

The environment itself is already configured on this repo (mirroring BossTerm's):
- **Required reviewer**: @kshivang (self-review allowed, matching BossTerm)
- **Deployment refs**: branch `main` + tags `v*` (adapted from BossTerm's dev/master to this repo's layout, and tag-triggered releases keep working)

Post-release automation (`sync-release.yml`, `release-notes.yml`) is deliberately **not** gated — those react to already-approved releases via `workflow_run`, and gating them would stall the pipeline waiting for approvals on automation.

Known nuance: `promote-release.yml` → `promote-with-rebuild` calls `release.yml` as a reusable workflow, so that one path asks for approval twice (promote's gate, then release's). The no-rebuild path has a single gate.


