### PR TITLE
ci: use GitHub-hosted arm64 runners instead of self-hosted labels

### DIFF
--- a/.github/workflows/build-chromium-branding.yml
+++ b/.github/workflows/build-chromium-branding.yml
@@ -756,7 +756,7 @@ jobs:
   # Windows ARM64 build
   build-windows-arm64:
     needs: build-branding-tool
-    runs-on: windows_arm64
+    runs-on: windows-11-arm
     continue-on-error: true  # Graceful failure if ARM runners unavailable
     # Bound it like windows-x64 — continue-on-error tolerates a FAILURE, but a 6h hang
     # would still make upload-to-releases (which `needs` this job) wait the full limit.
@@ -979,7 +979,7 @@ jobs:
   # Linux ARM64 build
   build-linux-arm64:
     needs: build-branding-tool
-    runs-on: linux_arm64
+    runs-on: ubuntu-24.04-arm
     continue-on-error: true  # Graceful failure if ARM runners unavailable
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -818,7 +818,7 @@ jobs:
   build-linux-arm64:
     needs: prepare-version
     if: needs.prepare-version.outputs.should-build == 'true'
-    runs-on: linux_arm64
+    runs-on: ubuntu-24.04-arm
     continue-on-error: true  # Graceful failure if ARM runners unavailable
 
     steps:
@@ -1286,7 +1286,7 @@ jobs:
   build-windows-arm64:
     needs: prepare-version
     if: needs.prepare-version.outputs.should-build == 'true'
-    runs-on: windows_arm64
+    runs-on: windows-11-arm
     continue-on-error: true  # Graceful failure if ARM runner unavailable
 
     steps:


### PR DESCRIPTION
## Why

The arm64 build jobs (`build-linux-arm64`, `build-windows-arm64`) target custom self-hosted runner labels `linux_arm64` / `windows_arm64` that only existed on the old private repo. On this public repo there are **no registered runners** (repo or org), so those jobs sit `queued` forever and the whole release stalls before `create-release`. (macOS arm64 was unaffected — it uses the real hosted label `macos-14`.)

## Fix

Public repos get GitHub-hosted arm64 runners at no cost, so switch to them:

| was (self-hosted) | now (hosted, free for public repos) |
|---|---|
| `linux_arm64` | `ubuntu-24.04-arm` |
| `windows_arm64` | `windows-11-arm` |

Applied in `release.yml` and `build-chromium-branding.yml`. Both jobs already run `actions/setup-java`, Setup Gradle, checkout, and install their own packaging deps, so they need nothing else on a clean hosted runner. The `GOARCH=arm64` / `*_arm64.exe` build-artifact names are unchanged (those are filenames, not runner labels).

## Note

Reruns use the workflow from the run's original commit, so this takes effect on the **next dispatched** release, not on retries of the current run.