### PR TITLE
security: stop DigiCert signing secrets leaking into public CI logs

### DIFF
--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -422,7 +422,7 @@ jobs:
 
       - name: Sign Windows MSI
         if: steps.check-secret.outputs.can_sign == 'true'
-        run: smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}" --verbose
+        run: smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"
         shell: bash
         env:
           SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1203,7 +1203,6 @@ jobs:
           SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
           SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          SM_TRACE: true
 
       - name: Reset SMCTL Credentials
         if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
@@ -1216,33 +1215,19 @@ jobs:
           SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
           SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          SM_TRACE: true
-
-      - name: Run SMCTL Healthcheck
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        run: |
-          smctl healthcheck
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          SM_TRACE: true
 
       - name: Sign Windows MSI with DigiCert KeyLocker
         if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
         run: |
           echo "Signing MSI: ${{ steps.find-msi.outputs.msi-path }}"
           echo "Using keypair: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}"
-          smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}" --verbose
+          smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"
         shell: bash
         env:
           SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
           SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
           SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          SM_TRACE: true
 
       - name: Check SMKSP Log (for diagnostics)
         if: always()  # Runs even if signing fails

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ local.properties
 
 # Signing assets and build-time embedded config — never commit
 *.provisionprofile
+*.p12
+*.pfx
+*.jks
+*.keystore
+*.p8
+*.pem
+*.cer
+*.crt
 boss-build-config.properties
 .idea
 .DS_Store


### PR DESCRIPTION
## Problem

On a **public** repo, Actions logs are world-readable, and GitHub's `***` masking only redacts the *exact* registered secret string. The DigiCert `smctl` steps ran with `SM_TRACE: true` and a `smctl healthcheck` step that printed smctl's **own** partially-masked rendering of the API key (`prefix…suffix`) and client-cert password — a *transformed* string GitHub can't match. Result: fragments of a code-signing credential landed in permanent, public logs (release runs 29804999201 and 29802233431).

Verified: everywhere the *verbatim* secret appeared it WAS masked (`SM_API_KEY: ***`, `credentials save *** ***`); only smctl's transformed partial slipped through.

## Fix

- Remove `SM_TRACE: true` from every smctl step (`release.yml`).
- Delete the `Run SMCTL Healthcheck` diagnostic step — it's what printed the credential block; not needed for signing.
- Drop `--verbose` from `smctl sign` (`release.yml`, `release-lite.yml`).
- `.gitignore`: add `*.p12 *.pfx *.jks *.keystore *.p8 *.pem *.cer *.crt` so a contributor can't accidentally commit a signing cert/key to the public repo.

## Deliberately NOT changed (to preserve the just-validated signing)

- **`smctl credentials save <key> <pw>`** kept — GitHub masks its verbatim-secret args, and `credentials save` has no env-only form; removing it risks breaking the auth flow that v9.2.54 signed with.
- **Notarization creds in `$GITHUB_ENV`** left as-is — masked and not leaking; moving them to step-level `env:` is a careful follow-up so it doesn't destabilize verified macOS notarization.

## Containment already done

The two leaking run logs were purged via the API. Because public logs may already be cached/scraped, the `CODE_SIGNING_CERT_HOST_API_KEY` and `CODE_SIGNING_CLIENT_CERT_PASSWORD` should still be **rotated in DigiCert ONE** (owner action) — the exposure was partial (key-ID + a few chars of the secret; ~half the cert password), so it's prudent-hygiene, not a confirmed compromise.