### PR TITLE
docs: rewrite README as a showcase (AI agents, governance, Toolbox, BossTerm sharing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
-# BOSS - Business OS + Simulator
+# BOSS — Business OS + Simulator
 
 [![BOSS Version](https://img.shields.io/github/v/release/risa-labs-inc/BossConsole-Releases.svg?label=BOSS&color=brightgreen)](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-blue.svg)](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-BOSS (Business OS + Simulator) is a sophisticated, AI-powered desktop workspace built with Kotlin Multiplatform and Compose Multiplatform. It combines **AI automation**, **configurable layouts**, and **intelligent workflow management** into a unified platform designed for complex business operations.
+**BOSS is an AI-native desktop workspace — a browser, terminal, editor, and automation surface where you run coding agents like Claude Code, Codex, Gemini, or OpenCode with real tools, and stay in control of everything they can touch.**
 
-> **Looking to download BOSS?** Visit the [**BossConsole-Releases**](https://github.com/risa-labs-inc/BossConsole-Releases) repository for pre-built installers for all platforms.
+Built with Kotlin Multiplatform and Compose Multiplatform, BOSS combines an embedded browser, a blazing-fast shareable terminal, a code editor, an extensible **Toolbox** of plugins, and a governed **MCP** tool layer into one operator's console for complex, AI-assisted work.
+
+> **Just want to download BOSS?** Head to [**BossConsole-Releases**](https://github.com/risa-labs-inc/BossConsole-Releases) for pre-built installers.
+
+---
+
+## Contents
+
+- [Downloads](#downloads)
+- [Why BOSS](#why-boss)
+- [Run any AI coding agent](#run-any-ai-coding-agent)
+- [You decide what your agents can touch](#you-decide-what-your-agents-can-touch)
+- [MCP — give agents real tools](#mcp--give-agents-real-tools)
+- [Toolbox — an app store inside the app](#toolbox--an-app-store-inside-the-app)
+- [BossTerm — a terminal you can share to any device](#bossterm--a-terminal-you-can-share-to-any-device)
+- [Design System](#design-system)
+- [Development](#development)
+- [CLI](#cli) · [CI/CD](#cicd) · [Documentation](#documentation) · [Related Repositories](#related-repositories)
 
 ---
 
@@ -20,12 +37,12 @@ BOSS (Business OS + Simulator) is a sophisticated, AI-powered desktop workspace 
 | **Linux** | AMD64 | [DEB](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=deb&arch=amd64) \| [RPM](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=rpm&arch=amd64) \| [JAR](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=jar&arch=amd64) |
 | **Linux** | ARM64 | [DEB](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=deb&arch=arm64) \| [RPM](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=rpm&arch=arm64) \| [JAR](https://api.risaboss.com/functions/v1/latest-release?app=boss&download=jar&arch=arm64) |
 
-Download links always fetch the newest release directly (via the [`latest-release`](supabase/functions/latest-release/app.ts) edge function; the saved file keeps its versioned name). Release metadata as JSON — version, assets, sha256 checksums — is at [`?app=boss`](https://api.risaboss.com/functions/v1/latest-release?app=boss) without the `download` parameter. To browse all versions, use [BossConsole-Releases](https://github.com/risa-labs-inc/BossConsole-Releases/releases).
+Download links always fetch the newest release directly (via the [`latest-release`](supabase/functions/latest-release/app.ts) edge function; the saved file keeps its versioned name). Release metadata as JSON — version, assets, sha256 checksums — is at [`?app=boss`](https://api.risaboss.com/functions/v1/latest-release?app=boss). To browse all versions, see [BossConsole-Releases](https://github.com/risa-labs-inc/BossConsole-Releases/releases).
 
 ### Quick Install
 
 ```bash
-# macOS (Homebrew - Recommended)
+# macOS (Homebrew — Recommended)
 brew install --cask boss
 
 # macOS/Linux (Universal Script)
@@ -35,46 +52,142 @@ curl -fsSL https://raw.githubusercontent.com/risa-labs-inc/BossConsole-Releases/
 iwr -useb https://raw.githubusercontent.com/risa-labs-inc/BossConsole-Releases/main/install.ps1 | iex
 ```
 
-For detailed installation instructions, system requirements, and troubleshooting, see the [BossConsole-Releases README](https://github.com/risa-labs-inc/BossConsole-Releases#readme).
+---
+
+## Why BOSS
+
+- 🤖 **Bring your own agent** — run **Claude Code, Codex, Gemini, or OpenCode** in a BOSS terminal and give them a real toolset (browser, files, git, shell, secrets, automation) over MCP.
+- 🧰 **Extensible by design** — a built-in **Toolbox** plugin store; the terminal, editor, and browser are themselves hot-loadable plugins, and you can scaffold your own with an AI agent.
+- 🔐 **You stay in control** — server-enforced role-based access control, a per-user kill-switch for every agent tool, and user-scoped secrets. You decide exactly what an agent can call.
+- 🖥️ **A terminal built to share** — hand a live terminal session to your phone via QR, or to a teammate over an end-to-end-encrypted link, with view-only or full control.
+- ⚡ **Fast and native** — Compose Multiplatform desktop app with a BOSS-branded Chromium engine, on macOS, Windows, and Linux (x64 + ARM64).
 
 ---
 
-## Key Features
+## Run any AI coding agent
 
-- **Modular Workspace Architecture**: Configurable panels, multi-tab browser, code editor, terminal integration
-- **AI & Automation**: LLM integration with robotic process automation, smart workflows, browser automation
-- **Extensible via Plugins, Toolbox & MCP**: A dynamic plugin system with a built-in **Toolbox** plugin store; plugins expose `mcp__boss__*` tools to in-terminal AI agents (Claude Code, Codex, …) over the **Model Context Protocol** — see [Plugins, Toolbox & MCP](#plugins-toolbox--mcp)
-- **Healthcare Focus**: Prior authorization, patient triage, EHR management, compliance workflows
-- **Enterprise Ready**: Auto-updates, workspace configuration management, Git integration, cross-platform support
+BOSS is agent-agnostic. Open a terminal, launch your preferred CLI, and — once attached — it gains the `boss` toolset automatically.
+
+| Agent | Binary | Attach method |
+|-------|--------|---------------|
+| **Claude Code** | `claude` | `claude mcp add --scope user --transport sse boss <url>` |
+| **Codex** | `codex` | `codex mcp add boss --url <url>/mcp` (streamable HTTP) |
+| **Gemini CLI** | `gemini` | `gemini mcp add boss <url> --transport sse --scope user` |
+| **OpenCode** | `opencode` | writes the server into `~/.config/opencode/opencode.json` |
+
+**How it works:** the `terminal-tab` plugin runs a small loopback MCP server named **`boss`**. You attach a CLI once (one click from **Toolbox → MCP**, or the BossTerm AI menu); BOSS then **re-attaches it automatically** on every restart and port change, and injects `BOSS_MCP_PORT` into each terminal so an agent launched inside BOSS always dials the right instance. If a CLI isn't scriptable, BOSS copies a ready-to-paste config snippet to your clipboard.
+
+**Scaffold a tool for any of them** — the built-in **Tool Creator** generates a new plugin (build files, manifest, skeleton UI, CI) and writes its skill in *all four* CLI formats (`.claude/`, `.codex/`, `.gemini/`, `.opencode/`), so the repo works with whichever agent you open it with — then launches that agent in a fresh terminal to start building.
+
+---
+
+## You decide what your agents can touch
+
+An agent with tools is only as safe as the controls around it. BOSS is a **governed** environment for tool-using agents — not a black box.
+
+- **Server-enforced RBAC.** Roles and permissions live in Postgres and are enforced server-side via row-level security (Supabase). Plugins declare the permissions they need; a plugin — and its tools — only appear for users whose role grants them. See the [RBAC Guide](docs/RBAC_GUIDE.md).
+- **A kill-switch for every tool.** Every `mcp__boss__*` tool an agent can call is listed in **Toolbox → MCP**, and you can toggle any of them off. The exposed set is `all tools − your disabled set − permission-denied`, persisted to `~/.boss/mcp-disabled-tools.json` and enforced on the live server. Disable a plugin and its tools vanish from every agent instantly.
+- **User-scoped secrets.** The [Secret Manager](#security--secrets) stores encrypted credentials that are row-level-scoped to you. Its **browser auto-fill** injects a username/password straight into a web page's form fields — the value goes to the page, never to the model. (A secret is handed to an agent only if you explicitly call the permission-gated `secret_get` tool, which you can also toggle off.)
+- **Signed plugins.** Plugins installed from the BOSS Plugin Store carry a store signature binding `pluginId | version | sha256`; a **tampered or invalid signature fails closed** at download and load time — a re-signed or swapped JAR won't load.
+- **Fault isolation.** Each plugin runs in a supervised scope with a watchdog and auto-restart, so a crashing or hung plugin can't take down the host.
+
+> **Honest scope:** the `boss` MCP server is loopback-only and single-user (local machine), and plugins run in-process (crash-isolated, not OS-sandboxed). BOSS's guarantees are about **governance** — RBAC, per-tool toggles, secret scoping, and signed plugins — giving you fine-grained say over what an agent can do, rather than OS-level process sandboxing.
+
+---
+
+## MCP — give agents real tools
+
+BOSS speaks the **Model Context Protocol**. The `terminal-tab` plugin hosts a loopback `boss` server (SSE over HTTP, `127.0.0.1:7677`, with a fallback port walk), and every active plugin contributes tools that surface to agents as **`mcp__boss__<tool>`** — roughly **100+ tools across ~20 plugins**, appearing and disappearing automatically as plugins load. A sampling:
+
+| Area | Example tools |
+|------|---------------|
+| Terminal | `run_command`, `run_in_sidebar`, `run_in_panel`, `list_tabs`, `read_scrollback`, `send_input` |
+| Code & Git | `codebase_read`, `codebase_write`, `codebase_tree`, `git_status`, `git_log`, `git_stage`, `git_checkout` |
+| Browser | `browser_navigate`, `browser_get_url`, `browser_run_js` |
+| Secrets | `secrets_list`, `secret_search`, `secret_get`, `secret_create` |
+| Automation | `flow_run`, `rpa_run`, `rpa_record_toggle`, `llmrpa_run`, `evolver_evolve` |
+| Productivity | `bookmarks_list`, `bookmark_add`, `downloads_list`, `plugins_list` |
+
+Plugin authors add tools by implementing `McpToolProvider` (boss-plugin-api 1.0.51+). Full reference: [**PLUGIN_DEVELOPMENT.md**](https://github.com/risa-labs-inc/boss-plugins/blob/main/PLUGIN_DEVELOPMENT.md) in boss-plugins.
+
+---
+
+## Toolbox — an app store inside the app
+
+**Toolbox** is BOSS's built-in plugin store (a left-sidebar panel; internally the `plugin-manager` system plugin). Browse, install, update, and enable/disable plugins; toggle individual MCP tools; and — for admins — **Create** new plugins with an AI agent via Tool Creator. Plugins are hot-loaded at runtime and live in the separate [**boss-plugins**](https://github.com/risa-labs-inc/boss-plugins) repo.
+
+### Core tabs
+| Plugin | What it does |
+|--------|--------------|
+| **Terminal Tab** | Full terminal built on the BossTerm library — persistent sessions, split panes, sharing, and the `boss` MCP server |
+| **Code Editor Tab** | Code editor with syntax highlighting (50+ languages), code folding, and run-gutter icons |
+| **Fluck Browser** | Embedded web browser — zoom, security/loading indicators, downloads, and Secret Manager autofill |
+| **Jupyter Notebook** | Cursor-style `.ipynb` editor running against a local Python kernel over Jupyter's ZeroMQ protocol |
+
+### Dev tools
+| Plugin | What it does |
+|--------|--------------|
+| **Codebase** | Browse and explore project files (`codebase_*` MCP tools) |
+| **Console** | Captured stdout/stderr logs, filterable per plugin (`console_*` MCP tools) |
+| **Git Status / Git Log** | Working-tree status & staged changes; commit history with a graph |
+| **Run Configurations** | Auto-detect and run project run-configs (`run_config_*` MCP tools) |
+| **Performance** | Live JVM metrics — CPU, memory, resource counts |
+
+### AI & automation
+| Plugin | What it does |
+|--------|--------------|
+| **Tool Creator** | Scaffold a new plugin and hand it to Claude Code / Codex / Gemini / OpenCode to build |
+| **Tool Evolver** | Probe a plugin's memory/leaks/logs, then AI-evolve it with hot-reload + a PR (`evolver_*`) |
+| **LLM RPA** | AI-powered robotic process automation (`llmrpa_*`) |
+| **RPA Engine / Recorder** | Record browser interactions and replay them as automation (`rpa_*`) |
+| **ChatGPT** | Embedded ChatGPT integration |
+
+### Security & secrets
+| Plugin | What it does |
+|--------|--------------|
+| **Secret Manager** | Encrypted credential vault — website/username/password, notes, tags, 2FA, expiry. Row-level-scoped to you, browser auto-fill, and permission-gated `secret_*` MCP tools |
+| **My Secrets** | Read-only view of your own and shared credentials |
+
+### Productivity & admin
+| Plugin | What it does |
+|--------|--------------|
+| **Bookmarks** | Bookmark management with global-search integration (`bookmark_*`) |
+| **Downloads** | Active and completed downloads |
+| **Top of Mind** | Quick access to frequently used items |
+| **Admin Role Management / Role Creation** | Manage roles and permissions; build custom roles (admin) |
+
+*…and more in [boss-plugins](https://github.com/risa-labs-inc/boss-plugins), including analytics, atlas (chat about the current page), and hardware integrations.*
+
+---
+
+## BossTerm — a terminal you can share to any device
+
+The terminal is powered by [**BossTerm**](https://github.com/kshivang/BossTerm) — a fast, embeddable terminal emulator (also published to Maven Central as `com.risaboss:bossterm-compose`). Its headline feature: **session sharing**.
+
+### Share a live session — to your phone or a teammate
+Your machine *is* the server: BossTerm runs a small embedded web server and streams the session to an `xterm.js` viewer over a WebSocket — **no cloud relay, no account**.
+
+- **Scan a QR code with your phone** → the session opens in any mobile browser (nothing to install), touch-tuned with an on-screen key bar, drag-to-scroll, and pinch-zoom.
+- **Two links, two QR codes:** a **View** link (read-only) and a **Control** link (full typing access). A view-only viewer can request control mid-session; you approve it.
+- **Share a tab, a window, or all windows** — splits are preserved (they collapse into swipeable sub-tabs on a phone).
+- **Multiple people at once:** send someone the link, or have another BossTerm *"add remote"* to mirror your tabs as first-class remote tabs — with control requests relayed hop-by-hop, each host approving in turn.
+- **End-to-end encrypted:** a per-share key rides in the URL *fragment* (never sent to any server), and each connection derives a fresh **AES-256-GCM** key via HKDF-SHA256; both ends show a short verification code. Public tunnels can't read your session.
+- **Reach it anywhere:** LAN by default, or a public link via **Cloudflare** (the default — BossTerm fetches `cloudflared` for you, no account) or **Tailscale**.
+
+### More BossTerm features
+- **Drive it with AI** — an in-process MCP server exposes the terminal to agents; a phone or second machine can even point an AI client at the host's terminals.
+- **Inline images** in the terminal (iTerm2 OSC 1337), true color, full Unicode/emoji, Nerd Fonts, OSC 52 clipboard, and shell integration.
+- **Split panes & multiple windows**, per-pane titles, regex search, command-complete notifications.
+- **Optional session daemon** (tmux-style) with a tray icon, so sessions, shares, and the MCP server survive closing the GUI.
 
 ---
 
 ## Design System
 
-BOSS and BossTerm share one visual language — **"Operator's Console"**: an amber **signal** (`#F2A93B`) for what's live/now on a calm **ink** floor (`#0E1217`), cyan **data** accents, and a MesloLGS mono voice. The whole app re-skins live across three themes — **Operator** (the signature dark identity), **Daylight** (light), and **Clean** (neutral charcoal) — and every dynamic plugin follows along.
+BOSS and BossTerm share one visual language — **"Operator's Console"**: an amber **signal** (`#F2A93B`) for what's live on a calm **ink** floor (`#0E1217`), cyan **data** accents, and a MesloLGS mono voice. The whole app re-skins live across three themes — **Operator** (dark), **Daylight** (light), and **Clean** (neutral) — and every dynamic plugin follows along.
 
 - 📖 **[Design System spec](docs/DESIGN_SYSTEM.md)** — tokens, themes, and where they ship in code
-- 🎨 **[Visual styleguide](docs/design-system.html)** — a self-contained HTML reference for colors / type / components (open it in a browser)
-
----
-
-## Plugins, Toolbox & MCP
-
-BOSS is extensible through **dynamic plugins** — panels, tab types, and background tools loaded at runtime. The host-side loader and SDK live under [`plugin-platform/`](plugin-platform/README.md); the plugins themselves live in the separate [**boss-plugins**](https://github.com/risa-labs-inc/boss-plugins) repository (the terminal, editor, and browser tabs are themselves plugins).
-
-### Toolbox
-
-**Toolbox** is BOSS's built-in plugin store — a left-sidebar panel (internally the `plugin-manager` system plugin). From it you can:
-
-- **Browse, install & update** plugins from the BOSS Plugin Store (Installed / Available / Updates tabs)
-- **Manage MCP tools** — toggle individual `mcp__boss__*` tools on or off (MCP tab)
-- **Create** new plugins — admins/publishers can scaffold a plugin with an AI coding agent via the built-in **Tool Creator**: name the tool, pick permissions and a CLI (Claude Code, Codex, Gemini, or OpenCode), and it generates the repo + CI + a matching skill and opens a terminal running the agent
-
-### MCP (Model Context Protocol)
-
-BOSS plugins expose tools to AI agents running inside BOSS terminals over MCP. The `terminal-tab` plugin hosts a loopback **`boss`** MCP server (SSE transport, bound to `127.0.0.1:7677` with a fallback port walk if busy). Tools surface to agents as **`mcp__boss__<tool>`** and appear/disappear automatically with their plugin — roughly **100+ tools** across ~20 plugins today, for example `run_command`, `run_in_sidebar`, `codebase_read`, `git_status`, `browser_navigate`, `secret_get`, `flow_run`, and `rpa_run`.
-
-Every terminal session gets `BOSS_MCP_SERVER=boss` and `BOSS_MCP_PORT=<bound port>` injected, so an in-shell agent auto-connects to the right instance's toolset. Plugin authors add tools by implementing `McpToolProvider` (boss-plugin-api 1.0.51+). Full reference: [**PLUGIN_DEVELOPMENT.md**](https://github.com/risa-labs-inc/boss-plugins/blob/main/PLUGIN_DEVELOPMENT.md) in boss-plugins.
+- 🎨 **[Visual styleguide](docs/design-system.html)** — a self-contained HTML reference (open it in a browser)
 
 ---
 
@@ -83,7 +196,6 @@ Every terminal session gets `BOSS_MCP_SERVER=boss` and `BOSS_MCP_PORT=<bound por
 This repository contains the source code for BOSS. For building from source and contributing, follow the instructions below.
 
 ### Prerequisites
-
 - **JDK 17+** (recommended: Azul Zulu or Oracle JDK)
 - **Gradle 8.x** (wrapper included)
 
@@ -117,29 +229,28 @@ This repository contains the source code for BOSS. For building from source and 
 
 ### Configuration
 
-Create `local.properties` in project root:
+Create `local.properties` in the project root:
 
 ```properties
-# JxBrowser (Required)
+# JxBrowser (required to run the embedded browser)
 jxbrowser.license.key=<your-license-key>
 
-# Supabase (Required)
+# Supabase (required for auth / backend)
 SUPABASE_URL=https://api.risaboss.com
 SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_FUNCTION_URL=https://api.risaboss.com/functions/v1
 
-# GitHub (Optional - 60 req/hr without)
+# GitHub (optional — 60 req/hr without)
 GITHUB_TOKEN=ghp_your_token_here
 ```
 
-**Priority**: Environment variables > System properties > local.properties > Fallbacks
+**Resolution order:** environment variables → system properties → `local.properties` → build-time embedded config. There are no credential fallbacks in source; official builds embed these at build time from CI secrets, and a fork without keys still builds (browser/auth features degrade with a clear log).
 
 ### Key Technologies
-
 - **Kotlin Multiplatform** + **Compose Multiplatform**
 - **JxBrowser 9.x** (BOSS-branded Chromium)
 - **Decompose** for navigation
-- **Supabase** + Edge Functions for backend
+- **Supabase** + Edge Functions for backend and RBAC
 - **BossTerm** for terminal integration (also hosts the `boss` MCP server)
 - **MCP (Model Context Protocol)** for exposing plugin tools to in-terminal AI agents
 - **kotlin-compiler-embeddable** for PSI code analysis
@@ -150,9 +261,9 @@ GITHUB_TOKEN=ghp_your_token_here
 
 ```bash
 ./gradlew showVersion       # Display current version
-./gradlew incrementVersion  # Increment patch (8.8.0 → 8.8.1)
-./gradlew incrementMinor    # Increment minor (8.8.0 → 8.9.0)
-./gradlew incrementMajor    # Increment major (8.8.0 → 9.0.0)
+./gradlew incrementVersion  # Increment patch (9.2.0 → 9.2.1)
+./gradlew incrementMinor    # Increment minor (9.2.0 → 9.3.0)
+./gradlew incrementMajor    # Increment major (9.2.0 → 10.0.0)
 ```
 
 All version info is stored in [`version.properties`](./version.properties).
@@ -161,27 +272,15 @@ All version info is stored in [`version.properties`](./version.properties).
 
 ## CI/CD
 
-### Workflows
+Releases build and sign for all platforms (macOS, Windows, Linux × x64/ARM64), notarize on macOS, and publish to the BOSS Plugin Store and Maven Central. Release-capable workflows are gated behind an owner-approved GitHub environment.
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| **Release** | Tags `v*.*.*` | Builds and publishes releases for all platforms |
+| **Release Build** | Manual dispatch / `v*.*.*` tags | Builds, signs, notarizes, and publishes releases for all platforms |
 | **Build** | Push to `main`, PRs | Cross-platform builds and tests |
-| **Version Bump** | Manual | Automated version management |
+| **Claude Code Review** | Pull requests | Automated review (org members) |
 
-### Creating a Release
-
-```bash
-# Option 1: Tag-based
-./gradlew incrementMinor
-git add version.properties
-git commit -m "Release v8.9.0"
-git tag v8.9.0
-git push origin main --tags
-
-# Option 2: GitHub Actions UI
-# Actions → Release Build → Run workflow
-```
+**Cutting a release:** *Actions → Release Build → Run workflow* (pick a version bump), then approve the `release` environment prompt.
 
 ---
 
@@ -190,36 +289,36 @@ git push origin main --tags
 BOSS includes a command-line interface for quick access:
 
 ```bash
-boss url https://github.com    # Open URL
-boss folder ~/Documents        # Open folder
-boss file README.md            # Open file
-boss terminal                  # Open terminal
-boss plugin bookmarks          # Access plugin
+boss url https://github.com    # Open a URL in a browser tab
+boss folder ~/Documents        # Open a folder
+boss file README.md            # Open a file in the editor
+boss terminal                  # Open a terminal
+boss plugin bookmarks          # Open a plugin panel
 boss --help                    # Show help
 ```
 
-**Installation**: Tools > Install BOSS CLI (or automatically via Homebrew)
+**Installation:** Toolbox / Tools → Install BOSS CLI (or automatically via Homebrew).
 
 ---
 
 ## Documentation
 
-- [Core Subsystems](docs/SUBSYSTEMS.md) - Auth, UI, keyboard shortcuts, threading
-- [Design System](docs/DESIGN_SYSTEM.md) - "Operator's Console" tokens, themes, and the live styleguide
-- [BossEditor Module](docs/BOSSEDITOR.md) - LSP, PSI, editor features
-- [Application Features](docs/FEATURES.md) - Performance monitoring, dashboard, downloads
-- [Keyboard Shortcuts](docs/KEYBOARD_SHORTCUTS.md) - Detailed shortcuts reference
-- [Threading Best Practices](docs/THREADING.md) - Threading patterns and pitfalls
-- [RBAC Guide](docs/RBAC_GUIDE.md) - Role-based access control
-- [Plugin System](plugin-platform/README.md) - Host-side plugin platform / SDK
-- [Plugin Development & MCP](https://github.com/risa-labs-inc/boss-plugins/blob/main/PLUGIN_DEVELOPMENT.md) - Writing plugins, the manifest, RBAC, and exposing `mcp__boss__*` tools
+- [Core Subsystems](docs/SUBSYSTEMS.md) — Auth, UI, keyboard shortcuts, threading
+- [Design System](docs/DESIGN_SYSTEM.md) — "Operator's Console" tokens, themes, and the live styleguide
+- [BossEditor Module](docs/BOSSEDITOR.md) — LSP, PSI, editor features
+- [Application Features](docs/FEATURES.md) — Performance monitoring, dashboard, downloads
+- [Keyboard Shortcuts](docs/KEYBOARD_SHORTCUTS.md) — Detailed shortcuts reference
+- [RBAC Guide](docs/RBAC_GUIDE.md) — Role-based access control
+- [Plugin System](plugin-platform/README.md) — Host-side plugin platform / SDK
+- [Plugin Development & MCP](https://github.com/risa-labs-inc/boss-plugins/blob/main/PLUGIN_DEVELOPMENT.md) — Writing plugins, the manifest, RBAC, and exposing `mcp__boss__*` tools
 
 ---
 
 ## Related Repositories
 
-- [**boss-plugins**](https://github.com/risa-labs-inc/boss-plugins) - Master repository for all BOSS plugins, managed as git submodules
-- [**BossConsole-Releases**](https://github.com/risa-labs-inc/BossConsole-Releases) - Pre-built installers for all platforms
+- [**boss-plugins**](https://github.com/risa-labs-inc/boss-plugins) — All BOSS plugins (git submodules) and the plugin development guide
+- [**BossTerm**](https://github.com/kshivang/BossTerm) — The terminal emulator library (`com.risaboss:bossterm-compose`)
+- [**BossConsole-Releases**](https://github.com/risa-labs-inc/BossConsole-Releases) — Pre-built installers for all platforms
 
 ---
 


### PR DESCRIPTION
Makes the public README a proper showcase of what BOSS does, per request — covering supported AI harnesses, the Toolbox plugins, BossTerm session sharing, the Secret Manager, and the governed environment for running tool-using agents.

## Highlights
- **Run any AI coding agent** — Claude Code, Codex, Gemini, OpenCode: how the loopback `boss` MCP server attaches to each (with the real per-CLI commands) and auto-reattaches across restarts/ports; Tool Creator scaffolds a plugin + a skill in all four CLI formats.
- **You decide what your agents can touch** — the governance story: server-enforced RBAC, a per-tool MCP kill-switch (`~/.boss/mcp-disabled-tools.json`), user-scoped secrets, store-signature verification (tampered → fail closed), and plugin crash isolation. Includes an explicit *honest-scope* callout.
- **MCP** — the `boss` server + a sampling of `mcp__boss__*` tools.
- **Toolbox** — a categorized catalog of the plugins, incl. the **Secret Manager**.
- **BossTerm** — session sharing as the headline: **QR to phone**, View/Control links, multi-user (browser viewers + native *add-remote* with relayed control), **end-to-end AES-256-GCM** (key in the URL fragment, so no relay can read it), Cloudflare/Tailscale reach, account-free.

## Accuracy
Every claim was verified against the codebase/docs by exploration. The security section deliberately avoids overclaiming: it does **not** call plugins OS-sandboxed (they're in-process, crash-isolated), does **not** say 'secrets are never seen by the agent' (the permission-gated `secret_get` reveals one on request), and does **not** claim all plugins are signature-enforced (unsigned is warn-and-allow today; *invalid* signatures fail closed). Also corrects the co-browse/voice features that are **not** BossTerm's.

Builds on the earlier README PR (#7): keeps the Apache-2.0 badge/footer, real download links, and the corrected project structure.