### PR TITLE
ci: commit automated version bumps as a human identity, not a bot

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -259,8 +259,8 @@ jobs:
           TARGET_CHANNEL: ${{ needs.validate-and-prepare.outputs.target-channel }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Shivang"
+          git config user.email "shivang.iitk@gmail.com"
           git add version.properties
           if [[ "$TARGET_CHANNEL" == "stable" ]]; then
             git commit -m "🎉 Promote v$PRERELEASE_VERSION to stable v$TARGET_VERSION"

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -124,8 +124,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Shivang"
+          git config user.email "shivang.iitk@gmail.com"
 
           if git diff --quiet version.properties; then
             echo "No version changes to commit"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -138,8 +138,8 @@ jobs:
         run: |
           VERSION="${{ steps.release-info.outputs.version }}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Shivang"
+          git config user.email "shivang.iitk@gmail.com"
 
           if git diff --quiet docs/release-notes/; then
             echo "No changes to commit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,8 @@ jobs:
           set -euo pipefail
 
           # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Shivang"
+          git config user.email "shivang.iitk@gmail.com"
 
           # Check if there are changes to commit
           if git diff --quiet version.properties; then

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -394,8 +394,8 @@ jobs:
         cd public-repo
 
         # Configure git
-        git config user.name "BOSS Release Bot"
-        git config user.email "noreply@risa-labs.com"
+        git config user.name "Shivang"
+        git config user.email "shivang.iitk@gmail.com"
 
         # Create backup of README
         cp README.md README.md.backup


### PR DESCRIPTION
The release-related workflows set git `user.name`/`user.email` to `github-actions[bot]` (and sync-release to "BOSS Release Bot"), so every release's version-bump / release-notes commit was attributed to a bot — surfacing `github-actions[bot]` in the repo's contributor graph.

Switches all five (`release`, `release-lite`, `promote-release`, `release-notes`, `sync-release`) to a plain human identity so future automated commits aren't bot-attributed. Identity-only change (10 lines).