### PR TITLE
docs(compare): add Runtime (JVM multi-threaded) and hot-reload rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 _🧪 Built for enterprises, science, and research._
 
+**⚡ Natively multi-threaded — built on the JVM, not Electron — with live hot-reload and laptop-to-supercomputer scale.**
+
 Bring your own agent — Claude Code, Codex, Gemini, or OpenCode — and give it a real browser, terminal, editor, secrets, and automation. Then decide exactly what each one is allowed to touch. Run it on your own machine, hand a live terminal to your phone with a QR code, and reshape any tool — by hand or by the agent itself — while the app keeps running.
 
 [![BOSS Version](https://img.shields.io/github/v/release/risa-labs-inc/BossConsole-Releases.svg?label=BOSS&color=brightgreen)](https://github.com/risa-labs-inc/BossConsole-Releases/releases/latest)
@@ -103,7 +105,7 @@ iwr -useb https://raw.githubusercontent.com/risa-labs-inc/BossConsole-Releases/m
 - 🔐 **You stay in control** — server-enforced role-based access control, a per-user kill-switch for every agent tool, and user-scoped secrets. You decide exactly what an agent can call.
 - 🖥️ **A terminal built to share** — hand a live terminal session to your phone via QR, or to a teammate over an end-to-end-encrypted link, with view-only or full control.
 - ⚡ **Fast and native** — Compose Multiplatform desktop app with the built-in **Fluck** browser, on macOS, Windows, and Linux (x64 + ARM64).
-- ⚙️ **Built to scale** — multi-threaded by default, on an out-of-process microkernel architecture engineered to run from a laptop to a supercomputer.
+- ⚙️ **Multi-threaded, built to scale** — **truly multi-threaded** on the JVM (not a single-threaded Electron/JS event loop), with an out-of-process microkernel architecture engineered to run from a laptop to a supercomputer.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The deeper difference: **BOSS is both the agent's home _and_ an agent-operable a
 
 And unlike most of the field, BOSS bundles a **real embedded browser — Fluck —** the agent can navigate, script, and automate (`browser_navigate`, `browser_run_js`, plus record-and-replay RPA), with logins filled from the **Secret Manager** and never handed to the model.
 
+It's also **native, not Electron.** BOSS runs on the JVM with true multithreading and **hot-reloads plugins at runtime** — so an agent can evolve a tool and see it live, without restarting the app — while Claude Desktop and the VS Code-fork IDEs (Cursor, Windsurf/Devin, Antigravity) run on a single-threaded JavaScript event loop.
+
 | | **BOSS** | Claude Desktop | Codex | Google Antigravity | Cursor | Windsurf / Devin |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|
 | **Open source** | ✅ Apache-2.0 | ❌ | △ CLI only¹ | ❌ | ❌ | ❌ |
@@ -42,9 +44,11 @@ And unlike most of the field, BOSS bundles a **real embedded browser — Fluck �
 | **Share terminal session** (QR / multi-user / E2E) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Per-tool governance** (RBAC + kill-switch) | ✅ | △³ | △³ | △³ | △ Teams | △ Enterprise |
 | **Plugin ecosystem** | ✅ Toolbox store | △ MCP extensions | △ IDE ext. | ✅ VS Code ext. | ✅ VS Code ext. | ✅ VS Code ext. |
+| **Hot-reload / evolvable at runtime** | ✅ live plugins + Tool Evolver | ❌ | ❌ | △⁵ | △⁵ | △⁵ |
+| **Runtime** | ✅ JVM, multi-threaded | Electron / JS⁶ | Rust (CLI) | Electron / JS⁶ | Electron / JS⁶ | Electron / JS⁶ |
 | **Platforms** | mac · Win · Linux (x64+ARM64) | mac · Win · Linux (beta) | mac · Win · Linux⁴ | mac · Win · Linux | mac · Win · Linux | mac · Win · Linux |
 
-<sub>✅ yes · △ partial/limited · ❌ no. &nbsp;¹ Only OpenAI's Codex **CLI** is open source (Apache-2.0); the Codex desktop app is proprietary. &nbsp;² Claude Desktop's "Computer Use" controls the whole screen rather than bundling a scriptable in-app browser. &nbsp;³ Enterprise-plan admin controls exist, but fine-grained per-tool RBAC isn't documented. &nbsp;⁴ Codex CLI is cross-platform; the desktop app is macOS/Windows. &nbsp;Compiled from public sources, July 2026 — these products move fast, so corrections are welcome via issue or PR.</sub>
+<sub>✅ yes · △ partial/limited · ❌ no. &nbsp;¹ Only OpenAI's Codex **CLI** is open source (Apache-2.0); the Codex desktop app is proprietary. &nbsp;² Claude Desktop's "Computer Use" controls the whole screen rather than bundling a scriptable in-app browser. &nbsp;³ Enterprise-plan admin controls exist, but fine-grained per-tool RBAC isn't documented. &nbsp;⁴ Codex CLI is cross-platform; the desktop app is macOS/Windows. &nbsp;⁵ VS Code-fork IDEs reload extensions via a full window reload; none offers BOSS-style live plugin hot-reload + agent-driven tool evolution. &nbsp;⁶ Claude Desktop and the VS Code-fork IDEs run on Electron (Chromium + Node.js) — a single-threaded JavaScript event loop with worker/child-process offloading; BOSS runs natively on the JVM with true multithreading. &nbsp;Compiled from public sources, July 2026 — these products move fast, so corrections are welcome via issue or PR.</sub>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The deeper difference: **BOSS is both the agent's home _and_ an agent-operable a
 
 And unlike most of the field, BOSS bundles a **real embedded browser — Fluck —** the agent can navigate, script, and automate (`browser_navigate`, `browser_run_js`, plus record-and-replay RPA), with logins filled from the **Secret Manager** and never handed to the model.
 
-It's also **native, not Electron.** BOSS runs on the JVM with true multithreading and **hot-reloads plugins at runtime** — so an agent can evolve a tool and see it live, without restarting the app — while Claude Desktop and the VS Code-fork IDEs (Cursor, Windsurf/Devin, Antigravity) run on a single-threaded JavaScript event loop.
+It's also **native, not Electron.** BOSS runs on the JVM with true multithreading and **hot-reloads plugins at runtime** — so an agent can evolve a tool and see it live, without restarting the app — while Claude Desktop and the VS Code-fork IDEs (Antigravity, Cursor, Windsurf/Devin) run on a single-threaded JavaScript event loop.
 
 | | **BOSS** | Claude Desktop | Codex | Google Antigravity | Cursor | Windsurf / Devin |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|
@@ -47,7 +47,7 @@ It's also **native, not Electron.** BOSS runs on the JVM with true multithreadin
 | **Per-tool governance** (RBAC + kill-switch) | ✅ | △³ | △³ | △³ | △ Teams | △ Enterprise |
 | **Plugin ecosystem** | ✅ Toolbox store | △ MCP extensions | △ IDE ext. | ✅ VS Code ext. | ✅ VS Code ext. | ✅ VS Code ext. |
 | **Hot-reload / evolvable at runtime** | ✅ live plugins + Tool Evolver | ❌ | ❌ | △⁵ | △⁵ | △⁵ |
-| **Runtime** | ✅ JVM, multi-threaded | Electron / JS⁶ | Rust (CLI) | Electron / JS⁶ | Electron / JS⁶ | Electron / JS⁶ |
+| **Runtime** | JVM, multi-threaded | Electron / JS⁶ | Rust (CLI) | Electron / JS⁶ | Electron / JS⁶ | Electron / JS⁶ |
 | **Platforms** | mac · Win · Linux (x64+ARM64) | mac · Win · Linux (beta) | mac · Win · Linux⁴ | mac · Win · Linux | mac · Win · Linux | mac · Win · Linux |
 
 <sub>✅ yes · △ partial/limited · ❌ no. &nbsp;¹ Only OpenAI's Codex **CLI** is open source (Apache-2.0); the Codex desktop app is proprietary. &nbsp;² Claude Desktop's "Computer Use" controls the whole screen rather than bundling a scriptable in-app browser. &nbsp;³ Enterprise-plan admin controls exist, but fine-grained per-tool RBAC isn't documented. &nbsp;⁴ Codex CLI is cross-platform; the desktop app is macOS/Windows. &nbsp;⁵ VS Code-fork IDEs reload extensions via a full window reload; none offers BOSS-style live plugin hot-reload + agent-driven tool evolution. &nbsp;⁶ Claude Desktop and the VS Code-fork IDEs run on Electron (Chromium + Node.js) — a single-threaded JavaScript event loop with worker/child-process offloading; BOSS runs natively on the JVM with true multithreading. &nbsp;Compiled from public sources, July 2026 — these products move fast, so corrections are welcome via issue or PR.</sub>


### PR DESCRIPTION
Adds two differentiators to the comparison table (and a prose line):

- **Hot-reload / evolvable at runtime** — BOSS hot-reloads plugins live and evolves tools via Tool Evolver; the VS Code-fork IDEs only reload extensions via a full window reload (△), Claude Desktop / Codex ❌.
- **Runtime** — BOSS runs natively on the **JVM with true multithreading**; Claude Desktop and the VS Code-fork IDEs (Cursor, Windsurf/Devin, Antigravity) run on **Electron (Chromium + Node.js) — a single-threaded JavaScript event loop**; Codex's core is a Rust CLI.

Accuracy: Claude Desktop being Electron is confirmed via public sources; footnotes explain the JS event-loop concurrency model and that JS offloads via worker/child processes (so "△/Electron" not a flat "no threads"). Codex CLI is Rust (native), noted honestly rather than lumped in.

Table remains column-consistent (11 rows × 7 cols).