### PR TITLE
fix(updater): survive macOS App Translocation so updates restart the app

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.updater
 
 import ai.rever.boss.utils.AppVersion
+import ai.rever.boss.utils.BOSS_MACOS_APP_BUNDLE_NAME
 import ai.rever.boss.utils.BOSS_MACOS_BUNDLE_ID
 import ai.rever.boss.utils.Version
 import ai.rever.boss.utils.logging.BossLogger
@@ -564,7 +565,7 @@ object UpdateInstaller {
             }
 
             // Method 3: Check if running from Applications folder
-            val applicationsPath = "/Applications/BOSS.app"
+            val applicationsPath = "$MACOS_APPLICATIONS_DIRECTORY/$BOSS_MACOS_APP_BUNDLE_NAME"
             if (File(applicationsPath).exists()) {
                 logger.debug(LogCategory.SYSTEM, "Found BOSS in Applications folder", mapOf("path" to applicationsPath))
                 return applicationsPath

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.updater
 
 import ai.rever.boss.utils.AppVersion
+import ai.rever.boss.utils.BOSS_MACOS_BUNDLE_ID
 import ai.rever.boss.utils.Version
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -8,7 +9,40 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.nio.file.Paths
-import java.util.*
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+private const val APP_TRANSLOCATION_PATH_SEGMENT = "/AppTranslocation/"
+private const val MACOS_APP_BUNDLE_SUFFIX = ".app"
+private const val MACOS_APPLICATIONS_DIRECTORY = "/Applications"
+private const val SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS = 5L
+
+/**
+ * Resolve a macOS app bundle path without coupling the decision logic to the
+ * filesystem or Spotlight. The injected functions keep App Translocation path
+ * parsing and fallback ordering directly unit-testable.
+ */
+internal fun realAppPathFor(
+    path: String,
+    appExists: (String) -> Boolean,
+    installedAppLookup: () -> String?
+): String {
+    if (!path.contains(APP_TRANSLOCATION_PATH_SEGMENT)) return path
+
+    val bundleEnd = path.indexOf(MACOS_APP_BUNDLE_SUFFIX)
+    if (bundleEnd < 0) return path
+
+    val bundleName = path
+        .substring(0, bundleEnd + MACOS_APP_BUNDLE_SUFFIX.length)
+        .substringAfterLast('/')
+        .takeIf { it.isNotBlank() }
+        ?: return path
+
+    val applicationsPath = "$MACOS_APPLICATIONS_DIRECTORY/$bundleName"
+    if (appExists(applicationsPath)) return applicationsPath
+
+    return installedAppLookup()?.takeIf(appExists) ?: path
+}
 
 /**
  * Platform-specific update installation logic
@@ -549,7 +583,7 @@ object UpdateInstaller {
      * When the given path is not translocated it is returned unchanged.
      */
     private fun resolveRealAppPath(path: String): String {
-        if (!path.contains("/AppTranslocation/")) return path
+        if (!path.contains(APP_TRANSLOCATION_PATH_SEGMENT)) return path
 
         logger.warn(
             LogCategory.SYSTEM,
@@ -557,20 +591,15 @@ object UpdateInstaller {
             mapOf("translocatedPath" to path)
         )
 
-        // Bundle name from the translocated path, e.g. "BOSS.app"
-        val bundleName = path.substringBeforeLast(".app").substringAfterLast('/') + ".app"
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { File(it).exists() },
+            installedAppLookup = ::findInstalledAppViaSpotlight
+        )
 
-        // 1. Standard install location (covers the overwhelming majority of installs).
-        val applicationsPath = "/Applications/$bundleName"
-        if (File(applicationsPath).exists()) {
-            logger.info(LogCategory.SYSTEM, "Resolved real app path in /Applications", mapOf("path" to applicationsPath))
-            return applicationsPath
-        }
-
-        // 2. Non-standard install location: ask Spotlight for the installed bundle.
-        findInstalledAppViaSpotlight()?.let {
-            logger.info(LogCategory.SYSTEM, "Resolved real app path via mdfind", mapOf("path" to it))
-            return it
+        if (resolvedPath != path) {
+            logger.info(LogCategory.SYSTEM, "Resolved real app path", mapOf("path" to resolvedPath))
+            return resolvedPath
         }
 
         // 3. Give up and keep the translocated path (update will likely still fail, but
@@ -586,14 +615,35 @@ object UpdateInstaller {
     private fun findInstalledAppViaSpotlight(): String? {
         return try {
             val process = ProcessBuilder(
-                "mdfind", "kMDItemCFBundleIdentifier == 'ai.rever.boss'"
-            ).start()
-            val output = process.inputStream.bufferedReader().readText()
-            process.waitFor()
+                "mdfind", "kMDItemCFBundleIdentifier == '$BOSS_MACOS_BUNDLE_ID'"
+            )
+                .redirectErrorStream(true)
+                .start()
+
+            if (!process.waitFor(SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "mdfind lookup for installed app timed out",
+                    mapOf("timeoutSeconds" to SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS)
+                )
+                return null
+            }
+
+            if (process.exitValue() != 0) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "mdfind lookup for installed app failed",
+                    mapOf("exitCode" to process.exitValue())
+                )
+                return null
+            }
+
+            val output = process.inputStream.bufferedReader().use { it.readText() }
             output.lineSequence()
                 .map { it.trim() }
-                .filter { it.endsWith(".app") }
-                .filterNot { it.contains("/AppTranslocation/") }
+                .filter { it.endsWith(MACOS_APP_BUNDLE_SUFFIX) }
+                .filterNot { it.contains(APP_TRANSLOCATION_PATH_SEGMENT) }
                 .filterNot { it.contains("/Frameworks/") || it.contains("/Helpers/") }
                 .firstOrNull { File(it).exists() }
         } catch (e: Exception) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -29,13 +29,15 @@ internal fun realAppPathFor(
 ): String {
     if (!path.contains(APP_TRANSLOCATION_PATH_SEGMENT)) return path
 
-    val bundleEnd = path.indexOf(MACOS_APP_BUNDLE_SUFFIX)
-    if (bundleEnd < 0) return path
-
+    // Match the suffix at a path-segment boundary. Searching the raw path for
+    // the first ".app" would misparse names such as "My.application.app".
     val bundleName = path
-        .substring(0, bundleEnd + MACOS_APP_BUNDLE_SUFFIX.length)
-        .substringAfterLast('/')
-        .takeIf { it.isNotBlank() }
+        .substringAfter(APP_TRANSLOCATION_PATH_SEGMENT)
+        .split('/')
+        .firstOrNull {
+            it.length > MACOS_APP_BUNDLE_SUFFIX.length &&
+                it.endsWith(MACOS_APP_BUNDLE_SUFFIX)
+        }
         ?: return path
 
     val applicationsPath = "$MACOS_APPLICATIONS_DIRECTORY/$bundleName"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.nio.file.Paths
 import java.util.Locale
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 private const val APP_TRANSLOCATION_PATH_SEGMENT = "/AppTranslocation/"
@@ -634,8 +635,15 @@ object UpdateInstaller {
                 .redirectErrorStream(true)
                 .start()
 
+            // Drain output while mdfind runs so a full OS pipe buffer cannot
+            // block the child and turn a successful lookup into a timeout.
+            val outputFuture = CompletableFuture.supplyAsync {
+                process.inputStream.bufferedReader().use { it.readText() }
+            }
+
             if (!process.waitFor(SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
+                outputFuture.cancel(true)
                 logger.warn(
                     LogCategory.SYSTEM,
                     "mdfind lookup for installed app timed out",
@@ -643,6 +651,8 @@ object UpdateInstaller {
                 )
                 return null
             }
+
+            val output = outputFuture.get(1, TimeUnit.SECONDS)
 
             if (process.exitValue() != 0) {
                 logger.warn(
@@ -653,7 +663,6 @@ object UpdateInstaller {
                 return null
             }
 
-            val output = process.inputStream.bufferedReader().use { it.readText() }
             output.lineSequence()
                 .map { it.trim() }
                 .filter { it.endsWith(MACOS_APP_BUNDLE_SUFFIX) }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -498,7 +498,7 @@ object UpdateInstaller {
 
             if (bundlePath?.contains(".app") == true && File(bundlePath).exists()) {
                 logger.debug(LogCategory.SYSTEM, "Found app bundle via library path", mapOf("path" to bundlePath))
-                return bundlePath
+                return resolveRealAppPath(bundlePath)
             }
 
             // Method 2: Try to find app bundle from current JAR/class location
@@ -511,7 +511,7 @@ object UpdateInstaller {
                 logger.trace(LogCategory.SYSTEM, "Checking parent", mapOf("index" to i, "path" to currentFile.absolutePath))
                 if (currentFile.name.endsWith(".app")) {
                     logger.debug(LogCategory.SYSTEM, "Found app bundle via directory traversal", mapOf("path" to currentFile.absolutePath))
-                    return currentFile.absolutePath
+                    return resolveRealAppPath(currentFile.absolutePath)
                 }
                 currentFile = currentFile.parentFile ?: break
             }
@@ -528,6 +528,76 @@ object UpdateInstaller {
 
         } catch (e: Exception) {
             logger.error(LogCategory.SYSTEM, "Error getting application path", error = e)
+            null
+        }
+    }
+
+    /**
+     * Resolve a possibly *translocated* app path back to the real install location.
+     *
+     * macOS App Translocation (Gatekeeper path randomization) runs a quarantined,
+     * "not-yet-moved-by-Finder" app from a **read-only, randomized, ephemeral** mount
+     * under `/private/var/folders/.../T/AppTranslocation/<uuid>/d/<App>.app`. If we feed
+     * that path to the update script it will:
+     *   - `rm -rf` / `cp -R` into a read-only volume (every write fails), and
+     *   - relaunch a path that no longer exists (macOS auto-unmounts the translocation
+     *     mount the moment the app quits),
+     * so the update silently fails and the app never restarts. See the update helper
+     * script in [UpdateScriptGenerator] which also strips the quarantine attribute so
+     * future launches are not translocated.
+     *
+     * When the given path is not translocated it is returned unchanged.
+     */
+    private fun resolveRealAppPath(path: String): String {
+        if (!path.contains("/AppTranslocation/")) return path
+
+        logger.warn(
+            LogCategory.SYSTEM,
+            "App is running translocated by Gatekeeper - resolving real install path",
+            mapOf("translocatedPath" to path)
+        )
+
+        // Bundle name from the translocated path, e.g. "BOSS.app"
+        val bundleName = path.substringBeforeLast(".app").substringAfterLast('/') + ".app"
+
+        // 1. Standard install location (covers the overwhelming majority of installs).
+        val applicationsPath = "/Applications/$bundleName"
+        if (File(applicationsPath).exists()) {
+            logger.info(LogCategory.SYSTEM, "Resolved real app path in /Applications", mapOf("path" to applicationsPath))
+            return applicationsPath
+        }
+
+        // 2. Non-standard install location: ask Spotlight for the installed bundle.
+        findInstalledAppViaSpotlight()?.let {
+            logger.info(LogCategory.SYSTEM, "Resolved real app path via mdfind", mapOf("path" to it))
+            return it
+        }
+
+        // 3. Give up and keep the translocated path (update will likely still fail, but
+        //    we have logged exactly why).
+        logger.warn(LogCategory.SYSTEM, "Could not resolve real app path - falling back to translocated path")
+        return path
+    }
+
+    /**
+     * Locate the installed BOSS.app by its bundle identifier via Spotlight (`mdfind`),
+     * skipping translocated mounts and nested helper/framework bundles.
+     */
+    private fun findInstalledAppViaSpotlight(): String? {
+        return try {
+            val process = ProcessBuilder(
+                "mdfind", "kMDItemCFBundleIdentifier == 'ai.rever.boss'"
+            ).start()
+            val output = process.inputStream.bufferedReader().readText()
+            process.waitFor()
+            output.lineSequence()
+                .map { it.trim() }
+                .filter { it.endsWith(".app") }
+                .filterNot { it.contains("/AppTranslocation/") }
+                .filterNot { it.contains("/Frameworks/") || it.contains("/Helpers/") }
+                .firstOrNull { File(it).exists() }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "mdfind lookup for installed app failed", error = e)
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -17,6 +17,25 @@ private const val MACOS_APP_BUNDLE_SUFFIX = ".app"
 private const val MACOS_APPLICATIONS_DIRECTORY = "/Applications"
 private const val SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS = 5L
 
+/** Return the outermost complete `.app` path segment in [path]. */
+internal fun macOSAppBundlePathIn(path: String): String? {
+    val pathSegments = path.split('/')
+    val bundleIndex = pathSegments.indexOfFirst {
+        it.length > MACOS_APP_BUNDLE_SUFFIX.length &&
+            it.endsWith(MACOS_APP_BUNDLE_SUFFIX)
+    }
+    if (bundleIndex < 0) return null
+
+    return pathSegments.take(bundleIndex + 1).joinToString("/")
+}
+
+/** Extract the first app bundle represented in `java.library.path`. */
+internal fun macOSAppBundlePathFromLibraryPath(libraryPath: String): String? {
+    return libraryPath
+        .split(File.pathSeparatorChar)
+        .firstNotNullOfOrNull(::macOSAppBundlePathIn)
+}
+
 /**
  * Resolve a macOS app bundle path without coupling the decision logic to the
  * filesystem or Spotlight. The injected functions keep App Translocation path
@@ -29,15 +48,10 @@ internal fun realAppPathFor(
 ): String {
     if (!path.contains(APP_TRANSLOCATION_PATH_SEGMENT)) return path
 
-    // Match the suffix at a path-segment boundary. Searching the raw path for
-    // the first ".app" would misparse names such as "My.application.app".
-    val bundleName = path
-        .substringAfter(APP_TRANSLOCATION_PATH_SEGMENT)
-        .split('/')
-        .firstOrNull {
-            it.length > MACOS_APP_BUNDLE_SUFFIX.length &&
-                it.endsWith(MACOS_APP_BUNDLE_SUFFIX)
-        }
+    val bundleName = macOSAppBundlePathIn(
+        path.substringAfter(APP_TRANSLOCATION_PATH_SEGMENT)
+    )
+        ?.substringAfterLast('/')
         ?: return path
 
     val applicationsPath = "$MACOS_APPLICATIONS_DIRECTORY/$bundleName"
@@ -527,12 +541,9 @@ object UpdateInstaller {
             val libraryPath = System.getProperty("java.library.path")
             logger.trace(LogCategory.SYSTEM, "java.library.path", mapOf("path" to (libraryPath ?: "null")))
 
-            val bundlePath = libraryPath
-                ?.split(":")
-                ?.find { it.contains(".app") }
-                ?.let { "${it.substringBefore(".app")}.app" }
+            val bundlePath = libraryPath?.let(::macOSAppBundlePathFromLibraryPath)
 
-            if (bundlePath?.contains(".app") == true && File(bundlePath).exists()) {
+            if (bundlePath != null && File(bundlePath).exists()) {
                 logger.debug(LogCategory.SYSTEM, "Found app bundle via library path", mapOf("path" to bundlePath))
                 return resolveRealAppPath(bundlePath)
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -199,7 +199,7 @@ object UpdateScriptGenerator {
             if [ -d $escapedTargetAppPath ]; then
                 rm -rf $escapedTargetAppPath
                 if [ ${'$'}? -ne 0 ]; then
-                    echo "Failed to remove old app (may need admin permissions)"
+                    echo "Failed to remove old app at $escapedTargetAppPath (path may be read-only or need admin permissions)"
                     hdiutil detach "${'$'}VOLUME" -quiet
                     exit 1
                 fi
@@ -216,6 +216,14 @@ object UpdateScriptGenerator {
 
             echo "Installation successful!"
 
+            # Clear the quarantine attribute on the freshly installed bundle.
+            # A quarantined, not-yet-moved app is launched by Gatekeeper via App
+            # Translocation from a read-only randomized mount, which breaks in-place
+            # updates and the relaunch below. BOSS is notarized, so stripping the
+            # attribute here is safe and mirrors what Sparkle does.
+            echo "Clearing quarantine attribute..."
+            xattr -dr com.apple.quarantine $escapedTargetAppPath 2>/dev/null || true
+
             # Unmount DMG
             echo "Cleaning up..."
             hdiutil detach "${'$'}VOLUME" -quiet
@@ -223,6 +231,11 @@ object UpdateScriptGenerator {
             # Launch the updated app (using escaped path for security)
             echo "Launching new BOSS..."
             open $escapedTargetAppPath
+            if [ ${'$'}? -ne 0 ]; then
+                echo "First relaunch attempt failed - retrying in 2s..."
+                sleep 2
+                open $escapedTargetAppPath || echo "Relaunch failed - please start BOSS manually"
+            fi
 
             # Give the app time to start
             sleep 2

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -222,7 +222,9 @@ object UpdateScriptGenerator {
             # updates and the relaunch below. BOSS is notarized, so stripping the
             # attribute here is safe and mirrors what Sparkle does.
             echo "Clearing quarantine attribute..."
-            xattr -dr com.apple.quarantine $escapedTargetAppPath 2>/dev/null || true
+            if ! xattr -dr com.apple.quarantine $escapedTargetAppPath; then
+                echo "Warning: failed to clear quarantine attribute; future launches may be translocated"
+            fi
 
             # Unmount DMG
             echo "Cleaning up..."

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -228,7 +228,9 @@ object UpdateScriptGenerator {
             echo "Cleaning up..."
             hdiutil detach "${'$'}VOLUME" -quiet
 
-            # Launch the updated app (using escaped path for security)
+            # Ask LaunchServices to launch the updated app (using the escaped path).
+            # A successful `open` only means the request was accepted; it does not
+            # verify that the app stayed running after launch.
             echo "Launching new BOSS..."
             open $escapedTargetAppPath
             if [ ${'$'}? -ne 0 ]; then

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSAppIdentity.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSAppIdentity.kt
@@ -1,0 +1,4 @@
+package ai.rever.boss.utils
+
+/** Bundle identifier shared by macOS runtime integrations. */
+internal const val BOSS_MACOS_BUNDLE_ID = "ai.rever.boss"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSAppIdentity.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSAppIdentity.kt
@@ -2,3 +2,6 @@ package ai.rever.boss.utils
 
 /** Bundle identifier shared by macOS runtime integrations. */
 internal const val BOSS_MACOS_BUNDLE_ID = "ai.rever.boss"
+
+/** Shipping app-bundle name used by the default `/Applications` fallback. */
+internal const val BOSS_MACOS_APP_BUNDLE_NAME = "BOSS.app"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSDefaultBrowserHandler.kt
@@ -20,7 +20,6 @@ private val logger = BossLogger.forComponent("MacOSDefaultBrowserHandler")
  * - Set BOSS as the default browser
  */
 object MacOSDefaultBrowserHandler {
-    private const val BUNDLE_ID = "ai.rever.boss"
     private const val PROCESS_TIMEOUT_SECONDS = 30L
 
     /**
@@ -38,8 +37,8 @@ object MacOSDefaultBrowserHandler {
             logger.debug(LogCategory.BROWSER, "macOS default browser check", mapOf("httpHandler" to (httpDefault ?: "none"), "httpsHandler" to (httpsDefault ?: "none")))
 
             // BOSS is default if both schemes point to our bundle ID
-            val isDefault = BUNDLE_ID.equals(httpDefault, ignoreCase = true) &&
-                BUNDLE_ID.equals(httpsDefault, ignoreCase = true)
+            val isDefault = BOSS_MACOS_BUNDLE_ID.equals(httpDefault, ignoreCase = true) &&
+                BOSS_MACOS_BUNDLE_ID.equals(httpsDefault, ignoreCase = true)
 
             Result.success(isDefault)
         } catch (e: Exception) {
@@ -148,7 +147,7 @@ object MacOSDefaultBrowserHandler {
                 import AppKit
                 import ApplicationServices
 
-                let bundleId = "$BUNDLE_ID"
+                let bundleId = "$BOSS_MACOS_BUNDLE_ID"
                 let scheme = "$scheme"
 
                 let status = LSSetDefaultHandlerForURLScheme(scheme as CFString, bundleId as CFString)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateInstallerPathResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateInstallerPathResolutionTest.kt
@@ -1,0 +1,62 @@
+package ai.rever.boss.updater
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class UpdateInstallerPathResolutionTest {
+
+    @Test
+    fun `non-translocated app path is returned without filesystem lookup`() {
+        val path = "/Applications/BOSS.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { fail("Non-translocated paths must not query the filesystem") },
+            installedAppLookup = { fail("Non-translocated paths must not query Spotlight") }
+        )
+
+        assertEquals(path, resolvedPath)
+    }
+
+    @Test
+    fun `translocated path resolves bundle name in Applications`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BOSS Preview.app/Contents/MacOS/BOSS"
+        val expectedPath = "/Applications/BOSS Preview.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { it == expectedPath },
+            installedAppLookup = { fail("Applications path should be preferred over Spotlight") }
+        )
+
+        assertEquals(expectedPath, resolvedPath)
+    }
+
+    @Test
+    fun `translocated path falls back to installed app lookup`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BOSS.app"
+        val spotlightPath = "/Users/test/Applications/BOSS.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { it == spotlightPath },
+            installedAppLookup = { spotlightPath }
+        )
+
+        assertEquals(spotlightPath, resolvedPath)
+    }
+
+    @Test
+    fun `unresolved translocated path is preserved`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BOSS.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { false },
+            installedAppLookup = { null }
+        )
+
+        assertEquals(path, resolvedPath)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateInstallerPathResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateInstallerPathResolutionTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.updater
 
 import org.junit.jupiter.api.Test
+import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
@@ -45,6 +46,19 @@ class UpdateInstallerPathResolutionTest {
         )
 
         assertEquals(expectedPath, resolvedPath)
+    }
+
+    @Test
+    fun `library path preserves app substring inside bundle name`() {
+        val libraryPath = listOf(
+            "/usr/local/lib",
+            "/Applications/My.application.app/Contents/runtime/Contents/Home/lib"
+        ).joinToString(File.pathSeparator)
+
+        assertEquals(
+            "/Applications/My.application.app",
+            macOSAppBundlePathFromLibraryPath(libraryPath)
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateInstallerPathResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateInstallerPathResolutionTest.kt
@@ -34,6 +34,20 @@ class UpdateInstallerPathResolutionTest {
     }
 
     @Test
+    fun `bundle suffix is matched at path segment boundary`() {
+        val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/My.application.app/Contents/MacOS/App"
+        val expectedPath = "/Applications/My.application.app"
+
+        val resolvedPath = realAppPathFor(
+            path = path,
+            appExists = { it == expectedPath },
+            installedAppLookup = { fail("Applications path should be preferred over Spotlight") }
+        )
+
+        assertEquals(expectedPath, resolvedPath)
+    }
+
+    @Test
     fun `translocated path falls back to installed app lookup`() {
         val path = "/private/var/folders/xx/T/AppTranslocation/uuid/d/BOSS.app"
         val spotlightPath = "/Users/test/Applications/BOSS.app"

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
@@ -205,6 +205,51 @@ class UpdateScriptGeneratorSecurityTest {
     }
 
     /**
+     * Test that generated script strips the quarantine attribute after install so
+     * the relaunched app is not App-Translocated by Gatekeeper (which would break
+     * future in-place updates). Regression test for the "update does not restart" bug.
+     */
+    @Test
+    fun `test generated script strips quarantine attribute`() {
+        val scriptFile = UpdateScriptGenerator.generateMacOSUpdateScript(
+            dmgPath = "/tmp/update.dmg",
+            targetAppPath = "/Applications/BOSS.app",
+            appPid = 12345
+        )
+
+        val scriptContent = scriptFile.readText()
+        assertTrue(
+            scriptContent.contains("xattr -dr com.apple.quarantine '/Applications/BOSS.app'"),
+            "Script should strip the quarantine attribute from the installed bundle"
+        )
+
+        // Cleanup
+        scriptFile.delete()
+    }
+
+    /**
+     * Test that the generated script retries the relaunch if the first `open` fails,
+     * so a transient LaunchServices failure does not leave the app un-restarted.
+     */
+    @Test
+    fun `test generated script retries relaunch on failure`() {
+        val scriptFile = UpdateScriptGenerator.generateMacOSUpdateScript(
+            dmgPath = "/tmp/update.dmg",
+            targetAppPath = "/Applications/BOSS.app",
+            appPid = 12345
+        )
+
+        val scriptContent = scriptFile.readText()
+        assertTrue(
+            scriptContent.contains("please start BOSS manually"),
+            "Script should fall back to a manual-launch message if relaunch keeps failing"
+        )
+
+        // Cleanup
+        scriptFile.delete()
+    }
+
+    /**
      * Test that generated script waits for PID termination
      */
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
@@ -240,9 +240,17 @@ class UpdateScriptGeneratorSecurityTest {
         )
 
         val scriptContent = scriptFile.readText()
+        val expectedRetryBlock = """
+            open '/Applications/BOSS.app'
+            if [ ${'$'}? -ne 0 ]; then
+                echo "First relaunch attempt failed - retrying in 2s..."
+                sleep 2
+                open '/Applications/BOSS.app' || echo "Relaunch failed - please start BOSS manually"
+            fi
+        """.trimIndent()
         assertTrue(
-            scriptContent.contains("please start BOSS manually"),
-            "Script should fall back to a manual-launch message if relaunch keeps failing"
+            scriptContent.contains(expectedRetryBlock),
+            "Script should retry the escaped app path after two seconds and provide a manual-launch fallback"
         )
 
         // Cleanup

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
@@ -222,6 +222,10 @@ class UpdateScriptGeneratorSecurityTest {
             scriptContent.contains("xattr -dr com.apple.quarantine '/Applications/BOSS.app'"),
             "Script should strip the quarantine attribute from the installed bundle"
         )
+        assertTrue(
+            scriptContent.contains("Warning: failed to clear quarantine attribute"),
+            "Script should keep quarantine-removal failures visible without aborting the update"
+        )
 
         // Cleanup
         scriptFile.delete()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateScriptGeneratorSecurityTest.kt
@@ -228,8 +228,8 @@ class UpdateScriptGeneratorSecurityTest {
     }
 
     /**
-     * Test that the generated script retries the relaunch if the first `open` fails,
-     * so a transient LaunchServices failure does not leave the app un-restarted.
+     * Test that the generated script retries when LaunchServices rejects the first
+     * `open` request. A successful request does not prove the app stayed running.
      */
     @Test
     fun `test generated script retries relaunch on failure`() {


### PR DESCRIPTION
## Problem

On newer/other Macs, updating BossConsole from the in-app updater **does not install the update and never restarts BOSS**. Reproduced from a real user's install: `/Applications/BOSS.app` carried `com.apple.quarantine`, and the generated helper script logged 638 lines of:

```
rm: /private/var/folders/.../T/AppTranslocation/<uuid>/d/BOSS.app/...: Read-only file system
Failed to remove old app (may need admin permissions)
```
…then `exit 1` — **before ever reaching the `open` relaunch**.

## Root cause: macOS App Translocation (not a permissions issue)

A quarantined app that hasn't been *moved by Finder* is launched by Gatekeeper via **App Translocation** — it runs from a **read-only, randomized, ephemeral** mount:
```
/private/var/folders/.../T/AppTranslocation/<uuid>/d/BOSS.app
```
`UpdateInstaller.getCurrentApplicationPath()` resolves the app's *own running path*, which under translocation is that read-only mount, and bakes it into the helper script as the delete/copy/relaunch target. So `rm -rf`/`cp -R` fail (read-only), the script exits early, `/Applications/BOSS.app` is never updated, and the app never relaunches. The `open` target would also be gone anyway — macOS unmounts the translocation mount the instant the app quits.

Why it doesn't repro on a dev machine: a locally-built app has no quarantine → runs from the real `/Applications/BOSS.app` → the updater works. A downloaded copy on another Mac is quarantined → translocated → breaks.

## Fix

- **`UpdateInstaller.getCurrentApplicationPath()`** — new `resolveRealAppPath()`: if the resolved path contains `/AppTranslocation/`, resolve the real install location (`/Applications/<App>.app`, else a Spotlight `mdfind` lookup by bundle id, filtering out translocated/helper/framework bundles) before handing it to the script.
- **`UpdateScriptGenerator` macOS script** — after `cp -R`, strip `com.apple.quarantine` from the installed bundle so future launches are **not** translocated (BOSS is notarized — this is safe and mirrors Sparkle); retry the `open` relaunch and print a manual-launch message if it keeps failing; clarify the read-only removal error message.
- **Tests** — regression tests asserting the script strips quarantine and has a relaunch fallback.

## Migration note

This fixes updates performed **by a build that contains this change**. A user currently on an affected older build still can't auto-update *to* the first fixed build (the broken script is generated by the already-installed code) — they need one manual install of a fixed build; auto-update works from then on. Optional follow-up: a startup self-heal that strips quarantine when it detects it's running translocated, to rescue already-broken installs without a manual reinstall.

## Testing

- `./gradlew :composeApp:desktopTest --tests "ai.rever.boss.updater.UpdateScriptGeneratorSecurityTest"` → BUILD SUCCESSFUL.
- Not run as the full app (per repo workflow — verify against a built, signed DMG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)