### PR TITLE
chore: bump boss-plugin-api pin to 1.0.68

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ intellij-platform = "243.21565.199"
 # bump it when consuming a new SDK release. Distribution is store/GitHub-
 # releases ONLY: plugin-platform/plugin-api-core downloads this release's jar and
 # filters the api package locally (no Maven registry involved).
-boss-plugin-api = "1.0.66"
+boss-plugin-api = "1.0.68"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
## Why

api 1.0.68 added `PluginContext.llmProvider` (the LlmProvider / LlmConfig / LlmApiFormat access layer, boss-plugin-api#21). Member additions to host-compiled types can't ship via the hot-swappable api jar — the host's baked-in copy of `PluginContext` shadows it parent-first (see the `ApiClassLoader` doc). So any plugin built against 1.0.68 fails `BinaryCompatibilityValidator` on every existing host:

```
PluginBinaryIncompatibilityException: ai.rever.boss.plugin.api.PluginContext.getLlmProvider
(()Lai/rever/boss/plugin/api/LlmProvider;): method not found
```

This is currently biting **jupyter-notebook 1.0.12** ("Reapply multi-provider LLM support"), which is uninstallable on BOSS 9.2.54 — the store gate didn't catch it because the plugin shipped with `minBossVersion: 9.2.0`.

## What

Bump the api contract pin `1.0.66` → `1.0.68` in `gradle/libs.versions.toml`. The interface declares `val llmProvider: LlmProvider? get() = null`, so the host compiles without wiring an implementation — plugins get `null` and degrade gracefully until a real provider lands in a follow-up.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` — BUILD SUCCESSFUL; `fetchApiPluginJar` resolves the 1.0.68 GitHub release.

## Follow-ups

- Wire a real `LlmProvider` implementation in the host (owner: @mahmood-risa's LLM access layer work).
- jupyter-notebook releases that call the new member should set `minBossVersion` to the host release that ships this pin, so Toolbox hides them from older hosts instead of failing install.