### PR TITLE
ci: real quality gates — detekt with tuned config and baselines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig for BossConsole — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+indent_style = space
+indent_size = 4
+max_line_length = 140
+# Matches kotlin.code.style=official in gradle.properties.
+ktlint_code_style = intellij_idea
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,12 +155,22 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: 🔍 Lint Check
+      - name: 🔍 Static Analysis (detekt)
         run: |
-          echo "🔍 Running lint checks"
-          # Add lint tasks if available
-          # ./gradlew ktlintCheck
-          echo "Lint check completed"
+          echo "🔍 Running detekt across all modules"
+          # Baselined per module: existing debt is frozen in detekt-baseline.xml
+          # files, only NEW violations fail this step.
+          ./gradlew detekt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📊 Upload detekt Reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: detekt-reports
+          path: '**/build/reports/detekt/'
+          retention-days: 7
 
       - name: 🔒 Dependency Check
         run: |
@@ -168,11 +178,6 @@ jobs:
           ./gradlew :composeApp:dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 📊 Generate Build Report
-        run: |
-          echo "📊 Generating build report"
-          ./gradlew buildHealth || true
 
   compatibility-test:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
@@ -8,6 +11,43 @@ plugins {
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.mavenPublish) apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.ktlint) apply false
+}
+
+// ---------------------------------------------------------------------------
+// Quality gates
+//
+// detekt: static analysis on every module, wired into `check` (and therefore
+// `build` and CI). Existing debt is frozen in per-module detekt-baseline.xml
+// files — only NEW violations fail the build. Regenerate a module's baseline
+// with `./gradlew :<module>:detektBaseline` (root: `./gradlew detektBaseline`).
+//
+// ktlint: formatting check tasks only for now (`ktlintCheck` /
+// `ktlintFormat`). ignoreFailures stays true until a format-the-world PR
+// lands; flipping it earlier would gate every build on legacy formatting.
+// ---------------------------------------------------------------------------
+allprojects {
+    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    extensions.configure<DetektExtension> {
+        buildUponDefaultConfig = true
+        config.setFrom(rootProject.layout.projectDirectory.file("config/detekt/detekt.yml"))
+        baseline = file("detekt-baseline.xml")
+        // The default task only scans src/main + src/test; this build mixes KMP
+        // (src/commonMain, src/desktopMain, …) and plain JVM modules, so point
+        // detekt at the whole src tree — it only picks up .kt/.kts files.
+        source.setFrom(files("src"))
+        parallel = true
+    }
+
+    extensions.configure<KtlintExtension> {
+        // Report-only until the format-the-world PR lands; ktlintCheck is part
+        // of `check`, so failing here would gate every build on legacy
+        // formatting before it has been normalized.
+        ignoreFailures.set(true)
+    }
 }
 
 // Apply version management script (Kotlin DSL with Provider API)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -752,12 +752,12 @@ kotlin {
             implementation(libs.ktor.serialization.kotlinx.json)
 
             // CLI argument parsing
-            implementation("com.github.ajalt.clikt:clikt:5.1.0")
+            implementation(libs.clikt)
         }
 
         desktopTest.dependencies {
             implementation(kotlin("test-junit5"))
-            implementation("org.junit.jupiter:junit-jupiter:6.1.0")
+            implementation(libs.junit.jupiter)
             // Test-only: lets the suite assert the IPC proxy's skip-list stays
             // equal to the in-process scanner's (no production coupling).
             // Resolved by path with a presence guard, NOT the type-safe

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -1,0 +1,2847 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>
+    <ID>ComplexCondition:BrowserHandleImpl.kt$BrowserHandleImpl$ch != '\u0000' &amp;&amp; !ch.isISOControl() &amp;&amp; !bool("ctrl") &amp;&amp; !bool("meta")</ID>
+    <ID>ComplexCondition:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$isMacOSExecutable || isChromium || isSharedLib || isShellScript || hasNoExtension</ID>
+    <ID>ComplexCondition:DynamicPluginManager.kt$DynamicPluginManager$candidate != null &amp;&amp; (force || (candidate.manifest.canUnload &amp;&amp; checkCanUnload(pluginId).isAllowed))</ID>
+    <ID>ComplexCondition:FileNameSanitizer.kt$FileNameSanitizer$sanitized.startsWith("/") || sanitized.startsWith("\\") || sanitized.contains("..") || sanitized.contains(":/")</ID>
+    <ID>ComplexCondition:FullscreenBrowserWindow.kt$FullscreenBrowserWindow.&lt;no name provided&gt;$hasReachedFullscreen &amp;&amp; isInFullscreenMode &amp;&amp; !isExiting &amp;&amp; fullscreenFrame != null</ID>
+    <ID>ComplexCondition:NewTabDialog.kt$lowerTrimmed.startsWith("http://") || lowerTrimmed.startsWith("https://") || lowerTrimmed.startsWith("file://") || lowerTrimmed.startsWith("javascript:") || lowerTrimmed.startsWith("chrome://")</ID>
+    <ID>ComplexCondition:PasskeyBrowserScreen.kt$link != null &amp;&amp; ( link.contains("auth/verify") || link.contains("passkey/registered") || link.contains("passkey/authenticated") )</ID>
+    <ID>ComplexCondition:PluginInstallService.kt$PluginInstallService$name.endsWith(".jar") &amp;&amp; !name.contains("-sources", ignoreCase = true) &amp;&amp; !name.contains("-javadoc", ignoreCase = true) &amp;&amp; !name.contains("-test", ignoreCase = true)</ID>
+    <ID>ComplexCondition:SplitTemplatesManager.kt$SplitTemplatesManager$exitCode != 0 || (!url.startsWith("git@") &amp;&amp; !url.startsWith("https://") &amp;&amp; !url.startsWith("http://") &amp;&amp; !url.startsWith("ssh://"))</ID>
+    <ID>ComplexCondition:SplitView.kt$SplitViewState$panel.tabsComponent.tabsState.value.tabs.any { tab -&gt; (tab is EditorTabInfo &amp;&amp; tab.filePath == filePath) || (tab is FluckTabInfo &amp;&amp; tab.currentUrl == fileUrl) }</ID>
+    <ID>ComplexCondition:UpdateManager.kt$UpdateManager$current is UpdateState.Downloading || current is UpdateState.ReadyToInstall || current is UpdateState.Installing || current is UpdateState.RestartRequired</ID>
+    <ID>ConstructorParameterNaming:DefaultPlugin.kt$DefaultPlugin$private val _windowId: String? = null</ID>
+    <ID>ConstructorParameterNaming:Fluck.kt$FluckTabInfo$@Volatile private var _currentUrl: String = url</ID>
+    <ID>ConstructorParameterNaming:Fluck.kt$FluckTabInfo$private var _currentZoomLevel: Double = 1.0</ID>
+    <ID>ConstructorParameterNaming:Fluck.kt$FluckTabInfo$private var _icon: ImageVector = Icons.Outlined.Language</ID>
+    <ID>ConstructorParameterNaming:Fluck.kt$FluckTabInfo$private var _tabIcon: TabIcon? = null</ID>
+    <ID>ConstructorParameterNaming:Fluck.kt$FluckTabInfo$private var _title: String</ID>
+    <ID>ConstructorParameterNaming:PasskeyDataModels.kt$PasskeyCredential$val created_at: Long = System.currentTimeMillis()</ID>
+    <ID>ConstructorParameterNaming:PasskeyDataModels.kt$PasskeyCredential$val credential_id: String</ID>
+    <ID>ConstructorParameterNaming:PasskeyDataModels.kt$PasskeyCredential$val display_name: String</ID>
+    <ID>ConstructorParameterNaming:PasskeyDataModels.kt$PasskeyCredential$val last_used_at: Long? = null</ID>
+    <ID>ConstructorParameterNaming:PasskeyDataModels.kt$PasskeyCredential$val public_key: String? = null</ID>
+    <ID>ConstructorParameterNaming:PasskeyDataModels.kt$PasskeyCredential$val user_id: String? = null</ID>
+    <ID>ConstructorParameterNaming:RoleCreationService.kt$RpcResponse$val permission_id: String? = null</ID>
+    <ID>ConstructorParameterNaming:RoleCreationService.kt$RpcResponse$val role_id: String? = null // Returned by create_new_role() (table-based)</ID>
+    <ID>ConstructorParameterNaming:SecretService.kt$SecretService.RpcResponse$val revoked_count: Int? = null // Number of shares revoked (for unshare_secret)</ID>
+    <ID>ConstructorParameterNaming:SecretService.kt$SecretService.RpcResponse$val secret_id: String? = null</ID>
+    <ID>ConstructorParameterNaming:SecretService.kt$SecretService.RpcResponse$val target_email: String? = null</ID>
+    <ID>ConstructorParameterNaming:SecretService.kt$SecretService.RpcResponse$val target_role: String? = null</ID>
+    <ID>ConstructorParameterNaming:UpdateService.kt$GitHubAsset$val browser_download_url: String? = null</ID>
+    <ID>ConstructorParameterNaming:UpdateService.kt$GitHubAsset$val content_type: String = ""</ID>
+    <ID>ConstructorParameterNaming:UpdateService.kt$GitHubRelease$val published_at: String</ID>
+    <ID>ConstructorParameterNaming:UpdateService.kt$GitHubRelease$val tag_name: String</ID>
+    <ID>ConstructorParameterNaming:UserService.kt$UserBasicInfo$val created_at: String? = null</ID>
+    <ID>ConstructorParameterNaming:UserService.kt$UserBasicInfo$val updated_at: String? = null</ID>
+    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
+    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun chordMatchesEvent(modifiers: Collection&lt;String&gt;, event: KeyEvent): Boolean</ID>
+    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun dispatchAction(actionId: String, windowId: String): Boolean</ID>
+    <ID>CyclomaticComplexMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun getKeyName(keyCode: Int): String</ID>
+    <ID>CyclomaticComplexMethod:AuthScreenContainer.kt$@Composable fun AuthScreenContainer( onLoginSuccess: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:BossActionButton.kt$@Composable fun BossActionButton( imageVector: ImageVector? = null, leftLogo: (@Composable () -&gt; Unit)? = null, leftIcon: ImageVector? = null, text: String, fontSize: TextUnit = 13.sp, color: Color = BossTheme.colors.textPrimary, iconColor: Color? = null, // Optional separate icon color (defaults to color if null) iconSize: Dp = 20.dp, // Icon size for imageVector mode maxTextWidth: Dp? = null, // Optional max width for text (truncates with ellipsis) modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(2.dp), isSelected: Boolean = false, contextMenuItems: List&lt;ContextMenuItem&gt;? = null, contextDirection: Panel = bottom, hintText: String? = null, showHintWithDelay: Boolean = true, hintDirection: Panel = bottom, onClick: () -&gt; Unit = {} )</ID>
+    <ID>CyclomaticComplexMethod:BossAppDialogs.kt$@Composable internal fun BossAppDialogs(state: BossAppState)</ID>
+    <ID>CyclomaticComplexMethod:BossAppEventBusEffects.kt$@Composable internal fun BossAppEventBusEffects(state: BossAppState)</ID>
+    <ID>CyclomaticComplexMethod:BossAppMenuActionEffects.kt$@Composable internal fun BossAppMenuActionEffects(state: BossAppState, reveal: FocusModeRevealState)</ID>
+    <ID>CyclomaticComplexMethod:BossAppStartupEffects.kt$@Composable internal fun BossAppStartupEffects(state: BossAppState)</ID>
+    <ID>CyclomaticComplexMethod:BossAppWithAuth.kt$@Composable fun ComponentContext.BossAppWithAuth( windowId: String, isFirstWindow: Boolean = false, panelRegistry: ai.rever.boss.components.registery.PanelRegistry, onToggleMaximize: (() -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:BossDraggableComponent.kt$BossDraggableComponent$fun stopDragging()</ID>
+    <ID>CyclomaticComplexMethod:BossDraggableComponent.kt$BossDraggableComponent$private fun updateHoverTarget()</ID>
+    <ID>CyclomaticComplexMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainPanelContent( modifier: Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainTabBar( splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, focusRequester: FocusRequester? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {} )</ID>
+    <ID>CyclomaticComplexMethod:BossPanelTopBar.kt$@Composable fun BossPanelTopBar( title: String?, isHovered: Boolean, onReset: (() -&gt; Unit)? = null, onReloadPlugin: (() -&gt; Unit)? = null, onOpenAsTab: (() -&gt; Unit)? = null, onCheckForUpdates: (() -&gt; Unit)? = null, onOpenEvolver: (() -&gt; Unit)? = null, onReportIssue: (() -&gt; Unit)? = null, onMinimize: () -&gt; Unit, updateAvailable: AvailablePluginUpdate? = null, onUpdateClick: (() -&gt; Unit)? = null, panelId: PanelId? = null, windowId: String? = null, dragModifier: Modifier = Modifier, content: (@Composable () -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:BossResizablePanel.kt$@Composable fun BossResizablePanel(modifier: Modifier, panel: Panel, isPanelVisible: Boolean = false, isMainVisible: Boolean = true, isRelative: Boolean = false, defaultWeight: Float = 1f, sideContent: (@Composable BoxScope.() -&gt; Unit)? = null, mainContent: (@Composable BoxScope.() -&gt; Unit)? = null)</ID>
+    <ID>CyclomaticComplexMethod:BossTabButton.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun BossTabButton( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>CyclomaticComplexMethod:BossTopBar.kt$@Composable fun BossDraggableComponent.BossTopLeftBar( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:BossWindow.kt$@Composable fun ApplicationScope.BossWindow( windowState: BossWindowState, onCloseRequest: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:BrowserEngineSettings.kt$@Composable fun BrowserEngineSettings()</ID>
+    <ID>CyclomaticComplexMethod:BrowserFunctions.kt$actual fun getBrowserState( url: String, onOpenInNewTab: ((String) -&gt; Unit)?, onBrowserClosed: (() -&gt; Unit)?, window: Any? ): Pair&lt;Any, Any&gt;?</ID>
+    <ID>CyclomaticComplexMethod:BrowserFunctions.kt$private fun configureBrowserPopupHandler( browser: Browser, onOpenInNewTab: (String) -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$@OptIn(ExperimentalComposeUiApi::class) @Composable override fun Content()</ID>
+    <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$override fun dispatchCoBrowseInput(inputJson: String)</ID>
+    <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun getFormFieldInfoFromJS(frame: com.teamdev.jxbrowser.frame.Frame): FormFieldInfo?</ID>
+    <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun jsKeyToKeyCode(key: String, code: String): KeyCode</ID>
+    <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupEventListeners()</ID>
+    <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupPopupHandler()</ID>
+    <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun createBrowser(config: BrowserConfig): BrowserHandle?</ID>
+    <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private fun seedCookiesAndHeaders(profile: Profile, auth: BrowserAuthSpec)</ID>
+    <ID>CyclomaticComplexMethod:ChromiumDownloader.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>CyclomaticComplexMethod:CloneProjectDialog.kt$@Composable private fun ConfigurationStep( onDismiss: () -&gt; Unit, onClone: (url: String, directory: String) -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:CommitDialog.kt$@Composable fun CommitDialog( onDismiss: () -&gt; Unit, onCommitSuccess: (String) -&gt; Unit = {} )</ID>
+    <ID>CyclomaticComplexMethod:CommitDialog.kt$@Composable private fun CommitFileRow( file: GitFileStatus, isStaged: Boolean, onToggle: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:ContextMenu.kt$@Composable private fun ContextMenuContent( items: List&lt;ContextMenuItem&gt;, modifier: Modifier = Modifier, onDismissRequest: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:ContextMenu.kt$@Composable private fun SubMenuContent( items: List&lt;ContextMenuItem&gt;, onDismissRequest: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:CoreAuthService.kt$CoreAuthService$private fun initializeWithNetwork()</ID>
+    <ID>CyclomaticComplexMethod:CrashHandler.kt$CrashHandler$internal fun isIgnorable(throwable: Throwable): Boolean</ID>
+    <ID>CyclomaticComplexMethod:CrashReportDialog.kt$@Composable fun CrashReportDialog( crashReport: CrashReport, onDismiss: () -&gt; Unit, onSubmit: (userNotes: String?, includeLogs: Boolean) -&gt; Unit, onCleanAndRestart: (() -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:CrossDeviceAuthenticationDialog.kt$@Composable fun CrossDeviceAuthenticationDialog( qrCodeUrl: String?, challenge: String?, sessionId: String? = null, onDismiss: () -&gt; Unit, onSuccess: () -&gt; Unit, onCreateFluckTab: ((FluckTabInfo) -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:Dashboard.kt$@Composable fun Dashboard( onOpenFile: (String) -&gt; Unit, onOpenUrl: (String) -&gt; Unit, onOpenProject: (Project) -&gt; Unit, selectedProject: Project = Project("No Project", "", 0L), onNewTab: () -&gt; Unit, onNewTerminal: () -&gt; Unit, onNewWindow: () -&gt; Unit, onOpenProjectDialog: () -&gt; Unit, onOpenFileDialog: () -&gt; Unit, onNewProject: () -&gt; Unit, onApplySplitTemplate: (SplitTemplate) -&gt; Unit, onActivatePlugin: (String) -&gt; Unit, onShowSettings: (() -&gt; Unit)? = null, modifier: Modifier = Modifier )</ID>
+    <ID>CyclomaticComplexMethod:DefaultBrowserSection.kt$@Composable fun DefaultBrowserSection()</ID>
+    <ID>CyclomaticComplexMethod:DesktopBrowserAccessor.kt$private fun findBrowserForTab( splitViewState: ai.rever.boss.components.window_panel.SplitViewState, tabId: String ): LockedBrowser?</ID>
+    <ID>CyclomaticComplexMethod:DesktopGitService.kt$GitService$actual suspend fun cloneRepository( repositoryUrl: String, targetDirectory: String, onProgress: (String) -&gt; Unit ): GitOperationResult</ID>
+    <ID>CyclomaticComplexMethod:DesktopGitService.kt$GitService$actual suspend fun watchGitHeadForWindow( projectPath: String, windowGitState: WindowGitState?, )</ID>
+    <ID>CyclomaticComplexMethod:DesktopUpdateService.kt$UpdateService$actual suspend fun checkForUpdates(): UpdateInfo</ID>
+    <ID>CyclomaticComplexMethod:DesktopUpdateService.kt$UpdateService$private suspend fun downloadFrom( url: String, assetName: String, assetSize: Long, sha256: String?, onProgress: (progress: Float) -&gt; Unit ): String?</ID>
+    <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun installPlugin(jarPath: String, enabled: Boolean = true): Result&lt;DynamicPluginInfo&gt;</ID>
+    <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun uninstallPlugin( pluginId: String, force: Boolean = false, waitForGC: Boolean = false ): Result&lt;Unit&gt;</ID>
+    <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager.Companion$private suspend fun hotSwapApiLayerOrchestration(pluginDir: java.io.File): Result&lt;Int&gt;</ID>
+    <ID>CyclomaticComplexMethod:EditableKeymapSettings.kt$@Composable fun EditableKeymapSettings()</ID>
+    <ID>CyclomaticComplexMethod:EditorContentProviderImpl.kt$EditorContentProviderImpl$override fun detectLanguage(filePath: String): String</ID>
+    <ID>CyclomaticComplexMethod:EmailAuthService.kt$EmailAuthService$suspend fun verifyMagicLinkToken(token: String, email: String? = null, type: String = "magiclink"): Result&lt;Boolean&gt;</ID>
+    <ID>CyclomaticComplexMethod:EmptyContentScreen.kt$@Composable private fun Card( icon: ImageVector, title: String, description: String, isSelected: Boolean, enabled: Boolean, onClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>CyclomaticComplexMethod:FileIndexer.kt$FileIndexer$private fun scanDirectory( dir: File, rootCanonicalPath: String, rootPathLength: Int, files: MutableList&lt;IndexedFile&gt;, depth: Int = 0 )</ID>
+    <ID>CyclomaticComplexMethod:FileNameSanitizer.kt$FileNameSanitizer$fun sanitize(fileName: String, replacement: Char = '_'): String</ID>
+    <ID>CyclomaticComplexMethod:Fluck.kt$@Composable fun BrowserErrorView( error: Throwable, url: String, retryCount: Int = 0, maxRetries: Int = 3, onRetry: (() -&gt; Unit)? = null, onReset: (() -&gt; Unit)? = null, onResetBrowser: (() -&gt; Unit)? = null, onRetryEngine: (() -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:Fluck.kt$FluckTabComponent$@Composable override fun Content()</ID>
+    <ID>CyclomaticComplexMethod:FluckBrowserSettings.kt$@Composable fun FluckBrowserSettings()</ID>
+    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
+    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun classifyError(e: Throwable): EngineInitError</ID>
+    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun createEngineInstance(chromiumDir: java.nio.file.Path, profileDirPath: java.nio.file.Path, profileName: String): Engine</ID>
+    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses(userHome: String)</ID>
+    <ID>CyclomaticComplexMethod:FocusModeReveal.kt$@Composable internal fun rememberFocusModeReveal( isFocusModeEnabled: Boolean, revealDelayMs: Long, ): FocusModeRevealState</ID>
+    <ID>CyclomaticComplexMethod:FormFieldDetector.kt$FormFieldDetector$private fun determineFieldType( inputType: String, fieldName: String, fieldId: String, placeholder: String, autocomplete: String, className: String, ariaLabel: String ): FieldType</ID>
+    <ID>CyclomaticComplexMethod:FormFieldInjector.kt$FormFieldInjector$suspend fun fillCredentials( browser: LockedBrowser, username: String, password: String, mode: FillMode = FillMode.BOTH ): FillResult</ID>
+    <ID>CyclomaticComplexMethod:GlobalSearchDialog.kt$@Composable fun GlobalSearchDialog( projectPath: String, workspaceManager: WorkspaceManager, onDismiss: () -&gt; Unit, onFileSelect: (String) -&gt; Unit, onTabSelect: ((windowId: String, panelId: String, tabId: String) -&gt; Unit)? = null, onBookmarkSelect: ((bookmarkId: String, collectionId: String) -&gt; Unit)? = null, onRunConfigSelect: ((configId: String) -&gt; Unit)? = null, onCommandSelect: ((actionId: String) -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:GlobalSearchService.kt$GlobalSearchService$private fun convertPluginSearchResult(result: PluginSearchResult): SearchResult?</ID>
+    <ID>CyclomaticComplexMethod:KernelBootstrap.kt$KernelBootstrap$fun registerPluginServices( performanceDataProvider: PerformanceDataProvider? = null, downloadDataProvider: DownloadDataProvider? = null, gitDataProvider: GitDataProvider? = null, logDataProvider: LogDataProvider? = null, activeTabsProvider: ActiveTabsProvider? = null, secretDataProvider: SecretDataProvider? = null, supabaseDataProvider: SupabaseDataProvider? = null, splitViewOperations: SplitViewOperations? = null, contextMenuProvider: ContextMenuProvider? = null, runConfigurationDataProvider: RunConfigurationDataProvider? = null, panelEventProvider: PanelEventProvider? = null, roleManagementProvider: RoleManagementProvider? = null, directoryPickerProvider: DirectoryPickerProvider? = null, projectDataProvider: ProjectDataProvider? = null, notificationProvider: NotificationProvider? = null, )</ID>
+    <ID>CyclomaticComplexMethod:KeyCaptureDialog.kt$@Composable fun KeyCaptureDialog( actionId: String, actionDescription: String, context: ShortcutContext, category: String, currentBinding: KeyBinding?, onKeyCaptured: (KeyBinding) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:KeymapMatcher.kt$KeymapMatcher$private fun matchesBinding(event: KeyEvent, binding: KeyBinding): Boolean</ID>
+    <ID>CyclomaticComplexMethod:KeymapMatcher.kt$KeymapMatcher$private fun normalizeKeyName(keyName: String): String</ID>
+    <ID>CyclomaticComplexMethod:LLMProvidersSettings.kt$@Composable fun LLMProvidersSettings()</ID>
+    <ID>CyclomaticComplexMethod:LoginFormScreen.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun LoginFormScreen( viewModel: LoginViewModel, onLoginSuccess: () -&gt; Unit, isLoading: Boolean, errorMessage: String?, onMagicLinkSent: (String) -&gt; Unit = {}, onPasskeyAuthInitiated: (String) -&gt; Unit = {}, onPasskeySelectionRequired: (String) -&gt; Unit = {} )</ID>
+    <ID>CyclomaticComplexMethod:MacOSGestureHandler.kt$MacOSGestureHandler$fun addMagnificationListener( component: Component, onZoomIn: () -&gt; Unit, onZoomOut: () -&gt; Unit ): Any?</ID>
+    <ID>CyclomaticComplexMethod:MagicLinkWaitingScreen.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun MagicLinkWaitingScreen( email: String, viewModel: LoginViewModel, onBack: () -&gt; Unit, onSuccess: () -&gt; Unit, isLoading: Boolean = false, errorMessage: String? = null )</ID>
+    <ID>CyclomaticComplexMethod:MenuShortcutBridge.kt$MenuShortcutBridge$private fun keyNameToComposeKey(keyName: String): Key?</ID>
+    <ID>CyclomaticComplexMethod:NewProjectWizardDialog.kt$@Composable private fun TemplateCard( template: ProjectTemplate, isSelected: Boolean, onClick: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:NewTabDialog.kt$@Composable fun NewTabDialog( onDismiss: () -&gt; Unit, onCreateTab: (type: TabType, path: String) -&gt; Unit, tabRegistry: TabRegistry, initialTabType: TabType? = null, /** * Opens a [TabInfo] built by a plugin tab type's [TabTypeInfo.createTabInfo]. * When null, plugin-registered tab types are not offered (legacy callers). */ onCreateTabInfo: ((TabInfo) -&gt; Unit)? = null, projectPath: String? = null, windowId: String? = null )</ID>
+    <ID>CyclomaticComplexMethod:PasskeyAuthService.kt$PasskeyAuthService$suspend fun authenticateWithPasskey(email: String? = null, credentialId: String? = null): Result&lt;Unit&gt;</ID>
+    <ID>CyclomaticComplexMethod:PasskeyWaitingScreen.kt$@Composable fun PasskeyWaitingScreen( email: String, viewModel: LoginViewModel, onBack: () -&gt; Unit, onSuccess: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$private fun queryProcessMetrics(pids: List&lt;Long&gt;): Map&lt;Long, OsProcessMetrics&gt;</ID>
+    <ID>CyclomaticComplexMethod:PerformanceMonitor.kt$PerformanceMonitor$fun start()</ID>
+    <ID>CyclomaticComplexMethod:PluginInstallService.kt$PluginInstallService$private fun downloadFromGitHubRelease(owner: String, repo: String, pluginDir: File): String?</ID>
+    <ID>CyclomaticComplexMethod:PluginInstallService.kt$PluginInstallService$suspend fun installPlugins( plugins: List&lt;WizardPluginInfo&gt;, onProgress: (Float, String) -&gt; Unit ): Result&lt;PluginInstallResult&gt;</ID>
+    <ID>CyclomaticComplexMethod:PluginInstallWizardWindow.kt$@Composable fun PluginInstallWizardWindow( state: PluginInstallWizardState, onDismiss: () -&gt; Unit, onComplete: () -&gt; Unit, onInstallPlugins: suspend (List&lt;WizardPluginInfo&gt;, (Float, String) -&gt; Unit) -&gt; Result&lt;PluginInstallResult&gt; )</ID>
+    <ID>CyclomaticComplexMethod:PluginJarReconciler.kt$PluginJarReconciler$fun reconcilePluginDir(pluginDir: File): ReconcileResult</ID>
+    <ID>CyclomaticComplexMethod:PluginStoreSetup.kt$PluginStoreSetup$private fun copyBundledPluginsToPluginDir( dynamicPluginManager: ai.rever.boss.components.plugin.DynamicPluginManager )</ID>
+    <ID>CyclomaticComplexMethod:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun downloadSystemPluginFromGitHub(plugin: SystemPluginInfo): Boolean</ID>
+    <ID>CyclomaticComplexMethod:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun ensureSystemPluginsInstalled()</ID>
+    <ID>CyclomaticComplexMethod:ReleaseNotesMarkdown.kt$internal fun parseReleaseNotes(source: String): List&lt;NotesBlock&gt;</ID>
+    <ID>CyclomaticComplexMethod:RemoteWidgetRenderer.kt$@Composable private fun RenderNode( node: WidgetNode, tree: WidgetTree, onEvent: (nodeId: String, eventType: String, eventData: String) -&gt; Unit, )</ID>
+    <ID>CyclomaticComplexMethod:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$fun requestCapture( requestId: String, sources: CaptureSources, tell: StartCaptureSessionCallback.Action )</ID>
+    <ID>CyclomaticComplexMethod:SecuritySettings.kt$@Composable fun SecuritySettings()</ID>
+    <ID>CyclomaticComplexMethod:SecuritySettings.kt$private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities</ID>
+    <ID>CyclomaticComplexMethod:SettingsWindow.kt$@Composable private fun SettingsContentArea( section: SettingsSection, modifier: Modifier = Modifier )</ID>
+    <ID>CyclomaticComplexMethod:ShortcutTestDialog.kt$@Composable private fun TestResultItem(result: ShortcutTestResult)</ID>
+    <ID>CyclomaticComplexMethod:SidePanel.kt$@Composable fun BossDraggableComponent.SidePanel( panel: Panel, panelComponentStore: PanelComponentStore )</ID>
+    <ID>CyclomaticComplexMethod:SidebarCustomizeMenu.kt$@Composable fun BossDraggableComponent.SidebarCustomizeMenu( /** Slot the button visually belongs to; controls hint direction &amp; drag overlay rendering. */ slot: Panel = left.top.bottom, modifier: Modifier = Modifier, )</ID>
+    <ID>CyclomaticComplexMethod:SingleInstanceManager.kt$SingleInstanceManager$private fun startServer()</ID>
+    <ID>CyclomaticComplexMethod:SplitView.kt$SplitViewState$fun splitPanel( panelId: String, orientation: SplitOrientation, tabToMove: TabInfo? = null, detachedTab: BossTabsComponent.DetachedTab? = null ): String</ID>
+    <ID>CyclomaticComplexMethod:SplitView.kt$SplitViewState$private fun removePanel(node: SplitNode, targetPanelId: String): SplitNode</ID>
+    <ID>CyclomaticComplexMethod:SupabaseServiceBridge.kt$SupabaseServiceBridge$override suspend fun select(request: SupabaseSelectRequest): SupabaseJsonResponse</ID>
+    <ID>CyclomaticComplexMethod:TabDropHandler.kt$internal fun handleTabDropResult(result: TabDropResult, splitViewState: SplitViewState)</ID>
+    <ID>CyclomaticComplexMethod:TerminalLinkOpener.kt$private fun openTerminalLinkInternal( url: String, mode: TerminalLinkOpenMode, splitViewState: SplitViewState, validSourcePanelId: String, isFile: Boolean, fileLine: Int = 0, fileColumn: Int = 0, scope: CoroutineScope, windowId: String? = null )</ID>
+    <ID>CyclomaticComplexMethod:TopOfMindDialog.kt$@Composable fun TopOfMindDialog( splitViewState: SplitViewState? = null, // Kept for backward compatibility but not used workspaceManager: WorkspaceManager, onDismiss: () -&gt; Unit, onTabSelect: (ActiveTab) -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:TopOfMindDialog.kt$@Composable private fun ActiveTabDialogItem( activeTab: ActiveTab, isSelected: Boolean, onTabClick: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:UpdateInstaller.kt$UpdateInstaller$private fun detectLinuxDistroType(): String</ID>
+    <ID>CyclomaticComplexMethod:UpdateInstaller.kt$UpdateInstaller$suspend fun installUpdate(downloadPath: String): InstallResult</ID>
+    <ID>CyclomaticComplexMethod:UpdateUI.kt$@Composable fun UpdateSettingsSection( updateManager: UpdateManager = UpdateManager.instance )</ID>
+    <ID>CyclomaticComplexMethod:UpdateUI.kt$private fun formatTime(instant: kotlin.time.Instant): String</ID>
+    <ID>CyclomaticComplexMethod:UserExistenceService.kt$UserExistenceService$suspend fun checkUserExists(email: String): Result&lt;UserExistence&gt;</ID>
+    <ID>CyclomaticComplexMethod:WizardComponents.kt$@Composable fun CheckboxCard( title: String, description: String, icon: ImageVector? = null, isChecked: Boolean, onCheckedChange: (Boolean) -&gt; Unit, enabled: Boolean = true, modifier: Modifier = Modifier )</ID>
+    <ID>CyclomaticComplexMethod:WorkspaceApplier.kt$private fun createTabFromWorkspaceConfig(tabConfig: TabConfig, projectPath: String, splitViewState: SplitViewState): TabInfo?</ID>
+    <ID>CyclomaticComplexMethod:WorkspaceApplier.kt$private suspend fun applyWorkspaceNode( node: SplitConfig, splitViewState: SplitViewState, currentPanelId: String, projectPath: String )</ID>
+    <ID>CyclomaticComplexMethod:WorkspaceButton.kt$@Composable fun WorkspaceButton( onOpenWorkspace: (LayoutWorkspace) -&gt; Unit, workspaceManager: WorkspaceManager = remember { WorkspaceManager() }, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:WorkspaceSelectionDialog.kt$@Composable private fun WorkspaceSelectionItem( workspace: ai.rever.boss.components.workspaces.LayoutWorkspace, isSelected: Boolean, selectedPanelId: String?, onToggle: () -&gt; Unit, onPanelSelected: (String?) -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:main.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>CyclomaticComplexMethod:main.kt$private fun extractPty4jNatives(targetDir: File)</ID>
+    <ID>EmptyCatchBlock:FluckEngine.kt$FluckEngine${ }</ID>
+    <ID>EmptyCatchBlock:WasmWorkspaceFileManager.kt$WorkspaceFileManager${ }</ID>
+    <ID>EmptyCatchBlock:WorkspaceButton.android.kt${ }</ID>
+    <ID>EmptyCatchBlock:WorkspaceButton.desktop.kt${ }</ID>
+    <ID>EmptyCatchBlock:WorkspaceButton.ios.kt${ }</ID>
+    <ID>EmptyClassBlock:PasskeySessionEventHandler.kt$PasskeySessionEventHandler.SessionType${ }</ID>
+    <ID>EmptyElseBlock:FluckEngine.kt$FluckEngine${ }</ID>
+    <ID>EmptyFunctionBlock:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest.TestTabComponent${ }</ID>
+    <ID>EmptyFunctionBlock:BrowserServiceProvider.kt${}</ID>
+    <ID>EmptyFunctionBlock:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest.FakePanelComponent${ }</ID>
+    <ID>EmptyFunctionBlock:TabDropResultHandlingTest.kt$TabDropResultHandlingTest.DropTestComponent${ }</ID>
+    <ID>EmptyIfBlock:FluckEngine.kt$FluckEngine${ }</ID>
+    <ID>ExplicitGarbageCollectionCall:PerformanceMonitor.kt$PerformanceMonitor$gc()</ID>
+    <ID>ForbiddenComment:AndroidFilePicker.kt$// TODO: Implement Android directory picker using Intent.ACTION_OPEN_DOCUMENT_TREE</ID>
+    <ID>ForbiddenComment:BossTopBar.kt$// TODO: #91 - BossTopRunBar function (currently disabled)</ID>
+    <ID>ForbiddenComment:BossTopBar.kt$// TODO: #93 - Lanager functionality (currently disabled - plugin removed)</ID>
+    <ID>ForbiddenComment:CodeEditor.kt$CodeEditorTabComponent$/* TODO: Update EditorTabInfo.isModified */</ID>
+    <ID>ForbiddenComment:FilePicker.kt$// TODO: Implement Android file picker using ActivityResultContracts</ID>
+    <ID>ForbiddenComment:FilePicker.kt$// TODO: Implement Web file picker using HTML5 File API</ID>
+    <ID>ForbiddenComment:FilePicker.kt$// TODO: Implement iOS file picker using UIDocumentPickerViewController</ID>
+    <ID>ForbiddenComment:FluckEngine.kt$FluckEngine$// TODO: Implement if needed</ID>
+    <ID>ForbiddenComment:FluckEngine.kt$FluckEngine$// TODO: Show user warning dialog (for now, just proceed)</ID>
+    <ID>ForbiddenComment:IosCodeEditor.kt$// TODO: Implement iOS file reading</ID>
+    <ID>ForbiddenComment:IosCodeEditor.kt$// TODO: Implement iOS file writing</ID>
+    <ID>ForbiddenComment:IosFilePicker.kt$// TODO: Implement iOS directory picker using UIDocumentPickerViewController</ID>
+    <ID>ForbiddenComment:PluginStateBridge.kt$PluginStateBridge$// TODO: Implement actual JSON Merge Patch for delta state.</ID>
+    <ID>ForbiddenComment:VersionVerifier.kt$VersionVerifier$// TODO: Consider adding analytics/crash reporting here</ID>
+    <ID>ForbiddenComment:WasmCodeEditor.kt$// TODO: Implement browser-based file reading</ID>
+    <ID>ForbiddenComment:WasmCodeEditor.kt$// TODO: Implement browser-based file writing</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `ComponentLogger logs at all levels`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `ComponentLogger name is preserved in entries`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `LogLevel fromString defaults to INFO for invalid values`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `LogLevel fromString handles valid values`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `clearCategoryLevel falls back to global level`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `clearLogs removes all entries`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `configure applies all settings`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `disableFileLogging stops writing to file`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `enableFileLogging creates log file`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `file rotation triggers at maxFileSize`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getEffectiveLevel returns category level when set`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getRecentLogs filters by category`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getRecentLogs filters by minimum level`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getRecentLogs respects limit parameter`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `listeners receive log entries`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log entries capture exceptions`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log entries contain correct metadata`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log filtering respects category-specific levels`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log filtering respects global level hierarchy`()</ID>
+    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `removeListener stops notifications`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `a move publishes MOVED instead of a CLOSED-OPENED pair`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `addTab drives the tab lifecycle to RESUMED`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `addTab returns -1 and stores nothing for an unregistered tab type`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `adoptTab closes a stale holder of the same tab id instead of orphaning it`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `detachTab and adoptTab move the live component without destroying it`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `detachTab returns null for unknown tab`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `removeTab destroys the tab component's lifecycle`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `removeTabById reports whether a tab was removed`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `splitPanel adopts a detached tab into the new panel without recreating it`()</ID>
+    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `splitPanel with a missing target panel rescues the detached tab instead of leaking it`()</ID>
+    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `cookieDomain strips scheme, path, query, fragment and port`()</ID>
+    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `meta json round-trips and tolerates missing diskBytes (back-compat)`()</ID>
+    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `sanitize keeps safe profile-name chars and replaces the rest`()</ID>
+    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `selectEvictionVictims evicts oldest first until under cap`()</ID>
+    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `selectEvictionVictims never evicts an in-use profile`()</ID>
+    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `selectEvictionVictims returns nothing when under cap`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `all candidates failing returns failure and reports the error`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `checksum mismatch rejects the candidate and falls through to the next source`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `complete staged install replaces the existing engine`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `falls back to the next source when a fetch fails`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `matching checksum is accepted`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `no-op when nothing is staged`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `promotes onto a missing target (fresh install)`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `staged install writes the commit marker last`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `staging with markers from the archive but no commit marker is not promoted`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `staging without commit marker is discarded and engine preserved`()</ID>
+    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `stale backup from an earlier failed swap is cleaned up`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `asset matching is by exact archive name`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `availableVersions returns newest first across sources with dedup`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `both sources failing throws`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `github fallback is the only candidate when supabase has no row or fails`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `single source failure is reported not thrown`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `stable release outranks its own pre-releases`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `supabase candidate comes first and carries sha256, github backup has none`()</ID>
+    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `versions sort numerically not lexicographically`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder creates disabled condition when check returns false`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder creates enabled condition when check returns true`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder throws when no check provided`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder with async check works`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions always and never work correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions canCreateSplit works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions canNavigateSplits works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions canUndo and canRedo work correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions context checks work correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions debugOnly works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions featureFlag works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasActiveTab works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasClipboardContent works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasMinTabs works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasMultipleTabs works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasSelection works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasTabs works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions isEditable works correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions navigation checks work correctly`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Real-world scenario - close tab enabled with tabs OR can create split`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Real-world scenario - paste enabled when clipboard has content and editor is active`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `and combinator requires both conditions`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `complex combinator chain works`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `condition DSL creates working condition`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `enabledWhen creates working condition`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `enabledWhenSync creates working condition`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `not combinator inverts condition`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `not combinator uses custom reason and description`()</ID>
+    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `or combinator requires at least one condition`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `default is used when no source has the key`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `embedded build config wins below local properties`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `env wins over all other tiers`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `getConfig picks up a live system property and falls back to default`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `local properties win below system property`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `null when no source has the key and no default given`()</ID>
+    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `system property wins below env`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `attribution prefers the root cause origin`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `attribution survives a closed loader`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `crash with plugin-defined stack frames attributes to the plugin`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `host-only crash attributes to nothing`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `plugin-defined exception class attributes even without walking frames`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `registry finds the defining plugin for a loaded class`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `self-referential cause chain terminates`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `shared parent-first classes are never attributed to a plugin`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `unknown class names are not attributed`()</ID>
+    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `wrapped plugin exception attributes via the cause chain`()</ID>
+    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `broken pipe io exception is ignorable`()</ID>
+    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `coroutine cancellation is ignorable`()</ID>
+    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `generic runtime exception is not ignorable`()</ID>
+    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `supabase token expiry is ignorable`()</ID>
+    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `token expiry nested in cause chain is ignorable`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `build and node_modules stay excluded even with showHidden`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren does not throw on a malformed path`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren follows a symlink to a non-empty directory`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false for a non-existent path`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false for an empty directory`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false when only a filtered directory name is present`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false when only hidden entries are present`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns true when a visible file is present`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren with showHidden counts a directory containing only hidden entries`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectory reports hasChildren false for a directory containing only node_modules`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectory reports hasChildren true for a directory with a visible file`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectory with showHidden includes hidden entries in children`()</ID>
+    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectoryWithDepth threads showHidden through recursion`()</ID>
+    <ID>FunctionNaming:EvolverContractTest.kt$EvolverContractTest$@Test fun `hostile characters in the id survive json building without corrupting the arg map`()</ID>
+    <ID>FunctionNaming:EvolverContractTest.kt$EvolverContractTest$@Test fun `menu gating predicate matches the registered tool name`()</ID>
+    <ID>FunctionNaming:EvolverContractTest.kt$EvolverContractTest$@Test fun `open evolver dispatch round-trips the plugin id to the handler`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference decodes URL-encoded spaces`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference decodes multiple URL-encoded characters`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles Windows path only`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles Windows path with line and column`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles Windows path with line`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles empty string`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles filename with colon but no line number`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles invalid URL encoding gracefully`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles large line numbers`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles lowercase Windows drive letter`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles multiple colons with only last being line number`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles path only`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles path with line and column`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles path with line`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles zero line number`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file colon only prefix`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file double slash prefix`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file single slash prefix`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file triple slash prefix`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix returns path unchanged when no prefix`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath resolves path traversal sequences`(@TempDir tempDir: Path)</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for blank path`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for directory`(@TempDir tempDir: Path)</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for empty path`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for non-existent file`()</ID>
+    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Valid for existing readable file`(@TempDir tempDir: Path)</ID>
+    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `finds the jar with the matching pluginId`()</ID>
+    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `ignores jars without a readable manifest`()</ID>
+    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `prefers the highest manifest version when several match`()</ID>
+    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `returns null when nothing matches`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `SkiaGraphite is opt-in only — it blanks OSR output on JxBrowser 9-3`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `cgroup predicate recognizes container runtimes and rejects host cgroups`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `extra switches are appended last so operator flags win ties`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `falsy flag accepts the documented disable spellings only`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `linux enables VA-API and adds container-only switches inside containers`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `parseExtraSwitches handles null, empty and switch-less input`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `parseExtraSwitches keeps comma-bearing feature lists intact`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `parseExtraSwitches splits on whitespace and keeps only switch-shaped entries`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `partitionExtraSwitches separates accepted switches from dropped tokens in one pass`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `truthy flag accepts the documented enable spellings only`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `unknown platforms get no platform-specific switches`()</ID>
+    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `windows disables the native-window occlusion tracker`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `concurrent navigation updates are thread-safe`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `concurrent reads and writes are thread-safe`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `copy creates independent navigation history`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `copy for split view preserves current URL as initial URL`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `copy with back navigation creates independent history`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `currentUrl returns initial URL when no navigation has occurred`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `currentUrl returns navigated URL after navigation`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `currentUrl tracks multiple navigations correctly`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `duplicate consecutive navigation does not add to history`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `empty URL is handled gracefully`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `equals is based on id and display content`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `equals returns false for different ids`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `explicit tabIcon override wins over the home icon`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `home landing transform sets Home title and clears the stale favicon`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `home page shows Home icon instead of the generic globe`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `icon follows navigation between home and real pages`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `isHomeUrl matches blank and about-blank urls only`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateBack at start of history does nothing`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateBack returns to previous URL`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateForward at end of history does nothing`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateForward returns to next URL after navigateBack`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigation after navigateBack truncates forward history`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigation to empty URL updates currentUrl`()</ID>
+    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `real page keeps the default browser icon`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `copy preserves unchanged values`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `default settings should have 30px reveal offset`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `default settings should have auto-reveal enabled`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `default settings should have focus mode disabled`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `settings can be created with auto-reveal disabled`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `settings can be created with custom reveal offset`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `settings can be created with focus mode enabled`()</ID>
+    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `toggling focus mode preserves other settings`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `compareResults should sort by score descending`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should collapse consecutive matches into single range`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should create separate ranges for non-consecutive matches`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give bonus for exact match`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give bonus for shorter targets`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for camelCase word boundary matches`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for consecutive matches`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for matches at beginning`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for path separator word boundaries`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for underscore word boundary matches`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should handle mixed consecutive and non-consecutive`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match all characters in order`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match case-insensitively`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match command descriptions`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match file names with fuzzy patterns`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should rank exact prefix higher than scattered match`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should return empty result for empty pattern`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should return null when not all characters match`()</ID>
+    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should return null when pattern longer than target`()</ID>
+    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `blank version is unknown and installable`()</ID>
+    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `equal version is compatible and installable`()</ID>
+    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `hostVersion reflects IpcVersion CURRENT`()</ID>
+    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `newer major is a major mismatch`()</ID>
+    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `newer minor within same major requires host update`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create derives title from unix path basename`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create derives title from windows path basename`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create falls back to derived title when override is blank`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create generates unique jupyter-prefixed ids`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create honours explicit title override`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create uses the shared jupyter type id`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create with blank path yields Notebook title`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `createUntitled trims the name and defaults to Notebook`()</ID>
+    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `updateTitle returns a retitled copy preserving id and path`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `COMPONENT priority is highest`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `GLOBAL priority is lowest`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `KeyEventSource has expected values`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `KeyboardEventResult consumed property works`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `KeyboardEventResult includes actionId when provided`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `WORKSPACE priority is medium`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `cancelled job removes handler`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `clearHandlers removes all handlers`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `consumed event stops propagation`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `debug mode can be enabled`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `emit returns false when no handlers registered`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `fromLevel returns GLOBAL for unknown level`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `fromLevel returns correct priority`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `getHandlerCounts returns correct counts per priority`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `getHandlerCounts returns empty map initially`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `handler exception does not stop other handlers`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `handler with targetWindowId only receives matching events`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `handlers are called in priority order`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `multiple handlers at same priority all called`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `multiple window-specific handlers filter correctly`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `subscribe adds handler`()</ID>
+    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `unconsumed event propagates to all handlers`()</ID>
+    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `a run after completion executes again instead of joining a stale result`()</ID>
+    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `concurrent runs for the same key coalesce onto one execution`()</ID>
+    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `detached failure after caller cancellation reaches onDetachedFailure`()</ID>
+    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `distinct keys run independently`()</ID>
+    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `job runs to completion although the caller is cancelled mid-run`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor builder chains correctly`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor executes registered handler`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor handles multiple executions`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor returns false for unregistered action`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns BROWSER for browser component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns BROWSER for fluck component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns EDITOR for code component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns EDITOR for editor component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns GLOBAL for null component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns GLOBAL for unknown component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns TERMINAL for terminal component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns WORKSPACE for workspace component`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `from factory creates handler with settings`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getBinding returns correct binding`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getBinding returns null for nonexistent action`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getDisplayString returns formatted string for bound action`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getDisplayString returns null for unbound action`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `isBound returns false for disabled binding`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `isBound returns false for unbound action`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `isBound returns true for bound action`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `settings property returns current settings`()</ID>
+    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `updateSettings changes handler settings`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke displayString formats correctly on Windows`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke displayString formats correctly on macOS`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke matches returns false for non-matching event`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke matches returns true for matching event`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke of factory creates correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke signature formats correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding allSignatures returns all signatures`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding displayStringAll shows all keystrokes`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding matches alternate keystroke`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding matches primary keystroke`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding with alternate keystrokes has correct allKeystrokes`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `clearAlternateKeystrokes removes all alternates`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `context-specific binding takes priority over global binding`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `crossPlatform creates binding with Cmd and Ctrl alternates`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `crossPlatform with additional modifiers works correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `disabled binding is not matched`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats arrow keys correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats correctly on Windows`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats correctly on macOS`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats special keys correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `enabled binding is matched`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `getBindingsByCategory groups correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `getBindingsForContext returns only matching context`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `getEnabledBindings filters out disabled`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `global binding matches when no context-specific binding exists`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `hasAlternates returns false when no alternates`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `hasAlternates returns true when alternates exist`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `matches returns false for disabled binding`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `matches returns false for wrong key`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `matches returns true for matching key and modifiers`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `signature includes context and modifiers`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `signature without modifiers formats correctly`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `withAlternateKeystroke adds new alternate`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `withoutAlternateKeystroke removes alternate`()</ID>
+    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `workspace binding is checked when context-specific not found`()</ID>
+    <ID>FunctionNaming:KeymapSettingsTabSwitchModeTest.kt$KeymapSettingsTabSwitchModeTest$@Test fun `an explicit tab switch mode survives a json round-trip`()</ID>
+    <ID>FunctionNaming:KeymapSettingsTabSwitchModeTest.kt$KeymapSettingsTabSwitchModeTest$@Test fun `legacy keymap json without tabSwitchMode falls back to the default`()</ID>
+    <ID>FunctionNaming:KeymapSettingsTabSwitchModeTest.kt$KeymapSettingsTabSwitchModeTest$@Test fun `tab switch mode defaults to MRU for new users`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding detects same context conflict`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding excludes action being edited`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding finds existing conflicts`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding uses signature which includes context`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `conflict description includes action names`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `conflictCount returns correct number`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `detects conflict between same context bindings`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `getSummary returns correct message for multiple conflicts`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `getSummary returns correct message for no conflicts`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `getSummary returns correct message for single conflict`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `global and specific context do not conflict with different signatures`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `hasConflicts returns false when no conflicts`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `hasConflicts returns true when conflicts exist`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `isSafeToSave returns true even with conflicts`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `multiple conflicts detected separately`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `no conflicts between different non-global contexts`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `no conflicts when one binding is disabled`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `no conflicts with unique key combinations`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `suggestFixes provides disable suggestions`()</ID>
+    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `suggestFixes provides key change suggestions`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri handles null`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri indicates fragment present`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri indicates query params present`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri shows scheme and host without params`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects GitHub tokens`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects JWT tokens`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects Stripe-style keys`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects long alphanumeric strings`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret returns false for blank`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret returns false for null`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret returns false for short strings`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskCredentialId handles null`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskCredentialId shows length only`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles blank input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles invalid email without at symbol`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles multiple at symbols`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles null input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles single char local part`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles standard email format`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles subdomain`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles two char local part`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskSessionId handles short ids`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskSessionId shows first 8 chars`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles blank input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles exactly 7 chars`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles null input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles short tokens`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken preserves first and last 3 chars`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles blank input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles case insensitive param names`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles fragment parameters`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles null input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles uri without params`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams preserves non-sensitive parameters`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts access_token parameter`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts api_key parameter`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts multiple sensitive parameters`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts refresh_token parameter`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts token parameter`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUserId handles null`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUserId handles short ids`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUserId shows first 4 chars`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap handles empty map`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap handles nested sensitive key names`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap handles null input`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap masks values that look like secrets`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap preserves non-sensitive values`()</ID>
+    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap redacts known sensitive keys`()</ID>
+    <ID>FunctionNaming:MacOSScreenCapture.kt$CoreGraphics$fun CGPreflightScreenCaptureAccess(): Boolean</ID>
+    <ID>FunctionNaming:MacOSScreenCapture.kt$CoreGraphics$fun CGRequestScreenCaptureAccess(): Boolean</ID>
+    <ID>FunctionNaming:MainViewController.kt$fun MainViewControllerV4()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `a provider whose tools() throws registers with no tools and does not affect siblings`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `admin bypasses requiredPermissions`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `admin bypasses requiresAdmin`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `allTools is not permission-filtered but tools is (metadata-only disclosure posture)`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `concurrent register, unregister, and updateAccess never leave a stale or torn snapshot`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `corrupt disabled-tools file fails open to emptySet rather than crashing`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `disabled set persists across a fresh core instance reading the same file`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `duplicate tool name across providers - first registered wins`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `int() returns null for values outside Int range instead of silently wrapping`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke coerces a JSON integer through int() and double()`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke parses string, boolean, integer, and double arguments`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke propagates caller cancellation rather than swallowing it into an error result`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke rejects a disabled tool by name (unreachable even though still registered)`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke rejects a permission-denied tool by name`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke rejects unknown tool name`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke times out a handler that never completes`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke with malformed JSON args runs the handler with an empty arg set instead of erroring`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke wraps a handler exception into an error result`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `missing disabled-tools file starts with an empty disabled set`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `non-admin with requiresAdmin is hidden even holding the listed permissions`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `null disabledFile skips persistence entirely (pure in-memory)`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `re-registering the same providerId replaces its tool set`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `revoking a permission live hides the tool without re-registration`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `save leaves no dangling tmp file (atomic rename completed)`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `setToolEnabled false removes the tool from tools but not allTools`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `tool requiring ALL permissions is hidden when only some are held`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `tool requiring a permission is hidden until the user holds it`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `tool with no requirements is exposed to a logged-out user`()</ID>
+    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `unregistering the winning provider lets the second provider's tool take over`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `open panel keeps its cached component when the factory is re-registered`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent drops the stale component when the panel is no longer registered`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent recreates the panel from the newly registered factory`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent returns false for a panel that is not open`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent survives the old component's cleanup hook throwing an Error`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetPanels resets only matching open slots across windows and leaves others untouched`()</ID>
+    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `store registry tracks stores per window`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test CPU load percent calculation`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test default settings are valid`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status CRITICAL when CPU exceeds critical threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status CRITICAL when memory exceeds critical threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status GOOD when below warning thresholds`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status WARNING when CPU exceeds warning threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status WARNING when memory exceeds warning threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test last GC memory reclaimed calculation`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory heap usage MB conversion`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory heap usage percent calculation`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory heap usage percent with zero max`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory pool max MB falls back to committed when max is negative`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory pool usage percent falls back to committed when max is negative`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory pool usage percent with max bytes`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test overall status is CRITICAL if any component is CRITICAL`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test overall status is WARNING if any component is WARNING and none CRITICAL`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps cpu critical threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps cpu warning threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps history retention`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps memory critical threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps memory warning threshold`()</ID>
+    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps sample intervals`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `admin bypasses required permissions`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `legacy plugin (no requirements) is visible to any authenticated user`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `requiresAdmin AND requiredPermissions both enforced for non-admin`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `requiresAdmin plugin hidden from non-admin even with permissions`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `requiresAdmin plugin visible to admin`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `user missing one required permission is denied`()</ID>
+    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `user with all required permissions is allowed`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `blank minIpcVersion is not gated`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `newer major is rejected`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `newer minor within same major is rejected`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `older minor within same major is compatible`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `version equal to host is compatible`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `basic semver ordering`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `multi-digit segments compare numerically not lexically`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `no minimum means never too old`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `non-matching filename yields null`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `pre-release of the minimum forces update`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `release is newer than its own pre-release`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `release with only a thin jar yields null`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `release without matching assets yields null`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `suffixed segment counts as its numeric prefix`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `thin jar listed first is skipped in favor of the real jar`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `unreadable installed version forces update`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version above minimum loads`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version below minimum forces update`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version equal to minimum loads`()</ID>
+    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version extracted from standard jar filename`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test Kotlin project placeholder substitution`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test Node js package json contains package name`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test Rust Cargo toml contains package name`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test concurrent creation with same name handled correctly`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Go project successfully`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Kotlin JVM project successfully`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Node js project successfully`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Python project successfully`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Rust project successfully`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create empty project successfully`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project in non-existent directory fails`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project where directory already exists fails`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project with Windows reserved name fails`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project with invalid name fails`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test empty project README contains project name`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test failed creation cleans up partial directory`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test progress callback is called with increasing values`()</ID>
+    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test project name with leading and trailing spaces is trimmed`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test Unicode normalization attacks are handled`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test created files do not escape project directory`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test legitimate template paths are accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test null byte in project name is handled`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test path traversal in project name is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test project creation does not follow symlinks outside directory`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test rejected names cannot be created`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test special shell characters in project name are safe`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test validation and creation are consistent`()</ID>
+    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test very long project name is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test CamelCase name is lowercased`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name AUX is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name COM1 is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name CON is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name LPT1 is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name NUL is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name PRN is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name with extension is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved names are case insensitive`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test blank project name with spaces is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test complex realistic name`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test empty name returns default`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test empty project name is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test existing project directory is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test hyphen is converted to dot`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test leading and trailing dots are trimmed`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test leading number gets prefix`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test mixed case name is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test mixed separators are converted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test multiple consecutive dots are collapsed`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test multiple separators are collapsed to single dot`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name starting with number is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with dot in middle is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with hyphen is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with numbers is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with only special chars returns default`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with spaces is trimmed and accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with underscore is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test non-existent parent directory is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test numbers in middle are preserved`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name at max length is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name exceeding max length is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with asterisk is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with backslash is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with colon is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with double quote is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with greater than is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with leading dot is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with less than is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with only trailing space is trimmed and accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with pipe is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with question mark is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with slash is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with space in middle is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with trailing dot is rejected`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test simple lowercase name derives correctly`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test simple lowercase name is accepted`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test space is converted to dot`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test special characters are removed`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test underscore is converted to dot`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test unicode characters are removed`()</ID>
+    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test uppercase name is lowercased`()</ID>
+    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `completes when a registry change satisfies the condition`()</ID>
+    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `notifications that do not satisfy the condition keep waiting until one does`()</ID>
+    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `returns false on timeout and removes the listener`()</ID>
+    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `returns immediately when condition already holds`()</ID>
+    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `inline markdown maps to styled spans`()</ID>
+    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `parses generated release notes into heading and table blocks`()</ID>
+    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `parses lists, code fences, breaks, and paragraphs`()</ID>
+    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `plain text passes through untouched`()</ID>
+    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `unterminated fence still yields a code block`()</ID>
+    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `admin claim parsed and effective permissions surfaced`()</ID>
+    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `defaults applied when role claims absent`()</ID>
+    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `missing user_permissions yields empty permissions`()</ID>
+    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `non-string entries in user_permissions are filtered out`()</ID>
+    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `parses user_permissions, user_roles and is_admin`()</ID>
+    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `4xx rejections clear the session`()</ID>
+    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `backoff doubles and caps at max`()</ID>
+    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `non-rest exceptions retry`()</ID>
+    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `server errors and cloudflare codes retry`()</ID>
+    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `transient 4xx codes retry instead of clearing`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AlwaysEnabledCondition disabledReason is descriptive`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AlwaysEnabledCondition enabledDescription is descriptive`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AlwaysEnabledCondition isEnabled returns true`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition enabledDescription joins with and`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition returns false when any condition false`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition returns true for empty list`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition returns true when all conditions true`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition enabledDescription is Never`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition isEnabled returns false`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition uses custom disabled reason`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition uses default disabled reason`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition disabledReason lists all conditions`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition enabledDescription joins with or`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition returns false for empty list`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition returns false when all conditions false`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition returns true when any condition true`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `clear removes all conditions and states`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `custom condition with dynamic state`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `debug mode can be toggled`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `default enabledDescription is Always`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getDisabledReason returns null for enabled action`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getDisabledReason returns reason for disabled action`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getRegisteredActions returns all registered action IDs`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getState returns null for unregistered action`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getState returns state after registration`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled handles condition exception`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled returns false for NeverEnabledCondition`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled returns true for AlwaysEnabledCondition`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled returns true for unregistered action`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `nested And and Or conditions work correctly`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `reevaluate updates all states`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `reevaluateSingle updates single state`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `registerCondition adds condition`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `startAutoReevaluation returns cancellable job`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `states flow emits initial empty map`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `states flow updates when condition registered`()</ID>
+    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `unregisterCondition removes condition`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `caps equal counts when everything fits`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `caps skip empty slots`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `empty slots are skipped entirely`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `every non-empty slot keeps one row even on zero or negative budget`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `everything fits when budget covers all items`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `guaranteed single row renders More only`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `overflowing slot yields its last row to the More button`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `surplus beyond item counts is not allocated`()</ID>
+    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `tight budget is dealt round-robin so no slot starves`()</ID>
+    <ID>FunctionNaming:SkipListDriftTest.kt$SkipListDriftTest$@Test fun `in-process and IPC name-visibility rules agree`()</ID>
+    <ID>FunctionNaming:SkipListDriftTest.kt$SkipListDriftTest$@Test fun `in-process and IPC skip-lists are identical`()</ID>
+    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `MoveToPanel drops the move when the tab was closed mid-drag`()</ID>
+    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `MoveToPanel transfers the live component and activates the target panel`()</ID>
+    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `cross-panel CreateSplit drops the move when the tab was closed mid-drag`()</ID>
+    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `cross-panel CreateSplit moves the live component into the new split`()</ID>
+    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `same-panel CreateSplit keeps copy semantics - original retained and not detached`()</ID>
+    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `all provider methods delegate to the current owner`()</ID>
+    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `cached provider no-ops safely when the owner is gone mid-flight`()</ID>
+    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `cached provider routes updates to the tab's current owner after a move`()</ID>
+    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `createProvider returns null when no component owns the tab`()</ID>
+    <ID>FunctionNaming:TerminalLinkSettingsSerializationTest.kt$TerminalLinkSettingsSerializationTest$@Test fun `defaults still apply when fields are missing`()</ID>
+    <ID>FunctionNaming:TerminalLinkSettingsSerializationTest.kt$TerminalLinkSettingsSerializationTest$@Test fun `every open mode round-trips`()</ID>
+    <ID>FunctionNaming:TerminalLinkSettingsSerializationTest.kt$TerminalLinkSettingsSerializationTest$@Test fun `system default decodes from persisted json by name`()</ID>
+    <ID>FunctionNaming:TrackingPluginContextMcpTest.kt$TrackingPluginContextMcpTest$@Test fun `tracker isolates plugins - unregisterAll only tears down its own plugin's providers`()</ID>
+    <ID>FunctionNaming:TrackingPluginContextMcpTest.kt$TrackingPluginContextMcpTest$@Test fun `unregisterAll clears the tracker so a second call does not re-unregister`()</ID>
+    <ID>FunctionNaming:TrackingPluginContextMcpTest.kt$TrackingPluginContextMcpTest$@Test fun `unregisterAll unregisters every MCP tool provider the plugin registered`()</ID>
+    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `bundle suffix is matched at path segment boundary`()</ID>
+    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `library path preserves app substring inside bundle name`()</ID>
+    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `non-translocated app path is returned without filesystem lookup`()</ID>
+    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `translocated path falls back to installed app lookup`()</ID>
+    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `translocated path resolves bundle name in Applications`()</ID>
+    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `unresolved translocated path is preserved`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows batch metacharacters are rejected`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows batch percent sign escaping`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows batch quote escaping with legitimate path`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows script handles spaces correctly`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows script validation`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test backtick command substitution is rejected`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test command separators are rejected as errors`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test command substitution is rejected`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script contains self-destruct command`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script is executable`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script retries relaunch on failure`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script strips quarantine attribute`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script waits for PID`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test legitimate paths with spaces work correctly`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test newline injection is rejected`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test null byte injection is rejected`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test path traversal is rejected as error`()</ID>
+    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test paths with single quotes are properly escaped`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `app_releases row maps to GitHubRelease with assets and sha256`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `falls back to backup when primary returns empty`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `falls back to backup when primary throws`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `getReleaseByTag falls back to backup when primary has none`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `getReleaseByTag prefers primary`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `multi-asset row maps every asset and tolerates missing sha256`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `prerelease row maps prerelease flag`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `returns empty when both sources fail`()</ID>
+    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `uses primary when it returns releases and does not call backup`()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun clamps_to_usable_screen()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun floors_at_min_fit_size()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun grow_at_1x_adds_delta_as_dp()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun negative_delta_shrinks()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun non_positive_scale_is_treated_as_1x()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun scale_2x_halves_the_px_delta()</ID>
+    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun usable_below_floor_yields_screen_not_a_throw()</ID>
+    <ID>FunctionNaming:WindowManagerReflectionContractTest.kt$WindowManagerReflectionContractTest$@Test fun fitWindowByDelta_isReachableByReflection()</ID>
+    <ID>FunctionNaming:WindowManagerReflectionContractTest.kt$WindowManagerReflectionContractTest$@Test fun restoreWindowSize_isReachableByReflection()</ID>
+    <ID>FunctionNaming:WindowManagerReflectionContractTest.kt$WindowManagerReflectionContractTest$@Test fun windowManager_exposesSingletonInstance()</ID>
+    <ID>FunctionOnlyReturningConstant:CLIInstaller.kt$CLIInstaller$private fun getHomebrewBinPath(): String</ID>
+    <ID>FunctionOnlyReturningConstant:CLIInstaller.kt$CLIInstaller$private fun getHomebrewCLISourcePath(): String</ID>
+    <ID>FunctionOnlyReturningConstant:FluckEngine.kt$FluckEngine$private fun isShiftPressed(): Boolean</ID>
+    <ID>FunctionOnlyReturningConstant:KeymapValidator.kt$KeymapValidator$fun isSafeToSave(settings: KeymapSettings): Boolean</ID>
+    <ID>FunctionOnlyReturningConstant:LLMModelFetcher.kt$LLMModelFetcher$private suspend fun loadCachedModels(): ModelCache?</ID>
+    <ID>FunctionOnlyReturningConstant:PasskeyConfigHelper.kt$PasskeyConfigHelper$fun getRpName(): String</ID>
+    <ID>FunctionOnlyReturningConstant:WindowManager.kt$WindowManager$fun shouldQuitApp(): Boolean</ID>
+    <ID>FunctionOnlyReturningConstant:WorkspaceFileManager.kt$WorkspaceFileManagerCommon$fun getDefaultWorkspaceDirectoryName(): String</ID>
+    <ID>FunctionParameterNaming:Fluck.kt$FluckTabInfo$_currentUrl: String = this._currentUrl</ID>
+    <ID>FunctionParameterNaming:Fluck.kt$FluckTabInfo$_currentZoomLevel: Double = this._currentZoomLevel</ID>
+    <ID>FunctionParameterNaming:Fluck.kt$FluckTabInfo$_icon: ImageVector = this._icon</ID>
+    <ID>FunctionParameterNaming:Fluck.kt$FluckTabInfo$_tabIcon: TabIcon? = this._tabIcon</ID>
+    <ID>FunctionParameterNaming:Fluck.kt$FluckTabInfo$_title: String = this._title</ID>
+    <ID>ImplicitDefaultLocale:LLMProvidersSettings.kt$String.format("%.1f", temperature)</ID>
+    <ID>InstanceOfCheckForException:FluckEngine.kt$FluckEngine$e is Error</ID>
+    <ID>InstanceOfCheckForException:PasskeyCredentialManager.kt$PasskeyCredentialManager$e is java.util.concurrent.CancellationException</ID>
+    <ID>InstanceOfCheckForException:SupabasePasskeyService.kt$SupabasePasskeyService$e is java.util.concurrent.CancellationException</ID>
+    <ID>LargeClass:BrowserHandleImpl.kt$BrowserHandleImpl : BrowserHandle</ID>
+    <ID>LargeClass:DesktopGitService.kt$GitService</ID>
+    <ID>LargeClass:DynamicPluginManager.kt$DynamicPluginManager</ID>
+    <ID>LargeClass:FluckEngine.kt$FluckEngine</ID>
+    <ID>LargeClass:FormFieldInjector.kt$FormFieldInjector</ID>
+    <ID>LargeClass:KeymapPresets.kt$KeymapPresets</ID>
+    <ID>LargeClass:PluginStoreSetup.kt$PluginStoreSetup</ID>
+    <ID>LargeClass:SplitView.kt$SplitViewState</ID>
+    <ID>LargeClass:UpdateScriptGenerator.kt$UpdateScriptGenerator</ID>
+    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$fun install()</ID>
+    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun dispatchAction(actionId: String, windowId: String): Boolean</ID>
+    <ID>LongMethod:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun getKeyName(keyCode: Int): String</ID>
+    <ID>LongMethod:ActionCard.kt$@Composable fun ActionCard( icon: ImageVector, title: String, shortcut: String? = null, onClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:AdvancedSettings.kt$@Composable fun AdvancedSettings()</ID>
+    <ID>LongMethod:AuthScreenContainer.kt$@Composable fun AuthScreenContainer( onLoginSuccess: () -&gt; Unit )</ID>
+    <ID>LongMethod:BookmarkDialog.kt$@Composable fun BookmarkDialog( tabTitle: String, collections: List&lt;BookmarkCollection&gt;, workspaces: List&lt;ai.rever.boss.components.workspaces.LayoutWorkspace&gt;, onDismiss: () -&gt; Unit, onConfirm: (collectionIds: Set&lt;String&gt;, workspacePanelMap: Map&lt;String, String?&gt;) -&gt; Unit )</ID>
+    <ID>LongMethod:BookmarkDialog.kt$@Composable private fun WorkspacePill( workspace: ai.rever.boss.components.workspaces.LayoutWorkspace, isSelected: Boolean, selectedPanelId: String?, onToggle: () -&gt; Unit, onPanelSelected: (String?) -&gt; Unit )</ID>
+    <ID>LongMethod:BossActionButton.kt$@Composable fun BossActionButton( imageVector: ImageVector? = null, leftLogo: (@Composable () -&gt; Unit)? = null, leftIcon: ImageVector? = null, text: String, fontSize: TextUnit = 13.sp, color: Color = BossTheme.colors.textPrimary, iconColor: Color? = null, // Optional separate icon color (defaults to color if null) iconSize: Dp = 20.dp, // Icon size for imageVector mode maxTextWidth: Dp? = null, // Optional max width for text (truncates with ellipsis) modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(2.dp), isSelected: Boolean = false, contextMenuItems: List&lt;ContextMenuItem&gt;? = null, contextDirection: Panel = bottom, hintText: String? = null, showHintWithDelay: Boolean = true, hintDirection: Panel = bottom, onClick: () -&gt; Unit = {} )</ID>
+    <ID>LongMethod:BossAppDialogs.kt$@Composable internal fun BossAppDialogs(state: BossAppState)</ID>
+    <ID>LongMethod:BossAppEventBusEffects.kt$@Composable internal fun BossAppEventBusEffects(state: BossAppState)</ID>
+    <ID>LongMethod:BossAppMenuActionEffects.kt$@Composable internal fun BossAppMenuActionEffects(state: BossAppState, reveal: FocusModeRevealState)</ID>
+    <ID>LongMethod:BossAppScaffold.kt$@Composable internal fun BossAppScaffold( state: BossAppState, reveal: FocusModeRevealState, isFocusModeEnabled: Boolean, isAutoRevealEnabled: Boolean, revealOffsetDp: Dp, showTitleBar: Boolean, onToggleMaximize: (() -&gt; Unit)?, )</ID>
+    <ID>LongMethod:BossAppStartupEffects.kt$@Composable internal fun BossAppStartupEffects(state: BossAppState)</ID>
+    <ID>LongMethod:BossAppWithAuth.kt$@Composable fun ComponentContext.BossAppWithAuth( windowId: String, isFirstWindow: Boolean = false, panelRegistry: ai.rever.boss.components.registery.PanelRegistry, onToggleMaximize: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:BossBottomBar.kt$@Composable fun RowScope.BossLeftBottomBar(tabsComponent: BossTabsComponent? = null)</ID>
+    <ID>LongMethod:BossDraggableComponent.kt$BossDraggableComponent$fun stopDragging()</ID>
+    <ID>LongMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainPanelContent( modifier: Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainTabBar( splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, focusRequester: FocusRequester? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {} )</ID>
+    <ID>LongMethod:BossPanelTopBar.kt$@Composable fun BossPanelTopBar( title: String?, isHovered: Boolean, onReset: (() -&gt; Unit)? = null, onReloadPlugin: (() -&gt; Unit)? = null, onOpenAsTab: (() -&gt; Unit)? = null, onCheckForUpdates: (() -&gt; Unit)? = null, onOpenEvolver: (() -&gt; Unit)? = null, onReportIssue: (() -&gt; Unit)? = null, onMinimize: () -&gt; Unit, updateAvailable: AvailablePluginUpdate? = null, onUpdateClick: (() -&gt; Unit)? = null, panelId: PanelId? = null, windowId: String? = null, dragModifier: Modifier = Modifier, content: (@Composable () -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:BossTabButton.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun BossTabButton( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>LongMethod:BossTopBar.kt$@Composable fun BossDraggableComponent.BossTopLeftBar( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:BossTopBar.kt$@Composable private fun getGitContextMenuItems( currentBranch: String?, localBranches: List&lt;GitBranchInfo&gt;, remoteBranches: List&lt;GitBranchInfo&gt;, stashList: List&lt;GitStashInfo&gt;, isLoading: Boolean, onCheckout: (String) -&gt; Unit, onMerge: (String) -&gt; Unit, onRebase: (String) -&gt; Unit, onCreateBranch: () -&gt; Unit, onCommit: () -&gt; Unit, onPull: () -&gt; Unit, onPush: () -&gt; Unit, onCreatePR: (() -&gt; Unit)?, onStash: () -&gt; Unit, onStashPop: (Int) -&gt; Unit, onRefresh: () -&gt; Unit ): List&lt;ContextMenuItem&gt;</ID>
+    <ID>LongMethod:BossTopRunBar.kt$@Composable fun BossTopRunBar()</ID>
+    <ID>LongMethod:BossWindow.kt$@Composable fun ApplicationScope.BossWindow( windowState: BossWindowState, onCloseRequest: () -&gt; Unit )</ID>
+    <ID>LongMethod:BrowserEngineSettings.kt$@Composable fun BrowserEngineSettings()</ID>
+    <ID>LongMethod:BrowserFunctions.kt$private fun configureBrowserPopupHandler( browser: Browser, onOpenInNewTab: (String) -&gt; Unit )</ID>
+    <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$@OptIn(ExperimentalComposeUiApi::class) @Composable override fun Content()</ID>
+    <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$override fun dispatchCoBrowseInput(inputJson: String)</ID>
+    <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun getFormFieldInfoFromJS(frame: com.teamdev.jxbrowser.frame.Frame): FormFieldInfo?</ID>
+    <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupEventListeners()</ID>
+    <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupPopupHandler()</ID>
+    <ID>LongMethod:BrowserPageCard.kt$@Composable fun BrowserPageCard( page: RecentBrowserPage, onClick: () -&gt; Unit, onRemove: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:CLIInstallationDialog.kt$@Composable fun CLIInstallationDialog( onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:CLIInstallationDialog.kt$@Composable private fun ErrorContent( message: String, onRetry: () -&gt; Unit, onClose: () -&gt; Unit )</ID>
+    <ID>LongMethod:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal suspend fun installFromCandidates( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) } ): Result&lt;Path&gt;</ID>
+    <ID>LongMethod:ChromiumDownloadDialog.kt$@Composable private fun DownloadSurface( progress: Float, downloadedMB: Long, totalMB: Long, status: String, error: String?, onCancel: () -&gt; Unit, onRetry: (() -&gt; Unit)? )</ID>
+    <ID>LongMethod:CloneProjectDialog.kt$@Composable fun CloneProjectDialog( onDismiss: () -&gt; Unit, onProjectCloned: (String) -&gt; Unit )</ID>
+    <ID>LongMethod:CloneProjectDialog.kt$@Composable private fun ConfigurationStep( onDismiss: () -&gt; Unit, onClone: (url: String, directory: String) -&gt; Unit )</ID>
+    <ID>LongMethod:CloneProjectDialog.kt$@Composable private fun ErrorStep( message: String, onRetry: () -&gt; Unit, onClose: () -&gt; Unit )</ID>
+    <ID>LongMethod:CoBrowseScripts.kt$CoBrowseScripts$fun applyControl(payloadJsonLiteral: String): String</ID>
+    <ID>LongMethod:CodeEditor.kt$@Composable fun CodeEditorUI( content: String, onContentChange: (String) -&gt; Unit, language: String = "kotlin", filePath: String = "", projectPath: String = "", modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:CollectionSelectionDialog.kt$@Composable fun CollectionSelectionDialog( title: String, collections: List&lt;BookmarkCollection&gt;, excludeCollectionId: String? = null, mode: CollectionSelectionMode = CollectionSelectionMode.COPY, onDismiss: () -&gt; Unit, onConfirm: (selectedCollectionIds: Set&lt;String&gt;) -&gt; Unit )</ID>
+    <ID>LongMethod:CommitDialog.kt$@Composable fun CommitDialog( onDismiss: () -&gt; Unit, onCommitSuccess: (String) -&gt; Unit = {} )</ID>
+    <ID>LongMethod:ConfirmationDialog.kt$@Composable fun ConfirmationDialog( title: String, message: String, icon: ImageVector? = null, iconTint: Color = BossTheme.colors.warn, confirmText: String = "Confirm", confirmColor: Color = BossTheme.colors.alert, // destructive onDismiss: () -&gt; Unit, onConfirm: () -&gt; Unit )</ID>
+    <ID>LongMethod:ContextMenu.kt$@Composable private fun ContextMenuContent( items: List&lt;ContextMenuItem&gt;, modifier: Modifier = Modifier, onDismissRequest: () -&gt; Unit )</ID>
+    <ID>LongMethod:ContextMenu.kt$@Composable private fun SubMenuContent( items: List&lt;ContextMenuItem&gt;, onDismissRequest: () -&gt; Unit )</ID>
+    <ID>LongMethod:CoreAuthService.kt$CoreAuthService$private fun initializeWithNetwork()</ID>
+    <ID>LongMethod:CrashReportDialog.kt$@Composable fun CrashReportDialog( crashReport: CrashReport, onDismiss: () -&gt; Unit, onSubmit: (userNotes: String?, includeLogs: Boolean) -&gt; Unit, onCleanAndRestart: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:CrashReportService.kt$CrashReportService$private fun formatIssueBody(report: CrashReport, isNewReport: Boolean): String</ID>
+    <ID>LongMethod:CrossDeviceAuthenticationDialog.kt$@Composable fun CrossDeviceAuthenticationDialog( qrCodeUrl: String?, challenge: String?, sessionId: String? = null, onDismiss: () -&gt; Unit, onSuccess: () -&gt; Unit, onCreateFluckTab: ((FluckTabInfo) -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:Dashboard.kt$@Composable fun Dashboard( onOpenFile: (String) -&gt; Unit, onOpenUrl: (String) -&gt; Unit, onOpenProject: (Project) -&gt; Unit, selectedProject: Project = Project("No Project", "", 0L), onNewTab: () -&gt; Unit, onNewTerminal: () -&gt; Unit, onNewWindow: () -&gt; Unit, onOpenProjectDialog: () -&gt; Unit, onOpenFileDialog: () -&gt; Unit, onNewProject: () -&gt; Unit, onApplySplitTemplate: (SplitTemplate) -&gt; Unit, onActivatePlugin: (String) -&gt; Unit, onShowSettings: (() -&gt; Unit)? = null, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:DefaultBrowserSection.kt$@Composable fun DefaultBrowserSection()</ID>
+    <ID>LongMethod:DefaultPlugin.kt$DefaultPlugin$private fun registerKernelPluginServices()</ID>
+    <ID>LongMethod:DesktopBrowserAccessor.kt$private fun findBrowserForTab( splitViewState: ai.rever.boss.components.window_panel.SplitViewState, tabId: String ): LockedBrowser?</ID>
+    <ID>LongMethod:DesktopGitService.kt$GitService$actual suspend fun cloneRepository( repositoryUrl: String, targetDirectory: String, onProgress: (String) -&gt; Unit ): GitOperationResult</ID>
+    <ID>LongMethod:DesktopPasskeyBrowserView.kt$@Composable actual fun PasskeyBrowserView( url: String, onLoadComplete: () -&gt; Unit, onError: (String) -&gt; Unit )</ID>
+    <ID>LongMethod:DesktopPasskeyService.kt$DesktopPasskeyService$override suspend fun authenticateWithPasskey( challenge: ByteArray, allowedCredentials: List&lt;String&gt;?, rpId: String, userEmail: String, sessionId: String?, allowedCredentialTransports: Map&lt;String, List&lt;String&gt;&gt;? ): Result&lt;PasskeyAssertion&gt;</ID>
+    <ID>LongMethod:DesktopUpdateService.kt$UpdateService$actual suspend fun checkForUpdates(): UpdateInfo</ID>
+    <ID>LongMethod:DowngradeWarningDialog.kt$@Composable fun DowngradeWarningDialog( currentVersion: Version, targetVersion: Version, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:DraggableActionButton.kt$@Composable fun BossDraggableComponent.DraggableActionButton( item: SidebarItem, slot: Panel, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun installPlugin(jarPath: String, enabled: Boolean = true): Result&lt;DynamicPluginInfo&gt;</ID>
+    <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun uninstallPlugin( pluginId: String, force: Boolean = false, waitForGC: Boolean = false ): Result&lt;Unit&gt;</ID>
+    <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager.Companion$private suspend fun hotSwapApiLayerOrchestration(pluginDir: java.io.File): Result&lt;Int&gt;</ID>
+    <ID>LongMethod:EditableKeymapSettings.kt$@Composable fun EditableKeymapSettings()</ID>
+    <ID>LongMethod:EditableKeymapSettings.kt$@Composable private fun ShortcutItem( binding: KeyBinding, hasConflict: Boolean, conflictingBindings: List&lt;KeyBinding&gt;, onEdit: () -&gt; Unit )</ID>
+    <ID>LongMethod:EmailAuthService.kt$EmailAuthService$suspend fun verifyMagicLinkToken(token: String, email: String? = null, type: String = "magiclink"): Result&lt;Boolean&gt;</ID>
+    <ID>LongMethod:EmptyContentScreen.kt$@Composable fun EmptyContent( onOpenFile: () -&gt; Unit, onNewTab: () -&gt; Unit, onSplitPanel: (() -&gt; Unit)? = null, onSwitchPanel: (() -&gt; Unit)? = null, onNewWindow: () -&gt; Unit )</ID>
+    <ID>LongMethod:EmptyContentScreen.kt$@Composable private fun Card( icon: ImageVector, title: String, description: String, isSelected: Boolean, enabled: Boolean, onClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:FileCard.kt$@Composable fun FileCard( file: RecentFile, onClick: () -&gt; Unit, onRemove: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:Fluck.kt$@Composable fun BrowserErrorView( error: Throwable, url: String, retryCount: Int = 0, maxRetries: Int = 3, onRetry: (() -&gt; Unit)? = null, onReset: (() -&gt; Unit)? = null, onResetBrowser: (() -&gt; Unit)? = null, onRetryEngine: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:Fluck.kt$FluckTabComponent$@Composable override fun Content()</ID>
+    <ID>LongMethod:FluckBrowserSettings.kt$@Composable fun FluckBrowserSettings()</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupBrowserDownloadHandler(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses(userHome: String)</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine$suspend fun resetBrowserProfile(): ResetResult</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine.BrowserFindBar$private fun createDialog(owner: java.awt.Window)</ID>
+    <ID>LongMethod:FocusModeReveal.kt$@Composable internal fun rememberFocusModeReveal( isFocusModeEnabled: Boolean, revealDelayMs: Long, ): FocusModeRevealState</ID>
+    <ID>LongMethod:FocusModeSettings.kt$@Composable fun FocusModeSettings()</ID>
+    <ID>LongMethod:FormFieldDetector.kt$FormFieldDetector$fun injectFormDetectionScript(browser: LockedBrowser)</ID>
+    <ID>LongMethod:FormFieldInjector.kt$FormFieldInjector$private suspend fun applyDiscreteMode(browser: LockedBrowser)</ID>
+    <ID>LongMethod:FormFieldInjector.kt$FormFieldInjector$suspend fun fillField( browser: LockedBrowser, fieldInfo: FormFieldDetector.FormFieldInfo, value: String ): FillResult</ID>
+    <ID>LongMethod:FormFieldInjector.kt$FormFieldInjector$suspend fun findAndFillPassword(browser: LockedBrowser, password: String): FillResult</ID>
+    <ID>LongMethod:FormFieldInjector.kt$FormFieldInjector$suspend fun findAndFillUsername(browser: LockedBrowser, username: String): FillResult</ID>
+    <ID>LongMethod:FormFieldInjector.kt$FormFieldInjector$suspend fun installFormSubmissionMonitor(browser: LockedBrowser)</ID>
+    <ID>LongMethod:FullscreenBrowserWindow.kt$FullscreenBrowserWindow$private fun createFullscreenWindow(browser: Browser, tabId: String)</ID>
+    <ID>LongMethod:GenericDialogHost.kt$@Composable private fun MultiChoiceDialog(request: DialogRequest.MultiChoice)</ID>
+    <ID>LongMethod:GenericDialogHost.kt$@Composable private fun SingleChoiceDialog(request: DialogRequest.SingleChoice)</ID>
+    <ID>LongMethod:GenericDialogHost.kt$@Composable private fun TextInputDialog(request: DialogRequest.TextInput)</ID>
+    <ID>LongMethod:GlobalSearchDialog.kt$@Composable fun GlobalSearchDialog( projectPath: String, workspaceManager: WorkspaceManager, onDismiss: () -&gt; Unit, onFileSelect: (String) -&gt; Unit, onTabSelect: ((windowId: String, panelId: String, tabId: String) -&gt; Unit)? = null, onBookmarkSelect: ((bookmarkId: String, collectionId: String) -&gt; Unit)? = null, onRunConfigSelect: ((configId: String) -&gt; Unit)? = null, onCommandSelect: ((actionId: String) -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:GlobalSearchDialog.kt$@Composable private fun SearchDialogHeader( fileCount: Int, isIndexing: Boolean, onClose: () -&gt; Unit )</ID>
+    <ID>LongMethod:GlobalSearchDialog.kt$@Composable private fun SearchInputField( query: String, onQueryChange: (String) -&gt; Unit, focusRequester: FocusRequester, isSearching: Boolean )</ID>
+    <ID>LongMethod:KernelBootstrap.kt$KernelBootstrap$fun initialize()</ID>
+    <ID>LongMethod:KernelBootstrap.kt$KernelBootstrap$private fun spawnServices(registry: ProcessRegistry, spawner: ProcessSpawner)</ID>
+    <ID>LongMethod:KeyCaptureDialog.kt$@Composable fun KeyCaptureDialog( actionId: String, actionDescription: String, context: ShortcutContext, category: String, currentBinding: KeyBinding?, onKeyCaptured: (KeyBinding) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:KeymapData.kt$fun getKeyboardShortcuts(): List&lt;KeyboardShortcut&gt;</ID>
+    <ID>LongMethod:KeymapImportExport.kt$@Composable fun KeymapImportExport( onImport: suspend (String) -&gt; Boolean, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:KeymapImportExport.kt$@Composable private fun ExportDialog( onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:KeymapImportExport.kt$@Composable private fun ImportDialog( onImport: (String) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:KeymapPresets.kt$KeymapPresets$fun getBOSSDefault(): KeymapSettings</ID>
+    <ID>LongMethod:KeymapPresets.kt$KeymapPresets$fun getIntelliJPreset(): KeymapSettings</ID>
+    <ID>LongMethod:KeymapPresets.kt$KeymapPresets$fun getVSCodePreset(): KeymapSettings</ID>
+    <ID>LongMethod:KeymapSettings.kt$@Composable fun KeymapSettings()</ID>
+    <ID>LongMethod:LLMProvidersSettings.kt$@Composable fun LLMProvidersSettings()</ID>
+    <ID>LongMethod:LoginFormScreen.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun LoginFormScreen( viewModel: LoginViewModel, onLoginSuccess: () -&gt; Unit, isLoading: Boolean, errorMessage: String?, onMagicLinkSent: (String) -&gt; Unit = {}, onPasskeyAuthInitiated: (String) -&gt; Unit = {}, onPasskeySelectionRequired: (String) -&gt; Unit = {} )</ID>
+    <ID>LongMethod:LogoutConfirmationDialog.kt$@Composable fun LogoutConfirmationDialog( onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:MagicLinkWaitingScreen.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun MagicLinkWaitingScreen( email: String, viewModel: LoginViewModel, onBack: () -&gt; Unit, onSuccess: () -&gt; Unit, isLoading: Boolean = false, errorMessage: String? = null )</ID>
+    <ID>LongMethod:MenuShortcutBridge.kt$MenuShortcutBridge$private fun keyNameToComposeKey(keyName: String): Key?</ID>
+    <ID>LongMethod:NameInputDialog.kt$@Composable fun NewCollectionDialog( onDismiss: () -&gt; Unit, onCreate: (name: String) -&gt; Unit )</ID>
+    <ID>LongMethod:NameInputDialog.kt$@Composable fun NewWorkspaceDialog( onDismiss: () -&gt; Unit, onCreate: (name: String) -&gt; Unit )</ID>
+    <ID>LongMethod:NewProjectWizardDialog.kt$@Composable fun NewProjectWizardDialog( onDismiss: () -&gt; Unit, onProjectCreated: (Project) -&gt; Unit )</ID>
+    <ID>LongMethod:NewProjectWizardDialog.kt$@Composable private fun ConfigurationStep( template: ProjectTemplate, onBack: () -&gt; Unit, onCreate: (name: String, path: String) -&gt; Unit )</ID>
+    <ID>LongMethod:NewProjectWizardDialog.kt$@Composable private fun ErrorStep( message: String, onRetry: () -&gt; Unit, onClose: () -&gt; Unit )</ID>
+    <ID>LongMethod:NewProjectWizardDialog.kt$@Composable private fun TemplateCard( template: ProjectTemplate, isSelected: Boolean, onClick: () -&gt; Unit )</ID>
+    <ID>LongMethod:NewProjectWizardDialog.kt$@Composable private fun TemplateSelectionStep( onDismiss: () -&gt; Unit, onTemplateSelected: (ProjectTemplate) -&gt; Unit )</ID>
+    <ID>LongMethod:NewTabDialog.kt$@Composable fun NewTabDialog( onDismiss: () -&gt; Unit, onCreateTab: (type: TabType, path: String) -&gt; Unit, tabRegistry: TabRegistry, initialTabType: TabType? = null, /** * Opens a [TabInfo] built by a plugin tab type's [TabTypeInfo.createTabInfo]. * When null, plugin-registered tab types are not offered (legacy callers). */ onCreateTabInfo: ((TabInfo) -&gt; Unit)? = null, projectPath: String? = null, windowId: String? = null )</ID>
+    <ID>LongMethod:NewTabDialog.kt$@Composable private fun DialogFileTreeItem( node: FileNodeData, level: Int, expandedPaths: Set&lt;String&gt;, onToggleExpanded: (String) -&gt; Unit, onFileClick: (FileNodeData) -&gt; Unit )</ID>
+    <ID>LongMethod:OfflineScreen.kt$@Composable fun OfflineScreen( onRetry: suspend () -&gt; Boolean )</ID>
+    <ID>LongMethod:OutOfProcessPluginSpawnerImpl.kt$OutOfProcessPluginSpawnerImpl$override suspend fun spawn(manifest: PluginManifest, jarPath: String): Result&lt;Unit&gt;</ID>
+    <ID>LongMethod:PasskeyAuthService.kt$PasskeyAuthService$suspend fun authenticateWithPasskey(email: String? = null, credentialId: String? = null): Result&lt;Unit&gt;</ID>
+    <ID>LongMethod:PasskeyBrowserScreen.kt$@Composable fun PasskeyBrowserScreen( url: String, sessionId: String, onSuccess: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
+    <ID>LongMethod:PasskeySessionHandler.kt$PasskeySessionHandler$suspend fun completeAuthentication(authData: PasskeyAuthenticationResult): Result&lt;Unit&gt;</ID>
+    <ID>LongMethod:PasskeyWaitingScreen.kt$@Composable fun PasskeyWaitingScreen( email: String, viewModel: LoginViewModel, onBack: () -&gt; Unit, onSuccess: () -&gt; Unit )</ID>
+    <ID>LongMethod:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$private fun collectViaKernelRegistry(): List&lt;ChildProcessData&gt;</ID>
+    <ID>LongMethod:PerformanceMonitor.kt$PerformanceMonitor$fun start()</ID>
+    <ID>LongMethod:PerformanceSettings.kt$@Composable fun PerformanceSettings()</ID>
+    <ID>LongMethod:PluginInstallService.kt$PluginInstallService$private fun downloadFromGitHubRelease(owner: String, repo: String, pluginDir: File): String?</ID>
+    <ID>LongMethod:PluginInstallService.kt$PluginInstallService$suspend fun installPlugins( plugins: List&lt;WizardPluginInfo&gt;, onProgress: (Float, String) -&gt; Unit ): Result&lt;PluginInstallResult&gt;</ID>
+    <ID>LongMethod:PluginInstallWizard.kt$@Composable internal fun CompleteStepContent( installedCount: Int, failedPlugins: List&lt;Pair&lt;String, String&gt;&gt; = emptyList() )</ID>
+    <ID>LongMethod:PluginInstallWizard.kt$@Composable internal fun InstallingStepContent( progress: Float, status: String, error: String?, onRetry: () -&gt; Unit )</ID>
+    <ID>LongMethod:PluginInstallWizard.kt$@Composable internal fun WizardNavigation( currentStep: PluginInstallStep, isInstalling: Boolean, hasSelectedPlugins: Boolean, onBack: () -&gt; Unit, onNext: () -&gt; Unit, onSkip: () -&gt; Unit, onFinish: () -&gt; Unit )</ID>
+    <ID>LongMethod:PluginInstallWizardWindow.kt$@Composable fun PluginInstallWizardWindow( state: PluginInstallWizardState, onDismiss: () -&gt; Unit, onComplete: () -&gt; Unit, onInstallPlugins: suspend (List&lt;WizardPluginInfo&gt;, (Float, String) -&gt; Unit) -&gt; Result&lt;PluginInstallResult&gt; )</ID>
+    <ID>LongMethod:PluginListProvider.kt$PluginListProvider$private fun getFallbackPluginList(): List&lt;WizardPluginInfo&gt;</ID>
+    <ID>LongMethod:PluginStoreSetup.kt$PluginStoreSetup$private fun copyBundledPluginsToPluginDir( dynamicPluginManager: ai.rever.boss.components.plugin.DynamicPluginManager )</ID>
+    <ID>LongMethod:PluginStoreSetup.kt$PluginStoreSetup$private fun scheduleBackgroundUpdateCheck( systemPlugin: SystemPluginInfo, existingJar: File, )</ID>
+    <ID>LongMethod:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun downloadSystemPluginFromGitHub(plugin: SystemPluginInfo): Boolean</ID>
+    <ID>LongMethod:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun ensureSystemPluginsInstalled()</ID>
+    <ID>LongMethod:PresetDefinitions.kt$EmacsPresetDefinition$fun create(): KeymapSettings</ID>
+    <ID>LongMethod:PresetSelector.kt$@Composable fun PresetSelector( currentSettings: KeymapSettings, onPresetSelected: suspend (String) -&gt; Unit, onResetToDefault: suspend () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:ProfileManagementSection.kt$@Composable fun ProfileManagementSection( currentProfile: String, onProfileChange: (String) -&gt; Unit )</ID>
+    <ID>LongMethod:ProjectCard.kt$@Composable fun ProjectCard( project: Project, onClick: () -&gt; Unit, onRemove: (() -&gt; Unit)? = null, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:ProjectOpenModeDialog.kt$@Composable fun ProjectOpenModeDialog( project: Project, onDismiss: () -&gt; Unit, onOpenInCurrentWindow: (Project) -&gt; Unit, onOpenInNewWindow: (Project) -&gt; Unit )</ID>
+    <ID>LongMethod:ProjectSelectionDialog.kt$@Composable fun ProjectSelectionDialog( onDismiss: () -&gt; Unit, onOpenDirectoryPicker: () -&gt; Unit = {} )</ID>
+    <ID>LongMethod:ReleaseNotesMarkdown.kt$@Composable internal fun NotesBlockView(block: NotesBlock)</ID>
+    <ID>LongMethod:ReleaseNotesMarkdown.kt$internal fun parseReleaseNotes(source: String): List&lt;NotesBlock&gt;</ID>
+    <ID>LongMethod:RemoteWidgetRenderer.kt$@Composable private fun RenderNode( node: WidgetNode, tree: WidgetTree, onEvent: (nodeId: String, eventType: String, eventData: String) -&gt; Unit, )</ID>
+    <ID>LongMethod:RemoveBookmarkConfirmationDialog.kt$@Composable fun RemoveBookmarkConfirmationDialog( bookmarkTitle: String, onDismiss: () -&gt; Unit, onConfirm: () -&gt; Unit )</ID>
+    <ID>LongMethod:RenameDialog.kt$@Composable fun RenameDialog( title: String, currentName: String, label: String, onDismiss: () -&gt; Unit, onRename: (newName: String) -&gt; Unit )</ID>
+    <ID>LongMethod:RunnerSettings.kt$@Composable fun RunnerSettings()</ID>
+    <ID>LongMethod:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$fun requestCapture( requestId: String, sources: CaptureSources, tell: StartCaptureSessionCallback.Action )</ID>
+    <ID>LongMethod:ScreenCapturePickerDialog.kt$@Composable fun ScreenCapturePickerDialog( screens: List&lt;ScreenCaptureNotifier.CaptureSourceItem&gt;, windows: List&lt;ScreenCaptureNotifier.CaptureSourceItem&gt;, browsers: List&lt;ScreenCaptureNotifier.CaptureSourceItem&gt;, onDismiss: () -&gt; Unit, onSelect: (ScreenCaptureNotifier.CaptureSourceItem, AudioCaptureMode) -&gt; Unit )</ID>
+    <ID>LongMethod:ScrollbarSettings.kt$@Composable fun ScrollbarSettings()</ID>
+    <ID>LongMethod:SecuritySettings.kt$@Composable fun SecuritySettings()</ID>
+    <ID>LongMethod:SecuritySettings.kt$@Composable private fun PasskeyEnrollmentDialog( onDismiss: () -&gt; Unit, onSuccess: () -&gt; Unit, onError: (String) -&gt; Unit )</ID>
+    <ID>LongMethod:SecuritySettings.kt$private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities</ID>
+    <ID>LongMethod:SettingsComponents.kt$@Composable fun ColorPickerDialog( initialColor: Color, onColorSelected: (Color) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:SettingsComponents.kt$@Composable fun SettingsDropdown( label: String, options: List&lt;String&gt;, selectedOption: String, onOptionSelected: (String) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongMethod:SettingsComponents.kt$@Composable fun SettingsFilePicker( label: String, value: String, onValueChange: (String) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, fileExtensions: List&lt;String&gt; = emptyList(), enabled: Boolean = true )</ID>
+    <ID>LongMethod:SettingsComponents.kt$@Composable fun SettingsSectionedDropdown( label: String, sections: Map&lt;String, List&lt;String&gt;&gt;, selectedOption: String, onOptionSelected: (String) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongMethod:SettingsWindow.kt$@Composable private fun SettingsContent(initialSection: String? = null)</ID>
+    <ID>LongMethod:SettingsWindow.kt$@Composable private fun SettingsContentArea( section: SettingsSection, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:ShortcutHelpDialog.kt$@Composable fun ShortcutHelpDialog( keymapSettings: KeymapSettings, onDismiss: () -&gt; Unit, onOpenSettings: () -&gt; Unit )</ID>
+    <ID>LongMethod:ShortcutTestDialog.kt$@Composable fun ShortcutTestDialog( keymapSettings: KeymapSettings, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:ShortcutTestDialog.kt$@Composable private fun TestResultItem(result: ShortcutTestResult)</ID>
+    <ID>LongMethod:ShortcutTestRunner.kt$ShortcutTestRunner$suspend fun testShortcut(binding: KeyBinding): ShortcutTestResult</ID>
+    <ID>LongMethod:SidePanel.kt$@Composable fun BossDraggableComponent.SidePanel( panel: Panel, panelComponentStore: PanelComponentStore )</ID>
+    <ID>LongMethod:SidebarCustomizeMenu.kt$@Composable fun BossDraggableComponent.SidebarCustomizeMenu( /** Slot the button visually belongs to; controls hint direction &amp; drag overlay rendering. */ slot: Panel = left.top.bottom, modifier: Modifier = Modifier, )</ID>
+    <ID>LongMethod:SplitView.kt$@Composable private fun PanelDropZoneOverlay( panelId: String, dropTarget: TabDropTarget? )</ID>
+    <ID>LongMethod:SplitView.kt$@Composable private fun RenderSplitNode( node: SplitNode, splitViewState: SplitViewState, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {}, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:SplitView.kt$SplitViewState$fun splitPanel( panelId: String, orientation: SplitOrientation, tabToMove: TabInfo? = null, detachedTab: BossTabsComponent.DetachedTab? = null ): String</ID>
+    <ID>LongMethod:TabDraggingOverlay.kt$@Composable fun TabDraggableComponent.TabDraggingOverlay()</ID>
+    <ID>LongMethod:TerminalLinkOpenDialog.kt$@Composable fun TerminalLinkOpenDialog( url: String, hasTabs: Boolean, hasSplits: Boolean, onDismiss: () -&gt; Unit, onOpenLink: (mode: TerminalLinkOpenMode, rememberChoice: Boolean) -&gt; Unit )</ID>
+    <ID>LongMethod:TopOfMindDialog.kt$@Composable fun TopOfMindDialog( splitViewState: SplitViewState? = null, // Kept for backward compatibility but not used workspaceManager: WorkspaceManager, onDismiss: () -&gt; Unit, onTabSelect: (ActiveTab) -&gt; Unit )</ID>
+    <ID>LongMethod:TopOfMindDialog.kt$@Composable private fun ActiveTabDialogItem( activeTab: ActiveTab, isSelected: Boolean, onTabClick: () -&gt; Unit )</ID>
+    <ID>LongMethod:UpdateAvailableDialog.kt$@Composable fun UpdateAvailableDialog( updateInfo: UpdateInfo, onUpdateNow: () -&gt; Unit, onLater: () -&gt; Unit )</ID>
+    <ID>LongMethod:UpdateScriptGenerator.kt$UpdateScriptGenerator$fun generateLinuxDebUpdateScript( debPath: String, appPid: Long ): File</ID>
+    <ID>LongMethod:UpdateScriptGenerator.kt$UpdateScriptGenerator$fun generateLinuxRpmUpdateScript( rpmPath: String, appPid: Long ): File</ID>
+    <ID>LongMethod:UpdateScriptGenerator.kt$UpdateScriptGenerator$fun generateMacOSUpdateScript( dmgPath: String, targetAppPath: String, appPid: Long ): File</ID>
+    <ID>LongMethod:UpdateUI.kt$@Composable fun UpdateSettingsSection( updateManager: UpdateManager = UpdateManager.instance )</ID>
+    <ID>LongMethod:UserExistenceService.kt$UserExistenceService$suspend fun checkUserExists(email: String): Result&lt;UserExistence&gt;</ID>
+    <ID>LongMethod:VersionSelectionDialog.kt$@Composable fun VersionSelectionDialog( currentVersion: Version, versions: List&lt;VersionInfo&gt;, isLoading: Boolean, error: String? = null, onVersionSelected: (VersionInfo) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongMethod:VersionSelectionDialog.kt$@Composable private fun VersionItem( versionInfo: VersionInfo, isCurrent: Boolean, isLatest: Boolean = false, onClick: () -&gt; Unit )</ID>
+    <ID>LongMethod:WasmFluckView.kt$@Composable actual fun FluckView( fileId: String, content: String, browser: Any?, browserViewState: Any?, browserLock: Any?, onContentChange: (String) -&gt; Unit, onTitleChange: (String) -&gt; Unit, onIconChange: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)?, onNavigationStateChange: ((isBack: Boolean) -&gt; Unit)?, onFaviconCached: ((String?) -&gt; Unit)?, onCloseTab: (() -&gt; Unit)? )</ID>
+    <ID>LongMethod:WizardComponents.kt$@Composable fun CheckboxCard( title: String, description: String, icon: ImageVector? = null, isChecked: Boolean, onCheckedChange: (Boolean) -&gt; Unit, enabled: Boolean = true, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:WizardComponents.kt$@Composable fun SelectionCard( title: String, description: String, icon: ImageVector? = null, isSelected: Boolean, onClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:WizardComponents.kt$@Composable fun WizardStepIndicator( currentStep: Int, totalSteps: Int, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:WorkspaceApplier.kt$private suspend fun applyWorkspaceNode( node: SplitConfig, splitViewState: SplitViewState, currentPanelId: String, projectPath: String )</ID>
+    <ID>LongMethod:WorkspaceButton.kt$@Composable fun WorkspaceButton( onOpenWorkspace: (LayoutWorkspace) -&gt; Unit, workspaceManager: WorkspaceManager = remember { WorkspaceManager() }, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:WorkspaceSelectionDialog.kt$@Composable fun WorkspaceSelectionDialog( title: String, workspaces: List&lt;ai.rever.boss.components.workspaces.LayoutWorkspace&gt;, preselectedWorkspaces: Map&lt;String, String?&gt; = emptyMap(), onDismiss: () -&gt; Unit, onConfirm: (workspacePanelMap: Map&lt;String, String?&gt;) -&gt; Unit )</ID>
+    <ID>LongMethod:WorkspaceSelectionDialog.kt$@Composable private fun WorkspaceSelectionItem( workspace: ai.rever.boss.components.workspaces.LayoutWorkspace, isSelected: Boolean, selectedPanelId: String?, onToggle: () -&gt; Unit, onPanelSelected: (String?) -&gt; Unit )</ID>
+    <ID>LongMethod:main.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>LongMethod:main.kt$private fun extractPty4jNatives(targetDir: File)</ID>
+    <ID>LongParameterList:AndroidCodeEditor.kt$( content: String, onContentChange: (String) -&gt; Unit, language: String, filePath: String, projectPath: String, modifier: Modifier, onModifiedStateChange: (Boolean) -&gt; Unit, onSaveRequested: suspend () -&gt; Boolean )</ID>
+    <ID>LongParameterList:AndroidFluckTabComponent.kt$( config: TabInfo, componentContext: ComponentContext, onTitleUpdate: (String) -&gt; Unit, onIconUpdate: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)? )</ID>
+    <ID>LongParameterList:AndroidFluckView.kt$( fileId: String, content: String, browser: Any?, browserViewState: Any?, browserLock: Any?, onContentChange: (String) -&gt; Unit, onTitleChange: (String) -&gt; Unit, onIconChange: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)?, onNavigationStateChange: ((isBack: Boolean) -&gt; Unit)?, onFaviconCached: ((String?) -&gt; Unit)?, onCloseTab: (() -&gt; Unit)? )</ID>
+    <ID>LongParameterList:BossActionButton.kt$( imageVector: ImageVector, text: String, isSelected: Boolean, modifier: Modifier, hintDirection: Panel = bottom, onClick: () -&gt; Unit )</ID>
+    <ID>LongParameterList:BossActionButton.kt$( imageVector: ImageVector? = null, leftLogo: (@Composable () -&gt; Unit)? = null, leftIcon: ImageVector? = null, text: String, fontSize: TextUnit = 13.sp, color: Color = BossTheme.colors.textPrimary, iconColor: Color? = null, // Optional separate icon color (defaults to color if null) iconSize: Dp = 20.dp, // Icon size for imageVector mode maxTextWidth: Dp? = null, // Optional max width for text (truncates with ellipsis) modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(2.dp), isSelected: Boolean = false, contextMenuItems: List&lt;ContextMenuItem&gt;? = null, contextDirection: Panel = bottom, hintText: String? = null, showHintWithDelay: Boolean = true, hintDirection: Panel = bottom, onClick: () -&gt; Unit = {} )</ID>
+    <ID>LongParameterList:BossAppScaffold.kt$( state: BossAppState, reveal: FocusModeRevealState, isFocusModeEnabled: Boolean, isAutoRevealEnabled: Boolean, revealOffsetDp: Dp, showTitleBar: Boolean, onToggleMaximize: (() -&gt; Unit)?, )</ID>
+    <ID>LongParameterList:BossAppState.kt$BossAppState$( val windowId: String, val isFirstWindow: Boolean, val panelRegistry: PanelRegistry, val tabRegistry: TabRegistry, val panelComponentStore: PanelComponentStore, val draggablePanelComponent: BossDraggableComponent, val tabDragComponent: TabDraggableComponent, val tabsComponent: BossTabsComponent, val splitViewState: SplitViewState, val splitViewOperations: SplitViewOperationsImpl, val workspaceDataProvider: WorkspaceDataProviderImpl, val windowProjectState: WindowProjectState, val windowRunnerState: WindowRunnerState, val windowGitState: WindowGitState, val coroutineScope: CoroutineScope, )</ID>
+    <ID>LongParameterList:BossMainWindowPanel.kt$( config: TabInfo, isSelected: Boolean, isFocused: Boolean, onClick: () -&gt; Unit, onClose: () -&gt; Unit, contextMenuItems: List&lt;ContextMenuItem&gt;, // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, panelId: String? = null, tabIndex: Int = -1, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>LongParameterList:BossMainWindowPanel.kt$( modifier: Modifier = Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {}, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossMainWindowPanel.kt$( modifier: Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossPanelTopBar.kt$( title: String?, isHovered: Boolean, onReset: (() -&gt; Unit)? = null, onReloadPlugin: (() -&gt; Unit)? = null, onOpenAsTab: (() -&gt; Unit)? = null, onCheckForUpdates: (() -&gt; Unit)? = null, onOpenEvolver: (() -&gt; Unit)? = null, onReportIssue: (() -&gt; Unit)? = null, onMinimize: () -&gt; Unit, updateAvailable: AvailablePluginUpdate? = null, onUpdateClick: (() -&gt; Unit)? = null, panelId: PanelId? = null, windowId: String? = null, dragModifier: Modifier = Modifier, content: (@Composable () -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossResizablePanel.kt$(modifier: Modifier, panel: Panel, isPanelVisible: Boolean = false, isMainVisible: Boolean = true, isRelative: Boolean = false, defaultWeight: Float = 1f, sideContent: (@Composable BoxScope.() -&gt; Unit)? = null, mainContent: (@Composable BoxScope.() -&gt; Unit)? = null)</ID>
+    <ID>LongParameterList:BossSearchBar.kt$( query: String, onQueryChange: (String) -&gt; Unit, placeholder: String = "Search...", modifier: Modifier = Modifier, leadingIcon: ImageVector = Icons.Outlined.Search, showClearButton: Boolean = true, onFocusChanged: ((Boolean) -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossTabButton.kt$( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>LongParameterList:BossTopBar.kt$( currentBranch: String?, localBranches: List&lt;GitBranchInfo&gt;, remoteBranches: List&lt;GitBranchInfo&gt;, stashList: List&lt;GitStashInfo&gt;, isLoading: Boolean, onCheckout: (String) -&gt; Unit, onMerge: (String) -&gt; Unit, onRebase: (String) -&gt; Unit, onCreateBranch: () -&gt; Unit, onCommit: () -&gt; Unit, onPull: () -&gt; Unit, onPush: () -&gt; Unit, onCreatePR: (() -&gt; Unit)?, onStash: () -&gt; Unit, onStashPop: (Int) -&gt; Unit, onRefresh: () -&gt; Unit )</ID>
+    <ID>LongParameterList:BossTopBar.kt$( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossTopBar.kt$( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onShowSettings: (() -&gt; Unit)? = null, onShowSearch: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossTopRunBar.kt$( selectedConfig: RunConfiguration?, runHistory: List&lt;RunConfiguration&gt;, isConfigRunning: (String) -&gt; Boolean, onSelect: (RunConfiguration) -&gt; Unit, onRun: (RunConfiguration) -&gt; Unit, onRerun: (RunConfiguration) -&gt; Unit, onStop: (RunConfiguration) -&gt; Unit, onDelete: (RunConfiguration) -&gt; Unit )</ID>
+    <ID>LongParameterList:BossWindow.kt$( current: DpSize, deltaWidthPx: Float, deltaHeightPx: Float, scaleX: Float, scaleY: Float, maxWidthDp: Float, maxHeightDp: Float, minWidthDp: Float = MIN_FIT_WIDTH_DP, minHeightDp: Float = MIN_FIT_HEIGHT_DP, )</ID>
+    <ID>LongParameterList:BossWindow.kt$( modifier: Modifier = Modifier, tabsComponent: BossTabsComponent, panelComponentStore: PanelComponentStore, splitViewState: SplitViewState? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {}, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) } )</ID>
+    <ID>LongParameterList:ChromiumDownloadDialog.kt$( progress: Float, downloadedMB: Long, totalMB: Long, status: String = "Installing BOSS Browser Engine...", error: String? = null, onCancel: () -&gt; Unit, onRetry: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:ChromiumDownloadDialog.kt$( progress: Float, downloadedMB: Long, totalMB: Long, status: String, error: String?, onCancel: () -&gt; Unit, onRetry: (() -&gt; Unit)? )</ID>
+    <ID>LongParameterList:CloneProjectDialog.kt$( repositoryUrl: String, targetDirectory: String, progressMessage: String, onProgress: (String) -&gt; Unit, onSuccess: (String) -&gt; Unit, onError: (String) -&gt; Unit )</ID>
+    <ID>LongParameterList:CodeEditor.kt$( content: String, onContentChange: (String) -&gt; Unit, language: String = "kotlin", filePath: String = "", projectPath: String = "", modifier: Modifier = Modifier )</ID>
+    <ID>LongParameterList:CodeEditor.kt$( content: String, onContentChange: (String) -&gt; Unit, language: String, filePath: String, projectPath: String, modifier: Modifier, onModifiedStateChange: (Boolean) -&gt; Unit, onSaveRequested: suspend () -&gt; Boolean )</ID>
+    <ID>LongParameterList:CollectionSelectionDialog.kt$( title: String, collections: List&lt;BookmarkCollection&gt;, excludeCollectionId: String? = null, mode: CollectionSelectionMode = CollectionSelectionMode.COPY, onDismiss: () -&gt; Unit, onConfirm: (selectedCollectionIds: Set&lt;String&gt;) -&gt; Unit )</ID>
+    <ID>LongParameterList:ConfigLoader.kt$ConfigLoader$( key: String, defaultValue: String?, envValue: String?, sysPropValue: String?, localProps: Properties, embeddedProps: Properties, )</ID>
+    <ID>LongParameterList:ConfirmationDialog.kt$( title: String, message: String, icon: ImageVector? = null, iconTint: Color = BossTheme.colors.warn, confirmText: String = "Confirm", confirmColor: Color = BossTheme.colors.alert, // destructive onDismiss: () -&gt; Unit, onConfirm: () -&gt; Unit )</ID>
+    <ID>LongParameterList:CrossDeviceAuthenticationDialog.kt$( qrCodeUrl: String?, challenge: String?, sessionId: String? = null, onDismiss: () -&gt; Unit, onSuccess: () -&gt; Unit, onCreateFluckTab: ((FluckTabInfo) -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:Dashboard.kt$( onOpenFile: (String) -&gt; Unit, onOpenUrl: (String) -&gt; Unit, onOpenProject: (Project) -&gt; Unit, selectedProject: Project = Project("No Project", "", 0L), onNewTab: () -&gt; Unit, onNewTerminal: () -&gt; Unit, onNewWindow: () -&gt; Unit, onOpenProjectDialog: () -&gt; Unit, onOpenFileDialog: () -&gt; Unit, onNewProject: () -&gt; Unit, onApplySplitTemplate: (SplitTemplate) -&gt; Unit, onActivatePlugin: (String) -&gt; Unit, onShowSettings: (() -&gt; Unit)? = null, modifier: Modifier = Modifier )</ID>
+    <ID>LongParameterList:DashboardSection.kt$( title: String, subtitle: String? = null, actionText: String? = null, onAction: (() -&gt; Unit)? = null, modifier: Modifier = Modifier, content: @Composable () -&gt; Unit )</ID>
+    <ID>LongParameterList:DefaultPlugin.kt$DefaultPlugin$( override val panelRegistry: PanelRegistry, override val tabRegistry: TabRegistry, val windowProjectState: WindowProjectState?, val windowGitState: WindowGitState? = null, private val _windowId: String? = null, private val workspaceManager: ai.rever.boss.components.workspaces.WorkspaceManager? = null, private val splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null )</ID>
+    <ID>LongParameterList:DesktopCodeEditor.kt$( content: String, onContentChange: (String) -&gt; Unit, language: String, filePath: String, projectPath: String, modifier: Modifier, onModifiedStateChange: (Boolean) -&gt; Unit, onSaveRequested: suspend () -&gt; Boolean )</ID>
+    <ID>LongParameterList:DesktopFluckTabComponent.kt$( config: TabInfo, componentContext: ComponentContext, onTitleUpdate: (String) -&gt; Unit, onIconUpdate: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)?, onFaviconCacheKeyUpdate: ((String?) -&gt; Unit)?, onCloseTab: (() -&gt; Unit)? )</ID>
+    <ID>LongParameterList:DesktopFluckView.kt$( fileId: String, content: String, browser: Any?, browserViewState: Any?, browserLock: Any?, onContentChange: (String) -&gt; Unit, onTitleChange: (String) -&gt; Unit, onIconChange: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)?, onNavigationStateChange: ((isBack: Boolean) -&gt; Unit)?, onFaviconCached: ((String?) -&gt; Unit)?, onCloseTab: (() -&gt; Unit)? )</ID>
+    <ID>LongParameterList:DesktopRunnerTerminalService.kt$RunnerTerminalService$( windowId: String, configId: String, command: String, workingDirectory: String?, tabTitle: String, isRerun: Boolean )</ID>
+    <ID>LongParameterList:DisplayUtils.kt$DisplayUtils$( widthPercentage: Float, heightPercentage: Float, minWidth: Int, minHeight: Int, maxWidth: Int, maxHeight: Int, taskbarOffset: Int = 0, windowType: String )</ID>
+    <ID>LongParameterList:EmptyContentScreen.kt$( icon: ImageVector, title: String, description: String, isSelected: Boolean, enabled: Boolean, onClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongParameterList:Fluck.kt$( config: TabInfo, componentContext: ComponentContext, onTitleUpdate: (String) -&gt; Unit, onIconUpdate: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)? = null, onFaviconCacheKeyUpdate: ((String?) -&gt; Unit)? = null, onCloseTab: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:Fluck.kt$( error: Throwable, url: String, retryCount: Int = 0, maxRetries: Int = 3, onRetry: (() -&gt; Unit)? = null, onReset: (() -&gt; Unit)? = null, onResetBrowser: (() -&gt; Unit)? = null, onRetryEngine: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:Fluck.kt$FluckTabComponent$( override val config: TabInfo, private val componentContext: ComponentContext, private val onTitleUpdate: (String) -&gt; Unit, private val onIconUpdate: (ImageVector) -&gt; Unit, private val onTabIconUpdate: (TabIcon) -&gt; Unit, private val onOpenInNewTab: (String) -&gt; Unit, private val onNavigationUpdate: ((String, String) -&gt; Unit)? = null, private val onFaviconCacheKeyUpdate: ((String?) -&gt; Unit)? = null, private val onCloseTab: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:Fluck.kt$FluckTabInfo$( id: String = this.id, typeId: TabTypeId = this.typeId, _title: String = this._title, _icon: ImageVector = this._icon, _tabIcon: TabIcon? = this._tabIcon, url: String = this.url, _currentUrl: String = this._currentUrl, _currentZoomLevel: Double = this._currentZoomLevel, faviconCacheKey: String? = this.faviconCacheKey, navigationHistory: MutableList&lt;Pair&lt;String, String&gt;&gt;? = null, historyIndex: Int = this.historyIndex )</ID>
+    <ID>LongParameterList:Fluck.kt$FluckTabInfo$( override val id: String, override val typeId: TabTypeId, private var _title: String, private var _icon: ImageVector = Icons.Outlined.Language, private var _tabIcon: TabIcon? = null, val url: String = "", // Initial URL @Volatile private var _currentUrl: String = url, // Current URL being viewed (volatile for visibility) val navigationHistory: MutableList&lt;Pair&lt;String, String&gt;&gt; = mutableListOf(), // List of (title, url) pairs @Volatile var historyIndex: Int = -1, // Current position in navigation history private var _currentZoomLevel: Double = 1.0, // Current zoom level (1.0 = 100%) var faviconCacheKey: String? = null // Cache key for persisted favicon )</ID>
+    <ID>LongParameterList:FluckView.kt$( fileId: String, content: String, browser: Any? = null, // Browser instance (platform-specific type) browserViewState: Any? = null, // Browser view state (platform-specific type) browserLock: Any? = null, // ReentrantReadWriteLock for thread-safe browser access onContentChange: (String) -&gt; Unit, onTitleChange: (String) -&gt; Unit = {}, onIconChange: (ImageVector) -&gt; Unit = {}, onTabIconUpdate: (TabIcon) -&gt; Unit = {}, onOpenInNewTab: (String) -&gt; Unit = {}, onNavigationUpdate: ((String, String) -&gt; Unit)? = null, onNavigationStateChange: ((isBack: Boolean) -&gt; Unit)? = null, onFaviconCached: ((String?) -&gt; Unit)? = null, onCloseTab: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:FormFieldDetector.kt$FormFieldDetector$( inputType: String, fieldName: String, fieldId: String, placeholder: String, autocomplete: String, className: String, ariaLabel: String )</ID>
+    <ID>LongParameterList:GlobalSearchDialog.kt$( projectPath: String, workspaceManager: WorkspaceManager, onDismiss: () -&gt; Unit, onFileSelect: (String) -&gt; Unit, onTabSelect: ((windowId: String, panelId: String, tabId: String) -&gt; Unit)? = null, onBookmarkSelect: ((bookmarkId: String, collectionId: String) -&gt; Unit)? = null, onRunConfigSelect: ((configId: String) -&gt; Unit)? = null, onCommandSelect: ((actionId: String) -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:GlobalSearchDialog.kt$( result: SearchResult.BookmarkResult, isSelected: Boolean, isHovered: Boolean, scale: Float, backgroundColor: Color, interactionSource: MutableInteractionSource, onClick: () -&gt; Unit )</ID>
+    <ID>LongParameterList:GlobalSearchDialog.kt$( result: SearchResult.CommandResult, isSelected: Boolean, isHovered: Boolean, scale: Float, backgroundColor: Color, interactionSource: MutableInteractionSource, onClick: () -&gt; Unit )</ID>
+    <ID>LongParameterList:GlobalSearchDialog.kt$( result: SearchResult.FileResult, isSelected: Boolean, isHovered: Boolean, scale: Float, backgroundColor: Color, interactionSource: MutableInteractionSource, onClick: () -&gt; Unit )</ID>
+    <ID>LongParameterList:GlobalSearchDialog.kt$( result: SearchResult.RunConfigResult, isSelected: Boolean, isHovered: Boolean, scale: Float, backgroundColor: Color, interactionSource: MutableInteractionSource, onClick: () -&gt; Unit )</ID>
+    <ID>LongParameterList:GlobalSearchDialog.kt$( result: SearchResult.TabResult, isSelected: Boolean, isHovered: Boolean, scale: Float, backgroundColor: Color, interactionSource: MutableInteractionSource, onClick: () -&gt; Unit )</ID>
+    <ID>LongParameterList:IosCodeEditor.kt$( content: String, onContentChange: (String) -&gt; Unit, language: String, filePath: String, projectPath: String, modifier: Modifier, onModifiedStateChange: (Boolean) -&gt; Unit, onSaveRequested: suspend () -&gt; Boolean )</ID>
+    <ID>LongParameterList:IosFluckTabComponent.kt$( config: TabInfo, componentContext: ComponentContext, onTitleUpdate: (String) -&gt; Unit, onIconUpdate: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)? )</ID>
+    <ID>LongParameterList:IosFluckView.kt$( fileId: String, content: String, browser: Any?, browserViewState: Any?, browserLock: Any?, onContentChange: (String) -&gt; Unit, onTitleChange: (String) -&gt; Unit, onIconChange: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)?, onNavigationStateChange: ((isBack: Boolean) -&gt; Unit)?, onFaviconCached: ((String?) -&gt; Unit)?, onCloseTab: (() -&gt; Unit)? )</ID>
+    <ID>LongParameterList:KernelBootstrap.kt$KernelBootstrap$( performanceDataProvider: PerformanceDataProvider? = null, downloadDataProvider: DownloadDataProvider? = null, gitDataProvider: GitDataProvider? = null, logDataProvider: LogDataProvider? = null, activeTabsProvider: ActiveTabsProvider? = null, secretDataProvider: SecretDataProvider? = null, supabaseDataProvider: SupabaseDataProvider? = null, splitViewOperations: SplitViewOperations? = null, contextMenuProvider: ContextMenuProvider? = null, runConfigurationDataProvider: RunConfigurationDataProvider? = null, panelEventProvider: PanelEventProvider? = null, roleManagementProvider: RoleManagementProvider? = null, directoryPickerProvider: DirectoryPickerProvider? = null, projectDataProvider: ProjectDataProvider? = null, notificationProvider: NotificationProvider? = null, )</ID>
+    <ID>LongParameterList:KeyBinding.kt$KeyBinding.Companion$( actionId: String, key: Key, isMetaPressed: Boolean, isCtrlPressed: Boolean, isShiftPressed: Boolean, isAltPressed: Boolean, context: ShortcutContext = ShortcutContext.GLOBAL, category: String = "Other", description: String = "" )</ID>
+    <ID>LongParameterList:KeyBinding.kt$KeyBinding.Companion$( actionId: String, key: String, vararg additionalModifiers: String, context: ShortcutContext = ShortcutContext.GLOBAL, category: String = "Other", description: String = "" )</ID>
+    <ID>LongParameterList:KeyBinding.kt$KeyBinding.Companion$( actionId: String, primaryKey: String, primaryModifiers: List&lt;String&gt;, alternates: List&lt;KeyStroke&gt;, context: ShortcutContext = ShortcutContext.GLOBAL, category: String = "Other", description: String = "" )</ID>
+    <ID>LongParameterList:KeyCaptureDialog.kt$( actionId: String, actionDescription: String, context: ShortcutContext, category: String, currentBinding: KeyBinding?, onKeyCaptured: (KeyBinding) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongParameterList:LoginFormScreen.kt$( viewModel: LoginViewModel, onLoginSuccess: () -&gt; Unit, isLoading: Boolean, errorMessage: String?, onMagicLinkSent: (String) -&gt; Unit = {}, onPasskeyAuthInitiated: (String) -&gt; Unit = {}, onPasskeySelectionRequired: (String) -&gt; Unit = {} )</ID>
+    <ID>LongParameterList:MagicLinkWaitingScreen.kt$( email: String, viewModel: LoginViewModel, onBack: () -&gt; Unit, onSuccess: () -&gt; Unit, isLoading: Boolean = false, errorMessage: String? = null )</ID>
+    <ID>LongParameterList:NewTabDialog.kt$( onDismiss: () -&gt; Unit, onCreateTab: (type: TabType, path: String) -&gt; Unit, tabRegistry: TabRegistry, initialTabType: TabType? = null, /** * Opens a [TabInfo] built by a plugin tab type's [TabTypeInfo.createTabInfo]. * When null, plugin-registered tab types are not offered (legacy callers). */ onCreateTabInfo: ((TabInfo) -&gt; Unit)? = null, projectPath: String? = null, windowId: String? = null )</ID>
+    <ID>LongParameterList:PasskeyService.kt$PasskeyService$( challenge: ByteArray, allowedCredentials: List&lt;String&gt;? = null, rpId: String = "api.risaboss.com", userEmail: String, sessionId: String? = null, allowedCredentialTransports: Map&lt;String, List&lt;String&gt;&gt;? = null )</ID>
+    <ID>LongParameterList:PluginCrashFallbackUI.kt$( displayName: String, errorMessage: String?, restartCount: Int, maxRestarts: Int, onRestart: () -&gt; Unit, onRunInProcess: () -&gt; Unit, )</ID>
+    <ID>LongParameterList:PluginCrashFallbackUI.kt$( pluginId: String, displayName: String, processState: PluginProcessState, errorMessage: String? = null, restartCount: Int = 0, maxRestarts: Int = 3, onRestart: () -&gt; Unit = {}, onRunInProcess: () -&gt; Unit = {}, )</ID>
+    <ID>LongParameterList:PluginInstallWizard.kt$( category: PluginCategory, plugins: List&lt;WizardPluginInfo&gt;, isPluginSelected: (String) -&gt; Boolean, onTogglePlugin: (String) -&gt; Unit, onSelectAll: () -&gt; Unit, onDeselectAll: () -&gt; Unit )</ID>
+    <ID>LongParameterList:PluginInstallWizard.kt$( currentStep: PluginInstallStep, isInstalling: Boolean, hasSelectedPlugins: Boolean, onBack: () -&gt; Unit, onNext: () -&gt; Unit, onSkip: () -&gt; Unit, onFinish: () -&gt; Unit )</ID>
+    <ID>LongParameterList:RunnerTerminalEventBus.kt$RunnerTerminalEventBus$( terminalId: String, command: String, configId: String, configName: String, workingDirectory: String?, isRerun: Boolean, sourceWindowId: String )</ID>
+    <ID>LongParameterList:RunnerTerminalService.kt$RunnerTerminalService$( windowId: String, configId: String, command: String, workingDirectory: String?, tabTitle: String, isRerun: Boolean = false )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, buttonText: String, onClick: () -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true, isDestructive: Boolean = false )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, checked: Boolean, onCheckedChange: (Boolean) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, color: Color, onColorChange: (Color) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, options: List&lt;String&gt;, selectedOption: String, onOptionSelected: (String) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, sections: Map&lt;String, List&lt;String&gt;&gt;, selectedOption: String, onOptionSelected: (String) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, value: Float, onValueChange: (Float) -&gt; Unit, modifier: Modifier = Modifier, onValueChangeFinished: (() -&gt; Unit)? = null, valueRange: ClosedFloatingPointRange&lt;Float&gt; = 0f..1f, steps: Int = 0, valueDisplay: (Float) -&gt; String = { "%.1f".format(it) }, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, value: Int, onValueChange: (Int) -&gt; Unit, modifier: Modifier = Modifier, range: IntRange = Int.MIN_VALUE..Int.MAX_VALUE, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, value: Long, onValueChange: (Long) -&gt; Unit, modifier: Modifier = Modifier, range: LongRange = Long.MIN_VALUE..Long.MAX_VALUE, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, value: String, onValueChange: (String) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, fileExtensions: List&lt;String&gt; = emptyList(), enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SettingsComponents.kt$( label: String, value: String, onValueChange: (String) -&gt; Unit, modifier: Modifier = Modifier, placeholder: String = "", description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:SplitView.kt$( node: SplitNode, splitViewState: SplitViewState, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {}, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:SplitView.kt$( splitViewState: SplitViewState, modifier: Modifier = Modifier, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {}, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:SplitView.kt$SplitViewState$( node: SplitNode, workspaceId: String, workspaceName: String, windowId: String, result: MutableList&lt;ActiveTab&gt;, seenTabIds: MutableSet&lt;String&gt; )</ID>
+    <ID>LongParameterList:TerminalLinkOpener.kt$( url: String, mode: TerminalLinkOpenMode, splitViewState: SplitViewState, sourceTerminalId: String? = null, scope: CoroutineScope, windowId: String? = null )</ID>
+    <ID>LongParameterList:TerminalLinkOpener.kt$( url: String, mode: TerminalLinkOpenMode, splitViewState: SplitViewState, validSourcePanelId: String, isFile: Boolean, fileLine: Int = 0, fileColumn: Int = 0, scope: CoroutineScope, windowId: String? = null )</ID>
+    <ID>LongParameterList:VersionSelectionDialog.kt$( currentVersion: Version, versions: List&lt;VersionInfo&gt;, isLoading: Boolean, error: String? = null, onVersionSelected: (VersionInfo) -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
+    <ID>LongParameterList:WasmCodeEditor.kt$( content: String, onContentChange: (String) -&gt; Unit, language: String, filePath: String, projectPath: String, modifier: Modifier, onModifiedStateChange: (Boolean) -&gt; Unit, onSaveRequested: suspend () -&gt; Boolean )</ID>
+    <ID>LongParameterList:WasmFluckTabComponent.kt$( config: TabInfo, componentContext: ComponentContext, onTitleUpdate: (String) -&gt; Unit, onIconUpdate: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)? )</ID>
+    <ID>LongParameterList:WasmFluckView.kt$( fileId: String, content: String, browser: Any?, browserViewState: Any?, browserLock: Any?, onContentChange: (String) -&gt; Unit, onTitleChange: (String) -&gt; Unit, onIconChange: (ImageVector) -&gt; Unit, onTabIconUpdate: (TabIcon) -&gt; Unit, onOpenInNewTab: (String) -&gt; Unit, onNavigationUpdate: ((String, String) -&gt; Unit)?, onNavigationStateChange: ((isBack: Boolean) -&gt; Unit)?, onFaviconCached: ((String?) -&gt; Unit)?, onCloseTab: (() -&gt; Unit)? )</ID>
+    <ID>LongParameterList:WizardComponents.kt$( title: String, description: String, icon: ImageVector? = null, isChecked: Boolean, onCheckedChange: (Boolean) -&gt; Unit, enabled: Boolean = true, modifier: Modifier = Modifier )</ID>
+    <ID>LongParameterList:WizardComponents.kt$( title: String, description: String, icon: ImageVector? = null, isSelected: Boolean, onClick: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongParameterList:WizardDialog.kt$( title: String, subtitle: String? = null, onDismiss: () -&gt; Unit, currentStep: Int, totalSteps: Int, onBack: (() -&gt; Unit)?, onNext: () -&gt; Unit, isLastStep: Boolean, nextButtonText: String = if (isLastStep) "Finish" else "Next", nextButtonEnabled: Boolean = true, showCloseButton: Boolean = true, dismissOnClickOutside: Boolean = true, width: Dp = 650.dp, minHeight: Dp = 500.dp, maxHeight: Dp = 600.dp, content: @Composable () -&gt; Unit )</ID>
+    <ID>LoopWithTooManyJumpStatements:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$for</ID>
+    <ID>LoopWithTooManyJumpStatements:BrowserServiceImpl.kt$BrowserServiceImpl$for</ID>
+    <ID>LoopWithTooManyJumpStatements:CLIInstaller.kt$CLIInstaller$for</ID>
+    <ID>LoopWithTooManyJumpStatements:DesktopGitService.kt$GitService$while</ID>
+    <ID>LoopWithTooManyJumpStatements:FileIndexer.kt$FileIndexer$for</ID>
+    <ID>LoopWithTooManyJumpStatements:GitHubUpdateSource.kt$GitHubUpdateSource$while</ID>
+    <ID>LoopWithTooManyJumpStatements:GlobalSearchDialog.kt$for</ID>
+    <ID>LoopWithTooManyJumpStatements:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$for</ID>
+    <ID>LoopWithTooManyJumpStatements:PluginInstallService.kt$PluginInstallService$for</ID>
+    <ID>LoopWithTooManyJumpStatements:PluginStoreSetup.kt$PluginStoreSetup$for</ID>
+    <ID>LoopWithTooManyJumpStatements:ReleaseNotesMarkdown.kt$while</ID>
+    <ID>MatchingDeclarationName:AndroidBrowserAccessor.kt$BrowserAccessor</ID>
+    <ID>MatchingDeclarationName:AndroidDirectoryPickerProviderImpl.kt$DirectoryPickerProviderImpl : DirectoryPickerProvider</ID>
+    <ID>MatchingDeclarationName:AndroidUpdateService.kt$UpdateService</ID>
+    <ID>MatchingDeclarationName:AndroidWorkspaceFileManager.kt$WorkspaceFileManager</ID>
+    <ID>MatchingDeclarationName:BrowserSettingsConfig.kt$BrowserSettings</ID>
+    <ID>MatchingDeclarationName:CodeBase.kt$ProjectState</ID>
+    <ID>MatchingDeclarationName:CollectionSelectionDialog.kt$CollectionSelectionMode</ID>
+    <ID>MatchingDeclarationName:ContextMenu.kt$ContextMenuItem</ID>
+    <ID>MatchingDeclarationName:DesktopCommandProcessor.kt$CommandProcessor</ID>
+    <ID>MatchingDeclarationName:DesktopDirectoryPickerProviderImpl.kt$DirectoryPickerProviderImpl : DirectoryPickerProvider</ID>
+    <ID>MatchingDeclarationName:DesktopGitService.kt$GitService</ID>
+    <ID>MatchingDeclarationName:DesktopGitTerminalService.kt$GitTerminalService</ID>
+    <ID>MatchingDeclarationName:DesktopProjectCreationService.kt$ProjectCreationService</ID>
+    <ID>MatchingDeclarationName:DesktopRunConfigurationManager.kt$RunConfigurationManager</ID>
+    <ID>MatchingDeclarationName:DesktopRunExecutionService.kt$RunExecutionService</ID>
+    <ID>MatchingDeclarationName:DesktopRunnerSettingsManager.kt$RunnerSettingsManager</ID>
+    <ID>MatchingDeclarationName:DesktopRunnerTerminalService.kt$RunnerTerminalService</ID>
+    <ID>MatchingDeclarationName:DesktopStartupSettingsManager.kt$StartupSettingsManager</ID>
+    <ID>MatchingDeclarationName:DesktopTerminalLinkSettingsManager.kt$TerminalLinkSettingsManager</ID>
+    <ID>MatchingDeclarationName:DesktopUpdateService.kt$UpdateService</ID>
+    <ID>MatchingDeclarationName:DesktopWindowOperations.kt$WindowOperations</ID>
+    <ID>MatchingDeclarationName:DesktopWorkspaceFileManager.kt$WorkspaceFileManager</ID>
+    <ID>MatchingDeclarationName:DesktopWorkspaceSettingsManager.kt$WorkspaceSettingsManager</ID>
+    <ID>MatchingDeclarationName:FluckPanelProviders.kt$FluckPanelContentProviderImpl : FluckPanelContentProvider</ID>
+    <ID>MatchingDeclarationName:FocusModeReveal.kt$FocusModeRevealState</ID>
+    <ID>MatchingDeclarationName:IOSUpdateService.kt$UpdateService</ID>
+    <ID>MatchingDeclarationName:IosBrowserAccessor.kt$BrowserAccessor</ID>
+    <ID>MatchingDeclarationName:IosDirectoryPickerProviderImpl.kt$DirectoryPickerProviderImpl : DirectoryPickerProvider</ID>
+    <ID>MatchingDeclarationName:IosWorkspaceFileManager.kt$WorkspaceFileManager</ID>
+    <ID>MatchingDeclarationName:NewTabDialog.android.kt$UrlHistoryProvider</ID>
+    <ID>MatchingDeclarationName:NewTabDialog.desktop.kt$UrlHistoryProvider</ID>
+    <ID>MatchingDeclarationName:NewTabDialog.ios.kt$UrlHistoryProvider</ID>
+    <ID>MatchingDeclarationName:NewTabDialog.wasm.kt$UrlHistoryProvider</ID>
+    <ID>MatchingDeclarationName:PluginCrashFallbackUI.kt$PluginProcessState</ID>
+    <ID>MatchingDeclarationName:PresetDefinitions.kt$EmacsPresetDefinition</ID>
+    <ID>MatchingDeclarationName:ReleaseNotesMarkdown.kt$NotesBlock</ID>
+    <ID>MatchingDeclarationName:SettingsSidebar.kt$SettingsSection</ID>
+    <ID>MatchingDeclarationName:SidebarIconLimits.kt$SidebarIconRail</ID>
+    <ID>MatchingDeclarationName:SupabaseModels.kt$User</ID>
+    <ID>MatchingDeclarationName:WasmBrowserAccessor.kt$BrowserAccessor</ID>
+    <ID>MatchingDeclarationName:WasmDirectoryPickerProviderImpl.kt$DirectoryPickerProviderImpl : DirectoryPickerProvider</ID>
+    <ID>MatchingDeclarationName:WasmUpdateService.kt$UpdateService</ID>
+    <ID>MatchingDeclarationName:WasmWorkspaceFileManager.kt$WorkspaceFileManager</ID>
+    <ID>MaxLineLength:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$if</ID>
+    <ID>MaxLineLength:AdvancedSettings.kt$"Max plugin allocation: ${"%.1f".format(totalPluginMb / 1024f)} GB (16 plugins × ${pluginHeap.toInt()} MB)"</ID>
+    <ID>MaxLineLength:AdvancedSettings.kt$var pluginInitHeap by remember(perfSettings) { mutableStateOf(perfSettings.pluginJvmInitialHeapMb.toFloat()) }</ID>
+    <ID>MaxLineLength:AndroidFileScanner.kt$actual suspend</ID>
+    <ID>MaxLineLength:AndroidFileScanner.kt$hasChildren = if (isDirectory) children.isNotEmpty() || directoryHasChildren(file.absolutePath, showHidden) else false</ID>
+    <ID>MaxLineLength:AndroidFileScanner.kt$private</ID>
+    <ID>MaxLineLength:AndroidWorkspaceFileManager.kt$WorkspaceFileManager$get() = appContext ?: throw IllegalStateException("WorkspaceFileManager not initialized. Call WorkspaceFileManager.init() in your Application or Activity.")</ID>
+    <ID>MaxLineLength:AuthOptionsManager.kt$AuthOptionsManager$logger.debug(LogCategory.AUTH, "Stored available credentials", mapOf("count" to userExistence.availableCredentials.size))</ID>
+    <ID>MaxLineLength:AuthScreenContainer.kt$logger.debug(LogCategory.AUTH, "AuthState changed", mapOf("state" to authState.toString(), "currentScreen" to currentScreen.toString()))</ID>
+    <ID>MaxLineLength:AuthScreenContainer.kt$logger.debug(LogCategory.PASSKEY, "Passkey state changed to ShowEmbeddedBrowser, navigating to browser screen")</ID>
+    <ID>MaxLineLength:BookmarkDialog.kt$imageVector = if (workspacesSectionExpanded) Icons.Filled.ExpandMore else Icons.Filled.ChevronRight</ID>
+    <ID>MaxLineLength:BookmarkDialog.kt$var selectedCollections by remember { mutableStateOf(if (defaultCollection != null) setOf(defaultCollection) else emptySet()) }</ID>
+    <ID>MaxLineLength:BookmarkDialog.kt$workspacePanelSelections</ID>
+    <ID>MaxLineLength:BossAppDialogs.kt$FileEventBus.openFile(filePath, sourceWindowId = windowId, projectPath = selectedProject.path)</ID>
+    <ID>MaxLineLength:BossAppDialogs.kt$openTerminalLink(state.pendingTerminalLinkUrl, mode, splitViewState, state.pendingTerminalSourceId, coroutineScope, windowId = windowId)</ID>
+    <ID>MaxLineLength:BossAppEventBusEffects.kt$ProcessingState(totalTabs, isProcessingURLs, isProcessingTerminals, isProcessingFiles, state.workspaceRestorationComplete)</ID>
+    <ID>MaxLineLength:BossAppEventBusEffects.kt$openTerminalLink(event.url, settings.openMode, splitViewState, event.sourceTerminalId, this, windowId = windowId)</ID>
+    <ID>MaxLineLength:BossAppMenuActionEffects.kt$StatusMessageManager.showMessage("Failed to reload plugin: ${result.exceptionOrNull()?.message}")</ID>
+    <ID>MaxLineLength:BossAppMenuActionEffects.kt$val currentLayout = extractCurrentWorkspace(splitViewState, windowProjectState.selectedProject.value.path)</ID>
+    <ID>MaxLineLength:BossAppStartupEffects.kt$// CRITICAL: Mark handlers as ready AFTER Last Session loads (or after determining no session exists)</ID>
+    <ID>MaxLineLength:BossAppStartupEffects.kt$DisposableEffect</ID>
+    <ID>MaxLineLength:BossAppStartupEffects.kt$ai.rever.boss.components.plugin.InstalledPluginRef(it.manifest.pluginId, it.manifest.displayName, it.manifest.version)</ID>
+    <ID>MaxLineLength:BossAppStartupEffects.kt$logger.error(LogCategory.WORKSPACE, "Last Session restore failed - continuing startup", error = e)</ID>
+    <ID>MaxLineLength:BossAppStartupEffects.kt$logger.warn(LogCategory.SYSTEM, "Startup plugin load still running after 30s; skipping wizard check")</ID>
+    <ID>MaxLineLength:BossAppWithAuth.kt$// Route non-auth deep links (boss://url, boss://file, boss://folder, boss://terminal, boss://workspace)</ID>
+    <ID>MaxLineLength:BossAppWithAuth.kt$logger.debug(LogCategory.AUTH, "Checking authentication status", mapOf("sessionId" to id))</ID>
+    <ID>MaxLineLength:BossDraggableComponent.kt$BossDraggableComponent$dropTgt = TabDropTarget.SplitPanel(panelId, SplitOrientation.HORIZONTAL)</ID>
+    <ID>MaxLineLength:BossDraggableComponent.kt$BossDraggableComponent$dropTgt = TabDropTarget.SplitPanel(panelId, SplitOrientation.VERTICAL)</ID>
+    <ID>MaxLineLength:BossDraggableComponent.kt$BossDraggableComponent$val currentTargetItems = itemsBySlot[currentDropTarget]?.toList() ?: emptyList() // Use current items in target</ID>
+    <ID>MaxLineLength:BossEditorSettings.kt$PluginSettingsUnavailableNotice("Editor settings are provided by the Code Editor plugin, which isn't loaded yet.")</ID>
+    <ID>MaxLineLength:BossLogger.kt$BossLogger$fun</ID>
+    <ID>MaxLineLength:BossLoggerTest.kt$BossLoggerTest$private val testLogDir = File(System.getProperty("java.io.tmpdir"), "boss-logger-test-${System.currentTimeMillis()}")</ID>
+    <ID>MaxLineLength:BossMainWindowPanel.kt$BookmarkAPIAccess.addFavoriteWorkspace(currentWorkspace.id, currentWorkspace.name)</ID>
+    <ID>MaxLineLength:BossMainWindowPanel.kt$BossTabsComponent.BossTabUpdateProvider$bossMainWindowPanelLogger</ID>
+    <ID>MaxLineLength:BossMainWindowPanel.kt$add</ID>
+    <ID>MaxLineLength:BossMainWindowPanel.kt$bossMainWindowPanelLogger.debug(LogCategory.UI, "Plugin activation requested", mapOf("pluginId" to pluginId))</ID>
+    <ID>MaxLineLength:BossMainWindowPanel.kt$val pluginLogger = if (sandbox != null) remember { BossLogger.forComponent("BossMainPanelContent") } else null</ID>
+    <ID>MaxLineLength:BossPanelTopBar.kt$contentDescription = "Update available: v${updateAvailable.currentVersion} → v${updateAvailable.newVersion}"</ID>
+    <ID>MaxLineLength:BossPanelTopBar.kt$onCheckForUpdates?.let { cb -&gt; add(ContextMenuItem(text = "Check for Updates", icon = Icons.Outlined.Upgrade, onClick = cb)) }</ID>
+    <ID>MaxLineLength:BossPanelTopBar.kt$onOpenEvolver?.let { cb -&gt; add(ContextMenuItem(text = "Open Evolver", icon = Icons.Outlined.MonitorHeart, onClick = cb)) }</ID>
+    <ID>MaxLineLength:BossPanelTopBar.kt$onReloadPlugin?.let { cb -&gt; add(ContextMenuItem(text = "Reload Plugin", icon = Icons.Outlined.Refresh, onClick = cb)) }</ID>
+    <ID>MaxLineLength:BossPanelTopBar.kt$onReportIssue?.let { cb -&gt; add(ContextMenuItem(text = "Report Issue", icon = Icons.Outlined.BugReport, onClick = cb)) }</ID>
+    <ID>MaxLineLength:BossPanelTopBar.kt$onReset?.let { cb -&gt; add(ContextMenuItem(text = "Restart Panel", icon = Icons.Outlined.RestartAlt, onClick = cb)) }</ID>
+    <ID>MaxLineLength:BossScrollBar.kt$)</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.alert", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.data", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.ink", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.line", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.ok", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.panel", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.raised", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.signal", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.textMuted", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.textPrimary", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.textSecondary", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTheme.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.warn", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossTopBar.kt$BossTopLeftBar(workspaceManager, onApplyWorkspace, getCurrentWorkspace, onShowTopOfMind, onNewProject, onCloneProject)</ID>
+    <ID>MaxLineLength:BossTopBar.kt$gitSuccessMessage = "Committed: ${message.lines().first().take(50)}${if (message.length &gt; 50) "..." else ""}"</ID>
+    <ID>MaxLineLength:BossTopBar.kt$hintText = if (selectedProject.path.isEmpty()) "Click to open a project" else "Current Project: ${selectedProject.path}"</ID>
+    <ID>MaxLineLength:BossTopBar.kt$text = "stash@{${stash.index}}: ${stash.message.take(40)}${if (stash.message.length &gt; 40) "..." else ""}"</ID>
+    <ID>MaxLineLength:BossTopBar.kt$text = { Text("The project \"$projectName\" no longer exists. It has been removed from the recent projects list.") }</ID>
+    <ID>MaxLineLength:BossTopRunBar.kt$secondaryTrailingIconColor = if (isRunning) BossTheme.colors.alert else BossTheme.colors.textSecondary</ID>
+    <ID>MaxLineLength:BossWindow.kt$"You can change this anytime in System Settings \u203A Privacy &amp; Security \u203A Screen Recording."</ID>
+    <ID>MaxLineLength:BossWindow.kt$// Use IO dispatcher for resource disposal per CLAUDE.md threading guidelines</ID>
+    <ID>MaxLineLength:BossWindow.kt$TextButton(onClick = { ScreenCaptureNotifier.resolvePermissionRationale(false) }) { Text("Not now") }</ID>
+    <ID>MaxLineLength:BossWindow.kt$TextButton(onClick = { ScreenCaptureNotifier.resolvePermissionRationale(true) }) { Text("Continue") }</ID>
+    <ID>MaxLineLength:BossWindow.kt$envFile.writeText(if (it) "BOSS_MODE=KERNEL\n" else "# BOSS_MODE=KERNEL\n", Charsets.UTF_8)</ID>
+    <ID>MaxLineLength:BossWindow.kt$placement = if (windowState.windowType == WindowType.MAIN) WindowPlacement.Maximized else WindowPlacement.Floating</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$logger.debug(LogCategory.BROWSER, "Popup LoadStarted", mapOf("url" to loadedUrl, "isDownload" to isDownload))</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$logger.debug(LogCategory.BROWSER, "Popup with immediate URL", mapOf("url" to targetUrl, "isDownload" to isDownload))</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$logger.error(LogCategory.BROWSER, "getBrowserState failed: $errorType", mapOf("details" to (e.message ?: "none")))</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$logger.warn(LogCategory.BROWSER, "Exception during browser disposal", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$logger.warn(LogCategory.BROWSER, "getBrowserState: Could not create BrowserViewState - no valid window available")</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$logger.warn(LogCategory.BROWSER, "isBrowserValid: Exception checking browser state", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:BrowserFunctions.kt$subscriptions</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$code.length == 4 &amp;&amp; code.startsWith("Key") -&gt; runCatching { KeyCode.valueOf("KEY_CODE_${code[3]}") }.getOrDefault(KeyCode.UNKNOWN)</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$code.length == 6 &amp;&amp; code.startsWith("Digit") -&gt; runCatching { KeyCode.valueOf("KEY_CODE_${code[5]}") }.getOrDefault(KeyCode.UNKNOWN)</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$else -&gt; logger.warn(LogCategory.BROWSER, "Co-browse input unknown kind", mapOf("handleId" to id, "kind" to kind))</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$logger.debug(LogCategory.BROWSER, "Co-browse control ${if (granted) "granted" else "revoked"}", mapOf("handleId" to id))</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$logger.debug(LogCategory.BROWSER, "Context menu and navigation trackers injected", mapOf("handleId" to id))</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$logger.error(LogCategory.BROWSER, "Co-browse recorder bundle missing; capture not started", mapOf("handleId" to id))</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$logger.warn(LogCategory.BROWSER, "Co-browse input dispatch failed", mapOf("handleId" to id, "kind" to kind), error = e)</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$logger.warn(LogCategory.BROWSER, "JS execution error", mapOf("handleId" to id, "error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:BrowserHandleImpl.kt$BrowserHandleImpl$val bufferedImage = java.awt.image.BufferedImage(width, height, java.awt.image.BufferedImage.TYPE_INT_ARGB)</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl$Files.move(tmp.toPath(), metaFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl$logger.debug(LogCategory.BROWSER, "Forcing Secure on a SameSite=None cookie (Chromium requires it)", mapOf("name" to c.name))</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl$mapOf("name" to c.name, "url" to LogSanitizer.maskUriParams(c.url), "error" to (e.message ?: "unknown"))</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl$meta[it.namedId] = NamedMeta(it.namedId, it.profileName, it.profile.path(), System.currentTimeMillis())</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl$val profile = FluckEngine.findProfile(fence) ?: run { evictIfNeeded(); FluckEngine.newRpaProfile(fence) }</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl.NamedMeta$internal</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$ai.rever.boss.components.events.WorkspaceEventBus.loadWorkspace(file.absolutePath, sourceWindowId = focusedWindowId)</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.debug(LogCategory.SYSTEM, "File handler not ready, queueing file", mapOf("path" to command.filePath))</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.debug(LogCategory.SYSTEM, "File handler ready, executing immediately", mapOf("path" to command.filePath))</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.debug(LogCategory.SYSTEM, "Workspace handler not ready, queueing", mapOf("path" to file.absolutePath))</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.warn(LogCategory.SYSTEM, "Invalid file path (security check failed)", mapOf("path" to file.absolutePath))</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.warn(LogCategory.SYSTEM, "Invalid folder path (security check failed)", mapOf("path" to folder.absolutePath))</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.warn(LogCategory.SYSTEM, "Invalid workspace path (security check failed)", mapOf("path" to file.absolutePath))</ID>
+    <ID>MaxLineLength:CLICommandHandler.kt$CLICommandHandler$logger.warn(LogCategory.SYSTEM, "No window focused, cannot load workspace", mapOf("path" to file.absolutePath))</ID>
+    <ID>MaxLineLength:CLIInstaller.kt$CLIInstaller$logger.warn(LogCategory.SYSTEM, "Failed to update shell config", mapOf("configPath" to configPath), error = e)</ID>
+    <ID>MaxLineLength:CLIVersionManager.kt$CLIVersionManager$logger.debug(LogCategory.SYSTEM, "CLI version check", mapOf("installed" to installedVersion, "current" to currentVersion, "upToDate" to isCurrent))</ID>
+    <ID>MaxLineLength:CLIVersionManager.kt$CLIVersionManager$logger.debug(LogCategory.SYSTEM, "CLI version check: Found installed version", mapOf("version" to version))</ID>
+    <ID>MaxLineLength:CLIVersionManager.kt$CLIVersionManager$logger.info(LogCategory.SYSTEM, "CLI version check: Update needed", mapOf("from" to installedVersion, "to" to AppVersion.CURRENT.toString()))</ID>
+    <ID>MaxLineLength:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$logger.warn(LogCategory.BROWSER, "Unknown platform, defaulting to linux-x64", mapOf("os" to os, "arch" to arch))</ID>
+    <ID>MaxLineLength:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$assertEquals(listOf("https://supabase/a.zip"), attempted, "github must not be attempted after a verified supabase download")</ID>
+    <ID>MaxLineLength:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$candidates = listOf(candidate("supabase", "https://supabase/a.zip"), candidate("github", "https://github/a.zip"))</ID>
+    <ID>MaxLineLength:ChromiumDownloader.kt$logger.debug(LogCategory.BROWSER, "Directory contents", mapOf("files" to (files?.map { it.name } ?: emptyList())))</ID>
+    <ID>MaxLineLength:ClipboardHelper.kt$ClipboardHelper$logger.warn(LogCategory.UI, "Failed to initialize Robot for clipboard operations - may need accessibility permissions", error = e)</ID>
+    <ID>MaxLineLength:CoBrowseRtcPeerImpl.kt$CoBrowseRtcPeerImpl$bridge.onAnswer = null</ID>
+    <ID>MaxLineLength:CoBrowseRtcPeerImpl.kt$CoBrowseRtcPeerImpl$logger.info(LogCategory.BROWSER, "WebRTC video: selecting capture source '${chosen.name()}'")</ID>
+    <ID>MaxLineLength:CoBrowseRtcPeerImpl.kt$CoBrowseRtcPeerImpl$val chosen = (want?.let { t -&gt; browsers.firstOrNull { it.name() == t } }) ?: browsers.firstOrNull()</ID>
+    <ID>MaxLineLength:CoBrowseRtcPeerImpl.kt$CoBrowseRtcPeerImpl.Companion$sb.append(""",{"urls":${jsStr(url)},"username":"openrelayproject","credential":"openrelayproject"}""")</ID>
+    <ID>MaxLineLength:CodeBase.kt$ProjectState$logger.debug(LogCategory.FILE, "Loaded recent projects from disk", mapOf("count" to validProjects.size, "removed" to (projects.size - validProjects.size)))</ID>
+    <ID>MaxLineLength:CodeBase.kt$ProjectState$logger.debug(LogCategory.FILE, "Normalizing project name", mapOf("old" to project.name, "new" to normalizedName))</ID>
+    <ID>MaxLineLength:CodeBase.kt$ProjectState$logger.debug(LogCategory.FILE, "Removing deleted project from recent", mapOf("name" to project.name, "path" to project.path))</ID>
+    <ID>MaxLineLength:CommitDialog.kt$placeholder = { Text("Enter commit message...", color = BossTheme.colors.textSecondary.copy(alpha = 0.5f)) }</ID>
+    <ID>MaxLineLength:ConfigLoader.kt$ConfigLoader$logger.debug(LogCategory.SYSTEM, "Loading local.properties", mapOf("path" to localPropertiesFile.absolutePath))</ID>
+    <ID>MaxLineLength:ContextMenu.kt$modifier = Modifier.size(if (item.onTrailingClick != null) 16.dp else 8.dp)</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$AuthStateManager.setAuthState(AuthService.AuthState.Error(e.message ?: "Failed to initialize authentication"))</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.debug(LogCategory.AUTH, "No user data available (session.user is null and no stored data)")</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.debug(LogCategory.AUTH, "Other session status", mapOf("status" to sessionStatus.toString()))</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.debug(LogCategory.AUTH, "Session authenticated", mapOf("hasUserId" to userId.isNotEmpty()))</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.debug(LogCategory.AUTH, "SessionStatus changed", mapOf("status" to sessionStatus::class.simpleName))</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.debug(LogCategory.AUTH, "Still waiting for session status", mapOf("status" to sessionStatus.toString()))</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.error(LogCategory.AUTH, "Refresh token rejected by auth server; clearing session for re-login", error = e)</ID>
+    <ID>MaxLineLength:CoreAuthService.kt$CoreAuthService$logger.info(LogCategory.AUTH, "Auth state set to Offline (startup session refresh failed)")</ID>
+    <ID>MaxLineLength:CrashReportService.kt$CrashReportService$appendLine("[$entryTime] [${entry.level}] [${entry.category}] ${entry.component}: ${entry.message}")</ID>
+    <ID>MaxLineLength:CrossDeviceAuthService.kt$CrossDeviceAuthService$logger.trace(LogCategory.PASSKEY, "Polling attempt", mapOf("attempt" to attempts, "maxAttempts" to maxAttempts))</ID>
+    <ID>MaxLineLength:CrossDeviceAuthService.kt$CrossDeviceAuthService$return Result.failure(pollingResult.exceptionOrNull() ?: Exception("Cross-device authentication failed"))</ID>
+    <ID>MaxLineLength:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend</ID>
+    <ID>MaxLineLength:CrossDeviceAuthenticationDialog.kt$else -&gt; "The authentication page is opening in your browser. You'll see a QR code to scan with your iPhone."</ID>
+    <ID>MaxLineLength:CrossDeviceAuthenticationDialog.kt$isPolling -&gt; "A QR code is displayed in the browser tab. Scan it with your iPhone to complete authentication."</ID>
+    <ID>MaxLineLength:CrossDeviceAuthenticationDialog.kt$onCreateFluckTab != null -&gt; "The authentication page is opening in a new FLUCK tab. You'll see a QR code to scan with your iPhone."</ID>
+    <ID>MaxLineLength:CrossDeviceBrowserManager.kt$CrossDeviceBrowserManager$logger.debug(LogCategory.BROWSER, "Ready to display WebAuthn in embedded browser", mapOf("sessionId" to sessionId))</ID>
+    <ID>MaxLineLength:CrossDeviceBrowserManager.kt$CrossDeviceBrowserManager$logger.warn(LogCategory.BROWSER, "Failed to initialize WebAuthn - using system browser fallback", error = e)</ID>
+    <ID>MaxLineLength:DashboardEventBus.kt$DashboardEventBus$private</ID>
+    <ID>MaxLineLength:DashboardEventBus.kt$DashboardEventBus$val applySplitTemplateEvents: SharedFlow&lt;DashboardApplySplitTemplateEvent&gt; = _applySplitTemplateEvents.asSharedFlow()</ID>
+    <ID>MaxLineLength:DeepLinkHandler.kt$DeepLinkHandler$logger.info(LogCategory.SYSTEM, "Received deep link (Windows via Desktop)", mapOf("uri" to LogSanitizer.maskUriParams(uri)))</ID>
+    <ID>MaxLineLength:DeepLinkHandler.kt$DeepLinkHandler$logger.info(LogCategory.SYSTEM, "Received deep link (macOS)", mapOf("uri" to LogSanitizer.maskUriParams(uri)))</ID>
+    <ID>MaxLineLength:DeepLinkHandler.kt$DeepLinkHandler$logger.info(LogCategory.SYSTEM, "Received deep link from command line", mapOf("uri" to LogSanitizer.maskUriParams(url)))</ID>
+    <ID>MaxLineLength:DeepLinkHandler.kt$DeepLinkHandler$logger.info(LogCategory.SYSTEM, "Received deep link", mapOf("uri" to LogSanitizer.maskUriParams(uri)))</ID>
+    <ID>MaxLineLength:DeepLinkHandler.kt$DeepLinkHandler$logger.info(LogCategory.UI, "Emitted panel open event", mapOf("panelId" to panelIdStr, "windowId" to focusedWindowId))</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$ApiActiveTabsProviderAdapter$.</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$DefaultPlugin$cfgCls.getMethod("getConfig", String::class.java, String::class.java).invoke(cfgInstance, "BOSS_MODE", null) as? String</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$DefaultPlugin$configCls.getMethod("getConfig", String::class.java, String::class.java).invoke(cfgInst, "BOSS_MODE", null) as? String</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$DefaultPlugin$logger.info(LogCategory.SYSTEM, "OOP spawner: BOSS_MODE resolved", mapOf("bossMode" to (bossMode ?: "null")))</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$DefaultPlugin$logger.info(LogCategory.SYSTEM, "OOP spawner: KernelBootstrap.instance", mapOf("isNull" to (kernelInstance == null)))</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$DefaultPlugin$logger.warn(LogCategory.SYSTEM, "OOP spawner: kernel addr failed", mapOf("error" to e.toString()))</ID>
+    <ID>MaxLineLength:DefaultPlugin.kt$DefaultPlugin$}</ID>
+    <ID>MaxLineLength:DesktopBrowserAccessor.kt$DesktopBrowserIntegration$browserAccessorLogger.warn(LogCategory.BROWSER, "navigate failed", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:DesktopBrowserAccessor.kt$browserAccessorLogger.warn(LogCategory.BROWSER, "Error finding browser for tab", mapOf("tabId" to tabId), error = e)</ID>
+    <ID>MaxLineLength:DesktopFileScanner.kt$actual suspend</ID>
+    <ID>MaxLineLength:DesktopGitService.kt$GitService$actual suspend</ID>
+    <ID>MaxLineLength:DesktopGitService.kt$GitService$logger.warn(LogCategory.SYSTEM, "Could not create FS watcher; HEAD updates won't auto-refresh", error = e)</ID>
+    <ID>MaxLineLength:DesktopGitService.kt$GitService$progressLine.contains("remote: Counting objects") -&gt; onProgress("Receiving objects...")</ID>
+    <ID>MaxLineLength:DesktopGitService.kt$GitService$val errorMessage = "Clone operation timed out after 10 minutes. The repository may be too large or the connection too slow. Try cloning from terminal instead."</ID>
+    <ID>MaxLineLength:DesktopGitService.kt$GitService$val errorMessage = "Security permission denied. Check file system permissions for '${File(targetDirectory).parentFile?.absolutePath}'."</ID>
+    <ID>MaxLineLength:DesktopGitService.kt$GitService$val errorMessage = "Unexpected error during clone: ${e.message ?: e.javaClass.simpleName}. Please check logs for details."</ID>
+    <ID>MaxLineLength:DesktopGitTerminalService.kt$GitTerminalService$logger.debug(LogCategory.TERMINAL, "Opened command in sidebar terminal", mapOf("operationName" to operationName, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopGitTerminalService.kt$GitTerminalService$logger.warn(LogCategory.TERMINAL, "Failed to open in sidebar terminal - panel may not be open", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopLLMSettingsManager.kt$LLMSettingsManager$logger.info(LogCategory.SYSTEM, "Created environment variables template", mapOf("path" to envFile.absolutePath))</ID>
+    <ID>MaxLineLength:DesktopPasskeyService.kt$DesktopPasskeyService$logger.info(LogCategory.PASSKEY, "Starting biometric authentication", mapOf("platform" to biometricAuthProvider.getCurrentPlatform()))</ID>
+    <ID>MaxLineLength:DesktopRunConfigurationManager.kt$RunConfigurationManager$logger.debug(LogCategory.SYSTEM, "Cleaned up duplicate run configurations", mapOf("removed" to (settings.configurations.size - deduplicated.size)))</ID>
+    <ID>MaxLineLength:DesktopRunConfigurationManager.kt$RunConfigurationManager$logger.debug(LogCategory.SYSTEM, "Configuration already exists, skipping", mapOf("filePath" to config.filePath))</ID>
+    <ID>MaxLineLength:DesktopRunConfigurationManager.kt$RunConfigurationManager$logger.debug(LogCategory.SYSTEM, "Found runnable configurations", mapOf("count" to detectedWithUniqueNames.size))</ID>
+    <ID>MaxLineLength:DesktopRunConfigurationManager.kt$RunConfigurationManager$logger.debug(LogCategory.SYSTEM, "Loaded run configurations", mapOf("count" to cleanedSettings.configurations.size, "path" to settingsFile.absolutePath))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Cleaned up configs for closed window", mapOf("count" to configsToRemove.size, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Closed terminal tab", mapOf("terminalId" to terminalId, "configId" to configId, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Config not running in window", mapOf("configId" to configId, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Config removed", mapOf("configId" to configId, "terminalId" to terminalId, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Failed to close tab - terminal not found", mapOf("terminalId" to terminalId, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Failed to open in sidebar terminal - panel may not be open", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Opened command in sidebar terminal", mapOf("tabTitle" to tabTitle, "windowId" to windowId, "mappedTo" to SIDEBAR_TERMINAL_ID, "isRerun" to isRerun))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Opening terminal for config", mapOf("configName" to config.name, "command" to command))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Sent Ctrl+C to stop existing process", mapOf("windowId" to existingWindowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Terminal removed", mapOf("terminalId" to terminalId, "configs" to configIds.toString(), "windowId" to windowId))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.debug(LogCategory.TERMINAL, "Terminal stopped", mapOf("terminalId" to terminalId, "configs" to configIds.toString()))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$logger.warn(LogCategory.TERMINAL, "Error stopping existing terminal", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$val newTerminalId = existingTerminalId ?: "$RUNNER_TERMINAL_PREFIX${config.id}-${System.currentTimeMillis()}"</ID>
+    <ID>MaxLineLength:DesktopRunnerTerminalService.kt$RunnerTerminalService$val usesSidebar = RunnerSettingsManager.currentSettings.value.terminalTarget == RunnerTerminalTarget.SIDEBAR_PANEL</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.debug(LogCategory.SYSTEM, "Platform package not found, trying JAR fallback", mapOf("jarAsset" to jarAssetName))</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.error(LogCategory.NETWORK, "Error fetching version details", mapOf("version" to version.toString()), error = e)</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.info(LogCategory.SYSTEM, "Starting update download", mapOf("asset" to assetName, "size" to assetSize))</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.info(LogCategory.SYSTEM, "Update downloaded successfully", mapOf("path" to downloadFile.absolutePath))</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.trace(LogCategory.SYSTEM, "Download info", mapOf("totalSize" to totalSize, "expectedSize" to expectedSize))</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.warn(LogCategory.NETWORK, "Failed to parse release", mapOf("tag" to release.tag_name), error = e)</ID>
+    <ID>MaxLineLength:DesktopUpdateService.kt$UpdateService$logger.warn(LogCategory.SYSTEM, "Expected asset not found in release", mapOf("expected" to expectedAssetName))</ID>
+    <ID>MaxLineLength:DesktopWorkspaceFileManager.kt$WorkspaceFileManager$val documentsPath = Paths.get(userHome, "Documents", WorkspaceFileManagerCommon.getDefaultWorkspaceDirectoryName())</ID>
+    <ID>MaxLineLength:DisplayUtils.kt$DisplayUtils$logger.debug(LogCategory.UI, "Adjusted for Windows scaling", mapOf("physical" to "${displayMode.width}x${displayMode.height}", "logical" to "${width}x${height}"))</ID>
+    <ID>MaxLineLength:DisplayUtils.kt$DisplayUtils$logger.debug(LogCategory.UI, "Windows DPI scaling", mapOf("dpi" to screenResolution, "scalingFactor" to scalingFactor))</ID>
+    <ID>MaxLineLength:DownloadDataProviderImpl.kt$DownloadDataProviderImpl$logger.warn(LogCategory.FILE, "Failed to delete file", mapOf("path" to download.destinationPath))</ID>
+    <ID>MaxLineLength:DownloadSettings.kt$downloadSettingsLogger.debug(LogCategory.BROWSER, "Could not read XDG user-dirs config", mapOf("error" to (e.message ?: "Unknown")))</ID>
+    <ID>MaxLineLength:DynamicPluginManager.kt$DynamicPluginManager$logger</ID>
+    <ID>MaxLineLength:DynamicPluginManager.kt$DynamicPluginManager.Companion$companionLogger</ID>
+    <ID>MaxLineLength:DynamicPluginManager.kt$DynamicPluginManager.Companion$companionLogger.error(LogCategory.SYSTEM, "API-layer hot swap orchestration threw after caller cancellation", error = cause)</ID>
+    <ID>MaxLineLength:EditableKeymapSettings.kt$description = spec.displayName + (spec.description.takeIf { it.isNotBlank() }?.let { " — $it" } ?: "")</ID>
+    <ID>MaxLineLength:EmailAuthService.kt$EmailAuthService$logger.warn(LogCategory.AUTH, "Magic link sending failed", mapOf("exceptionType" to e.javaClass.simpleName), error = e)</ID>
+    <ID>MaxLineLength:EmailAuthService.kt$EmailAuthService$suspend</ID>
+    <ID>MaxLineLength:EmptyContentScreen.kt$Text("Welcome to BOSS", color = BossTheme.colors.textPrimary, fontSize = 28.sp, fontWeight = FontWeight.Bold)</ID>
+    <ID>MaxLineLength:FallbackUpdateSource.kt$FallbackUpdateSource$logger.warn(LogCategory.NETWORK, "${primary.name} failed for $tag; falling back to ${backup.name}", error = e)</ID>
+    <ID>MaxLineLength:FaviconCache.kt$FaviconCache$logger.debug(LogCategory.BROWSER, "Favicon too large, skipping cache", mapOf("size" to tempFile.length(), "maxSize" to MAX_FAVICON_SIZE_BYTES))</ID>
+    <ID>MaxLineLength:FaviconCacheInterface.kt$actual suspend</ID>
+    <ID>MaxLineLength:FaviconCacheInterface.kt$expect suspend</ID>
+    <ID>MaxLineLength:FileEventBus.kt$FileEventBus$ipcBridge?.forward("FileOpenEvent", FileOpenEvent(cleanPath, fileName, line, column, sourceWindowId), sourceWindowId)</ID>
+    <ID>MaxLineLength:FileEventBus.kt$FileEventBus$suspend</ID>
+    <ID>MaxLineLength:FileEventBus.kt$fun validateFilePath(filePath: String): ai.rever.boss.plugin.events.FileValidationResult</ID>
+    <ID>MaxLineLength:FileHandlerService.kt$FileHandlerService$logger.debug(LogCategory.FILE, "decrementProcessing", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:FileHandlerService.kt$FileHandlerService$logger.debug(LogCategory.FILE, "incrementProcessing", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:FileIndexCache.kt$expect suspend</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$override suspend</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(IllegalArgumentException("Parent directory does not exist: $parentPath"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(IllegalStateException("A file or folder with that name already exists"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(IllegalStateException("File already exists: ${newFile.absolutePath}"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(IllegalStateException("Folder already exists: ${newFolder.absolutePath}"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(SecurityException("Access denied: file path outside user directory"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(SecurityException("Path traversal detected: file would be created outside parent directory"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(SecurityException("Path traversal detected: file would be moved outside parent directory"))</ID>
+    <ID>MaxLineLength:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$return@withContext Result.failure(SecurityException("Path traversal detected: folder would be created outside parent directory"))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$browserError = Exception("Browser recovery failed after $maxRecoveryAttempts attempts. Please close and reopen this tab.")</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$if</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.debug(LogCategory.BROWSER, "Browser closed for disposed tab, skipping recovery", mapOf("tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.error(LogCategory.BROWSER, "Max recovery attempts reached", mapOf("maxAttempts" to maxRecoveryAttempts, "tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.error(LogCategory.BROWSER, "Max retries exhausted", mapOf("maxRetries" to maxRetries, "tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.error(LogCategory.BROWSER, "Max retries exhausted", mapOf("tabId" to config.id, "error" to (engineError ?: e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.info(LogCategory.BROWSER, "Browser recovered successfully, resetting recovery counter", mapOf("tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.info(LogCategory.BROWSER, "Browser retry attempt", mapOf("attempt" to "${retryCount + 1}/$maxRetries", "tabId" to config.id, "delayMs" to delayMs))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.info(LogCategory.BROWSER, "Browser retry succeeded", mapOf("attempt" to "${retryCount + 1}/$maxRetries", "tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.info(LogCategory.BROWSER, "BrowserViewState recreated successfully", mapOf("tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.info(LogCategory.BROWSER, "Recreating BrowserViewState after fullscreen exit", mapOf("tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.info(LogCategory.BROWSER, "Triggering recovery", mapOf("reason" to reason, "tabId" to config.id, "attempt" to "$recoveryAttempts/$maxRecoveryAttempts"))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Browser init failed - window not ready", mapOf("attempt" to "$retryCount/$maxRetries"))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Browser init failed", mapOf("attempt" to "$retryCount/$maxRetries", "error" to engineError))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Browser retry failed", mapOf("attempt" to "$retryCount/$maxRetries", "error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Error disposing browser (blocking)", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Error disposing browser", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Failed to recreate BrowserViewState", mapOf("tabId" to config.id))</ID>
+    <ID>MaxLineLength:Fluck.kt$FluckTabComponent$logger.warn(LogCategory.BROWSER, "Skipping browser init - tab already disposed", mapOf("tabId" to config.id))</ID>
+    <ID>MaxLineLength:FluckBrowserSettings.kt$selectedOption = targetModeOptions.find { it.second == existingSplitTarget }?.first ?: "Most Recent Active"</ID>
+    <ID>MaxLineLength:FluckBrowserSettings.kt$text = "When enabled, auto-filled password fields are blurred for shoulder surfing protection. Blur persists even on \"show password\" toggles."</ID>
+    <ID>MaxLineLength:FluckBrowserSettings.kt$var existingSplitTarget by remember(terminalLinkSettings) { mutableStateOf(terminalLinkSettings.existingSplitTarget) }</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$"Chrome" to "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$"Edge" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$"Safari" to "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15"</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Error cleaning orphaned RPA profiles", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Failed to apply engine color scheme", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Failed to set initial engine theme", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "No window focused, cannot dispatch shortcut", mapOf("shortcut" to "$modifierName+${keyCode.name}"))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "No window focused, cannot dispatch shortcut", mapOf("shortcut" to "$modifierName+Shift+${keyCode.name}"))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Paste without formatting failed", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Widevine activation call failed", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Widevine activation completed", mapOf("status" to status.toString()))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.debug(LogCategory.BROWSER, "Widevine activation failed", mapOf("error" to (error.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$logger.warn(LogCategory.BROWSER, "Engine pre-warm failed with a serious error (lazy init will retry on first use)", error = e)</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$private</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine$val plainText = clipboard.getData(java.awt.datatransfer.DataFlavor.stringFlavor) as? String</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$infoLabel?.foreground = java.awt.Color(BossThemeController.current.colors.alert.toArgb(), true)</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$infoLabel?.foreground = java.awt.Color(BossThemeController.current.colors.textPrimary.toArgb(), true)</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$logger.debug(LogCategory.BROWSER, "Error clearing find highlights", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$val caseBtn = makeBtn("&lt;html&gt;&lt;span style='font-size:12px;color:${cssHex(mutedFg)};'&gt;Aa&lt;/span&gt;&lt;/html&gt;", "Case sensitive")</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$val closeBtn = makeBtn("&lt;html&gt;&lt;span style='font-size:12px;color:${cssHex(fg)};'&gt;\u2715&lt;/span&gt;&lt;/html&gt;", "Close (Esc)")</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$val color = if (caseSensitive) cssHex(java.awt.Color(BossThemeController.current.colors.signal.toArgb(), true)) else cssHex(mutedFg)</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$val nextBtn = makeBtn("&lt;html&gt;&lt;span style='font-size:10px;color:${cssHex(fg)};'&gt;\u25BC&lt;/span&gt;&lt;/html&gt;", "Next (Enter)")</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar$val prevBtn = makeBtn("&lt;html&gt;&lt;span style='font-size:10px;color:${cssHex(fg)};'&gt;\u25B2&lt;/span&gt;&lt;/html&gt;", "Previous (Shift+Enter)")</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar.&lt;no name provided&gt;$e.keyCode == java.awt.event.KeyEvent.VK_ENTER &amp;&amp; e.isShiftDown -&gt; { performFind(true); e.consume() }</ID>
+    <ID>MaxLineLength:FluckEngine.kt$FluckEngine.BrowserFindBar.&lt;no name provided&gt;$e.keyCode == java.awt.event.KeyEvent.VK_F &amp;&amp; isMainMod &amp;&amp; !e.isShiftDown -&gt; { hide(); e.consume() }</ID>
+    <ID>MaxLineLength:FocusModeSettingsManager.kt$FocusModeSettingsManager$logger.debug(LogCategory.SYSTEM, "Created default settings file", mapOf("path" to settingsFile.absolutePath))</ID>
+    <ID>MaxLineLength:FontManager.kt$FontManager$logger.debug(LogCategory.SYSTEM, "Font not found, using bundled JetBrains Mono", mapOf("fontName" to fontName))</ID>
+    <ID>MaxLineLength:FontManager.kt$FontManager$logger.warn(LogCategory.SYSTEM, "Font resource not found for Compose", mapOf("resourcePath" to resourcePath))</ID>
+    <ID>MaxLineLength:GitHubConfig.kt$GitHubConfig$logger.warn(LogCategory.NETWORK, "GitHub CLI token retrieval timed out", mapOf("timeoutSeconds" to GH_TIMEOUT_SECONDS))</ID>
+    <ID>MaxLineLength:GitService.kt$GitService$suspend</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$enter = fadeIn(tween(200, delayMillis = 100)) + slideInVertically(tween(200, delayMillis = 100)) { it / 2 }</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$enter = fadeIn(tween(200, delayMillis = 50)) + slideInVertically(tween(200, delayMillis = 50)) { -it / 2 }</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$globalSearchLogger.debug(LogCategory.UI, "Bookmark selected from search", mapOf("bookmark" to result.bookmarkId))</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$globalSearchLogger.debug(LogCategory.UI, "Command selected from search", mapOf("actionId" to result.actionId))</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$globalSearchLogger.debug(LogCategory.UI, "Run config selected from search", mapOf("config" to result.configId))</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$is SearchResult.BookmarkResult -&gt; BookmarkResultItem(result, isSelected, isHovered, scale, backgroundColor, interactionSource, onClick)</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$is SearchResult.CommandResult -&gt; CommandResultItem(result, isSelected, isHovered, scale, backgroundColor, interactionSource, onClick)</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$is SearchResult.FileResult -&gt; FileResultItem(result, isSelected, isHovered, scale, backgroundColor, interactionSource, onClick)</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$is SearchResult.RunConfigResult -&gt; RunConfigResultItem(result, isSelected, isHovered, scale, backgroundColor, interactionSource, onClick)</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$is SearchResult.TabResult -&gt; TabResultItem(result, isSelected, isHovered, scale, backgroundColor, interactionSource, onClick)</ID>
+    <ID>MaxLineLength:GlobalSearchDialog.kt$val textColor = if (isHighlighted) BossThemeController.current.colors.textPrimary else BossThemeController.current.colors.textSecondary</ID>
+    <ID>MaxLineLength:IosFileScanner.kt$actual suspend</ID>
+    <ID>MaxLineLength:IosWorkspaceFileManager.kt$WorkspaceFileManager$lastModified = (attributes?.get(NSFileModificationDate) as? NSDate)?.timeIntervalSince1970?.toLong() ?: 0L</ID>
+    <ID>MaxLineLength:IosWorkspaceFileManager.kt$WorkspaceFileManager$val nsString = NSString.stringWithContentsOfFile(filePath, encoding = NSUTF8StringEncoding, error = null) ?: return@withContext null</ID>
+    <ID>MaxLineLength:JsDialogNotifier.kt$JsDialogNotifier.JsDialogEvent.Confirm$data</ID>
+    <ID>MaxLineLength:JsDialogNotifier.kt$JsDialogNotifier.JsDialogEvent.Prompt$data</ID>
+    <ID>MaxLineLength:KeyboardEventBus.kt$KeyboardEventBus$logger.debug(LogCategory.UI, "Registered handler", mapOf("handler" to handlerName, "windowId" to targetWindowId, "priority" to priority.name))</ID>
+    <ID>MaxLineLength:KeyboardEventBus.kt$KeyboardEventBus$logger.warn(LogCategory.UI, "Error in keyboard handler", mapOf("handler" to handlerInfo.handlerName), error = e)</ID>
+    <ID>MaxLineLength:KeymapActions.kt$KeymapActions$EDITOR_SAVE</ID>
+    <ID>MaxLineLength:KeymapHandler.kt$KeymapHandler$logger.debug(LogCategory.UI, "Executed action", mapOf("actionId" to binding.actionId, "description" to binding.description))</ID>
+    <ID>MaxLineLength:KeymapImportExport.kt$Text(if (copied) "Copied!" else "Copy to Clipboard", color = BossDarkTextPrimary, fontSize = 13.sp)</ID>
+    <ID>MaxLineLength:KeymapMatcher.kt$KeymapMatcher$"zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" -&gt; keyName.replaceFirstChar { it.uppercase() }</ID>
+    <ID>MaxLineLength:KeymapMatcherTest.kt$KeymapMatcherTest$assertFalse(keystroke.matches("M", isMetaPressed = true, isCtrlPressed = false, isShiftPressed = false, isAltPressed = false))</ID>
+    <ID>MaxLineLength:KeymapMatcherTest.kt$KeymapMatcherTest$assertTrue(binding.matches("C", isMetaPressed = false, isCtrlPressed = true, isShiftPressed = false, isAltPressed = false))</ID>
+    <ID>MaxLineLength:KeymapMatcherTest.kt$KeymapMatcherTest$assertTrue(binding.matches("C", isMetaPressed = true, isCtrlPressed = false, isShiftPressed = false, isAltPressed = false))</ID>
+    <ID>MaxLineLength:KeymapMatcherTest.kt$KeymapMatcherTest$assertTrue(keystroke.matches("N", isMetaPressed = true, isCtrlPressed = false, isShiftPressed = false, isAltPressed = false))</ID>
+    <ID>MaxLineLength:KeymapSettingsManager.kt$KeymapSettingsManager$logger.debug(LogCategory.SYSTEM, "Created default keymap settings file", mapOf("path" to settingsFile.absolutePath))</ID>
+    <ID>MaxLineLength:KeymapSettingsManager.kt$KeymapSettingsManager$logger.warn(LogCategory.SYSTEM, "Unknown keymap preset, using BOSS Default", mapOf("presetName" to presetName))</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action1", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true)</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action1", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true, description = "Action One")</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action1", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true, description = "New Window")</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action2", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true)</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action2", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true, description = "Action Two")</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action2", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true, description = "New Tab")</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action2", key = "T", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true)</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action3", key = "T", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true)</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$KeyBinding(actionId = "action4", key = "T", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true)</ID>
+    <ID>MaxLineLength:KeymapValidatorTest.kt$KeymapValidatorTest$listOf(KeyBinding(actionId = "action1", key = "N", modifiers = listOf("Cmd"), context = ShortcutContext.GLOBAL, enabled = true))</ID>
+    <ID>MaxLineLength:LLMModelFetcher.kt$LLMModelFetcher$capabilities = listOf("text", "vision", "function-calling", "code-execution", "web-search", "extended-thinking")</ID>
+    <ID>MaxLineLength:LLMProvidersSettings.kt$placeholder = { Text("https://api.example.com/v1/chat", color = BossDarkTextSecondary.copy(alpha = 0.5f)) }</ID>
+    <ID>MaxLineLength:LLMProvidersSettings.kt$text = "Context: ${it.toString().reversed().chunked(3).reversed().joinToString(",")} tokens"</ID>
+    <ID>MaxLineLength:LLMProvidersSettings.kt$val providerModels = availableModels[provider.name] ?: LLMModelFetcher.getModelsForProvider(provider)</ID>
+    <ID>MaxLineLength:LLMProvidersSettings.kt$val providerModels = availableModels[selectedProvider.name] ?: LLMModelFetcher.getModelsForProvider(selectedProvider)</ID>
+    <ID>MaxLineLength:LLMProvidersSettings.kt$visualTransformation = if (showApiKey) VisualTransformation.None else PasswordVisualTransformation()</ID>
+    <ID>MaxLineLength:LLMSettings.kt$LLMModel$LLAMA_3_2_11B_VISION : LLMModel</ID>
+    <ID>MaxLineLength:LLMSettings.kt$LLMModel$LLAMA_3_2_90B_VISION : LLMModel</ID>
+    <ID>MaxLineLength:LayoutWorkspace.kt$PredefinedWorkspaces$initialCommand = "cd {projectPath} &amp;&amp; clear &amp;&amp; claude {claudeContinueFlag} --dangerously-skip-permissions"</ID>
+    <ID>MaxLineLength:LinuxDefaultBrowserHandler.kt$LinuxDefaultBrowserHandler$logger.debug(LogCategory.BROWSER, "Linux default browser check", mapOf("defaultBrowser" to (defaultBrowser ?: "none")))</ID>
+    <ID>MaxLineLength:LspSettings.kt$PluginSettingsUnavailableNotice("Language-server settings are provided by the Code Editor plugin, which isn't loaded yet.")</ID>
+    <ID>MaxLineLength:MacOSCamera.kt$MacOSCamera$macOSCameraLogger.info(LogCategory.SYSTEM, "macOS camera permission is handled by system dialog when accessed")</ID>
+    <ID>MaxLineLength:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$logger.debug(LogCategory.BROWSER, "macOS default browser check", mapOf("httpHandler" to (httpDefault ?: "none"), "httpsHandler" to (httpsDefault ?: "none")))</ID>
+    <ID>MaxLineLength:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$logger.warn(LogCategory.BROWSER, "Error setting default handler", mapOf("scheme" to scheme, "error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$logger.warn(LogCategory.BROWSER, "Swift process timed out setting default handler", mapOf("scheme" to scheme))</ID>
+    <ID>MaxLineLength:MacOSScreenCapture.kt$CoreGraphics.Companion$macOSScreenCaptureLogger.debug(LogCategory.SYSTEM, "CoreGraphics not available", mapOf("error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:MacOSScreenCapture.kt$MacOSScreenCapture$macOSScreenCaptureLogger.debug(LogCategory.SYSTEM, "Screen capture permission request", mapOf("result" to result))</ID>
+    <ID>MaxLineLength:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$provider("p1", echoTool("bad_args_tool", handler = McpToolHandler { args -&gt; captured = args; McpToolResult("ok") }))</ID>
+    <ID>MaxLineLength:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$provider("p1", echoTool("big_tool", handler = McpToolHandler { args -&gt; captured = args; McpToolResult("ok") }))</ID>
+    <ID>MaxLineLength:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$provider("p1", echoTool("num_tool", handler = McpToolHandler { args -&gt; captured = args; McpToolResult("ok") }))</ID>
+    <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$private val _applyWorkspaceEvents = MutableSharedFlow&lt;Pair&lt;String, ai.rever.boss.components.workspaces.LayoutWorkspace&gt;&gt;(extraBufferCapacity = 10)</ID>
+    <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$private val _checkPluginUpdatesEvents = MutableSharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt;(extraBufferCapacity = 10)</ID>
+    <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$private val _reloadPluginEvents = MutableSharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt;(extraBufferCapacity = 10)</ID>
+    <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$val applyWorkspaceEvents: SharedFlow&lt;Pair&lt;String, ai.rever.boss.components.workspaces.LayoutWorkspace&gt;&gt; = _applyWorkspaceEvents.asSharedFlow()</ID>
+    <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$val checkPluginUpdatesEvents: SharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt; = _checkPluginUpdatesEvents.asSharedFlow()</ID>
+    <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$val reloadPluginEvents: SharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt; = _reloadPluginEvents.asSharedFlow()</ID>
+    <ID>MaxLineLength:NavigationTargetProviderImpl.kt$NavigationTargetProviderImpl$println("[HOST-DEBUG] NavigationTargetProviderImpl: received event from NavigationTargetBus: ${event.filePath}:${event.line}:${event.column}")</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$availableTypes.isNotEmpty() &amp;&amp; (selectedType == TabType.TERMINAL || selectedType == TabType.JUPYTER || inputText.isNotBlank())</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$fileTree</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$hasChildren = loadedChildren.isNotEmpty()</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$if</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$imageVector = if (suggestion.isSearchSuggestion) Icons.Default.Search else Icons.Default.History</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$newTabDialogLogger.warn(LogCategory.FILE, "Error loading folder children", error = e)</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$scanDirectoryWithDepth(path, maxDepth = 1, startDepth = 0)</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$selectedSuggestionIndex = (selectedSuggestionIndex + 1).coerceAtMost(urlSuggestions.size - 1)</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$selectedSuggestionIndex = (selectedSuggestionIndex - 1).coerceAtLeast(-1)</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$urlSuggestions = urlSuggestions.filterNot { it.url == suggestion.url }</ID>
+    <ID>MaxLineLength:NewTabDialog.kt$val</ID>
+    <ID>MaxLineLength:PanelComponentStore.kt$PanelComponentStore$logger.warn(LogCategory.UI, "onBeforeReset failed during panel reset (continuing)", mapOf("panelId" to panelId.panelId), t)</ID>
+    <ID>MaxLineLength:PasskeyAuthService.kt$PasskeyAuthService$logger.debug(LogCategory.PASSKEY, "About to call completeRegistration", mapOf("credentialId" to LogSanitizer.maskCredentialId(registration.credentialId)))</ID>
+    <ID>MaxLineLength:PasskeyAuthService.kt$PasskeyAuthService$logger.info(LogCategory.PASSKEY, "Starting passkey authentication", mapOf("email" to (email?.let { LogSanitizer.maskEmail(it) } ?: "usernameless")))</ID>
+    <ID>MaxLineLength:PasskeyAuthService.kt$PasskeyAuthService$logger.info(LogCategory.PASSKEY, "Starting passkey registration", mapOf("userId" to LogSanitizer.maskUserId(currentUser.id)))</ID>
+    <ID>MaxLineLength:PasskeyAuthService.kt$PasskeyAuthService$return Result.failure(completionResult.exceptionOrNull() ?: Exception("Failed to complete registration"))</ID>
+    <ID>MaxLineLength:PasskeyAuthService.kt$PasskeyAuthService$userEmail = email ?: return Result.failure(Exception("User email is required for passkey authentication"))</ID>
+    <ID>MaxLineLength:PasskeyAuthService.kt$PasskeyAuthService$val currentUser = AuthStateManager.currentUser.value ?: return Result.failure(Exception("No user logged in"))</ID>
+    <ID>MaxLineLength:PasskeyAuthViewModel.kt$PasskeyAuthViewModel$logger.debug(LogCategory.PASSKEY, "Set available passkeys from credentials", mapOf("count" to passkeyInfos.size))</ID>
+    <ID>MaxLineLength:PasskeyAuthViewModel.kt$PasskeyAuthViewModel$val availablePasskeys: StateFlow&lt;List&lt;ai.rever.boss.services.passkey.PasskeyInfo&gt;&gt; = _availablePasskeys.asStateFlow()</ID>
+    <ID>MaxLineLength:PasskeyAuthenticationHandler.kt$PasskeyAuthenticationHandler$logger.debug(LogCategory.PASSKEY, "Completing authentication", mapOf("credentialId" to LogSanitizer.maskCredentialId(assertion.credentialId)))</ID>
+    <ID>MaxLineLength:PasskeyAuthenticationHandler.kt$PasskeyAuthenticationHandler$logger.warn(LogCategory.PASSKEY, "Passkey authentication failed", mapOf("error" to (authResult.error ?: "unknown")))</ID>
+    <ID>MaxLineLength:PasskeyAuthenticationHandler.kt$PasskeyAuthenticationHandler$logger.warn(LogCategory.PASSKEY, "Server returned error status", mapOf("status" to response.status.toString()))</ID>
+    <ID>MaxLineLength:PasskeyBrowserScreen.kt$passkeyBrowserLogger.debug(LogCategory.AUTH, "Displaying WebAuthn page", mapOf("url" to LogSanitizer.maskUriParams(url)))</ID>
+    <ID>MaxLineLength:PasskeyRegistrationHandler.kt$PasskeyRegistrationHandler$IllegalArgumentException("Invalid authenticator attachment: ${authenticatorSelection.authenticatorAttachment}")</ID>
+    <ID>MaxLineLength:PasskeyRegistrationHandler.kt$PasskeyRegistrationHandler$IllegalArgumentException("Invalid user verification requirement: ${authenticatorSelection.userVerification}")</ID>
+    <ID>MaxLineLength:PasskeyRegistrationHandler.kt$PasskeyRegistrationHandler$logger.debug(LogCategory.PASSKEY, "Completing passkey registration", mapOf("userId" to LogSanitizer.maskUserId(userId)))</ID>
+    <ID>MaxLineLength:PasskeyRegistrationHandler.kt$PasskeyRegistrationHandler$logger.debug(LogCategory.PASSKEY, "Registration completion response received", mapOf("status" to response.status.toString()))</ID>
+    <ID>MaxLineLength:PasskeyRegistrationHandler.kt$PasskeyRegistrationHandler$logger.debug(LogCategory.PASSKEY, "Requesting registration challenge", mapOf("userId" to LogSanitizer.maskUserId(userId)))</ID>
+    <ID>MaxLineLength:PasskeySelectionScreen.kt$LazyColumn</ID>
+    <ID>MaxLineLength:PasskeySelectionScreen.kt$PasskeyCard(passkey, selectedCredentialId == passkey.credentialId) { selectedCredentialId = passkey.credentialId }</ID>
+    <ID>MaxLineLength:PasskeySelectionScreen.kt$Text("Back to Sign In", fontSize = 14.sp, color = BossDarkAccent, textDecoration = TextDecoration.Underline)</ID>
+    <ID>MaxLineLength:PasskeySelectionScreen.kt$Text("No passkeys available.", fontSize = 14.sp, color = BossDarkTextPrimary, textAlign = TextAlign.Center, modifier = Modifier.padding(vertical = 20.dp))</ID>
+    <ID>MaxLineLength:PasskeySelectionScreen.kt$Text("Select the device you want to use:", fontSize = 13.sp, color = BossDarkTextSecondary, modifier = Modifier.padding(bottom = 12.dp))</ID>
+    <ID>MaxLineLength:PasskeySelectionScreen.kt$Text(email, fontSize = 16.sp, fontWeight = FontWeight.Medium, color = BossDarkAccent, textAlign = TextAlign.Center)</ID>
+    <ID>MaxLineLength:PasskeySessionHandler.kt$PasskeySessionHandler$logger.info(LogCategory.PASSKEY, "Magic link sent for session creation", mapOf("email" to LogSanitizer.maskEmail(authData.email)))</ID>
+    <ID>MaxLineLength:PasskeySessionHandler.kt$PasskeySessionHandler$logger.info(LogCategory.PASSKEY, "Processing authentication", mapOf("email" to LogSanitizer.maskEmail(authData.email)))</ID>
+    <ID>MaxLineLength:PasskeySessionHandler.kt$PasskeySessionHandler$return Result.failure(Exception("Magic link sent to ${authData.email}. Please check your email to complete sign-in."))</ID>
+    <ID>MaxLineLength:PasskeySessionHandler.kt$PasskeySessionHandler$return Result.failure(Exception("Passkey authentication succeeded but failed to create session. Please try magic link login."))</ID>
+    <ID>MaxLineLength:PasskeyWaitingScreen.kt$"Use Touch ID, Face ID, Windows Hello, or your device's biometric authentication to sign in."</ID>
+    <ID>MaxLineLength:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$val isAlive = try { processCls.getMethod("isAlive").invoke(process) as Boolean } catch (_: Exception) { false }</ID>
+    <ID>MaxLineLength:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$val pid = try { processCls.getMethod("getPid").invoke(process) as Long } catch (_: Exception) { -1L }</ID>
+    <ID>MaxLineLength:PluginInstallWizard.kt$text = "${failedPlugins.size} tool${if (failedPlugins.size &gt; 1) "s" else ""} failed to install:"</ID>
+    <ID>MaxLineLength:PluginInstallWizard.kt$text = "Customize your workspace by selecting the tools you need.\nWe'll help you get started with some recommended essentials."</ID>
+    <ID>MaxLineLength:PluginInstallWizardWindow.kt$onBack</ID>
+    <ID>MaxLineLength:PluginListProvider.kt$PluginListProvider$.</ID>
+    <ID>MaxLineLength:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$/** Remove the given tabs on the EDT and block until they detach. [pluginId] is null for the all-plugins (API-swap) teardown. */</ID>
+    <ID>MaxLineLength:PluginShortcutRegistryImpl.kt$PluginShortcutRegistryImpl$logger</ID>
+    <ID>MaxLineLength:PluginStoreSetup.kt$PluginStoreSetup$logger</ID>
+    <ID>MaxLineLength:PluginUpdateBridge.kt$PluginUpdateBridge$AvailablePluginUpdate(ref.pluginId, ref.displayName, available.currentVersion, available.newVersion)</ID>
+    <ID>MaxLineLength:PluginUpdateRegistry.kt$UpdateCheckOutcome$Available : UpdateCheckOutcome</ID>
+    <ID>MaxLineLength:PowerShellExecutor.kt$PowerShellExecutor$throw RuntimeException("PowerShell script failed with exit code: ${process.exitValue()}, output: $output")</ID>
+    <ID>MaxLineLength:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$assertTrue(result.reason.contains("dot", ignoreCase = true) || result.reason.contains("space", ignoreCase = true))</ID>
+    <ID>MaxLineLength:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$assertTrue(result.reason.contains("exist", ignoreCase = true) || result.reason.contains("directory", ignoreCase = true))</ID>
+    <ID>MaxLineLength:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$assertTrue(result.reason.contains("length", ignoreCase = true) || result.reason.contains("255", ignoreCase = true))</ID>
+    <ID>MaxLineLength:RecentBrowserPagesManager.kt$RecentBrowserPagesManager$logger.debug(LogCategory.SYSTEM, "Bootstrapped pages from browser history", mapOf("count" to recentPages.size))</ID>
+    <ID>MaxLineLength:ReleaseNotesMarkdown.kt$withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) { append(token.removeSurrounding("~~")) }</ID>
+    <ID>MaxLineLength:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$assertEquals(listOf("**macOS**", "Universal (Apple Silicon + Intel via Rosetta)", "`BOSS-9.2.21-Universal.dmg`"), table.rows[0])</ID>
+    <ID>MaxLineLength:RoleCreationService.kt$RoleCreationService$!regex.matches(permissionName) -&gt; "Permission must be domain.action format (e.g., \"code.review\"), lowercase, alphanumeric + underscore"</ID>
+    <ID>MaxLineLength:RoleCreationService.kt$RoleCreationService$!regex.matches(roleName) -&gt; "Role name must be lowercase, start with letter, 3-50 characters, alphanumeric + underscore only"</ID>
+    <ID>MaxLineLength:RoleService.kt$RoleService$logger.debug(LogCategory.AUTH, "RoleClaims created", mapOf("isAdmin" to rc.isAdmin, "roleCount" to rc.userRoles.size))</ID>
+    <ID>MaxLineLength:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$fun</ID>
+    <ID>MaxLineLength:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$logger.debug(LogCategory.BROWSER, "Full picker sources", mapOf("screens" to screens.size, "windows" to windows.size, "browsers" to browsers.size))</ID>
+    <ID>MaxLineLength:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$logger.debug(LogCategory.BROWSER, "User selected capture source", mapOf("name" to source.name, "category" to source.category.name))</ID>
+    <ID>MaxLineLength:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$logger.error(LogCategory.BROWSER, "Invalid browser index", mapOf("index" to source.index, "size" to browsers.size))</ID>
+    <ID>MaxLineLength:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$logger.error(LogCategory.BROWSER, "Invalid screen index", mapOf("index" to source.index, "size" to screens.size))</ID>
+    <ID>MaxLineLength:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$logger.error(LogCategory.BROWSER, "Invalid window index", mapOf("index" to source.index, "size" to windows.size))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$EmptyState(icon = Icons.Default.Monitor, message = "No screens available.\nPlease grant screen recording permission.")</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Icon(imageVector = Icons.Default.CheckCircle, contentDescription = "Selected", tint = BossTheme.colors.signal, modifier = Modifier.size(20.dp))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Icon(imageVector = Icons.Default.Close, contentDescription = "Close", tint = BossTheme.colors.textSecondary, modifier = Modifier.size(20.dp))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Icon(imageVector = fallbackIcon, contentDescription = null, tint = fallbackTint, modifier = Modifier.size(24.dp))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Icon(imageVector = icon, contentDescription = null, tint = BossTheme.colors.textSecondary.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Row</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$SourceList(sources = browsers, selectedSource = selectedSource, onSourceSelected = { selectedSource = it })</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$SourceList(sources = screens, selectedSource = selectedSource, onSourceSelected = { selectedSource = it })</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$SourceList(sources = windows, selectedSource = selectedSource, onSourceSelected = { selectedSource = it })</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Surface</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$TabItem(title = "Screen", count = screenCount, isSelected = selectedTab == ShareTab.SCREEN, onClick = { onTabSelected(ShareTab.SCREEN) })</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$TabItem(title = "Tab", count = tabCount, isSelected = selectedTab == ShareTab.TAB, onClick = { onTabSelected(ShareTab.TAB) })</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$TabItem(title = "Window", count = windowCount, isSelected = selectedTab == ShareTab.WINDOW, onClick = { onTabSelected(ShareTab.WINDOW) })</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Text(text = count.toString(), fontSize = 12.sp, color = textColor, modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Text(text = message, fontSize = 14.sp, color = BossTheme.colors.textSecondary, textAlign = TextAlign.Center, lineHeight = 20.sp)</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Text(text = source.name, fontSize = 14.sp, color = textColor, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Text(text = subtitle, fontSize = 13.sp, color = BossTheme.colors.textSecondary, modifier = Modifier.padding(top = 2.dp))</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$Text(text = title, fontSize = 14.sp, fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal, color = textColor)</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$TextButton</ID>
+    <ID>MaxLineLength:ScreenCapturePickerDialog.kt$colors = CheckboxDefaults.colors(checkedColor = BossTheme.colors.signal, uncheckedColor = BossTheme.colors.textSecondary, checkmarkColor = BossTheme.colors.onSignal)</ID>
+    <ID>MaxLineLength:SecretChangeNotifier.kt$SecretChangeNotifier$logger.debug(LogCategory.GENERAL, "Notifying secret created", mapOf("secretId" to secretId, "website" to website))</ID>
+    <ID>MaxLineLength:SecretDataProviderImpl.kt$SecretDataProviderImpl$override suspend</ID>
+    <ID>MaxLineLength:SecretServiceBridge.kt$SecretServiceBridge$override suspend</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$icon = if (capabilities.hasHybridTransport) Icons.Outlined.Smartphone else Icons.Outlined.Error</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$icon = if (capabilities.hasJxBrowserEngine) Icons.Outlined.CheckCircle else Icons.Outlined.Error</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$icon = if (capabilities.hasNfcSupport) Icons.Outlined.Nfc else Icons.Outlined.Error</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$icon = if (capabilities.hasSecurityKeySupport) Icons.Outlined.Usb else Icons.Outlined.Error</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$icon = if (capabilities.hasTouchId) Icons.Outlined.Fingerprint else Icons.Outlined.Error</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$securitySettingsLogger.debug(LogCategory.PASSKEY, "New passkey detected via polling, closing embedded browser", mapOf("previousCount" to currentCount, "newCount" to passkeys.size))</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$securitySettingsLogger.debug(LogCategory.PASSKEY, "Passkey state changed to ShowEmbeddedBrowser, showing browser screen")</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$status = if (capabilities.hasHybridTransport) "QR Code/Bluetooth available" else "Not supported"</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$status = if (capabilities.hasNfcSupport) "NFC authenticators supported" else "Not supported"</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$status = if (capabilities.hasSecurityKeySupport) "USB/NFC keys supported" else "Not supported"</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$status = if (capabilities.hasTouchId) "Touch ID/Windows Hello" else "Not available"</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$text = "WebAuthn is not supported on this device. Please ensure you have biometric authentication enabled in System Preferences."</ID>
+    <ID>MaxLineLength:SecuritySettings.kt$text = if (passkeyFactors.isEmpty()) "No credentials enrolled" else "${passkeyFactors.size} credential(s) enrolled"</ID>
+    <ID>MaxLineLength:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$assertEquals(SessionRecoveryPolicy.Action.Retry, SessionRecoveryPolicy.actionFor(IOException("Connect timeout has expired")))</ID>
+    <ID>MaxLineLength:SettingsComponents.kt$val fileDialog = java.awt.FileDialog(null as java.awt.Frame?, "Select File", java.awt.FileDialog.LOAD)</ID>
+    <ID>MaxLineLength:ShortcutHelpDialog.kt$text = if (searchQuery.isNotBlank()) "No shortcuts match \"$searchQuery\"" else "No shortcuts configured"</ID>
+    <ID>MaxLineLength:ShortcutLifecycleManager.kt$ShortcutLifecycleManager$logger.debug(LogCategory.UI, "Condition evaluated", mapOf("actionId" to actionId, "enabled" to enabled, "reason" to condition.disabledReason))</ID>
+    <ID>MaxLineLength:ShortcutLifecycleManager.kt$ShortcutLifecycleManager$logger.debug(LogCategory.UI, "Updated condition", mapOf("actionId" to actionId, "enabled" to enabled, "reason" to condition.disabledReason))</ID>
+    <ID>MaxLineLength:ShortcutTestDialog.kt$text = "Test complete: ${stats.success} success, ${stats.failed} failed, ${stats.skipped} skipped"</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$TestStatus.FAILED -&gt; logger.warn(LogCategory.UI, "Failed", mapOf("description" to binding.description, "message" to message))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$TestStatus.SUCCESS -&gt; logger.debug(LogCategory.UI, "Configuration valid", mapOf("description" to binding.description))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$binding.actionId in listOf("panel.navigate_left", "panel.navigate_right", "panel.navigate_up", "panel.navigate_down")</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$else -&gt; logger.debug(LogCategory.UI, "Warning", mapOf("description" to binding.description, "message" to message))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$logger.debug(LogCategory.UI, "Skipped (lifecycle)", mapOf("description" to binding.description, "reason" to reason))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$logger.debug(LogCategory.UI, "Testing shortcut", mapOf("description" to binding.description, "keys" to binding.displayString()))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$logger.info(LogCategory.UI, "Batch test complete", mapOf("success" to countByStatus(TestStatus.SUCCESS), "failed" to countByStatus(TestStatus.FAILED), "skipped" to countByStatus(TestStatus.SKIPPED)))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$logger.warn(LogCategory.UI, "Failed (invalid key)", mapOf("description" to binding.description, "error" to keyValidation.second))</ID>
+    <ID>MaxLineLength:ShortcutTestRunner.kt$ShortcutTestRunner$logger.warn(LogCategory.UI, "Failed (no handler)", mapOf("description" to binding.description, "actionId" to binding.actionId))</ID>
+    <ID>MaxLineLength:SidePanel.kt$if (evolverOpenAvailable) { { dispatchEvolverOpen(EvolverContract.SECTION_ISSUE, "Report Issue") } } else null</ID>
+    <ID>MaxLineLength:SingleInstanceManager.kt$SingleInstanceManager$"Unable to bind IPC server: All ports $IPC_PORT_BASE-${IPC_PORT_BASE + IPC_PORT_RANGE - 1} are in use. "</ID>
+    <ID>MaxLineLength:SingleInstanceManager.kt$SingleInstanceManager$logger.warn(LogCategory.SYSTEM, "Unexpected response from existing instance", mapOf("response" to (response ?: "null")))</ID>
+    <ID>MaxLineLength:SplitView.kt$SplitViewState$collectAllTabsFromNode(state.rootNode, workspaceId, getWorkspaceName(workspaceId), windowId, result, seenTabIds)</ID>
+    <ID>MaxLineLength:SplitView.kt$SplitViewState$fun</ID>
+    <ID>MaxLineLength:SplitView.kt$SplitViewState$splitViewLogger.debug(LogCategory.UI, "Terminal tab created in first panel", if (command != null) mapOf("command" to command) else emptyMap())</ID>
+    <ID>MaxLineLength:SplitView.kt$SplitViewState$splitViewLogger.debug(LogCategory.UI, "Terminal tab created", if (command != null) mapOf("command" to command) else emptyMap())</ID>
+    <ID>MaxLineLength:SplitView.kt$SplitViewState$val foundTab = sourcePanel?.tabsComponent?.tabsState?.value?.tabs?.find { it.id == tab.id } as? FluckTabInfo</ID>
+    <ID>MaxLineLength:SplitViewOperationsImpl.kt$SplitViewOperationsImpl$// The workspace is already the correct type (plugin LayoutWorkspace == composeApp LayoutWorkspace via typealias)</ID>
+    <ID>MaxLineLength:SplitViewStateRegistry.kt$SplitViewStateRegistry$splitViewStateRegistryLogger.debug(LogCategory.UI, "Registering state for window", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:SplitViewStateRegistry.kt$SplitViewStateRegistry$splitViewStateRegistryLogger.debug(LogCategory.UI, "Total registered windows", mapOf("count" to _states.value.size))</ID>
+    <ID>MaxLineLength:SplitViewStateRegistry.kt$SplitViewStateRegistry$splitViewStateRegistryLogger.debug(LogCategory.UI, "Unregistering state for window", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:StartupSettings.kt$"If no workspaces are found within the timeout, it assumes a fresh install and shows the New Tab dialog."</ID>
+    <ID>MaxLineLength:StatusBarRegistryImpl.kt$StatusBarRegistryImpl$.</ID>
+    <ID>MaxLineLength:SupabaseApiClient.kt$SupabaseApiClient$// Secure configuration - values loaded from ConfigLoader (environment variables, system properties, or local.properties)</ID>
+    <ID>MaxLineLength:SupabasePasskeyService.kt$SupabasePasskeyService$logger.debug(LogCategory.PASSKEY, "Fetching passkeys for user", mapOf("userId" to LogSanitizer.maskUserId(userId)))</ID>
+    <ID>MaxLineLength:SupabasePasskeyService.kt$SupabasePasskeyService$logger.warn(LogCategory.PASSKEY, "Failed to fetch user passkeys", mapOf("error" to managementResponse.error))</ID>
+    <ID>MaxLineLength:SupabasePasskeyService.kt$SupabasePasskeyService$suspend</ID>
+    <ID>MaxLineLength:SystemPluginManifestService.kt$SystemPluginManifestService$logger</ID>
+    <ID>MaxLineLength:TerminalAPIAccess.kt$TerminalAPIAccess$fun</ID>
+    <ID>MaxLineLength:TerminalAPIAccess.kt$TerminalAPIAccess$logger.warn(LogCategory.SYSTEM, "Could not wire runner callbacks (plugin may be different version)", error = e)</ID>
+    <ID>MaxLineLength:TerminalAPIAccess.kt$TerminalAPIAccess$logger.warn(LogCategory.TERMINAL, "Failed to notify RunnerTerminalService of config removal", error = e)</ID>
+    <ID>MaxLineLength:TerminalAPIAccess.kt$TerminalAPIAccess$logger.warn(LogCategory.TERMINAL, "Failed to notify RunnerTerminalService of terminal removal", error = e)</ID>
+    <ID>MaxLineLength:TerminalHandlerService.kt$TerminalHandlerService$logger.debug(LogCategory.TERMINAL, "decrementProcessing", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:TerminalHandlerService.kt$TerminalHandlerService$logger.debug(LogCategory.TERMINAL, "incrementProcessing", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:TopOfMindDialog.kt$text = if (searchQuery.isBlank()) "No active tabs found" else "No tabs matching \"$searchQuery\""</ID>
+    <ID>MaxLineLength:TopOfMindDialog.kt$topOfMindLogger.debug(LogCategory.UI, "Selecting tab", mapOf("title" to activeTab.tabInfo.title, "windowId" to activeTab.windowId))</ID>
+    <ID>MaxLineLength:TrackingPluginContext.kt$TrackingPluginContext$override val runConfigurationDataProvider: RunConfigurationDataProvider? get() = delegate.runConfigurationDataProvider</ID>
+    <ID>MaxLineLength:URLHandlerService.kt$URLHandlerService$logger.debug(LogCategory.BROWSER, "Emitted URL open event", mapOf("url" to url, "windowId" to focusedWindowId))</ID>
+    <ID>MaxLineLength:URLHandlerService.kt$URLHandlerService$logger.debug(LogCategory.BROWSER, "Processing count decremented due to error", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:URLHandlerService.kt$URLHandlerService$logger.debug(LogCategory.BROWSER, "Processing count decremented", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:URLHandlerService.kt$URLHandlerService$logger.debug(LogCategory.BROWSER, "Processing count incremented", mapOf("count" to count, "isProcessing" to _isProcessing.value))</ID>
+    <ID>MaxLineLength:UpdateInstaller.kt$UpdateInstaller$"Downloaded file type '$fileName' is not valid for this platform. Expected: ${validExtensions.joinToString()}"</ID>
+    <ID>MaxLineLength:UpdateInstaller.kt$UpdateInstaller$logger.debug(LogCategory.SYSTEM, "Found app bundle via directory traversal", mapOf("path" to currentFile.absolutePath))</ID>
+    <ID>MaxLineLength:UpdateInstaller.kt$UpdateInstaller$logger.info(LogCategory.SYSTEM, "DMG opened for manual installation", mapOf("path" to downloadFile.absolutePath))</ID>
+    <ID>MaxLineLength:UpdateInstaller.kt$UpdateInstaller$logger.trace(LogCategory.SYSTEM, "Checking parent", mapOf("index" to i, "path" to currentFile.absolutePath))</ID>
+    <ID>MaxLineLength:UserExistenceService.kt$UserExistenceService$cred.transports?.contains("hybrid") == true &amp;&amp; !cred.id.contains("touchid-credential") -&gt; WebAuthnCredentialType.CROSS_DEVICE</ID>
+    <ID>MaxLineLength:UserExistenceService.kt$UserExistenceService$cred.transports?.contains("nfc") == true &amp;&amp; !cred.transports.contains("internal") -&gt; WebAuthnCredentialType.NFC_KEY</ID>
+    <ID>MaxLineLength:UserExistenceService.kt$UserExistenceService$cred.transports?.contains("usb") == true &amp;&amp; !cred.transports.contains("internal") -&gt; WebAuthnCredentialType.USB_KEY</ID>
+    <ID>MaxLineLength:UserExistenceService.kt$UserExistenceService$logger.debug(LogCategory.AUTH, "Server passkeys check result", mapOf("hasPasskeys" to hasServerPasskeys))</ID>
+    <ID>MaxLineLength:UserExistenceService.kt$UserExistenceService$val challengeResult = SupabasePasskeyService.requestAuthenticationChallenge(email, "check-${java.util.UUID.randomUUID()}")</ID>
+    <ID>MaxLineLength:UserService.kt$UserService$logger.debug(LogCategory.AUTH, "Fetched users", mapOf("count" to actualUsers.size, "offset" to offset, "hasMore" to hasMore))</ID>
+    <ID>MaxLineLength:UserService.kt$UserService$logger.debug(LogCategory.AUTH, "Search found users", mapOf("count" to actualUsers.size, "query" to searchQuery, "offset" to offset, "hasMore" to hasMore))</ID>
+    <ID>MaxLineLength:UserService.kt$UserService$logger.debug(LogCategory.AUTH, "Successfully fetched users with roles for search", mapOf("count" to usersWithRoles.size, "query" to searchQuery))</ID>
+    <ID>MaxLineLength:UserService.kt$UserService$logger.debug(LogCategory.AUTH, "Successfully fetched users with roles", mapOf("count" to usersWithRoles.size, "hasMore" to paginatedUsers.hasMore))</ID>
+    <ID>MaxLineLength:UserService.kt$UserService$logger.error(LogCategory.AUTH, "Failed to fetch user", mapOf("userId" to userId, "error" to (e.message ?: "unknown")))</ID>
+    <ID>MaxLineLength:VersionSelectionDialog.kt$text = "Released: ${formatReleaseDate(versionInfo.releaseDate)} • ${formatFileSize(versionInfo.downloadSize)}"</ID>
+    <ID>MaxLineLength:VersionVerifier.kt$VersionVerifier$logger</ID>
+    <ID>MaxLineLength:VersionVerifier.kt$VersionVerifier$logger.debug(LogCategory.SYSTEM, "Version verification passed", mapOf("version" to runtimeVersion.toString()))</ID>
+    <ID>MaxLineLength:VersionVerifier.kt$VersionVerifier$logger.debug(LogCategory.SYSTEM, "Version verification skipped (production build)", mapOf("version" to runtimeVersion.toString()))</ID>
+    <ID>MaxLineLength:WasmFileScanner.kt$actual suspend</ID>
+    <ID>MaxLineLength:WasmFluckView.kt$text = "Browser implementation for WASM/JS platform is pending.\nThis could use an iframe or other web-based solution."</ID>
+    <ID>MaxLineLength:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$val commonSubdomains = listOf("login", "accounts", "auth", "signin", "signup", "sso", "id", "portal", "app", "my")</ID>
+    <ID>MaxLineLength:WindowAppearanceSettingsManager.kt$WindowAppearanceSettingsManager$logger.debug(LogCategory.SYSTEM, "Created default settings", mapOf("path" to settingsFile.absolutePath))</ID>
+    <ID>MaxLineLength:WindowFitMathTest.kt$WindowFitMathTest$val r = computeFitSize(current, -1000f, -1000f, scaleX = 1f, scaleY = 1f, maxWidthDp = noClamp, maxHeightDp = noClamp)</ID>
+    <ID>MaxLineLength:WindowFitMathTest.kt$WindowFitMathTest$val r = computeFitSize(current, -200f, -100f, scaleX = 1f, scaleY = 1f, maxWidthDp = noClamp, maxHeightDp = noClamp)</ID>
+    <ID>MaxLineLength:WindowFitMathTest.kt$WindowFitMathTest$val r = computeFitSize(current, 200f, 100f, scaleX = 0f, scaleY = -1f, maxWidthDp = noClamp, maxHeightDp = noClamp)</ID>
+    <ID>MaxLineLength:WindowFitMathTest.kt$WindowFitMathTest$val r = computeFitSize(current, 200f, 100f, scaleX = 1f, scaleY = 1f, maxWidthDp = noClamp, maxHeightDp = noClamp)</ID>
+    <ID>MaxLineLength:WindowFitMathTest.kt$WindowFitMathTest$val r = computeFitSize(current, 200f, 100f, scaleX = 2f, scaleY = 2f, maxWidthDp = noClamp, maxHeightDp = noClamp)</ID>
+    <ID>MaxLineLength:WindowManager.kt$WindowManager$logger.debug(LogCategory.UI, "Closed window", mapOf("windowId" to windowId, "remainingWindows" to _windows.size))</ID>
+    <ID>MaxLineLength:WindowManager.kt$WindowManager$logger.debug(LogCategory.UI, "Consumed pending project", mapOf("project" to it.name, "windowId" to windowId))</ID>
+    <ID>MaxLineLength:WindowManager.kt$WindowManager$logger.debug(LogCategory.UI, "Created new window", mapOf("windowId" to windowId, "type" to windowType.toString(), "totalWindows" to _windows.size))</ID>
+    <ID>MaxLineLength:WindowManager.kt$WindowManager$logger.debug(LogCategory.UI, "Stored pending project for new window", mapOf("project" to project.name, "windowId" to windowState.id))</ID>
+    <ID>MaxLineLength:WindowManager.kt$WindowManager$logger.debug(LogCategory.UI, "Stored pending tab for new window", mapOf("tab" to initialTab.title, "windowId" to windowState.id))</ID>
+    <ID>MaxLineLength:WindowProjectStateRegistry.kt$WindowProjectStateRegistry$windowProjectStateLogger.debug(LogCategory.UI, "Creating new state for window", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:WindowRunnerState.kt$WindowRunnerState$logger.debug(LogCategory.UI, "Selected configuration", mapOf("windowId" to windowId, "name" to (config?.name ?: "none")))</ID>
+    <ID>MaxLineLength:WindowRunnerStateRegistry.kt$WindowRunnerStateRegistry$windowRunnerStateRegistryLogger.debug(LogCategory.UI, "Creating new state for window", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:WindowRunnerStateRegistry.kt$WindowRunnerStateRegistry$windowRunnerStateRegistryLogger.debug(LogCategory.UI, "Registered state for window", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:WindowRunnerStateRegistry.kt$WindowRunnerStateRegistry$windowRunnerStateRegistryLogger.debug(LogCategory.UI, "Unregistered state for window", mapOf("windowId" to windowId))</ID>
+    <ID>MaxLineLength:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$"""reg add "$REGISTERED_APPS" /v BOSS /d "SOFTWARE\\Clients\\StartMenuInternet\\BOSS\\Capabilities" /f"""</ID>
+    <ID>MaxLineLength:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$"""reg add "$START_MENU_KEY\Capabilities" /v ApplicationDescription /d "Business Operating System + Simulation - Intelligent service automation platform" /f"""</ID>
+    <ID>MaxLineLength:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$logger.error(LogCategory.BROWSER, "Critical registry key failed with exception, aborting registration")</ID>
+    <ID>MaxLineLength:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private const val HTTPS_USER_CHOICE = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\https\\UserChoice"</ID>
+    <ID>MaxLineLength:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private const val HTTP_USER_CHOICE = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice"</ID>
+    <ID>MaxLineLength:WindowsProtocolHandler.kt$WindowsProtocolHandler$logger.debug(LogCategory.SYSTEM, "Running in development mode - deep links require MSI installation")</ID>
+    <ID>MaxLineLength:WindowsProtocolHandler.kt$WindowsProtocolHandler$logger.info(LogCategory.SYSTEM, "Protocol already registered to different valid BOSS installation, skipping", mapOf("path" to currentExePath))</ID>
+    <ID>MaxLineLength:WindowsProtocolHandler.kt$WindowsProtocolHandler$logger.info(LogCategory.SYSTEM, "Protocol points to invalid path, re-registering", mapOf("command" to currentCommand))</ID>
+    <ID>MaxLineLength:WindowsProtocolHandler.kt$WindowsProtocolHandler$logger.info(LogCategory.SYSTEM, "Protocol points to non-existent path, re-registering", mapOf("command" to currentCommand))</ID>
+    <ID>MaxLineLength:WindowsProtocolHandler.kt$WindowsProtocolHandler$logger.warn(LogCategory.SYSTEM, "jpackage.app-path set but file doesn't exist", mapOf("path" to jpackagePath))</ID>
+    <ID>MaxLineLength:WizardComponents.kt$color = if (isSelected || isHovered) BossTheme.colors.textPrimary else BossTheme.colors.textSecondary</ID>
+    <ID>MaxLineLength:WorkspaceApplier.kt$createTabFromWorkspaceConfig(tabConfig, projectPath, splitViewState)?.let { tabsComponent?.addTab(it) }</ID>
+    <ID>MaxLineLength:WorkspaceApplier.kt$logger</ID>
+    <ID>MaxLineLength:WorkspaceApplier.kt$private</ID>
+    <ID>MaxLineLength:WorkspaceApplier.kt$val firstBottomTabInfo = getFirstTab(node.bottom)?.let { createTabFromWorkspaceConfig(it, projectPath, splitViewState) }</ID>
+    <ID>MaxLineLength:WorkspaceApplier.kt$val firstRightTabInfo = getFirstTab(node.right)?.let { createTabFromWorkspaceConfig(it, projectPath, splitViewState) }</ID>
+    <ID>MaxLineLength:WorkspaceSelectionDialog.kt$workspacePanelSelections</ID>
+    <ID>MaxLineLength:main.kt$logger</ID>
+    <ID>MaxLineLength:main.kt$logger.debug(LogCategory.SYSTEM, "API key availability", apiKeyStatus.mapValues { if (it.value) "set" else "not set" })</ID>
+    <ID>MaxLineLength:main.kt$val screenBounds = awtWindow.graphicsConfiguration?.device?.defaultConfiguration?.bounds</ID>
+    <ID>MayBeConst:AndroidLLMSettingsManager.kt$LLMSettingsManager$private val prefsName = "llm_settings"</ID>
+    <ID>MayBeConst:AndroidLLMSettingsManager.kt$LLMSettingsManager$private val settingsKey = "settings_json"</ID>
+    <ID>MayBeConst:IosLLMSettingsManager.kt$LLMSettingsManager$private val settingsKey = "llm_settings_json"</ID>
+    <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$fun activatePlugin(pluginId: String)</ID>
+    <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$fun stopDragging()</ID>
+    <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$private fun updateHoverTarget()</ID>
+    <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun createBrowser(config: BrowserConfig): BrowserHandle?</ID>
+    <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun disposeBrowser(handle: BrowserHandle)</ID>
+    <ID>NestedBlockDepth:CLICommandHandler.kt$CLICommandHandler$private suspend fun executeCommand(command: CLICommand)</ID>
+    <ID>NestedBlockDepth:CLIInstaller.kt$CLIInstaller$private fun installHomebrewStyle(): CLIInstallResult</ID>
+    <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal suspend fun installFromCandidates( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) } ): Result&lt;Path&gt;</ID>
+    <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$private fun downloadWithProgress( urlString: String, targetPath: Path, onProgress: (DownloadProgress) -&gt; Unit )</ID>
+    <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$private fun extractWithJava(zipPath: Path, targetDir: Path)</ID>
+    <ID>NestedBlockDepth:ConfigLoader.kt$ConfigLoader$private fun loadLocalProperties()</ID>
+    <ID>NestedBlockDepth:CrashHandler.kt$CrashHandler$internal fun attributePluginId(throwable: Throwable): String?</ID>
+    <ID>NestedBlockDepth:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend fun pollForAuthenticationCompletion(challenge: String, sessionId: String? = null): Result&lt;PasskeyAuthenticationResult&gt;</ID>
+    <ID>NestedBlockDepth:DesktopBrowserAccessor.kt$private fun findBrowserForTab( splitViewState: ai.rever.boss.components.window_panel.SplitViewState, tabId: String ): LockedBrowser?</ID>
+    <ID>NestedBlockDepth:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun findProjectRootInternal(startDir: File?): File?</ID>
+    <ID>NestedBlockDepth:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun scanDirectory( directory: File, projectPath: String, configurations: MutableList&lt;RunConfiguration&gt; )</ID>
+    <ID>NestedBlockDepth:DesktopProjectCreationService.kt$ProjectCreationService$actual fun validateProjectLocation(parentDirectory: String, projectName: String): ValidationResult</ID>
+    <ID>NestedBlockDepth:DesktopUpdateService.kt$UpdateService$private suspend fun downloadFrom( url: String, assetName: String, assetSize: Long, sha256: String?, onProgress: (progress: Float) -&gt; Unit ): String?</ID>
+    <ID>NestedBlockDepth:DesktopUrlOpener.kt$actual fun openUrlInBrowser(url: String)</ID>
+    <ID>NestedBlockDepth:DownloadDataProviderImpl.kt$DownloadDataProviderImpl$override suspend fun removeDownload(id: String): Result&lt;Unit&gt;</ID>
+    <ID>NestedBlockDepth:DownloadSettings.kt$private fun getLinuxDownloadsDirectory(userHome: String): String</ID>
+    <ID>NestedBlockDepth:DynamicPluginManager.kt$DynamicPluginManager$suspend fun installPlugin(jarPath: String, enabled: Boolean = true): Result&lt;DynamicPluginInfo&gt;</ID>
+    <ID>NestedBlockDepth:DynamicPluginManager.kt$DynamicPluginManager$suspend fun loadPersistedPlugins( plugins: List&lt;PersistedPluginEntry&gt; ): Map&lt;String, Result&lt;DynamicPluginInfo&gt;&gt;</ID>
+    <ID>NestedBlockDepth:DynamicPluginManager.kt$DynamicPluginManager.Companion$private suspend fun hotSwapApiLayerOrchestration(pluginDir: java.io.File): Result&lt;Int&gt;</ID>
+    <ID>NestedBlockDepth:FileIndexer.kt$FileIndexer$private fun scanDirectory( dir: File, rootCanonicalPath: String, rootPathLength: Int, files: MutableList&lt;IndexedFile&gt;, depth: Int = 0 )</ID>
+    <ID>NestedBlockDepth:FluckEngine.kt$FluckEngine$private fun cleanupStaleLockFiles(profileDir: java.nio.file.Path): Boolean</ID>
+    <ID>NestedBlockDepth:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses(userHome: String)</ID>
+    <ID>NestedBlockDepth:FontManager.kt$FontManager$private fun discoverAndCategorizeFonts(): Map&lt;String, List&lt;String&gt;&gt;</ID>
+    <ID>NestedBlockDepth:GitHubUpdateSource.kt$GitHubUpdateSource$override suspend fun listReleases(): List&lt;GitHubRelease&gt;</ID>
+    <ID>NestedBlockDepth:GlobalSearchService.kt$GlobalSearchService$private suspend fun searchPluginProviders(query: String): List&lt;SearchResult&gt;</ID>
+    <ID>NestedBlockDepth:KeyboardEventBus.kt$KeyboardEventBus$suspend fun emit(event: KeyboardEvent): Boolean</ID>
+    <ID>NestedBlockDepth:KeymapSettingsManager.kt$KeymapSettingsManager$private fun loadSettingsSync()</ID>
+    <ID>NestedBlockDepth:PasskeyAuthService.kt$PasskeyAuthService$suspend fun authenticateWithPasskey(email: String? = null, credentialId: String? = null): Result&lt;Unit&gt;</ID>
+    <ID>NestedBlockDepth:PasskeySessionHandler.kt$PasskeySessionHandler$suspend fun completeAuthentication(authData: PasskeyAuthenticationResult): Result&lt;Unit&gt;</ID>
+    <ID>NestedBlockDepth:PluginStoreSetup.kt$PluginStoreSetup$private fun copyBundledPluginsToPluginDir( dynamicPluginManager: ai.rever.boss.components.plugin.DynamicPluginManager )</ID>
+    <ID>NestedBlockDepth:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun ensureSystemPluginsInstalled()</ID>
+    <ID>NestedBlockDepth:RoleService.kt$RoleService$suspend fun canPerformAction(userId: String, permissionName: String): Result&lt;Boolean&gt;</ID>
+    <ID>NestedBlockDepth:SplitView.kt$SplitViewState$fun collectAllActiveFluckTabs(windowId: String = "unknown"): List&lt;ActiveTab&gt;</ID>
+    <ID>NestedBlockDepth:SplitView.kt$SplitViewState$fun collectAllActiveTabs(workspaceManager: ai.rever.boss.components.workspaces.WorkspaceManager? = null, windowId: String = "unknown"): List&lt;ActiveTab&gt;</ID>
+    <ID>NestedBlockDepth:SplitView.kt$SplitViewState$fun splitPanel( panelId: String, orientation: SplitOrientation, tabToMove: TabInfo? = null, detachedTab: BossTabsComponent.DetachedTab? = null ): String</ID>
+    <ID>NestedBlockDepth:UrlHistoryManager.kt$UrlHistoryManager$private fun loadHistory()</ID>
+    <ID>NestedBlockDepth:UserExistenceService.kt$UserExistenceService$suspend fun checkUserExists(email: String): Result&lt;UserExistence&gt;</ID>
+    <ID>NestedBlockDepth:WorkspaceApplier.kt$private suspend fun applyWorkspaceNode( node: SplitConfig, splitViewState: SplitViewState, currentPanelId: String, projectPath: String )</ID>
+    <ID>NestedBlockDepth:main.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>NestedBlockDepth:main.kt$private fun extractPty4jNatives(targetDir: File)</ID>
+    <ID>NewLineAtEndOfFile:PluginStoreSetup.kt$ai.rever.boss.plugin.PluginStoreSetup.kt</ID>
+    <ID>NewLineAtEndOfFile:WorkspaceButton.wasm.kt$ai.rever.boss.components.workspaces.WorkspaceButton.wasm.kt</ID>
+    <ID>NewLineAtEndOfFile:WorkspaceFileManager.kt$ai.rever.boss.components.workspaces.WorkspaceFileManager.kt</ID>
+    <ID>NewLineAtEndOfFile:WorkspaceManager.kt$ai.rever.boss.components.workspaces.WorkspaceManager.kt</ID>
+    <ID>PackageNaming:AndroidBrowserAccessor.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:AndroidBrowserFunctions.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:AndroidCodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:AndroidFileScanner.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:AndroidFluckTabComponent.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:AndroidFluckView.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:AndroidLLMSettingsManager.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:BookmarksDialogProviderImpl.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:BossMainWindowPanel.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
+    <ID>PackageNaming:BossPanelTopBar.kt$package ai.rever.boss.components.window_panel.components</ID>
+    <ID>PackageNaming:BossResizablePanel.kt$package ai.rever.boss.components.window_panel.components</ID>
+    <ID>PackageNaming:BossTabBar.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
+    <ID>PackageNaming:BossTabsComponentMoveTest.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:BossWindow.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:BrowserFunctions.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:BrowserIntegration.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:BrowserSecretIntegrationViewModel.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:CodeBase.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:CodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:DesktopBrowserAccessor.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:DesktopCodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:DesktopFileScanner.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:DesktopFileScannerTest.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:DesktopFluckTabComponent.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:DesktopFluckView.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:DesktopLLMSettingsManager.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:DownloadDataProviderFactory.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:DownloadDataProviderImpl.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:DownloadManager.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:DownloadSettings.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:DownloadState.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:EditorSyntaxColors.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:EmptyContentScreen.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
+    <ID>PackageNaming:FileIndexCache.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:Fluck.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:FluckView.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:GutterRunIcon.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:IosBrowserAccessor.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:IosBrowserFunctions.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:IosCodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:IosFileScanner.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:IosFluckTabComponent.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:IosFluckView.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:IosLLMSettingsManager.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:JsDialogNotifier.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:LLMModelFetcher.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:LLMSettings.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:PanelHostTab.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:PromoteSidebarToTab.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:SecretChangeNotifier.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:SidePanel.kt$package ai.rever.boss.components.window_panel.components.side_panel</ID>
+    <ID>PackageNaming:SkipListDriftTest.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:SplitView.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:SplitViewStateRegistry.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:TabCycleOverlay.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
+    <ID>PackageNaming:TabsNavigation.kt$package ai.rever.boss.components.tabs_navigation</ID>
+    <ID>PackageNaming:TopOfMindProvider.kt$package ai.rever.boss.components.plugin.panels.left_bottom.TopOfMind</ID>
+    <ID>PackageNaming:WasmBrowserAccessor.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PackageNaming:WasmBrowserFunctions.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:WasmCodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:WasmFileScanner.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
+    <ID>PackageNaming:WasmFluckTabComponent.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:WasmFluckView.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
+    <ID>PackageNaming:WasmLLMSettingsManager.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
+    <ID>PrintStackTrace:CrashHandler.kt$CrashHandler$e</ID>
+    <ID>RethrowCaughtException:FluckEngine.kt$FluckEngine$throw e2</ID>
+    <ID>ReturnCount:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun detectContextFromAwtComponent(component: java.awt.Component?): ShortcutContext</ID>
+    <ID>ReturnCount:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$private fun findMatchingPluginDefault(event: KeyEvent): String?</ID>
+    <ID>ReturnCount:AndroidFileScanner.kt$actual fun directoryHasChildren(path: String, showHidden: Boolean): Boolean</ID>
+    <ID>ReturnCount:ApplicationRestarter.kt$ApplicationRestarter$private fun buildRelaunchCommand(): List&lt;String&gt;</ID>
+    <ID>ReturnCount:ApplicationRestarter.kt$ApplicationRestarter$private fun detectMacAppBundle(launcher: String?): String?</ID>
+    <ID>ReturnCount:BossDraggableComponent.kt$BossDraggableComponent$fun getItemsForSlot(slot: Panel, hidden: Set&lt;String&gt;): List&lt;SidebarItem&gt;</ID>
+    <ID>ReturnCount:BossDraggableComponent.kt$BossDraggableComponent$fun isVisible(panel: Panel): Boolean</ID>
+    <ID>ReturnCount:BossMainWindowPanel.kt$BossTabsComponent$fun currentCycleOverlay(): TabCycleOverlayData?</ID>
+    <ID>ReturnCount:BossMainWindowPanel.kt$BossTabsComponent$fun detachTab(tabId: String): DetachedTab?</ID>
+    <ID>ReturnCount:BossMainWindowPanel.kt$BossTabsComponent.BossTabUpdateProvider$override fun updateFavicon(faviconUrl: String?)</ID>
+    <ID>ReturnCount:BossMainWindowPanel.kt$BossTabsComponent.BossTabUpdateProvider$override fun updateTitle(title: String)</ID>
+    <ID>ReturnCount:BrowserFunctions.kt$actual fun getBrowserState( url: String, onOpenInNewTab: ((String) -&gt; Unit)?, onBrowserClosed: (() -&gt; Unit)?, window: Any? ): Pair&lt;Any, Any&gt;?</ID>
+    <ID>ReturnCount:BrowserFunctions.kt$actual fun isBrowserValid(browser: Any?): Boolean</ID>
+    <ID>ReturnCount:BrowserFunctions.kt$actual fun recreateBrowserViewState(browser: Any, window: Any?): Any?</ID>
+    <ID>ReturnCount:BrowserServiceImpl.kt$BrowserServiceImpl$override fun deleteProfile(profileName: String): Boolean</ID>
+    <ID>ReturnCount:CLICommandHandler.kt$CLICommandHandler$private suspend fun handleLoadWorkspace(configPath: String)</ID>
+    <ID>ReturnCount:CLICommandHandler.kt$CLICommandHandler$private suspend fun handleOpenFile(filePath: String)</ID>
+    <ID>ReturnCount:CLICommandHandler.kt$CLICommandHandler$private suspend fun handleOpenFolder(folderPath: String)</ID>
+    <ID>ReturnCount:CLIInstaller.kt$CLIInstaller$private fun installHomebrewStyle(): CLIInstallResult</ID>
+    <ID>ReturnCount:CLIInstaller.kt$CLIInstaller$private fun updateShellConfig(binPath: String): ShellConfigResult</ID>
+    <ID>ReturnCount:CLISecurityValidator.kt$CLISecurityValidator$fun isValidPath(path: String): Boolean</ID>
+    <ID>ReturnCount:CLISecurityValidator.kt$CLISecurityValidator$fun normalizeAndValidateUrl(url: String): String?</ID>
+    <ID>ReturnCount:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$fun isChromiumInstalled(): Boolean</ID>
+    <ID>ReturnCount:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal fun promotePendingInstall(pending: File, target: File, backup: File)</ID>
+    <ID>ReturnCount:ChromiumReleaseSource.kt$ChromiumReleaseResolver.Companion$private fun comparePreRelease(a: List&lt;String&gt;, b: List&lt;String&gt;): Int</ID>
+    <ID>ReturnCount:CrashHandler.kt$CrashHandler$internal fun attributePluginId(throwable: Throwable): String?</ID>
+    <ID>ReturnCount:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend fun handleCrossDeviceAuthentication( exception: CrossDeviceAuthenticationRequired, onAuthenticationComplete: suspend (PasskeyAuthenticationResult) -&gt; Result&lt;Unit&gt; ): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:CrossDeviceAuthService.kt$CrossDeviceAuthService$suspend fun pollForAuthenticationCompletion(challenge: String, sessionId: String? = null): Result&lt;PasskeyAuthenticationResult&gt;</ID>
+    <ID>ReturnCount:DeepLinkHandler.kt$DeepLinkHandler$actual fun extractVerificationToken(uri: String): String?</ID>
+    <ID>ReturnCount:DeepLinkHandler.kt$DeepLinkHandler$actual fun extractVerificationType(uri: String): String?</ID>
+    <ID>ReturnCount:DeepLinkHandler.kt$DeepLinkHandler$private fun handleFolderLink(uri: String)</ID>
+    <ID>ReturnCount:DefaultPlugin.kt$ApiActiveTabsProviderAdapter$override fun getFaviconCacheKey(tabId: String): String?</ID>
+    <ID>ReturnCount:DefaultPlugin.kt$ApiActiveTabsProviderAdapter$override fun getTabUrl(tabId: String): String?</ID>
+    <ID>ReturnCount:DesktopBrowserAccessor.kt$BrowserAccessor$actual fun getActiveBrowserIntegration(): BrowserIntegration?</ID>
+    <ID>ReturnCount:DesktopBrowserAccessor.kt$actual fun createFluckTabInfo(activeTab: Any): FluckTabInfo?</ID>
+    <ID>ReturnCount:DesktopBrowserAccessor.kt$private fun findBrowserForTab( splitViewState: ai.rever.boss.components.window_panel.SplitViewState, tabId: String ): LockedBrowser?</ID>
+    <ID>ReturnCount:DesktopLLMSettingsManager.kt$actual fun getEnvironmentVariable(name: String): String?</ID>
+    <ID>ReturnCount:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun findProjectRootInternal(startDir: File?): File?</ID>
+    <ID>ReturnCount:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun generateJavaCommand(detected: DetectedMainFunction, projectDir: File): String</ID>
+    <ID>ReturnCount:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun generateKotlinCommand(detected: DetectedMainFunction, projectDir: File): String</ID>
+    <ID>ReturnCount:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$private fun generateRustCommand(detected: DetectedMainFunction, projectDir: File): String</ID>
+    <ID>ReturnCount:DesktopProjectCreationService.kt$ProjectCreationService$actual fun validateProjectLocation(parentDirectory: String, projectName: String): ValidationResult</ID>
+    <ID>ReturnCount:DesktopRunnerTerminalService.kt$RunnerTerminalService$actual suspend fun stopRunner(windowId: String, configId: String): Boolean</ID>
+    <ID>ReturnCount:DesktopUpdateService.kt$UpdateService$actual suspend fun checkForUpdates(): UpdateInfo</ID>
+    <ID>ReturnCount:DesktopUpdateService.kt$UpdateService$actual suspend fun downloadUpdate( updateInfo: UpdateInfo, onProgress: (progress: Float) -&gt; Unit ): String?</ID>
+    <ID>ReturnCount:DynamicPluginManager.kt$DynamicPluginManager$fun getBundledPluginsDirectory(): java.io.File</ID>
+    <ID>ReturnCount:DynamicPluginManager.kt$DynamicPluginManager$suspend fun installPlugin(jarPath: String, enabled: Boolean = true): Result&lt;DynamicPluginInfo&gt;</ID>
+    <ID>ReturnCount:DynamicPluginManager.kt$DynamicPluginManager$suspend fun loadBundledPlugins( bundledDir: java.io.File ): Map&lt;String, Result&lt;DynamicPluginInfo&gt;&gt;</ID>
+    <ID>ReturnCount:DynamicPluginManager.kt$DynamicPluginManager$suspend fun reloadPlugin(pluginId: String): Result&lt;DynamicPluginInfo&gt;</ID>
+    <ID>ReturnCount:DynamicPluginManager.kt$DynamicPluginManager.Companion$private suspend fun hotSwapApiLayerOrchestration(pluginDir: java.io.File): Result&lt;Int&gt;</ID>
+    <ID>ReturnCount:DynamicPluginManager.kt$internal fun pluginAccessAllowed( isAdmin: Boolean, userPermissions: Set&lt;String&gt;, requiresAdmin: Boolean, requiredPermissions: List&lt;String&gt;, ): Boolean</ID>
+    <ID>ReturnCount:FaviconCache.kt$FaviconCache$fun loadFavicon(cacheKey: String): ai.rever.boss.plugin.api.TabIcon.Image?</ID>
+    <ID>ReturnCount:FaviconCache.kt$FaviconCache$fun saveFavicon(url: String, imageBitmap: ImageBitmap): String?</ID>
+    <ID>ReturnCount:FluckEngine.kt$FluckEngine$private fun cleanupStaleLockFiles(profileDir: java.nio.file.Path): Boolean</ID>
+    <ID>ReturnCount:FluckEngine.kt$FluckEngine$private fun getMacOSBundledChromiumPath(): java.nio.file.Path?</ID>
+    <ID>ReturnCount:FluckEngine.kt$FluckEngine$private fun getWindowsBundledChromiumPath(): java.nio.file.Path?</ID>
+    <ID>ReturnCount:FluckEngine.kt$FluckEngine$private fun runningInContainer(): Boolean</ID>
+    <ID>ReturnCount:FluckEngine.kt$FluckEngine.BrowserFindBar$private fun performFind(backward: Boolean)</ID>
+    <ID>ReturnCount:FontManager.kt$FontManager$fun isFontAvailable(fontName: String): Boolean</ID>
+    <ID>ReturnCount:FormFieldDetector.kt$FormFieldDetector$private fun determineFieldType( inputType: String, fieldName: String, fieldId: String, placeholder: String, autocomplete: String, className: String, ariaLabel: String ): FieldType</ID>
+    <ID>ReturnCount:FuzzyMatcher.kt$FuzzyMatcher$fun match(pattern: String, target: String, targetLower: String = target.lowercase()): MatchResult?</ID>
+    <ID>ReturnCount:FuzzyMatcher.kt$FuzzyMatcher$private fun isWordBoundary(text: String, index: Int): Boolean</ID>
+    <ID>ReturnCount:GitHubUpdateSource.kt$GitHubUpdateSource$private suspend fun makeGitHubRequest( url: String, authContext: GitHubConfig.GitHubAuthContext ): HttpResponse</ID>
+    <ID>ReturnCount:HighQualityFaviconService.kt$HighQualityFaviconService$private fun loadFromCache(cacheKey: String): ai.rever.boss.plugin.api.TabIcon.Image?</ID>
+    <ID>ReturnCount:IpcCompatibility.kt$IpcCompatibility$fun status(minIpcVersion: String): Status</ID>
+    <ID>ReturnCount:IpcCompatibility.kt$IpcCompatibility$private fun parse(version: String): Triple&lt;Int, Int, Int&gt;?</ID>
+    <ID>ReturnCount:KeymapMatcher.kt$KeymapMatcher$fun match(event: KeyEvent, context: ShortcutContext): KeyBinding?</ID>
+    <ID>ReturnCount:KeymapMatcher.kt$KeymapMatcher$private fun matchesBinding(event: KeyEvent, binding: KeyBinding): Boolean</ID>
+    <ID>ReturnCount:LLMSettings.kt$LLMSettings$fun getApiKey(provider: LLMProvider): String?</ID>
+    <ID>ReturnCount:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$private fun getDefaultHandlers(): Map&lt;String, String&gt;</ID>
+    <ID>ReturnCount:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$private fun setDefaultHandlerForScheme(scheme: String): Boolean</ID>
+    <ID>ReturnCount:McpToolRegistryImpl.kt$McpToolRegistryCore$private fun permitted(def: McpToolDefinition): Boolean</ID>
+    <ID>ReturnCount:MenuShortcutBridge.kt$MenuShortcutBridge$fun getKeyShortcut(actionId: String): androidx.compose.ui.input.key.KeyShortcut?</ID>
+    <ID>ReturnCount:NewTabDialog.kt$private fun validateFilePath(path: String, basePath: String? = null): String?</ID>
+    <ID>ReturnCount:PanelComponentStore.kt$PanelComponentStore$fun getOrCreateComponent(panelId: PanelId): PanelComponentWithUI?</ID>
+    <ID>ReturnCount:PanelComponentStore.kt$PanelComponentStore$fun resetComponent(panelId: PanelId): Boolean</ID>
+    <ID>ReturnCount:PasskeyAuthService.kt$PasskeyAuthService$suspend fun authenticateWithPasskey(email: String? = null, credentialId: String? = null): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:PasskeyAuthService.kt$PasskeyAuthService$suspend fun registerPasskey(): Result&lt;String&gt;</ID>
+    <ID>ReturnCount:PasskeyAuthenticationHandler.kt$PasskeyAuthenticationHandler$suspend fun requestChallenge( email: String? = null, sessionId: String? = null ): Result&lt;PasskeyAuthenticationChallenge&gt;</ID>
+    <ID>ReturnCount:PasskeyCredentialManager.kt$PasskeyCredentialManager$suspend fun deletePasskey(credentialId: String): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:PasskeyCredentialManager.kt$PasskeyCredentialManager$suspend fun getUserPasskeys(): Result&lt;List&lt;PasskeyInfo&gt;&gt;</ID>
+    <ID>ReturnCount:PasskeySessionHandler.kt$PasskeySessionHandler$suspend fun completeAuthentication(authData: PasskeyAuthenticationResult): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$private fun collectViaKernelRegistry(): List&lt;ChildProcessData&gt;</ID>
+    <ID>ReturnCount:PerformanceMonitor.kt$PerformanceMonitor$private fun hasSignificantChange(old: PerformanceSnapshot, new: PerformanceSnapshot): Boolean</ID>
+    <ID>ReturnCount:PluginInstallService.kt$PluginInstallService$private fun downloadFromGitHubRelease(owner: String, repo: String, pluginDir: File): String?</ID>
+    <ID>ReturnCount:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$private fun isMicrokernelRuntimeJar(jarPath: String): Boolean</ID>
+    <ID>ReturnCount:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$private suspend fun doReloadPlugin(pluginId: String): LoadedPluginInfo?</ID>
+    <ID>ReturnCount:PluginStoreSetup.kt$PluginStoreSetup$internal fun isNewerVersion(version1: String, version2: String): Boolean</ID>
+    <ID>ReturnCount:PluginStoreSetup.kt$PluginStoreSetup$private fun copyBundledPluginsToPluginDir( dynamicPluginManager: ai.rever.boss.components.plugin.DynamicPluginManager )</ID>
+    <ID>ReturnCount:PluginUpdateBridge.kt$PluginUpdateBridge$actual suspend fun performUpdate(pluginId: String, manager: DynamicPluginManager): Result&lt;String&gt;</ID>
+    <ID>ReturnCount:PluginUpdateBridge.kt$PluginUpdateBridge$actual suspend fun refreshAll(installed: List&lt;InstalledPluginRef&gt;)</ID>
+    <ID>ReturnCount:RoleService.kt$RoleService$suspend fun canPerformAction(userId: String, permissionName: String): Result&lt;Boolean&gt;</ID>
+    <ID>ReturnCount:SecretModels.kt$CreateSecretRequest$fun validate(): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:SecretModels.kt$ShareSecretRequest$fun validate(): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:SecretModels.kt$UnshareSecretRequest$fun validate(): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:SecretModels.kt$UpdateSecretRequest$fun validate(): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:SessionManager.kt$SessionManager$suspend fun establishSession( accessToken: String, refreshToken: String, userInfo: UserInfo, authMethod: AuthMethod, expiresIn: Long = 3600L ): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:SessionManager.kt$SessionManager$suspend fun loadSession(): Result&lt;UserInfo?&gt;</ID>
+    <ID>ReturnCount:ShortcutTestRunner.kt$ShortcutTestRunner$private fun validateKeyName(keyName: String): Pair&lt;Boolean, String&gt;</ID>
+    <ID>ReturnCount:ShortcutTestRunner.kt$ShortcutTestRunner$suspend fun testShortcut(binding: KeyBinding): ShortcutTestResult</ID>
+    <ID>ReturnCount:SplitTemplatesManager.kt$SplitTemplatesManager$private fun getGitRemoteUrl(projectPath: String): String</ID>
+    <ID>ReturnCount:SplitView.kt$SplitViewState$fun openUrlInActivePanel(url: String, title: String, forceNewTab: Boolean = false)</ID>
+    <ID>ReturnCount:SplitView.kt$SplitViewState$fun setActivePanel(panelId: String)</ID>
+    <ID>ReturnCount:SupabasePasskeyService.kt$SupabasePasskeyService$suspend fun getUserPasskeys(userId: String): Result&lt;List&lt;PasskeyCredential&gt;&gt;</ID>
+    <ID>ReturnCount:SupabasePasskeyService.kt$SupabasePasskeyService$suspend fun requestRegistrationChallenge( userId: String, displayName: String, authenticatorSelection: AuthenticatorSelectionCriteria? ): Result&lt;PasskeyChallenge&gt;</ID>
+    <ID>ReturnCount:TabDraggableComponent.kt$TabDraggableComponent$private fun calculateReorderIndex(panelId: String, position: Offset): Int</ID>
+    <ID>ReturnCount:TabDraggableComponent.kt$TabDraggableComponent$private fun checkEdgeScroll()</ID>
+    <ID>ReturnCount:TabDraggableComponent.kt$TabDraggableComponent$private fun updateDropTarget()</ID>
+    <ID>ReturnCount:TabUpdateRegistry.kt$TabUpdateRegistry$private fun resolveProvider(tabId: String, typeId: TabTypeId): TabUpdateProvider?</ID>
+    <ID>ReturnCount:URLHandlerService.kt$URLHandlerService$private fun isValidURL(url: String): Boolean</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$fun getCurrentApplicationPath(): String?</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$private fun detectLinuxDistroType(): String</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$private fun findInstalledAppViaSpotlight(): String?</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$private fun resolveRealAppPath(path: String): String</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$private fun verifyNoDowngrade(downloadFile: File): Boolean</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$suspend fun installUpdate(downloadPath: String): InstallResult</ID>
+    <ID>ReturnCount:UpdateInstaller.kt$internal fun realAppPathFor( path: String, appExists: (String) -&gt; Boolean, installedAppLookup: () -&gt; String? ): String</ID>
+    <ID>ReturnCount:UpdateManager.kt$UpdateManager$private suspend fun checkForUpdatesInternal(force: Boolean = false): UpdateResult</ID>
+    <ID>ReturnCount:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$fun extractMainDomain(url: String): String?</ID>
+    <ID>ReturnCount:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private fun registerAsBrowserCandidate(): Boolean</ID>
+    <ID>SpreadOperator:CrashHandler.kt$CrashHandler$(javaBin, *getRestartArgs())</ID>
+    <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, *args.toTypedArray())</ID>
+    <ID>SpreadOperator:FilePickerProviderFactory.kt$DesktopFilePickerProvider$( filters.joinToString(", ") { "*.$it" }, *filters.toTypedArray() )</ID>
+    <ID>SwallowedException:AndroidCodeEditor.kt$e: Exception</ID>
+    <ID>SwallowedException:AndroidWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>SwallowedException:BossWindow.kt$e: Exception</ID>
+    <ID>SwallowedException:BrowserFunctions.kt$e: Exception</ID>
+    <ID>SwallowedException:BrowserHandleImpl.kt$BrowserHandleImpl$e: Exception</ID>
+    <ID>SwallowedException:BrowserPageCard.kt$e: Exception</ID>
+    <ID>SwallowedException:BrowserZoomSettingsManager.kt$BrowserZoomSettingsManager$e: Exception</ID>
+    <ID>SwallowedException:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$e: Exception</ID>
+    <ID>SwallowedException:CloneProjectDialog.kt$e: Exception</ID>
+    <ID>SwallowedException:ContextMenuHandler.kt$ContextMenuHandler$e: Throwable</ID>
+    <ID>SwallowedException:DefaultPlugin.kt$ApiActiveTabsProviderAdapter$e: Exception</ID>
+    <ID>SwallowedException:DefaultPlugin.kt$DefaultBackgroundTaskProvider$e: Exception</ID>
+    <ID>SwallowedException:DefaultPlugin.kt$DefaultCacheProvider$e: Exception</ID>
+    <ID>SwallowedException:DesktopBrowserAccessor.kt$DesktopBrowserIntegration$e: Exception</ID>
+    <ID>SwallowedException:DesktopBrowserAccessor.kt$e: Exception</ID>
+    <ID>SwallowedException:DesktopCodeEditor.kt$e: Exception</ID>
+    <ID>SwallowedException:DesktopDirectoryPickerProviderImpl.kt$DirectoryPickerProviderImpl$e: Exception</ID>
+    <ID>SwallowedException:DesktopFilePicker.kt$DesktopDirectoryPicker$e: Exception</ID>
+    <ID>SwallowedException:DesktopFileScanner.kt$e: Exception</ID>
+    <ID>SwallowedException:DesktopGitService.kt$GitService$e: Exception</ID>
+    <ID>SwallowedException:DesktopLLMSettingsManager.kt$e: Exception</ID>
+    <ID>SwallowedException:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$e: Exception</ID>
+    <ID>SwallowedException:DesktopWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>SwallowedException:DynamicPluginManager.kt$DynamicPluginManager$e: Exception</ID>
+    <ID>SwallowedException:FaviconLoader.kt$e: Exception</ID>
+    <ID>SwallowedException:FileIndexer.kt$FileIndexer$e: Exception</ID>
+    <ID>SwallowedException:FilePicker.kt$DesktopFilePicker$e: Exception</ID>
+    <ID>SwallowedException:FileSystemUtils.kt$FileSystemUtils$e: Exception</ID>
+    <ID>SwallowedException:FluckEngine.kt$FluckEngine$e2: Exception</ID>
+    <ID>SwallowedException:FluckEngine.kt$FluckEngine$e: Exception</ID>
+    <ID>SwallowedException:FluckEngine.kt$FluckEngine$e: UserDataDirectoryAlreadyInUseException</ID>
+    <ID>SwallowedException:FluckEngine.kt$FluckEngine$e: java.util.concurrent.TimeoutException</ID>
+    <ID>SwallowedException:FontManager.kt$FontManager$e: Exception</ID>
+    <ID>SwallowedException:FormFieldDetector.kt$FormFieldDetector$e: Exception</ID>
+    <ID>SwallowedException:FormFieldInjector.kt$FormFieldInjector$e: Exception</ID>
+    <ID>SwallowedException:GitHubConfig.kt$GitHubConfig$e: Exception</ID>
+    <ID>SwallowedException:HighQualityFaviconService.kt$HighQualityFaviconService$e: Exception</ID>
+    <ID>SwallowedException:IosWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>SwallowedException:IpcEventBridgeImpl.kt$IpcEventBridgeImpl$e: Exception</ID>
+    <ID>SwallowedException:LLMSettings.kt$LLMSettings$e: Exception</ID>
+    <ID>SwallowedException:LinuxDefaultBrowserHandler.kt$LinuxDefaultBrowserHandler$e: Exception</ID>
+    <ID>SwallowedException:LockedBrowser.kt$LockedBrowser$e: Exception</ID>
+    <ID>SwallowedException:LogEntry.kt$LogEntry$e: Exception</ID>
+    <ID>SwallowedException:MacOSGestureHandler.kt$MacOSGestureHandler$e: Exception</ID>
+    <ID>SwallowedException:McpToolRegistryImpl.kt$McpToolRegistryCore$t: Throwable</ID>
+    <ID>SwallowedException:McpToolRegistryImpl.kt$McpToolRegistryCore$t: TimeoutCancellationException</ID>
+    <ID>SwallowedException:NetworkMonitorService.kt$NetworkMonitorService$e: Exception</ID>
+    <ID>SwallowedException:NewTabDialog.kt$e: Exception</ID>
+    <ID>SwallowedException:PasskeyConfigHelper.kt$PasskeyConfigHelper$e: Exception</ID>
+    <ID>SwallowedException:PasskeyDataMapper.kt$PasskeyDataMapper$e: Exception</ID>
+    <ID>SwallowedException:PasskeyDataMapper.kt$PasskeyDataMapper$parseException: Exception</ID>
+    <ID>SwallowedException:PerformanceSettingsManager.kt$PerformanceSettingsManager$e: Exception</ID>
+    <ID>SwallowedException:PluginInstallService.kt$PluginInstallService$e: Exception</ID>
+    <ID>SwallowedException:PluginPersistence.kt$PluginPersistence$e: Exception</ID>
+    <ID>SwallowedException:PowerShellExecutor.kt$PowerShellExecutor$e: Exception</ID>
+    <ID>SwallowedException:RecentBrowserPagesManager.kt$RecentBrowserPagesManager$e: Exception</ID>
+    <ID>SwallowedException:RevealInFileManager.kt$e: IOException</ID>
+    <ID>SwallowedException:ScreenCapturePickerDialog.kt$e: Exception</ID>
+    <ID>SwallowedException:SecuritySettings.kt$e: Exception</ID>
+    <ID>SwallowedException:SingleInstanceManager.kt$SingleInstanceManager$e: Exception</ID>
+    <ID>SwallowedException:SingleInstanceManager.kt$SingleInstanceManager$e: SocketTimeoutException</ID>
+    <ID>SwallowedException:SplitTemplatesManager.kt$SplitTemplatesManager$e: Exception</ID>
+    <ID>SwallowedException:SwiftScriptExecutor.kt$SwiftScriptExecutor$e: Exception</ID>
+    <ID>SwallowedException:UpdateInstaller.kt$UpdateInstaller$e: Exception</ID>
+    <ID>SwallowedException:UpdateScriptGenerator.kt$UpdateScriptGenerator$e: Exception</ID>
+    <ID>SwallowedException:UrlHistoryManager.kt$UrlHistoryManager$e: Exception</ID>
+    <ID>SwallowedException:UserDataStorage.kt$UserDataStorage$e: Exception</ID>
+    <ID>SwallowedException:VersionSelectionDialog.kt$e: Exception</ID>
+    <ID>SwallowedException:VersionVerifier.kt$VersionVerifier$e: Exception</ID>
+    <ID>SwallowedException:WasmWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>SwallowedException:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$e: Exception</ID>
+    <ID>SwallowedException:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$e: Exception</ID>
+    <ID>SwallowedException:WindowsProtocolHandler.kt$WindowsProtocolHandler$e: Exception</ID>
+    <ID>SwallowedException:WorkspaceButton.android.kt$e: Exception</ID>
+    <ID>SwallowedException:WorkspaceButton.desktop.kt$e: Exception</ID>
+    <ID>SwallowedException:WorkspaceButton.ios.kt$e: Exception</ID>
+    <ID>SwallowedException:WorkspaceManager.kt$WorkspaceManager$e: Exception</ID>
+    <ID>SwallowedException:main.kt$e: Exception</ID>
+    <ID>ThrowsCount:PowerShellExecutor.kt$PowerShellExecutor$fun executePowerShellScript(scriptName: String, vararg args: String): String</ID>
+    <ID>ThrowsCount:UpdateInstaller.kt$UpdateInstaller$private fun validateDownloadFile(downloadFile: File, expectedExtension: String)</ID>
+    <ID>ThrowsCount:UpdateScriptGenerator.kt$UpdateScriptGenerator$private fun validatePath(path: String, description: String)</ID>
+    <ID>TooGenericExceptionCaught:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AndroidCodeEditor.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AndroidLLMSettingsManager.kt$LLMSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AndroidUrlOpener.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AndroidWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AppThemeSettingsManager.kt$AppThemeSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AppUpdateRealtimeService.kt$AppUpdateRealtimeService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ApplicationRestarter.kt$ApplicationRestarter$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BiometricAuthProvider.kt$BiometricAuthProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BossAppDialogs.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BossAppEventBusEffects.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BossAppStartupEffects.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BossMainWindowPanel.kt$BossTabsComponent.BossTabUpdateProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BossWindow.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BridgedPluginViewModel.kt$BridgedPluginViewModel$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserEngineSettings.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserEngineSettingsManager.kt$BrowserEngineSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserFunctions.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserHandleImpl.kt$BrowserHandleImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserHandleImpl.kt$BrowserHandleImpl.Companion$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserInjectDispatcher.kt$BrowserInjectDispatcher$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:BrowserPageCard.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserProviders.kt$DesktopScreenCaptureProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserServiceImpl.kt$BrowserServiceImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserServiceImpl.kt$BrowserServiceImpl$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:BrowserSettingsManager.kt$BrowserSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BrowserZoomSettingsManager.kt$BrowserZoomSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CLICommandHandler.kt$CLICommandHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CLIInstaller.kt$CLIInstaller$e2: Exception</ID>
+    <ID>TooGenericExceptionCaught:CLIInstaller.kt$CLIInstaller$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CLIVersionManager.kt$CLIVersionManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ChromiumDownloader.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ChromiumReleaseSource.kt$ChromiumReleaseResolver$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ClipboardHelper.kt$ClipboardHelper$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ClipboardProviderFactory.kt$DesktopClipboardProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CloneProjectDialog.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CoBrowseRtcPeerImpl.kt$CoBrowseRtcPeerImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CoBrowseRtcPeerImpl.kt$CoBrowseRtcPeerImpl$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:CoBrowseRtcPeerImpl.kt$CoBrowseRtcProviderImpl$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:CoBrowseScripts.kt$CoBrowseScripts$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CodeBase.kt$ProjectState$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CodeEditor.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ConfigLoader.kt$ConfigLoader$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ContextMenuHandler.kt$ContextMenuHandler$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:CoreAuthService.kt$CoreAuthService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CrashHandler.kt$CrashHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CrashHandler.kt$CrashHandler$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:CrashReportService.kt$CrashReportService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CrossDeviceAuthService.kt$CrossDeviceAuthService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CrossDeviceBrowserManager.kt$CrossDeviceBrowserManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:CrossDeviceBrowserManager.kt$CrossDeviceBrowserManager$fallbackException: Exception</ID>
+    <ID>TooGenericExceptionCaught:DashboardStatsManager.kt$DashboardStatsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DeepLinkActionRegistryImpl.kt$DeepLinkActionRegistryImpl$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:DeepLinkHandler.kt$DeepLinkHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DefaultPlugin.kt$ApiActiveTabsProviderAdapter$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DefaultPlugin.kt$DefaultBackgroundTaskProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DefaultPlugin.kt$DefaultCacheProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DefaultPlugin.kt$DefaultPlugin$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopBrowserAccessor.kt$DesktopBrowserIntegration$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopBrowserAccessor.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopCodeEditor.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopDirectoryPickerProviderImpl.kt$DirectoryPickerProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopFilePicker.kt$DesktopDirectoryPicker$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopFileScanner.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopGitService.kt$GitService$cleanupError: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopGitService.kt$GitService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopLLMSettingsManager.kt$LLMSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopLLMSettingsManager.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopPasskeyBrowserView.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopPasskeyService.kt$DesktopPasskeyService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopProjectCreationService.kt$ProjectCreationService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopRunConfigurationManager.kt$RunConfigurationManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopRunExecutionService.kt$RunExecutionService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopRunnerSettingsManager.kt$RunnerSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopRunnerTerminalService.kt$RunnerTerminalService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopStartupSettingsManager.kt$StartupSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopTerminalLinkSettingsManager.kt$TerminalLinkSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopUpdateService.kt$UpdateService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopUrlOpener.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DesktopWorkspaceSettingsManager.kt$WorkspaceSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DisplayUtils.kt$DisplayUtils$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DownloadDataProviderImpl.kt$DownloadDataProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DownloadSettings.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DynamicPluginManager.kt$DynamicPluginManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DynamicPluginManager.kt$DynamicPluginManager$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:DynamicPluginManager.kt$DynamicPluginManager$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:DynamicPluginManager.kt$DynamicPluginManager.Companion$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:EditorContentProviderImpl.kt$EditorContentProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:EmailAuthService.kt$EmailAuthService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FallbackUpdateSource.kt$FallbackUpdateSource$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FaviconCache.kt$FaviconCache$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FaviconLoader.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FileIndexer.kt$FileIndexer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FilePicker.kt$DesktopFilePicker$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FilePicker.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FilePickerProviderFactory.kt$DesktopFilePickerProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FileSystemUtils.kt$FileSystemUtils$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Fluck.kt$FluckTabComponent$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FluckEngine.kt$FluckEngine$e2: Exception</ID>
+    <ID>TooGenericExceptionCaught:FluckEngine.kt$FluckEngine$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FluckEngine.kt$FluckEngine$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FluckEngine.kt$FluckEngine.BrowserFindBar$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FluckPanelProviders.kt$FluckPanelContentProviderImpl$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FluckTabInfoTest.kt$FluckTabInfoTest$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FocusModeSettingsManager.kt$FocusModeSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FontManager.kt$FontManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FormFieldDetector.kt$FormFieldDetector$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FormFieldInjector.kt$FormFieldInjector$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FullscreenBrowserWindow.kt$FullscreenBrowserWindow$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GitHubConfig.kt$GitHubConfig$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GlobalSearchService.kt$GlobalSearchService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:HighQualityFaviconService.kt$HighQualityFaviconService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:IosLLMSettingsManager.kt$LLMSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:IosUrlOpener.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:IosWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:IpcEventBridgeImpl.kt$IpcEventBridgeImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KernelBootstrap.kt$KernelBootstrap$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KeyboardEventBus.kt$KeyboardEventBus$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KeymapSettingsManager.kt$KeymapSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LLMModelFetcher.kt$LLMModelFetcher$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LLMProvidersSettings.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LLMSettings.kt$LLMSettings$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LinuxDefaultBrowserHandler.kt$LinuxDefaultBrowserHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LockedBrowser.kt$LockedBrowser$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LogEntry.kt$LogEntry$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MacOSCamera.kt$MacOSCamera$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MacOSGestureHandler.kt$MacOSGestureHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MacOSScreenCapture.kt$CoreGraphics.Companion$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MacOSScreenCapture.kt$MacOSScreenCapture$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MacOSTouchIDAuth.kt$MacOSTouchIDAuth$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MagicLinkWaitingScreen.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:McpToolRegistryImpl.kt$McpToolRegistryCore$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:NetworkMonitorService.kt$NetworkMonitorService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:NewTabDialog.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:OutOfProcessPluginSpawnerImpl.kt$OutOfProcessPluginSpawnerImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PanelComponentStore.kt$PanelComponentStore$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PanelMenuRegistryImpl.kt$PanelMenuRegistryImpl$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PasskeyAuthService.kt$PasskeyAuthService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyAuthenticationHandler.kt$PasskeyAuthenticationHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyConfigHelper.kt$PasskeyConfigHelper$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyCredentialManager.kt$PasskeyCredentialManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyDataMapper.kt$PasskeyDataMapper$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyDataMapper.kt$PasskeyDataMapper$parseException: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyPlatformInit.kt$PasskeyPlatformInit$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeyRegistrationHandler.kt$PasskeyRegistrationHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PasskeySessionHandler.kt$PasskeySessionHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PerformanceDataProviderImpl.kt$PerformanceDataProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PerformanceMonitor.kt$PerformanceMonitor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PerformanceSettingsManager.kt$PerformanceSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginInstallService.kt$PluginInstallService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginListProvider.kt$PluginListProvider$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PluginPersistence.kt$PluginPersistence$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginProcessMonitor.kt$PluginProcessMonitor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginShortcutRegistryImpl.kt$PluginShortcutRegistryImpl$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PluginStateBridge.kt$PluginStateBridge$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginStateManager.kt$PluginStateManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginStorageFactoryProvider.kt$PluginStorageProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginStoreApiKeyProviderImpl.kt$PluginStoreApiKeyProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginStoreSetup.kt$PluginStoreSetup$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginStoreSetup.kt$PluginStoreSetup$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PluginUpdateBridge.kt$PluginUpdateBridge$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PowerShellExecutor.kt$PowerShellExecutor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RecentBrowserPagesManager.kt$RecentBrowserPagesManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RecentFilesManager.kt$RecentFilesManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RemotePanelComponent.kt$RemotePanelComponent$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RemoteTabComponent.kt$RemoteTabComponent$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RoleCreationService.kt$RoleCreationService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RoleService.kt$RoleService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ScreenCapturePickerDialog.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SecretService.kt$SecretService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SecuritySettings.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SessionManager.kt$SessionManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ShortcutLifecycleManager.kt$ShortcutLifecycleManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SidebarVisibilitySettingsManager.kt$SidebarVisibilitySettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SingleInstanceManager.kt$SingleInstanceManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SplitTemplatesManager.kt$SplitTemplatesManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SupabaseConfig.kt$SupabaseConfig$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SupabaseDataProviderImpl.kt$SupabaseDataProviderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SupabasePasskeyService.kt$SupabasePasskeyService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SwiftScriptExecutor.kt$SwiftScriptExecutor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SystemPluginManifestService.kt$SystemPluginManifestService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:TerminalAPIAccess.kt$TerminalAPIAccess$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:URLHandlerService.kt$URLHandlerService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UpdateInstaller.kt$UpdateInstaller$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UpdateManager.kt$UpdateManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UpdateScriptGenerator.kt$UpdateScriptGenerator$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UpdateSettingsManager.kt$UpdateSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UrlHistoryManager.kt$UrlHistoryManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UserDataStorage.kt$UserDataStorage$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UserExistenceService.kt$UserExistenceService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:UserService.kt$UserService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:VersionListManager.kt$VersionListManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:VersionSelectionDialog.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:VersionVerifier.kt$VersionVerifier$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WasmLLMSettingsManager.kt$LLMSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WasmUrlOpener.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WasmWorkspaceFileManager.kt$WorkspaceFileManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WindowAppearanceSettingsManager.kt$WindowAppearanceSettingsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WindowsHelloAuth.kt$WindowsHelloAuth$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WindowsProtocolHandler.kt$WindowsProtocolHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WorkspaceButton.android.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WorkspaceButton.desktop.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WorkspaceButton.ios.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WorkspaceButton.wasm.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WorkspaceManager.kt$WorkspaceManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:main.kt$e: Exception</ID>
+    <ID>TooGenericExceptionThrown:CrashHandler.kt$CrashHandler$throw RuntimeException("Test crash triggered via CrashHandler.triggerTestCrash()")</ID>
+    <ID>TooGenericExceptionThrown:CrossDeviceBrowserManager.kt$CrossDeviceBrowserManager$throw Exception("Unsupported platform for opening browser: $os")</ID>
+    <ID>TooGenericExceptionThrown:KeyboardEventBusTest.kt$KeyboardEventBusTest$throw RuntimeException("Test error")</ID>
+    <ID>TooGenericExceptionThrown:PowerShellExecutor.kt$PowerShellExecutor$throw RuntimeException("Could not find or create PowerShell scripts directory")</ID>
+    <ID>TooGenericExceptionThrown:PowerShellExecutor.kt$PowerShellExecutor$throw RuntimeException("PowerShell script failed with exit code: ${process.exitValue()}, output: $output")</ID>
+    <ID>TooGenericExceptionThrown:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest.&lt;no name provided&gt;$throw RuntimeException("Test error")</ID>
+    <ID>TooManyFunctions:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor</ID>
+    <ID>TooManyFunctions:AndroidBrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.AndroidBrowserFunctions.kt</ID>
+    <ID>TooManyFunctions:AndroidCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.AndroidCodeEditor.kt</ID>
+    <ID>TooManyFunctions:AuthService.kt$AuthService</ID>
+    <ID>TooManyFunctions:BookmarkAPIAccess.kt$BookmarkAPIAccess</ID>
+    <ID>TooManyFunctions:BossDraggableComponent.kt$BossDraggableComponent</ID>
+    <ID>TooManyFunctions:BossLogger.kt$BossLogger</ID>
+    <ID>TooManyFunctions:BossLoggerTest.kt$BossLoggerTest</ID>
+    <ID>TooManyFunctions:BossMainWindowPanel.kt$BossTabsComponent : ComponentContext</ID>
+    <ID>TooManyFunctions:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest</ID>
+    <ID>TooManyFunctions:BrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.BrowserFunctions.kt</ID>
+    <ID>TooManyFunctions:BrowserHandleImpl.kt$BrowserHandleImpl : BrowserHandle</ID>
+    <ID>TooManyFunctions:BrowserSecretIntegrationViewModel.kt$BrowserSecretIntegrationViewModel</ID>
+    <ID>TooManyFunctions:BrowserServiceImpl.kt$BrowserServiceImpl : BrowserService</ID>
+    <ID>TooManyFunctions:CLICommandHandler.kt$CLICommandHandler</ID>
+    <ID>TooManyFunctions:CLIInstaller.kt$CLIInstaller</ID>
+    <ID>TooManyFunctions:ChromiumAutoDownloader.kt$ChromiumAutoDownloader</ID>
+    <ID>TooManyFunctions:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest</ID>
+    <ID>TooManyFunctions:CodeEditor.kt$ai.rever.boss.components.plugin.tab_types.CodeEditor.kt</ID>
+    <ID>TooManyFunctions:CommonConditions.kt$Conditions</ID>
+    <ID>TooManyFunctions:CommonConditionsTest.kt$CommonConditionsTest</ID>
+    <ID>TooManyFunctions:CrashHandler.kt$CrashHandler</ID>
+    <ID>TooManyFunctions:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest</ID>
+    <ID>TooManyFunctions:DeepLinkHandler.kt$DeepLinkHandler</ID>
+    <ID>TooManyFunctions:DefaultPlugin.kt$ApiActiveTabsProviderAdapter : ActiveTabsProvider</ID>
+    <ID>TooManyFunctions:DefaultPlugin.kt$DefaultPlugin : PluginContext</ID>
+    <ID>TooManyFunctions:DesktopCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.DesktopCodeEditor.kt</ID>
+    <ID>TooManyFunctions:DesktopFileScannerTest.kt$DesktopFileScannerTest</ID>
+    <ID>TooManyFunctions:DesktopGitService.kt$GitService</ID>
+    <ID>TooManyFunctions:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector : MainFunctionDetector</ID>
+    <ID>TooManyFunctions:DesktopRunConfigurationManager.kt$RunConfigurationManager</ID>
+    <ID>TooManyFunctions:DesktopRunnerTerminalService.kt$RunnerTerminalService</ID>
+    <ID>TooManyFunctions:DesktopUpdateService.kt$UpdateService</ID>
+    <ID>TooManyFunctions:DownloadManager.kt$DownloadManager</ID>
+    <ID>TooManyFunctions:DynamicPluginManager.kt$DynamicPluginManager</ID>
+    <ID>TooManyFunctions:FileEventBusTest.kt$FileEventBusTest</ID>
+    <ID>TooManyFunctions:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl : FileSystemDataProvider</ID>
+    <ID>TooManyFunctions:Fluck.kt$FluckTabInfo : TabInfo</ID>
+    <ID>TooManyFunctions:Fluck.kt$ai.rever.boss.components.plugin.tab_types.fluck.Fluck.kt</ID>
+    <ID>TooManyFunctions:FluckEngine.kt$FluckEngine</ID>
+    <ID>TooManyFunctions:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest</ID>
+    <ID>TooManyFunctions:FluckTabInfoTest.kt$FluckTabInfoTest</ID>
+    <ID>TooManyFunctions:FontManager.kt$FontManager</ID>
+    <ID>TooManyFunctions:FullscreenBrowserWindow.kt$FullscreenBrowserWindow</ID>
+    <ID>TooManyFunctions:FuzzyMatcherTest.kt$FuzzyMatcherTest</ID>
+    <ID>TooManyFunctions:GitDataProviderImpl.kt$GitDataProviderImpl : GitDataProvider</ID>
+    <ID>TooManyFunctions:GitService.kt$GitService</ID>
+    <ID>TooManyFunctions:GitServiceBridge.kt$GitServiceBridge : GitServiceCoroutineImplBase</ID>
+    <ID>TooManyFunctions:GlobalSearchDialog.kt$ai.rever.boss.components.dialogs.GlobalSearchDialog.kt</ID>
+    <ID>TooManyFunctions:GlobalSearchService.kt$GlobalSearchService</ID>
+    <ID>TooManyFunctions:IosBrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.IosBrowserFunctions.kt</ID>
+    <ID>TooManyFunctions:IosCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.IosCodeEditor.kt</ID>
+    <ID>TooManyFunctions:KeyboardEventBusTest.kt$KeyboardEventBusTest</ID>
+    <ID>TooManyFunctions:KeymapHandlerTest.kt$KeymapHandlerTest</ID>
+    <ID>TooManyFunctions:KeymapMatcherTest.kt$KeymapMatcherTest</ID>
+    <ID>TooManyFunctions:KeymapValidatorTest.kt$KeymapValidatorTest</ID>
+    <ID>TooManyFunctions:LLMModelFetcher.kt$LLMModelFetcher</ID>
+    <ID>TooManyFunctions:LogSanitizer.kt$LogSanitizer</ID>
+    <ID>TooManyFunctions:LogSanitizerTest.kt$LogSanitizerTest</ID>
+    <ID>TooManyFunctions:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest</ID>
+    <ID>TooManyFunctions:McpToolRegistryImpl.kt$McpToolRegistryCore</ID>
+    <ID>TooManyFunctions:MenuActionsHandler.kt$MenuActionsHandler</ID>
+    <ID>TooManyFunctions:PasskeyDataMapper.kt$PasskeyDataMapper</ID>
+    <ID>TooManyFunctions:PerformanceMonitor.kt$PerformanceMonitor</ID>
+    <ID>TooManyFunctions:PerformanceMonitorTest.kt$PerformanceMonitorTest</ID>
+    <ID>TooManyFunctions:PluginInstallWizardState.kt$PluginInstallWizardState</ID>
+    <ID>TooManyFunctions:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl : PluginLoaderDelegate</ID>
+    <ID>TooManyFunctions:PluginPersistence.kt$PluginPersistence</ID>
+    <ID>TooManyFunctions:PluginStorageFactoryProvider.kt$PluginStorageProviderImpl : PluginStorageProvider</ID>
+    <ID>TooManyFunctions:PluginStoreSetup.kt$PluginStoreSetup</ID>
+    <ID>TooManyFunctions:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest</ID>
+    <ID>TooManyFunctions:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest</ID>
+    <ID>TooManyFunctions:ProjectCreationServiceTest.kt$ProjectCreationServiceTest</ID>
+    <ID>TooManyFunctions:RoleCreationService.kt$RoleCreationService</ID>
+    <ID>TooManyFunctions:RoleManagementProviderImpl.kt$RoleManagementProviderImpl : RoleManagementProvider</ID>
+    <ID>TooManyFunctions:RoleManagementServiceBridge.kt$RoleManagementServiceBridge : RoleManagementServiceCoroutineImplBase</ID>
+    <ID>TooManyFunctions:RunnerTerminalService.kt$RunnerTerminalService</ID>
+    <ID>TooManyFunctions:SecretDataProviderImpl.kt$SecretDataProviderImpl : SecretDataProvider</ID>
+    <ID>TooManyFunctions:SecretServiceBridge.kt$SecretServiceBridge : SecretServiceCoroutineImplBase</ID>
+    <ID>TooManyFunctions:SettingsComponents.kt$ai.rever.boss.components.settings.shared.SettingsComponents.kt</ID>
+    <ID>TooManyFunctions:ShortcutLifecycleManager.kt$ShortcutLifecycleManager</ID>
+    <ID>TooManyFunctions:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest</ID>
+    <ID>TooManyFunctions:SplitTemplatesManager.kt$SplitTemplatesManager</ID>
+    <ID>TooManyFunctions:SplitView.kt$SplitViewState</ID>
+    <ID>TooManyFunctions:SplitViewOperationsImpl.kt$SplitViewOperationsImpl : SplitViewOperations</ID>
+    <ID>TooManyFunctions:TabDraggableComponent.kt$TabDraggableComponent</ID>
+    <ID>TooManyFunctions:TerminalAPIAccess.kt$TerminalAPIAccess</ID>
+    <ID>TooManyFunctions:TrackingPluginContext.kt$PluginRegistrationTracker</ID>
+    <ID>TooManyFunctions:TrackingPluginContext.kt$TrackingPluginContext : PluginContext</ID>
+    <ID>TooManyFunctions:UpdateInstaller.kt$UpdateInstaller</ID>
+    <ID>TooManyFunctions:UpdateManager.kt$UpdateManager</ID>
+    <ID>TooManyFunctions:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest</ID>
+    <ID>TooManyFunctions:WasmBrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.WasmBrowserFunctions.kt</ID>
+    <ID>TooManyFunctions:WasmCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.WasmCodeEditor.kt</ID>
+    <ID>TooManyFunctions:WindowManager.kt$WindowManager</ID>
+    <ID>TooManyFunctions:WorkspaceManager.kt$WorkspaceManager</ID>
+    <ID>UnusedParameter:AWTKeyboardInterceptor.kt$AWTKeyboardInterceptor$matcher: KeymapMatcher</ID>
+    <ID>UnusedParameter:CLIInstaller.kt$CLIInstaller$binPath: String</ID>
+    <ID>UnusedParameter:CodeEditor.kt$projectPath: String</ID>
+    <ID>UnusedParameter:Dashboard.kt$onActivatePlugin: (String) -&gt; Unit</ID>
+    <ID>UnusedParameter:Dashboard.kt$onNewTerminal: () -&gt; Unit</ID>
+    <ID>UnusedParameter:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector$content: String</ID>
+    <ID>UnusedParameter:FluckEngine.kt$FluckEngine$fileName: String</ID>
+    <ID>UnusedParameter:FluckEngine.kt$FluckEngine$profileName: String</ID>
+    <ID>UnusedParameter:FluckEngine.kt$FluckEngine$userHome: String</ID>
+    <ID>UnusedParameter:FormFieldInjector.kt$FormFieldInjector$fieldIdentifier: String = "activeElement"</ID>
+    <ID>UnusedParameter:FormFieldInjector.kt$FormFieldInjector$fieldInfo: FormFieldDetector.FormFieldInfo</ID>
+    <ID>UnusedParameter:KeymapValidator.kt$KeymapValidator$settings: KeymapSettings</ID>
+    <ID>UnusedParameter:LoginFormScreen.kt$onLoginSuccess: () -&gt; Unit</ID>
+    <ID>UnusedParameter:OutOfProcessPluginSpawnerImpl.kt$OutOfProcessPluginSpawnerImpl$manifest: PluginManifest</ID>
+    <ID>UnusedParameter:OutOfProcessPluginSpawnerImpl.kt$OutOfProcessPluginSpawnerImpl$pluginId: String</ID>
+    <ID>UnusedParameter:PasskeyAuthViewModel.kt$PasskeyAuthViewModel$email: String</ID>
+    <ID>UnusedParameter:PasskeyBrowserScreen.kt$sessionId: String</ID>
+    <ID>UnusedParameter:PluginCrashFallbackUI.kt$pluginId: String</ID>
+    <ID>UnusedParameter:PluginInstallWizard.kt$category: PluginCategory</ID>
+    <ID>UnusedParameter:PluginInstallWizard.kt$hasSelectedPlugins: Boolean</ID>
+    <ID>UnusedParameter:PluginInstallWizard.kt$isInstalling: Boolean</ID>
+    <ID>UnusedParameter:PluginInstallWizard.kt$onBack: () -&gt; Unit</ID>
+    <ID>UnusedParameter:SingleInstanceManager.kt$SingleInstanceManager$onUrlReceived: (String) -&gt; Unit</ID>
+    <ID>UnusedParameter:TopOfMindDialog.kt$splitViewState: SplitViewState? = null</ID>
+    <ID>UnusedParameter:WindowManager.kt$WindowManager$sourceWindowId: String</ID>
+    <ID>UnusedParameter:WindowManager.kt$WindowManager$windowId: String</ID>
+    <ID>UnusedParameter:WizardDialog.kt$isLastStep: Boolean</ID>
+    <ID>UnusedPrivateMember:FormFieldDetector.kt$FormFieldDetector$private fun parseFieldInfo(jsObjectString: String): FormFieldInfo?</ID>
+    <ID>UnusedPrivateMember:FormFieldInjector.kt$FormFieldInjector$private suspend fun logFieldDebugInfo( browser: LockedBrowser, phase: String, fieldIdentifier: String = "activeElement" ): String</ID>
+    <ID>UnusedPrivateMember:PluginPersistence.kt$PluginPersistence$private fun saveConfig()</ID>
+    <ID>UnusedPrivateMember:SplitView.kt$SplitViewState$private fun findPanelWithFile(filePath: String): Pair&lt;String, BossTabsComponent&gt;?</ID>
+    <ID>UnusedPrivateProperty:BossWindow.kt$val currentWindow = window</ID>
+    <ID>UnusedPrivateProperty:BridgedPanelComponent.kt$BridgedPanelComponent$private val logger = LoggerFactory.getLogger(BridgedPanelComponent::class.java)</ID>
+    <ID>UnusedPrivateProperty:BrowserHandleImpl.kt$BrowserHandleImpl$val className = extractValue("className")</ID>
+    <ID>UnusedPrivateProperty:CLIInstaller.kt$CLIInstaller$private val isLinux = System.getProperty("os.name").lowercase().contains("linux")</ID>
+    <ID>UnusedPrivateProperty:ContextMenuServiceBridge.kt$ContextMenuServiceBridge$private val provider: ContextMenuProvider</ID>
+    <ID>UnusedPrivateProperty:Dashboard.kt$val dialogScope = rememberCoroutineScope()</ID>
+    <ID>UnusedPrivateProperty:DashboardContentProviderImpl.kt$DashboardContentProviderImpl$val scope = rememberCoroutineScope()</ID>
+    <ID>UnusedPrivateProperty:DashboardContentProviderImpl.kt$DashboardContentProviderImpl$val windowId = LocalWindowId.current</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin$private val notificationListener = PluginSandboxNotificationListener(notificationService).also { (sandboxManager as? PluginSandboxManagerImpl)?.addListener(it) }</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$// Plugin IDs for sandboxing - using consistent naming private const val PLUGIN_ID_BOOKMARKS = "panel-bookmarks"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$// Tab plugin IDs private const val PLUGIN_ID_TAB_FLUCK = "tab-fluck"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_ADMIN_ROLE_MGMT = "panel-admin-role-management"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_CODEBASE = "panel-codebase"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_CONSOLE = "panel-console"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_DOWNLOADS = "panel-downloads"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_FLUCK = "panel-fluck"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_GIT_LOG = "panel-git-log"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_GIT_STATUS = "panel-git-status"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_LLM_RPA = "panel-llm-rpa"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_PERFORMANCE = "panel-performance"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_PLUGIN_MANAGER = "panel-plugin-manager"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_ROLE_CREATION = "panel-role-creation"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_RPA_ENGINE = "panel-rpa-engine"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_RPA_RECORDER = "panel-rpa-recorder"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_RUN_CONFIGS = "panel-run-configurations"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_SECRET_MANAGER = "panel-secret-manager"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_TAB_CODE_EDITOR = "tab-code-editor"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_TAB_TERMINAL = "tab-terminal"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_TERMINAL = "panel-terminal"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_TOP_OF_MIND = "panel-top-of-mind"</ID>
+    <ID>UnusedPrivateProperty:DefaultPlugin.kt$DefaultPlugin.Companion$private const val PLUGIN_ID_USER_SECRET_LIST = "panel-user-secret-list"</ID>
+    <ID>UnusedPrivateProperty:DesktopLogCapture.kt$DesktopLogCapture$private val maxSize = 10000</ID>
+    <ID>UnusedPrivateProperty:DisplayUtils.kt$DisplayUtils$private val isMac = System.getProperty("os.name").startsWith("Mac", ignoreCase = true)</ID>
+    <ID>UnusedPrivateProperty:DynamicPluginManager.kt$DynamicPluginManager$private val panelRegistry: PanelRegistry</ID>
+    <ID>UnusedPrivateProperty:DynamicPluginManager.kt$DynamicPluginManager$private val tabRegistry: TabRegistry</ID>
+    <ID>UnusedPrivateProperty:FluckBrowserSettings.kt$val originalProfile = remember { BrowserSettings.currentProfile }</ID>
+    <ID>UnusedPrivateProperty:FluckBrowserSettings.kt$val originalUserAgent = remember { BrowserSettings.userAgent }</ID>
+    <ID>UnusedPrivateProperty:FluckEngine.kt$FluckEngine$val deleted = file.delete()</ID>
+    <ID>UnusedPrivateProperty:FormFieldDetector.kt$FormFieldDetector$val jsResult = frame.executeJavaScript&lt;Any&gt;(script)</ID>
+    <ID>UnusedPrivateProperty:KeymapMatcherTest.kt$KeymapMatcherTest$val matcher = KeymapMatcher.from(settings)</ID>
+    <ID>UnusedPrivateProperty:NewProjectWizardDialog.kt$val borderColor = when { isSelected -&gt; Accent isHovered -&gt; BossTheme.colors.line.copy(alpha = 0.8f) else -&gt; Color.Transparent }</ID>
+    <ID>UnusedPrivateProperty:PluginInstallWizardWindow.kt$val scope = rememberCoroutineScope()</ID>
+    <ID>UseCheckOrError:AndroidWorkspaceFileManager.kt$WorkspaceFileManager$throw IllegalStateException("WorkspaceFileManager not initialized. Call WorkspaceFileManager.init() in your Application or Activity.")</ID>
+    <ID>UseCheckOrError:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$throw IllegalStateException("HTTP error: $responseCode ${connection.responseMessage}")</ID>
+    <ID>UseCheckOrError:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$throw IllegalStateException("supabase down")</ID>
+    <ID>UseCheckOrError:CommonConditions.kt$ConditionBuilder$throw IllegalStateException("Condition check not set. Call whenTrue() or whenTrueSync() first.")</ID>
+    <ID>UseCheckOrError:OutOfProcessPluginSpawnerImpl.kt$OutOfProcessPluginSpawnerImpl$throw IllegalStateException( "Cannot find ${MicrokernelRuntime.ARTIFACT_PREFIX} JAR. Set BOSS_PLUGIN_RUNTIME_JAR env var." )</ID>
+    <ID>UseCheckOrError:OutOfProcessPluginSpawnerImpl.kt$OutOfProcessPluginSpawnerImpl$throw IllegalStateException( "Plugin process died during startup: $pluginId (exit=${process.process.exitValue()})" )</ID>
+    <ID>UseCheckOrError:PluginProbe.kt$PluginProbe$throw IllegalStateException("probe boom")</ID>
+    <ID>UseCheckOrError:SupabaseConfig.kt$SupabaseConfig$throw IllegalStateException("Supabase client not initialized. Call initialize() first.")</ID>
+    <ID>UseCheckOrError:SwiftScriptExecutor.kt$SwiftScriptExecutor$throw IllegalStateException("Swift files directory not found. Checked paths: $possiblePaths")</ID>
+    <ID>UseCheckOrError:UpdateInstaller.kt$UpdateInstaller$throw IllegalStateException("Could not find BOSS.app in mounted DMG")</ID>
+    <ID>UseRequire:RoleService.kt$RoleService$throw IllegalArgumentException("Invalid JWT format")</ID>
+    <ID>UseRequire:SwiftScriptExecutor.kt$SwiftScriptExecutor$throw IllegalArgumentException("Swift file not found: ${swiftFile.absolutePath}")</ID>
+    <ID>VariableNaming:BossActionButton.kt$var _contentPadding = contentPadding</ID>
+    <ID>VariableNaming:BossActionButton.kt$var _leftLogo = leftLogo</ID>
+    <ID>WildcardImport:ActiveTabsServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:AdvancedSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:AdvancedSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:AndroidFluckView.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:AndroidFluckView.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:AndroidFluckView.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:AuthFormComponents.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:AuthFormComponents.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:AuthFormComponents.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:AuthScreenContainer.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:AuthService.kt$import ai.rever.boss.services.auth.*</ID>
+    <ID>WildcardImport:AuthService.kt$import ai.rever.boss.services.supabase.models.*</ID>
+    <ID>WildcardImport:BookmarkDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BookmarkDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:BookmarkDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossActionButton.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossActionButton.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:BossActionButton.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossActionButton.kt$import androidx.compose.ui.unit.*</ID>
+    <ID>WildcardImport:BossAppWithAuth.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossBottomBar.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossDraggableComponent.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossLoggerTest.kt$import kotlin.test.*</ID>
+    <ID>WildcardImport:BossMainWindowPanel.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossMainWindowPanel.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:BossMainWindowPanel.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossPanelTopBar.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossPanelTopBar.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossResizablePanel.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossResizablePanel.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:BossTabBar.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossTabButton.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossTabButton.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossTopBar.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BossTopBar.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:BossTopBar.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:BossWindow.kt$import androidx.compose.ui.window.*</ID>
+    <ID>WildcardImport:BrowserEngineSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:BrowserEngineSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CLICommandHandler.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:CLIInstallationDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CLIInstallationDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CLIInstallationDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ChromiumDownloadDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ChromiumDownloadDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ChromiumDownloadDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CloneProjectDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CloneProjectDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CloneProjectDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CodeEditor.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CodeEditor.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CodeEditor.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CodeEditor.kt$import androidx.compose.ui.text.*</ID>
+    <ID>WildcardImport:CodeEditor.kt$import androidx.compose.ui.text.input.*</ID>
+    <ID>WildcardImport:CollectionSelectionDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CollectionSelectionDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CollectionSelectionDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CommitDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CommitDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CommitDialog.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:CommitDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CommonConditionsTest.kt$import ai.rever.boss.keymap.lifecycle.conditions.*</ID>
+    <ID>WildcardImport:CommonConditionsTest.kt$import kotlin.test.*</ID>
+    <ID>WildcardImport:ConfirmationDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ConfirmationDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ConfirmationDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ConflictWarningBadge.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ConflictWarningBadge.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ConflictWarningBadge.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ContextMenu.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ContextMenu.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ContextMenuHandler.kt$import androidx.compose.ui.input.pointer.*</ID>
+    <ID>WildcardImport:ContextMenuServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:CrashReportDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CrashReportDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CrashReportDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:CrashReportDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.call.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.plugins.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.plugins.contentnegotiation.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.http.*</ID>
+    <ID>WildcardImport:CrashReportService.kt$import io.ktor.serialization.kotlinx.json.*</ID>
+    <ID>WildcardImport:CrossDeviceAuthenticationDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:CrossDeviceAuthenticationDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:CrossDeviceAuthenticationDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:DefaultBrowserSection.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:DefaultBrowserSection.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:DefaultBrowserSection.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:DefaultBrowserSection.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:DesktopPasskeyBrowserView.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:DesktopPasskeyBrowserView.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:DesktopPasskeyDataMapper.kt$import ai.rever.boss.services.passkey.*</ID>
+    <ID>WildcardImport:DesktopPasskeyService.kt$import ai.rever.boss.services.passkey.desktop.*</ID>
+    <ID>WildcardImport:DesktopPasskeyService.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.client.network.sockets.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.client.plugins.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:DesktopUpdateService.kt$import io.ktor.utils.io.*</ID>
+    <ID>WildcardImport:DirectoryPickerServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:DowngradeWarningDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:DowngradeWarningDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:DownloadManager.kt$import kotlinx.coroutines.flow.*</ID>
+    <ID>WildcardImport:DownloadServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:EditableKeymapSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:EditableKeymapSettings.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:EditableKeymapSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:EmptyContentScreen.kt$import androidx.compose.animation.*</ID>
+    <ID>WildcardImport:EmptyContentScreen.kt$import androidx.compose.animation.core.*</ID>
+    <ID>WildcardImport:EmptyContentScreen.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:EmptyContentScreen.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:EmptyContentScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:FaviconLoader.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:Fluck.kt$import ai.rever.boss.components.registery.*</ID>
+    <ID>WildcardImport:Fluck.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:Fluck.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:Fluck.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:FluckBrowserSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:FluckBrowserSettings.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:FluckBrowserSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:FluckEngine.kt$import com.teamdev.jxbrowser.download.event.*</ID>
+    <ID>WildcardImport:FluckPanelProviders.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:FluckPanelProviders.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:FocusModeSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:FocusModeSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.call.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.plugins.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.plugins.contentnegotiation.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:GitHubUpdateSource.kt$import io.ktor.serialization.kotlinx.json.*</ID>
+    <ID>WildcardImport:GitServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:GlobalSearchDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:GlobalSearchDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:GlobalSearchDialog.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:GlobalSearchDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:GlobalSearchDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:HighQualityFaviconService.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:HighQualityFaviconService.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:HighQualityFaviconService.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:HighQualityFaviconService.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:HighQualityFaviconService.kt$import io.ktor.http.*</ID>
+    <ID>WildcardImport:HorizontalBar.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:IosFluckView.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:IosFluckView.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:IosFluckView.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:IosLLMSettingsManager.kt$import platform.Foundation.*</ID>
+    <ID>WildcardImport:IosWorkspaceFileManager.kt$import platform.Foundation.*</ID>
+    <ID>WildcardImport:KernelBootstrap.kt$import ai.rever.boss.kernel.services.*</ID>
+    <ID>WildcardImport:KernelBootstrap.kt$import ai.rever.boss.plugin.api.*</ID>
+    <ID>WildcardImport:KeyCaptureDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:KeyCaptureDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:KeyCaptureDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:KeyCaptureDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:KeyboardEventBus.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:KeyboardEventBus.kt$import kotlinx.coroutines.flow.*</ID>
+    <ID>WildcardImport:KeymapImportExport.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:KeymapImportExport.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:KeymapImportExport.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:KeymapSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:KeymapSettings.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:KeymapSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:LLMProvidersSettings.kt$import ai.rever.boss.components.plugin.panels.right_top.*</ID>
+    <ID>WildcardImport:LLMProvidersSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:LLMProvidersSettings.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:LLMProvidersSettings.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:LLMProvidersSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:LogServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:LoginFormScreen.kt$import ai.rever.boss.components.auth.forms.*</ID>
+    <ID>WildcardImport:LoginFormScreen.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:LoginFormScreen.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:LoginFormScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:LoginViewModel.kt$import ai.rever.boss.services.supabase.models.*</ID>
+    <ID>WildcardImport:LogoutConfirmationDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:LogoutConfirmationDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:LogoutConfirmationDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:MagicLinkWaitingScreen.kt$import ai.rever.boss.components.auth.forms.*</ID>
+    <ID>WildcardImport:MagicLinkWaitingScreen.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:MagicLinkWaitingScreen.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:MagicLinkWaitingScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:NameInputDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:NameInputDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:NameInputDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:NewProjectWizardDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:NewProjectWizardDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:NewProjectWizardDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:NewTabDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:NewTabDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:NewTabDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:NewTabDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:NotificationServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:OfflineScreen.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:OfflineScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:PanelEventServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:PasskeyAuthViewModel.kt$import ai.rever.boss.services.supabase.models.*</ID>
+    <ID>WildcardImport:PasskeyAuthenticationHandler.kt$import ai.rever.boss.services.passkey.*</ID>
+    <ID>WildcardImport:PasskeyAuthenticationHandler.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:PasskeyAuthenticationHandler.kt$import io.ktor.http.*</ID>
+    <ID>WildcardImport:PasskeyBrowserScreen.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PasskeyBrowserScreen.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:PasskeyBrowserScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:PasskeyDataMapper.kt$import ai.rever.boss.services.passkey.*</ID>
+    <ID>WildcardImport:PasskeyRegistrationHandler.kt$import ai.rever.boss.services.passkey.*</ID>
+    <ID>WildcardImport:PasskeyRegistrationHandler.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:PasskeySelectionScreen.kt$import ai.rever.boss.components.auth.forms.*</ID>
+    <ID>WildcardImport:PasskeySelectionScreen.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PasskeySelectionScreen.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:PasskeySelectionScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:PasskeyWaitingScreen.kt$import ai.rever.boss.components.auth.forms.*</ID>
+    <ID>WildcardImport:PasskeyWaitingScreen.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PasskeyWaitingScreen.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:PasskeyWaitingScreen.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:PerformanceServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:PerformanceSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PerformanceSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:PluginCrashFallbackUI.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PluginCrashFallbackUI.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:PluginInstallWizardWindow.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PresetSelector.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:PresetSelector.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:PresetSelector.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ProfileManagementSection.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ProfileManagementSection.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ProfileManagementSection.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:ProfileManagementSection.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ProjectDataServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:ProjectOpenModeDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ProjectOpenModeDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ProjectOpenModeDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ProjectSelectionDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ProjectSelectionDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ProjectSelectionDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ProjectSelectionDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:RemotePanelComponent.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:RemoteTabComponent.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:RemoteWidgetRenderer.kt$import ai.rever.boss.ui.sdk.*</ID>
+    <ID>WildcardImport:RemoteWidgetRenderer.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:RemoteWidgetRenderer.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:RemoteWidgetRenderer.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:RemoveBookmarkConfirmationDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:RemoveBookmarkConfirmationDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:RemoveBookmarkConfirmationDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:RenameDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:RenameDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:RenameDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:RoleCreationService.kt$import kotlinx.serialization.json.*</ID>
+    <ID>WildcardImport:RoleManagementServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:RoleService.kt$import ai.rever.boss.services.supabase.models.*</ID>
+    <ID>WildcardImport:RoleService.kt$import kotlinx.serialization.json.*</ID>
+    <ID>WildcardImport:RunConfigServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:RunnerSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:RunnerSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ScreenCapturePickerDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ScreenCapturePickerDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ScreenCapturePickerDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ScrollbarSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ScrollbarSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SecretService.kt$import kotlinx.serialization.json.*</ID>
+    <ID>WildcardImport:SecretServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:SecuritySettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:SecuritySettings.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:SecuritySettings.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:SecuritySettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SettingsComponents.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:SettingsComponents.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:SettingsComponents.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SettingsSidebar.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:SettingsSidebar.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:SettingsSidebar.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:SettingsUI.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:SettingsUI.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:SettingsUI.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SettingsWindow.kt$import ai.rever.boss.components.settings.sections.*</ID>
+    <ID>WildcardImport:SettingsWindow.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:SettingsWindow.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:SettingsWindow.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ShortcutHelpDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ShortcutHelpDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ShortcutHelpDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:ShortcutLifecycleManager.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:ShortcutLifecycleManager.kt$import kotlinx.coroutines.flow.*</ID>
+    <ID>WildcardImport:ShortcutTestDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:ShortcutTestDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:ShortcutTestDialog.kt$import androidx.compose.material.icons.filled.*</ID>
+    <ID>WildcardImport:ShortcutTestDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SidebarSlotContainer.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:SidebarSlotContainer.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SplitView.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SplitViewServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:StartupSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:StartupSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:SupabaseApiClient.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:SupabaseApiClient.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:SupabaseApiClient.kt$import io.ktor.http.*</ID>
+    <ID>WildcardImport:SupabasePasskeyService.kt$import ai.rever.boss.services.passkey.supabase.*</ID>
+    <ID>WildcardImport:SupabaseServiceBridge.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.call.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.plugins.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.plugins.contentnegotiation.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.http.*</ID>
+    <ID>WildcardImport:SupabaseUpdateSource.kt$import io.ktor.serialization.kotlinx.json.*</ID>
+    <ID>WildcardImport:TerminalLinkOpenDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:TerminalLinkOpenDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:TerminalLinkOpenDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:TerminalLinkOpenDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:TopOfMindDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:TopOfMindDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:TopOfMindDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:TopOfMindDialog.kt$import androidx.compose.ui.input.key.*</ID>
+    <ID>WildcardImport:UpdateManager.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:UpdateUI.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:UpdateUI.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:UpdateUI.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:UserExistenceService.kt$import ai.rever.boss.services.supabase.models.*</ID>
+    <ID>WildcardImport:UserService.kt$import ai.rever.boss.services.supabase.models.*</ID>
+    <ID>WildcardImport:VersionListManager.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:VersionSelectionDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:VersionSelectionDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:VersionSelectionDialog.kt$import androidx.compose.material.icons.filled.*</ID>
+    <ID>WildcardImport:VersionSelectionDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:WasmFluckView.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:WasmFluckView.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:WasmFluckView.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:WindowAppearanceSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:WindowAppearanceSettings.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:WorkspaceSelectionDialog.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:WorkspaceSelectionDialog.kt$import androidx.compose.material.*</ID>
+    <ID>WildcardImport:WorkspaceSelectionDialog.kt$import androidx.compose.runtime.*</ID>
+    <ID>WildcardImport:WorkspaceSettings.kt$import androidx.compose.foundation.layout.*</ID>
+    <ID>WildcardImport:WorkspaceSettings.kt$import androidx.compose.runtime.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -5,7 +5,7 @@
     <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>
     <ID>ComplexCondition:BrowserHandleImpl.kt$BrowserHandleImpl$ch != '\u0000' &amp;&amp; !ch.isISOControl() &amp;&amp; !bool("ctrl") &amp;&amp; !bool("meta")</ID>
     <ID>ComplexCondition:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$isMacOSExecutable || isChromium || isSharedLib || isShellScript || hasNoExtension</ID>
-    <ID>ComplexCondition:DynamicPluginManager.kt$DynamicPluginManager$candidate != null &amp;&amp; (force || (candidate.manifest.canUnload &amp;&amp; checkCanUnload(pluginId).isAllowed))</ID>
+    <ID>ComplexCondition:DynamicPluginManager.kt$DynamicPluginManager$closeTabsAcrossWindows &amp;&amp; candidate != null &amp;&amp; (force || (candidate.manifest.canUnload &amp;&amp; checkCanUnload(pluginId).isAllowed))</ID>
     <ID>ComplexCondition:FileNameSanitizer.kt$FileNameSanitizer$sanitized.startsWith("/") || sanitized.startsWith("\\") || sanitized.contains("..") || sanitized.contains(":/")</ID>
     <ID>ComplexCondition:FullscreenBrowserWindow.kt$FullscreenBrowserWindow.&lt;no name provided&gt;$hasReachedFullscreen &amp;&amp; isInFullscreenMode &amp;&amp; !isExiting &amp;&amp; fullscreenFrame != null</ID>
     <ID>ComplexCondition:NewTabDialog.kt$lowerTrimmed.startsWith("http://") || lowerTrimmed.startsWith("https://") || lowerTrimmed.startsWith("file://") || lowerTrimmed.startsWith("javascript:") || lowerTrimmed.startsWith("chrome://")</ID>
@@ -55,7 +55,7 @@
     <ID>CyclomaticComplexMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainTabBar( splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, focusRequester: FocusRequester? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {} )</ID>
     <ID>CyclomaticComplexMethod:BossPanelTopBar.kt$@Composable fun BossPanelTopBar( title: String?, isHovered: Boolean, onReset: (() -&gt; Unit)? = null, onReloadPlugin: (() -&gt; Unit)? = null, onOpenAsTab: (() -&gt; Unit)? = null, onCheckForUpdates: (() -&gt; Unit)? = null, onOpenEvolver: (() -&gt; Unit)? = null, onReportIssue: (() -&gt; Unit)? = null, onMinimize: () -&gt; Unit, updateAvailable: AvailablePluginUpdate? = null, onUpdateClick: (() -&gt; Unit)? = null, panelId: PanelId? = null, windowId: String? = null, dragModifier: Modifier = Modifier, content: (@Composable () -&gt; Unit)? = null )</ID>
     <ID>CyclomaticComplexMethod:BossResizablePanel.kt$@Composable fun BossResizablePanel(modifier: Modifier, panel: Panel, isPanelVisible: Boolean = false, isMainVisible: Boolean = true, isRelative: Boolean = false, defaultWeight: Float = 1f, sideContent: (@Composable BoxScope.() -&gt; Unit)? = null, mainContent: (@Composable BoxScope.() -&gt; Unit)? = null)</ID>
-    <ID>CyclomaticComplexMethod:BossTabButton.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun BossTabButton( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>CyclomaticComplexMethod:BossTabButton.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun BossTabButton( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), /** * Explicit width for this tab. When provided, the tab is sized exactly to this value * (no min/max content sizing). Callers compute this from available row width to get * Safari-style "shrink to fit, then scroll" behaviour. Defaults to null which falls * back to the legacy intrinsic-min sizing with a 180–450 dp width clamp. */ tabWidth: Dp? = null, // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
     <ID>CyclomaticComplexMethod:BossTopBar.kt$@Composable fun BossDraggableComponent.BossTopLeftBar( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
     <ID>CyclomaticComplexMethod:BossWindow.kt$@Composable fun ApplicationScope.BossWindow( windowState: BossWindowState, onCloseRequest: () -&gt; Unit )</ID>
     <ID>CyclomaticComplexMethod:BrowserEngineSettings.kt$@Composable fun BrowserEngineSettings()</ID>
@@ -67,8 +67,8 @@
     <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun jsKeyToKeyCode(key: String, code: String): KeyCode</ID>
     <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupEventListeners()</ID>
     <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupPopupHandler()</ID>
-    <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun createBrowser(config: BrowserConfig): BrowserHandle?</ID>
     <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private fun seedCookiesAndHeaders(profile: Profile, auth: BrowserAuthSpec)</ID>
+    <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun createBrowser( config: BrowserConfig, ownerWindowId: String ): BrowserHandle?</ID>
     <ID>CyclomaticComplexMethod:ChromiumDownloader.kt$fun main(args: Array&lt;String&gt;)</ID>
     <ID>CyclomaticComplexMethod:CloneProjectDialog.kt$@Composable private fun ConfigurationStep( onDismiss: () -&gt; Unit, onClone: (url: String, directory: String) -&gt; Unit )</ID>
     <ID>CyclomaticComplexMethod:CommitDialog.kt$@Composable fun CommitDialog( onDismiss: () -&gt; Unit, onCommitSuccess: (String) -&gt; Unit = {} )</ID>
@@ -86,8 +86,8 @@
     <ID>CyclomaticComplexMethod:DesktopGitService.kt$GitService$actual suspend fun watchGitHeadForWindow( projectPath: String, windowGitState: WindowGitState?, )</ID>
     <ID>CyclomaticComplexMethod:DesktopUpdateService.kt$UpdateService$actual suspend fun checkForUpdates(): UpdateInfo</ID>
     <ID>CyclomaticComplexMethod:DesktopUpdateService.kt$UpdateService$private suspend fun downloadFrom( url: String, assetName: String, assetSize: Long, sha256: String?, onProgress: (progress: Float) -&gt; Unit ): String?</ID>
+    <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager$private suspend fun uninstallPlugin( pluginId: String, force: Boolean, waitForGC: Boolean, closeTabsAcrossWindows: Boolean ): Result&lt;Unit&gt;</ID>
     <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun installPlugin(jarPath: String, enabled: Boolean = true): Result&lt;DynamicPluginInfo&gt;</ID>
-    <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun uninstallPlugin( pluginId: String, force: Boolean = false, waitForGC: Boolean = false ): Result&lt;Unit&gt;</ID>
     <ID>CyclomaticComplexMethod:DynamicPluginManager.kt$DynamicPluginManager.Companion$private suspend fun hotSwapApiLayerOrchestration(pluginDir: java.io.File): Result&lt;Int&gt;</ID>
     <ID>CyclomaticComplexMethod:EditableKeymapSettings.kt$@Composable fun EditableKeymapSettings()</ID>
     <ID>CyclomaticComplexMethod:EditorContentProviderImpl.kt$EditorContentProviderImpl$override fun detectLanguage(filePath: String): String</ID>
@@ -98,7 +98,7 @@
     <ID>CyclomaticComplexMethod:Fluck.kt$@Composable fun BrowserErrorView( error: Throwable, url: String, retryCount: Int = 0, maxRetries: Int = 3, onRetry: (() -&gt; Unit)? = null, onReset: (() -&gt; Unit)? = null, onResetBrowser: (() -&gt; Unit)? = null, onRetryEngine: (() -&gt; Unit)? = null )</ID>
     <ID>CyclomaticComplexMethod:Fluck.kt$FluckTabComponent$@Composable override fun Content()</ID>
     <ID>CyclomaticComplexMethod:FluckBrowserSettings.kt$@Composable fun FluckBrowserSettings()</ID>
-    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
+    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor( browser: com.teamdev.jxbrowser.browser.Browser, ownerWindowId: String? = null )</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun classifyError(e: Throwable): EngineInitError</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun createEngineInstance(chromiumDir: java.nio.file.Path, profileDirPath: java.nio.file.Path, profileName: String): Engine</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses(userHome: String)</ID>
@@ -187,683 +187,9 @@
     <ID>ForbiddenComment:VersionVerifier.kt$VersionVerifier$// TODO: Consider adding analytics/crash reporting here</ID>
     <ID>ForbiddenComment:WasmCodeEditor.kt$// TODO: Implement browser-based file reading</ID>
     <ID>ForbiddenComment:WasmCodeEditor.kt$// TODO: Implement browser-based file writing</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `ComponentLogger logs at all levels`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `ComponentLogger name is preserved in entries`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `LogLevel fromString defaults to INFO for invalid values`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `LogLevel fromString handles valid values`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `clearCategoryLevel falls back to global level`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `clearLogs removes all entries`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `configure applies all settings`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `disableFileLogging stops writing to file`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `enableFileLogging creates log file`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `file rotation triggers at maxFileSize`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getEffectiveLevel returns category level when set`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getRecentLogs filters by category`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getRecentLogs filters by minimum level`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `getRecentLogs respects limit parameter`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `listeners receive log entries`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log entries capture exceptions`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log entries contain correct metadata`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log filtering respects category-specific levels`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `log filtering respects global level hierarchy`()</ID>
-    <ID>FunctionNaming:BossLoggerTest.kt$BossLoggerTest$@Test fun `removeListener stops notifications`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `a move publishes MOVED instead of a CLOSED-OPENED pair`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `addTab drives the tab lifecycle to RESUMED`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `addTab returns -1 and stores nothing for an unregistered tab type`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `adoptTab closes a stale holder of the same tab id instead of orphaning it`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `detachTab and adoptTab move the live component without destroying it`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `detachTab returns null for unknown tab`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `removeTab destroys the tab component's lifecycle`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `removeTabById reports whether a tab was removed`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `splitPanel adopts a detached tab into the new panel without recreating it`()</ID>
-    <ID>FunctionNaming:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest$@Test fun `splitPanel with a missing target panel rescues the detached tab instead of leaking it`()</ID>
-    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `cookieDomain strips scheme, path, query, fragment and port`()</ID>
-    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `meta json round-trips and tolerates missing diskBytes (back-compat)`()</ID>
-    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `sanitize keeps safe profile-name chars and replaces the rest`()</ID>
-    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `selectEvictionVictims evicts oldest first until under cap`()</ID>
-    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `selectEvictionVictims never evicts an in-use profile`()</ID>
-    <ID>FunctionNaming:BrowserServiceImplTest.kt$BrowserServiceImplTest$@Test fun `selectEvictionVictims returns nothing when under cap`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `all candidates failing returns failure and reports the error`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `checksum mismatch rejects the candidate and falls through to the next source`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `complete staged install replaces the existing engine`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `falls back to the next source when a fetch fails`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `matching checksum is accepted`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `no-op when nothing is staged`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `promotes onto a missing target (fresh install)`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `staged install writes the commit marker last`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `staging with markers from the archive but no commit marker is not promoted`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `staging without commit marker is discarded and engine preserved`()</ID>
-    <ID>FunctionNaming:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest$@Test fun `stale backup from an earlier failed swap is cleaned up`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `asset matching is by exact archive name`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `availableVersions returns newest first across sources with dedup`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `both sources failing throws`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `github fallback is the only candidate when supabase has no row or fails`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `single source failure is reported not thrown`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `stable release outranks its own pre-releases`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `supabase candidate comes first and carries sha256, github backup has none`()</ID>
-    <ID>FunctionNaming:ChromiumReleaseSourceTest.kt$ChromiumReleaseSourceTest$@Test fun `versions sort numerically not lexicographically`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder creates disabled condition when check returns false`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder creates enabled condition when check returns true`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder throws when no check provided`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `ConditionBuilder with async check works`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions always and never work correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions canCreateSplit works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions canNavigateSplits works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions canUndo and canRedo work correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions context checks work correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions debugOnly works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions featureFlag works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasActiveTab works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasClipboardContent works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasMinTabs works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasMultipleTabs works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasSelection works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions hasTabs works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions isEditable works correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Conditions navigation checks work correctly`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Real-world scenario - close tab enabled with tabs OR can create split`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `Real-world scenario - paste enabled when clipboard has content and editor is active`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `and combinator requires both conditions`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `complex combinator chain works`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `condition DSL creates working condition`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `enabledWhen creates working condition`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `enabledWhenSync creates working condition`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `not combinator inverts condition`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `not combinator uses custom reason and description`()</ID>
-    <ID>FunctionNaming:CommonConditionsTest.kt$CommonConditionsTest$@Test fun `or combinator requires at least one condition`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `default is used when no source has the key`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `embedded build config wins below local properties`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `env wins over all other tiers`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `getConfig picks up a live system property and falls back to default`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `local properties win below system property`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `null when no source has the key and no default given`()</ID>
-    <ID>FunctionNaming:ConfigLoaderTest.kt$ConfigLoaderTest$@Test fun `system property wins below env`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `attribution prefers the root cause origin`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `attribution survives a closed loader`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `crash with plugin-defined stack frames attributes to the plugin`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `host-only crash attributes to nothing`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `plugin-defined exception class attributes even without walking frames`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `registry finds the defining plugin for a loaded class`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `self-referential cause chain terminates`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `shared parent-first classes are never attributed to a plugin`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `unknown class names are not attributed`()</ID>
-    <ID>FunctionNaming:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest$@Test fun `wrapped plugin exception attributes via the cause chain`()</ID>
-    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `broken pipe io exception is ignorable`()</ID>
-    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `coroutine cancellation is ignorable`()</ID>
-    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `generic runtime exception is not ignorable`()</ID>
-    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `supabase token expiry is ignorable`()</ID>
-    <ID>FunctionNaming:CrashHandlerIgnorableTest.kt$CrashHandlerIgnorableTest$@Test fun `token expiry nested in cause chain is ignorable`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `build and node_modules stay excluded even with showHidden`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren does not throw on a malformed path`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren follows a symlink to a non-empty directory`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false for a non-existent path`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false for an empty directory`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false when only a filtered directory name is present`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns false when only hidden entries are present`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren returns true when a visible file is present`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `directoryHasChildren with showHidden counts a directory containing only hidden entries`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectory reports hasChildren false for a directory containing only node_modules`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectory reports hasChildren true for a directory with a visible file`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectory with showHidden includes hidden entries in children`()</ID>
-    <ID>FunctionNaming:DesktopFileScannerTest.kt$DesktopFileScannerTest$@Test fun `scanDirectoryWithDepth threads showHidden through recursion`()</ID>
-    <ID>FunctionNaming:EvolverContractTest.kt$EvolverContractTest$@Test fun `hostile characters in the id survive json building without corrupting the arg map`()</ID>
-    <ID>FunctionNaming:EvolverContractTest.kt$EvolverContractTest$@Test fun `menu gating predicate matches the registered tool name`()</ID>
-    <ID>FunctionNaming:EvolverContractTest.kt$EvolverContractTest$@Test fun `open evolver dispatch round-trips the plugin id to the handler`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference decodes URL-encoded spaces`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference decodes multiple URL-encoded characters`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles Windows path only`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles Windows path with line and column`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles Windows path with line`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles empty string`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles filename with colon but no line number`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles invalid URL encoding gracefully`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles large line numbers`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles lowercase Windows drive letter`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles multiple colons with only last being line number`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles path only`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles path with line and column`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles path with line`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `parseFileReference handles zero line number`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file colon only prefix`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file double slash prefix`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file single slash prefix`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix handles file triple slash prefix`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `stripFilePrefix returns path unchanged when no prefix`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath resolves path traversal sequences`(@TempDir tempDir: Path)</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for blank path`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for directory`(@TempDir tempDir: Path)</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for empty path`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Invalid for non-existent file`()</ID>
-    <ID>FunctionNaming:FileEventBusTest.kt$FileEventBusTest$@Test fun `validateFilePath returns Valid for existing readable file`(@TempDir tempDir: Path)</ID>
-    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `finds the jar with the matching pluginId`()</ID>
-    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `ignores jars without a readable manifest`()</ID>
-    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `prefers the highest manifest version when several match`()</ID>
-    <ID>FunctionNaming:FindRelocatedPluginJarTest.kt$FindRelocatedPluginJarTest$@Test fun `returns null when nothing matches`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `SkiaGraphite is opt-in only — it blanks OSR output on JxBrowser 9-3`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `cgroup predicate recognizes container runtimes and rejects host cgroups`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `extra switches are appended last so operator flags win ties`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `falsy flag accepts the documented disable spellings only`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `linux enables VA-API and adds container-only switches inside containers`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `parseExtraSwitches handles null, empty and switch-less input`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `parseExtraSwitches keeps comma-bearing feature lists intact`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `parseExtraSwitches splits on whitespace and keeps only switch-shaped entries`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `partitionExtraSwitches separates accepted switches from dropped tokens in one pass`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `truthy flag accepts the documented enable spellings only`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `unknown platforms get no platform-specific switches`()</ID>
-    <ID>FunctionNaming:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest$@Test fun `windows disables the native-window occlusion tracker`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `concurrent navigation updates are thread-safe`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `concurrent reads and writes are thread-safe`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `copy creates independent navigation history`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `copy for split view preserves current URL as initial URL`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `copy with back navigation creates independent history`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `currentUrl returns initial URL when no navigation has occurred`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `currentUrl returns navigated URL after navigation`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `currentUrl tracks multiple navigations correctly`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `duplicate consecutive navigation does not add to history`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `empty URL is handled gracefully`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `equals is based on id and display content`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `equals returns false for different ids`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `explicit tabIcon override wins over the home icon`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `home landing transform sets Home title and clears the stale favicon`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `home page shows Home icon instead of the generic globe`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `icon follows navigation between home and real pages`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `isHomeUrl matches blank and about-blank urls only`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateBack at start of history does nothing`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateBack returns to previous URL`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateForward at end of history does nothing`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigateForward returns to next URL after navigateBack`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigation after navigateBack truncates forward history`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `navigation to empty URL updates currentUrl`()</ID>
-    <ID>FunctionNaming:FluckTabInfoTest.kt$FluckTabInfoTest$@Test fun `real page keeps the default browser icon`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `copy preserves unchanged values`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `default settings should have 30px reveal offset`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `default settings should have auto-reveal enabled`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `default settings should have focus mode disabled`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `settings can be created with auto-reveal disabled`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `settings can be created with custom reveal offset`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `settings can be created with focus mode enabled`()</ID>
-    <ID>FunctionNaming:FocusModeSettingsTest.kt$FocusModeSettingsTest$@Test fun `toggling focus mode preserves other settings`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `compareResults should sort by score descending`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should collapse consecutive matches into single range`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should create separate ranges for non-consecutive matches`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give bonus for exact match`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give bonus for shorter targets`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for camelCase word boundary matches`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for consecutive matches`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for matches at beginning`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for path separator word boundaries`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should give higher score for underscore word boundary matches`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should handle mixed consecutive and non-consecutive`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match all characters in order`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match case-insensitively`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match command descriptions`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should match file names with fuzzy patterns`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should rank exact prefix higher than scattered match`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should return empty result for empty pattern`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should return null when not all characters match`()</ID>
-    <ID>FunctionNaming:FuzzyMatcherTest.kt$FuzzyMatcherTest$@Test fun `should return null when pattern longer than target`()</ID>
-    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `blank version is unknown and installable`()</ID>
-    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `equal version is compatible and installable`()</ID>
-    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `hostVersion reflects IpcVersion CURRENT`()</ID>
-    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `newer major is a major mismatch`()</ID>
-    <ID>FunctionNaming:IpcCompatibilityTest.kt$IpcCompatibilityTest$@Test fun `newer minor within same major requires host update`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create derives title from unix path basename`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create derives title from windows path basename`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create falls back to derived title when override is blank`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create generates unique jupyter-prefixed ids`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create honours explicit title override`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create uses the shared jupyter type id`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `create with blank path yields Notebook title`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `createUntitled trims the name and defaults to Notebook`()</ID>
-    <ID>FunctionNaming:JupyterTabInfoTest.kt$JupyterTabInfoTest$@Test fun `updateTitle returns a retitled copy preserving id and path`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `COMPONENT priority is highest`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `GLOBAL priority is lowest`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `KeyEventSource has expected values`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `KeyboardEventResult consumed property works`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `KeyboardEventResult includes actionId when provided`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `WORKSPACE priority is medium`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `cancelled job removes handler`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `clearHandlers removes all handlers`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `consumed event stops propagation`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `debug mode can be enabled`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `emit returns false when no handlers registered`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `fromLevel returns GLOBAL for unknown level`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `fromLevel returns correct priority`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `getHandlerCounts returns correct counts per priority`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `getHandlerCounts returns empty map initially`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `handler exception does not stop other handlers`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `handler with targetWindowId only receives matching events`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `handlers are called in priority order`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `multiple handlers at same priority all called`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `multiple window-specific handlers filter correctly`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `subscribe adds handler`()</ID>
-    <ID>FunctionNaming:KeyboardEventBusTest.kt$KeyboardEventBusTest$@Test fun `unconsumed event propagates to all handlers`()</ID>
-    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `a run after completion executes again instead of joining a stale result`()</ID>
-    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `concurrent runs for the same key coalesce onto one execution`()</ID>
-    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `detached failure after caller cancellation reaches onDetachedFailure`()</ID>
-    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `distinct keys run independently`()</ID>
-    <ID>FunctionNaming:KeyedDetachedJobsTest.kt$KeyedDetachedJobsTest$@Test fun `job runs to completion although the caller is cancelled mid-run`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor builder chains correctly`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor executes registered handler`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor handles multiple executions`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `MapBasedActionExecutor returns false for unregistered action`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns BROWSER for browser component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns BROWSER for fluck component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns EDITOR for code component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns EDITOR for editor component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns GLOBAL for null component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns GLOBAL for unknown component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns TERMINAL for terminal component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `determineContext returns WORKSPACE for workspace component`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `from factory creates handler with settings`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getBinding returns correct binding`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getBinding returns null for nonexistent action`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getDisplayString returns formatted string for bound action`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `getDisplayString returns null for unbound action`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `isBound returns false for disabled binding`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `isBound returns false for unbound action`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `isBound returns true for bound action`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `settings property returns current settings`()</ID>
-    <ID>FunctionNaming:KeymapHandlerTest.kt$KeymapHandlerTest$@Test fun `updateSettings changes handler settings`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke displayString formats correctly on Windows`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke displayString formats correctly on macOS`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke matches returns false for non-matching event`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke matches returns true for matching event`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke of factory creates correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `KeyStroke signature formats correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding allSignatures returns all signatures`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding displayStringAll shows all keystrokes`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding matches alternate keystroke`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding matches primary keystroke`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `binding with alternate keystrokes has correct allKeystrokes`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `clearAlternateKeystrokes removes all alternates`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `context-specific binding takes priority over global binding`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `crossPlatform creates binding with Cmd and Ctrl alternates`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `crossPlatform with additional modifiers works correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `disabled binding is not matched`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats arrow keys correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats correctly on Windows`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats correctly on macOS`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `display string formats special keys correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `enabled binding is matched`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `getBindingsByCategory groups correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `getBindingsForContext returns only matching context`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `getEnabledBindings filters out disabled`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `global binding matches when no context-specific binding exists`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `hasAlternates returns false when no alternates`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `hasAlternates returns true when alternates exist`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `matches returns false for disabled binding`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `matches returns false for wrong key`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `matches returns true for matching key and modifiers`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `signature includes context and modifiers`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `signature without modifiers formats correctly`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `withAlternateKeystroke adds new alternate`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `withoutAlternateKeystroke removes alternate`()</ID>
-    <ID>FunctionNaming:KeymapMatcherTest.kt$KeymapMatcherTest$@Test fun `workspace binding is checked when context-specific not found`()</ID>
-    <ID>FunctionNaming:KeymapSettingsTabSwitchModeTest.kt$KeymapSettingsTabSwitchModeTest$@Test fun `an explicit tab switch mode survives a json round-trip`()</ID>
-    <ID>FunctionNaming:KeymapSettingsTabSwitchModeTest.kt$KeymapSettingsTabSwitchModeTest$@Test fun `legacy keymap json without tabSwitchMode falls back to the default`()</ID>
-    <ID>FunctionNaming:KeymapSettingsTabSwitchModeTest.kt$KeymapSettingsTabSwitchModeTest$@Test fun `tab switch mode defaults to MRU for new users`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding detects same context conflict`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding excludes action being edited`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding finds existing conflicts`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `checkBinding uses signature which includes context`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `conflict description includes action names`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `conflictCount returns correct number`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `detects conflict between same context bindings`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `getSummary returns correct message for multiple conflicts`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `getSummary returns correct message for no conflicts`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `getSummary returns correct message for single conflict`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `global and specific context do not conflict with different signatures`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `hasConflicts returns false when no conflicts`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `hasConflicts returns true when conflicts exist`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `isSafeToSave returns true even with conflicts`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `multiple conflicts detected separately`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `no conflicts between different non-global contexts`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `no conflicts when one binding is disabled`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `no conflicts with unique key combinations`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `suggestFixes provides disable suggestions`()</ID>
-    <ID>FunctionNaming:KeymapValidatorTest.kt$KeymapValidatorTest$@Test fun `suggestFixes provides key change suggestions`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri handles null`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri indicates fragment present`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri indicates query params present`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `describeUri shows scheme and host without params`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects GitHub tokens`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects JWT tokens`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects Stripe-style keys`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret detects long alphanumeric strings`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret returns false for blank`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret returns false for null`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `looksLikeSecret returns false for short strings`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskCredentialId handles null`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskCredentialId shows length only`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles blank input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles invalid email without at symbol`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles multiple at symbols`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles null input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles single char local part`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles standard email format`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles subdomain`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskEmail handles two char local part`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskSessionId handles short ids`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskSessionId shows first 8 chars`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles blank input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles exactly 7 chars`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles null input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken handles short tokens`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskToken preserves first and last 3 chars`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles blank input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles case insensitive param names`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles fragment parameters`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles null input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams handles uri without params`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams preserves non-sensitive parameters`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts access_token parameter`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts api_key parameter`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts multiple sensitive parameters`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts refresh_token parameter`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUriParams redacts token parameter`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUserId handles null`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUserId handles short ids`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `maskUserId shows first 4 chars`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap handles empty map`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap handles nested sensitive key names`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap handles null input`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap masks values that look like secrets`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap preserves non-sensitive values`()</ID>
-    <ID>FunctionNaming:LogSanitizerTest.kt$LogSanitizerTest$@Test fun `sanitizeMap redacts known sensitive keys`()</ID>
     <ID>FunctionNaming:MacOSScreenCapture.kt$CoreGraphics$fun CGPreflightScreenCaptureAccess(): Boolean</ID>
     <ID>FunctionNaming:MacOSScreenCapture.kt$CoreGraphics$fun CGRequestScreenCaptureAccess(): Boolean</ID>
     <ID>FunctionNaming:MainViewController.kt$fun MainViewControllerV4()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `a provider whose tools() throws registers with no tools and does not affect siblings`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `admin bypasses requiredPermissions`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `admin bypasses requiresAdmin`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `allTools is not permission-filtered but tools is (metadata-only disclosure posture)`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `concurrent register, unregister, and updateAccess never leave a stale or torn snapshot`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `corrupt disabled-tools file fails open to emptySet rather than crashing`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `disabled set persists across a fresh core instance reading the same file`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `duplicate tool name across providers - first registered wins`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `int() returns null for values outside Int range instead of silently wrapping`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke coerces a JSON integer through int() and double()`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke parses string, boolean, integer, and double arguments`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke propagates caller cancellation rather than swallowing it into an error result`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke rejects a disabled tool by name (unreachable even though still registered)`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke rejects a permission-denied tool by name`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke rejects unknown tool name`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke times out a handler that never completes`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke with malformed JSON args runs the handler with an empty arg set instead of erroring`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `invoke wraps a handler exception into an error result`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `missing disabled-tools file starts with an empty disabled set`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `non-admin with requiresAdmin is hidden even holding the listed permissions`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `null disabledFile skips persistence entirely (pure in-memory)`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `re-registering the same providerId replaces its tool set`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `revoking a permission live hides the tool without re-registration`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `save leaves no dangling tmp file (atomic rename completed)`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `setToolEnabled false removes the tool from tools but not allTools`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `tool requiring ALL permissions is hidden when only some are held`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `tool requiring a permission is hidden until the user holds it`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `tool with no requirements is exposed to a logged-out user`()</ID>
-    <ID>FunctionNaming:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest$@Test fun `unregistering the winning provider lets the second provider's tool take over`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `open panel keeps its cached component when the factory is re-registered`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent drops the stale component when the panel is no longer registered`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent recreates the panel from the newly registered factory`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent returns false for a panel that is not open`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetComponent survives the old component's cleanup hook throwing an Error`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `resetPanels resets only matching open slots across windows and leaves others untouched`()</ID>
-    <ID>FunctionNaming:PanelComponentStoreResetTest.kt$PanelComponentStoreResetTest$@Test fun `store registry tracks stores per window`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test CPU load percent calculation`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test default settings are valid`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status CRITICAL when CPU exceeds critical threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status CRITICAL when memory exceeds critical threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status GOOD when below warning thresholds`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status WARNING when CPU exceeds warning threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test health status WARNING when memory exceeds warning threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test last GC memory reclaimed calculation`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory heap usage MB conversion`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory heap usage percent calculation`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory heap usage percent with zero max`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory pool max MB falls back to committed when max is negative`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory pool usage percent falls back to committed when max is negative`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test memory pool usage percent with max bytes`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test overall status is CRITICAL if any component is CRITICAL`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test overall status is WARNING if any component is WARNING and none CRITICAL`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps cpu critical threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps cpu warning threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps history retention`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps memory critical threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps memory warning threshold`()</ID>
-    <ID>FunctionNaming:PerformanceMonitorTest.kt$PerformanceMonitorTest$@Test fun `test settings validation clamps sample intervals`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `admin bypasses required permissions`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `legacy plugin (no requirements) is visible to any authenticated user`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `requiresAdmin AND requiredPermissions both enforced for non-admin`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `requiresAdmin plugin hidden from non-admin even with permissions`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `requiresAdmin plugin visible to admin`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `user missing one required permission is denied`()</ID>
-    <ID>FunctionNaming:PluginAccessGateTest.kt$PluginAccessGateTest$@Test fun `user with all required permissions is allowed`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `blank minIpcVersion is not gated`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `newer major is rejected`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `newer minor within same major is rejected`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `older minor within same major is compatible`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupIpcGateTest.kt$PluginStoreSetupIpcGateTest$@Test fun `version equal to host is compatible`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `basic semver ordering`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `multi-digit segments compare numerically not lexically`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `no minimum means never too old`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `non-matching filename yields null`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `pre-release of the minimum forces update`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `release is newer than its own pre-release`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `release with only a thin jar yields null`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `release without matching assets yields null`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `suffixed segment counts as its numeric prefix`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `thin jar listed first is skipped in favor of the real jar`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `unreadable installed version forces update`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version above minimum loads`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version below minimum forces update`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version equal to minimum loads`()</ID>
-    <ID>FunctionNaming:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest$@Test fun `version extracted from standard jar filename`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test Kotlin project placeholder substitution`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test Node js package json contains package name`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test Rust Cargo toml contains package name`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test concurrent creation with same name handled correctly`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Go project successfully`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Kotlin JVM project successfully`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Node js project successfully`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Python project successfully`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create Rust project successfully`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create empty project successfully`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project in non-existent directory fails`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project where directory already exists fails`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project with Windows reserved name fails`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test create project with invalid name fails`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test empty project README contains project name`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test failed creation cleans up partial directory`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test progress callback is called with increasing values`()</ID>
-    <ID>FunctionNaming:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest$@Test fun `test project name with leading and trailing spaces is trimmed`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test Unicode normalization attacks are handled`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test created files do not escape project directory`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test legitimate template paths are accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test null byte in project name is handled`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test path traversal in project name is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test project creation does not follow symlinks outside directory`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test rejected names cannot be created`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test special shell characters in project name are safe`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test validation and creation are consistent`()</ID>
-    <ID>FunctionNaming:ProjectCreationSecurityTest.kt$ProjectCreationSecurityTest$@Test fun `test very long project name is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test CamelCase name is lowercased`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name AUX is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name COM1 is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name CON is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name LPT1 is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name NUL is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name PRN is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved name with extension is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test Windows reserved names are case insensitive`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test blank project name with spaces is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test complex realistic name`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test empty name returns default`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test empty project name is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test existing project directory is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test hyphen is converted to dot`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test leading and trailing dots are trimmed`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test leading number gets prefix`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test mixed case name is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test mixed separators are converted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test multiple consecutive dots are collapsed`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test multiple separators are collapsed to single dot`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name starting with number is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with dot in middle is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with hyphen is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with numbers is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with only special chars returns default`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with spaces is trimmed and accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test name with underscore is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test non-existent parent directory is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test numbers in middle are preserved`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name at max length is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name exceeding max length is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with asterisk is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with backslash is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with colon is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with double quote is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with greater than is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with leading dot is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with less than is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with only trailing space is trimmed and accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with pipe is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with question mark is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with slash is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with space in middle is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test project name with trailing dot is rejected`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test simple lowercase name derives correctly`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test simple lowercase name is accepted`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test space is converted to dot`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test special characters are removed`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test underscore is converted to dot`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test unicode characters are removed`()</ID>
-    <ID>FunctionNaming:ProjectCreationServiceTest.kt$ProjectCreationServiceTest$@Test fun `test uppercase name is lowercased`()</ID>
-    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `completes when a registry change satisfies the condition`()</ID>
-    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `notifications that do not satisfy the condition keep waiting until one does`()</ID>
-    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `returns false on timeout and removes the listener`()</ID>
-    <ID>FunctionNaming:RegistryAwaitTest.kt$RegistryAwaitTest$@Test fun `returns immediately when condition already holds`()</ID>
-    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `inline markdown maps to styled spans`()</ID>
-    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `parses generated release notes into heading and table blocks`()</ID>
-    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `parses lists, code fences, breaks, and paragraphs`()</ID>
-    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `plain text passes through untouched`()</ID>
-    <ID>FunctionNaming:ReleaseNotesMarkdownTest.kt$ReleaseNotesMarkdownTest$@Test fun `unterminated fence still yields a code block`()</ID>
-    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `admin claim parsed and effective permissions surfaced`()</ID>
-    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `defaults applied when role claims absent`()</ID>
-    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `missing user_permissions yields empty permissions`()</ID>
-    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `non-string entries in user_permissions are filtered out`()</ID>
-    <ID>FunctionNaming:RoleClaimsTest.kt$RoleClaimsTest$@Test fun `parses user_permissions, user_roles and is_admin`()</ID>
-    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `4xx rejections clear the session`()</ID>
-    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `backoff doubles and caps at max`()</ID>
-    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `non-rest exceptions retry`()</ID>
-    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `server errors and cloudflare codes retry`()</ID>
-    <ID>FunctionNaming:SessionRecoveryPolicyTest.kt$SessionRecoveryPolicyTest$@Test fun `transient 4xx codes retry instead of clearing`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AlwaysEnabledCondition disabledReason is descriptive`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AlwaysEnabledCondition enabledDescription is descriptive`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AlwaysEnabledCondition isEnabled returns true`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition enabledDescription joins with and`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition returns false when any condition false`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition returns true for empty list`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `AndCondition returns true when all conditions true`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition enabledDescription is Never`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition isEnabled returns false`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition uses custom disabled reason`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `NeverEnabledCondition uses default disabled reason`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition disabledReason lists all conditions`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition enabledDescription joins with or`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition returns false for empty list`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition returns false when all conditions false`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `OrCondition returns true when any condition true`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `clear removes all conditions and states`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `custom condition with dynamic state`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `debug mode can be toggled`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `default enabledDescription is Always`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getDisabledReason returns null for enabled action`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getDisabledReason returns reason for disabled action`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getRegisteredActions returns all registered action IDs`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getState returns null for unregistered action`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `getState returns state after registration`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled handles condition exception`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled returns false for NeverEnabledCondition`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled returns true for AlwaysEnabledCondition`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `isEnabled returns true for unregistered action`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `nested And and Or conditions work correctly`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `reevaluate updates all states`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `reevaluateSingle updates single state`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `registerCondition adds condition`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `startAutoReevaluation returns cancellable job`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `states flow emits initial empty map`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `states flow updates when condition registered`()</ID>
-    <ID>FunctionNaming:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest$@Test fun `unregisterCondition removes condition`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `caps equal counts when everything fits`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `caps skip empty slots`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `empty slots are skipped entirely`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `every non-empty slot keeps one row even on zero or negative budget`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `everything fits when budget covers all items`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `guaranteed single row renders More only`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `overflowing slot yields its last row to the More button`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `surplus beyond item counts is not allocated`()</ID>
-    <ID>FunctionNaming:SidebarIconLimitsTest.kt$SidebarIconLimitsTest$@Test fun `tight budget is dealt round-robin so no slot starves`()</ID>
-    <ID>FunctionNaming:SkipListDriftTest.kt$SkipListDriftTest$@Test fun `in-process and IPC name-visibility rules agree`()</ID>
-    <ID>FunctionNaming:SkipListDriftTest.kt$SkipListDriftTest$@Test fun `in-process and IPC skip-lists are identical`()</ID>
-    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `MoveToPanel drops the move when the tab was closed mid-drag`()</ID>
-    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `MoveToPanel transfers the live component and activates the target panel`()</ID>
-    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `cross-panel CreateSplit drops the move when the tab was closed mid-drag`()</ID>
-    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `cross-panel CreateSplit moves the live component into the new split`()</ID>
-    <ID>FunctionNaming:TabDropResultHandlingTest.kt$TabDropResultHandlingTest$@Test fun `same-panel CreateSplit keeps copy semantics - original retained and not detached`()</ID>
-    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `all provider methods delegate to the current owner`()</ID>
-    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `cached provider no-ops safely when the owner is gone mid-flight`()</ID>
-    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `cached provider routes updates to the tab's current owner after a move`()</ID>
-    <ID>FunctionNaming:TabUpdateRegistryMoveTest.kt$TabUpdateRegistryMoveTest$@Test fun `createProvider returns null when no component owns the tab`()</ID>
-    <ID>FunctionNaming:TerminalLinkSettingsSerializationTest.kt$TerminalLinkSettingsSerializationTest$@Test fun `defaults still apply when fields are missing`()</ID>
-    <ID>FunctionNaming:TerminalLinkSettingsSerializationTest.kt$TerminalLinkSettingsSerializationTest$@Test fun `every open mode round-trips`()</ID>
-    <ID>FunctionNaming:TerminalLinkSettingsSerializationTest.kt$TerminalLinkSettingsSerializationTest$@Test fun `system default decodes from persisted json by name`()</ID>
-    <ID>FunctionNaming:TrackingPluginContextMcpTest.kt$TrackingPluginContextMcpTest$@Test fun `tracker isolates plugins - unregisterAll only tears down its own plugin's providers`()</ID>
-    <ID>FunctionNaming:TrackingPluginContextMcpTest.kt$TrackingPluginContextMcpTest$@Test fun `unregisterAll clears the tracker so a second call does not re-unregister`()</ID>
-    <ID>FunctionNaming:TrackingPluginContextMcpTest.kt$TrackingPluginContextMcpTest$@Test fun `unregisterAll unregisters every MCP tool provider the plugin registered`()</ID>
-    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `bundle suffix is matched at path segment boundary`()</ID>
-    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `library path preserves app substring inside bundle name`()</ID>
-    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `non-translocated app path is returned without filesystem lookup`()</ID>
-    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `translocated path falls back to installed app lookup`()</ID>
-    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `translocated path resolves bundle name in Applications`()</ID>
-    <ID>FunctionNaming:UpdateInstallerPathResolutionTest.kt$UpdateInstallerPathResolutionTest$@Test fun `unresolved translocated path is preserved`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows batch metacharacters are rejected`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows batch percent sign escaping`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows batch quote escaping with legitimate path`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows script handles spaces correctly`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test Windows script validation`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test backtick command substitution is rejected`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test command separators are rejected as errors`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test command substitution is rejected`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script contains self-destruct command`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script is executable`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script retries relaunch on failure`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script strips quarantine attribute`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test generated script waits for PID`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test legitimate paths with spaces work correctly`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test newline injection is rejected`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test null byte injection is rejected`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test path traversal is rejected as error`()</ID>
-    <ID>FunctionNaming:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest$@Test fun `test paths with single quotes are properly escaped`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `app_releases row maps to GitHubRelease with assets and sha256`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `falls back to backup when primary returns empty`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `falls back to backup when primary throws`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `getReleaseByTag falls back to backup when primary has none`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `getReleaseByTag prefers primary`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `multi-asset row maps every asset and tolerates missing sha256`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `prerelease row maps prerelease flag`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `returns empty when both sources fail`()</ID>
-    <ID>FunctionNaming:UpdateSourceTest.kt$UpdateSourceTest$@Test fun `uses primary when it returns releases and does not call backup`()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun clamps_to_usable_screen()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun floors_at_min_fit_size()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun grow_at_1x_adds_delta_as_dp()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun negative_delta_shrinks()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun non_positive_scale_is_treated_as_1x()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun scale_2x_halves_the_px_delta()</ID>
-    <ID>FunctionNaming:WindowFitMathTest.kt$WindowFitMathTest$@Test fun usable_below_floor_yields_screen_not_a_throw()</ID>
-    <ID>FunctionNaming:WindowManagerReflectionContractTest.kt$WindowManagerReflectionContractTest$@Test fun fitWindowByDelta_isReachableByReflection()</ID>
-    <ID>FunctionNaming:WindowManagerReflectionContractTest.kt$WindowManagerReflectionContractTest$@Test fun restoreWindowSize_isReachableByReflection()</ID>
-    <ID>FunctionNaming:WindowManagerReflectionContractTest.kt$WindowManagerReflectionContractTest$@Test fun windowManager_exposesSingletonInstance()</ID>
     <ID>FunctionOnlyReturningConstant:CLIInstaller.kt$CLIInstaller$private fun getHomebrewBinPath(): String</ID>
     <ID>FunctionOnlyReturningConstant:CLIInstaller.kt$CLIInstaller$private fun getHomebrewCLISourcePath(): String</ID>
     <ID>FunctionOnlyReturningConstant:FluckEngine.kt$FluckEngine$private fun isShiftPressed(): Boolean</ID>
@@ -910,7 +236,7 @@
     <ID>LongMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainPanelContent( modifier: Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
     <ID>LongMethod:BossMainWindowPanel.kt$@Composable fun BossTabsComponent.BossMainTabBar( splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, focusRequester: FocusRequester? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {} )</ID>
     <ID>LongMethod:BossPanelTopBar.kt$@Composable fun BossPanelTopBar( title: String?, isHovered: Boolean, onReset: (() -&gt; Unit)? = null, onReloadPlugin: (() -&gt; Unit)? = null, onOpenAsTab: (() -&gt; Unit)? = null, onCheckForUpdates: (() -&gt; Unit)? = null, onOpenEvolver: (() -&gt; Unit)? = null, onReportIssue: (() -&gt; Unit)? = null, onMinimize: () -&gt; Unit, updateAvailable: AvailablePluginUpdate? = null, onUpdateClick: (() -&gt; Unit)? = null, panelId: PanelId? = null, windowId: String? = null, dragModifier: Modifier = Modifier, content: (@Composable () -&gt; Unit)? = null )</ID>
-    <ID>LongMethod:BossTabButton.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun BossTabButton( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>LongMethod:BossTabButton.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun BossTabButton( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), /** * Explicit width for this tab. When provided, the tab is sized exactly to this value * (no min/max content sizing). Callers compute this from available row width to get * Safari-style "shrink to fit, then scroll" behaviour. Defaults to null which falls * back to the legacy intrinsic-min sizing with a 180–450 dp width clamp. */ tabWidth: Dp? = null, // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
     <ID>LongMethod:BossTopBar.kt$@Composable fun BossDraggableComponent.BossTopLeftBar( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
     <ID>LongMethod:BossTopBar.kt$@Composable private fun getGitContextMenuItems( currentBranch: String?, localBranches: List&lt;GitBranchInfo&gt;, remoteBranches: List&lt;GitBranchInfo&gt;, stashList: List&lt;GitStashInfo&gt;, isLoading: Boolean, onCheckout: (String) -&gt; Unit, onMerge: (String) -&gt; Unit, onRebase: (String) -&gt; Unit, onCreateBranch: () -&gt; Unit, onCommit: () -&gt; Unit, onPull: () -&gt; Unit, onPush: () -&gt; Unit, onCreatePR: (() -&gt; Unit)?, onStash: () -&gt; Unit, onStashPop: (Int) -&gt; Unit, onRefresh: () -&gt; Unit ): List&lt;ContextMenuItem&gt;</ID>
     <ID>LongMethod:BossTopRunBar.kt$@Composable fun BossTopRunBar()</ID>
@@ -923,6 +249,7 @@
     <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupEventListeners()</ID>
     <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupPopupHandler()</ID>
     <ID>LongMethod:BrowserPageCard.kt$@Composable fun BrowserPageCard( page: RecentBrowserPage, onClick: () -&gt; Unit, onRemove: () -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun createBrowser( config: BrowserConfig, ownerWindowId: String ): BrowserHandle?</ID>
     <ID>LongMethod:CLIInstallationDialog.kt$@Composable fun CLIInstallationDialog( onDismiss: () -&gt; Unit )</ID>
     <ID>LongMethod:CLIInstallationDialog.kt$@Composable private fun ErrorContent( message: String, onRetry: () -&gt; Unit, onClose: () -&gt; Unit )</ID>
     <ID>LongMethod:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal suspend fun installFromCandidates( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) } ): Result&lt;Path&gt;</ID>
@@ -951,8 +278,8 @@
     <ID>LongMethod:DesktopUpdateService.kt$UpdateService$actual suspend fun checkForUpdates(): UpdateInfo</ID>
     <ID>LongMethod:DowngradeWarningDialog.kt$@Composable fun DowngradeWarningDialog( currentVersion: Version, targetVersion: Version, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit )</ID>
     <ID>LongMethod:DraggableActionButton.kt$@Composable fun BossDraggableComponent.DraggableActionButton( item: SidebarItem, slot: Panel, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager$private suspend fun uninstallPlugin( pluginId: String, force: Boolean, waitForGC: Boolean, closeTabsAcrossWindows: Boolean ): Result&lt;Unit&gt;</ID>
     <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun installPlugin(jarPath: String, enabled: Boolean = true): Result&lt;DynamicPluginInfo&gt;</ID>
-    <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager$suspend fun uninstallPlugin( pluginId: String, force: Boolean = false, waitForGC: Boolean = false ): Result&lt;Unit&gt;</ID>
     <ID>LongMethod:DynamicPluginManager.kt$DynamicPluginManager.Companion$private suspend fun hotSwapApiLayerOrchestration(pluginDir: java.io.File): Result&lt;Int&gt;</ID>
     <ID>LongMethod:EditableKeymapSettings.kt$@Composable fun EditableKeymapSettings()</ID>
     <ID>LongMethod:EditableKeymapSettings.kt$@Composable private fun ShortcutItem( binding: KeyBinding, hasConflict: Boolean, conflictingBindings: List&lt;KeyBinding&gt;, onEdit: () -&gt; Unit )</ID>
@@ -964,7 +291,7 @@
     <ID>LongMethod:Fluck.kt$FluckTabComponent$@Composable override fun Content()</ID>
     <ID>LongMethod:FluckBrowserSettings.kt$@Composable fun FluckBrowserSettings()</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupBrowserDownloadHandler(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
-    <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor( browser: com.teamdev.jxbrowser.browser.Browser, ownerWindowId: String? = null )</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses(userHome: String)</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$suspend fun resetBrowserProfile(): ResetResult</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine.BrowserFindBar$private fun createDialog(owner: java.awt.Window)</ID>
@@ -1090,13 +417,13 @@
     <ID>LongParameterList:BossActionButton.kt$( imageVector: ImageVector? = null, leftLogo: (@Composable () -&gt; Unit)? = null, leftIcon: ImageVector? = null, text: String, fontSize: TextUnit = 13.sp, color: Color = BossTheme.colors.textPrimary, iconColor: Color? = null, // Optional separate icon color (defaults to color if null) iconSize: Dp = 20.dp, // Icon size for imageVector mode maxTextWidth: Dp? = null, // Optional max width for text (truncates with ellipsis) modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(2.dp), isSelected: Boolean = false, contextMenuItems: List&lt;ContextMenuItem&gt;? = null, contextDirection: Panel = bottom, hintText: String? = null, showHintWithDelay: Boolean = true, hintDirection: Panel = bottom, onClick: () -&gt; Unit = {} )</ID>
     <ID>LongParameterList:BossAppScaffold.kt$( state: BossAppState, reveal: FocusModeRevealState, isFocusModeEnabled: Boolean, isAutoRevealEnabled: Boolean, revealOffsetDp: Dp, showTitleBar: Boolean, onToggleMaximize: (() -&gt; Unit)?, )</ID>
     <ID>LongParameterList:BossAppState.kt$BossAppState$( val windowId: String, val isFirstWindow: Boolean, val panelRegistry: PanelRegistry, val tabRegistry: TabRegistry, val panelComponentStore: PanelComponentStore, val draggablePanelComponent: BossDraggableComponent, val tabDragComponent: TabDraggableComponent, val tabsComponent: BossTabsComponent, val splitViewState: SplitViewState, val splitViewOperations: SplitViewOperationsImpl, val workspaceDataProvider: WorkspaceDataProviderImpl, val windowProjectState: WindowProjectState, val windowRunnerState: WindowRunnerState, val windowGitState: WindowGitState, val coroutineScope: CoroutineScope, )</ID>
-    <ID>LongParameterList:BossMainWindowPanel.kt$( config: TabInfo, isSelected: Boolean, isFocused: Boolean, onClick: () -&gt; Unit, onClose: () -&gt; Unit, contextMenuItems: List&lt;ContextMenuItem&gt;, // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, panelId: String? = null, tabIndex: Int = -1, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>LongParameterList:BossMainWindowPanel.kt$( config: TabInfo, isSelected: Boolean, isFocused: Boolean, onClick: () -&gt; Unit, onClose: () -&gt; Unit, contextMenuItems: List&lt;ContextMenuItem&gt;, tabWidth: Dp?, // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, panelId: String? = null, tabIndex: Int = -1, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
     <ID>LongParameterList:BossMainWindowPanel.kt$( modifier: Modifier = Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, tabDragComponent: TabDraggableComponent? = null, onTabDropResult: (TabDropResult) -&gt; Unit = {}, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
     <ID>LongParameterList:BossMainWindowPanel.kt$( modifier: Modifier, splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null, currentPanelId: String? = null, onShowSettings: (() -&gt; Unit)? = null, onOpenProjectDialog: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null )</ID>
     <ID>LongParameterList:BossPanelTopBar.kt$( title: String?, isHovered: Boolean, onReset: (() -&gt; Unit)? = null, onReloadPlugin: (() -&gt; Unit)? = null, onOpenAsTab: (() -&gt; Unit)? = null, onCheckForUpdates: (() -&gt; Unit)? = null, onOpenEvolver: (() -&gt; Unit)? = null, onReportIssue: (() -&gt; Unit)? = null, onMinimize: () -&gt; Unit, updateAvailable: AvailablePluginUpdate? = null, onUpdateClick: (() -&gt; Unit)? = null, panelId: PanelId? = null, windowId: String? = null, dragModifier: Modifier = Modifier, content: (@Composable () -&gt; Unit)? = null )</ID>
     <ID>LongParameterList:BossResizablePanel.kt$(modifier: Modifier, panel: Panel, isPanelVisible: Boolean = false, isMainVisible: Boolean = true, isRelative: Boolean = false, defaultWeight: Float = 1f, sideContent: (@Composable BoxScope.() -&gt; Unit)? = null, mainContent: (@Composable BoxScope.() -&gt; Unit)? = null)</ID>
     <ID>LongParameterList:BossSearchBar.kt$( query: String, onQueryChange: (String) -&gt; Unit, placeholder: String = "Search...", modifier: Modifier = Modifier, leadingIcon: ImageVector = Icons.Outlined.Search, showClearButton: Boolean = true, onFocusChanged: ((Boolean) -&gt; Unit)? = null )</ID>
-    <ID>LongParameterList:BossTabButton.kt$( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
+    <ID>LongParameterList:BossTabButton.kt$( fileName: String, icon: ImageVector? = null, iconPainter: Painter? = null, tabIcon: TabIcon? = null, isSelected: Boolean = false, isFocused: Boolean = true, modifier: Modifier = Modifier, onClick: () -&gt; Unit, onClose: () -&gt; Unit = {}, contextMenuItems: List&lt;ContextMenuItem&gt; = emptyList(), /** * Explicit width for this tab. When provided, the tab is sized exactly to this value * (no min/max content sizing). Callers compute this from available row width to get * Safari-style "shrink to fit, then scroll" behaviour. Defaults to null which falls * back to the legacy intrinsic-min sizing with a 180–450 dp width clamp. */ tabWidth: Dp? = null, // Drag-related parameters tabDragComponent: TabDraggableComponent? = null, tabInfo: TabInfo? = null, panelId: String? = null, tabIndex: Int = -1, onDragStart: () -&gt; Unit = {}, onDragEnd: (TabDropResult?) -&gt; Unit = {} )</ID>
     <ID>LongParameterList:BossTopBar.kt$( currentBranch: String?, localBranches: List&lt;GitBranchInfo&gt;, remoteBranches: List&lt;GitBranchInfo&gt;, stashList: List&lt;GitStashInfo&gt;, isLoading: Boolean, onCheckout: (String) -&gt; Unit, onMerge: (String) -&gt; Unit, onRebase: (String) -&gt; Unit, onCreateBranch: () -&gt; Unit, onCommit: () -&gt; Unit, onPull: () -&gt; Unit, onPush: () -&gt; Unit, onCreatePR: (() -&gt; Unit)?, onStash: () -&gt; Unit, onStashPop: (Int) -&gt; Unit, onRefresh: () -&gt; Unit )</ID>
     <ID>LongParameterList:BossTopBar.kt$( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
     <ID>LongParameterList:BossTopBar.kt$( workspaceManager: WorkspaceManager? = null, onApplyWorkspace: ((LayoutWorkspace) -&gt; Unit)? = null, getCurrentWorkspace: (() -&gt; LayoutWorkspace)? = null, onShowTopOfMind: (() -&gt; Unit)? = null, onShowSettings: (() -&gt; Unit)? = null, onShowSearch: (() -&gt; Unit)? = null, onNewProject: (() -&gt; Unit)? = null, onCloneProject: (() -&gt; Unit)? = null )</ID>
@@ -1779,8 +1106,8 @@
     <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$fun activatePlugin(pluginId: String)</ID>
     <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$fun stopDragging()</ID>
     <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$private fun updateHoverTarget()</ID>
-    <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun createBrowser(config: BrowserConfig): BrowserHandle?</ID>
     <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun disposeBrowser(handle: BrowserHandle)</ID>
+    <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun createBrowser( config: BrowserConfig, ownerWindowId: String ): BrowserHandle?</ID>
     <ID>NestedBlockDepth:CLICommandHandler.kt$CLICommandHandler$private suspend fun executeCommand(command: CLICommand)</ID>
     <ID>NestedBlockDepth:CLIInstaller.kt$CLIInstaller$private fun installHomebrewStyle(): CLIInstallResult</ID>
     <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal suspend fun installFromCandidates( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) } ): Result&lt;Path&gt;</ID>
@@ -1844,6 +1171,7 @@
     <ID>PackageNaming:BrowserSecretIntegrationViewModel.kt$package ai.rever.boss.components.plugin.tab_types.fluck</ID>
     <ID>PackageNaming:CodeBase.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
     <ID>PackageNaming:CodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
+    <ID>PackageNaming:ComputeTabWidthPxTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:DesktopBrowserAccessor.kt$package ai.rever.boss.components.plugin.panels.right_top</ID>
     <ID>PackageNaming:DesktopCodeEditor.kt$package ai.rever.boss.components.plugin.tab_types</ID>
     <ID>PackageNaming:DesktopFileScanner.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
@@ -2325,9 +1653,7 @@
     <ID>TooManyFunctions:BookmarkAPIAccess.kt$BookmarkAPIAccess</ID>
     <ID>TooManyFunctions:BossDraggableComponent.kt$BossDraggableComponent</ID>
     <ID>TooManyFunctions:BossLogger.kt$BossLogger</ID>
-    <ID>TooManyFunctions:BossLoggerTest.kt$BossLoggerTest</ID>
     <ID>TooManyFunctions:BossMainWindowPanel.kt$BossTabsComponent : ComponentContext</ID>
-    <ID>TooManyFunctions:BossTabsComponentMoveTest.kt$BossTabsComponentMoveTest</ID>
     <ID>TooManyFunctions:BrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.BrowserFunctions.kt</ID>
     <ID>TooManyFunctions:BrowserHandleImpl.kt$BrowserHandleImpl : BrowserHandle</ID>
     <ID>TooManyFunctions:BrowserSecretIntegrationViewModel.kt$BrowserSecretIntegrationViewModel</ID>
@@ -2335,17 +1661,13 @@
     <ID>TooManyFunctions:CLICommandHandler.kt$CLICommandHandler</ID>
     <ID>TooManyFunctions:CLIInstaller.kt$CLIInstaller</ID>
     <ID>TooManyFunctions:ChromiumAutoDownloader.kt$ChromiumAutoDownloader</ID>
-    <ID>TooManyFunctions:ChromiumAutoDownloaderTest.kt$ChromiumAutoDownloaderTest</ID>
     <ID>TooManyFunctions:CodeEditor.kt$ai.rever.boss.components.plugin.tab_types.CodeEditor.kt</ID>
     <ID>TooManyFunctions:CommonConditions.kt$Conditions</ID>
-    <ID>TooManyFunctions:CommonConditionsTest.kt$CommonConditionsTest</ID>
     <ID>TooManyFunctions:CrashHandler.kt$CrashHandler</ID>
-    <ID>TooManyFunctions:CrashHandlerAttributionTest.kt$CrashHandlerAttributionTest</ID>
     <ID>TooManyFunctions:DeepLinkHandler.kt$DeepLinkHandler</ID>
     <ID>TooManyFunctions:DefaultPlugin.kt$ApiActiveTabsProviderAdapter : ActiveTabsProvider</ID>
     <ID>TooManyFunctions:DefaultPlugin.kt$DefaultPlugin : PluginContext</ID>
     <ID>TooManyFunctions:DesktopCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.DesktopCodeEditor.kt</ID>
-    <ID>TooManyFunctions:DesktopFileScannerTest.kt$DesktopFileScannerTest</ID>
     <ID>TooManyFunctions:DesktopGitService.kt$GitService</ID>
     <ID>TooManyFunctions:DesktopMainFunctionDetector.kt$DesktopMainFunctionDetector : MainFunctionDetector</ID>
     <ID>TooManyFunctions:DesktopRunConfigurationManager.kt$RunConfigurationManager</ID>
@@ -2353,16 +1675,12 @@
     <ID>TooManyFunctions:DesktopUpdateService.kt$UpdateService</ID>
     <ID>TooManyFunctions:DownloadManager.kt$DownloadManager</ID>
     <ID>TooManyFunctions:DynamicPluginManager.kt$DynamicPluginManager</ID>
-    <ID>TooManyFunctions:FileEventBusTest.kt$FileEventBusTest</ID>
     <ID>TooManyFunctions:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl : FileSystemDataProvider</ID>
     <ID>TooManyFunctions:Fluck.kt$FluckTabInfo : TabInfo</ID>
     <ID>TooManyFunctions:Fluck.kt$ai.rever.boss.components.plugin.tab_types.fluck.Fluck.kt</ID>
     <ID>TooManyFunctions:FluckEngine.kt$FluckEngine</ID>
-    <ID>TooManyFunctions:FluckEngineSwitchesTest.kt$FluckEngineSwitchesTest</ID>
-    <ID>TooManyFunctions:FluckTabInfoTest.kt$FluckTabInfoTest</ID>
     <ID>TooManyFunctions:FontManager.kt$FontManager</ID>
     <ID>TooManyFunctions:FullscreenBrowserWindow.kt$FullscreenBrowserWindow</ID>
-    <ID>TooManyFunctions:FuzzyMatcherTest.kt$FuzzyMatcherTest</ID>
     <ID>TooManyFunctions:GitDataProviderImpl.kt$GitDataProviderImpl : GitDataProvider</ID>
     <ID>TooManyFunctions:GitService.kt$GitService</ID>
     <ID>TooManyFunctions:GitServiceBridge.kt$GitServiceBridge : GitServiceCoroutineImplBase</ID>
@@ -2370,27 +1688,17 @@
     <ID>TooManyFunctions:GlobalSearchService.kt$GlobalSearchService</ID>
     <ID>TooManyFunctions:IosBrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.IosBrowserFunctions.kt</ID>
     <ID>TooManyFunctions:IosCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.IosCodeEditor.kt</ID>
-    <ID>TooManyFunctions:KeyboardEventBusTest.kt$KeyboardEventBusTest</ID>
-    <ID>TooManyFunctions:KeymapHandlerTest.kt$KeymapHandlerTest</ID>
-    <ID>TooManyFunctions:KeymapMatcherTest.kt$KeymapMatcherTest</ID>
-    <ID>TooManyFunctions:KeymapValidatorTest.kt$KeymapValidatorTest</ID>
     <ID>TooManyFunctions:LLMModelFetcher.kt$LLMModelFetcher</ID>
     <ID>TooManyFunctions:LogSanitizer.kt$LogSanitizer</ID>
-    <ID>TooManyFunctions:LogSanitizerTest.kt$LogSanitizerTest</ID>
-    <ID>TooManyFunctions:McpToolRegistryCoreTest.kt$McpToolRegistryCoreTest</ID>
     <ID>TooManyFunctions:McpToolRegistryImpl.kt$McpToolRegistryCore</ID>
     <ID>TooManyFunctions:MenuActionsHandler.kt$MenuActionsHandler</ID>
     <ID>TooManyFunctions:PasskeyDataMapper.kt$PasskeyDataMapper</ID>
     <ID>TooManyFunctions:PerformanceMonitor.kt$PerformanceMonitor</ID>
-    <ID>TooManyFunctions:PerformanceMonitorTest.kt$PerformanceMonitorTest</ID>
     <ID>TooManyFunctions:PluginInstallWizardState.kt$PluginInstallWizardState</ID>
     <ID>TooManyFunctions:PluginLoaderDelegateImpl.kt$PluginLoaderDelegateImpl : PluginLoaderDelegate</ID>
     <ID>TooManyFunctions:PluginPersistence.kt$PluginPersistence</ID>
     <ID>TooManyFunctions:PluginStorageFactoryProvider.kt$PluginStorageProviderImpl : PluginStorageProvider</ID>
     <ID>TooManyFunctions:PluginStoreSetup.kt$PluginStoreSetup</ID>
-    <ID>TooManyFunctions:PluginStoreSetupMinVersionGateTest.kt$PluginStoreSetupMinVersionGateTest</ID>
-    <ID>TooManyFunctions:ProjectCreationIntegrationTest.kt$ProjectCreationIntegrationTest</ID>
-    <ID>TooManyFunctions:ProjectCreationServiceTest.kt$ProjectCreationServiceTest</ID>
     <ID>TooManyFunctions:RoleCreationService.kt$RoleCreationService</ID>
     <ID>TooManyFunctions:RoleManagementProviderImpl.kt$RoleManagementProviderImpl : RoleManagementProvider</ID>
     <ID>TooManyFunctions:RoleManagementServiceBridge.kt$RoleManagementServiceBridge : RoleManagementServiceCoroutineImplBase</ID>
@@ -2399,7 +1707,6 @@
     <ID>TooManyFunctions:SecretServiceBridge.kt$SecretServiceBridge : SecretServiceCoroutineImplBase</ID>
     <ID>TooManyFunctions:SettingsComponents.kt$ai.rever.boss.components.settings.shared.SettingsComponents.kt</ID>
     <ID>TooManyFunctions:ShortcutLifecycleManager.kt$ShortcutLifecycleManager</ID>
-    <ID>TooManyFunctions:ShortcutLifecycleManagerTest.kt$ShortcutLifecycleManagerTest</ID>
     <ID>TooManyFunctions:SplitTemplatesManager.kt$SplitTemplatesManager</ID>
     <ID>TooManyFunctions:SplitView.kt$SplitViewState</ID>
     <ID>TooManyFunctions:SplitViewOperationsImpl.kt$SplitViewOperationsImpl : SplitViewOperations</ID>
@@ -2409,7 +1716,6 @@
     <ID>TooManyFunctions:TrackingPluginContext.kt$TrackingPluginContext : PluginContext</ID>
     <ID>TooManyFunctions:UpdateInstaller.kt$UpdateInstaller</ID>
     <ID>TooManyFunctions:UpdateManager.kt$UpdateManager</ID>
-    <ID>TooManyFunctions:UpdateScriptGeneratorSecurityTest.kt$UpdateScriptGeneratorSecurityTest</ID>
     <ID>TooManyFunctions:WasmBrowserFunctions.kt$ai.rever.boss.components.plugin.tab_types.fluck.WasmBrowserFunctions.kt</ID>
     <ID>TooManyFunctions:WasmCodeEditor.kt$ai.rever.boss.components.plugin.tab_types.WasmCodeEditor.kt</ID>
     <ID>TooManyFunctions:WindowManager.kt$WindowManager</ID>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,28 @@
+# BossConsole detekt configuration.
+#
+# Applied with buildUponDefaultConfig = true, so this file only contains
+# deliberate deviations from detekt's default ruleset — everything not listed
+# here runs with default settings.
+#
+# Existing debt is frozen in per-module detekt-baseline.xml files; only new
+# violations fail the build. Regenerate with `./gradlew detektBaseline`.
+
+naming:
+  FunctionNaming:
+    # Composable functions are PascalCase by convention.
+    ignoreAnnotated: ['Composable']
+
+style:
+  MagicNumber:
+    # Disabled for now: ~1,400 findings, almost all Compose dp/sp/weight UI
+    # values where extracting a constant hurts readability. A targeted policy
+    # (ignore UI literals, keep logic/protocol constants) comes in a follow-up.
+    active: false
+
+exceptions:
+  TooGenericExceptionCaught:
+    # Kept active on purpose — catching Exception/Throwable hides real error
+    # handling. Existing catches are baselined; new ones should catch the
+    # narrowest type that makes sense.
+    active: true
+    severity: warning

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -11,6 +11,39 @@ naming:
   FunctionNaming:
     # Composable functions are PascalCase by convention.
     ignoreAnnotated: ['Composable']
+    # Default excludes plus desktopTest: detekt's defaults exempt every test
+    # source set (test, jvmTest, commonTest, ...) EXCEPT the KMP desktop one,
+    # so idiomatic backtick test names were flagged only there.
+    excludes:
+      [
+        '**/test/**',
+        '**/androidTest/**',
+        '**/commonTest/**',
+        '**/jvmTest/**',
+        '**/androidUnitTest/**',
+        '**/androidInstrumentedTest/**',
+        '**/jsTest/**',
+        '**/iosTest/**',
+        '**/desktopTest/**',
+      ]
+
+complexity:
+  TooManyFunctions:
+    # Same desktopTest gap as FunctionNaming above: test classes grow one
+    # function per case by design and are exempt in every other test source
+    # set by default.
+    excludes:
+      [
+        '**/test/**',
+        '**/androidTest/**',
+        '**/commonTest/**',
+        '**/jvmTest/**',
+        '**/androidUnitTest/**',
+        '**/androidInstrumentedTest/**',
+        '**/jsTest/**',
+        '**/iosTest/**',
+        '**/desktopTest/**',
+      ]
 
 style:
   MagicNumber:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,13 @@ androidx-lifecycle = "2.10.0"
 compose-multiplatform = "1.11.1"
 compose-icons = "1.1.1"
 decompose = "3.5.0"
+detekt = "1.23.8"
 essenty = "2.5.0"
 junit-jupiter = "6.1.0"
 clikt = "5.1.0"
 kotlin = "2.4.0"
 kotlinx-coroutines = "1.11.0"
+ktlint-gradle = "14.2.0"
 kotlinx-datetime = "0.8.0-0.6.x-compat"
 # Pinned to the stack the MCP Kotlin SDK supports (ktor <= 3.3/3.4 → serialization 1.9.x).
 # The terminal-tab plugin bundles ktor 3.3 + mcp-sdk, but resolves kotlinx-serialization
@@ -123,6 +125,8 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,10 +8,10 @@ androidx-activityCompose = "1.10.1"
 androidx-lifecycle = "2.10.0"
 compose-multiplatform = "1.11.1"
 compose-icons = "1.1.1"
-compose-ui = "1.8.2"
-compose-compiler = "1.5.8"
 decompose = "3.5.0"
 essenty = "2.5.0"
+junit-jupiter = "6.1.0"
+clikt = "5.1.0"
 kotlin = "2.4.0"
 kotlinx-coroutines = "1.11.0"
 kotlinx-datetime = "0.8.0-0.6.x-compat"
@@ -23,11 +23,9 @@ kotlinx-datetime = "0.8.0-0.6.x-compat"
 kotlinx-serialization = "1.11.0"
 ktor = "3.4.3"
 logback = "1.5.38"
-foundationLayoutAndroid = "1.8.2"
 precompose = "1.6.2"
 slf4j = "2.0.18"
 supabase = "3.6.0"
-uiAndroid = "1.8.2"
 zxing = "3.5.4"
 jxbrowser = "9.3.0"
 jxbrowser-gradle-plugin = "2.1.0"
@@ -50,12 +48,11 @@ boss-plugin-api = "1.0.68"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
@@ -68,8 +65,6 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
-androidx-ui-android = { group = "androidx.compose.ui", name = "ui-android", version.ref = "uiAndroid" }
 decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
 decompose-extensions-compose = { module = "com.arkivanov.decompose:extensions-compose", version.ref = "decompose" }
 decompose-extensions-compose-experimental = { module = "com.arkivanov.decompose:extensions-compose-experimental", version.ref = "decompose" }

--- a/modules/boss-app-browser/build.gradle.kts
+++ b/modules/boss-app-browser/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.app.browser"

--- a/modules/boss-app-browser/detekt-baseline.xml
+++ b/modules/boss-app-browser/detekt-baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:BrowserServiceMain.kt$fun main()</ID>
+    <ID>MaxLineLength:BrowserServiceImpl.kt$BrowserServiceImpl$logger.warn("getPageInfo called with {} windows tracked — returning first window only; use a window-specific RPC for multi-window support", windowStates.size)</ID>
+    <ID>MaxLineLength:BrowserServiceMain.kt$.</ID>
+    <ID>WildcardImport:BrowserServiceImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:BrowserServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-app-editor/build.gradle.kts
+++ b/modules/boss-app-editor/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.app.editor"

--- a/modules/boss-app-editor/detekt-baseline.xml
+++ b/modules/boss-app-editor/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:EditorServiceImpl.kt$EditorServiceImpl$private fun detectLanguage(ext: String): String</ID>
+    <ID>LongMethod:EditorServiceMain.kt$fun main()</ID>
+    <ID>MaxLineLength:EditorServiceMain.kt$.</ID>
+    <ID>TooGenericExceptionCaught:EditorServiceImpl.kt$EditorServiceImpl$e: Exception</ID>
+    <ID>VariableNaming:EditorServiceImpl.kt$EditorServiceImpl$/** Paths that must not be accessed via IPC — mirrors FileSystemServiceImpl policy. */ private val BLOCKED_PATH_PREFIXES = listOf("/etc", "/sys", "/proc")</ID>
+    <ID>WildcardImport:EditorServiceImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:EditorServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-app-terminal/build.gradle.kts
+++ b/modules/boss-app-terminal/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.app.terminal"

--- a/modules/boss-app-terminal/detekt-baseline.xml
+++ b/modules/boss-app-terminal/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:TerminalServiceImpl.kt$TerminalServiceImpl$override suspend fun createSession(request: CreateSessionRequest): CreateSessionResponse</ID>
+    <ID>LongMethod:TerminalServiceImpl.kt$TerminalServiceImpl$override suspend fun createSession(request: CreateSessionRequest): CreateSessionResponse</ID>
+    <ID>LongMethod:TerminalServiceMain.kt$fun main()</ID>
+    <ID>MaxLineLength:TerminalServiceMain.kt$.</ID>
+    <ID>TooGenericExceptionCaught:TerminalServiceImpl.kt$TerminalServiceImpl$e: Exception</ID>
+    <ID>WildcardImport:TerminalServiceImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:TerminalServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-ipc/detekt-baseline.xml
+++ b/modules/boss-ipc/detekt-baseline.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongParameterList:ChildProcessBootstrap.kt$ChildProcessConnection$( val processId: String, val kernelClient: BossIpcClient, val kernelStub: KernelServiceGrpcKt.KernelServiceCoroutineStub, val processServer: BossIpcServer, val heartbeatJob: Job, val serviceAddresses: Map&lt;String, String&gt;, private val scope: CoroutineScope, )</ID>
+    <ID>ReturnCount:BossIpcClient.kt$BossIpcClient$suspend fun waitForReady(timeoutMs: Long = 30_000): Boolean</ID>
+    <ID>ReturnCount:IpcVersion.kt$IpcVersion$fun isCompatible( runtimeMinIpcVersion: String, hostIpcVersion: String = CURRENT, ): CompatResult</ID>
+    <ID>ReturnCount:IpcVersion.kt$IpcVersion$fun parse(version: String): Triple&lt;Int, Int, Int&gt;?</ID>
+    <ID>TooGenericExceptionCaught:ChildProcessBootstrap.kt$ChildProcessBootstrap$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:IpcAddressResolver.kt$IpcAddressResolver$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KernelServiceImpl.kt$KernelServiceImpl$e: Exception</ID>
+    <ID>UseCheckOrError:ChildProcessBootstrap.kt$ChildProcessBootstrap$throw IllegalStateException( "Failed to register with kernel: ${registerResponse.errorMessage}" )</ID>
+    <ID>UseCheckOrError:ChildProcessBootstrap.kt$ChildProcessBootstrap$throw IllegalStateException("BOSS_KERNEL_IPC_ADDR environment variable not set")</ID>
+    <ID>UseCheckOrError:ChildProcessBootstrap.kt$ChildProcessBootstrap$throw IllegalStateException("BOSS_PROCESS_ID environment variable not set")</ID>
+    <ID>UseCheckOrError:ChildProcessBootstrap.kt$ChildProcessBootstrap$throw IllegalStateException("BOSS_PROCESS_TYPE environment variable not set")</ID>
+    <ID>UseCheckOrError:ChildProcessBootstrap.kt$ChildProcessBootstrap$throw IllegalStateException("Failed to connect to kernel at $kernelAddress")</ID>
+    <ID>UseCheckOrError:IpcAddressResolver.kt$IpcAddressResolver$throw IllegalStateException("No available TCP ports in range $TCP_PORT_BASE-${TCP_PORT_BASE + TCP_PORT_RANGE}")</ID>
+    <ID>WildcardImport:ChildProcessBootstrap.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:ChildProcessBootstrap.kt$import kotlinx.coroutines.*</ID>
+    <ID>WildcardImport:EventBusServiceImpl.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:EventBusServiceTest.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:IpcRoundTripTest.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:KernelServiceImpl.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:StateServiceImpl.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:StateServiceTest.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-mastery-orchestrator/build.gradle.kts
+++ b/modules/boss-mastery-orchestrator/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.mastery.orchestrator"

--- a/modules/boss-mastery-orchestrator/detekt-baseline.xml
+++ b/modules/boss-mastery-orchestrator/detekt-baseline.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:MasteryOrchestratorMain.kt$"boss-mastery-orchestrator/src/main/kotlin/ai/rever/boss/mastery/orchestrator/ProcessRegistryCapabilityResolver.kt"</ID>
+    <ID>MaxLineLength:MasteryServiceImpl.kt$b.setCompleted(MasteryCompleted.newBuilder().putAllOutput(output).setTotalDurationMs(totalDurationMs).build())</ID>
+    <ID>MaxLineLength:MasteryServiceImpl.kt$b.setNodeCompleted(NodeCompleted.newBuilder().setNodeId(nodeId).putAllOutput(output).setDurationMs(durationMs).build())</ID>
+    <ID>MaxLineLength:MasteryServiceImpl.kt$b.setNodeFailed(NodeFailed.newBuilder().setNodeId(nodeId).setErrorMessage(error).setWillRetry(willRetry).build())</ID>
+    <ID>TooGenericExceptionThrown:ProcessRegistryCapabilityResolver.kt$ProcessRegistryCapabilityResolver$throw RuntimeException("Capability invocation failed: ${response.errorMessage}")</ID>
+    <ID>UseCheckOrError:ProcessRegistryCapabilityResolver.kt$ProcessRegistryCapabilityResolver$throw IllegalStateException("No IPC client for process: $pluginId")</ID>
+    <ID>UseCheckOrError:ProcessRegistryCapabilityResolver.kt$ProcessRegistryCapabilityResolver$throw IllegalStateException("Process not found: $pluginId")</ID>
+    <ID>WildcardImport:MasteryOrchestratorMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-mastery-sdk/detekt-baseline.xml
+++ b/modules/boss-mastery-sdk/detekt-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>NestedBlockDepth:TopologicalSort.kt$TopologicalSort$fun &lt;T : Any&gt; sort( nodes: List&lt;T&gt;, getId: (T) -&gt; String, getDeps: (T) -&gt; List&lt;String&gt;, ): List&lt;List&lt;T&gt;&gt;</ID>
+    <ID>TooGenericExceptionCaught:MasteryExecutor.kt$MasteryExecutor$e: Exception</ID>
+    <ID>UnusedParameter:MasteryExecutor.kt$MasteryExecutor$mastery: MasteryDefinition</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-orchestrator/build.gradle.kts
+++ b/modules/boss-orchestrator/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.orchestrator"

--- a/modules/boss-orchestrator/detekt-baseline.xml
+++ b/modules/boss-orchestrator/detekt-baseline.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:CrashAnalyzer.kt$CrashAnalyzer$fun analyze(report: ProcessFailureReport, manifest: ProcessManifest?): DiagnosticResult</ID>
+    <ID>LongMethod:CrashAnalyzer.kt$CrashAnalyzer$fun analyze(report: ProcessFailureReport, manifest: ProcessManifest?): DiagnosticResult</ID>
+    <ID>LongMethod:OrchestratorMain.kt$fun main()</ID>
+    <ID>LongMethod:RepairEngine.kt$RepairEngine$private suspend fun executeStrategy( processId: String, strategy: RepairStrategy, report: ProcessFailureReport, manifest: ProcessManifest?, diagnostic: DiagnosticResult, ): RepairOutcome</ID>
+    <ID>LoopWithTooManyJumpStatements:CrashAnalyzer.kt$CrashAnalyzer$for</ID>
+    <ID>MaxLineLength:HttpAiRepairClient.kt$HttpAiRepairClient$"""{"explanation":"&lt;why this fix works&gt;","patches":[{"filePath":"&lt;path&gt;","description":"&lt;what changed&gt;","originalSnippet":"&lt;exact lines to replace&gt;","patchedSnippet":"&lt;replacement lines&gt;"}]}"""</ID>
+    <ID>MaxLineLength:HttpAiRepairClient.kt$HttpAiRepairClient$appendLine("You are an AI code repair assistant. Analyze the process failure below and propose a minimal surgical fix.")</ID>
+    <ID>MaxLineLength:HttpAiRepairClient.kt$HttpAiRepairClient$appendLine("You are an AI configuration repair assistant. Suggest configuration changes for the failing process.")</ID>
+    <ID>MaxLineLength:HttpAiRepairClient.kt$HttpAiRepairClient$put("content", "You are a precise code repair assistant. Always respond with valid JSON only. Do not include markdown code fences.")</ID>
+    <ID>TooGenericExceptionCaught:HttpAiRepairClient.kt$HttpAiRepairClient$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:OrchestratorServiceImpl.kt$OrchestratorServiceImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RepairEngine.kt$RepairEngine$e: Exception</ID>
+    <ID>WildcardImport:CrashAnalyzerTest.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:OrchestratorMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+    <ID>WildcardImport:OrchestratorServiceImpl.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-process-manager/detekt-baseline.xml
+++ b/modules/boss-process-manager/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:ProcessSpawner.kt$ProcessSpawner.Companion$currentCommand != null &amp;&amp; (currentCommand.endsWith("/java") || currentCommand.endsWith("\\java.exe") || currentCommand.endsWith("/java.exe"))</ID>
+    <ID>LoopWithTooManyJumpStatements:ProcessMonitor.kt$ProcessMonitor$while</ID>
+    <ID>NestedBlockDepth:DependencyGraph.kt$DependencyGraph$fun getDependents(id: String): Set&lt;String&gt;</ID>
+    <ID>ReturnCount:ProcessSpawner.kt$ProcessSpawner.Companion$fun findJavaExecutable(): String</ID>
+    <ID>TooManyFunctions:ProcessRegistry.kt$ProcessRegistry</ID>
+    <ID>UseCheckOrError:DependencyGraph.kt$DependencyGraph$throw IllegalStateException("Circular dependency detected among: $cycle")</ID>
+    <ID>WildcardImport:ProcessMonitor.kt$import kotlinx.coroutines.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-service-auth/build.gradle.kts
+++ b/modules/boss-service-auth/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.service.auth"

--- a/modules/boss-service-auth/detekt-baseline.xml
+++ b/modules/boss-service-auth/detekt-baseline.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:AuthServiceMain.kt$fun main()</ID>
+    <ID>MaxLineLength:AuthServiceMain.kt$.</ID>
+    <ID>TooGenericExceptionCaught:SupabaseAuthClient.kt$SupabaseAuthClient$e: Exception</ID>
+    <ID>TooManyFunctions:AuthServiceGrpcImpl.kt$AuthServiceGrpcImpl : AuthServiceCoroutineImplBase</ID>
+    <ID>WildcardImport:AuthServiceGrpcImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:AuthServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-service-filesystem/build.gradle.kts
+++ b/modules/boss-service-filesystem/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.service.filesystem"

--- a/modules/boss-service-filesystem/detekt-baseline.xml
+++ b/modules/boss-service-filesystem/detekt-baseline.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:FileSystemServiceImpl.kt$FileSystemServiceImpl$override fun watchFileChanges(request: WatchFileChangesRequest): Flow&lt;FileChangeEvent&gt;</ID>
+    <ID>LongMethod:FileSystemServiceImpl.kt$FileSystemServiceImpl$override fun watchFileChanges(request: WatchFileChangesRequest): Flow&lt;FileChangeEvent&gt;</ID>
+    <ID>LoopWithTooManyJumpStatements:FileSystemServiceImpl.kt$FileSystemServiceImpl$while</ID>
+    <ID>MaxLineLength:FileSystemServiceImpl.kt$FileSystemServiceImpl$val slice = if (offsetBytes &gt; 0 &amp;&amp; offsetBytes &lt; bytes.size) bytes.drop(offsetBytes).toByteArray() else bytes</ID>
+    <ID>MaxLineLength:FileSystemServiceMain.kt$.</ID>
+    <ID>SpreadOperator:FileSystemServiceImpl.kt$FileSystemServiceImpl$(watchService, *kinds)</ID>
+    <ID>TooGenericExceptionCaught:FileSystemServiceImpl.kt$FileSystemServiceImpl$e: Exception</ID>
+    <ID>UseCheckOrError:FileSystemServiceImpl.kt$FileSystemServiceImpl$throw IllegalStateException("Destination already exists: ${request.destinationPath}")</ID>
+    <ID>VariableNaming:FileSystemServiceImpl.kt$FileSystemServiceImpl$/** Paths that must not be accessed via IPC — prevents privilege-escalation via path injection. */ private val BLOCKED_PATH_PREFIXES = listOf("/etc", "/sys", "/proc")</ID>
+    <ID>WildcardImport:FileSystemServiceImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:FileSystemServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-service-settings/build.gradle.kts
+++ b/modules/boss-service-settings/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.service.settings"

--- a/modules/boss-service-settings/detekt-baseline.xml
+++ b/modules/boss-service-settings/detekt-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>TooGenericExceptionCaught:SettingsServiceImpl.kt$SettingsServiceImpl$e: Exception</ID>
+    <ID>WildcardImport:SettingsServiceImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:SettingsServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-service-workspace/build.gradle.kts
+++ b/modules/boss-service-workspace/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
-    id("org.graalvm.buildtools.native") version "1.1.3"
+    alias(libs.plugins.graalvmNative)
 }
 
 group = "ai.rever.boss.service.workspace"

--- a/modules/boss-service-workspace/detekt-baseline.xml
+++ b/modules/boss-service-workspace/detekt-baseline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>TooGenericExceptionCaught:WorkspaceServiceImpl.kt$WorkspaceServiceImpl$e: Exception</ID>
+    <ID>TooManyFunctions:WorkspaceServiceImpl.kt$WorkspaceServiceImpl : WorkspaceServiceCoroutineImplBase</ID>
+    <ID>WildcardImport:WorkspaceServiceImpl.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:WorkspaceServiceMain.kt$import ai.rever.boss.ipc.proto.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/modules/boss-ui-sdk/detekt-baseline.xml
+++ b/modules/boss-ui-sdk/detekt-baseline.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:WidgetDiffEngine.kt$WidgetDiffEngine$fun apply(base: WidgetTree, operations: List&lt;DiffOperation&gt;): WidgetTree</ID>
+    <ID>CyclomaticComplexMethod:WidgetDiffEngine.kt$WidgetDiffEngine$fun diff(old: WidgetTree, new: WidgetTree): List&lt;DiffOperation&gt;</ID>
+    <ID>CyclomaticComplexMethod:WidgetProtoConverter.kt$WidgetProtoConverter$private fun ProtoWidgetType.toKotlin(): WidgetType</ID>
+    <ID>CyclomaticComplexMethod:WidgetProtoConverter.kt$WidgetProtoConverter$private fun WidgetType.toProto(): ProtoWidgetType</ID>
+    <ID>NestedBlockDepth:WidgetDiffEngine.kt$WidgetDiffEngine$fun apply(base: WidgetTree, operations: List&lt;DiffOperation&gt;): WidgetTree</ID>
+    <ID>NestedBlockDepth:WidgetProtoConverter.kt$WidgetProtoConverter$fun List&lt;DiffOperation&gt;.toProtoDiff(baseVersion: Long, newVersion: Long): ProtoWidgetDiff</ID>
+    <ID>TooManyFunctions:WidgetTreeBuilder.kt$WidgetTreeBuilder</ID>
+    <ID>UseCheckOrError:WidgetTreeBuilder.kt$WidgetTreeBuilder$throw IllegalStateException("No root widget defined")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-api-browser/detekt-baseline.xml
+++ b/plugin-platform/plugin-api-browser/detekt-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ReturnCount:BrowserConfig.kt$private fun ByteArray?.contentEqualsOrNull(other: ByteArray?): Boolean</ID>
+    <ID>TooManyFunctions:BrowserHandle.kt$BrowserHandle</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-api-ipc/detekt-baseline.xml
+++ b/plugin-platform/plugin-api-ipc/detekt-baseline.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `children of a hidden dir are hidden without the flag despite innocent names`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `entries under build or node_modules are always hidden`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `explicitly scanning inside build or a dot-directory still works`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `mixed separators between caller root and kernel paths still match as descendants`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `prefix mismatch degrades to a name-only check instead of emptying the scan`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `prefix requires a path-segment boundary`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `the root itself is not a visible entry`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `top-level dot entries follow the showHidden flag`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `trailing separator on the root is tolerated`()</ID>
+    <ID>FunctionNaming:ProviderScanFilterTest.kt$ProviderScanFilterTest$@Test fun `windows separators are handled in relative segments`()</ID>
+    <ID>MaxLineLength:ActiveTabsProviderProxy.kt$ActiveTabsProviderProxy$val resp: ActiveTabStringResponse = stub.getFaviconCacheKey(TabIdRequest.newBuilder().setTabId(tabId).build())</ID>
+    <ID>MaxLineLength:FileSystemDataProviderProxy.kt$FileSystemDataProviderProxy$override suspend</ID>
+    <ID>MaxLineLength:GitDataProviderProxy.kt$GitDataProviderProxy$override suspend fun cherryPick(commitHash: String)</ID>
+    <ID>MaxLineLength:GitDataProviderProxy.kt$GitDataProviderProxy$override suspend fun discardChanges(filePath: String)</ID>
+    <ID>MaxLineLength:GitDataProviderProxy.kt$GitDataProviderProxy$override suspend fun revert(commitHash: String)</ID>
+    <ID>MaxLineLength:GitDataProviderProxy.kt$GitDataProviderProxy$override suspend fun stage(filePath: String)</ID>
+    <ID>MaxLineLength:GitDataProviderProxy.kt$GitDataProviderProxy$override suspend fun unstage(filePath: String)</ID>
+    <ID>MaxLineLength:NotificationProviderProxy.kt$NotificationProviderProxy$NotificationDuration.INDEFINITE -&gt; ai.rever.boss.ipc.proto.services.NotificationDuration.NOTIFICATION_DURATION_INDEFINITE</ID>
+    <ID>MaxLineLength:ProviderScanFilterTest.kt$ProviderScanFilterTest$ProviderScanFilter.isVisibleProviderEntry(callerRoot, """C:\Users\dev\proj\.git\config""", showHidden = false)</ID>
+    <ID>MaxLineLength:ProviderScanFilterTest.kt$ProviderScanFilterTest$ProviderScanFilter.isVisibleProviderEntry(callerRoot, """C:\Users\dev\proj\src\main.kt""", showHidden = false)</ID>
+    <ID>MaxLineLength:ProviderScanFilterTest.kt$ProviderScanFilterTest$ProviderScanFilter.isVisibleProviderEntry(callerRoot, "/home/user/.config/myproj/.secret", showHidden = false)</ID>
+    <ID>MaxLineLength:ProviderScanFilterTest.kt$ProviderScanFilterTest$ProviderScanFilter.isVisibleProviderEntry(callerRoot, "/home/user/.config/myproj/file.txt", showHidden = false)</ID>
+    <ID>MaxLineLength:ProviderScanFilterTest.kt$ProviderScanFilterTest$assertFalse(ProviderScanFilter.isVisibleProviderEntry(root, "$root/node_modules/lodash/index.js", showHidden = false))</ID>
+    <ID>MaxLineLength:RoleManagementProviderProxy.kt$RoleManagementProviderProxy$return "Permission name must start with a letter and contain only letters, numbers, underscores, dots, and colons"</ID>
+    <ID>MaxLineLength:SecretDataProviderProxy.kt$SecretDataProviderProxy$override suspend</ID>
+    <ID>MaxLineLength:SecretDataProviderProxy.kt$SecretDataProviderProxy$val resp = stub.getUserSecretsWithSharingInfo(SecretPaginatedRequest.newBuilder().setLimit(limit).setOffset(offset).build())</ID>
+    <ID>ReturnCount:ProviderScanFilter.kt$ProviderScanFilter$fun isVisibleProviderEntry(rootPath: String, entryPath: String, showHidden: Boolean): Boolean</ID>
+    <ID>ReturnCount:RoleManagementProviderProxy.kt$RoleManagementProviderProxy$override fun validatePermissionName(permissionName: String): String?</ID>
+    <ID>ReturnCount:RoleManagementProviderProxy.kt$RoleManagementProviderProxy$override fun validateRoleName(roleName: String): String?</ID>
+    <ID>SwallowedException:AuthDataProviderProxy.kt$AuthDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AuthDataProviderProxy.kt$AuthDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DownloadDataProviderProxy.kt$DownloadDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FileSystemDataProviderProxy.kt$FileSystemDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GitDataProviderProxy.kt$GitDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PerformanceDataProviderProxy.kt$PerformanceDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:RoleManagementProviderProxy.kt$RoleManagementProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SecretDataProviderProxy.kt$SecretDataProviderProxy$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SupabaseDataProviderProxy.kt$SupabaseDataProviderProxy$e: Exception</ID>
+    <ID>TooManyFunctions:ActiveTabsProviderProxy.kt$ActiveTabsProviderProxy : ActiveTabsProvider</ID>
+    <ID>TooManyFunctions:FileSystemDataProviderProxy.kt$FileSystemDataProviderProxy : FileSystemDataProvider</ID>
+    <ID>TooManyFunctions:GitDataProviderProxy.kt$GitDataProviderProxy : GitDataProvider</ID>
+    <ID>TooManyFunctions:RoleManagementProviderProxy.kt$RoleManagementProviderProxy : RoleManagementProvider</ID>
+    <ID>TooManyFunctions:SecretDataProviderProxy.kt$SecretDataProviderProxy : SecretDataProvider</ID>
+    <ID>UnusedPrivateProperty:PanelEventProviderProxy.kt$PanelEventProviderProxy$private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())</ID>
+    <ID>UnusedPrivateProperty:RoleManagementProviderProxy.kt$RoleManagementProviderProxy$private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())</ID>
+    <ID>UnusedPrivateProperty:SecretDataProviderProxy.kt$SecretDataProviderProxy$private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())</ID>
+    <ID>UnusedPrivateProperty:SupabaseDataProviderProxy.kt$SupabaseDataProviderProxy$private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())</ID>
+    <ID>WildcardImport:ActiveTabsProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:AuthDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:ContextMenuProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:DirectoryPickerProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:DownloadDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:GitDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:LogDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:NotificationProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:PanelEventProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:PerformanceDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:ProjectDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:RoleManagementProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:RunConfigDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:SecretDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:SecretDataProviderProxy.kt$import ai.rever.boss.plugin.api.*</ID>
+    <ID>WildcardImport:SplitViewOperationsProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+    <ID>WildcardImport:SupabaseDataProviderProxy.kt$import ai.rever.boss.ipc.proto.services.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-dependency/build.gradle.kts
+++ b/plugin-platform/plugin-dependency/build.gradle.kts
@@ -43,8 +43,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+                implementation(libs.junit.jupiter)
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
     }

--- a/plugin-platform/plugin-dependency/detekt-baseline.xml
+++ b/plugin-platform/plugin-dependency/detekt-baseline.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `core precedence`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `equal versions compare zero and are equal`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `fewer prerelease identifiers rank lower`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `full semver precedence chain`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `missing minor and patch default to zero`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `numeric identifier ranks below alphanumeric`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `numeric prerelease identifiers order numerically not lexically`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `parses full version`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `parses prerelease and discards build metadata`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `rejects malformed input`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `release outranks its prerelease`()</ID>
+    <ID>FunctionNaming:SemanticVersionTest.kt$SemanticVersionTest$@Test fun `toString round-trips core and prerelease`()</ID>
+    <ID>ReturnCount:SemanticVersion.kt$SemanticVersion$override fun compareTo(other: SemanticVersion): Int</ID>
+    <ID>ReturnCount:SemanticVersion.kt$SemanticVersion.Companion$fun parse(version: String): SemanticVersion?</ID>
+    <ID>ReturnCount:SemanticVersion.kt$SemanticVersion.Companion$private fun comparePrerelease(a: String?, b: String?): Int</ID>
+    <ID>TooManyFunctions:SemanticVersionTest.kt$SemanticVersionTest</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-events/detekt-baseline.xml
+++ b/plugin-platform/plugin-events/detekt-baseline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:FileEventBus.kt$FileEventBus$logger.debug(LogCategory.FILE, "Opening file", mapOf("path" to cleanPath, "line" to line, "column" to column, "window" to sourceWindowId))</ID>
+    <ID>MaxLineLength:FileEventBus.kt$FileEventBus$suspend</ID>
+    <ID>SwallowedException:FileEventBus.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FileEventBus.kt$e: Exception</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-icons/build.gradle.kts
+++ b/plugin-platform/plugin-icons/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
         val desktopTest by getting {
             dependencies {
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
+                implementation(libs.junit.jupiter)
             }
         }
     }

--- a/plugin-platform/plugin-icons/detekt-baseline.xml
+++ b/plugin-platform/plugin-icons/detekt-baseline.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:FileIcons.kt$FileIcons$fun forFile(fileName: String): FileIconInfo</ID>
+    <ID>CyclomaticComplexMethod:FileIcons.kt$FileIcons$private fun forSpecialFileName(fileName: String): FileIconInfo?</ID>
+    <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forDatabase(database: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forExtension(extension: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forFramework(framework: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>CyclomaticComplexMethod:LanguageIcons.kt$LanguageIcons$fun forLanguage(language: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `handles case-insensitive extensions`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `handles paths with directories`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for CSS files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Go files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for HTML files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for JSON files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Java files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for JavaScript files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Kotlin files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Kotlin script files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Markdown files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Python files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for Rust files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for TypeScript files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for YAML files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns correct icon for shell scripts`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FileIconsForFileTests$@Test fun `returns default icon for unknown extensions`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FolderIconTests$@Test fun `default folder is not expanded`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FolderIconTests$@Test fun `returns closed folder icon when not expanded`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.FolderIconTests$@Test fun `returns open folder icon when expanded`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.MediaFileTests$@Test fun `returns archive icon for archive files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.MediaFileTests$@Test fun `returns audio icon for audio files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.MediaFileTests$@Test fun `returns font icon for font files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.MediaFileTests$@Test fun `returns image icon for image files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.MediaFileTests$@Test fun `returns video icon for video files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Docker icon for Dockerfile variants`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Docker icon for Dockerfile`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Docker icon for docker-compose files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Git icon for gitignore`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Go icon for go mod`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Gradle icon for build gradle files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Kubernetes icon for k8s yaml files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns Maven icon for pom xml`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns cargo icon for Cargo toml`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns lock icon for env files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns lock icon for key and pem files`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns npm icon for package json`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns npm icon for package-lock json`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns pip icon for requirements txt`()</ID>
+    <ID>FunctionNaming:FileIconsTest.kt$FileIconsTest.SpecialFileNameTests$@Test fun `returns yarn icon for yarn lock`()</ID>
+    <ID>LongMethod:FileIcons.kt$FileIcons$fun forFile(fileName: String): FileIconInfo</ID>
+    <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forExtension(extension: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>LongMethod:LanguageIcons.kt$LanguageIcons$fun forFramework(framework: String): Pair&lt;ImageVector, Color&gt;</ID>
+    <ID>MaxLineLength:FileIcons.kt$FileIcons$"bat", "cmd" -&gt; FileIconInfo(LanguageIcons.powershell, LanguageIcons.Colors.powershell)</ID>
+    <ID>MaxLineLength:FileIcons.kt$FileIcons$"png", "jpg", "jpeg", "gif", "bmp", "ico", "icns", "webp", "avif", "tiff", "tif" -&gt; FileIconInfo(image, Colors.image)</ID>
+    <ID>TooManyFunctions:FileIconsTest.kt$FileIconsTest$FileIconsForFileTests</ID>
+    <ID>TooManyFunctions:FileIconsTest.kt$FileIconsTest$SpecialFileNameTests</ID>
+    <ID>WildcardImport:FileIcons.kt$import androidx.compose.material.icons.outlined.*</ID>
+    <ID>WildcardImport:LanguageIcons.kt$import compose.icons.simpleicons.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-loader/build.gradle.kts
+++ b/plugin-platform/plugin-loader/build.gradle.kts
@@ -53,8 +53,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+                implementation(libs.junit.jupiter)
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
     }

--- a/plugin-platform/plugin-loader/detekt-baseline.xml
+++ b/plugin-platform/plugin-loader/detekt-baseline.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$fun validate(classLoader: ClassLoader, jarPath: String): ValidationResult</ID>
+    <ID>CyclomaticComplexMethod:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$private fun verifyReference( ref: ConstantPoolParser.MemberRef, classLoader: ClassLoader, sourceClass: String, errors: MutableList&lt;String&gt; )</ID>
+    <ID>CyclomaticComplexMethod:BinaryCompatibilityValidator.kt$ConstantPoolParser$fun extractReferences(classBytes: ByteArray): List&lt;MemberRef&gt;</ID>
+    <ID>CyclomaticComplexMethod:BinaryCompatibilityValidator.kt$ConstantPoolParser$fun parseDescriptorParams(descriptor: String, classLoader: ClassLoader): Array&lt;Class&lt;*&gt;&gt;</ID>
+    <ID>CyclomaticComplexMethod:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$override suspend fun loadPlugin(jarPath: String): Result&lt;LoadedPlugin&gt;</ID>
+    <ID>EmptyFunctionBlock:ForceUnloadTest.kt$LockedFixturePlugin${}</ID>
+    <ID>ExplicitGarbageCollectionCall:ClassLoaderGCWatcher.kt$ClassLoaderGCWatcher$gc()</ID>
+    <ID>ExplicitGarbageCollectionCall:ClassLoaderGCWatcher.kt$ClassLoaderGCWatcher$runFinalization()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `api layer is shared across manager instances (second-window gap)`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `api-jar-only type is unresolvable without the ApiClassLoader`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `api-jar-only type resolves with one identity across plugin classloaders`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `fromPluginDir degrades to an empty loader when no api jar exists`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `fromPluginDir ignores jars with a different pluginId`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `fromPluginDir picks the highest semver api jar`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `initializeApiLayer is idempotent`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `manager parents new plugin classloaders to the installed api layer`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `swapApiLayer replaces the shared layer and closes the old loader`()</ID>
+    <ID>FunctionNaming:ApiClassLoaderTest.kt$ApiClassLoaderTest$@Test fun `type present in the host wins parent-first over the api jar`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `api package references do not soft-fail`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `concrete class still resolves Object methods via the superclass walk`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `interface ref to Object's equals resolves`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `interface ref to Object's hashCode resolves`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `interface ref to Object's toString resolves`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `interface ref to a declared interface method resolves`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `interface ref to a genuinely missing method does not resolve`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `jdk and other packages do not soft-fail`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `prefix is anchored to the package boundary`()</ID>
+    <ID>FunctionNaming:BinaryCompatibilityValidatorTest.kt$BinaryCompatibilityValidatorTest$@Test fun `runtime package references soft-fail`()</ID>
+    <ID>FunctionNaming:ForceUnloadTest.kt$ForceUnloadTest$@Test fun `forced unload bypasses canUnload=false`()</ID>
+    <ID>FunctionNaming:ForceUnloadTest.kt$ForceUnloadTest$@Test fun `non-forced unload refuses a canUnload=false plugin`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `dev mode does not rescue a tampered sidecar`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `missing sidecar hard-fails once enforcement is on`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `missing sidecar is allowed during rollout`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `missing sidecar stays allowed in dev mode even under enforcement`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `sidecar signed for a different version is rejected`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `tampered jar with a valid-looking sidecar is rejected`()</ID>
+    <ID>FunctionNaming:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest$@Test fun `valid sidecar passes the signature gate`()</ID>
+    <ID>FunctionNaming:MinApiVersionGateTest.kt$MinApiVersionGateTest$@Test fun `gate fails open on unparseable requirement`()</ID>
+    <ID>FunctionNaming:MinApiVersionGateTest.kt$MinApiVersionGateTest$@Test fun `gate fails open when currentApiVersion is not set`()</ID>
+    <ID>FunctionNaming:MinApiVersionGateTest.kt$MinApiVersionGateTest$@Test fun `plugin requiring newer api layer is rejected with PluginApiLevelException`()</ID>
+    <ID>FunctionNaming:MinApiVersionGateTest.kt$MinApiVersionGateTest$@Test fun `plugin whose requirement is satisfied passes the gate`()</ID>
+    <ID>FunctionNaming:PluginClassLoaderManagerCloseTest.kt$PluginClassLoaderManagerCloseTest$@Test fun `closeClassLoader un-registers so the plugin can be loaded again`()</ID>
+    <ID>FunctionNaming:PluginClassLoaderManagerCloseTest.kt$PluginClassLoaderManagerCloseTest$@Test fun `closing a stale loader does not clobber a newer registration`()</ID>
+    <ID>FunctionNaming:PluginClassLoaderManagerCloseTest.kt$PluginClassLoaderManagerCloseTest$@Test fun `create still rejects a duplicate while the first is active`()</ID>
+    <ID>FunctionNaming:PluginSignatureEnforcementTest.kt$PluginSignatureEnforcementTest$@Test fun `common falsy spellings all disable enforcement`()</ID>
+    <ID>FunctionNaming:PluginSignatureEnforcementTest.kt$PluginSignatureEnforcementTest$@Test fun `common truthy spellings all enable enforcement`()</ID>
+    <ID>FunctionNaming:PluginSignatureEnforcementTest.kt$PluginSignatureEnforcementTest$@Test fun `unrecognized value falls back to default without throwing`()</ID>
+    <ID>FunctionNaming:PluginSignatureEnforcementTest.kt$PluginSignatureEnforcementTest$@Test fun `unset falls back to compiled default (warn during rollout)`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `delete removes the sidecar`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `persist with a signature writes it`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `persist with blank clears rather than writing an empty sidecar`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `persist with null clears a stale sidecar`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `read returns null for an empty sidecar`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `read returns null when no sidecar exists`()</ID>
+    <ID>FunctionNaming:PluginSignatureSidecarTest.kt$PluginSignatureSidecarTest$@Test fun `write then read round-trips the signature`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `anchor is case-insensitive on the digest`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `corrupted signature fails with sanitized reason`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `no trusted keys fails closed`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `signature from untrusted key fails`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `signature over a different message fails`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `store trust anchor parses`()</ID>
+    <ID>FunctionNaming:PluginSignatureVerifierTest.kt$PluginSignatureVerifierTest$@Test fun `valid message signature verifies`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `beta satisfies alpha requirement`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `isNewerThan works correctly`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `known prerelease satisfies unknown prerelease with lower patch`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `prerelease ordering alpha less than beta`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `prerelease ordering alpha satisfies earlier alpha`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `prerelease ordering beta less than rc`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `prerelease ordering same alpha version is equal`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `prerelease version is less than stable`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `rc satisfies beta requirement`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `stable satisfies unknown prerelease requirement`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `stable version satisfies prerelease requirement`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `unknown prerelease type is greater than rc`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `unknown prerelease type is less than stable`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `unknown prerelease types compared by ordinal then number`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version parsing returns null for invalid versions`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version parsing works for standard versions`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version parsing works with prerelease suffix`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version parsing works with v prefix`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version toString formats correctly`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation allows equal versions`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation allows newer major version`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation allows newer minor version`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation allows newer patch version`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation rejects older major version`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation rejects older minor version`()</ID>
+    <ID>FunctionNaming:VersionTest.kt$VersionTest$@Test fun `version validation rejects older patch version`()</ID>
+    <ID>LongMethod:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$fun validate(classLoader: ClassLoader, jarPath: String): ValidationResult</ID>
+    <ID>LongMethod:BinaryCompatibilityValidator.kt$ConstantPoolParser$fun extractReferences(classBytes: ByteArray): List&lt;MemberRef&gt;</ID>
+    <ID>LongMethod:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$override suspend fun loadPlugin(jarPath: String): Result&lt;LoadedPlugin&gt;</ID>
+    <ID>LongMethod:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$override suspend fun unloadPlugin(pluginId: String, waitForGC: Boolean, force: Boolean): Result&lt;Unit&gt;</ID>
+    <ID>LoopWithTooManyJumpStatements:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$for</ID>
+    <ID>MaxLineLength:ApiClassLoader.kt$ApiClassLoader.Companion$logger</ID>
+    <ID>MaxLineLength:ApiClassLoaderTest.kt$ApiClassLoaderTest$private</ID>
+    <ID>MaxLineLength:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$errors.add("$sourceClass -&gt; ${ref.ownerClassName}.${ref.name}(${ref.descriptor}): method not found")</ID>
+    <ID>MaxLineLength:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$errors.add("$sourceClass -&gt; ${ref.ownerClassName}.&lt;init&gt;(${ref.descriptor}): constructor not found")</ID>
+    <ID>MaxLineLength:BinaryCompatibilityValidator.kt$ConstantPoolParser$*</ID>
+    <ID>MaxLineLength:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$"Plugin requires API version ${manifest.apiVersion}, but current version is ${PluginManifestConstants.CURRENT_API_VERSION}"</ID>
+    <ID>MaxLineLength:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$"Plugin requires boss-plugin-api $minApiVersion or later, but installed API layer is $installedApiVersion"</ID>
+    <ID>MaxLineLength:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$logger</ID>
+    <ID>MaxLineLength:PluginManifestReader.kt$PluginManifestReader$val current = PluginManifestConstants.CURRENT_API_VERSION.split(".").firstOrNull()?.toIntOrNull() ?: return false</ID>
+    <ID>MaxLineLength:PluginSignatureEnforcement.kt$PluginSignatureEnforcement$logger</ID>
+    <ID>NestedBlockDepth:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$fun validate(classLoader: ClassLoader, jarPath: String): ValidationResult</ID>
+    <ID>NestedBlockDepth:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$override suspend fun unloadPlugin(pluginId: String, waitForGC: Boolean, force: Boolean): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$internal fun hasMethod(clazz: Class&lt;*&gt;, name: String, paramTypes: Array&lt;Class&lt;*&gt;&gt;): Boolean</ID>
+    <ID>ReturnCount:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$private fun verifyReference( ref: ConstantPoolParser.MemberRef, classLoader: ClassLoader, sourceClass: String, errors: MutableList&lt;String&gt; )</ID>
+    <ID>ReturnCount:BinaryCompatibilityValidator.kt$ConstantPoolParser$fun extractReferences(classBytes: ByteArray): List&lt;MemberRef&gt;</ID>
+    <ID>ReturnCount:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$override suspend fun unloadPlugin(pluginId: String, waitForGC: Boolean, force: Boolean): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$private fun isBossVersionCompatible(requiredVersion: String, currentVersion: String): Boolean</ID>
+    <ID>ReturnCount:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$private fun verifySignatureOrThrow(jarPath: String, manifest: PluginManifest): PluginSignatureException?</ID>
+    <ID>ReturnCount:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$suspend fun loadBundledPlugins(bundledDir: java.io.File): List&lt;LoadedPlugin&gt;</ID>
+    <ID>ReturnCount:PluginClassLoaderManager.kt$PluginClassLoaderManager$fun initializeApiLayer(pluginDir: File): ApiClassLoader</ID>
+    <ID>ReturnCount:PluginManifestReader.kt$PluginManifestReader$private fun isCompatibleApiVersion(requiredVersion: String): Boolean</ID>
+    <ID>ReturnCount:PluginSignatureVerifier.kt$PluginSignatureVerifier$fun verifySignedMessage(message: String, signatureBase64: String): SignatureVerificationResult</ID>
+    <ID>SpreadOperator:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$(*paramTypes)</ID>
+    <ID>SpreadOperator:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$(name, *paramTypes)</ID>
+    <ID>SwallowedException:ApiClassLoader.kt$ApiClassLoader.Companion$e: Exception</ID>
+    <ID>SwallowedException:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$e: ClassNotFoundException</ID>
+    <ID>SwallowedException:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$e: NoSuchFieldException</ID>
+    <ID>SwallowedException:PluginClassLoader.kt$PluginClassLoader$e: ClassNotFoundException</ID>
+    <ID>SwallowedException:PluginManifestReader.kt$PluginManifestReader$e: Exception</ID>
+    <ID>ThrowsCount:PluginManifestReader.kt$PluginManifestReader$fun readFromJar(jarPath: String): PluginManifest</ID>
+    <ID>TooGenericExceptionCaught:ApiClassLoader.kt$ApiClassLoader.Companion$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BinaryCompatibilityValidator.kt$BinaryCompatibilityValidator$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ClassLoaderGCWatcher.kt$ClassLoaderGCWatcher$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DynamicPluginLoader.kt$DynamicPluginLoaderImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginClassLoaderManager.kt$PluginClassLoaderManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginManifestReader.kt$PluginManifestReader$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginSignatureVerifier.kt$PluginSignatureVerifier$e: Exception</ID>
+    <ID>TooManyFunctions:ApiClassLoaderTest.kt$ApiClassLoaderTest</ID>
+    <ID>TooManyFunctions:DynamicPluginLoader.kt$DynamicPluginLoaderImpl : DynamicPluginLoader</ID>
+    <ID>TooManyFunctions:LoadTimeSignatureVerificationTest.kt$LoadTimeSignatureVerificationTest</ID>
+    <ID>TooManyFunctions:PluginClassLoaderManager.kt$PluginClassLoaderManager</ID>
+    <ID>TooManyFunctions:VersionTest.kt$VersionTest</ID>
+    <ID>UnusedPrivateProperty:PluginClassLoaderManager.kt$PluginClassLoaderManager.Companion$private val companionLogger = BossLogger.forComponent("PluginClassLoaderManager")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-logging/detekt-baseline.xml
+++ b/plugin-platform/plugin-logging/detekt-baseline.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:LogSanitizer.kt$LogSanitizer$val endIndex = if (endChar == '\u0000') uri.length else uri.indexOf(endChar).let { if (it &lt; 0) uri.length else it }</ID>
+    <ID>ReturnCount:LogSanitizer.kt$LogSanitizer$fun maskEmail(email: String?): String</ID>
+    <ID>SwallowedException:LogSanitizer.kt$LogSanitizer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BossLogger.kt$BossLogger$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LogSanitizer.kt$LogSanitizer$e: Exception</ID>
+    <ID>TooManyFunctions:BossLogger.kt$BossLogger</ID>
+    <ID>TooManyFunctions:LogSanitizer.kt$LogSanitizer</ID>
+    <ID>WildcardImport:BossLogger.kt$import kotlinx.coroutines.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-path-utils/build.gradle.kts
+++ b/plugin-platform/plugin-path-utils/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
         val desktopTest by getting {
             dependencies {
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
+                implementation(libs.junit.jupiter)
             }
         }
     }

--- a/plugin-platform/plugin-path-utils/detekt-baseline.xml
+++ b/plugin-platform/plugin-path-utils/detekt-baseline.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsDevModeTests$@Test fun `isDevMode reflects current runtime state`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `0 is not truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `1 is truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `arbitrary strings are not truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `false string variants are not truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `null and empty are not truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `true string variants are truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.IsTruthyTests$@Test fun `yes is truthy`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.ResolveTests$@Test fun `resolve handles nested paths`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.ResolveTests$@Test fun `resolve produces path under rootDir`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.RootDirTests$@Test fun `rootDir is under user home`()</ID>
+    <ID>FunctionNaming:BossDirectoriesTest.kt$BossDirectoriesTest.RootDirTests$@Test fun `rootDir name matches dev mode state`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractFileNameTests$@Test fun `handles Unix paths`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractFileNameTests$@Test fun `handles Windows paths`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractFileNameTests$@Test fun `handles edge cases`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractFileNameTests$@Test fun `handles files without path`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractFileNameTests$@Test fun `handles mixed separators`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractParentNameTests$@Test fun `handles Unix paths`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractParentNameTests$@Test fun `handles Windows paths`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractParentNameTests$@Test fun `handles edge cases`()</ID>
+    <ID>FunctionNaming:PathUtilsTest.kt$PathUtilsTest.ExtractParentNameTests$@Test fun `handles mixed separators`()</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-repository/build.gradle.kts
+++ b/plugin-platform/plugin-repository/build.gradle.kts
@@ -67,8 +67,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+                implementation(libs.junit.jupiter)
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
     }

--- a/plugin-platform/plugin-repository/detekt-baseline.xml
+++ b/plugin-platform/plugin-repository/detekt-baseline.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ForbiddenComment:PluginStoreClient.kt$PluginDetailResponse$// TODO: Implement proper timestamp parsing if needed</ID>
+    <ID>FunctionNaming:RemotePluginRepositoryDownloadTest.kt$RemotePluginRepositoryDownloadTest$@Test fun `cache hit still verifies signature and purges poisoned entry`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositoryDownloadTest.kt$RemotePluginRepositoryDownloadTest$@Test fun `cache hit with valid signature succeeds without re-downloading and writes the sidecar`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositoryDownloadTest.kt$RemotePluginRepositoryDownloadTest$@Test fun `fresh download with invalid signature fails and is never cached`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositoryDownloadTest.kt$RemotePluginRepositoryDownloadTest$@Test fun `fresh download with valid signature succeeds, caches, and writes the sidecar`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositoryDownloadTest.kt$RemotePluginRepositoryDownloadTest$@Test fun `unsigned download writes no sidecar`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `garbage signature throws and deletes rather than allowing`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `invalid signature throws and deletes all files`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `missing signature hard-fails once enforcement flag is on`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `missing signature warns but allows during rollout`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `store-reported version differing from requested version fails`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `substituted artifact with valid signature from another version fails`()</ID>
+    <ID>FunctionNaming:RemotePluginRepositorySignatureTest.kt$RemotePluginRepositorySignatureTest$@Test fun `valid anchor signature allows install and keeps files`()</ID>
+    <ID>LongMethod:RemotePluginRepository.kt$RemotePluginRepository$override suspend fun downloadPlugin( pluginId: String, version: String?, targetPath: String ): Result&lt;String&gt;</ID>
+    <ID>LongParameterList:RemotePluginRepository.kt$RemotePluginRepository$( sha256: String, signature: String?, pluginId: String, versionLabel: String, requestedVersion: String?, onVerificationFailure: () -&gt; Unit )</ID>
+    <ID>MaxLineLength:PluginStoreRealtimeService.kt$PluginStoreRealtimeService$logger.warn(LogCategory.NETWORK, "Plugins subscription lost, reconnecting in ${backoffMs}ms", error = e)</ID>
+    <ID>MaxLineLength:PluginStoreRealtimeService.kt$PluginStoreRealtimeService$logger.warn(LogCategory.NETWORK, "Versions subscription lost, reconnecting in ${backoffMs}ms", error = e)</ID>
+    <ID>MaxLineLength:RemotePluginRepository.kt$RemotePluginRepository$logger</ID>
+    <ID>MaxLineLength:RemotePluginRepository.kt$RemotePluginRepository$override suspend</ID>
+    <ID>MaxLineLength:RemotePluginRepository.kt$RemotePluginRepository$private</ID>
+    <ID>MaxLineLength:RemotePluginRepository.kt$RemotePluginRepository$suspend</ID>
+    <ID>MaxLineLength:RemotePluginRepository.kt$RemotePluginRepository$val totalBytes = response.headers[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull() ?: downloadInfo.size</ID>
+    <ID>ReturnCount:PluginDownloadCache.kt$PluginDownloadCache$fun getCachedJar(pluginId: String, version: String, expectedSha256: String): File?</ID>
+    <ID>ReturnCount:PluginDownloadCache.kt$PluginDownloadCache$fun removeAllVersions(pluginId: String): Int</ID>
+    <ID>ReturnCount:PluginRepositoryManager.kt$PluginRepositoryManager$private fun isNewerVersion(version1: String, version2: String): Boolean</ID>
+    <ID>ReturnCount:PluginRepositoryManager.kt$PluginRepositoryManager$suspend fun downloadPlugin( pluginId: String, version: String? = null, targetPath: String ): Result&lt;String&gt;</ID>
+    <ID>ReturnCount:PluginStoreConfig.kt$PluginStoreConfig$private fun decodeIsAdmin(token: String?): Boolean</ID>
+    <ID>SwallowedException:LocalPluginRepository.kt$LocalPluginRepository$e: Exception</ID>
+    <ID>ThrowsCount:RemotePluginRepository.kt$RemotePluginRepository$internal fun enforceStoreSignature( sha256: String, signature: String?, pluginId: String, versionLabel: String, requestedVersion: String?, onVerificationFailure: () -&gt; Unit )</ID>
+    <ID>TooGenericExceptionCaught:LocalPluginRepository.kt$LocalPluginRepository$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginStoreRealtimeService.kt$PluginStoreRealtimeService$e: Exception</ID>
+    <ID>TooManyFunctions:PluginDownloadCache.kt$PluginDownloadCache</ID>
+    <ID>TooManyFunctions:PluginRepositoryManager.kt$PluginRepositoryManager</ID>
+    <ID>TooManyFunctions:PluginStoreClient.kt$PluginStoreClient</ID>
+    <ID>TooManyFunctions:RemotePluginRepository.kt$RemotePluginRepository : PluginRepository</ID>
+    <ID>TooManyFunctions:RemotePluginRepositoryDownloadTest.kt$RemotePluginRepositoryDownloadTest</ID>
+    <ID>UnusedParameter:PluginStoreClient.kt$PluginDetailResponse$timestamp: String</ID>
+    <ID>UseCheckOrError:PluginStoreConfig.kt$PluginStoreConfig$throw IllegalStateException("PluginStoreConfig not initialized. Call initialize() first.")</ID>
+    <ID>WildcardImport:DesktopHttpClient.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:DesktopHttpClient.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:DesktopHttpClient.kt$import io.ktor.client.plugins.contentnegotiation.*</ID>
+    <ID>WildcardImport:DesktopHttpClient.kt$import io.ktor.serialization.kotlinx.json.*</ID>
+    <ID>WildcardImport:PluginStoreClient.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:PluginStoreClient.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:PluginStoreClient.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:PluginStoreClient.kt$import io.ktor.http.*</ID>
+    <ID>WildcardImport:RemotePluginRepository.kt$import ai.rever.boss.plugin.repository.*</ID>
+    <ID>WildcardImport:RemotePluginRepository.kt$import io.ktor.client.*</ID>
+    <ID>WildcardImport:RemotePluginRepository.kt$import io.ktor.client.engine.cio.*</ID>
+    <ID>WildcardImport:RemotePluginRepository.kt$import io.ktor.client.request.*</ID>
+    <ID>WildcardImport:RemotePluginRepository.kt$import io.ktor.client.statement.*</ID>
+    <ID>WildcardImport:RemotePluginRepository.kt$import io.ktor.utils.io.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-sandbox/build.gradle.kts
+++ b/plugin-platform/plugin-sandbox/build.gradle.kts
@@ -62,8 +62,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+                implementation(libs.junit.jupiter)
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
     }

--- a/plugin-platform/plugin-sandbox/detekt-baseline.xml
+++ b/plugin-platform/plugin-sandbox/detekt-baseline.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ConstructorParameterNaming:SandboxedPluginContext.kt$SandboxedPluginContext$private val _sandbox: PluginSandbox</ID>
+    <ID>CyclomaticComplexMethod:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun attributeToPlugin(throwable: Throwable, thread: Thread? = null): String?</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.DisabledStateTests$@Test fun `setDisabled changes state to DISABLED`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.DisabledStateTests$@Test fun `setState allows direct state changes`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.HealthMetricsTests$@Test fun `initial health metrics are correct`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.HealthMetricsTests$@Test fun `multiple errors increment consecutiveErrors`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.HealthMetricsTests$@Test fun `recordError increments error counters`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.HealthMetricsTests$@Test fun `recordHeartbeat updates lastHeartbeat`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.HealthMetricsTests$@Test fun `recordSuccess resets consecutive errors`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.LifecycleTests$@Test fun `double start is idempotent`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.LifecycleTests$@Test fun `double stop is idempotent`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.LifecycleTests$@Test fun `restart transitions through RESTARTING to RUNNING`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.LifecycleTests$@Test fun `sandbox starts in STOPPED state`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.LifecycleTests$@Test fun `start transitions to RUNNING state`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.LifecycleTests$@Test fun `stop transitions to STOPPED state`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.PluginExceptionTests$@Test fun `PluginException getPluginId extracts correct id`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.PluginExceptionTests$@Test fun `PluginException getPluginId returns null for non-PluginException`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.PluginExceptionTests$@Test fun `PluginException preserves pluginId`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.PluginExceptionTests$@Test fun `recordError wraps non-PluginException errors`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.SandboxScopeTests$@Test fun `coroutines can be launched in sandboxScope`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.SandboxScopeTests$@Test fun `restart creates new sandboxScope`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.SandboxScopeTests$@Test fun `sandboxScope is available after start`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.UnhealthyStateTests$@Test fun `exceeding maxConsecutiveErrors marks sandbox as UNHEALTHY`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.UnhealthyStateTests$@Test fun `markUnhealthy changes state from RUNNING to UNHEALTHY`()</ID>
+    <ID>FunctionNaming:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.UnhealthyStateTests$@Test fun `markUnhealthy does nothing when not RUNNING`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.DisableEnableTests$@Test fun `disablePlugin marks plugin as disabled`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.DisableEnableTests$@Test fun `disablePlugin sets sandbox state to DISABLED`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.DisableEnableTests$@Test fun `enablePlugin removes plugin from disabled set`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.DisableEnableTests$@Test fun `getDisabledPlugins returns all disabled plugins`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.DisableEnableTests$@Test fun `isPluginDisabled returns false for non-disabled plugin`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.DisposeTests$@Test fun `dispose clears all sandboxes`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.HealthSummaryTests$@Test fun `healthSummary is available`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.ListenerTests$@Test fun `listener receives onPluginDisabled event`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.ListenerTests$@Test fun `listener receives onPluginRestarted event`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.ListenerTests$@Test fun `listener receives onPluginRestarting event`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.ListenerTests$@Test fun `removeListener stops receiving events`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.RestartTests$@Test fun `restartPlugin returns failure for unknown plugin`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.RestartTests$@Test fun `restartPlugin returns success for known plugin`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxCreationTests$@Test fun `createSandbox creates different sandboxes for different pluginIds`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxCreationTests$@Test fun `createSandbox returns existing sandbox for same pluginId`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxCreationTests$@Test fun `createSandbox returns new sandbox`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxCreationTests$@Test fun `getSandbox returns null for unknown plugin`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxCreationTests$@Test fun `getSandbox returns sandbox after creation`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxRemovalTests$@Test fun `getAllSandboxes returns all created sandboxes`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxRemovalTests$@Test fun `removeSandbox is safe for unknown plugin`()</ID>
+    <ID>FunctionNaming:PluginSandboxManagerTest.kt$PluginSandboxManagerTest.SandboxRemovalTests$@Test fun `removeSandbox removes sandbox`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.DismissTests$@Test fun `dismiss cancels auto-dismiss timer`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.DismissTests$@Test fun `dismiss is safe for unknown id`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.DismissTests$@Test fun `dismiss removes specific toast by id`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.DismissTests$@Test fun `dismissAll clears all toasts`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ShowTests$@Test fun `INDEFINITE duration does not auto-dismiss`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ShowTests$@Test fun `LONG duration auto-dismisses after 6 seconds`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ShowTests$@Test fun `SHORT duration auto-dismisses after 3 seconds`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ShowTests$@Test fun `show adds toast to list`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ShowTests$@Test fun `show respects maxToasts limit`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ToastMessageTests$@Test fun `ToastAction stores label and callback`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.ToastMessageTests$@Test fun `ToastMessage has default id`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.UtilityTests$@Test fun `hasToasts returns true when toasts exist`()</ID>
+    <ID>FunctionNaming:PluginToastStateTest.kt$PluginToastStateTest.UtilityTests$@Test fun `toastCount returns correct count`()</ID>
+    <ID>LongMethod:PluginErrorBoundary.kt$@Composable fun PluginErrorBoundary( pluginId: String, sandbox: PluginSandbox, onRestart: () -&gt; Unit, content: @Composable () -&gt; Unit )</ID>
+    <ID>LongMethod:PluginErrorFallback.kt$@Composable fun PluginErrorFallback( pluginId: String, error: Throwable, isIncompatible: Boolean = false, onRestart: () -&gt; Unit, onDismiss: (() -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:PluginToastHost.kt$@Composable fun PluginToast( message: ToastMessage, onDismiss: () -&gt; Unit )</ID>
+    <ID>MaxLineLength:SandboxedPluginContext.kt$SandboxedPluginContext$println("[HOST-DEBUG] SandboxedPluginContext.navigationTargetProvider: delegate=${delegate::class.simpleName}, result=$result")</ID>
+    <ID>NestedBlockDepth:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun attributeToPlugin(throwable: Throwable, thread: Thread? = null): String?</ID>
+    <ID>NestedBlockDepth:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun register(pluginId: String, onError: (Throwable) -&gt; Unit): Registration</ID>
+    <ID>ReturnCount:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun attributeToPlugin(throwable: Throwable, thread: Thread? = null): String?</ID>
+    <ID>ReturnCount:PluginCrashInterceptor.kt$PluginCrashInterceptor$private fun tryHandlePluginCrash(thread: Thread, throwable: Throwable): Boolean</ID>
+    <ID>ReturnCount:PluginWatchdog.kt$PluginWatchdog$private suspend fun checkHealth()</ID>
+    <ID>TooGenericExceptionCaught:PluginCrashInterceptor.kt$PluginCrashInterceptor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginErrorBoundary.kt$PluginCrashRegistry$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PluginSandboxManager.kt$PluginSandboxManagerImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SandboxedPanelRegistry.kt$SandboxedPanelRegistry$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SandboxedTabRegistry.kt$SandboxedTabRegistry$e: Throwable</ID>
+    <ID>TooManyFunctions:InProcessPluginSandbox.kt$InProcessPluginSandbox : PluginSandbox</ID>
+    <ID>TooManyFunctions:PluginSandboxManager.kt$PluginSandboxManager</ID>
+    <ID>TooManyFunctions:PluginSandboxManager.kt$PluginSandboxManagerImpl : PluginSandboxManager</ID>
+    <ID>TooManyFunctions:SandboxedPluginContext.kt$SandboxedPluginContext : PluginContext</ID>
+    <ID>UnusedPrivateProperty:InProcessPluginSandboxTest.kt$InProcessPluginSandboxTest.SandboxScopeTests$val originalScope = sandbox.sandboxScope</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-scrollbar/detekt-baseline.xml
+++ b/plugin-platform/plugin-scrollbar/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:BossScrollBar.kt$fun Modifier.lazyListScrollbar( listState: LazyListState, direction: Orientation, config: ScrollbarConfig = ScrollbarConfig(), ): Modifier</ID>
+    <ID>CyclomaticComplexMethod:BossScrollBar.kt$fun Modifier.scrollbar( scrollState: ScrollState, direction: Orientation, config: ScrollbarConfig = ScrollbarConfig(), ): Modifier</ID>
+    <ID>DestructuringDeclarationWithTooManyEntries:BossScrollBar.kt$val (topPadding, bottomPadding, startPadding, endPadding) = arrayOf( padding.calculateTopPadding().toPx(), padding.calculateBottomPadding().toPx(), padding.calculateStartPadding(layoutDirection).toPx(), padding.calculateEndPadding(layoutDirection).toPx() )</ID>
+    <ID>DestructuringDeclarationWithTooManyEntries:BossScrollBar.kt$var ( indicatorThickness, indicatorColor, indicatorCornerRadius, alpha, alphaAnimationSpec, padding ) = config</ID>
+    <ID>LongMethod:BossScrollBar.kt$fun Modifier.lazyListScrollbar( listState: LazyListState, direction: Orientation, config: ScrollbarConfig = ScrollbarConfig(), ): Modifier</ID>
+    <ID>MaxLineLength:ScrollbarSettingsManager.kt$ScrollbarSettingsManager$logger.debug(LogCategory.SYSTEM, "Created default settings", mapOf("path" to settingsFile.absolutePath))</ID>
+    <ID>TooGenericExceptionCaught:ScrollbarSettingsManager.kt$ScrollbarSettingsManager$e: Exception</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-search/detekt-baseline.xml
+++ b/plugin-platform/plugin-search/detekt-baseline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:BossSearchBar.kt$@Composable fun BossSearchBar( query: String, onQueryChange: (String) -&gt; Unit, placeholder: String = "Search...", modifier: Modifier = Modifier, leadingIcon: ImageVector = Icons.Outlined.Search, showClearButton: Boolean = true, onFocusChanged: ((Boolean) -&gt; Unit)? = null )</ID>
+    <ID>LongParameterList:BossSearchBar.kt$( query: String, onQueryChange: (String) -&gt; Unit, placeholder: String = "Search...", modifier: Modifier = Modifier, leadingIcon: ImageVector = Icons.Outlined.Search, showClearButton: Boolean = true, onFocusChanged: ((Boolean) -&gt; Unit)? = null )</ID>
+    <ID>UnusedParameter:BossSearchBar.kt$onFocusChanged: ((Boolean) -&gt; Unit)? = null</ID>
+    <ID>WildcardImport:BossSearchBar.kt$import androidx.compose.foundation.layout.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-ui-core/detekt-baseline.xml
+++ b/plugin-platform/plugin-ui-core/detekt-baseline.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:BossComponents.kt$@Composable fun BossTextField( value: String, onValueChange: (String) -&gt; Unit, label: String, modifier: Modifier = Modifier, placeholder: String = "", enabled: Boolean = true, isError: Boolean = false, errorMessage: String? = null, singleLine: Boolean = true, required: Boolean = false )</ID>
+    <ID>LongParameterList:BossComponents.kt$( label: String, buttonText: String, onClick: () -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true, isDestructive: Boolean = false )</ID>
+    <ID>LongParameterList:BossComponents.kt$( label: String, checked: Boolean, onCheckedChange: (Boolean) -&gt; Unit, modifier: Modifier = Modifier, description: String? = null, enabled: Boolean = true )</ID>
+    <ID>LongParameterList:BossComponents.kt$( text: String, onClick: () -&gt; Unit, modifier: Modifier = Modifier, enabled: Boolean = true, isDestructive: Boolean = false, icon: ImageVector? = null )</ID>
+    <ID>LongParameterList:BossComponents.kt$( value: String, onValueChange: (String) -&gt; Unit, label: String, modifier: Modifier = Modifier, placeholder: String = "", enabled: Boolean = true, isError: Boolean = false, errorMessage: String? = null, minLines: Int = 3, maxLines: Int = 5 )</ID>
+    <ID>LongParameterList:BossComponents.kt$( value: String, onValueChange: (String) -&gt; Unit, label: String, modifier: Modifier = Modifier, placeholder: String = "", enabled: Boolean = true, isError: Boolean = false, errorMessage: String? = null, singleLine: Boolean = true, required: Boolean = false )</ID>
+    <ID>MatchingDeclarationName:BossTheme.kt$BossThemeColors</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.alert", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.data", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.ink", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.line", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.ok", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.panel", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.raised", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.signal", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.textMuted", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.textPrimary", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.textSecondary", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossColors.kt$@Deprecated(DARK_ALIAS_DEPRECATION, ReplaceWith("BossThemeController.current.colors.warn", "ai.rever.boss.plugin.ui.BossThemeController"))</ID>
+    <ID>MaxLineLength:BossComponents.kt$if (enabled) BossThemeColors.SurfaceColor else BossThemeColors.SurfaceColor.copy(alpha = 0.5f)</ID>
+    <ID>MaxLineLength:BossDesignSystem.kt$displayLarge = TextStyle(fontFamily = mono, fontWeight = FontWeight.SemiBold, fontSize = 28.sp, letterSpacing = (-0.5).sp)</ID>
+    <ID>TooManyFunctions:BossComponents.kt$ai.rever.boss.plugin.ui.BossComponents.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-updater/build.gradle.kts
+++ b/plugin-platform/plugin-updater/build.gradle.kts
@@ -54,8 +54,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
-                implementation("org.junit.jupiter:junit-jupiter:6.1.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
+                implementation(libs.junit.jupiter)
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
     }

--- a/plugin-platform/plugin-updater/detekt-baseline.xml
+++ b/plugin-platform/plugin-updater/detekt-baseline.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates( installedPlugins: Map&lt;String, String&gt; ): UpdateCheckResult</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `blank host version disables the gate`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `blank minBossVersion fails open`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `newer host than required is offered`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `prerelease of the required host version is offered, not gated`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `unparseable minBossVersion fails open`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `update requiring newer host is reported, not offered`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerBossVersionGateTest.kt$PluginUpdateManagerBossVersionGateTest$@Test fun `update whose minBossVersion the host satisfies is offered`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerCheckCompatTest.kt$PluginUpdateManagerCheckCompatTest$@Test fun `compatible newer version is offered`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerCheckCompatTest.kt$PluginUpdateManagerCheckCompatTest$@Test fun `incompatible newer version is reported, not offered`()</ID>
+    <ID>FunctionNaming:PluginUpdateManagerCheckCompatTest.kt$PluginUpdateManagerCheckCompatTest$@Test fun `no update when installed version is already current`()</ID>
+    <ID>LongMethod:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates( installedPlugins: Map&lt;String, String&gt; ): UpdateCheckResult</ID>
+    <ID>NestedBlockDepth:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates( installedPlugins: Map&lt;String, String&gt; ): UpdateCheckResult</ID>
+    <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$private fun isNewerVersion(version1: String, version2: String): Boolean</ID>
+    <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$private fun satisfiesFloor(required: String, installed: String): Boolean</ID>
+    <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$suspend fun updatePlugin( pluginId: String, downloadPath: String, unloadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, loadPlugin: suspend (String) -&gt; Result&lt;Unit&gt; ): Result&lt;Unit&gt;</ID>
+    <ID>TooGenericExceptionCaught:PluginUpdateManager.kt$PluginUpdateManager$e: Exception</ID>
+    <ID>TooManyFunctions:PluginUpdateManager.kt$PluginUpdateManager</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plugin-platform/plugin-window/detekt-baseline.xml
+++ b/plugin-platform/plugin-window/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:WindowProjectState.kt$WindowProjectState$logger.debug(LogCategory.FILE, "Selected project", mapOf("windowId" to windowId, "name" to project.name, "path" to project.path))</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/server/detekt-baseline.xml
+++ b/server/detekt-baseline.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>NewLineAtEndOfFile:Application.kt$ai.rever.boss.Application.kt</ID>
+    <ID>WildcardImport:Application.kt$import io.ktor.server.application.*</ID>
+    <ID>WildcardImport:Application.kt$import io.ktor.server.engine.*</ID>
+    <ID>WildcardImport:Application.kt$import io.ktor.server.netty.*</ID>
+    <ID>WildcardImport:Application.kt$import io.ktor.server.response.*</ID>
+    <ID>WildcardImport:Application.kt$import io.ktor.server.routing.*</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shared/detekt-baseline.xml
+++ b/shared/detekt-baseline.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MatchingDeclarationName:Platform.android.kt$AndroidPlatform : Platform</ID>
+    <ID>MatchingDeclarationName:Platform.ios.kt$IOSPlatform : Platform</ID>
+    <ID>MatchingDeclarationName:Platform.jvm.kt$JVMPlatform : Platform</ID>
+    <ID>MatchingDeclarationName:Platform.wasmJs.kt$WasmPlatform : Platform</ID>
+    <ID>NewLineAtEndOfFile:Constants.kt$ai.rever.boss.Constants.kt</ID>
+    <ID>NewLineAtEndOfFile:Greeting.kt$ai.rever.boss.Greeting.kt</ID>
+    <ID>NewLineAtEndOfFile:Platform.android.kt$ai.rever.boss.Platform.android.kt</ID>
+    <ID>NewLineAtEndOfFile:Platform.ios.kt$ai.rever.boss.Platform.ios.kt</ID>
+    <ID>NewLineAtEndOfFile:Platform.jvm.kt$ai.rever.boss.Platform.jvm.kt</ID>
+    <ID>NewLineAtEndOfFile:Platform.kt$ai.rever.boss.Platform.kt</ID>
+    <ID>NewLineAtEndOfFile:Platform.wasmJs.kt$ai.rever.boss.Platform.wasmJs.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>


### PR DESCRIPTION
PR 1 of the "pristine" campaign: turn the no-op code-quality job into real, enforceable gates without freezing development on 20k lines of legacy findings.

## detekt (gating)

- **detekt 1.23.8** applied to every module via `allprojects` in the root `build.gradle.kts`, wired into `check` (and therefore `build` and CI). Plays fine with Gradle 9.6, Kotlin 2.4 and the configuration cache.
- `source` points at each module's whole `src` tree, so KMP source sets (`commonMain`, `desktopMain`, ...) are analyzed, not just `src/main` — this build mixes KMP and plain JVM modules.
- **Tuned config** at `config/detekt/detekt.yml` (`buildUponDefaultConfig = true`, so only deviations live there):
  - `FunctionNaming`: `ignoreAnnotated: ['Composable']` — composables are PascalCase by convention.
  - `MagicNumber`: disabled for now. ~1,400 findings are Compose dp/sp/weight values where extracting constants hurts readability; a targeted policy (ignore UI literals, keep logic constants) comes in a follow-up.
  - `TooGenericExceptionCaught`: kept active at warning severity — new `catch (e: Exception)` should be a conscious choice.
  - Everything else is the default ruleset.

### Baseline mechanism

Existing debt (2,841 findings in `composeApp` alone) is frozen in per-module `detekt-baseline.xml` files — **the build only fails on NEW violations**. Fixing baselined debt is welcome anytime; regenerate a module's baseline with `./gradlew :<module>:detektBaseline` after paying some down.

One real bug surfaced while baselining: `BrowserHandleImpl.kt` contained two char literals with a **raw 0x00 byte** in the source (instead of the escaped `\u0000` form). NUL is unrepresentable in XML 1.0, so detekt could not round-trip its own baseline. Fixed in source (byte-identical semantics); the fix commit was later dropped on rebase because #28 shipped the identical escape upstream.

### Rebase onto v9.2.59

After #26 (tab shrinking), #27 (multi-window tab cleanup) and #28 (browser keyboard scoping) landed, the branch was rebased and the gate re-run against the new code. Two outcomes (commit `f2ca938`):

- **Config fix**: detekt's default test-dir excludes cover `test`, `jvmTest`, `commonTest`, etc. but not the KMP **`desktopTest`** source set, so the new test files' idiomatic backtick names raised 18 FunctionNaming + 1 TooManyFunctions findings (and 696 equivalent entries were sitting in the baseline). `FunctionNaming` and `TooManyFunctions` excludes now include `**/desktopTest/**` (default parity otherwise), shrinking the composeApp baseline by ~700 entries.
- **Newly baselined new-code debt** (substantive refactors, deliberately not for this PR):
  - `BossTabButton.kt` (#26): LongMethod, CyclomaticComplexMethod, LongParameterList
  - `BossMainWindowPanel.kt` (#26): LongParameterList
  - `DynamicPluginManager.kt` (#27): LongMethod, CyclomaticComplexMethod, ComplexCondition (`uninstallPlugin`)
  - `BrowserServiceImpl.kt` (#27/#28): LongMethod, CyclomaticComplexMethod, NestedBlockDepth (`createBrowser`)
  - `FluckEngine.kt` (#28): LongMethod, CyclomaticComplexMethod (`setupKeyboardInterceptor`)
  - `ComputeTabWidthPxTest.kt`: PackageNaming (new test joins the pre-existing `window_panel` package)

Verification re-run after the rebase: `./gradlew detekt` and `:composeApp:compileKotlinDesktop :composeApp:desktopTest` both BUILD SUCCESSFUL.

## ktlint (present, not gating)

`org.jlleitschuh.gradle.ktlint` 14.2.0 is applied the same way, but with `ignoreFailures = true`: `ktlintCheck` runs and reports, and `ktlintFormat` is available, but nothing fails yet. A format-the-world PR lands next; flipping `ignoreFailures` then makes it gate. Gating now would block every open branch on legacy formatting.

`.editorconfig` added at the repo root (UTF-8, LF, final newline, 4-space Kotlin indent, `max_line_length = 140`, `ktlint_code_style = intellij_idea` — matching `kotlin.code.style=official`).

## CI

The `code-quality` job previously "passed" by echoing around a commented-out lint command, and ran `./gradlew buildHealth || true` — a task that does not exist, with the failure swallowed. Now:

- the lint step runs `./gradlew detekt` for real (new findings fail the job);
- detekt HTML/XML reports are uploaded as a workflow artifact;
- the `buildHealth` sham step is removed.

`ktlintCheck` is deliberately NOT in CI in this PR (see above).

## Version-catalog cleanup

This PR also owns `gradle/libs.versions.toml` for this wave:

- Deleted dead entries (0 references, verified): `compose-compiler` pin, `compose-ui`, `compose-ui-tooling`, `compose-ui-tooling-preview`, `androidx-foundation-layout-android`, `androidx-ui-android`, plus their orphaned version keys.
- Added `junit-jupiter` (6.1.0) and replaced the 8 hardcoded copies (composeApp + 7 plugin-platform modules).
- Replaced the 5 hardcoded `kotlinx-coroutines-test:1.11.0` with the existing catalog alias.
- Switched the 9 microkernel modules to `alias(libs.plugins.graalvmNative)` instead of hardcoding `id("org.graalvm.buildtools.native") version "1.1.3"`.
- Added `clikt` (5.1.0) and used it in composeApp.

## Verification

- `./gradlew detekt` — BUILD SUCCESSFUL (36 modules analyzed, all baselined debt passes; config-cache entry stored and reused).
- `./gradlew :composeApp:compileKotlinDesktop :composeApp:desktopTest` — BUILD SUCCESSFUL.
- `./gradlew :server:ktlintCheck` — runs report-only as intended.

