### PR TITLE
test: cover git porcelain parsers, workspace extraction, shell quoting, main detection

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -347,7 +347,7 @@ actual object GitService {
      * Format: XY PATH or XY ORIG_PATH -> PATH (for renames)
      * X = index status, Y = worktree status
      */
-    private fun parseStatusLine(line: String): GitFileStatus? {
+    internal fun parseStatusLine(line: String): GitFileStatus? {
         if (line.length < 3) return null
 
         val indexChar = line[0]
@@ -380,7 +380,7 @@ actual object GitService {
         )
     }
 
-    private fun parseStatusChar(c: Char): GitFileStatusType? {
+    internal fun parseStatusChar(c: Char): GitFileStatusType? {
         return when (c) {
             'M' -> GitFileStatusType.MODIFIED
             'A' -> GitFileStatusType.ADDED
@@ -543,7 +543,7 @@ actual object GitService {
         }
     }
 
-    private fun parseCommitLine(line: String): GitCommitInfo? {
+    internal fun parseCommitLine(line: String): GitCommitInfo? {
         val parts = line.split("\u0000")
         if (parts.size < 6) return null
 
@@ -719,7 +719,7 @@ actual object GitService {
         }
     }
 
-    private fun parseStashLine(index: Int, line: String): GitStashInfo? {
+    internal fun parseStashLine(index: Int, line: String): GitStashInfo? {
         // Format: stash@{0}: On branch_name: message
         // or: stash@{0}: WIP on branch_name: hash message
         val regex = Regex("""stash@\{(\d+)\}:\s*(?:(?:WIP on|On)\s+(\S+?):\s*)?(.*)""")
@@ -922,7 +922,7 @@ actual object GitService {
      * - https://github.com/owner/repo.git -> https://github.com/owner/repo
      * - ssh://git@github.com/owner/repo.git -> https://github.com/owner/repo
      */
-    private fun parseRemoteUrl(remoteUrl: String): String? {
+    internal fun parseRemoteUrl(remoteUrl: String): String? {
         return try {
             when {
                 // SSH format: git@github.com:owner/repo.git

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractorTest.kt
@@ -1,0 +1,290 @@
+package ai.rever.boss.components.workspaces
+
+import ai.rever.boss.components.plugin.TabUpdateRegistry
+import ai.rever.boss.components.plugin.tab_types.PanelHostTabInfo
+import ai.rever.boss.components.plugin.tab_types.PanelHostTabType
+import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
+import ai.rever.boss.components.window_panel.SplitOrientation
+import ai.rever.boss.components.window_panel.SplitViewState
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.TabComponentWithUI
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabRegistry
+import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.api.TabTypeInfo
+import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
+import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
+import ai.rever.boss.plugin.tab.fluck.FluckTabType
+import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
+import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
+import ai.rever.boss.plugin.tab.terminal.TerminalTabType
+import ai.rever.boss.plugin.workspace.SplitConfig.HorizontalSplit
+import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
+import ai.rever.boss.plugin.workspace.SplitConfig.VerticalSplit
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.runtime.Composable
+import com.arkivanov.decompose.ComponentContext
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins down [extractCurrentWorkspace]: the SplitViewState → SplitConfig tree walk
+ * that serializes the live split layout (workspace save / session restore).
+ *
+ * Uses real [SplitViewState] / BossTabsComponent fixtures (same approach as
+ * BossTabsComponentMoveTest) so the walk runs over the exact runtime tree shape.
+ *
+ * Note: neither SplitNode nor SplitConfig carries a split ratio, so there is no
+ * ratio to preserve — structure, panel ids, and tab mapping are the contract.
+ */
+class WorkspaceExtractorTest {
+
+    private object JupyterStubType : TabTypeInfo {
+        override val typeId = JupyterTabInfo.TYPE_ID
+        override val displayName = "Notebook"
+        override val icon = Icons.Outlined.Code
+    }
+
+    private object CustomTabType : TabTypeInfo {
+        override val typeId = TabTypeId("custom-widget", "test.plugin")
+        override val displayName = "Custom Widget"
+        override val icon = Icons.Outlined.Language
+    }
+
+    private data class CustomTabInfo(
+        override val id: String,
+        override val title: String
+    ) : TabInfo {
+        override val typeId: TabTypeId = CustomTabType.typeId
+        override val icon get() = Icons.Outlined.Language
+    }
+
+    /** Minimal stand-in component; the extractor only reads TabInfo, never the component. */
+    private class StubTabComponent(
+        ctx: ComponentContext,
+        override val config: TabInfo,
+        override val tabTypeInfo: TabTypeInfo
+    ) : TabComponentWithUI, ComponentContext by ctx {
+        @Composable
+        override fun Content() {
+        }
+    }
+
+    private val tabRegistry = TabRegistry().apply {
+        listOf(TerminalTabType, CodeEditorTabType, FluckTabType, JupyterStubType, CustomTabType, PanelHostTabType)
+            .forEach { type ->
+                registerTabType(type) { config, ctx -> StubTabComponent(ctx, config, type) }
+            }
+    }
+
+    private fun newSplitViewState() = SplitViewState(tabRegistry, windowId = "test-window")
+
+    @AfterTest
+    fun tearDown() {
+        TabUpdateRegistry.clear()
+    }
+
+    // ==================== layout structure ====================
+
+    @Test
+    fun `fresh state extracts as a single empty main panel`() {
+        val workspace = extractCurrentWorkspace(newSplitViewState())
+
+        val layout = assertIs<SinglePanel>(workspace.layout)
+        assertEquals("main", layout.panel.id)
+        assertTrue(layout.panel.tabs.isEmpty())
+    }
+
+    @Test
+    fun `vertical split extracts with original panel on the left`() {
+        val state = newSplitViewState()
+        val newPanelId = state.splitPanel("main", SplitOrientation.VERTICAL)
+
+        val layout = assertIs<VerticalSplit>(extractCurrentWorkspace(state).layout)
+        assertEquals("main", assertIs<SinglePanel>(layout.left).panel.id)
+        assertEquals(newPanelId, assertIs<SinglePanel>(layout.right).panel.id)
+    }
+
+    @Test
+    fun `horizontal split extracts with original panel on top`() {
+        val state = newSplitViewState()
+        val newPanelId = state.splitPanel("main", SplitOrientation.HORIZONTAL)
+
+        val layout = assertIs<HorizontalSplit>(extractCurrentWorkspace(state).layout)
+        assertEquals("main", assertIs<SinglePanel>(layout.top).panel.id)
+        assertEquals(newPanelId, assertIs<SinglePanel>(layout.bottom).panel.id)
+    }
+
+    @Test
+    fun `nested splits extract the full tree with tabs in the right panels`() {
+        val state = newSplitViewState()
+        state.getPanel("main")!!.tabsComponent.addTab(TerminalTabInfo(id = "t-main", title = "Main Term"))
+
+        val rightId = state.splitPanel("main", SplitOrientation.VERTICAL)
+        state.getPanel(rightId)!!.tabsComponent.addTab(TerminalTabInfo(id = "t-right", title = "Right Term"))
+
+        val bottomId = state.splitPanel(rightId, SplitOrientation.HORIZONTAL)
+        state.getPanel(bottomId)!!.tabsComponent.addTab(TerminalTabInfo(id = "t-bottom", title = "Bottom Term"))
+
+        // main | (right / bottom)
+        val layout = assertIs<VerticalSplit>(extractCurrentWorkspace(state).layout)
+        val left = assertIs<SinglePanel>(layout.left)
+        assertEquals("main", left.panel.id)
+        assertEquals(listOf("Main Term"), left.panel.tabs.map { it.title })
+
+        val rightSplit = assertIs<HorizontalSplit>(layout.right)
+        val top = assertIs<SinglePanel>(rightSplit.top)
+        assertEquals(rightId, top.panel.id)
+        assertEquals(listOf("Right Term"), top.panel.tabs.map { it.title })
+
+        val bottom = assertIs<SinglePanel>(rightSplit.bottom)
+        assertEquals(bottomId, bottom.panel.id)
+        assertEquals(listOf("Bottom Term"), bottom.panel.tabs.map { it.title })
+    }
+
+    @Test
+    fun `empty side panels extract as panels with no tabs`() {
+        val state = newSplitViewState()
+        state.getPanel("main")!!.tabsComponent.addTab(TerminalTabInfo(id = "t-1", title = "Term"))
+        val newPanelId = state.splitPanel("main", SplitOrientation.VERTICAL)
+
+        val layout = assertIs<VerticalSplit>(extractCurrentWorkspace(state).layout)
+        assertEquals(1, assertIs<SinglePanel>(layout.left).panel.tabs.size)
+        val right = assertIs<SinglePanel>(layout.right)
+        assertEquals(newPanelId, right.panel.id)
+        assertTrue(right.panel.tabs.isEmpty())
+    }
+
+    // ==================== tab-info mapping ====================
+
+    @Test
+    fun `terminal tab maps command and working directory`() {
+        val state = newSplitViewState()
+        state.getPanel("main")!!.tabsComponent.addTab(
+            TerminalTabInfo(
+                id = "term-1",
+                title = "Terminal: build",
+                initialCommand = "./gradlew build",
+                workingDirectory = "/repo"
+            )
+        )
+
+        val tab = singleTab(state)
+        assertEquals("terminal", tab.type)
+        assertEquals("Terminal: build", tab.title)
+        assertEquals("./gradlew build", tab.initialCommand)
+        assertEquals("/repo", tab.workingDirectory)
+        assertNull(tab.url)
+        assertNull(tab.filePath)
+    }
+
+    @Test
+    fun `editor tab maps file path`() {
+        val state = newSplitViewState()
+        state.getPanel("main")!!.tabsComponent.addTab(
+            EditorTabInfo(id = "ed-1", title = "App.kt", filePath = "/repo/src/App.kt")
+        )
+
+        val tab = singleTab(state)
+        assertEquals("editor", tab.type)
+        assertEquals("App.kt", tab.title)
+        assertEquals("/repo/src/App.kt", tab.filePath)
+    }
+
+    @Test
+    fun `jupyter tab maps file path`() {
+        val state = newSplitViewState()
+        state.getPanel("main")!!.tabsComponent.addTab(
+            JupyterTabInfo(id = "jp-1", title = "analysis.ipynb", filePath = "/repo/analysis.ipynb")
+        )
+
+        val tab = singleTab(state)
+        assertEquals("jupyter", tab.type)
+        assertEquals("analysis.ipynb", tab.title)
+        assertEquals("/repo/analysis.ipynb", tab.filePath)
+    }
+
+    @Test
+    fun `browser tab saves the CURRENT url, not the initial one`() {
+        val state = newSplitViewState()
+        val fluckTab = FluckTabInfo(
+            id = "fluck-1",
+            typeId = FluckTabType.typeId,
+            _title = "Docs",
+            url = "https://start.example",
+            faviconCacheKey = "fav-1"
+        ).updateNavigation("Docs 2", "https://current.example/page")
+        state.getPanel("main")!!.tabsComponent.addTab(fluckTab)
+
+        val tab = singleTab(state)
+        assertEquals("browser", tab.type)
+        // Restoring the workspace must reopen where the user actually is.
+        assertEquals("https://current.example/page", tab.url)
+        assertEquals("fav-1", tab.faviconCacheKey)
+    }
+
+    @Test
+    fun `unrecognized tab types map to unknown with title only`() {
+        val state = newSplitViewState()
+        state.getPanel("main")!!.tabsComponent.addTab(CustomTabInfo(id = "c-1", title = "Widget"))
+
+        val tab = singleTab(state)
+        assertEquals("unknown", tab.type)
+        assertEquals("Widget", tab.title)
+        assertNull(tab.url)
+        assertNull(tab.filePath)
+    }
+
+    @Test
+    fun `transient panel-host tabs are excluded, other tabs keep their order`() {
+        val state = newSplitViewState()
+        val component = state.getPanel("main")!!.tabsComponent
+        component.addTab(TerminalTabInfo(id = "term-1", title = "Term"))
+        // Sidebar-promoted panel tab: persisting it would serialize as "unknown"
+        // and crash WorkspaceApplier on restore.
+        component.addTab(PanelHostTabInfo(PanelId("test-panel", 1), "Promoted", Icons.Outlined.Language))
+        component.addTab(EditorTabInfo(id = "ed-1", title = "App.kt", filePath = "/repo/App.kt"))
+
+        val layout = assertIs<SinglePanel>(extractCurrentWorkspace(state).layout)
+        assertEquals(listOf("terminal" to "Term", "editor" to "App.kt"), layout.panel.tabs.map { it.type to it.title })
+    }
+
+    // ==================== workspace metadata ====================
+
+    @Test
+    fun `defaults - generated id, default name and description, blank project path becomes null`() {
+        val workspace = extractCurrentWorkspace(newSplitViewState())
+
+        assertTrue(workspace.id.startsWith("workspace-"))
+        assertEquals("Current", workspace.name)
+        assertEquals("Current layout workspace", workspace.description)
+        assertNull(workspace.projectPath)
+        assertTrue(workspace.timestamp > 0)
+    }
+
+    @Test
+    fun `explicit name, description and project path are preserved`() {
+        val workspace = extractCurrentWorkspace(
+            newSplitViewState(),
+            projectPath = "/Users/dev/proj",
+            name = "My Workspace",
+            description = "Saved layout"
+        )
+
+        assertEquals("My Workspace", workspace.name)
+        assertEquals("Saved layout", workspace.description)
+        assertEquals("/Users/dev/proj", workspace.projectPath)
+    }
+
+    private fun singleTab(state: SplitViewState): TabConfig {
+        val layout = assertIs<SinglePanel>(extractCurrentWorkspace(state).layout)
+        assertEquals(1, layout.panel.tabs.size)
+        return layout.panel.tabs.single()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractorTest.kt
@@ -73,6 +73,7 @@ class WorkspaceExtractorTest {
     ) : TabComponentWithUI, ComponentContext by ctx {
         @Composable
         override fun Content() {
+            // Fixture tab renders nothing; extraction only reads tab metadata.
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
@@ -1,0 +1,469 @@
+package ai.rever.boss.git
+
+import org.junit.jupiter.api.Disabled
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Locks down [GitService]'s pure git-porcelain parsers, which every git panel
+ * (status list, commit log, stash list, PR-link building) renders from:
+ *
+ * - [GitService.parseStatusLine] / [GitService.parseStatusChar] — `git status --porcelain=v1`
+ * - [GitService.parseCommitLine] — `git log --format=%H%x00%h%x00…` (NUL-separated)
+ * - [GitService.parseStashLine] — `git stash list`
+ * - [GitService.parseRemoteUrl] — remote URL → https URL for "Create PR"
+ *
+ * These were `private`; they are now `internal` (visibility-only change) so the
+ * tests can feed them raw porcelain lines without spawning git processes.
+ */
+class GitPorcelainParserTest {
+
+    // ==================== parseStatusChar ====================
+
+    @Test
+    fun `parseStatusChar maps every documented porcelain code`() {
+        assertEquals(GitFileStatusType.MODIFIED, GitService.parseStatusChar('M'))
+        assertEquals(GitFileStatusType.ADDED, GitService.parseStatusChar('A'))
+        assertEquals(GitFileStatusType.DELETED, GitService.parseStatusChar('D'))
+        assertEquals(GitFileStatusType.RENAMED, GitService.parseStatusChar('R'))
+        assertEquals(GitFileStatusType.COPIED, GitService.parseStatusChar('C'))
+        assertEquals(GitFileStatusType.UNTRACKED, GitService.parseStatusChar('?'))
+        assertEquals(GitFileStatusType.IGNORED, GitService.parseStatusChar('!'))
+        assertEquals(GitFileStatusType.UNMERGED, GitService.parseStatusChar('U'))
+    }
+
+    @Test
+    fun `parseStatusChar returns null for space (no status)`() {
+        assertNull(GitService.parseStatusChar(' '))
+    }
+
+    @Test
+    fun `parseStatusChar returns null for unknown codes`() {
+        // 'T' (type change) is a real porcelain v1 code the parser deliberately
+        // does not model; unknown codes degrade to "no status" instead of crashing.
+        assertNull(GitService.parseStatusChar('T'))
+        assertNull(GitService.parseStatusChar('X'))
+        assertNull(GitService.parseStatusChar('z'))
+    }
+
+    // ==================== parseStatusLine: normal statuses ====================
+
+    @Test
+    fun `staged modification - index M, clean worktree`() {
+        val status = GitService.parseStatusLine("M  src/App.kt")
+        assertNotNull(status)
+        assertEquals("src/App.kt", status.path)
+        assertEquals(GitFileStatusType.MODIFIED, status.indexStatus)
+        assertNull(status.workTreeStatus)
+        assertTrue(status.isStaged)
+        assertFalse(status.isUnstaged)
+        assertNull(status.originalPath)
+    }
+
+    @Test
+    fun `unstaged modification - clean index, worktree M`() {
+        val status = GitService.parseStatusLine(" M src/App.kt")
+        assertNotNull(status)
+        assertEquals("src/App.kt", status.path)
+        assertNull(status.indexStatus)
+        assertEquals(GitFileStatusType.MODIFIED, status.workTreeStatus)
+        assertFalse(status.isStaged)
+        assertTrue(status.isUnstaged)
+    }
+
+    @Test
+    fun `staged plus unstaged combo - MM`() {
+        val status = GitService.parseStatusLine("MM src/App.kt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.MODIFIED, status.indexStatus)
+        assertEquals(GitFileStatusType.MODIFIED, status.workTreeStatus)
+        assertTrue(status.isStaged)
+        assertTrue(status.isUnstaged)
+    }
+
+    @Test
+    fun `staged add then modified in worktree - AM`() {
+        val status = GitService.parseStatusLine("AM new-file.txt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.ADDED, status.indexStatus)
+        assertEquals(GitFileStatusType.MODIFIED, status.workTreeStatus)
+        assertTrue(status.isStaged)
+        assertTrue(status.isUnstaged)
+    }
+
+    @Test
+    fun `staged deletion - D in index`() {
+        val status = GitService.parseStatusLine("D  gone.txt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.DELETED, status.indexStatus)
+        assertNull(status.workTreeStatus)
+        assertTrue(status.isStaged)
+        assertFalse(status.isUnstaged)
+    }
+
+    @Test
+    fun `untracked file - question marks`() {
+        val status = GitService.parseStatusLine("?? notes.md")
+        assertNotNull(status)
+        assertEquals("notes.md", status.path)
+        assertEquals(GitFileStatusType.UNTRACKED, status.indexStatus)
+        assertEquals(GitFileStatusType.UNTRACKED, status.workTreeStatus)
+        // UNTRACKED is explicitly carved out of "staged".
+        assertFalse(status.isStaged)
+        assertTrue(status.isUnstaged)
+    }
+
+    @Test
+    fun `ignored file - exclamation marks parse to IGNORED`() {
+        val status = GitService.parseStatusLine("!! build/")
+        assertNotNull(status)
+        assertEquals("build/", status.path)
+        assertEquals(GitFileStatusType.IGNORED, status.indexStatus)
+        assertEquals(GitFileStatusType.IGNORED, status.workTreeStatus)
+    }
+
+    @Disabled(
+        "documents bug: '!!' (ignored) sets isStaged=true because only UNTRACKED is " +
+            "carved out of the isStaged computation; an ignored file is never staged. " +
+            "Currently unreachable in production (getStatus never passes --ignored)."
+    )
+    @Test
+    fun `ignored file is not staged`() {
+        val status = GitService.parseStatusLine("!! build/")
+        assertNotNull(status)
+        assertFalse(status.isStaged)
+    }
+
+    // ==================== parseStatusLine: renames and copies ====================
+
+    @Test
+    fun `staged rename with arrow keeps both paths`() {
+        val status = GitService.parseStatusLine("R  old/name.kt -> new/name.kt")
+        assertNotNull(status)
+        assertEquals("new/name.kt", status.path)
+        assertEquals("old/name.kt", status.originalPath)
+        assertEquals(GitFileStatusType.RENAMED, status.indexStatus)
+        assertNull(status.workTreeStatus)
+        assertTrue(status.isStaged)
+        assertFalse(status.isUnstaged)
+    }
+
+    @Test
+    fun `staged copy with arrow keeps both paths`() {
+        val status = GitService.parseStatusLine("C  src/a.kt -> src/b.kt")
+        assertNotNull(status)
+        assertEquals("src/b.kt", status.path)
+        assertEquals("src/a.kt", status.originalPath)
+        assertEquals(GitFileStatusType.COPIED, status.indexStatus)
+    }
+
+    @Test
+    fun `rename then modified in worktree - RM`() {
+        val status = GitService.parseStatusLine("RM old.txt -> new.txt")
+        assertNotNull(status)
+        assertEquals("new.txt", status.path)
+        assertEquals("old.txt", status.originalPath)
+        assertEquals(GitFileStatusType.RENAMED, status.indexStatus)
+        assertEquals(GitFileStatusType.MODIFIED, status.workTreeStatus)
+        assertTrue(status.isStaged)
+        assertTrue(status.isUnstaged)
+    }
+
+    // ==================== parseStatusLine: path shapes ====================
+
+    @Test
+    fun `path with spaces passes through verbatim`() {
+        // porcelain v1 does not quote paths for spaces.
+        val status = GitService.parseStatusLine(" M My Documents/read me.txt")
+        assertNotNull(status)
+        assertEquals("My Documents/read me.txt", status.path)
+    }
+
+    @Test
+    fun `unicode path passes through verbatim`() {
+        // With core.quotePath=false git emits raw UTF-8; the parser must not mangle it.
+        val status = GitService.parseStatusLine("A  docs/日本語 déjà ✨.md")
+        assertNotNull(status)
+        assertEquals("docs/日本語 déjà ✨.md", status.path)
+        assertEquals(GitFileStatusType.ADDED, status.indexStatus)
+    }
+
+    @Test
+    fun `C-quoted path is passed through verbatim, not unquoted`() {
+        // Documents the parser's contract: with core.quotePath=true git C-quotes
+        // special paths (e.g. "a\"b.txt"); the parser performs no unquoting and the
+        // quoted token flows through as the path (display-level limitation).
+        val status = GitService.parseStatusLine("M  \"a\\\"b.txt\"")
+        assertNotNull(status)
+        assertEquals("\"a\\\"b.txt\"", status.path)
+    }
+
+    @Test
+    fun `rename of path with spaces on both sides`() {
+        val status = GitService.parseStatusLine("R  old dir/a file.txt -> new dir/a file.txt")
+        assertNotNull(status)
+        assertEquals("new dir/a file.txt", status.path)
+        assertEquals("old dir/a file.txt", status.originalPath)
+    }
+
+    // ==================== parseStatusLine: merge conflicts ====================
+
+    @Test
+    fun `both modified conflict - UU`() {
+        val status = GitService.parseStatusLine("UU src/conflict.kt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.UNMERGED, status.indexStatus)
+        assertEquals(GitFileStatusType.UNMERGED, status.workTreeStatus)
+        assertTrue(status.isUnstaged)
+    }
+
+    @Test
+    fun `both added conflict - AA`() {
+        val status = GitService.parseStatusLine("AA both-added.txt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.ADDED, status.indexStatus)
+        assertEquals(GitFileStatusType.ADDED, status.workTreeStatus)
+    }
+
+    @Test
+    fun `both deleted conflict - DD`() {
+        val status = GitService.parseStatusLine("DD both-deleted.txt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.DELETED, status.indexStatus)
+        assertEquals(GitFileStatusType.DELETED, status.workTreeStatus)
+    }
+
+    @Test
+    fun `deleted by them - UD`() {
+        val status = GitService.parseStatusLine("UD theirs-deleted.txt")
+        assertNotNull(status)
+        assertEquals(GitFileStatusType.UNMERGED, status.indexStatus)
+        assertEquals(GitFileStatusType.DELETED, status.workTreeStatus)
+    }
+
+    // ==================== parseStatusLine: empty and malformed ====================
+
+    @Test
+    fun `empty and too-short lines return null`() {
+        assertNull(GitService.parseStatusLine(""))
+        assertNull(GitService.parseStatusLine("M"))
+        assertNull(GitService.parseStatusLine("M "))
+    }
+
+    @Test
+    fun `line with unknown status codes degrades to no-status, never crashes`() {
+        val status = GitService.parseStatusLine("XY weird.txt")
+        assertNotNull(status)
+        assertEquals("weird.txt", status.path)
+        assertNull(status.indexStatus)
+        assertNull(status.workTreeStatus)
+        assertFalse(status.isStaged)
+        assertFalse(status.isUnstaged)
+    }
+
+    // ==================== parseCommitLine ====================
+
+    private val nul = "\u0000"
+
+    private fun commitLine(
+        hash: String = "a".repeat(40),
+        short: String = "aaaaaaa",
+        author: String = "Jane Doe",
+        email: String = "jane@example.com",
+        timestamp: String = "1721721600",
+        subject: String = "Fix the thing",
+        parents: String? = "b".repeat(40),
+        refs: String? = ""
+    ): String {
+        val fields = mutableListOf(hash, short, author, email, timestamp, subject)
+        if (parents != null) fields.add(parents)
+        if (refs != null) fields.add(refs)
+        return fields.joinToString(nul)
+    }
+
+    @Test
+    fun `parses a full commit line field by field`() {
+        val commit = GitService.parseCommitLine(
+            commitLine(refs = "HEAD -> main, origin/main, tag: v1.2.3")
+        )
+        assertNotNull(commit)
+        assertEquals("a".repeat(40), commit.hash)
+        assertEquals("aaaaaaa", commit.shortHash)
+        assertEquals("Jane Doe", commit.author)
+        assertEquals("jane@example.com", commit.authorEmail)
+        assertEquals(1721721600L, commit.date)
+        assertEquals("Fix the thing", commit.subject)
+        assertEquals(listOf("b".repeat(40)), commit.parentHashes)
+        assertEquals(listOf("HEAD -> main", "origin/main", "tag: v1.2.3"), commit.refs)
+    }
+
+    @Test
+    fun `subject with pipes, colons, arrows and emoji survives because separator is NUL`() {
+        val subject = "feat(ui): a | b -> c 🎉 \"quoted\" 100%"
+        val commit = GitService.parseCommitLine(commitLine(subject = subject))
+        assertNotNull(commit)
+        assertEquals(subject, commit.subject)
+    }
+
+    @Test
+    fun `root commit has no parents`() {
+        val commit = GitService.parseCommitLine(commitLine(parents = ""))
+        assertNotNull(commit)
+        assertTrue(commit.parentHashes.isEmpty())
+    }
+
+    @Test
+    fun `merge commit splits parent hashes on space`() {
+        val p1 = "1".repeat(40)
+        val p2 = "2".repeat(40)
+        val commit = GitService.parseCommitLine(commitLine(parents = "$p1 $p2"))
+        assertNotNull(commit)
+        assertEquals(listOf(p1, p2), commit.parentHashes)
+    }
+
+    @Test
+    fun `commit with no refs yields empty ref list`() {
+        val commit = GitService.parseCommitLine(commitLine(refs = ""))
+        assertNotNull(commit)
+        assertTrue(commit.refs.isEmpty())
+    }
+
+    @Test
+    fun `line with only six fields still parses with empty parents and refs`() {
+        val commit = GitService.parseCommitLine(commitLine(parents = null, refs = null))
+        assertNotNull(commit)
+        assertTrue(commit.parentHashes.isEmpty())
+        assertTrue(commit.refs.isEmpty())
+    }
+
+    @Test
+    fun `non-numeric timestamp degrades to zero`() {
+        val commit = GitService.parseCommitLine(commitLine(timestamp = "not-a-number"))
+        assertNotNull(commit)
+        assertEquals(0L, commit.date)
+    }
+
+    @Test
+    fun `lines with fewer than six fields return null`() {
+        assertNull(GitService.parseCommitLine(""))
+        assertNull(GitService.parseCommitLine("just some text"))
+        assertNull(GitService.parseCommitLine(listOf("h", "s", "a", "e", "1").joinToString(nul)))
+    }
+
+    // ==================== parseStashLine ====================
+
+    @Test
+    fun `WIP stash line extracts index, branch and message`() {
+        val stash = GitService.parseStashLine(0, "stash@{0}: WIP on main: 1a2b3c4 initial commit")
+        assertNotNull(stash)
+        assertEquals(0, stash.index)
+        assertEquals("main", stash.branch)
+        assertEquals("1a2b3c4 initial commit", stash.message)
+    }
+
+    @Test
+    fun `named stash line (On branch) extracts branch and message`() {
+        val stash = GitService.parseStashLine(1, "stash@{1}: On feature/login: saved experiment")
+        assertNotNull(stash)
+        assertEquals(1, stash.index)
+        assertEquals("feature/login", stash.branch)
+        assertEquals("saved experiment", stash.message)
+    }
+
+    @Test
+    fun `index parsed from the line wins over the list position`() {
+        val stash = GitService.parseStashLine(0, "stash@{7}: On main: deep stash")
+        assertNotNull(stash)
+        assertEquals(7, stash.index)
+    }
+
+    @Test
+    fun `message containing colons is kept intact`() {
+        val stash = GitService.parseStashLine(0, "stash@{0}: On main: fix: parser: edge case")
+        assertNotNull(stash)
+        assertEquals("main", stash.branch)
+        assertEquals("fix: parser: edge case", stash.message)
+    }
+
+    @Test
+    fun `stash without branch prefix keeps whole remainder as message`() {
+        val stash = GitService.parseStashLine(0, "stash@{0}: autostash")
+        assertNotNull(stash)
+        assertNull(stash.branch)
+        assertEquals("autostash", stash.message)
+    }
+
+    @Test
+    fun `detached-head stash falls back to branchless message`() {
+        // "(no branch)" contains a space, so the branch group (\S+?) cannot match;
+        // the parser degrades gracefully to a null branch with the full remainder.
+        val stash = GitService.parseStashLine(0, "stash@{0}: WIP on (no branch): abc1234 subject")
+        assertNotNull(stash)
+        assertNull(stash.branch)
+        assertEquals("WIP on (no branch): abc1234 subject", stash.message)
+    }
+
+    @Test
+    fun `non-stash lines return null`() {
+        assertNull(GitService.parseStashLine(0, ""))
+        assertNull(GitService.parseStashLine(0, "not a stash line"))
+        assertNull(GitService.parseStashLine(0, "stash@{x}: On main: bad index"))
+    }
+
+    // ==================== parseRemoteUrl (sibling pure helper) ====================
+
+    @Test
+    fun `scp-style ssh remote becomes https`() {
+        assertEquals(
+            "https://github.com/owner/repo",
+            GitService.parseRemoteUrl("git@github.com:owner/repo.git")
+        )
+    }
+
+    @Test
+    fun `scp-style ssh remote with nested groups`() {
+        assertEquals(
+            "https://gitlab.com/group/subgroup/repo",
+            GitService.parseRemoteUrl("git@gitlab.com:group/subgroup/repo.git")
+        )
+    }
+
+    @Test
+    fun `ssh protocol remote becomes https`() {
+        assertEquals(
+            "https://github.com/owner/repo",
+            GitService.parseRemoteUrl("ssh://git@github.com/owner/repo.git")
+        )
+    }
+
+    @Test
+    fun `https remote just loses the git suffix`() {
+        assertEquals(
+            "https://github.com/owner/repo",
+            GitService.parseRemoteUrl("https://github.com/owner/repo.git")
+        )
+        assertEquals(
+            "https://github.com/owner/repo",
+            GitService.parseRemoteUrl("https://github.com/owner/repo")
+        )
+    }
+
+    @Test
+    fun `http remote is kept as http`() {
+        assertEquals(
+            "http://git.internal/owner/repo",
+            GitService.parseRemoteUrl("http://git.internal/owner/repo.git")
+        )
+    }
+
+    @Test
+    fun `unsupported remote formats return null`() {
+        assertNull(GitService.parseRemoteUrl("file:///srv/git/repo.git"))
+        assertNull(GitService.parseRemoteUrl("/srv/git/repo.git"))
+        assertNull(GitService.parseRemoteUrl(""))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/MainFunctionDetectorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/MainFunctionDetectorTest.kt
@@ -1,0 +1,406 @@
+package ai.rever.boss.run
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Locks down [DesktopMainFunctionDetector]'s pure parsing surface:
+ *
+ * - [DesktopMainFunctionDetector.detectInFile] — per-language main/entry-point
+ *   detection over raw source text (no file system involved)
+ * - [DesktopMainFunctionDetector.generateCommand] — run-command construction,
+ *   including the single-quote shell escaping that keeps hostile paths inert
+ * - [DesktopMainFunctionDetector.findProjectRoot] — project-marker walk
+ *   (exercised against real temp dirs)
+ */
+class MainFunctionDetectorTest {
+
+    private val detector = DesktopMainFunctionDetector()
+
+    private fun lines(vararg lines: String) = lines.joinToString("\n")
+
+    // ==================== Kotlin ====================
+
+    @Test
+    fun `top-level kotlin main is detected with line number and package`() {
+        val content = lines(
+            "package com.example.app",
+            "",
+            "fun main() {",
+            "    println(\"hi\")",
+            "}"
+        )
+        val detected = detector.detectInFile("/proj/src/Main.kt", content)
+
+        assertEquals(1, detected.size)
+        with(detected.single()) {
+            assertEquals(2, lineNumber)
+            assertEquals("main", functionName)
+            assertNull(className)
+            assertEquals("com.example.app", packageName)
+            assertEquals(Language.KOTLIN, language)
+            assertEquals("/proj/src/Main.kt", filePath)
+        }
+    }
+
+    @Test
+    fun `kotlin main with args parameter is detected`() {
+        val content = lines("fun main(args: Array<String>) {", "}")
+        val detected = detector.detectInFile("/proj/Main.kt", content)
+
+        assertEquals(1, detected.size)
+        assertEquals(0, detected.single().lineNumber)
+        assertNull(detected.single().packageName)
+    }
+
+    @Test
+    fun `companion object main with JvmStatic on its own line is detected`() {
+        val content = lines(
+            "package com.example",
+            "",
+            "class App {",
+            "    companion object {",
+            "        @JvmStatic",
+            "        fun main(args: Array<String>) {",
+            "        }",
+            "    }",
+            "}"
+        )
+        val detected = detector.detectInFile("/proj/App.kt", content)
+
+        assertEquals(1, detected.size)
+        assertEquals(5, detected.single().lineNumber)
+        assertEquals("com.example", detected.single().packageName)
+    }
+
+    @Test
+    fun `JvmStatic and main on the same line are detected`() {
+        val content = lines(
+            "object App {",
+            "    @JvmStatic fun main(args: Array<String>) {}",
+            "}"
+        )
+        val detected = detector.detectInFile("/proj/App.kt", content)
+
+        assertEquals(1, detected.size)
+        assertEquals(1, detected.single().lineNumber)
+    }
+
+    @Test
+    fun `line-commented kotlin main is not detected`() {
+        val content = lines(
+            "// fun main() {",
+            "    // fun main(args: Array<String>) {}",
+            "val x = 1"
+        )
+        assertTrue(detector.detectInFile("/proj/Main.kt", content).isEmpty())
+    }
+
+    @Test
+    fun `main inside a triple-quoted string is skipped, real main is kept`() {
+        val tripleQuote = "\"\"\""
+        val content = lines(
+            "package com.example",
+            "val snippet = $tripleQuote",
+            "fun main() {",
+            "}",
+            tripleQuote,
+            "fun main() {",
+            "}"
+        )
+        val detected = detector.detectInFile("/proj/Main.kt", content)
+
+        assertEquals(1, detected.size)
+        assertEquals(5, detected.single().lineNumber)
+    }
+
+    @Test
+    fun `main inside a single-line string literal is not detected`() {
+        val content = lines("val usage = \"fun main() { ... }\"")
+        assertTrue(detector.detectInFile("/proj/Main.kt", content).isEmpty())
+    }
+
+    @Test
+    fun `multiple main candidates are all reported in order`() {
+        val content = lines(
+            "fun main() {}",
+            "object Alt {",
+            "    fun main() {}",
+            "}"
+        )
+        val detected = detector.detectInFile("/proj/Main.kt", content)
+
+        assertEquals(listOf(0, 2), detected.map { it.lineNumber })
+    }
+
+    @Test
+    fun `kotlin file without main yields nothing`() {
+        val content = lines("package com.example", "fun helper() = 42")
+        assertTrue(detector.detectInFile("/proj/Helper.kt", content).isEmpty())
+    }
+
+    // ==================== Java ====================
+
+    @Test
+    fun `java main is detected with class and package`() {
+        val content = lines(
+            "package com.example.demo;",
+            "",
+            "public class Main {",
+            "    public static void main(String[] args) {",
+            "    }",
+            "}"
+        )
+        val detected = detector.detectInFile("/proj/Main.java", content)
+
+        assertEquals(1, detected.size)
+        with(detected.single()) {
+            assertEquals(3, lineNumber)
+            assertEquals("main", functionName)
+            assertEquals("Main", className)
+            assertEquals("com.example.demo", packageName)
+            assertEquals(Language.JAVA, language)
+        }
+    }
+
+    @Test
+    fun `java class without main yields nothing`() {
+        val content = lines(
+            "package com.example;",
+            "public class Util {",
+            "    public static int add(int a, int b) { return a + b; }",
+            "}"
+        )
+        assertTrue(detector.detectInFile("/proj/Util.java", content).isEmpty())
+    }
+
+    // ==================== Python ====================
+
+    @Test
+    fun `python dunder-main guard is detected with either quote style`() {
+        val single = lines("def run():", "    pass", "", "if __name__ == '__main__':", "    run()")
+        val double = lines("if __name__ == \"__main__\":", "    pass")
+
+        val detectedSingle = detector.detectInFile("/proj/app.py", single)
+        assertEquals(1, detectedSingle.size)
+        assertEquals(3, detectedSingle.single().lineNumber)
+        assertEquals("__main__", detectedSingle.single().functionName)
+        assertEquals(Language.PYTHON, detectedSingle.single().language)
+
+        assertEquals(1, detector.detectInFile("/proj/app.py", double).size)
+    }
+
+    @Test
+    fun `commented python guard is not detected`() {
+        val content = lines("# if __name__ == '__main__':", "pass")
+        assertTrue(detector.detectInFile("/proj/app.py", content).isEmpty())
+    }
+
+    // ==================== Go ====================
+
+    @Test
+    fun `go main requires both package main and func main`() {
+        val runnable = lines("package main", "", "func main() {", "}")
+        val library = lines("package tools", "", "func main() {", "}")
+        val noFunc = lines("package main", "", "func run() {", "}")
+
+        val detected = detector.detectInFile("/proj/main.go", runnable)
+        assertEquals(1, detected.size)
+        assertEquals(2, detected.single().lineNumber)
+        assertEquals("main", detected.single().packageName)
+
+        assertTrue(detector.detectInFile("/proj/main.go", library).isEmpty())
+        assertTrue(detector.detectInFile("/proj/main.go", noFunc).isEmpty())
+    }
+
+    // ==================== Rust ====================
+
+    @Test
+    fun `rust fn main is detected`() {
+        val content = lines("fn main() {", "    println!(\"hi\");", "}")
+        val detected = detector.detectInFile("/proj/main.rs", content)
+
+        assertEquals(1, detected.size)
+        assertEquals(0, detected.single().lineNumber)
+        assertEquals(Language.RUST, detected.single().language)
+    }
+
+    @Test
+    fun `rust file without main yields nothing`() {
+        assertTrue(detector.detectInFile("/proj/lib.rs", "fn helper() {}").isEmpty())
+    }
+
+    // ==================== JavaScript / TypeScript ====================
+
+    @Test
+    fun `well-known js entry file names are entry points regardless of content`() {
+        val detected = detector.detectInFile("/proj/index.js", "console.log('hi')")
+
+        assertEquals(1, detected.size)
+        with(detected.single()) {
+            assertEquals(0, lineNumber)
+            assertEquals("entry", functionName)
+            assertEquals(Language.JAVASCRIPT, language)
+        }
+    }
+
+    @Test
+    fun `main-ts is a typescript entry point`() {
+        val detected = detector.detectInFile("/proj/src/main.ts", "export {}")
+        assertEquals(1, detected.size)
+        assertEquals(Language.TYPESCRIPT, detected.single().language)
+    }
+
+    @Test
+    fun `non-entry js file names yield nothing`() {
+        assertTrue(detector.detectInFile("/proj/src/helper.js", "console.log('hi')").isEmpty())
+    }
+
+    // ==================== language resolution ====================
+
+    @Test
+    fun `unknown extension yields nothing`() {
+        assertTrue(detector.detectInFile("/proj/notes.txt", "fun main() {}").isEmpty())
+    }
+
+    @Test
+    fun `explicit language parameter overrides the file extension`() {
+        val detected = detector.detectInFile("/proj/snippet.txt", "fun main() {}", Language.KOTLIN)
+        assertEquals(1, detected.size)
+        assertEquals(Language.KOTLIN, detected.single().language)
+    }
+
+    // ==================== generateCommand: quoting and injection safety ====================
+
+    private fun detectedIn(path: String, language: Language) = DetectedMainFunction(
+        lineNumber = 0,
+        functionName = "main",
+        className = null,
+        packageName = null,
+        language = language,
+        filePath = path
+    )
+
+    @Test
+    fun `python command single-quotes the path`() {
+        val command = detector.generateCommand(detectedIn("/no-such-root/app.py", Language.PYTHON), "/no-such-root")
+        assertEquals("python3 '/no-such-root/app.py'", command)
+    }
+
+    @Test
+    fun `injection-shaped path stays inert inside single quotes`() {
+        val command = detector.generateCommand(
+            detectedIn("/no-such-root/\$(rm -rf ~)/app.py", Language.PYTHON),
+            "/no-such-root"
+        )
+        assertEquals("python3 '/no-such-root/\$(rm -rf ~)/app.py'", command)
+    }
+
+    @Test
+    fun `single quote in path is escaped with the quote-backslash-quote idiom`() {
+        val command = detector.generateCommand(detectedIn("/no-such-root/it's.py", Language.PYTHON), "/no-such-root")
+        assertEquals("python3 '/no-such-root/it'\\''s.py'", command)
+    }
+
+    @Test
+    fun `javascript and typescript commands use node and ts-node`() {
+        assertEquals(
+            "node '/no-such-root/tool.js'",
+            detector.generateCommand(detectedIn("/no-such-root/tool.js", Language.JAVASCRIPT), "/no-such-root")
+        )
+        assertEquals(
+            "npx ts-node '/no-such-root/tool.ts'",
+            detector.generateCommand(detectedIn("/no-such-root/tool.ts", Language.TYPESCRIPT), "/no-such-root")
+        )
+    }
+
+    @Test
+    fun `go command runs the file directly`() {
+        assertEquals(
+            "go run '/no-such-root/main.go'",
+            detector.generateCommand(detectedIn("/no-such-root/main.go", Language.GO), "/no-such-root")
+        )
+    }
+
+    @Test
+    fun `kts scripts run via kotlinc -script`() {
+        assertEquals(
+            "kotlinc -script '/no-such-root/build tool.kts'",
+            detector.generateCommand(detectedIn("/no-such-root/build tool.kts", Language.KOTLIN), "/no-such-root")
+        )
+    }
+
+    // ==================== generateCommand: project-aware commands ====================
+
+    @Test
+    fun `kotlin file inside a gradle module runs the module's run task`(@TempDir tempDir: File) {
+        File(tempDir, "gradlew").writeText("#!/bin/sh")
+        val moduleDir = File(tempDir, "app")
+        File(moduleDir, "src/main/kotlin").mkdirs()
+        File(moduleDir, "build.gradle.kts").writeText("")
+        val source = File(moduleDir, "src/main/kotlin/Main.kt").apply { writeText("fun main() {}") }
+
+        val command = detector.generateCommand(
+            detectedIn(source.absolutePath, Language.KOTLIN),
+            tempDir.absolutePath
+        )
+        assertEquals("./gradlew :app:run", command)
+    }
+
+    @Test
+    fun `kotlin file outside any module falls back to the root run task`(@TempDir tempDir: File) {
+        File(tempDir, "gradlew").writeText("#!/bin/sh")
+        File(tempDir, "src/main/kotlin").mkdirs()
+        val source = File(tempDir, "src/main/kotlin/Main.kt").apply { writeText("fun main() {}") }
+
+        val command = detector.generateCommand(
+            detectedIn(source.absolutePath, Language.KOTLIN),
+            tempDir.absolutePath
+        )
+        assertEquals("./gradlew run", command)
+    }
+
+    @Test
+    fun `java file in a maven project runs the fully qualified class`(@TempDir tempDir: File) {
+        File(tempDir, "pom.xml").writeText("<project/>")
+        File(tempDir, "src/main/java").mkdirs()
+        val source = File(tempDir, "src/main/java/Main.java").apply { writeText("class Main {}") }
+
+        val detected = DetectedMainFunction(
+            lineNumber = 0,
+            functionName = "main",
+            className = "Main",
+            packageName = "com.example",
+            language = Language.JAVA,
+            filePath = source.absolutePath
+        )
+        assertEquals(
+            "mvn exec:java -Dexec.mainClass='com.example.Main'",
+            detector.generateCommand(detected, tempDir.absolutePath)
+        )
+    }
+
+    // ==================== findProjectRoot ====================
+
+    @Test
+    fun `findProjectRoot stops at the first marker directory`(@TempDir tempDir: File) {
+        File(tempDir, ".git").mkdirs()
+        val nested = File(tempDir, "a/b").apply { mkdirs() }
+        val source = File(nested, "script.py").apply { writeText("pass") }
+
+        assertEquals(tempDir.absolutePath, detector.findProjectRoot(source.absolutePath))
+    }
+
+    @Test
+    fun `findProjectRoot honors package json as a marker`(@TempDir tempDir: File) {
+        File(tempDir, "package.json").writeText("{}")
+        val nested = File(tempDir, "src").apply { mkdirs() }
+        val source = File(nested, "index.js").apply { writeText("") }
+
+        assertEquals(tempDir.absolutePath, detector.findProjectRoot(source.absolutePath))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/ShellUtilsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/ShellUtilsTest.kt
@@ -1,0 +1,166 @@
+package ai.rever.boss.run
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Locks down [ShellUtils]: the quoting/escaping/separator logic every runner
+ * command and "open terminal here" flow is built from.
+ *
+ * CI runs this suite on Linux, macOS AND Windows, and [ShellUtils.isWindows] is
+ * fixed at class-load from the real OS, so each expectation is written per
+ * platform: the POSIX branch is verified on Unix runners and the PowerShell
+ * branch on Windows runners.
+ */
+class ShellUtilsTest {
+
+    private val win = ShellUtils.isWindows
+    private val sep = ShellUtils.commandSeparator
+
+    private fun expect(unix: String, windows: String): String = if (win) windows else unix
+
+    // ==================== commandSeparator ====================
+
+    @Test
+    fun `separator is and-and on unix, semicolon on windows powershell`() {
+        assertEquals(expect(unix = " && ", windows = "; "), sep)
+    }
+
+    // ==================== escapeForDoubleQuotes: pass-through ====================
+
+    @Test
+    fun `plain text is unchanged`() {
+        assertEquals("hello-world_123", ShellUtils.escapeForDoubleQuotes("hello-world_123"))
+    }
+
+    @Test
+    fun `spaces are unchanged - the caller adds the surrounding quotes`() {
+        assertEquals("My Project Dir", ShellUtils.escapeForDoubleQuotes("My Project Dir"))
+    }
+
+    @Test
+    fun `unicode is unchanged`() {
+        assertEquals("docs/日本語 déjà ✨", ShellUtils.escapeForDoubleQuotes("docs/日本語 déjà ✨"))
+    }
+
+    @Test
+    fun `empty string stays empty`() {
+        assertEquals("", ShellUtils.escapeForDoubleQuotes(""))
+    }
+
+    @Test
+    fun `semicolon ampersand and pipe pass through - literal inside double quotes`() {
+        // The function only claims safety INSIDE double quotes, where these are literal.
+        assertEquals("a; b && c | d", ShellUtils.escapeForDoubleQuotes("a; b && c | d"))
+    }
+
+    // ==================== escapeForDoubleQuotes: escaped metacharacters ====================
+
+    @Test
+    fun `double quote is escaped`() {
+        assertEquals(
+            expect(unix = "say \\\"hi\\\"", windows = "say `\"hi`\""),
+            ShellUtils.escapeForDoubleQuotes("say \"hi\"")
+        )
+    }
+
+    @Test
+    fun `dollar is escaped to block variable expansion`() {
+        assertEquals(
+            expect(unix = "\\\$HOME", windows = "`\$HOME"),
+            ShellUtils.escapeForDoubleQuotes("\$HOME")
+        )
+    }
+
+    @Test
+    fun `command substitution via dollar-paren is neutralized`() {
+        assertEquals(
+            expect(unix = "\\\$(rm -rf ~)", windows = "`\$(rm -rf ~)"),
+            ShellUtils.escapeForDoubleQuotes("\$(rm -rf ~)")
+        )
+    }
+
+    @Test
+    fun `backtick is escaped to block command substitution`() {
+        assertEquals(
+            expect(unix = "a\\`whoami\\`b", windows = "a``whoami``b"),
+            ShellUtils.escapeForDoubleQuotes("a`whoami`b")
+        )
+    }
+
+    @Test
+    fun `backslash is doubled on unix and literal on powershell`() {
+        // PowerShell's escape character is the backtick; backslash is a literal there.
+        assertEquals(
+            expect(unix = "C:\\\\Temp", windows = "C:\\Temp"),
+            ShellUtils.escapeForDoubleQuotes("C:\\Temp")
+        )
+    }
+
+    @Test
+    fun `exclamation is escaped on unix only - history expansion`() {
+        assertEquals(
+            expect(unix = "deploy\\!", windows = "deploy!"),
+            ShellUtils.escapeForDoubleQuotes("deploy!")
+        )
+    }
+
+    @Test
+    fun `escape ordering - a backslash-quote pair does not double-escape`() {
+        // Unix: backslash is escaped first (\ -> \\), then the quote (" -> \"),
+        // so the two-char input backslash+quote becomes \\ + \" (four chars).
+        assertEquals(
+            expect(unix = "\\\\\\\"", windows = "\\`\""),
+            ShellUtils.escapeForDoubleQuotes("\\\"")
+        )
+    }
+
+    // ==================== buildCommandWithWorkingDirectory ====================
+
+    @Test
+    fun `null working directory returns the command untouched`() {
+        assertEquals("ls -la", ShellUtils.buildCommandWithWorkingDirectory("ls -la", null))
+    }
+
+    @Test
+    fun `blank working directory returns the command untouched`() {
+        assertEquals("ls -la", ShellUtils.buildCommandWithWorkingDirectory("ls -la", ""))
+        assertEquals("ls -la", ShellUtils.buildCommandWithWorkingDirectory("ls -la", "   "))
+    }
+
+    @Test
+    fun `working directory is quoted and chained with the platform separator`() {
+        assertEquals(
+            "cd \"/Users/dev/My Project\"${sep}ls -la",
+            ShellUtils.buildCommandWithWorkingDirectory("ls -la", "/Users/dev/My Project")
+        )
+    }
+
+    @Test
+    fun `working directory with a dollar sign cannot expand`() {
+        assertEquals(
+            expect(
+                unix = "cd \"/data/\\\$USER files\" && ls",
+                windows = "cd \"/data/`\$USER files\"; ls"
+            ),
+            ShellUtils.buildCommandWithWorkingDirectory("ls", "/data/\$USER files")
+        )
+    }
+
+    // ==================== chainCommands ====================
+
+    @Test
+    fun `chainCommands joins with the platform separator`() {
+        assertEquals("a${sep}b${sep}c", ShellUtils.chainCommands("a", "b", "c"))
+    }
+
+    @Test
+    fun `chainCommands with a single command returns it unchanged`() {
+        assertEquals("./gradlew build", ShellUtils.chainCommands("./gradlew build"))
+    }
+
+    @Test
+    fun `chainCommands with no commands yields an empty string`() {
+        assertEquals("", ShellUtils.chainCommands())
+    }
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -33,6 +33,21 @@ complexity:
     # pushes every piece of state + callback through the signature); the
     # threshold stays for regular functions.
     ignoreAnnotated: ['Composable']
+    # Test fixture builders (e.g. a git log-line builder mirroring the real
+    # field list) are parameter-heavy by design; same test-source-set
+    # treatment as TooManyFunctions below.
+    excludes:
+      [
+        '**/test/**',
+        '**/androidTest/**',
+        '**/commonTest/**',
+        '**/jvmTest/**',
+        '**/androidUnitTest/**',
+        '**/androidInstrumentedTest/**',
+        '**/jsTest/**',
+        '**/iosTest/**',
+        '**/desktopTest/**',
+      ]
   TooManyFunctions:
     # Same desktopTest gap as FunctionNaming above: test classes grow one
     # function per case by design and are exempt in every other test source


### PR DESCRIPTION
Part of the "pristine" campaign: unit tests for the four cheapest/highest-risk untested pure units, following the house pattern (extract-pure-helper -> plain JUnit 5 + kotlin.test, no mocking library). 110 new tests total; verified green via `:composeApp:desktopTest`.

## What's covered

### Git porcelain parsers — `GitPorcelainParserTest` (45 tests)
`DesktopGitService`'s pure parsers, which every git panel renders from:
- `parseStatusLine` / `parseStatusChar` (`git status --porcelain=v1`): all status codes (M/A/D/R/C/??/!!/U), staged+unstaged combos, renames/copies with ` -> `, space/unicode paths, C-quoted path pass-through (parser does not unquote — documented), merge conflicts (UU/AA/DD/UD), empty/short/malformed lines, unknown codes degrading to no-status.
- `parseCommitLine` (NUL-separated `git log` format): field-by-field parse, subjects with pipes/arrows/emoji (safe because the separator is NUL), root/merge commits, ref lists (`HEAD -> main, origin/main, tag: v1.2.3`), non-numeric timestamp -> 0, <6 fields -> null.
- `parseStashLine`: WIP/named stashes, index-from-line precedence, colons in messages, branchless fallback (autostash, detached HEAD), garbage -> null.
- Sibling pure helper `parseRemoteUrl` (Create-PR URL building): scp-style ssh, `ssh://`, https/http, nested groups, unsupported formats -> null.

### Workspace extraction — `WorkspaceExtractorTest` (13 tests)
`extractCurrentWorkspace` (SplitViewState -> SplitConfig tree walk behind workspace save/restore), using real `SplitViewState`/`BossTabsComponent` fixtures per the `BossTabsComponentMoveTest` approach: single panel, vertical/horizontal splits (original keeps left/top), nested trees, empty panels, tab-info mapping per type (terminal command/cwd, editor/jupyter file paths, browser saving the **current** URL rather than the initial one, favicon cache key), unknown types -> `"unknown"`, transient panel-host tabs excluded, and metadata defaults (generated id, blank projectPath -> null).

Honest note on the brief's "ratio preservation": neither `SplitNode` nor `SplitConfig` carries a split ratio, so there is no ratio to preserve or test — structure, panel ids and tab mapping are the whole contract.

### Shell quoting — `ShellUtilsTest` (20 tests)
Separator selection, pass-through (plain/space/unicode), escaping of `"`, `$`, `$(...)`, backticks, backslashes, `!`, escape ordering (no double-escape), injection-shaped input staying literal in double-quote context, `buildCommandWithWorkingDirectory` (null/blank/quoted/escaped dirs), `chainCommands`. Since CI runs tests on Linux/macOS/Windows and `ShellUtils.isWindows` is fixed at class-load, expectations are written per platform — Unix runners verify the POSIX branch, Windows runners the PowerShell branch.

### Main-function detection — `MainFunctionDetectorTest` (32 tests)
`detectInFile` across all seven languages: Kotlin top-level/args/companion `@JvmStatic` mains, commented-out mains rejected, mains inside triple-quoted and single-line strings skipped, multiple candidates with exact line numbers, package extraction; Java main + class/package; Python dunder-main (both quote styles); Go's package-main+func-main conjunction; Rust; JS/TS filename-based entries; unknown extensions; explicit language override. Plus `generateCommand` (single-quote escaping keeps `$(...)`/apostrophe paths inert; gradle `:module:run` vs root `run` and maven `exec:java` proven against temp-dir projects) and `findProjectRoot` marker walks.

## Visibility notes (only production change)
Five methods in `composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt` changed `private` -> `internal` so tests can feed them raw porcelain lines without spawning git processes: `parseStatusLine`, `parseStatusChar`, `parseCommitLine`, `parseStashLine`, `parseRemoteUrl`. No logic changes anywhere.

## Bug documented (not fixed)
`parseStatusLine("!! ...")` reports `isStaged = true`: only `UNTRACKED` is carved out of the `isStaged` computation, but an ignored file is never staged. Currently unreachable in production (`getStatus` never passes `--ignored`), so the correct-behavior test is committed as `@Disabled("documents bug: ...")` rather than changing parser logic in a test PR.

## Verification
`./gradlew :composeApp:desktopTest` — BUILD SUCCESSFUL; all four classes ran:
- `GitPorcelainParserTest`: 45 tests, 0 failures (1 skipped = the @Disabled bug doc)
- `WorkspaceExtractorTest`: 13 tests, 0 failures
- `ShellUtilsTest`: 20 tests, 0 failures
- `MainFunctionDetectorTest`: 32 tests, 0 failures
