### PR TITLE
fix: log every previously-swallowed exception (AGENTS.md hygiene)

### DIFF
--- a/buildSrc/src/main/kotlin/PublishPluginTask.kt
+++ b/buildSrc/src/main/kotlin/PublishPluginTask.kt
@@ -242,6 +242,8 @@ abstract class PublishPluginTask : DefaultTask() {
             val response = httpGet("$baseUrl/$pluginId", token, apiKey)
             response.statusCode == 200
         } catch (e: Exception) {
+            // Treat as "not yet published" so the task falls through to create
+            logger.info("Plugin existence check failed (${e.message}) - assuming plugin does not exist yet")
             false
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/common/FaviconLoader.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/common/FaviconLoader.kt
@@ -31,7 +31,11 @@ fun rememberFaviconLoader(tabInfo: TabInfo): ai.rever.boss.plugin.api.TabIcon.Im
                 val property = tabInfo::class.members.find { it.name == "faviconCacheKey" }
                 property?.call(tabInfo) as? String
             } catch (e: Exception) {
-                faviconLogger.debug(LogCategory.BROWSER, "faviconCacheKey reflection probe failed - tab has no favicon", mapOf("error" to e.toString()))
+                faviconLogger.debug(
+                    LogCategory.BROWSER,
+                    "faviconCacheKey reflection probe failed - tab has no favicon",
+                    mapOf("error" to e.toString()),
+                )
                 null
             }
         }
@@ -49,7 +53,11 @@ fun rememberFaviconLoader(tabInfo: TabInfo): ai.rever.boss.plugin.api.TabIcon.Im
                 try {
                     ai.rever.boss.cache.loadFaviconFromCache(faviconCacheKey)
                 } catch (e: Exception) {
-                    faviconLogger.debug(LogCategory.BROWSER, "Error loading favicon", mapOf("key" to faviconCacheKey, "error" to e.toString()))
+                    faviconLogger.debug(
+                        LogCategory.BROWSER,
+                        "Error loading favicon",
+                        mapOf("key" to faviconCacheKey, "error" to e.toString()),
+                    )
                     null
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/common/FaviconLoader.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/common/FaviconLoader.kt
@@ -31,6 +31,7 @@ fun rememberFaviconLoader(tabInfo: TabInfo): ai.rever.boss.plugin.api.TabIcon.Im
                 val property = tabInfo::class.members.find { it.name == "faviconCacheKey" }
                 property?.call(tabInfo) as? String
             } catch (e: Exception) {
+                faviconLogger.debug(LogCategory.BROWSER, "faviconCacheKey reflection probe failed - tab has no favicon", mapOf("error" to e.toString()))
                 null
             }
         }
@@ -48,7 +49,7 @@ fun rememberFaviconLoader(tabInfo: TabInfo): ai.rever.boss.plugin.api.TabIcon.Im
                 try {
                     ai.rever.boss.cache.loadFaviconFromCache(faviconCacheKey)
                 } catch (e: Exception) {
-                    faviconLogger.debug(LogCategory.BROWSER, "Error loading favicon", mapOf("key" to faviconCacheKey))
+                    faviconLogger.debug(LogCategory.BROWSER, "Error loading favicon", mapOf("key" to faviconCacheKey, "error" to e.toString()))
                     null
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/BrowserPageCard.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/BrowserPageCard.kt
@@ -78,7 +78,11 @@ fun BrowserPageCard(
         favicon = try {
             loadHighQualityFavicon(page.url, page.faviconCacheKey)
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Failed to load high-quality favicon - card shows fallback icon", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Failed to load high-quality favicon - card shows fallback icon",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/BrowserPageCard.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dashboard/cards/BrowserPageCard.kt
@@ -44,6 +44,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+private val logger = BossLogger.forComponent("BrowserPageCard")
 
 /**
  * Card displaying a recent browser page with favicon.
@@ -74,6 +78,7 @@ fun BrowserPageCard(
         favicon = try {
             loadHighQualityFavicon(page.url, page.faviconCacheKey)
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Failed to load high-quality favicon - card shows fallback icon", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CloneProjectDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CloneProjectDialog.kt
@@ -728,6 +728,7 @@ private fun extractRepoName(url: String): String {
 
         repoName
     } catch (e: Exception) {
+        logger.debug(LogCategory.WORKSPACE, "Could not derive repo name from URL - using default", mapOf("error" to e.toString()))
         "cloned-repo"
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CloneProjectDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CloneProjectDialog.kt
@@ -728,7 +728,11 @@ private fun extractRepoName(url: String): String {
 
         repoName
     } catch (e: Exception) {
-        logger.debug(LogCategory.WORKSPACE, "Could not derive repo name from URL - using default", mapOf("error" to e.toString()))
+        logger.debug(
+            LogCategory.WORKSPACE,
+            "Could not derive repo name from URL - using default",
+            mapOf("error" to e.toString()),
+        )
         "cloned-repo"
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -115,7 +115,7 @@ private fun validateFilePath(path: String, basePath: String? = null): String? {
 
         canonicalPath
     } catch (e: Exception) {
-        newTabDialogLogger.debug(LogCategory.FILE, "Invalid path", mapOf("path" to path))
+        newTabDialogLogger.debug(LogCategory.FILE, "Invalid path", mapOf("path" to path, "error" to e.toString()))
         null
     }
 }
@@ -782,6 +782,7 @@ fun NewTabDialog(
                                                                                 val hasKids = try {
                                                                                     directoryHasChildren(child.path)
                                                                                 } catch (e: Exception) {
+                                                                                    newTabDialogLogger.debug(LogCategory.FILE, "Cannot probe directory for children", mapOf("path" to child.path, "error" to e.toString()))
                                                                                     false
                                                                                 }
                                                                                 child.copy(hasChildren = hasKids)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -120,6 +120,15 @@ private fun validateFilePath(path: String, basePath: String? = null): String? {
     }
 }
 
+/** Breadcrumb for a failed directory-children probe; hoisted out of the deeply nested tree loader. */
+private fun logDirProbeFailure(path: String, e: Exception) {
+    newTabDialogLogger.debug(
+        LogCategory.FILE,
+        "Cannot probe directory for children",
+        mapOf("path" to path, "error" to e.toString()),
+    )
+}
+
 enum class TabType(val tabTypeId: TabTypeId) {
     URL(FluckTabType.typeId),
     FILE(CodeEditorTabType.typeId),
@@ -782,7 +791,7 @@ fun NewTabDialog(
                                                                                 val hasKids = try {
                                                                                     directoryHasChildren(child.path)
                                                                                 } catch (e: Exception) {
-                                                                                    newTabDialogLogger.debug(LogCategory.FILE, "Cannot probe directory for children", mapOf("path" to child.path, "error" to e.toString()))
+                                                                                    logDirProbeFailure(child.path, e)
                                                                                     false
                                                                                 }
                                                                                 child.copy(hasChildren = hasKids)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -1324,7 +1324,12 @@ private class DefaultCacheProvider : CacheProvider {
             }
             true
         } catch (e: Exception) {
-            cacheLogger.warn(LogCategory.SYSTEM, "Failed to clear plugin cache", mapOf("pluginId" to pluginId), error = e)
+            cacheLogger.warn(
+                LogCategory.SYSTEM,
+                "Failed to clear plugin cache",
+                mapOf("pluginId" to pluginId),
+                error = e,
+            )
             false
         }
     }
@@ -1338,7 +1343,12 @@ private class DefaultCacheProvider : CacheProvider {
                 0L
             }
         } catch (e: Exception) {
-            cacheLogger.warn(LogCategory.SYSTEM, "Failed to compute plugin cache size", mapOf("pluginId" to pluginId), error = e)
+            cacheLogger.warn(
+                LogCategory.SYSTEM,
+                "Failed to compute plugin cache size",
+                mapOf("pluginId" to pluginId),
+                error = e,
+            )
             -1L
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -1152,6 +1152,7 @@ private class ApiActiveTabsProviderAdapter(
             val component = splitViewState.getActiveTabsComponent() ?: return null
             openFluckTabIn(component, url, title)
         } catch (e: Exception) {
+            tabsLogger.warn(LogCategory.BROWSER, "createBrowserTab failed - returning null", error = e)
             null
         }
     }
@@ -1173,6 +1174,7 @@ private class ApiActiveTabsProviderAdapter(
             }
             tabId
         } catch (e: Exception) {
+            tabsLogger.warn(LogCategory.BROWSER, "createBrowserTabInRightSplit failed - returning null", error = e)
             null
         }
     }
@@ -1219,6 +1221,7 @@ private class ApiActiveTabsProviderAdapter(
             }
             false
         } catch (e: Exception) {
+            tabsLogger.warn(LogCategory.UI, "closeTab failed", mapOf("tabId" to tabId), error = e)
             false
         }
     }
@@ -1310,6 +1313,7 @@ private class BrowserIntegrationAdapter(
  * Uses ~/.boss/plugin-cache/{pluginId}/ for cache storage.
  */
 private class DefaultCacheProvider : CacheProvider {
+    private val cacheLogger = BossLogger.forComponent("DefaultCacheProvider")
     private val cacheBaseDir = BossDirectories.resolve("plugin-cache")
 
     override fun clearPluginCache(pluginId: String): Boolean {
@@ -1320,6 +1324,7 @@ private class DefaultCacheProvider : CacheProvider {
             }
             true
         } catch (e: Exception) {
+            cacheLogger.warn(LogCategory.SYSTEM, "Failed to clear plugin cache", mapOf("pluginId" to pluginId), error = e)
             false
         }
     }
@@ -1333,6 +1338,7 @@ private class DefaultCacheProvider : CacheProvider {
                 0L
             }
         } catch (e: Exception) {
+            cacheLogger.warn(LogCategory.SYSTEM, "Failed to compute plugin cache size", mapOf("pluginId" to pluginId), error = e)
             -1L
         }
     }
@@ -1351,6 +1357,7 @@ private class DefaultCacheProvider : CacheProvider {
 private class DefaultBackgroundTaskProvider(
     private val scope: kotlinx.coroutines.CoroutineScope
 ) : BackgroundTaskProvider {
+    private val taskLogger = BossLogger.forComponent("DefaultBackgroundTaskProvider")
     private val activeTasks = java.util.concurrent.ConcurrentHashMap<String, DefaultBackgroundTaskHandle>()
 
     override fun launchTask(name: String, task: suspend () -> Unit): BackgroundTaskHandle? {
@@ -1367,6 +1374,7 @@ private class DefaultBackgroundTaskProvider(
             activeTasks[taskId] = handle
             handle
         } catch (e: Exception) {
+            taskLogger.warn(LogCategory.SYSTEM, "Failed to launch background task", mapOf("task" to name), error = e)
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -948,7 +948,7 @@ class DynamicPluginManager(
                     } catch (e: Exception) {
                         logger.warn(LogCategory.SYSTEM, "Error preparing component for unload", mapOf(
                             "pluginId" to pluginId
-                        ))
+                        ), error = e)
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/LLMSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/LLMSettings.kt
@@ -180,8 +180,14 @@ object LLMSettings {
         try {
             settings = Json.decodeFromString(json)
         } catch (e: Exception) {
-            // Keep default settings if parsing fails
-            logger.warn(LogCategory.GENERAL, "Failed to parse LLM settings JSON - keeping defaults", error = e)
+            // Keep default settings if parsing fails.
+            // Deliberately NOT logging the throwable: kotlinx.serialization decode
+            // errors embed a snippet of the offending JSON near the failure offset,
+            // and this file holds provider API keys — the raw message could leak a
+            // key fragment into WARN logs. The exception type is enough to diagnose.
+            logger.warn(LogCategory.GENERAL, "Failed to parse LLM settings JSON - keeping defaults", mapOf(
+                "exception" to (e::class.simpleName ?: "Exception")
+            ))
         }
     }
     

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/LLMSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/LLMSettings.kt
@@ -94,7 +94,11 @@ object LLMSettings {
         get() = try {
             LLMProvider.valueOf(settings.selectedProvider)
         } catch (e: Exception) {
-            logger.debug(LogCategory.GENERAL, "Unknown LLM provider in settings - defaulting to ANTHROPIC", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.GENERAL,
+                "Unknown LLM provider in settings - defaulting to ANTHROPIC",
+                mapOf("error" to e.toString()),
+            )
             LLMProvider.ANTHROPIC
         }
         set(value) {
@@ -105,7 +109,11 @@ object LLMSettings {
         get() = try {
             LLMModel.valueOf(settings.selectedModel)
         } catch (e: Exception) {
-            logger.debug(LogCategory.GENERAL, "Unknown LLM model in settings - using default", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.GENERAL,
+                "Unknown LLM model in settings - using default",
+                mapOf("error" to e.toString()),
+            )
             LLMModel.CLAUDE_3_5_SONNET_V2
         }
         set(value) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/LLMSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/LLMSettings.kt
@@ -94,6 +94,7 @@ object LLMSettings {
         get() = try {
             LLMProvider.valueOf(settings.selectedProvider)
         } catch (e: Exception) {
+            logger.debug(LogCategory.GENERAL, "Unknown LLM provider in settings - defaulting to ANTHROPIC", mapOf("error" to e.toString()))
             LLMProvider.ANTHROPIC
         }
         set(value) {
@@ -104,6 +105,7 @@ object LLMSettings {
         get() = try {
             LLMModel.valueOf(settings.selectedModel)
         } catch (e: Exception) {
+            logger.debug(LogCategory.GENERAL, "Unknown LLM model in settings - using default", mapOf("error" to e.toString()))
             LLMModel.CLAUDE_3_5_SONNET_V2
         }
         set(value) {
@@ -179,6 +181,7 @@ object LLMSettings {
             settings = Json.decodeFromString(json)
         } catch (e: Exception) {
             // Keep default settings if parsing fails
+            logger.warn(LogCategory.GENERAL, "Failed to parse LLM settings JSON - keeping defaults", error = e)
         }
     }
     

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceManager.kt
@@ -150,6 +150,7 @@ class WorkspaceManager {
 
             workspace
         } catch (e: Exception) {
+            logger.warn(LogCategory.WORKSPACE, "Failed to import workspace from JSON", error = e)
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -367,6 +367,7 @@ object RecentBrowserPagesManager {
             val withoutProtocol = url.removePrefix("https://").removePrefix("http://")
             withoutProtocol.substringBefore('/').substringBefore('?')
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Failed to parse domain from URL - showing full URL", mapOf("error" to e.toString()))
             url
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -367,7 +367,11 @@ object RecentBrowserPagesManager {
             val withoutProtocol = url.removePrefix("https://").removePrefix("http://")
             withoutProtocol.substringBefore('/').substringBefore('?')
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Failed to parse domain from URL - showing full URL", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Failed to parse domain from URL - showing full URL",
+                mapOf("error" to e.toString()),
+            )
             url
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/SplitTemplatesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/SplitTemplatesManager.kt
@@ -424,7 +424,7 @@ object SplitTemplatesManager {
             // Convert SSH URL to HTTPS if needed
             convertGitUrlToWebUrl(url)
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Error getting git remote")
+            logger.debug(LogCategory.SYSTEM, "Error getting git remote", mapOf("error" to e.toString()))
             "https://google.com"
         }
     }
@@ -475,7 +475,7 @@ object SplitTemplatesManager {
                 file.length() > 0
             } ?: false
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Error checking Claude session")
+            logger.debug(LogCategory.SYSTEM, "Error checking Claude session", mapOf("error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -326,7 +326,11 @@ internal class McpToolRegistryCore(
                 ?.mapValues { (_, el) -> scalarOf(el) }
                 ?: emptyMap()
         } catch (t: Throwable) {
-            logger.debug(LogCategory.SYSTEM, "MCP tool arguments are not a JSON object - using empty args", mapOf("error" to t.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "MCP tool arguments are not a JSON object - using empty args",
+                mapOf("error" to t.toString()),
+            )
             emptyMap()
         }
         return McpToolArgs(map, arguments.ifBlank { "{}" })

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/mcp/McpToolRegistryImpl.kt
@@ -276,6 +276,7 @@ internal class McpToolRegistryCore(
             logger.warn(
                 LogCategory.SYSTEM, "MCP tool handler timed out",
                 mapOf("tool" to toolName, "providerId" to tool.providerId, "timeoutMs" to invokeTimeoutMs),
+                error = t,
             )
             McpToolResult("Tool '$toolName' timed out after ${invokeTimeoutMs / 1000}s", isError = true)
         } catch (t: CancellationException) {
@@ -325,6 +326,7 @@ internal class McpToolRegistryCore(
                 ?.mapValues { (_, el) -> scalarOf(el) }
                 ?: emptyMap()
         } catch (t: Throwable) {
+            logger.debug(LogCategory.SYSTEM, "MCP tool arguments are not a JSON object - using empty args", mapOf("error" to t.toString()))
             emptyMap()
         }
         return McpToolArgs(map, arguments.ifBlank { "{}" })

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/FileIndexer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/FileIndexer.kt
@@ -190,6 +190,7 @@ class FileIndexer {
                 child.canonicalPath
             } catch (e: Exception) {
                 // Skip files we can't resolve (broken symlinks, permission issues)
+                logger.debug(LogCategory.FILE, "Skipping unresolvable path", mapOf("path" to child.path, "error" to e.toString()))
                 continue
             }
             if (!childCanonicalPath.startsWith(rootCanonicalPath)) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/FileIndexer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/FileIndexer.kt
@@ -190,7 +190,11 @@ class FileIndexer {
                 child.canonicalPath
             } catch (e: Exception) {
                 // Skip files we can't resolve (broken symlinks, permission issues)
-                logger.debug(LogCategory.FILE, "Skipping unresolvable path", mapOf("path" to child.path, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.FILE,
+                    "Skipping unresolvable path",
+                    mapOf("path" to child.path, "error" to e.toString()),
+                )
                 continue
             }
             if (!childCanonicalPath.startsWith(rootCanonicalPath)) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/UserDataStorage.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/UserDataStorage.kt
@@ -113,7 +113,11 @@ object UserDataStorage {
                     try {
                         pendingWizardCompletedFile.readText().trim().toBoolean()
                     } catch (e: Exception) {
-                        logger.debug(LogCategory.AUTH, "Could not read pending wizard-completed marker - assuming false", mapOf("error" to e.toString()))
+                        logger.debug(
+                            LogCategory.AUTH,
+                            "Could not read pending wizard-completed marker - assuming false",
+                            mapOf("error" to e.toString()),
+                        )
                         false
                     }
                 } else {
@@ -127,7 +131,11 @@ object UserDataStorage {
                         val existingData = json.decodeFromString<StoredUserData>(existingContent)
                         existingData.pluginWizardCompleted
                     } catch (e: Exception) {
-                        logger.debug(LogCategory.AUTH, "Could not read stored wizard status - assuming false", mapOf("error" to e.toString()))
+                        logger.debug(
+                            LogCategory.AUTH,
+                            "Could not read stored wizard status - assuming false",
+                            mapOf("error" to e.toString()),
+                        )
                         false
                     }
                 } else {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/UserDataStorage.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/UserDataStorage.kt
@@ -113,6 +113,7 @@ object UserDataStorage {
                     try {
                         pendingWizardCompletedFile.readText().trim().toBoolean()
                     } catch (e: Exception) {
+                        logger.debug(LogCategory.AUTH, "Could not read pending wizard-completed marker - assuming false", mapOf("error" to e.toString()))
                         false
                     }
                 } else {
@@ -126,6 +127,7 @@ object UserDataStorage {
                         val existingData = json.decodeFromString<StoredUserData>(existingContent)
                         existingData.pluginWizardCompleted
                     } catch (e: Exception) {
+                        logger.debug(LogCategory.AUTH, "Could not read stored wizard status - assuming false", mapOf("error" to e.toString()))
                         false
                     }
                 } else {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/network/NetworkMonitorService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/network/NetworkMonitorService.kt
@@ -123,7 +123,11 @@ object NetworkMonitorService {
             connection.disconnect()
             responseCode in 200..399
         } catch (e: Exception) {
-            logger.debug(LogCategory.NETWORK, "Connectivity check failed", mapOf("url" to urlString, "error" to e.toString()))
+            logger.debug(
+                LogCategory.NETWORK,
+                "Connectivity check failed",
+                mapOf("url" to urlString, "error" to e.toString()),
+            )
             false
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/network/NetworkMonitorService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/network/NetworkMonitorService.kt
@@ -123,7 +123,7 @@ object NetworkMonitorService {
             connection.disconnect()
             responseCode in 200..399
         } catch (e: Exception) {
-            logger.debug(LogCategory.NETWORK, "Connectivity check failed", mapOf("url" to urlString))
+            logger.debug(LogCategory.NETWORK, "Connectivity check failed", mapOf("url" to urlString, "error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/PasskeyConfigHelper.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/PasskeyConfigHelper.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.services.passkey
 
 import ai.rever.boss.services.supabase.getSupabaseFunctionUrl
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 
 /**
  * Helper object to extract RP ID from Supabase Function URL
@@ -14,6 +16,8 @@ import ai.rever.boss.services.supabase.getSupabaseFunctionUrl
  * - Base Supabase URL might point to internal services (like kong gateway)
  */
 object PasskeyConfigHelper {
+
+    private val logger = BossLogger.forComponent("PasskeyConfigHelper")
 
     /**
      * Extract RP ID from Supabase Function base URL
@@ -40,6 +44,7 @@ object PasskeyConfigHelper {
             // WebAuthn requires "localhost" instead of "127.0.0.1" for local development
             if (rpId == "127.0.0.1") "localhost" else rpId
         } catch (e: Exception) {
+            logger.warn(LogCategory.PASSKEY, "Failed to derive RP ID from function URL - falling back to production", error = e)
             "api.risaboss.com" // Fallback to production
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/PasskeyConfigHelper.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/PasskeyConfigHelper.kt
@@ -44,7 +44,11 @@ object PasskeyConfigHelper {
             // WebAuthn requires "localhost" instead of "127.0.0.1" for local development
             if (rpId == "127.0.0.1") "localhost" else rpId
         } catch (e: Exception) {
-            logger.warn(LogCategory.PASSKEY, "Failed to derive RP ID from function URL - falling back to production", error = e)
+            logger.warn(
+                LogCategory.PASSKEY,
+                "Failed to derive RP ID from function URL - falling back to production",
+                error = e,
+            )
             "api.risaboss.com" // Fallback to production
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/supabase/PasskeyDataMapper.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/supabase/PasskeyDataMapper.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.services.passkey.supabase
 
 import ai.rever.boss.services.passkey.*
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import java.security.SecureRandom
@@ -10,7 +12,9 @@ import java.util.Base64
  * Handles data transformation and CBOR parsing for passkey operations
  */
 internal object PasskeyDataMapper {
-    
+
+    private val logger = BossLogger.forComponent("PasskeyDataMapper")
+
     private val json = Json { 
         ignoreUnknownKeys = true
         encodeDefaults = true
@@ -152,11 +156,13 @@ internal object PasskeyDataMapper {
                 Result.failure(Exception(credentialResponse.error ?: "Registration failed"))
             }
         } catch (parseException: Exception) {
+            logger.warn(LogCategory.PASSKEY, "Registration response did not parse as credential - extracting error message", error = parseException)
             // Try to extract error message from raw response
             val errorMessage = try {
                 val errorResponse = json.decodeFromString<JsonObject>(responseText)
                 errorResponse["error"]?.toString()?.removeSurrounding("\"") ?: "Unknown error"
             } catch (e: Exception) {
+                logger.debug(LogCategory.PASSKEY, "Raw error extraction from response also failed", mapOf("error" to e.toString()))
                 "Failed to parse response: $responseText"
             }
             
@@ -216,6 +222,7 @@ internal object PasskeyDataMapper {
             }
         } catch (e: Exception) {
             // Fall back to parsing as authentication result (for completion endpoints)
+            logger.debug(LogCategory.PASSKEY, "Response is not a status envelope - parsing as authentication result", mapOf("error" to e.toString()))
             json.decodeFromString<PasskeyAuthenticationResult>(responseText)
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/supabase/PasskeyDataMapper.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/supabase/PasskeyDataMapper.kt
@@ -156,13 +156,20 @@ internal object PasskeyDataMapper {
                 Result.failure(Exception(credentialResponse.error ?: "Registration failed"))
             }
         } catch (parseException: Exception) {
-            logger.warn(LogCategory.PASSKEY, "Registration response did not parse as credential - extracting error message", error = parseException)
+            // Exception type only: kotlinx decode errors embed a snippet of the
+            // response near the failure offset, and server responses can carry
+            // credential/session material that must not reach the logs.
+            logger.warn(LogCategory.PASSKEY, "Registration response did not parse as credential - extracting error message", mapOf(
+                "exception" to (parseException::class.simpleName ?: "Exception")
+            ))
             // Try to extract error message from raw response
             val errorMessage = try {
                 val errorResponse = json.decodeFromString<JsonObject>(responseText)
                 errorResponse["error"]?.toString()?.removeSurrounding("\"") ?: "Unknown error"
             } catch (e: Exception) {
-                logger.debug(LogCategory.PASSKEY, "Raw error extraction from response also failed", mapOf("error" to e.toString()))
+                logger.debug(LogCategory.PASSKEY, "Raw error extraction from response also failed", mapOf(
+                    "exception" to (e::class.simpleName ?: "Exception")
+                ))
                 "Failed to parse response: $responseText"
             }
             
@@ -221,8 +228,11 @@ internal object PasskeyDataMapper {
                 )
             }
         } catch (e: Exception) {
-            // Fall back to parsing as authentication result (for completion endpoints)
-            logger.debug(LogCategory.PASSKEY, "Response is not a status envelope - parsing as authentication result", mapOf("error" to e.toString()))
+            // Fall back to parsing as authentication result (for completion endpoints).
+            // Exception type only - decode errors can embed response snippets.
+            logger.debug(LogCategory.PASSKEY, "Response is not a status envelope - parsing as authentication result", mapOf(
+                "exception" to (e::class.simpleName ?: "Exception")
+            ))
             json.decodeFromString<PasskeyAuthenticationResult>(responseText)
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/supabase/PasskeyDataMapper.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/passkey/supabase/PasskeyDataMapper.kt
@@ -159,9 +159,11 @@ internal object PasskeyDataMapper {
             // Exception type only: kotlinx decode errors embed a snippet of the
             // response near the failure offset, and server responses can carry
             // credential/session material that must not reach the logs.
-            logger.warn(LogCategory.PASSKEY, "Registration response did not parse as credential - extracting error message", mapOf(
-                "exception" to (parseException::class.simpleName ?: "Exception")
-            ))
+            logger.warn(
+                LogCategory.PASSKEY,
+                "Registration response did not parse as credential - extracting error message",
+                mapOf("exception" to (parseException::class.simpleName ?: "Exception")),
+            )
             // Try to extract error message from raw response
             val errorMessage = try {
                 val errorResponse = json.decodeFromString<JsonObject>(responseText)
@@ -230,9 +232,11 @@ internal object PasskeyDataMapper {
         } catch (e: Exception) {
             // Fall back to parsing as authentication result (for completion endpoints).
             // Exception type only - decode errors can embed response snippets.
-            logger.debug(LogCategory.PASSKEY, "Response is not a status envelope - parsing as authentication result", mapOf(
-                "exception" to (e::class.simpleName ?: "Exception")
-            ))
+            logger.debug(
+                LogCategory.PASSKEY,
+                "Response is not a status envelope - parsing as authentication result",
+                mapOf("exception" to (e::class.simpleName ?: "Exception")),
+            )
             json.decodeFromString<PasskeyAuthenticationResult>(responseText)
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/VersionSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/VersionSelectionDialog.kt
@@ -327,7 +327,11 @@ private fun formatReleaseDate(dateString: String): String {
         // Extract just the date part
         dateString.substringBefore("T")
     } catch (e: Exception) {
-        logger.debug(LogCategory.SYSTEM, "Failed to format release date - showing raw value", mapOf("error" to e.toString()))
+        logger.debug(
+            LogCategory.SYSTEM,
+            "Failed to format release date - showing raw value",
+            mapOf("error" to e.toString()),
+        )
         dateString
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/VersionSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/VersionSelectionDialog.kt
@@ -21,6 +21,10 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import ai.rever.boss.components.common.BossSearchBar
 import ai.rever.boss.utils.Version
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+private val logger = BossLogger.forComponent("VersionSelectionDialog")
 
 /**
  * Dialog for selecting a specific version to install
@@ -323,6 +327,7 @@ private fun formatReleaseDate(dateString: String): String {
         // Extract just the date part
         dateString.substringBefore("T")
     } catch (e: Exception) {
+        logger.debug(LogCategory.SYSTEM, "Failed to format release date - showing raw value", mapOf("error" to e.toString()))
         dateString
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/RevealInFileManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/RevealInFileManager.kt
@@ -53,6 +53,7 @@ fun revealInFileManager(path: String): Result<Unit> {
                 } catch (e: IOException) {
                     // Minimal environments may lack xdg-utils; glib's `gio open` is the
                     // most common secondary launcher.
+                    revealLogger.debug(LogCategory.FILE, "xdg-open unavailable, falling back to gio open", mapOf("error" to e.toString()))
                     Runtime.getRuntime().exec(arrayOf("gio", "open", dir))
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/RevealInFileManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/RevealInFileManager.kt
@@ -53,7 +53,11 @@ fun revealInFileManager(path: String): Result<Unit> {
                 } catch (e: IOException) {
                     // Minimal environments may lack xdg-utils; glib's `gio open` is the
                     // most common secondary launcher.
-                    revealLogger.debug(LogCategory.FILE, "xdg-open unavailable, falling back to gio open", mapOf("error" to e.toString()))
+                    revealLogger.debug(
+                        LogCategory.FILE,
+                        "xdg-open unavailable, falling back to gio open",
+                        mapOf("error" to e.toString()),
+                    )
                     Runtime.getRuntime().exec(arrayOf("gio", "open", dir))
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/VersionVerifier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/VersionVerifier.kt
@@ -90,7 +90,11 @@ object VersionVerifier {
             }
         } catch (e: Exception) {
             // version.properties not available - normal for production
-            logger.debug(LogCategory.SYSTEM, "version.properties not readable - expected in packaged builds", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "version.properties not readable - expected in packaged builds",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/VersionVerifier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/VersionVerifier.kt
@@ -90,6 +90,7 @@ object VersionVerifier {
             }
         } catch (e: Exception) {
             // version.properties not available - normal for production
+            logger.debug(LogCategory.SYSTEM, "version.properties not readable - expected in packaged builds", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
@@ -263,7 +263,11 @@ object WebsiteMatchingUtil {
                 null
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Failed to extract subdomain - treating as none", mapOf("url" to url, "error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Failed to extract subdomain - treating as none",
+                mapOf("url" to url, "error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/WebsiteMatchingUtil.kt
@@ -98,7 +98,7 @@ object WebsiteMatchingUtil {
 
             host
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Failed to extract domain", mapOf("url" to url))
+            logger.debug(LogCategory.BROWSER, "Failed to extract domain", mapOf("url" to url, "error" to e.toString()))
             null
         }
     }
@@ -263,6 +263,7 @@ object WebsiteMatchingUtil {
                 null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Failed to extract subdomain - treating as none", mapOf("url" to url, "error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/HighQualityFaviconService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/HighQualityFaviconService.kt
@@ -102,7 +102,11 @@ object HighQualityFaviconService {
                 // Fall back to standard favicon
                 loadStandardFavicon(standardCacheKey)
             } catch (e: Exception) {
-                logger.debug(LogCategory.BROWSER, "HQ favicon fetch failed - falling back to standard favicon", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "HQ favicon fetch failed - falling back to standard favicon",
+                    mapOf("error" to e.toString()),
+                )
                 loadStandardFavicon(standardCacheKey)
             }
         }
@@ -116,7 +120,11 @@ object HighQualityFaviconService {
             val withoutProtocol = url.removePrefix("https://").removePrefix("http://")
             withoutProtocol.substringBefore('/').substringBefore('?').removePrefix("www.")
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Could not extract domain from URL for favicon", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Could not extract domain from URL for favicon",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -146,7 +154,11 @@ object HighQualityFaviconService {
             val imageBitmap = bufferedImage.toComposeImageBitmap()
             ai.rever.boss.plugin.api.TabIcon.Image(BitmapPainter(imageBitmap))
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Failed to read cached HQ favicon - treating as cache miss", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Failed to read cached HQ favicon - treating as cache miss",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -187,7 +199,11 @@ object HighQualityFaviconService {
                 null
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.NETWORK, "HQ favicon fetch from Google failed - falling back", mapOf("domain" to domain, "error" to e.toString()))
+            logger.debug(
+                LogCategory.NETWORK,
+                "HQ favicon fetch from Google failed - falling back",
+                mapOf("domain" to domain, "error" to e.toString()),
+            )
             null
         }
     }
@@ -211,7 +227,11 @@ object HighQualityFaviconService {
                         file.delete()
                     } catch (e: Exception) {
                         // Deletion errors are non-fatal - entry will be retried on next eviction
-                        logger.debug(LogCategory.FILE, "Failed to evict HQ favicon cache entry", mapOf("file" to file.name, "error" to e.toString()))
+                        logger.debug(
+                            LogCategory.FILE,
+                            "Failed to evict HQ favicon cache entry",
+                            mapOf("file" to file.name, "error" to e.toString()),
+                        )
                     }
                 }
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/HighQualityFaviconService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/HighQualityFaviconService.kt
@@ -2,6 +2,8 @@ package ai.rever.boss.cache
 
 import ai.rever.boss.plugin.api.TabIcon
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import io.ktor.client.*
@@ -33,6 +35,7 @@ import javax.imageio.ImageIO
  * - Cache-first approach to minimize network requests
  */
 object HighQualityFaviconService {
+    private val logger = BossLogger.forComponent("HighQualityFaviconService")
     private const val HQ_CACHE_DIR_NAME = "favicon-hq-cache"
     private const val ICON_SIZE = 128 // Request 128px icons from Google
     private const val REQUEST_TIMEOUT_MS = 2500L
@@ -99,6 +102,7 @@ object HighQualityFaviconService {
                 // Fall back to standard favicon
                 loadStandardFavicon(standardCacheKey)
             } catch (e: Exception) {
+                logger.debug(LogCategory.BROWSER, "HQ favicon fetch failed - falling back to standard favicon", mapOf("error" to e.toString()))
                 loadStandardFavicon(standardCacheKey)
             }
         }
@@ -112,6 +116,7 @@ object HighQualityFaviconService {
             val withoutProtocol = url.removePrefix("https://").removePrefix("http://")
             withoutProtocol.substringBefore('/').substringBefore('?').removePrefix("www.")
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Could not extract domain from URL for favicon", mapOf("error" to e.toString()))
             null
         }
     }
@@ -141,6 +146,7 @@ object HighQualityFaviconService {
             val imageBitmap = bufferedImage.toComposeImageBitmap()
             ai.rever.boss.plugin.api.TabIcon.Image(BitmapPainter(imageBitmap))
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Failed to read cached HQ favicon - treating as cache miss", mapOf("error" to e.toString()))
             null
         }
     }
@@ -181,6 +187,7 @@ object HighQualityFaviconService {
                 null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.NETWORK, "HQ favicon fetch from Google failed - falling back", mapOf("domain" to domain, "error" to e.toString()))
             null
         }
     }
@@ -203,7 +210,8 @@ object HighQualityFaviconService {
                     try {
                         file.delete()
                     } catch (e: Exception) {
-                        // Ignore deletion errors
+                        // Deletion errors are non-fatal - entry will be retried on next eviction
+                        logger.debug(LogCategory.FILE, "Failed to evict HQ favicon cache entry", mapOf("file" to file.name, "error" to e.toString()))
                     }
                 }
             }
@@ -225,7 +233,8 @@ object HighQualityFaviconService {
         try {
             cacheDir.listFiles()?.forEach { it.delete() }
         } catch (e: Exception) {
-            // Ignore cache clearing errors
+            // Cache clearing is best-effort - stale entries are harmless
+            logger.debug(LogCategory.FILE, "Failed to clear HQ favicon cache", mapOf("error" to e.toString()))
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/left_top/DesktopFileScanner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/left_top/DesktopFileScanner.kt
@@ -50,7 +50,11 @@ actual fun directoryHasChildren(path: String, showHidden: Boolean): Boolean {
     } catch (e: Exception) {
         // Covers InvalidPathException (malformed input, e.g. a NUL byte) as well as
         // I/O errors -- File(path) never threw here, so callers rely on false-on-error.
-        logger.debug(LogCategory.FILE, "Directory children probe failed - reporting none", mapOf("path" to path, "error" to e.toString()))
+        logger.debug(
+            LogCategory.FILE,
+            "Directory children probe failed - reporting none",
+            mapOf("path" to path, "error" to e.toString()),
+        )
         false
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/left_top/DesktopFileScanner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/left_top/DesktopFileScanner.kt
@@ -2,9 +2,13 @@ package ai.rever.boss.components.plugin.panels.left_top
 
 import ai.rever.boss.plugin.api.FileNodeData
 import ai.rever.boss.plugin.api.NodeLoadingStateData
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+
+private val logger = BossLogger.forComponent("DesktopFileScanner")
 
 actual fun scanDirectory(path: String): FileNodeData? = scanDirectory(path, showHidden = false)
 
@@ -46,6 +50,7 @@ actual fun directoryHasChildren(path: String, showHidden: Boolean): Boolean {
     } catch (e: Exception) {
         // Covers InvalidPathException (malformed input, e.g. a NUL byte) as well as
         // I/O errors -- File(path) never threw here, so callers rely on false-on-error.
+        logger.debug(LogCategory.FILE, "Directory children probe failed - reporting none", mapOf("path" to path, "error" to e.toString()))
         false
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
@@ -68,7 +68,11 @@ class DesktopBrowserIntegration(
                 null
             }
         } catch (e: Exception) {
-            browserAccessorLogger.debug(LogCategory.BROWSER, "executeJavaScript failed - returning null", mapOf("error" to e.toString()))
+            browserAccessorLogger.debug(
+                LogCategory.BROWSER,
+                "executeJavaScript failed - returning null",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -88,7 +92,11 @@ class DesktopBrowserIntegration(
             !browser.isClosed
         } catch (e: Exception) {
             // Browser was disposed or became inaccessible
-            browserAccessorLogger.debug(LogCategory.BROWSER, "Browser liveness check failed - treating as unavailable", mapOf("error" to e.toString()))
+            browserAccessorLogger.debug(
+                LogCategory.BROWSER,
+                "Browser liveness check failed - treating as unavailable",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     }
@@ -97,7 +105,11 @@ class DesktopBrowserIntegration(
         try {
             browser.url()
         } catch (e: Exception) {
-            browserAccessorLogger.debug(LogCategory.BROWSER, "Could not read current URL - browser likely disposed", mapOf("error" to e.toString()))
+            browserAccessorLogger.debug(
+                LogCategory.BROWSER,
+                "Could not read current URL - browser likely disposed",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -140,7 +152,11 @@ private fun findBrowserForTab(
                                 null
                             }
                         } catch (e: Exception) {
-                            browserAccessorLogger.debug(LogCategory.BROWSER, "Browser handle unavailable for Fluck tab - skipping", mapOf("error" to e.toString()))
+                            browserAccessorLogger.debug(
+                                LogCategory.BROWSER,
+                                "Browser handle unavailable for Fluck tab - skipping",
+                                mapOf("error" to e.toString()),
+                            )
                             null
                         }
                     } else {
@@ -156,7 +172,11 @@ private fun findBrowserForTab(
                             null
                         }
                     } catch (e: Exception) {
-                        browserAccessorLogger.debug(LogCategory.BROWSER, "Browser handle unavailable for tab component - skipping", mapOf("error" to e.toString()))
+                        browserAccessorLogger.debug(
+                            LogCategory.BROWSER,
+                            "Browser handle unavailable for tab component - skipping",
+                            mapOf("error" to e.toString()),
+                        )
                         null
                     }
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
@@ -68,6 +68,7 @@ class DesktopBrowserIntegration(
                 null
             }
         } catch (e: Exception) {
+            browserAccessorLogger.debug(LogCategory.BROWSER, "executeJavaScript failed - returning null", mapOf("error" to e.toString()))
             null
         }
     }
@@ -87,6 +88,7 @@ class DesktopBrowserIntegration(
             !browser.isClosed
         } catch (e: Exception) {
             // Browser was disposed or became inaccessible
+            browserAccessorLogger.debug(LogCategory.BROWSER, "Browser liveness check failed - treating as unavailable", mapOf("error" to e.toString()))
             false
         }
     }
@@ -95,6 +97,7 @@ class DesktopBrowserIntegration(
         try {
             browser.url()
         } catch (e: Exception) {
+            browserAccessorLogger.debug(LogCategory.BROWSER, "Could not read current URL - browser likely disposed", mapOf("error" to e.toString()))
             null
         }
     }
@@ -137,6 +140,7 @@ private fun findBrowserForTab(
                                 null
                             }
                         } catch (e: Exception) {
+                            browserAccessorLogger.debug(LogCategory.BROWSER, "Browser handle unavailable for Fluck tab - skipping", mapOf("error" to e.toString()))
                             null
                         }
                     } else {
@@ -152,6 +156,7 @@ private fun findBrowserForTab(
                             null
                         }
                     } catch (e: Exception) {
+                        browserAccessorLogger.debug(LogCategory.BROWSER, "Browser handle unavailable for tab component - skipping", mapOf("error" to e.toString()))
                         null
                     }
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopLLMSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopLLMSettingsManager.kt
@@ -39,6 +39,7 @@ actual fun getEnvironmentVariable(name: String): String? {
         }
     } catch (e: Exception) {
         // launchctl might not be available or might fail - this is normal
+        logger.debug(LogCategory.SYSTEM, "launchctl getenv failed - falling back to env file", mapOf("name" to name, "error" to e.toString()))
     }
 
     // Fallback to reading from ~/.boss/env_vars file for DMG distributions

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopLLMSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopLLMSettingsManager.kt
@@ -39,7 +39,11 @@ actual fun getEnvironmentVariable(name: String): String? {
         }
     } catch (e: Exception) {
         // launchctl might not be available or might fail - this is normal
-        logger.debug(LogCategory.SYSTEM, "launchctl getenv failed - falling back to env file", mapOf("name" to name, "error" to e.toString()))
+        logger.debug(
+            LogCategory.SYSTEM,
+            "launchctl getenv failed - falling back to env file",
+            mapOf("name" to name, "error" to e.toString()),
+        )
     }
 
     // Fallback to reading from ~/.boss/env_vars file for DMG distributions

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/DesktopDirectoryPickerProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/DesktopDirectoryPickerProviderImpl.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.components.plugin.providers
 
 import ai.rever.boss.plugin.api.DirectoryPickerProvider
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
@@ -13,6 +15,8 @@ import javax.swing.UIManager
  */
 actual class DirectoryPickerProviderImpl : DirectoryPickerProvider {
 
+    private val logger = BossLogger.forComponent("DirectoryPickerProvider")
+
     override fun pickDirectory(onResult: (String?) -> Unit) {
         SwingUtilities.invokeLater {
             // Set system look and feel for native appearance
@@ -20,6 +24,7 @@ actual class DirectoryPickerProviderImpl : DirectoryPickerProvider {
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
             } catch (e: Exception) {
                 // If setting system L&F fails, continue with default
+                logger.debug(LogCategory.UI, "Could not set system look and feel - using default", mapOf("error" to e.toString()))
             }
 
             // Use native file dialog for better macOS integration

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/DesktopDirectoryPickerProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/DesktopDirectoryPickerProviderImpl.kt
@@ -24,7 +24,11 @@ actual class DirectoryPickerProviderImpl : DirectoryPickerProvider {
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
             } catch (e: Exception) {
                 // If setting system L&F fails, continue with default
-                logger.debug(LogCategory.UI, "Could not set system look and feel - using default", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.UI,
+                    "Could not set system look and feel - using default",
+                    mapOf("error" to e.toString()),
+                )
             }
 
             // Use native file dialog for better macOS integration

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/DesktopCodeEditor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/DesktopCodeEditor.kt
@@ -20,6 +20,7 @@ actual fun readFileContent(filePath: String): String? {
             null
         }
     } catch (e: Exception) {
+        codeEditorLogger.warn(LogCategory.EDITOR, "Failed to read file content", mapOf("path" to filePath), error = e)
         null
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -49,6 +49,7 @@ private fun getValidComposeWindow(): Window? {
                 window.isDisplayable && window.isShowing
             } catch (e: Exception) {
                 // Window might be in invalid state during disposal
+                logger.debug(LogCategory.BROWSER, "Window state probe failed during disposal - skipping window", mapOf("error" to e.toString()))
                 false
             }
         }
@@ -197,6 +198,7 @@ private fun configureBrowserPopupHandler(
                             }
                         } catch (e: Exception) {
                             // Issue #255: Gracefully handle "closed object" exceptions
+                            logger.debug(LogCategory.BROWSER, "Popup browser hit closed-object exception - cleaning up", mapOf("error" to e.toString()))
                             if (cleanedUp.compareAndSet(false, true)) {
                                 subscription?.unsubscribe()
                                 scope.cancel()
@@ -313,7 +315,13 @@ actual fun createBrowserViewState(browser: Any, window: Any?): Any? {
     val jxBrowser = browser as Browser
 
     val awtWindow = (window as? Window)?.takeIf {
-        try { it.isDisplayable && it.isShowing } catch (e: Exception) { false }
+        try {
+            it.isDisplayable && it.isShowing
+        } catch (e: Exception) {
+            // Window can be mid-disposal - fall back to scanning open windows
+            logger.debug(LogCategory.BROWSER, "Provided window probe failed - falling back to window scan", mapOf("error" to e.toString()))
+            false
+        }
     } ?: getValidComposeWindow()
 
     if (awtWindow == null) {
@@ -332,7 +340,13 @@ actual fun recreateBrowserViewState(browser: Any, window: Any?): Any? {
     }
 
     val awtWindow = (window as? Window)?.takeIf {
-        try { it.isDisplayable && it.isShowing } catch (e: Exception) { false }
+        try {
+            it.isDisplayable && it.isShowing
+        } catch (e: Exception) {
+            // Window can be mid-disposal - fall back to scanning open windows
+            logger.debug(LogCategory.BROWSER, "Provided window probe failed - falling back to window scan", mapOf("error" to e.toString()))
+            false
+        }
     } ?: getValidComposeWindow()
 
     if (awtWindow == null) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -49,7 +49,11 @@ private fun getValidComposeWindow(): Window? {
                 window.isDisplayable && window.isShowing
             } catch (e: Exception) {
                 // Window might be in invalid state during disposal
-                logger.debug(LogCategory.BROWSER, "Window state probe failed during disposal - skipping window", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Window state probe failed during disposal - skipping window",
+                    mapOf("error" to e.toString()),
+                )
                 false
             }
         }
@@ -198,7 +202,11 @@ private fun configureBrowserPopupHandler(
                             }
                         } catch (e: Exception) {
                             // Issue #255: Gracefully handle "closed object" exceptions
-                            logger.debug(LogCategory.BROWSER, "Popup browser hit closed-object exception - cleaning up", mapOf("error" to e.toString()))
+                            logger.debug(
+                                LogCategory.BROWSER,
+                                "Popup browser hit closed-object exception - cleaning up",
+                                mapOf("error" to e.toString()),
+                            )
                             if (cleanedUp.compareAndSet(false, true)) {
                                 subscription?.unsubscribe()
                                 scope.cancel()
@@ -319,7 +327,11 @@ actual fun createBrowserViewState(browser: Any, window: Any?): Any? {
             it.isDisplayable && it.isShowing
         } catch (e: Exception) {
             // Window can be mid-disposal - fall back to scanning open windows
-            logger.debug(LogCategory.BROWSER, "Provided window probe failed - falling back to window scan", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Provided window probe failed - falling back to window scan",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     } ?: getValidComposeWindow()
@@ -344,7 +356,11 @@ actual fun recreateBrowserViewState(browser: Any, window: Any?): Any? {
             it.isDisplayable && it.isShowing
         } catch (e: Exception) {
             // Window can be mid-disposal - fall back to scanning open windows
-            logger.debug(LogCategory.BROWSER, "Provided window probe failed - falling back to window scan", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Provided window probe failed - falling back to window scan",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     } ?: getValidComposeWindow()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SecuritySettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SecuritySettings.kt
@@ -57,14 +57,18 @@ private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities {
             // This is a simplified check - we assume JxBrowser is available if passkeys are supported
             AuthService.isPasskeySupported()
         } catch (e: Exception) {
+            securitySettingsLogger.debug(LogCategory.PASSKEY, "Passkey support probe failed - assuming no JxBrowser", mapOf("error" to e.toString()))
             false
         }
-        
+
         val hasTouchId = when {
             os.contains("mac") -> {
                 try {
                     AuthService.isPasskeySupported()
-                } catch (e: Exception) { false }
+                } catch (e: Exception) {
+                    securitySettingsLogger.debug(LogCategory.PASSKEY, "Passkey support probe failed - assuming no Touch ID", mapOf("error" to e.toString()))
+                    false
+                }
             }
             else -> false
         }
@@ -104,6 +108,7 @@ private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities {
         
     } catch (e: Exception) {
         // Fallback capabilities
+        securitySettingsLogger.warn(LogCategory.PASSKEY, "WebAuthn capability detection failed - using fallback capabilities", error = e)
         val os = System.getProperty("os.name").lowercase()
         WebAuthnCapabilities(
             hasJxBrowserEngine = false,
@@ -167,6 +172,7 @@ fun SecuritySettings() {
                     touchIDSupported = AuthService.isPasskeySupported()
                     webAuthnCapabilities = detectWebAuthnCapabilities()
                 } catch (e: Exception) {
+                    securitySettingsLogger.warn(LogCategory.PASSKEY, "Passkey capability detection failed - showing as unsupported", error = e)
                     touchIDSupported = false
                     webAuthnCapabilities = null
                 }
@@ -909,6 +915,7 @@ private fun formatPasskeyDetails(passkey: PasskeyInfo): String {
         val date = java.util.Date(passkey.createdAt)
         java.text.SimpleDateFormat("MMM dd, yyyy", java.util.Locale.getDefault()).format(date)
     } catch (e: Exception) {
+        securitySettingsLogger.debug(LogCategory.UI, "Failed to format passkey creation date", mapOf("error" to e.toString()))
         "Unknown date"
     }
     
@@ -924,6 +931,7 @@ private fun formatPasskeyDetails(passkey: PasskeyInfo): String {
                 else -> java.text.SimpleDateFormat("MMM dd", java.util.Locale.getDefault()).format(date)
             }
         } catch (e: Exception) {
+            securitySettingsLogger.debug(LogCategory.UI, "Failed to format passkey last-used date", mapOf("error" to e.toString()))
             "recently"
         }
     } else {
@@ -942,6 +950,7 @@ private fun formatTimestamp(timestamp: Long): String {
         val format = java.text.SimpleDateFormat("MMM dd, yyyy", java.util.Locale.getDefault())
         format.format(date)
     } catch (e: Exception) {
+        securitySettingsLogger.debug(LogCategory.UI, "Failed to format credential timestamp", mapOf("error" to e.toString()))
         "Unknown"
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SecuritySettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SecuritySettings.kt
@@ -57,7 +57,11 @@ private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities {
             // This is a simplified check - we assume JxBrowser is available if passkeys are supported
             AuthService.isPasskeySupported()
         } catch (e: Exception) {
-            securitySettingsLogger.debug(LogCategory.PASSKEY, "Passkey support probe failed - assuming no JxBrowser", mapOf("error" to e.toString()))
+            securitySettingsLogger.debug(
+                LogCategory.PASSKEY,
+                "Passkey support probe failed - assuming no JxBrowser",
+                mapOf("error" to e.toString()),
+            )
             false
         }
 
@@ -66,7 +70,11 @@ private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities {
                 try {
                     AuthService.isPasskeySupported()
                 } catch (e: Exception) {
-                    securitySettingsLogger.debug(LogCategory.PASSKEY, "Passkey support probe failed - assuming no Touch ID", mapOf("error" to e.toString()))
+                    securitySettingsLogger.debug(
+                        LogCategory.PASSKEY,
+                        "Passkey support probe failed - assuming no Touch ID",
+                        mapOf("error" to e.toString()),
+                    )
                     false
                 }
             }
@@ -108,7 +116,11 @@ private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities {
         
     } catch (e: Exception) {
         // Fallback capabilities
-        securitySettingsLogger.warn(LogCategory.PASSKEY, "WebAuthn capability detection failed - using fallback capabilities", error = e)
+        securitySettingsLogger.warn(
+            LogCategory.PASSKEY,
+            "WebAuthn capability detection failed - using fallback capabilities",
+            error = e,
+        )
         val os = System.getProperty("os.name").lowercase()
         WebAuthnCapabilities(
             hasJxBrowserEngine = false,
@@ -172,7 +184,11 @@ fun SecuritySettings() {
                     touchIDSupported = AuthService.isPasskeySupported()
                     webAuthnCapabilities = detectWebAuthnCapabilities()
                 } catch (e: Exception) {
-                    securitySettingsLogger.warn(LogCategory.PASSKEY, "Passkey capability detection failed - showing as unsupported", error = e)
+                    securitySettingsLogger.warn(
+                        LogCategory.PASSKEY,
+                        "Passkey capability detection failed - showing as unsupported",
+                        error = e,
+                    )
                     touchIDSupported = false
                     webAuthnCapabilities = null
                 }
@@ -915,7 +931,11 @@ private fun formatPasskeyDetails(passkey: PasskeyInfo): String {
         val date = java.util.Date(passkey.createdAt)
         java.text.SimpleDateFormat("MMM dd, yyyy", java.util.Locale.getDefault()).format(date)
     } catch (e: Exception) {
-        securitySettingsLogger.debug(LogCategory.UI, "Failed to format passkey creation date", mapOf("error" to e.toString()))
+        securitySettingsLogger.debug(
+            LogCategory.UI,
+            "Failed to format passkey creation date",
+            mapOf("error" to e.toString()),
+        )
         "Unknown date"
     }
     
@@ -931,7 +951,11 @@ private fun formatPasskeyDetails(passkey: PasskeyInfo): String {
                 else -> java.text.SimpleDateFormat("MMM dd", java.util.Locale.getDefault()).format(date)
             }
         } catch (e: Exception) {
-            securitySettingsLogger.debug(LogCategory.UI, "Failed to format passkey last-used date", mapOf("error" to e.toString()))
+            securitySettingsLogger.debug(
+                LogCategory.UI,
+                "Failed to format passkey last-used date",
+                mapOf("error" to e.toString()),
+            )
             "recently"
         }
     } else {
@@ -950,7 +974,11 @@ private fun formatTimestamp(timestamp: Long): String {
         val format = java.text.SimpleDateFormat("MMM dd, yyyy", java.util.Locale.getDefault())
         format.format(date)
     } catch (e: Exception) {
-        securitySettingsLogger.debug(LogCategory.UI, "Failed to format credential timestamp", mapOf("error" to e.toString()))
+        securitySettingsLogger.debug(
+            LogCategory.UI,
+            "Failed to format credential timestamp",
+            mapOf("error" to e.toString()),
+        )
         "Unknown"
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -411,7 +411,11 @@ class PluginInstallService(
                 } else null
             } catch (e: Exception) {
                 // No token means lower GitHub rate limits, not a failure
-                logger.debug(LogCategory.SYSTEM, "Could not read GITHUB_TOKEN from local.properties", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Could not read GITHUB_TOKEN from local.properties",
+                    mapOf("error" to e.toString()),
+                )
                 null
             }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -410,6 +410,8 @@ class PluginInstallService(
                         ?.trim()
                 } else null
             } catch (e: Exception) {
+                // No token means lower GitHub rate limits, not a failure
+                logger.debug(LogCategory.SYSTEM, "Could not read GITHUB_TOKEN from local.properties", mapOf("error" to e.toString()))
                 null
             }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceFileManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceFileManager.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.components.workspaces
 
 import ai.rever.boss.utils.SystemUtils
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -12,6 +14,7 @@ import java.nio.file.StandardOpenOption
  * Desktop implementation of WorkspaceFileManager
  */
 actual class WorkspaceFileManager {
+    private val logger = BossLogger.forComponent("WorkspaceFileManager")
     private val workspaceDirectory: String by lazy {
         val userHome = SystemUtils.getUserHome()
         val documentsPath = Paths.get(userHome, "Documents", WorkspaceFileManagerCommon.getDefaultWorkspaceDirectoryName())
@@ -28,6 +31,7 @@ actual class WorkspaceFileManager {
             }
             dir.exists() && dir.isDirectory
         } catch (e: Exception) {
+            logger.warn(LogCategory.WORKSPACE, "Failed to create workspace directory", error = e)
             false
         }
     }
@@ -51,6 +55,7 @@ actual class WorkspaceFileManager {
             
             filePath
         } catch (e: Exception) {
+            logger.warn(LogCategory.WORKSPACE, "Failed to save workspace to disk", mapOf("workspace" to workspace.name), error = e)
             null
         }
     }
@@ -67,6 +72,7 @@ actual class WorkspaceFileManager {
             val json = file.readText()
             WorkspaceSerializer.deserialize(json)
         } catch (e: Exception) {
+            logger.warn(LogCategory.WORKSPACE, "Failed to load workspace file", mapOf("fileName" to fileName), error = e)
             null
         }
     }
@@ -89,6 +95,7 @@ actual class WorkspaceFileManager {
                 )
             } ?: emptyList()
         } catch (e: Exception) {
+            logger.warn(LogCategory.WORKSPACE, "Failed to list workspace files", error = e)
             emptyList()
         }
     }
@@ -104,6 +111,7 @@ actual class WorkspaceFileManager {
                 false
             }
         } catch (e: Exception) {
+            logger.warn(LogCategory.WORKSPACE, "Failed to delete workspace file", mapOf("fileName" to fileName), error = e)
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceFileManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceFileManager.kt
@@ -55,7 +55,12 @@ actual class WorkspaceFileManager {
             
             filePath
         } catch (e: Exception) {
-            logger.warn(LogCategory.WORKSPACE, "Failed to save workspace to disk", mapOf("workspace" to workspace.name), error = e)
+            logger.warn(
+                LogCategory.WORKSPACE,
+                "Failed to save workspace to disk",
+                mapOf("workspace" to workspace.name),
+                error = e,
+            )
             null
         }
     }
@@ -72,7 +77,12 @@ actual class WorkspaceFileManager {
             val json = file.readText()
             WorkspaceSerializer.deserialize(json)
         } catch (e: Exception) {
-            logger.warn(LogCategory.WORKSPACE, "Failed to load workspace file", mapOf("fileName" to fileName), error = e)
+            logger.warn(
+                LogCategory.WORKSPACE,
+                "Failed to load workspace file",
+                mapOf("fileName" to fileName),
+                error = e,
+            )
             null
         }
     }
@@ -111,7 +121,12 @@ actual class WorkspaceFileManager {
                 false
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.WORKSPACE, "Failed to delete workspace file", mapOf("fileName" to fileName), error = e)
+            logger.warn(
+                LogCategory.WORKSPACE,
+                "Failed to delete workspace file",
+                mapOf("fileName" to fileName),
+                error = e,
+            )
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceButton.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceButton.desktop.kt
@@ -1,7 +1,11 @@
 package ai.rever.boss.components.workspaces
 
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.awt.Desktop
 import java.io.File
+
+private val logger = BossLogger.forComponent("WorkspaceButton")
 
 /**
  * Desktop implementation to open workspace directory
@@ -13,5 +17,7 @@ actual fun openWorkspaceDirectory(path: String) {
             Desktop.getDesktop().open(directory)
         }
     } catch (e: Exception) {
+        // Non-fatal: the button just does nothing if the OS file manager refuses
+        logger.warn(LogCategory.WORKSPACE, "Failed to open workspace directory in file manager", mapOf("path" to path), error = e)
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceButton.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceButton.desktop.kt
@@ -18,6 +18,11 @@ actual fun openWorkspaceDirectory(path: String) {
         }
     } catch (e: Exception) {
         // Non-fatal: the button just does nothing if the OS file manager refuses
-        logger.warn(LogCategory.WORKSPACE, "Failed to open workspace directory in file manager", mapOf("path" to path), error = e)
+        logger.warn(
+            LogCategory.WORKSPACE,
+            "Failed to open workspace directory in file manager",
+            mapOf("path" to path),
+            error = e,
+        )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -80,6 +80,7 @@ object ChromiumAutoDownloader {
         return try {
             if (versionFile.exists()) versionFile.readText().trim().takeIf { it.isNotEmpty() } else null
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Could not read installed Chromium version marker", mapOf("error" to e.toString()))
             null
         }
     }
@@ -348,7 +349,7 @@ object ChromiumAutoDownloader {
                         try {
                             Files.deleteIfExists(tempFile)
                         } catch (e: Exception) {
-                            logger.debug(LogCategory.BROWSER, "Could not delete temp file")
+                            logger.debug(LogCategory.BROWSER, "Could not delete temp file", mapOf("error" to e.toString()))
                         }
                     }
                 } catch (e: Exception) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -80,7 +80,11 @@ object ChromiumAutoDownloader {
         return try {
             if (versionFile.exists()) versionFile.readText().trim().takeIf { it.isNotEmpty() } else null
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Could not read installed Chromium version marker", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Could not read installed Chromium version marker",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -349,7 +353,11 @@ object ChromiumAutoDownloader {
                         try {
                             Files.deleteIfExists(tempFile)
                         } catch (e: Exception) {
-                            logger.debug(LogCategory.BROWSER, "Could not delete temp file", mapOf("error" to e.toString()))
+                            logger.debug(
+                                LogCategory.BROWSER,
+                                "Could not delete temp file",
+                                mapOf("error" to e.toString()),
+                            )
                         }
                     }
                 } catch (e: Exception) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/GitHubConfig.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/GitHubConfig.kt
@@ -124,7 +124,7 @@ object GitHubConfig {
                 }
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.NETWORK, "GitHub CLI not available")
+            logger.debug(LogCategory.NETWORK, "GitHub CLI not available", mapOf("error" to e.toString()))
             null
         } finally {
             process?.let {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/font/FontManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/font/FontManager.kt
@@ -263,6 +263,7 @@ object FontManager {
                         FontFamily.Monospace
                     }
                 } catch (e: Exception) {
+                    logger.debug(LogCategory.UI, "System font lookup failed - falling back to Monospace", mapOf("font" to fontName, "error" to e.toString()))
                     FontFamily.Monospace
                 }
             }
@@ -304,6 +305,7 @@ object FontManager {
                 }
             } catch (e: Exception) {
                 // Skip fonts that fail to load
+                logger.debug(LogCategory.UI, "Skipping font that failed to load during discovery", mapOf("font" to familyName, "error" to e.toString()))
             }
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/font/FontManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/font/FontManager.kt
@@ -263,7 +263,11 @@ object FontManager {
                         FontFamily.Monospace
                     }
                 } catch (e: Exception) {
-                    logger.debug(LogCategory.UI, "System font lookup failed - falling back to Monospace", mapOf("font" to fontName, "error" to e.toString()))
+                    logger.debug(
+                        LogCategory.UI,
+                        "System font lookup failed - falling back to Monospace",
+                        mapOf("font" to fontName, "error" to e.toString()),
+                    )
                     FontFamily.Monospace
                 }
             }
@@ -305,7 +309,11 @@ object FontManager {
                 }
             } catch (e: Exception) {
                 // Skip fonts that fail to load
-                logger.debug(LogCategory.UI, "Skipping font that failed to load during discovery", mapOf("font" to familyName, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.UI,
+                    "Skipping font that failed to load during discovery",
+                    mapOf("font" to familyName, "error" to e.toString()),
+                )
             }
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -813,7 +813,11 @@ actual object GitService {
             val result = runGitCommand(projectPath, "rev-parse", "--is-inside-work-tree")
             result.exitCode == 0 && result.output.trim() == "true"
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "git rev-parse failed - treating path as non-repo", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "git rev-parse failed - treating path as non-repo",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -512,6 +512,7 @@ actual object GitService {
                 null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not read last commit message", mapOf("error" to e.toString()))
             null
         }
     }
@@ -559,6 +560,7 @@ actual object GitService {
                 refs = parts.getOrNull(7)?.split(", ")?.filter { it.isNotBlank() } ?: emptyList()
             )
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Skipping unparsable git log line", mapOf("error" to e.toString()))
             null
         }
     }
@@ -811,6 +813,7 @@ actual object GitService {
             val result = runGitCommand(projectPath, "rev-parse", "--is-inside-work-tree")
             result.exitCode == 0 && result.output.trim() == "true"
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "git rev-parse failed - treating path as non-repo", mapOf("error" to e.toString()))
             false
         }
     }
@@ -835,6 +838,7 @@ actual object GitService {
                 null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not determine current branch", mapOf("error" to e.toString()))
             null
         }
     }
@@ -859,6 +863,7 @@ actual object GitService {
                 }
                 .sortedWith(compareBy({ !it.isCurrent }, { it.name })) // Current branch first
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not list local branches", mapOf("error" to e.toString()))
             emptyList()
         }
     }
@@ -881,6 +886,7 @@ actual object GitService {
                 }
                 .sortedBy { it.name }
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not list remote branches", mapOf("error" to e.toString()))
             emptyList()
         }
     }
@@ -946,6 +952,7 @@ actual object GitService {
                 else -> null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not resolve remote URL to web URL", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/IpcEventBridgeImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/IpcEventBridgeImpl.kt
@@ -31,7 +31,11 @@ class IpcEventBridgeImpl(
                 .toByteArray(Charsets.UTF_8)
         } catch (e: Exception) {
             // Fall back to toString() if serialization fails — for debugging
-            logger.debug("Payload serialization failed for event {} - forwarding toString(): {}", eventType, e.toString())
+            logger.debug(
+                "Payload serialization failed for event {} - forwarding toString(): {}",
+                eventType,
+                e.toString(),
+            )
             payload.toString().toByteArray(Charsets.UTF_8)
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/IpcEventBridgeImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/IpcEventBridgeImpl.kt
@@ -31,6 +31,7 @@ class IpcEventBridgeImpl(
                 .toByteArray(Charsets.UTF_8)
         } catch (e: Exception) {
             // Fall back to toString() if serialization fails — for debugging
+            logger.debug("Payload serialization failed for event {} - forwarding toString(): {}", eventType, e.toString())
             payload.toString().toByteArray(Charsets.UTF_8)
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/logging/LogEntry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/logging/LogEntry.kt
@@ -28,7 +28,10 @@ data class LogEntry(
             } else {
                 "00:00:00.000"
             }
-        } catch (e: Exception) {
+        } catch (ignored: Exception) {
+            // Deliberately unlogged: this formatter runs inside the stdout/stderr
+            // capture pipeline, so logging here could feed back into the capture
+            // loop. A placeholder timestamp is the safe fallback.
             "00:00:00.000"
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -687,7 +687,11 @@ private fun extractPty4jNatives(targetDir: File) {
                 }
             } catch (e: Exception) {
                 // Try next resource
-                logger.debug(LogCategory.SYSTEM, "PTY4J native extraction failed for resource - trying next", mapOf("resource" to resource, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "PTY4J native extraction failed for resource - trying next",
+                    mapOf("resource" to resource, "error" to e.toString()),
+                )
             }
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -687,6 +687,7 @@ private fun extractPty4jNatives(targetDir: File) {
                 }
             } catch (e: Exception) {
                 // Try next resource
+                logger.debug(LogCategory.SYSTEM, "PTY4J native extraction failed for resource - trying next", mapOf("resource" to resource, "error" to e.toString()))
             }
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceSettingsManager.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.performance
 
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +20,7 @@ import java.io.File
  * - Graceful error handling with fallback to defaults
  */
 actual object PerformanceSettingsManager {
+    private val logger = BossLogger.forComponent("PerformanceSettingsManager")
     private val settingsFile = BossDirectories.resolve("performance-settings.json")
     private val json = Json {
         prettyPrint = true
@@ -43,6 +46,7 @@ actual object PerformanceSettingsManager {
                 _currentSettings.value = PerformanceSettings()
             }
         } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Failed to load performance settings - using defaults", error = e)
             _currentSettings.value = PerformanceSettings()
         }
     }
@@ -53,6 +57,7 @@ actual object PerformanceSettingsManager {
             settingsFile.writeText(content)
         } catch (e: Exception) {
             // Settings save failed - not critical, will use in-memory settings
+            logger.warn(LogCategory.SYSTEM, "Failed to persist performance settings - keeping in-memory only", error = e)
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceSettingsManager.kt
@@ -57,7 +57,11 @@ actual object PerformanceSettingsManager {
             settingsFile.writeText(content)
         } catch (e: Exception) {
             // Settings save failed - not critical, will use in-memory settings
-            logger.warn(LogCategory.SYSTEM, "Failed to persist performance settings - keeping in-memory only", error = e)
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Failed to persist performance settings - keeping in-memory only",
+                error = e,
+            )
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/DesktopFilePicker.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/DesktopFilePicker.kt
@@ -4,9 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import java.awt.FileDialog
 import java.awt.Frame
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
+
+private val logger = BossLogger.forComponent("DesktopFilePicker")
 
 @Composable
 actual fun rememberDirectoryPicker(
@@ -28,6 +32,7 @@ class DesktopDirectoryPicker(
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
             } catch (e: Exception) {
                 // If setting system L&F fails, continue with default
+                logger.debug(LogCategory.UI, "Could not set system look and feel - using default", mapOf("error" to e.toString()))
             }
             
             // Use native file dialog for better macOS integration

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/DesktopFilePicker.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/DesktopFilePicker.kt
@@ -32,7 +32,11 @@ class DesktopDirectoryPicker(
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
             } catch (e: Exception) {
                 // If setting system L&F fails, continue with default
-                logger.debug(LogCategory.UI, "Could not set system look and feel - using default", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.UI,
+                    "Could not set system look and feel - using default",
+                    mapOf("error" to e.toString()),
+                )
             }
             
             // Use native file dialog for better macOS integration

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FilePicker.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FilePicker.kt
@@ -48,6 +48,7 @@ class DesktopFilePicker(
                 onFileSelected(null, null)
             }
         } catch (e: Exception) {
+            filePickerLogger.warn(LogCategory.FILE, "Failed to read picked file - reporting no selection", error = e)
             onFileSelected(null, null)
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
@@ -177,6 +177,7 @@ object FileSystemUtils {
             val dir = File(directoryPath)
             dir.isDirectory && dir.canWrite()
         } catch (e: Exception) {
+            logger.debug(LogCategory.FILE, "Writability check failed - treating directory as not writable", mapOf("path" to directoryPath, "error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
@@ -177,7 +177,11 @@ object FileSystemUtils {
             val dir = File(directoryPath)
             dir.isDirectory && dir.canWrite()
         } catch (e: Exception) {
-            logger.debug(LogCategory.FILE, "Writability check failed - treating directory as not writable", mapOf("path" to directoryPath, "error" to e.toString()))
+            logger.debug(
+                LogCategory.FILE,
+                "Writability check failed - treating directory as not writable",
+                mapOf("path" to directoryPath, "error" to e.toString()),
+            )
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginPersistence.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginPersistence.kt
@@ -111,7 +111,11 @@ object PluginPersistence {
                 null
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Could not extract version from plugin JAR", mapOf("jarPath" to jarPath, "error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not extract version from plugin JAR",
+                mapOf("jarPath" to jarPath, "error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginPersistence.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginPersistence.kt
@@ -111,6 +111,7 @@ object PluginPersistence {
                 null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not extract version from plugin JAR", mapOf("jarPath" to jarPath, "error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -356,6 +356,7 @@ internal class BrowserHandleImpl(
                 val pageUrl = try {
                     params.browser().url()
                 } catch (e: Exception) {
+                    logger.debug(LogCategory.BROWSER, "Could not read page URL for context menu - using empty", mapOf("error" to e.toString()))
                     ""
                 }
 
@@ -398,6 +399,7 @@ internal class BrowserHandleImpl(
                     }
                 } catch (e: Exception) {
                     // JavaScript execution failed - proceed with defaults
+                    logger.debug(LogCategory.BROWSER, "Context-menu JS inspection failed - proceeding with defaults", mapOf("error" to e.toString()))
                 }
 
                 val info = BrowserContextMenuInfo(
@@ -1330,6 +1332,8 @@ internal class BrowserHandleImpl(
                     try {
                         window.isDisplayable && window.isShowing
                     } catch (e: Exception) {
+                        // Window can be mid-disposal - treat as not a candidate
+                        logger.debug(LogCategory.BROWSER, "Window state probe failed - skipping window", mapOf("error" to e.toString()))
                         false
                     }
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -356,7 +356,10 @@ internal class BrowserHandleImpl(
                 val pageUrl = try {
                     params.browser().url()
                 } catch (e: Exception) {
-                    logger.debug(LogCategory.BROWSER, "Could not read page URL for context menu - using empty", mapOf("error" to e.toString()))
+                    logger.debug(
+                        LogCategory.BROWSER, "Could not read page URL for context menu - using empty",
+                        mapOf("error" to e.toString()),
+                    )
                     ""
                 }
 
@@ -399,7 +402,10 @@ internal class BrowserHandleImpl(
                     }
                 } catch (e: Exception) {
                     // JavaScript execution failed - proceed with defaults
-                    logger.debug(LogCategory.BROWSER, "Context-menu JS inspection failed - proceeding with defaults", mapOf("error" to e.toString()))
+                    logger.debug(
+                        LogCategory.BROWSER, "Context-menu JS inspection failed - proceeding with defaults",
+                        mapOf("error" to e.toString()),
+                    )
                 }
 
                 val info = BrowserContextMenuInfo(
@@ -1333,7 +1339,11 @@ internal class BrowserHandleImpl(
                         window.isDisplayable && window.isShowing
                     } catch (e: Exception) {
                         // Window can be mid-disposal - treat as not a candidate
-                        logger.debug(LogCategory.BROWSER, "Window state probe failed - skipping window", mapOf("error" to e.toString()))
+                        logger.debug(
+                            LogCategory.BROWSER,
+                            "Window state probe failed - skipping window",
+                            mapOf("error" to e.toString()),
+                        )
                         false
                     }
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserZoomSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserZoomSettingsManager.kt
@@ -141,6 +141,7 @@ object BrowserZoomSettingsManager {
         return try {
             java.net.URL(url).host.let { normalizeDomain(it) }
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "URL has no parsable host - no per-domain zoom", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserZoomSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserZoomSettingsManager.kt
@@ -141,7 +141,11 @@ object BrowserZoomSettingsManager {
         return try {
             java.net.URL(url).host.let { normalizeDomain(it) }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "URL has no parsable host - no per-domain zoom", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "URL has no parsable host - no per-domain zoom",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -599,8 +599,10 @@ object FluckEngine {
 
         lockFiles.forEach { fileName ->
             val file = profileDir.resolve(fileName).toFile()
-            if (file.exists()) {
-                file.delete()
+            if (file.exists() && !file.delete()) {
+                // A surviving lock file can make the next engine start think another
+                // instance owns the profile - worth a breadcrumb, not a failure.
+                logger.debug(LogCategory.BROWSER, "Could not delete stale browser lock file", mapOf("file" to fileName))
             }
         }
 
@@ -609,8 +611,8 @@ object FluckEngine {
         if (defaultDir.toFile().exists()) {
             lockFiles.forEach { fileName ->
                 val file = defaultDir.resolve(fileName).toFile()
-                if (file.exists()) {
-                    file.delete()
+                if (file.exists() && !file.delete()) {
+                    logger.debug(LogCategory.BROWSER, "Could not delete stale browser lock file", mapOf("file" to "Default/" + fileName))
                 }
             }
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -531,7 +531,11 @@ object FluckEngine {
                         isJxBrowserChromium && !isOurChild && !isTooRecent
                     } catch (e: Exception) {
                         // Process may have exited mid-inspection - skip it
-                        logger.debug(LogCategory.BROWSER, "Could not inspect process during stale Chromium scan - skipping", mapOf("error" to e.toString()))
+                        logger.debug(
+                            LogCategory.BROWSER,
+                            "Could not inspect process during stale Chromium scan - skipping",
+                            mapOf("error" to e.toString()),
+                        )
                         false
                     }
                 }
@@ -555,15 +559,27 @@ object FluckEngine {
                         process.onExit().get(100, java.util.concurrent.TimeUnit.MILLISECONDS)
                     } catch (e: java.util.concurrent.TimeoutException) {
                         // Process didn't exit in time - force kill
-                        logger.debug(LogCategory.BROWSER, "Stale Chromium process did not exit in 100ms - force killing", mapOf("error" to e.toString()))
+                        logger.debug(
+                            LogCategory.BROWSER,
+                            "Stale Chromium process did not exit in 100ms - force killing",
+                            mapOf("error" to e.toString()),
+                        )
                         process.destroyForcibly()
                     } catch (e: Exception) {
                         // Process already exited or other error
-                        logger.debug(LogCategory.BROWSER, "Wait for stale Chromium exit failed - likely already gone", mapOf("error" to e.toString()))
+                        logger.debug(
+                            LogCategory.BROWSER,
+                            "Wait for stale Chromium exit failed - likely already gone",
+                            mapOf("error" to e.toString()),
+                        )
                     }
                 } catch (e: Exception) {
                     // Kill of one stale process failed - continue with the rest
-                    logger.debug(LogCategory.BROWSER, "Failed to terminate stale Chromium process - skipping", mapOf("error" to e.toString()))
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Failed to terminate stale Chromium process - skipping",
+                        mapOf("error" to e.toString()),
+                    )
                 }
             }
 
@@ -612,7 +628,11 @@ object FluckEngine {
             lockFiles.forEach { fileName ->
                 val file = defaultDir.resolve(fileName).toFile()
                 if (file.exists() && !file.delete()) {
-                    logger.debug(LogCategory.BROWSER, "Could not delete stale browser lock file", mapOf("file" to "Default/" + fileName))
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Could not delete stale browser lock file",
+                        mapOf("file" to "Default/" + fileName),
+                    )
                 }
             }
         }
@@ -698,7 +718,11 @@ object FluckEngine {
                 download.pause()
             } catch (e: Exception) {
                 // Download may already be finished or cancelled
-                logger.debug(LogCategory.BROWSER, "Failed to pause download", mapOf("downloadId" to downloadId, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Failed to pause download",
+                    mapOf("downloadId" to downloadId, "error" to e.toString()),
+                )
             }
         }
     }
@@ -713,7 +737,11 @@ object FluckEngine {
                 download.resume()
             } catch (e: Exception) {
                 // Download may already be finished or cancelled
-                logger.debug(LogCategory.BROWSER, "Failed to resume download", mapOf("downloadId" to downloadId, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Failed to resume download",
+                    mapOf("downloadId" to downloadId, "error" to e.toString()),
+                )
             }
         }
     }
@@ -728,7 +756,11 @@ object FluckEngine {
                 download.cancel()
             } catch (e: Exception) {
                 // Download may already be finished or cancelled
-                logger.debug(LogCategory.BROWSER, "Failed to cancel download", mapOf("downloadId" to downloadId, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Failed to cancel download",
+                    mapOf("downloadId" to downloadId, "error" to e.toString()),
+                )
             }
         }
     }
@@ -776,7 +808,11 @@ object FluckEngine {
         try {
             synchronized(engineLock) { engine.profiles().list().firstOrNull { it.name() == name } }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Profile lookup failed - treating as not found", mapOf("profile" to name, "error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Profile lookup failed - treating as not found",
+                mapOf("profile" to name, "error" to e.toString()),
+            )
             null
         }
 
@@ -1116,7 +1152,11 @@ object FluckEngine {
                 }
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.BROWSER, "Could not inspect profile lock files - attempting cleanup anyway", error = e)
+            logger.warn(
+                LogCategory.BROWSER,
+                "Could not inspect profile lock files - attempting cleanup anyway",
+                error = e,
+            )
 
             // If we can't check, try to clean up anyway
             try {
@@ -1139,7 +1179,11 @@ object FluckEngine {
                 Files.deleteIfExists(file.toPath())
             } catch (e: Exception) {
                 // Fallback to File.delete()
-                logger.debug(LogCategory.BROWSER, "Files.deleteIfExists failed for lock file - falling back to File.delete", mapOf("file" to file.name, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Files.deleteIfExists failed for lock file - falling back to File.delete",
+                    mapOf("file" to file.name, "error" to e.toString()),
+                )
                 file.delete()
             }
         }
@@ -1209,14 +1253,22 @@ object FluckEngine {
         return try {
             createEngineInstance(chromiumDir, profileDirPath)
         } catch (e: UserDataDirectoryAlreadyInUseException) {
-            logger.warn(LogCategory.BROWSER, "Profile directory already in use - trying lock cleanup, then temp profile", error = e)
+            logger.warn(
+                LogCategory.BROWSER,
+                "Profile directory already in use - trying lock cleanup, then temp profile",
+                error = e,
+            )
             // Try to clean up stale lock files first
             if (cleanupStaleLockFiles(profileDirPath)) {
                 try {
                     return createEngineInstance(chromiumDir, profileDirPath)
                 } catch (e2: Exception) {
                     // Retry after cleanup still failed - fall through to temporary profile
-                    logger.warn(LogCategory.BROWSER, "Engine creation still failing after lock cleanup - using temporary profile", error = e2)
+                    logger.warn(
+                        LogCategory.BROWSER,
+                        "Engine creation still failing after lock cleanup - using temporary profile",
+                        error = e2,
+                    )
                 }
             }
 
@@ -1314,7 +1366,11 @@ object FluckEngine {
             val cgroup = java.io.File("/proc/1/cgroup")
             cgroup.exists() && cgroupIndicatesContainer(cgroup.readText())
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Could not read /proc/1/cgroup - assuming not in container", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not read /proc/1/cgroup - assuming not in container",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     }
@@ -2056,7 +2112,11 @@ object FluckEngine {
                 killStaleChromiumProcesses()
             } catch (e: Exception) {
                 // Continue - not critical
-                logger.debug(LogCategory.BROWSER, "Stale Chromium process kill failed during reset", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Stale Chromium process kill failed during reset",
+                    mapOf("error" to e.toString()),
+                )
             }
 
             // Step 4: Delete browser profile directory
@@ -2087,7 +2147,11 @@ object FluckEngine {
                 tempProfilesCleaned = true
             } catch (e: Exception) {
                 // Not critical - continue
-                logger.debug(LogCategory.BROWSER, "Temporary profile cleanup failed during reset", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Temporary profile cleanup failed during reset",
+                    mapOf("error" to e.toString()),
+                )
                 tempProfilesCleaned = false
             }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -530,6 +530,8 @@ object FluckEngine {
 
                         isJxBrowserChromium && !isOurChild && !isTooRecent
                     } catch (e: Exception) {
+                        // Process may have exited mid-inspection - skip it
+                        logger.debug(LogCategory.BROWSER, "Could not inspect process during stale Chromium scan - skipping", mapOf("error" to e.toString()))
                         false
                     }
                 }
@@ -553,11 +555,15 @@ object FluckEngine {
                         process.onExit().get(100, java.util.concurrent.TimeUnit.MILLISECONDS)
                     } catch (e: java.util.concurrent.TimeoutException) {
                         // Process didn't exit in time - force kill
+                        logger.debug(LogCategory.BROWSER, "Stale Chromium process did not exit in 100ms - force killing", mapOf("error" to e.toString()))
                         process.destroyForcibly()
                     } catch (e: Exception) {
                         // Process already exited or other error
+                        logger.debug(LogCategory.BROWSER, "Wait for stale Chromium exit failed - likely already gone", mapOf("error" to e.toString()))
                     }
                 } catch (e: Exception) {
+                    // Kill of one stale process failed - continue with the rest
+                    logger.debug(LogCategory.BROWSER, "Failed to terminate stale Chromium process - skipping", mapOf("error" to e.toString()))
                 }
             }
 
@@ -571,6 +577,8 @@ object FluckEngine {
                 Thread.sleep(500)
             }
         } catch (e: Exception) {
+            // Cleanup is best-effort - engine startup proceeds either way
+            logger.warn(LogCategory.BROWSER, "Stale Chromium process cleanup failed - continuing startup", error = e)
         }
     }
 
@@ -687,6 +695,8 @@ object FluckEngine {
             try {
                 download.pause()
             } catch (e: Exception) {
+                // Download may already be finished or cancelled
+                logger.debug(LogCategory.BROWSER, "Failed to pause download", mapOf("downloadId" to downloadId, "error" to e.toString()))
             }
         }
     }
@@ -700,6 +710,8 @@ object FluckEngine {
             try {
                 download.resume()
             } catch (e: Exception) {
+                // Download may already be finished or cancelled
+                logger.debug(LogCategory.BROWSER, "Failed to resume download", mapOf("downloadId" to downloadId, "error" to e.toString()))
             }
         }
     }
@@ -713,6 +725,8 @@ object FluckEngine {
             try {
                 download.cancel()
             } catch (e: Exception) {
+                // Download may already be finished or cancelled
+                logger.debug(LogCategory.BROWSER, "Failed to cancel download", mapOf("downloadId" to downloadId, "error" to e.toString()))
             }
         }
     }
@@ -760,6 +774,7 @@ object FluckEngine {
         try {
             synchronized(engineLock) { engine.profiles().list().firstOrNull { it.name() == name } }
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Profile lookup failed - treating as not found", mapOf("profile" to name, "error" to e.toString()))
             null
         }
 
@@ -1099,13 +1114,15 @@ object FluckEngine {
                 }
             }
         } catch (e: Exception) {
-            // Log error without printStackTrace per CLAUDE.md guidelines
+            logger.warn(LogCategory.BROWSER, "Could not inspect profile lock files - attempting cleanup anyway", error = e)
 
             // If we can't check, try to clean up anyway
             try {
                 deleteLockFiles(lockFile, socketFile, cookieFile)
                 return true
             } catch (e2: Exception) {
+                // Cleanup failed too - caller falls back to a temporary profile
+                logger.warn(LogCategory.BROWSER, "Stale lock-file cleanup failed - profile stays locked", error = e2)
             }
         }
 
@@ -1120,6 +1137,7 @@ object FluckEngine {
                 Files.deleteIfExists(file.toPath())
             } catch (e: Exception) {
                 // Fallback to File.delete()
+                logger.debug(LogCategory.BROWSER, "Files.deleteIfExists failed for lock file - falling back to File.delete", mapOf("file" to file.name, "error" to e.toString()))
                 file.delete()
             }
         }
@@ -1144,6 +1162,8 @@ object FluckEngine {
                 dir.deleteRecursively()
             }
         } catch (e: Exception) {
+            // Housekeeping only - old temp profiles are retried next startup
+            logger.debug(LogCategory.BROWSER, "Old temporary profile cleanup failed", mapOf("error" to e.toString()))
         }
     }
 
@@ -1187,11 +1207,14 @@ object FluckEngine {
         return try {
             createEngineInstance(chromiumDir, profileDirPath)
         } catch (e: UserDataDirectoryAlreadyInUseException) {
+            logger.warn(LogCategory.BROWSER, "Profile directory already in use - trying lock cleanup, then temp profile", error = e)
             // Try to clean up stale lock files first
             if (cleanupStaleLockFiles(profileDirPath)) {
                 try {
                     return createEngineInstance(chromiumDir, profileDirPath)
                 } catch (e2: Exception) {
+                    // Retry after cleanup still failed - fall through to temporary profile
+                    logger.warn(LogCategory.BROWSER, "Engine creation still failing after lock cleanup - using temporary profile", error = e2)
                 }
             }
 
@@ -1289,6 +1312,7 @@ object FluckEngine {
             val cgroup = java.io.File("/proc/1/cgroup")
             cgroup.exists() && cgroupIndicatesContainer(cgroup.readText())
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not read /proc/1/cgroup - assuming not in container", mapOf("error" to e.toString()))
             false
         }
     }
@@ -2007,6 +2031,7 @@ object FluckEngine {
                         engineClosed = true
                     } catch (e: Exception) {
                         // Continue anyway - engine may be in bad state
+                        logger.warn(LogCategory.BROWSER, "Engine close failed during reset - continuing", error = e)
                         engineClosed = true // Mark as closed since we tried
                     }
                 } else {
@@ -2029,6 +2054,7 @@ object FluckEngine {
                 killStaleChromiumProcesses()
             } catch (e: Exception) {
                 // Continue - not critical
+                logger.debug(LogCategory.BROWSER, "Stale Chromium process kill failed during reset", mapOf("error" to e.toString()))
             }
 
             // Step 4: Delete browser profile directory
@@ -2059,6 +2085,7 @@ object FluckEngine {
                 tempProfilesCleaned = true
             } catch (e: Exception) {
                 // Not critical - continue
+                logger.debug(LogCategory.BROWSER, "Temporary profile cleanup failed during reset", mapOf("error" to e.toString()))
                 tempProfilesCleaned = false
             }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldDetector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldDetector.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.plugin.browser
 
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import com.teamdev.jxbrowser.js.JsAccessible
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeout
@@ -17,6 +19,8 @@ import kotlin.time.Duration.Companion.seconds
  * Used by Issue #56 - Secret Access Integration with Fluck Browser
  */
 object FormFieldDetector {
+
+    private val logger = BossLogger.forComponent("FormFieldDetector")
 
     /**
      * Represents a form field detected in the browser
@@ -113,7 +117,8 @@ object FormFieldDetector {
                 frame.executeJavaScript<Any>(script)
             }
         } catch (e: Exception) {
-            // Detection script injection failed
+            // Detection script injection failed - auto-fill just won't offer for this page
+            logger.debug(LogCategory.BROWSER, "Form field detection script injection failed", mapOf("error" to e.toString()))
         }
     }
 
@@ -144,6 +149,7 @@ object FormFieldDetector {
                         }
                     } ?: result.complete(null)
                 } catch (e: Exception) {
+                    logger.debug(LogCategory.BROWSER, "Focused-field JS query failed - reporting no field", mapOf("error" to e.toString()))
                     result.complete(null)
                 }
             }
@@ -153,6 +159,7 @@ object FormFieldDetector {
                 result.await()
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Focused-field detection timed out or failed", mapOf("error" to e.toString()))
             null
         }
     }
@@ -204,6 +211,8 @@ object FormFieldDetector {
                 autocomplete = autocomplete
             )
         } catch (e: Exception) {
+            // Never log the JSON itself - it can contain a typed field value
+            logger.debug(LogCategory.BROWSER, "Failed to parse field info JSON - no field detected", mapOf("error" to e.toString()))
             null
         }
     }
@@ -263,6 +272,8 @@ object FormFieldDetector {
                 autocomplete = autocomplete
             )
         } catch (e: Exception) {
+            // Never log the object string itself - it can contain a typed field value
+            logger.debug(LogCategory.BROWSER, "Failed to parse legacy field info - no field detected", mapOf("error" to e.toString()))
             null
         }
     }
@@ -365,6 +376,7 @@ object FormFieldDetector {
                     // Parse result array (simplified)
                     result.complete(fields)
                 } catch (e: Exception) {
+                    logger.debug(LogCategory.BROWSER, "Form fields JS enumeration failed - reporting none", mapOf("error" to e.toString()))
                     result.complete(emptyList())
                 }
             }
@@ -373,6 +385,7 @@ object FormFieldDetector {
                 result.await()
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Form field enumeration timed out or failed", mapOf("error" to e.toString()))
             emptyList()
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldDetector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldDetector.kt
@@ -118,7 +118,11 @@ object FormFieldDetector {
             }
         } catch (e: Exception) {
             // Detection script injection failed - auto-fill just won't offer for this page
-            logger.debug(LogCategory.BROWSER, "Form field detection script injection failed", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Form field detection script injection failed",
+                mapOf("error" to e.toString()),
+            )
         }
     }
 
@@ -149,7 +153,11 @@ object FormFieldDetector {
                         }
                     } ?: result.complete(null)
                 } catch (e: Exception) {
-                    logger.debug(LogCategory.BROWSER, "Focused-field JS query failed - reporting no field", mapOf("error" to e.toString()))
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Focused-field JS query failed - reporting no field",
+                        mapOf("error" to e.toString()),
+                    )
                     result.complete(null)
                 }
             }
@@ -159,7 +167,11 @@ object FormFieldDetector {
                 result.await()
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Focused-field detection timed out or failed", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Focused-field detection timed out or failed",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -214,7 +226,11 @@ object FormFieldDetector {
             // Never log the JSON payload itself - it can contain a typed field value.
             // (e.toString() is safe here: this parser is regex/string-based, so its
             // exceptions never embed the input, unlike kotlinx.serialization's.)
-            logger.debug(LogCategory.BROWSER, "Failed to parse field info JSON - no field detected", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Failed to parse field info JSON - no field detected",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -276,7 +292,11 @@ object FormFieldDetector {
         } catch (e: Exception) {
             // Never log the object string itself - it can contain a typed field value.
             // (e.toString() is safe here: string-based parsing, exceptions never embed input.)
-            logger.debug(LogCategory.BROWSER, "Failed to parse legacy field info - no field detected", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Failed to parse legacy field info - no field detected",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }
@@ -379,7 +399,11 @@ object FormFieldDetector {
                     // Parse result array (simplified)
                     result.complete(fields)
                 } catch (e: Exception) {
-                    logger.debug(LogCategory.BROWSER, "Form fields JS enumeration failed - reporting none", mapOf("error" to e.toString()))
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Form fields JS enumeration failed - reporting none",
+                        mapOf("error" to e.toString()),
+                    )
                     result.complete(emptyList())
                 }
             }
@@ -388,7 +412,11 @@ object FormFieldDetector {
                 result.await()
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Form field enumeration timed out or failed", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Form field enumeration timed out or failed",
+                mapOf("error" to e.toString()),
+            )
             emptyList()
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldDetector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldDetector.kt
@@ -211,7 +211,9 @@ object FormFieldDetector {
                 autocomplete = autocomplete
             )
         } catch (e: Exception) {
-            // Never log the JSON itself - it can contain a typed field value
+            // Never log the JSON payload itself - it can contain a typed field value.
+            // (e.toString() is safe here: this parser is regex/string-based, so its
+            // exceptions never embed the input, unlike kotlinx.serialization's.)
             logger.debug(LogCategory.BROWSER, "Failed to parse field info JSON - no field detected", mapOf("error" to e.toString()))
             null
         }
@@ -272,7 +274,8 @@ object FormFieldDetector {
                 autocomplete = autocomplete
             )
         } catch (e: Exception) {
-            // Never log the object string itself - it can contain a typed field value
+            // Never log the object string itself - it can contain a typed field value.
+            // (e.toString() is safe here: string-based parsing, exceptions never embed input.)
             logger.debug(LogCategory.BROWSER, "Failed to parse legacy field info - no field detected", mapOf("error" to e.toString()))
             null
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldInjector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FormFieldInjector.kt
@@ -614,7 +614,8 @@ object FormFieldInjector {
             val stringSelection = java.awt.datatransfer.StringSelection(text)
             clipboard.setContents(stringSelection, null)
         } catch (e: Exception) {
-            // Clipboard copy failed
+            // Clipboard copy failed - never log the text itself (may be a secret)
+            logger.warn(LogCategory.BROWSER, "Failed to copy value to clipboard", error = e)
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/LockedBrowser.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/LockedBrowser.kt
@@ -56,7 +56,11 @@ class LockedBrowser(
         }
     } catch (e: Exception) {
         // Disposal race between the isClosed check and url() - empty is the safe answer
-        logger.debug(LogCategory.BROWSER, "browser.url() failed during disposal race - returning empty", mapOf("error" to e.toString()))
+        logger.debug(
+            LogCategory.BROWSER,
+            "browser.url() failed during disposal race - returning empty",
+            mapOf("error" to e.toString()),
+        )
         ""
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/LockedBrowser.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/LockedBrowser.kt
@@ -10,10 +10,14 @@ import com.teamdev.jxbrowser.search.FindResult
 import com.teamdev.jxbrowser.search.TextFinder
 import com.teamdev.jxbrowser.zoom.Zoom
 import com.teamdev.jxbrowser.zoom.ZoomLevel
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.util.Optional
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.function.Consumer
 import kotlin.concurrent.read
+
+private val logger = BossLogger.forComponent("LockedBrowser")
 
 /**
  * Thread-safe wrapper for JxBrowser operations.
@@ -51,6 +55,8 @@ class LockedBrowser(
             if (browser.isClosed) "" else browser.url()
         }
     } catch (e: Exception) {
+        // Disposal race between the isClosed check and url() - empty is the safe answer
+        logger.debug(LogCategory.BROWSER, "browser.url() failed during disposal race - returning empty", mapOf("error" to e.toString()))
         ""
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ScreenCapturePickerDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ScreenCapturePickerDialog.kt
@@ -35,6 +35,10 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.teamdev.jxbrowser.capture.AudioCaptureMode
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+private val logger = BossLogger.forComponent("ScreenCapturePickerDialog")
 
 /**
  * Screen capture picker dialog with Tab/Window/Screen tabs.
@@ -345,6 +349,7 @@ private fun rememberHighQualityFavicon(
             hqFavicon = try {
                 loadHighQualityFavicon(url, standardCacheKey)
             } catch (e: Exception) {
+                logger.debug(LogCategory.BROWSER, "HQ favicon load failed - using fallback icon", mapOf("error" to e.toString()))
                 null
             }
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ScreenCapturePickerDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ScreenCapturePickerDialog.kt
@@ -349,7 +349,11 @@ private fun rememberHighQualityFavicon(
             hqFavicon = try {
                 loadHighQualityFavicon(url, standardCacheKey)
             } catch (e: Exception) {
-                logger.debug(LogCategory.BROWSER, "HQ favicon load failed - using fallback icon", mapOf("error" to e.toString()))
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "HQ favicon load failed - using fallback icon",
+                    mapOf("error" to e.toString()),
+                )
                 null
             }
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -84,7 +84,11 @@ object UrlHistoryManager {
             }
         } catch (e: Exception) {
             // Invalid URL - not worth recording in history
-            logger.debug(LogCategory.BROWSER, "Ignoring history entry with unparsable URL", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Ignoring history entry with unparsable URL",
+                mapOf("error" to e.toString()),
+            )
         }
     }
     

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -83,7 +83,8 @@ object UrlHistoryManager {
                 )
             }
         } catch (e: Exception) {
-            // Invalid URL, ignore
+            // Invalid URL - not worth recording in history
+            logger.debug(LogCategory.BROWSER, "Ignoring history entry with unparsable URL", mapOf("error" to e.toString()))
         }
     }
     

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/DesktopMainFunctionDetector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/DesktopMainFunctionDetector.kt
@@ -118,7 +118,11 @@ class DesktopMainFunctionDetector : MainFunctionDetector {
                             )
                         }
                     } catch (e: Exception) {
-                        logger.debug(LogCategory.EDITOR, "Error scanning file", mapOf("path" to file.absolutePath, "error" to e.toString()))
+                        logger.debug(
+                            LogCategory.EDITOR,
+                            "Error scanning file",
+                            mapOf("path" to file.absolutePath, "error" to e.toString()),
+                        )
                     }
                 }
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/DesktopMainFunctionDetector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/DesktopMainFunctionDetector.kt
@@ -118,7 +118,7 @@ class DesktopMainFunctionDetector : MainFunctionDetector {
                             )
                         }
                     } catch (e: Exception) {
-                        logger.debug(LogCategory.EDITOR, "Error scanning file", mapOf("path" to file.absolutePath))
+                        logger.debug(LogCategory.EDITOR, "Error scanning file", mapOf("path" to file.absolutePath, "error" to e.toString()))
                     }
                 }
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/PowerShellExecutor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/PowerShellExecutor.kt
@@ -34,7 +34,7 @@ object PowerShellExecutor {
             val exitCode = process.waitFor(5, TimeUnit.SECONDS)
             exitCode && process.exitValue() == 0
         } catch (e: Exception) {
-            logger.debug(LogCategory.PASSKEY, "PowerShell not available")
+            logger.debug(LogCategory.PASSKEY, "PowerShell not available", mapOf("error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/SwiftScriptExecutor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/SwiftScriptExecutor.kt
@@ -68,7 +68,7 @@ object SwiftScriptExecutor {
             val exitCode = process.waitFor()
             exitCode == 0
         } catch (e: Exception) {
-            logger.debug(LogCategory.PASSKEY, "Swift not available")
+            logger.debug(LogCategory.PASSKEY, "Swift not available", mapOf("error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -108,6 +108,7 @@ object UpdateInstaller {
         val canonicalPath = try {
             downloadFile.canonicalPath
         } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Failed to canonicalize downloaded file path - rejecting update file", error = e)
             throw SecurityException("Failed to canonicalize path: ${downloadFile.absolutePath}")
         }
 
@@ -745,6 +746,7 @@ object UpdateInstaller {
                 jarFile
             } else null
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not determine current JAR path - not running from a JAR", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -108,7 +108,11 @@ object UpdateInstaller {
         val canonicalPath = try {
             downloadFile.canonicalPath
         } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Failed to canonicalize downloaded file path - rejecting update file", error = e)
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Failed to canonicalize downloaded file path - rejecting update file",
+                error = e,
+            )
             throw SecurityException("Failed to canonicalize path: ${downloadFile.absolutePath}")
         }
 
@@ -746,7 +750,11 @@ object UpdateInstaller {
                 jarFile
             } else null
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Could not determine current JAR path - not running from a JAR", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not determine current JAR path - not running from a JAR",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -820,7 +820,7 @@ ASKPASS_EOF
             logger.debug(LogCategory.SYSTEM, "Set executable permissions", mapOf("file" to file.name))
         } catch (e: Exception) {
             // Not a POSIX system (Windows) - ignore
-            logger.debug(LogCategory.SYSTEM, "Could not set POSIX permissions (probably Windows)")
+            logger.debug(LogCategory.SYSTEM, "Could not set POSIX permissions (probably Windows)", mapOf("error" to e.toString()))
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -820,7 +820,11 @@ ASKPASS_EOF
             logger.debug(LogCategory.SYSTEM, "Set executable permissions", mapOf("file" to file.name))
         } catch (e: Exception) {
             // Not a POSIX system (Windows) - ignore
-            logger.debug(LogCategory.SYSTEM, "Could not set POSIX permissions (probably Windows)", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not set POSIX permissions (probably Windows)",
+                mapOf("error" to e.toString()),
+            )
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
@@ -210,7 +210,11 @@ object LinuxDefaultBrowserHandler {
 
             possiblePaths.firstOrNull { it.exists() }?.absolutePath ?: "boss"
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "Icon path lookup failed - using default icon name", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "Icon path lookup failed - using default icon name",
+                mapOf("error" to e.toString()),
+            )
             "boss"
         }
     }
@@ -233,7 +237,11 @@ object LinuxDefaultBrowserHandler {
                 logger.debug(LogCategory.BROWSER, "update-desktop-database may have failed (non-critical)")
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "update-desktop-database not available or failed", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "update-desktop-database not available or failed",
+                mapOf("error" to e.toString()),
+            )
         }
     }
 
@@ -312,7 +320,11 @@ object LinuxDefaultBrowserHandler {
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "which xdg-settings failed - assuming unavailable", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "which xdg-settings failed - assuming unavailable",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
@@ -210,6 +210,7 @@ object LinuxDefaultBrowserHandler {
 
             possiblePaths.firstOrNull { it.exists() }?.absolutePath ?: "boss"
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Icon path lookup failed - using default icon name", mapOf("error" to e.toString()))
             "boss"
         }
     }
@@ -232,7 +233,7 @@ object LinuxDefaultBrowserHandler {
                 logger.debug(LogCategory.BROWSER, "update-desktop-database may have failed (non-critical)")
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "update-desktop-database not available or failed")
+            logger.debug(LogCategory.BROWSER, "update-desktop-database not available or failed", mapOf("error" to e.toString()))
         }
     }
 
@@ -311,6 +312,7 @@ object LinuxDefaultBrowserHandler {
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "which xdg-settings failed - assuming unavailable", mapOf("error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSGestureHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSGestureHandler.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.utils
 
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.awt.Component
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
@@ -14,6 +16,8 @@ import javax.swing.SwingUtilities
  * since they are NOT delivered as Ctrl+Wheel events to Java applications.
  */
 object MacOSGestureHandler {
+
+    private val logger = BossLogger.forComponent("MacOSGestureHandler")
 
     private var isAvailable: Boolean? = null
 
@@ -36,6 +40,7 @@ object MacOSGestureHandler {
                 true
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.UI, "GestureUtilities unavailable - trackpad pinch gestures disabled", mapOf("error" to e.toString()))
             false
         }
 
@@ -129,6 +134,7 @@ object MacOSGestureHandler {
                 null
             }
         } catch (e: Exception) {
+            logger.debug(LogCategory.UI, "Failed to register magnification listener via reflection - pinch zoom disabled for component", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSGestureHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSGestureHandler.kt
@@ -40,7 +40,11 @@ object MacOSGestureHandler {
                 true
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.UI, "GestureUtilities unavailable - trackpad pinch gestures disabled", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.UI,
+                "GestureUtilities unavailable - trackpad pinch gestures disabled",
+                mapOf("error" to e.toString()),
+            )
             false
         }
 
@@ -134,7 +138,9 @@ object MacOSGestureHandler {
                 null
             }
         } catch (e: Exception) {
-            logger.debug(LogCategory.UI, "Failed to register magnification listener via reflection - pinch zoom disabled for component", mapOf("error" to e.toString()))
+            logger.debug(LogCategory.UI,
+                "Failed to register magnification listener via reflection - pinch zoom disabled for component",
+                mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
@@ -325,7 +325,11 @@ object SingleInstanceManager {
                 .map { it.isAlive }
                 .orElse(false)
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Process liveness check failed - assuming dead", mapOf("pid" to pid, "error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Process liveness check failed - assuming dead",
+                mapOf("pid" to pid, "error" to e.toString()),
+            )
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
@@ -235,7 +235,7 @@ object SingleInstanceManager {
                     writer.println("OK")
                 }
             } catch (e: SocketTimeoutException) {
-                logger.warn(LogCategory.SYSTEM, "Client connection timeout")
+                logger.warn(LogCategory.SYSTEM, "Client connection timeout", error = e)
             } catch (e: Exception) {
                 logger.error(LogCategory.SYSTEM, "Error handling client", error = e)
             }
@@ -325,6 +325,7 @@ object SingleInstanceManager {
                 .map { it.isAlive }
                 .orElse(false)
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Process liveness check failed - assuming dead", mapOf("pid" to pid, "error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsDefaultBrowserHandler.kt
@@ -267,7 +267,11 @@ object WindowsDefaultBrowserHandler {
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
-            logger.debug(LogCategory.BROWSER, "reg query failed - treating browser candidate as unregistered", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.BROWSER,
+                "reg query failed - treating browser candidate as unregistered",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsDefaultBrowserHandler.kt
@@ -267,6 +267,7 @@ object WindowsDefaultBrowserHandler {
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "reg query failed - treating browser candidate as unregistered", mapOf("error" to e.toString()))
             false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
@@ -122,6 +122,7 @@ object WindowsProtocolHandler {
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "reg query failed - treating boss:// protocol as unregistered", mapOf("error" to e.toString()))
             false
         }
     }
@@ -203,6 +204,7 @@ object WindowsProtocolHandler {
             val match = Regex("""REG_SZ\s+(.+)$""", RegexOption.MULTILINE).find(output)
             match?.groupValues?.get(1)?.trim()
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "Could not read protocol handler command from registry", mapOf("error" to e.toString()))
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
@@ -122,7 +122,11 @@ object WindowsProtocolHandler {
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "reg query failed - treating boss:// protocol as unregistered", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "reg query failed - treating boss:// protocol as unregistered",
+                mapOf("error" to e.toString()),
+            )
             false
         }
     }
@@ -204,7 +208,11 @@ object WindowsProtocolHandler {
             val match = Regex("""REG_SZ\s+(.+)$""", RegexOption.MULTILINE).find(output)
             match?.groupValues?.get(1)?.trim()
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "Could not read protocol handler command from registry", mapOf("error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not read protocol handler command from registry",
+                mapOf("error" to e.toString()),
+            )
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -49,8 +49,12 @@ import org.jetbrains.compose.resources.painterResource
 import boss_kotlin.composeapp.generated.resources.Res
 import boss_kotlin.composeapp.generated.resources.boss_icon
 import androidx.compose.ui.window.*
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import java.awt.Color
 import java.awt.Frame
+
+private val bossWindowLogger = BossLogger.forComponent("BossWindow")
 
 /** Floor for a programmatic window fit ("Fit host to my screen"), in dp. Keeps a
  *  fit from collapsing the window below a usable size if a remote viewer reports a
@@ -1032,6 +1036,7 @@ fun ApplicationScope.BossWindow(
                                             }
                                             resetTerminalResult = true
                                         } catch (e: Exception) {
+                                            bossWindowLogger.warn(LogCategory.TERMINAL, "Terminal reset failed - dialog shows failure state", error = e)
                                             resetTerminalResult = false
                                         }
                                         isResetting = false

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -1036,7 +1036,11 @@ fun ApplicationScope.BossWindow(
                                             }
                                             resetTerminalResult = true
                                         } catch (e: Exception) {
-                                            bossWindowLogger.warn(LogCategory.TERMINAL, "Terminal reset failed - dialog shows failure state", error = e)
+                                            bossWindowLogger.warn(
+                                                LogCategory.TERMINAL,
+                                                "Terminal reset failed - dialog shows failure state",
+                                                error = e,
+                                            )
                                             resetTerminalResult = false
                                         }
                                         isResetting = false

--- a/plugin-platform/plugin-api-ipc/src/desktopMain/kotlin/ai/rever/boss/plugin/ipc/AuthDataProviderProxy.kt
+++ b/plugin-platform/plugin-api-ipc/src/desktopMain/kotlin/ai/rever/boss/plugin/ipc/AuthDataProviderProxy.kt
@@ -67,8 +67,11 @@ class AuthDataProviderProxy(
                     delayMs = 1_000L
                 } catch (e: kotlinx.coroutines.CancellationException) {
                     throw e
-                } catch (e: Exception) {
-                    // Connection lost — reset state and reconnect with backoff
+                } catch (ignored: Exception) {
+                    // Connection lost — the handling IS the state reset + reconnect
+                    // with backoff below. Deliberately unlogged: plugin-api-ipc has
+                    // no logging dependency, and this fires repeatedly while the
+                    // host service is down.
                     _currentUser.value = null
                     _isAdmin.value = false
                     _userPermissions.value = emptySet()

--- a/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
+++ b/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
@@ -113,7 +113,11 @@ fun parseFileReference(fileUrl: String): ParsedFileReference {
         java.net.URLDecoder.decode(fileUrl, "UTF-8")
     } catch (e: Exception) {
         // Fall back to original if decoding fails
-        fileRefLogger.debug(LogCategory.FILE, "URL-decode of file reference failed - using raw value", mapOf("error" to e.toString()))
+        fileRefLogger.debug(
+            LogCategory.FILE,
+            "URL-decode of file reference failed - using raw value",
+            mapOf("error" to e.toString()),
+        )
         fileUrl
     }
 

--- a/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
+++ b/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
+private val fileRefLogger = BossLogger.forComponent("FileEventBus")
+
 /**
  * Event emitted when a file should be opened in the editor.
  *
@@ -110,7 +112,9 @@ fun parseFileReference(fileUrl: String): ParsedFileReference {
     val decoded = try {
         java.net.URLDecoder.decode(fileUrl, "UTF-8")
     } catch (e: Exception) {
-        fileUrl // Fall back to original if decoding fails
+        // Fall back to original if decoding fails
+        fileRefLogger.debug(LogCategory.FILE, "URL-decode of file reference failed - using raw value", mapOf("error" to e.toString()))
+        fileUrl
     }
 
     // Check for Windows drive letter pattern (e.g., C:\)

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/ApiClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/ApiClassLoader.kt
@@ -74,7 +74,11 @@ class ApiClassLoader(
                     PluginManifestReader.readFromJar(jar.absolutePath)
                 } catch (e: Exception) {
                     // not a BOSS plugin jar
-                    logger.debug(LogCategory.SYSTEM, "Skipping jar without readable plugin manifest", mapOf("jar" to jar.name, "error" to e.toString()))
+                    logger.debug(
+                        LogCategory.SYSTEM,
+                        "Skipping jar without readable plugin manifest",
+                        mapOf("jar" to jar.name, "error" to e.toString()),
+                    )
                     null
                 }
                 if (manifest?.pluginId == API_PLUGIN_ID) {
@@ -103,7 +107,11 @@ class ApiClassLoader(
             val fromManifest = try {
                 JarFile(jar).use { it.manifest?.mainAttributes?.getValue("Implementation-Version") }
             } catch (e: Exception) {
-                logger.debug(LogCategory.SYSTEM, "Could not read Implementation-Version from jar manifest", mapOf("jar" to jar.name, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Could not read Implementation-Version from jar manifest",
+                    mapOf("jar" to jar.name, "error" to e.toString()),
+                )
                 null
             }
             if (!fromManifest.isNullOrBlank()) return fromManifest
@@ -111,7 +119,11 @@ class ApiClassLoader(
             return try {
                 PluginManifestReader.readFromJar(jar.absolutePath).version
             } catch (e: Exception) {
-                logger.debug(LogCategory.SYSTEM, "Could not read version from plugin manifest", mapOf("jar" to jar.name, "error" to e.toString()))
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Could not read version from plugin manifest",
+                    mapOf("jar" to jar.name, "error" to e.toString()),
+                )
                 null
             }
         }

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/ApiClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/ApiClassLoader.kt
@@ -73,7 +73,9 @@ class ApiClassLoader(
                 val manifest = try {
                     PluginManifestReader.readFromJar(jar.absolutePath)
                 } catch (e: Exception) {
-                    null // not a BOSS plugin jar
+                    // not a BOSS plugin jar
+                    logger.debug(LogCategory.SYSTEM, "Skipping jar without readable plugin manifest", mapOf("jar" to jar.name, "error" to e.toString()))
+                    null
                 }
                 if (manifest?.pluginId == API_PLUGIN_ID) {
                     val version = Version.parse(manifest.version)
@@ -101,6 +103,7 @@ class ApiClassLoader(
             val fromManifest = try {
                 JarFile(jar).use { it.manifest?.mainAttributes?.getValue("Implementation-Version") }
             } catch (e: Exception) {
+                logger.debug(LogCategory.SYSTEM, "Could not read Implementation-Version from jar manifest", mapOf("jar" to jar.name, "error" to e.toString()))
                 null
             }
             if (!fromManifest.isNullOrBlank()) return fromManifest
@@ -108,6 +111,7 @@ class ApiClassLoader(
             return try {
                 PluginManifestReader.readFromJar(jar.absolutePath).version
             } catch (e: Exception) {
+                logger.debug(LogCategory.SYSTEM, "Could not read version from plugin manifest", mapOf("jar" to jar.name, "error" to e.toString()))
                 null
             }
         }

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidator.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidator.kt
@@ -154,6 +154,7 @@ object BinaryCompatibilityValidator {
                 logger.debug(LogCategory.SYSTEM, "Soft-skipping runtime-package ref", mapOf(
                     "sourceClass" to sourceClass,
                     "ref" to ref.ownerClassName,
+                    "error" to e.toString(),
                 ))
             } else if (ref.ownerClassName.startsWith("ai.rever.boss.plugin.")) {
                 errors.add("$sourceClass -> ${ref.ownerClassName}: class not found")

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/DynamicPluginLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/DynamicPluginLoader.kt
@@ -242,6 +242,8 @@ class DynamicPluginLoaderImpl(
                 val instanceField = try {
                     pluginClass.getDeclaredField("INSTANCE")
                 } catch (e: NoSuchFieldException) {
+                    // Not a Kotlin object - fall through to constructor instantiation
+                    logger.debug(LogCategory.SYSTEM, "Plugin class has no INSTANCE field - using constructor", mapOf("error" to e.toString()))
                     null
                 }
 

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/DynamicPluginLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/DynamicPluginLoader.kt
@@ -243,7 +243,11 @@ class DynamicPluginLoaderImpl(
                     pluginClass.getDeclaredField("INSTANCE")
                 } catch (e: NoSuchFieldException) {
                     // Not a Kotlin object - fall through to constructor instantiation
-                    logger.debug(LogCategory.SYSTEM, "Plugin class has no INSTANCE field - using constructor", mapOf("error" to e.toString()))
+                    logger.debug(
+                        LogCategory.SYSTEM,
+                        "Plugin class has no INSTANCE field - using constructor",
+                        mapOf("error" to e.toString()),
+                    )
                     null
                 }
 

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -229,8 +229,10 @@ class PluginClassLoader(
                 resolveClass(clazz)
             }
             return clazz
-        } catch (e: ClassNotFoundException) {
-            // Fall back to parent
+        } catch (ignored: ClassNotFoundException) {
+            // Fall back to parent. Deliberately unlogged: this is the expected
+            // delegation path for every host-provided class a plugin touches, so
+            // logging here would flood at class-load time on a hot path.
             return parent.loadClass(name)
         }
     }

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginManifestReader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginManifestReader.kt
@@ -201,6 +201,7 @@ object PluginManifestReader {
             readFromJar(jarPath)
             true
         } catch (e: Exception) {
+            logger.debug(LogCategory.SYSTEM, "JAR has no valid plugin manifest", mapOf("jarPath" to jarPath, "error" to e.toString()))
             false
         }
     }

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginManifestReader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginManifestReader.kt
@@ -201,7 +201,11 @@ object PluginManifestReader {
             readFromJar(jarPath)
             true
         } catch (e: Exception) {
-            logger.debug(LogCategory.SYSTEM, "JAR has no valid plugin manifest", mapOf("jarPath" to jarPath, "error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "JAR has no valid plugin manifest",
+                mapOf("jarPath" to jarPath, "error" to e.toString()),
+            )
             false
         }
     }

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -56,7 +56,9 @@ object LogSanitizer {
             }
 
             "$maskedLocal@$maskedDomain"
-        } catch (e: Exception) {
+        } catch (ignored: Exception) {
+            // Deliberately unlogged: LogSanitizer runs inside the logging pipeline,
+            // so logging from here could recurse. The placeholder marks the failure.
             "[email-mask-error]"
         }
     }
@@ -203,7 +205,9 @@ object LogSanitizer {
             }
 
             base + suffix
-        } catch (e: Exception) {
+        } catch (ignored: Exception) {
+            // Deliberately unlogged: LogSanitizer runs inside the logging pipeline,
+            // so logging from here could recurse. The placeholder marks the failure.
             "[uri-parse-error]"
         }
     }
@@ -269,7 +273,9 @@ object LogSanitizer {
                 .replace(filePathPattern, "[PATH]")
                 .replace(urlPattern, "[URL]")
                 .replace(emailPattern, "[EMAIL]")
-        } catch (e: Exception) {
+        } catch (ignored: Exception) {
+            // Deliberately unlogged: LogSanitizer runs inside the logging pipeline,
+            // so logging from here could recurse. The placeholder marks the failure.
             "[sanitization-error]"
         }
     }
@@ -299,7 +305,9 @@ object LogSanitizer {
                 .replace(filePathPattern, "[PATH]")
                 .replace(urlPattern, "[URL]")
                 .replace(emailPattern, "[EMAIL]")
-        } catch (e: Exception) {
+        } catch (ignored: Exception) {
+            // Deliberately unlogged: LogSanitizer runs inside the logging pipeline,
+            // so logging from here could recurse. The placeholder marks the failure.
             "[sanitization-error]"
         }
     }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/LocalPluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/LocalPluginRepository.kt
@@ -201,7 +201,11 @@ class LocalPluginRepository(
             }
         } catch (e: Exception) {
             // Not a readable BOSS plugin JAR - callers treat null as "skip this file"
-            logger.debug(LogCategory.SYSTEM, "Could not read pluginId from JAR", mapOf("jar" to jarFile.name, "error" to e.toString()))
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not read pluginId from JAR",
+                mapOf("jar" to jarFile.name, "error" to e.toString()),
+            )
             null
         }
     }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/LocalPluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/LocalPluginRepository.kt
@@ -200,6 +200,8 @@ class LocalPluginRepository(
                 manifest.pluginId
             }
         } catch (e: Exception) {
+            // Not a readable BOSS plugin JAR - callers treat null as "skip this file"
+            logger.debug(LogCategory.SYSTEM, "Could not read pluginId from JAR", mapOf("jar" to jarFile.name, "error" to e.toString()))
             null
         }
     }


### PR DESCRIPTION
Part of the "pristine" campaign. AGENTS.md mandates BossLogger structured logging and forbids silent exception swallowing; detekt found 164 violations in live desktop code (androidMain/iosMain/wasmJsMain excluded — being deleted in a parallel PR). This PR adds a breadcrumb to every one of them with **zero behavior change**.

## Counts before / after (detekt `SwallowedException` + `EmptyCatchBlock`)

| Module | Before | After |
|---|---|---|
| composeApp (commonMain + desktopMain) | 149 (141 + 8 empty in desktopMain, incl. FluckEngine) | 0 |
| plugin-loader | 7 | 0 |
| plugin-logging | 4 | 0 |
| plugin-repository | 1 | 0 |
| plugin-events | 1 | 0 |
| plugin-api-ipc | 1 | 0 |
| buildSrc | 1 | 0 |
| **Total** | **164** | **0** |

Verified with:
`detekt --input composeApp/src/commonMain,composeApp/src/desktopMain,plugin-platform,buildSrc/src --excludes "**/build/**"`

## Zero-behavior-change guarantee

- Only log statements (and the exception-variable renames needed to reference `e`) were added.
- No control flow changed: no new rethrows, no new `CancellationException` arms, no changed return values, fallbacks, or thrown exceptions.
- Existing "deliberately ignore" comments were kept; logs were added alongside them.
- Sites that could carry secrets (clipboard copy of injected values, form-field JSON, GITHUB_TOKEN lookup) log only the exception, never the payload.

## Conventions used

- `logger.warn(LogCategory.X, "what failed and why it's non-fatal", error = e)` where the failure degrades user-visible functionality (workspace save/load, browser tab creation, settings persistence, terminal reset, passkey capability detection, engine profile lock handling).
- `logger.debug(LogCategory.X, "...", mapOf("error" to e.toString()))` where the failure is routine/expected probing (URL/domain parsing fallbacks, favicon cache misses, registry/`which`/`launchctl` probes, disposal races on JxBrowser objects, date-format fallbacks). `ComponentLogger.debug` has no `error` parameter, hence the data-map form.
- Categories follow the file's domain: BROWSER, PASSKEY, AUTH, NETWORK, UI, SYSTEM, EDITOR, FILE, WORKSPACE, TERMINAL, GENERAL.
- Files without a logger got `private val logger = BossLogger.forComponent("<Component>")` following each module's existing convention (`ai.rever.boss.utils.logging` re-exports in composeApp; `ai.rever.boss.plugin.logging` in plugin-platform). `IpcEventBridgeImpl` keeps its existing slf4j logger; `PublishPluginTask` (buildSrc) uses the Gradle task `logger`.

## Deliberate keeps (renamed `e` → `ignored` + explanatory comment, no log)

| Site | Reason |
|---|---|
| `plugin-logging/LogSanitizer.kt` (4 catches) | Runs inside the logging pipeline — logging from the sanitizer could recurse |
| `plugin-loader/PluginClassLoader.loadClassChildFirst` | Expected delegation path for every host-provided class; logging would flood a hot class-loading path |
| `plugin-api-ipc/AuthDataProviderProxy` watch loop | Module has no logging dependency; the reconnect-with-backoff below the catch is the handling, and it fires repeatedly while the host service is down |
| `composeApp/logging/LogEntry.formatTimestamp` | Runs inside the stdout/stderr capture pipeline — logging could feed back into the capture loop |

(The `ignored` name satisfies detekt's `allowedExceptionNameRegex`, so these are intentional, documented suppressions rather than lint debt.)

## Verification

- `./gradlew :composeApp:compileKotlinDesktop :composeApp:desktopTest` — BUILD SUCCESSFUL (all touched plugin-platform modules and buildSrc compiled in the same invocation).
- detekt re-run: 0 remaining `SwallowedException` / `EmptyCatchBlock` in the scanned inputs.
