### PR TITLE
Safari-style tab shrinking for the top tab bar (with Tab Sizing setting)

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/BossTabButton.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/BossTabButton.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -70,6 +71,13 @@ fun BossTabButton(
     onClick: () -> Unit,
     onClose: () -> Unit = {},
     contextMenuItems: List<ContextMenuItem> = emptyList(),
+    /**
+     * Explicit width for this tab. When provided, the tab is sized exactly to this value
+     * (no min/max content sizing). Callers compute this from available row width to get
+     * Safari-style "shrink to fit, then scroll" behaviour. Defaults to null which falls
+     * back to the legacy intrinsic-min sizing with a 180–450 dp width clamp.
+     */
+    tabWidth: Dp? = null,
     // Drag-related parameters
     tabDragComponent: TabDraggableComponent? = null,
     tabInfo: TabInfo? = null,
@@ -198,8 +206,15 @@ fun BossTabButton(
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .width(IntrinsicSize.Min)
-            .widthIn(min = 180.dp, max = 450.dp)
+            .let { base ->
+                if (tabWidth != null) {
+                    // Explicit width from the parent (Safari-style shrink-to-fit).
+                    base.width(tabWidth)
+                } else {
+                    // Legacy sizing: content-driven width clamped to 180–450 dp.
+                    base.width(IntrinsicSize.Min).widthIn(min = 180.dp, max = 450.dp)
+                }
+            }
             .hoverable(interactionSource)
             .onGloballyPositioned { coordinates ->
                 val pos = coordinates.positionInParent()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -98,6 +98,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
@@ -132,7 +133,7 @@ private fun BossTabButtonWithFavicon(
     onClick: () -> Unit,
     onClose: () -> Unit,
     contextMenuItems: List<ContextMenuItem>,
-    tabWidth: androidx.compose.ui.unit.Dp?,
+    tabWidth: Dp?,
     // Drag-related parameters
     tabDragComponent: TabDraggableComponent? = null,
     panelId: String? = null,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -165,6 +165,37 @@ private fun BossTabButtonWithFavicon(
     )
 }
 
+/**
+ * The "+" (new tab) button. Rendered either as a LazyRow item hugging the
+ * last tab (legacy FIXED sizing while everything fits) or as a fixed sibling
+ * at the right edge of the tab strip — see the call sites in BossMainTabBar.
+ */
+@Composable
+private fun NewTabButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .height(32.dp)
+            .width(32.dp)
+            .padding(4.dp)
+            .background(
+                color = BossDarkSurface,
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = "New Tab",
+            tint = BossDarkTextSecondary,
+            modifier = Modifier.size(16.dp)
+        )
+    }
+}
+
 @Composable
 fun BossTabsComponent.BossMainTabBar(
     splitViewState: ai.rever.boss.components.window_panel.SplitViewState? = null,
@@ -197,6 +228,16 @@ fun BossTabsComponent.BossMainTabBar(
     // FIXED passes null, which falls back to the legacy intrinsic sizing.
     val appearanceSettings by WindowAppearanceSettingsManager.currentSettings.collectAsState()
     val shrinkTabsToFit = appearanceSettings.tabWidthMode == TabWidthMode.SHRINK_TO_FIT
+
+    // Legacy FIXED mode only: drives whether the "+" button renders inside
+    // the row (hugging the last tab) or outside (fixed at the right edge).
+    // SHRINK_TO_FIT ignores this — its tabs always fill the bar, so the
+    // outside placement is both natural and race-free.
+    val isScrollable by remember {
+        derivedStateOf {
+            listState.canScrollForward || listState.canScrollBackward
+        }
+    }
 
     // Coroutine scope for edge scroll animation
     val edgeScrollScope = rememberCoroutineScope()
@@ -466,9 +507,11 @@ fun BossTabsComponent.BossMainTabBar(
                         }
                     )
 
-                    // Vertical divider after tab (only if not the last tab)
+                    // Vertical divider after tab (only if not the last tab).
+                    // Horizontal padding is shared with BossTabBar's width
+                    // budget — change it there, not here.
                     if (index < tabsState.value.tabs.size - 1) {
-                        VDivider(modifier = Modifier.padding(vertical = 8.dp, horizontal = 4.dp))
+                        VDivider(modifier = Modifier.padding(vertical = 8.dp, horizontal = INTER_TAB_DIVIDER_PADDING))
                     }
 
                     // Show reorder indicator after the last tab if dropping at the end
@@ -489,42 +532,45 @@ fun BossTabsComponent.BossMainTabBar(
                     }
                 }
 
+                // Legacy FIXED mode keeps its historical "+" placement:
+                // inside the row, hugging the last tab, while everything
+                // fits. This reintroduces the known one-frame glitch when
+                // isScrollable flips mid-drag, but that trade-off is what
+                // FIXED users always had — FIXED means legacy, glitch
+                // included.
+                if (!shrinkTabsToFit && !isScrollable) {
+                    item {
+                        NewTabButton(
+                            onClick = {
+                                showNewTabDialog = true
+                                // Track panel interaction when plus button is clicked
+                                if (splitViewState != null && currentPanelId != null) {
+                                    splitViewState.setActivePanel(currentPanelId)
+                                }
+                            }
+                        )
+                    }
+                }
             }
 
-            // Plus button — always rendered outside the LazyRow as a sibling
-            // of BossLeftTabBar, so it stays put when the tab strip scrolls.
-            // Previously this had inside/outside variants gated on `isScrollable`;
-            // the inside variant (a LazyRow `item { }`) scrolled off-screen the
-            // moment the user dragged the tab strip, before isScrollable could
-            // flip and the outside fallback could paint.
+            // Plus button outside the LazyRow, fixed at the right edge of the
+            // strip: always in SHRINK_TO_FIT (tabs fill the bar, so this is
+            // both natural and immune to the isScrollable race), and in FIXED
+            // mode once the row scrolls (so the button can't scroll away).
             //
             // `padding(end = 12.dp)` reserves extra breathing room on the right
             // edge so the icon doesn't feel jammed against the next bar
             // element (the right tab-bar section / window-control area).
-            Box(
-                modifier = Modifier
-                    .padding(end = 12.dp)
-                    .height(32.dp)
-                    .width(32.dp)
-                    .padding(4.dp)
-                    .background(
-                        color = BossDarkSurface,
-                        shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)
-                    )
-                    .clickable {
+            if (shrinkTabsToFit || isScrollable) {
+                NewTabButton(
+                    modifier = Modifier.padding(end = 12.dp),
+                    onClick = {
                         showNewTabDialog = true
                         // Track panel interaction when plus button is clicked
                         if (splitViewState != null && currentPanelId != null) {
                             splitViewState.setActivePanel(currentPanelId)
                         }
-                    },
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = "New Tab",
-                    tint = BossDarkTextSecondary,
-                    modifier = Modifier.size(16.dp)
+                    }
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -63,6 +63,8 @@ import ai.rever.boss.components.window_panel.SplitOrientation
 import ai.rever.boss.components.dashboard.Dashboard
 import ai.rever.boss.window.LocalWindowProjectState
 import ai.rever.boss.window.Project
+import ai.rever.boss.window.TabWidthMode
+import ai.rever.boss.window.WindowAppearanceSettingsManager
 import ai.rever.boss.window.selectProjectInWindow
 import ai.rever.boss.dashboard.SplitTemplate
 import ai.rever.boss.dashboard.SplitTemplatesManager
@@ -130,7 +132,7 @@ private fun BossTabButtonWithFavicon(
     onClick: () -> Unit,
     onClose: () -> Unit,
     contextMenuItems: List<ContextMenuItem>,
-    tabWidth: androidx.compose.ui.unit.Dp,
+    tabWidth: androidx.compose.ui.unit.Dp?,
     // Drag-related parameters
     tabDragComponent: TabDraggableComponent? = null,
     panelId: String? = null,
@@ -188,6 +190,12 @@ fun BossTabsComponent.BossMainTabBar(
 
     // LazyListState for tab bar scrolling
     val listState = rememberLazyListState()
+
+    // Tab sizing behaviour (Settings → Window Appearance → Tab Bar).
+    // SHRINK_TO_FIT passes the computed per-tab width down to each button;
+    // FIXED passes null, which falls back to the legacy intrinsic sizing.
+    val appearanceSettings by WindowAppearanceSettingsManager.currentSettings.collectAsState()
+    val shrinkTabsToFit = appearanceSettings.tabWidthMode == TabWidthMode.SHRINK_TO_FIT
 
     // Coroutine scope for edge scroll animation
     val edgeScrollScope = rememberCoroutineScope()
@@ -297,7 +305,7 @@ fun BossTabsComponent.BossMainTabBar(
                         config = config,
                         isSelected = isSelected,
                         isFocused = true, // Tab bars are always considered focused when window is active
-                        tabWidth = tabWidth,
+                        tabWidth = if (shrinkTabsToFit) tabWidth else null,
                         onClick = {
                             selectTab(index)
                             // Track this tab interaction for Cmd+R/Cmd+N

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -130,6 +130,7 @@ private fun BossTabButtonWithFavicon(
     onClick: () -> Unit,
     onClose: () -> Unit,
     contextMenuItems: List<ContextMenuItem>,
+    tabWidth: androidx.compose.ui.unit.Dp,
     // Drag-related parameters
     tabDragComponent: TabDraggableComponent? = null,
     panelId: String? = null,
@@ -152,6 +153,7 @@ private fun BossTabButtonWithFavicon(
         onClick = onClick,
         onClose = onClose,
         contextMenuItems = contextMenuItems,
+        tabWidth = tabWidth,
         tabDragComponent = tabDragComponent,
         tabInfo = config,
         panelId = panelId,
@@ -186,13 +188,6 @@ fun BossTabsComponent.BossMainTabBar(
 
     // LazyListState for tab bar scrolling
     val listState = rememberLazyListState()
-
-    // Track if tab bar is scrollable to determine plus button placement
-    val isScrollable by remember {
-        derivedStateOf {
-            listState.canScrollForward || listState.canScrollBackward
-        }
-    }
 
     // Coroutine scope for edge scroll animation
     val edgeScrollScope = rememberCoroutineScope()
@@ -277,7 +272,7 @@ fun BossTabsComponent.BossMainTabBar(
                 }
             }
         ) {
-            BossLeftTabBar(listState) {
+            BossLeftTabBar(listState, tabCount = tabsState.value.tabs.size) { tabWidth ->
                 // Render tab buttons as lazy items
                 itemsIndexed(tabsState.value.tabs) { index, config ->
                     val isSelected = index == tabsState.value.activeIndex
@@ -302,6 +297,7 @@ fun BossTabsComponent.BossMainTabBar(
                         config = config,
                         isSelected = isSelected,
                         isFocused = true, // Tab bars are always considered focused when window is active
+                        tabWidth = tabWidth,
                         onClick = {
                             selectTab(index)
                             // Track this tab interaction for Cmd+R/Cmd+N
@@ -484,65 +480,43 @@ fun BossTabsComponent.BossMainTabBar(
                     }
                 }
 
-                // Plus button as item when not scrollable (appears right after last tab)
-                if (!isScrollable) {
-                    item {
-                        Box(
-                            modifier = Modifier
-                                .height(32.dp)
-                                .width(32.dp)
-                                .padding(4.dp)
-                                .background(
-                                    color = BossDarkSurface,
-                                    shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)
-                                )
-                                .clickable {
-                                    showNewTabDialog = true
-                                    // Track panel interaction when plus button is clicked
-                                    if (splitViewState != null && currentPanelId != null) {
-                                        splitViewState.setActivePanel(currentPanelId)
-                                    }
-                                },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Add,
-                                contentDescription = "New Tab",
-                                tint = BossDarkTextSecondary,
-                                modifier = Modifier.size(16.dp)
-                            )
-                        }
-                    }
-                }
             }
 
-            // Fixed plus button (stays visible when tabs scroll - only when scrollable)
-            if (isScrollable) {
-                Box(
-                    modifier = Modifier
-                        .height(32.dp)
-                        .width(32.dp)
-                        .padding(4.dp)
-                        .background(
-                            color = BossDarkSurface,
-                            shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)
-                        )
-                        .clickable {
-                            showNewTabDialog = true
-                            // Track panel interaction when plus button is clicked
-                            if (splitViewState != null && currentPanelId != null) {
-                                splitViewState.setActivePanel(currentPanelId)
-                            }
-                        },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = "New Tab",
-                        tint = BossDarkTextSecondary,
-                        modifier = Modifier.size(16.dp)
+            // Plus button — always rendered outside the LazyRow as a sibling
+            // of BossLeftTabBar, so it stays put when the tab strip scrolls.
+            // Previously this had inside/outside variants gated on `isScrollable`;
+            // the inside variant (a LazyRow `item { }`) scrolled off-screen the
+            // moment the user dragged the tab strip, before isScrollable could
+            // flip and the outside fallback could paint.
+            //
+            // `padding(end = 12.dp)` reserves extra breathing room on the right
+            // edge so the icon doesn't feel jammed against the next bar
+            // element (the right tab-bar section / window-control area).
+            Box(
+                modifier = Modifier
+                    .padding(end = 12.dp)
+                    .height(32.dp)
+                    .width(32.dp)
+                    .padding(4.dp)
+                    .background(
+                        color = BossDarkSurface,
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)
                     )
-                }
+                    .clickable {
+                        showNewTabDialog = true
+                        // Track panel interaction when plus button is clicked
+                        if (splitViewState != null && currentPanelId != null) {
+                            splitViewState.setActivePanel(currentPanelId)
+                        }
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "New Tab",
+                    tint = BossDarkTextSecondary,
+                    modifier = Modifier.size(16.dp)
+                )
             }
 
             Spacer(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
@@ -41,6 +41,38 @@ private val MAX_TAB_WIDTH = 240.dp
 private val INTER_TAB_DIVIDER_WIDTH = 9.dp
 
 /**
+ * Per-tab width in INTEGER PIXELS, not Dp. A Dp-space division produces a
+ * fractional Dp that Compose rounds to the nearest pixel when it measures
+ * each tab. With N tabs the rounding can go up, making total content >
+ * [rowWidthPx] by a couple of pixels, which triggers the LazyRow scrollbar
+ * even when every tab is far below the max. Adding a tab swings the rounding
+ * the other way, so the bar flickers in and out.
+ *
+ * Integer-pixel division floors naturally, so total tab pixels
+ * (result * tabCount + dividersPx) is always ≤ [rowWidthPx], with at most
+ * `tabCount - 1` pixels of slack on the right — invisible and, crucially,
+ * stable.
+ *
+ * Two distinct fallbacks:
+ * - Not yet measured ([rowWidthPx] ≤ 0) or nothing to lay out
+ *   ([tabCount] ≤ 0) → [maxTabPx], the first-paint fallback.
+ * - Over-cramped (so many tabs that the dividers alone exceed the row and
+ *   the division goes ≤ 0) → the coercion clamps to [minTabPx] and the row
+ *   scrolls, same as any other below-floor result.
+ */
+internal fun computeTabWidthPx(
+    rowWidthPx: Int,
+    tabCount: Int,
+    dividerPx: Int,
+    minTabPx: Int,
+    maxTabPx: Int
+): Int {
+    if (rowWidthPx <= 0 || tabCount <= 0) return maxTabPx
+    val totalDividersPx = dividerPx * (tabCount - 1)
+    return ((rowWidthPx - totalDividersPx) / tabCount).coerceIn(minTabPx, maxTabPx)
+}
+
+/**
  * Horizontal scrollable tab bar for the left section of the main tab bar.
  *
  * Tabs shrink uniformly to fit the available width (Safari behaviour). When they
@@ -72,29 +104,16 @@ fun RowScope.BossLeftTabBar(
     val density = LocalDensity.current
 
     Column(modifier = Modifier.weight(1f).padding(horizontal = 8.dp)) {
-        // Compute tab width in INTEGER PIXELS, not Dp. A Dp-space division
-        // produces a fractional Dp that Compose rounds to the nearest pixel
-        // when it measures each tab. With N tabs the rounding can go up,
-        // making total content > rowWidthPx by a couple of pixels, which
-        // triggers the LazyRow scrollbar even when every tab is far below
-        // MAX_TAB_WIDTH. Adding a tab swings the rounding the other way, so
-        // the bar flickers in and out.
-        //
-        // Integer-pixel division floors naturally, so total tab pixels
-        // (perTabPx * tabCount + dividersPx) is always ≤ rowWidthPx, with
-        // at most `tabCount - 1` pixels of slack on the right — invisible
-        // and, crucially, stable.
-        val dividerPx = with(density) { INTER_TAB_DIVIDER_WIDTH.toPx().toInt() }
-        val totalDividersPx = if (tabCount > 1) dividerPx * (tabCount - 1) else 0
-        val perTabPx = if (tabCount > 0 && rowWidthPx > 0) {
-            (rowWidthPx - totalDividersPx) / tabCount
-        } else {
-            -1
-        }
-        val tabWidth = if (perTabPx >= 0) {
-            with(density) { perTabPx.toDp() }.coerceIn(MIN_TAB_WIDTH, MAX_TAB_WIDTH)
-        } else {
-            MAX_TAB_WIDTH
+        // All arithmetic lives in computeTabWidthPx (pure, unit-tested);
+        // here we only convert the Dp constants to pixels and back.
+        val tabWidth = with(density) {
+            computeTabWidthPx(
+                rowWidthPx = rowWidthPx,
+                tabCount = tabCount,
+                dividerPx = INTER_TAB_DIVIDER_WIDTH.toPx().toInt(),
+                minTabPx = MIN_TAB_WIDTH.roundToPx(),
+                maxTabPx = MAX_TAB_WIDTH.roundToPx()
+            ).toDp()
         }
 
         LazyRow(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
@@ -30,15 +30,20 @@ private val MIN_TAB_WIDTH = 36.dp
 private val MAX_TAB_WIDTH = 240.dp
 
 /**
- * Width consumed between adjacent tabs by the inter-tab VDivider
- * (Modifier.padding(horizontal = 4.dp) + the 1.dp line itself). Must be
- * subtracted from the available width before dividing, otherwise the rendered
- * row is wider than the viewport and the LazyRow scrolls even when every tab
- * is well below [MAX_TAB_WIDTH].
- *
- * Keep in sync with the VDivider in BossMainWindowPanel.kt's itemsIndexed block.
+ * Horizontal padding on each side of the inter-tab VDivider. Referenced by
+ * both the divider in BossMainWindowPanel.kt's itemsIndexed block and the
+ * width budget below, so the two can't drift apart.
  */
-private val INTER_TAB_DIVIDER_WIDTH = 9.dp
+internal val INTER_TAB_DIVIDER_PADDING = 4.dp
+
+/**
+ * Width consumed between adjacent tabs by the inter-tab VDivider: padding on
+ * both sides plus VDivider's fixed 1.dp line. Must be subtracted from the
+ * available width before dividing, otherwise the rendered row is wider than
+ * the viewport and the LazyRow scrolls even when every tab is well below
+ * [MAX_TAB_WIDTH].
+ */
+private val INTER_TAB_DIVIDER_WIDTH = INTER_TAB_DIVIDER_PADDING * 2 + 1.dp
 
 /**
  * Per-tab width in INTEGER PIXELS, not Dp. A Dp-space division produces a
@@ -59,6 +64,11 @@ private val INTER_TAB_DIVIDER_WIDTH = 9.dp
  * - Over-cramped (so many tabs that the dividers alone exceed the row and
  *   the division goes ≤ 0) → the coercion clamps to [minTabPx] and the row
  *   scrolls, same as any other below-floor result.
+ *
+ * Deliberately NOT budgeted: the 3.dp reorder indicator injected into the
+ * row during a tab drag. Including it would resize every tab the moment a
+ * drag starts; a transient 3px overflow near the fit boundary mid-drag is
+ * the lesser evil.
  */
 internal fun computeTabWidthPx(
     rowWidthPx: Int,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
@@ -7,35 +7,108 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+
+/**
+ * Smallest a tab is allowed to shrink to. At this width only the favicon
+ * remains visible; the title ellipses to nothing and the close button only
+ * shows on hover/select (per BossTabButton's `isSelected || isHovered`
+ * gate). Matches Safari's shrink floor.
+ */
+private val MIN_TAB_WIDTH = 36.dp
+
+/** Largest a tab will grow to even with plenty of room. Matches Safari's default. */
+private val MAX_TAB_WIDTH = 240.dp
+
+/**
+ * Width consumed between adjacent tabs by the inter-tab VDivider
+ * (Modifier.padding(horizontal = 4.dp) + the 1.dp line itself). Must be
+ * subtracted from the available width before dividing, otherwise the rendered
+ * row is wider than the viewport and the LazyRow scrolls even when every tab
+ * is well below [MAX_TAB_WIDTH].
+ *
+ * Keep in sync with the VDivider in BossMainWindowPanel.kt's itemsIndexed block.
+ */
+private val INTER_TAB_DIVIDER_WIDTH = 9.dp
 
 /**
  * Horizontal scrollable tab bar for the left section of the main tab bar.
  *
- * Displays tabs in a horizontally scrollable lazy row with a custom scrollbar indicator.
- * The scrollbar appears at the top of the content when scrolling is available.
- * Supports auto-scrolling to active tabs via the provided LazyListState.
+ * Tabs shrink uniformly to fit the available width (Safari behaviour). When they
+ * would shrink below [MIN_TAB_WIDTH], the width is clamped and the row scrolls.
+ *
+ * Implementation note: the available width is captured via [onSizeChanged]
+ * on the [LazyRow] itself, rather than wrapping the row in
+ * [BoxWithConstraints]. Both `BoxWithConstraints` and `LazyRow` are
+ * `SubcomposeLayout`s; nesting them caused every `tabCount` change to thrash
+ * the inner `LazyRow` through `disposeOrReuseStartingFromIndex` and resize
+ * the semantics `ScatterMap` on each reuse, pinning the EDT at 100% CPU
+ * after ~10 tabs. The trade-off here is one extra frame on first paint
+ * before [rowWidthPx] is populated (tabs initially render at
+ * [MAX_TAB_WIDTH], then re-measure once); after that, only tab additions
+ * trigger a re-measure and there is no nested subcomposition.
  *
  * @param listState The LazyListState for controlling scroll position
- * @param content Composable content to display in the tab bar (typically tab buttons)
+ * @param tabCount Number of tabs being rendered; needed to divide the available width
+ * @param content Receives the computed per-tab width and renders the tab buttons.
+ *   Each [content] body should size its tab to the supplied `tabWidth`.
  */
 @Composable
 fun RowScope.BossLeftTabBar(
     listState: LazyListState,
-    content: LazyListScope.() -> Unit
+    tabCount: Int,
+    content: LazyListScope.(tabWidth: Dp) -> Unit
 ) {
+    var rowWidthPx by remember { mutableStateOf(0) }
+    val density = LocalDensity.current
+
     Column(modifier = Modifier.weight(1f).padding(horizontal = 8.dp)) {
+        // Compute tab width in INTEGER PIXELS, not Dp. A Dp-space division
+        // produces a fractional Dp that Compose rounds to the nearest pixel
+        // when it measures each tab. With N tabs the rounding can go up,
+        // making total content > rowWidthPx by a couple of pixels, which
+        // triggers the LazyRow scrollbar even when every tab is far below
+        // MAX_TAB_WIDTH. Adding a tab swings the rounding the other way, so
+        // the bar flickers in and out.
+        //
+        // Integer-pixel division floors naturally, so total tab pixels
+        // (perTabPx * tabCount + dividersPx) is always ≤ rowWidthPx, with
+        // at most `tabCount - 1` pixels of slack on the right — invisible
+        // and, crucially, stable.
+        val dividerPx = with(density) { INTER_TAB_DIVIDER_WIDTH.toPx().toInt() }
+        val totalDividersPx = if (tabCount > 1) dividerPx * (tabCount - 1) else 0
+        val perTabPx = if (tabCount > 0 && rowWidthPx > 0) {
+            (rowWidthPx - totalDividersPx) / tabCount
+        } else {
+            -1
+        }
+        val tabWidth = if (perTabPx >= 0) {
+            with(density) { perTabPx.toDp() }.coerceIn(MIN_TAB_WIDTH, MAX_TAB_WIDTH)
+        } else {
+            MAX_TAB_WIDTH
+        }
+
         LazyRow(
             state = listState,
             modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { size -> rowWidthPx = size.width }
                 .horizontalLazyListScrollbar(
                     listState = listState,
                     scrollbarConfig = getBarScrollbarConfig()
                 ),
-            verticalAlignment = Alignment.CenterVertically,
-            content = content
-        )
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            content(tabWidth)
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
@@ -11,5 +11,29 @@ data class WindowAppearanceSettings(
      * Whether to show the Boss Console title bar
      * Default: true on macOS, false on Linux/Windows
      */
-    val showTitleBar: Boolean = true
+    val showTitleBar: Boolean = true,
+
+    /**
+     * How tabs in the main (top) tab bar are sized.
+     * Default: SHRINK_TO_FIT (Safari behaviour)
+     */
+    val tabWidthMode: TabWidthMode = TabWidthMode.SHRINK_TO_FIT
 )
+
+/**
+ * Sizing behaviour for top tabs in the main tab bar.
+ */
+@Serializable
+enum class TabWidthMode {
+    /**
+     * Tabs shrink uniformly to fit the available bar width (Safari behaviour).
+     * The row only scrolls once each tab has hit its favicon-sized floor.
+     */
+    SHRINK_TO_FIT,
+
+    /**
+     * Tabs take their content-driven width (clamped to 180–450 dp) and the
+     * row scrolls as soon as they overflow the bar.
+     */
+    FIXED
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/WindowAppearanceSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/WindowAppearanceSettings.kt
@@ -1,8 +1,10 @@
 package ai.rever.boss.components.settings.sections
 
+import ai.rever.boss.components.settings.shared.SettingsDropdown
 import ai.rever.boss.components.settings.shared.SettingsSection
 import ai.rever.boss.components.settings.shared.SettingsToggle
 import ai.rever.boss.components.settings.shared.SettingsInfoRow
+import ai.rever.boss.window.TabWidthMode
 import ai.rever.boss.window.WindowAppearanceSettingsManager
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
@@ -48,5 +50,30 @@ fun WindowAppearanceSettings() {
                 description = "The default setting for your operating system"
             )
         }
+
+        SettingsSection(title = "Tab Bar") {
+            SettingsDropdown(
+                label = "Tab Sizing",
+                options = TabWidthMode.entries.map { it.displayName },
+                selectedOption = settings.tabWidthMode.displayName,
+                onOptionSelected = { selected ->
+                    val mode = TabWidthMode.entries.first { it.displayName == selected }
+                    coroutineScope.launch {
+                        WindowAppearanceSettingsManager.updateSettings(
+                            settings.copy(tabWidthMode = mode)
+                        )
+                    }
+                },
+                description = "Shrink to Fit: tabs shrink evenly so they all stay visible, scrolling only " +
+                    "when each is favicon-sized (Safari style). Fixed Width: tabs keep their natural width " +
+                    "and the bar scrolls when they overflow."
+            )
+        }
     }
 }
+
+private val TabWidthMode.displayName: String
+    get() = when (this) {
+        TabWidthMode.SHRINK_TO_FIT -> "Shrink to Fit"
+        TabWidthMode.FIXED -> "Fixed Width"
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sidebar/SettingsSidebar.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sidebar/SettingsSidebar.kt
@@ -99,7 +99,7 @@ enum class SettingsSection(
     ),
     WINDOW_APPEARANCE(
         displayName = "Appearance",
-        description = "Title bar, window decorations, and theming",
+        description = "Title bar, tab sizing, and window decorations",
         icon = Icons.Outlined.DesktopWindows
     ),
     SIDEBAR(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
@@ -1,0 +1,81 @@
+package ai.rever.boss.components.window_panel
+
+import ai.rever.boss.components.window_panel.components.main_window_panels.computeTabWidthPx
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the Safari-style shrink-to-fit width computation behind
+ * BossLeftTabBar. All values are in pixels; at density 1.0 they map 1:1 to
+ * the Dp constants in BossTabBar.kt (min 36, max 240, divider 9).
+ */
+class ComputeTabWidthPxTest {
+
+    private val divider = 9
+    private val min = 36
+    private val max = 240
+
+    private fun compute(rowWidthPx: Int, tabCount: Int) =
+        computeTabWidthPx(rowWidthPx, tabCount, divider, min, max)
+
+    @Test
+    fun `single tab gets max width`() {
+        assertEquals(240, compute(rowWidthPx = 1000, tabCount = 1))
+    }
+
+    @Test
+    fun `tabs divide available width after dividers`() {
+        // (1000 - 9*9) / 10 = 91.9 → floors to 91
+        assertEquals(91, compute(rowWidthPx = 1000, tabCount = 10))
+    }
+
+    @Test
+    fun `below-floor result clamps to min and row scrolls`() {
+        // (1000 - 29*9) / 30 = 24.6 → 24 → clamped to 36
+        assertEquals(36, compute(rowWidthPx = 1000, tabCount = 30))
+    }
+
+    @Test
+    fun `dividers exceeding row width clamps to min not max`() {
+        // Regression: 30 tabs in a 200px row → dividers alone are 261px, the
+        // division goes negative. The old -1 sentinel conflated this with
+        // "not measured yet" and fell back to MAX (240) — the exact opposite
+        // of shrink-to-fit. Over-cramped must clamp to the floor.
+        assertEquals(36, compute(rowWidthPx = 200, tabCount = 30))
+    }
+
+    @Test
+    fun `unmeasured row falls back to max for first paint`() {
+        assertEquals(240, compute(rowWidthPx = 0, tabCount = 10))
+    }
+
+    @Test
+    fun `zero tabs falls back to max`() {
+        assertEquals(240, compute(rowWidthPx = 1000, tabCount = 0))
+    }
+
+    @Test
+    fun `exact fit divides evenly with no slack`() {
+        // 5 tabs at 100px + 4 dividers at 9px = 536px row
+        assertEquals(100, compute(rowWidthPx = 536, tabCount = 5))
+    }
+
+    @Test
+    fun `total content never exceeds row width in shrink range`() {
+        // The floor-division invariant that keeps the scrollbar from
+        // flickering: tabs + dividers ≤ row, for any count still above the
+        // clamp floor.
+        val row = 1234
+        for (tabCount in 1..20) {
+            val width = compute(row, tabCount)
+            if (width in (min + 1) until max) {
+                val total = width * tabCount + divider * (tabCount - 1)
+                assertTrue(
+                    total <= row,
+                    "tabCount=$tabCount: total ${total}px exceeds row ${row}px"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the top-tab "shrink to fit" behaviour from BossConsoleLite (Lite commits `75d4f503`, `fc14e840`, `833baff6`) and makes it user-selectable.

Tabs in the main tab bar previously took their content-driven width (180–450 dp) and overflowed into a scroll as soon as the bar filled. Now every tab shrinks uniformly to fit the available width — 240 dp max down to a 36 dp favicon-only floor (Safari behaviour) — and the row only scrolls once tabs hit the floor.

## Changes

- **BossTabBar** — `BossLeftTabBar` measures its own width and hands a computed per-tab width to its content lambda.
  - Width is captured with `Modifier.onSizeChanged` on the LazyRow itself, **not** `BoxWithConstraints`: nesting two SubcomposeLayouts thrashed `disposeOrReuseStartingFromIndex`/semantics `ScatterMap` on every tab-count change and pinned the EDT at 100% CPU after ~10 tabs (observed in Lite).
  - Per-tab width is computed in integer pixels (floors) rather than Dp (rounds), with the 9 dp inter-tab divider subtracted first — otherwise content overflows the viewport by a few px and the scrollbar flickers on every tab add.
- **BossTabButton** — new nullable `tabWidth` parameter; `null` preserves the legacy intrinsic sizing for callers without a parent width to apportion.
- **BossMainWindowPanel** — threads `tabWidth` through; the "+" (new tab) button is now always a sibling outside the LazyRow instead of two variants gated on `isScrollable`, whose inside variant scrolled off-screen for a frame the moment the strip was dragged.
- **Settings → Appearance → Tab Bar → Tab Sizing** — new `TabWidthMode` on `WindowAppearanceSettings` (`SHRINK_TO_FIT` default, `FIXED` legacy), persisted in `~/.boss/window-appearance-settings.json`; switching applies live. Older settings files load fine via the constructor default.

## Behaviour

| Tabs in a 1000 dp bar | Width each | Scroll? |
|---|---|---|
| 1 | 240 dp (max) | no |
| 10 | ~92 dp | no |
| 30 | 36 dp (floor) | yes |

## Testing

- `:composeApp:compileKotlinDesktop` green.
- Verified in the live dev app (`:composeApp:run` from the worktree): tabs shrink evenly as tabs open, row scrolls only at the floor, "+" stays fixed while scrolling, and the Tab Sizing dropdown switches behaviour live in both directions.