### PR TITLE
Fix multi-window tab cleanup

### DIFF
--- a/composeApp/src/androidMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/androidMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -7,6 +7,6 @@ import ai.rever.boss.plugin.browser.BrowserService
  *
  * JxBrowser is not available on Android, so this returns null.
  */
-actual fun getBrowserServiceInstance(): BrowserService? = null
+actual fun getBrowserServiceInstance(windowId: String?): BrowserService? = null
 
-internal actual fun disposePluginBrowsers() {}
+internal actual fun disposePluginBrowsers(windowId: String) {}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -5,16 +5,17 @@ import ai.rever.boss.plugin.browser.BrowserService
 /**
  * Platform-specific provider for BrowserService.
  *
- * On desktop platforms with JxBrowser support, this returns the actual implementation.
+ * On desktop platforms with JxBrowser support, this returns an implementation scoped
+ * to [windowId] so window teardown only disposes browsers owned by that window.
  * On other platforms, this returns null.
  */
-expect fun getBrowserServiceInstance(): BrowserService?
+expect fun getBrowserServiceInstance(windowId: String?): BrowserService?
 
 /**
- * Dispose all browsers created by dynamic plugins via BrowserService.
+ * Dispose browsers created by dynamic plugins in [windowId] via BrowserService.
  *
  * Called during window close to synchronously clean up plugin-created
  * JxBrowser instances before AWT window destruction.
  * No-op on non-desktop platforms.
  */
-internal expect fun disposePluginBrowsers()
+internal expect fun disposePluginBrowsers(windowId: String)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -392,7 +392,7 @@ class DefaultPlugin(
     // Browser service for plugins needing embedded browser capabilities.
     // Automation (isolated/headless sessions, auth seeding, named profiles) is
     // folded into this same service — see BrowserConfig.profileName/ephemeralProfile/auth.
-    override val browserService: BrowserService? = getBrowserServiceInstance()
+    override val browserService: BrowserService? = getBrowserServiceInstance(_windowId)
 
     // Git data provider for plugins that display git information
     override val gitDataProvider: GitDataProvider? by lazy {
@@ -926,7 +926,7 @@ class DefaultPlugin(
     fun dispose() {
         // Dispose dynamic plugin manager and sandbox manager
         runBlocking {
-            dynamicPluginManager.dispose()
+            dynamicPluginManager.disposeWindow()
             sandboxManager.dispose()
         }
         pluginScope.cancel()
@@ -1558,4 +1558,3 @@ private class DefaultContextMenuProvider : ContextMenuProvider {
             onClick = onClick
         )
 }
-

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -132,6 +132,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.File
 
+/**
+ * Per-window plugin context.
+ *
+ * @param _windowId stable ID of the owning application window. Production window
+ * contexts must provide it so plugin-created browsers participate in window-scoped
+ * cleanup. The null default is reserved for non-window/test contexts.
+ */
 class DefaultPlugin(
     override val panelRegistry: PanelRegistry,
     override val tabRegistry: TabRegistry,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -824,6 +824,18 @@ class DynamicPluginManager(
         pluginId: String,
         force: Boolean = false,
         waitForGC: Boolean = false
+    ): Result<Unit> = uninstallPlugin(
+        pluginId = pluginId,
+        force = force,
+        waitForGC = waitForGC,
+        closeTabsAcrossWindows = true
+    )
+
+    private suspend fun uninstallPlugin(
+        pluginId: String,
+        force: Boolean,
+        waitForGC: Boolean,
+        closeTabsAcrossWindows: Boolean
     ): Result<Unit> {
         // Close this plugin's open tabs on the UI thread FIRST, while its
         // classloader is still open, so Compose disposal resolves its
@@ -849,7 +861,8 @@ class DynamicPluginManager(
         // the doubled O(plugins) scan is the price of keeping the locked
         // check authoritative.)
         val candidate = pluginLoader.getPlugin(pluginId)
-        if (candidate != null &&
+        if (closeTabsAcrossWindows &&
+            candidate != null &&
             (force || (candidate.manifest.canUnload && checkCanUnload(pluginId).isAllowed))
         ) {
             pluginTabsTeardown?.let { teardown ->
@@ -1421,11 +1434,33 @@ class DynamicPluginManager(
      * Dispose the manager and all plugins.
      */
     suspend fun dispose() {
-        logger.info(LogCategory.SYSTEM, "Disposing DynamicPluginManager")
+        dispose(closeTabsAcrossWindows = true)
+    }
+
+    /**
+     * Dispose this window's plugin manager without closing plugin tabs in other windows.
+     *
+     * Each BossApp window owns a manager instance, while the global plugin tab teardown
+     * callback intentionally spans every window for explicit update/reload/uninstall.
+     * Window composition teardown must bypass that global callback.
+     */
+    suspend fun disposeWindow() {
+        dispose(closeTabsAcrossWindows = false)
+    }
+
+    private suspend fun dispose(closeTabsAcrossWindows: Boolean) {
+        logger.info(LogCategory.SYSTEM, "Disposing DynamicPluginManager", mapOf(
+            "scope" to if (closeTabsAcrossWindows) "global" else "window"
+        ))
 
         // Uninstall all plugins
         for (pluginId in _pluginStates.value.keys.toList()) {
-            uninstallPlugin(pluginId, force = true)
+            uninstallPlugin(
+                pluginId = pluginId,
+                force = true,
+                waitForGC = false,
+                closeTabsAcrossWindows = closeTabsAcrossWindows
+            )
         }
 
         // Cancel scope

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import BossDarkAccent
 import ai.rever.boss.plugin.api.Panel
+import ai.rever.boss.components.plugin.disposePluginBrowsers
 import ai.rever.boss.components.model.PanelDropZones
 import ai.rever.boss.components.model.TabDraggableComponent
 import ai.rever.boss.components.model.TabDropResult
@@ -823,6 +824,7 @@ class SplitViewState(
         getAllPanels().forEach { panel ->
             panel.tabsComponent.disposeAllTabsBlocking()
         }
+        disposePluginBrowsers(windowId)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -1832,11 +1832,10 @@ class BossTabsComponent(
         tabComponents.clear()
         // Destroy the per-tab lifecycles so plugin components that clean up in
         // lifecycle.onDestroy release their resources on window close too — same
-        // contract as removeTab, without relying on the disposeAll() hammer below.
+        // contract as removeTab. SplitViewState performs the window-scoped
+        // BrowserService fallback after every panel lifecycle has been destroyed.
         tabLifecycles.values.toList().forEach { it.destroy() }
         tabLifecycles.clear()
-        // Also dispose any browsers created by dynamic plugins via BrowserService
-        ai.rever.boss.components.plugin.disposePluginBrowsers()
     }
 }
 
@@ -1871,4 +1870,3 @@ private fun convertTabInfoToTabConfig(tabInfo: TabInfo): TabConfig {
         )
     }
 }
-

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -13,10 +13,10 @@ private val windowBrowserServices = ConcurrentHashMap<String, WindowScopedBrowse
  *
  * Returns a window-scoped view of the BrowserServiceImpl singleton that wraps
  * FluckEngine. The wrapper keeps plugin browser ownership isolated per window.
+ * A null window ID has no cleanup owner, so no browser service is exposed.
  */
 actual fun getBrowserServiceInstance(windowId: String?): BrowserService? =
     windowId?.let { windowBrowserServices.computeIfAbsent(it, ::WindowScopedBrowserService) }
-        ?: BrowserServiceImpl
 
 private class WindowScopedBrowserService(
     private val windowId: String
@@ -41,6 +41,9 @@ private class WindowScopedBrowserService(
         }
     }
 
+    /**
+     * Reports this window's owned handles, not the process-wide active count.
+     */
     override fun getActiveBrowserCount(): Int =
         BrowserServiceImpl.getActiveBrowserCountForWindow(windowId)
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -1,15 +1,29 @@
 package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.browser.BrowserService
+import ai.rever.boss.plugin.browser.BrowserConfig
+import ai.rever.boss.plugin.browser.BrowserHandle
 import ai.rever.boss.plugin.browser.BrowserServiceImpl
 
 /**
  * Desktop implementation of BrowserService provider.
  *
- * Returns the BrowserServiceImpl singleton that wraps FluckEngine.
+ * Returns a window-scoped view of the BrowserServiceImpl singleton that wraps
+ * FluckEngine. The wrapper keeps plugin browser ownership isolated per window.
  */
-actual fun getBrowserServiceInstance(): BrowserService? = BrowserServiceImpl
+actual fun getBrowserServiceInstance(windowId: String?): BrowserService? =
+    windowId?.let(::WindowScopedBrowserService) ?: BrowserServiceImpl
 
-internal actual fun disposePluginBrowsers() {
-    BrowserServiceImpl.disposeAll()
+private class WindowScopedBrowserService(
+    private val windowId: String
+) : BrowserService by BrowserServiceImpl {
+    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? =
+        BrowserServiceImpl.createBrowserForWindow(windowId, config)
+
+    override fun getActiveBrowserCount(): Int =
+        BrowserServiceImpl.getActiveBrowserCountForWindow(windowId)
+}
+
+internal actual fun disposePluginBrowsers(windowId: String) {
+    BrowserServiceImpl.disposeAllForWindow(windowId)
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -4,6 +4,9 @@ import ai.rever.boss.plugin.browser.BrowserService
 import ai.rever.boss.plugin.browser.BrowserConfig
 import ai.rever.boss.plugin.browser.BrowserHandle
 import ai.rever.boss.plugin.browser.BrowserServiceImpl
+import java.util.concurrent.ConcurrentHashMap
+
+private val windowBrowserServices = ConcurrentHashMap<String, WindowScopedBrowserService>()
 
 /**
  * Desktop implementation of BrowserService provider.
@@ -12,18 +15,45 @@ import ai.rever.boss.plugin.browser.BrowserServiceImpl
  * FluckEngine. The wrapper keeps plugin browser ownership isolated per window.
  */
 actual fun getBrowserServiceInstance(windowId: String?): BrowserService? =
-    windowId?.let(::WindowScopedBrowserService) ?: BrowserServiceImpl
+    windowId?.let { windowBrowserServices.computeIfAbsent(it, ::WindowScopedBrowserService) }
+        ?: BrowserServiceImpl
 
 private class WindowScopedBrowserService(
     private val windowId: String
 ) : BrowserService by BrowserServiceImpl {
-    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? =
-        BrowserServiceImpl.createBrowserForWindow(windowId, config)
+    private val lifecycleLock = Any()
+    private var closed = false
+
+    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? {
+        val creationStarted = synchronized(lifecycleLock) {
+            if (closed) {
+                false
+            } else {
+                BrowserServiceImpl.tryBeginBrowserCreation(windowId)
+            }
+        }
+        if (!creationStarted) return null
+
+        return try {
+            BrowserServiceImpl.createBrowserForWindow(windowId, config)
+        } finally {
+            BrowserServiceImpl.finishBrowserCreation(windowId)
+        }
+    }
 
     override fun getActiveBrowserCount(): Int =
         BrowserServiceImpl.getActiveBrowserCountForWindow(windowId)
+
+    fun close() {
+        synchronized(lifecycleLock) {
+            if (closed) return
+            closed = true
+            BrowserServiceImpl.disposeAllForWindow(windowId)
+        }
+    }
 }
 
 internal actual fun disposePluginBrowsers(windowId: String) {
-    BrowserServiceImpl.disposeAllForWindow(windowId)
+    windowBrowserServices.remove(windowId)?.close()
+        ?: BrowserServiceImpl.disposeAllForWindow(windowId)
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -103,7 +103,7 @@ internal class BrowserHandleImpl(
 
     override val id: String = UUID.randomUUID().toString()
 
-    private var _disposed = false
+    private val disposed = AtomicBoolean(false)
     private val subscriptions = mutableListOf<Subscription>()
 
     private val navigationListeners = CopyOnWriteArrayList<(String) -> Unit>()
@@ -323,7 +323,7 @@ internal class BrowserHandleImpl(
         // Browser closed
         subscriptions += browser.on(BrowserClosed::class.java) {
             logger.debug(LogCategory.BROWSER, "Browser closed", mapOf("handleId" to id))
-            _disposed = true
+            disposed.set(true)
             // Stop streaming: the underlying page is gone.
             coBrowseCapturing = false
             coBrowseSink = null
@@ -758,7 +758,7 @@ internal class BrowserHandleImpl(
     }
 
     override val isValid: Boolean
-        get() = !_disposed && !browser.isClosed &&
+        get() = !disposed.get() && !browser.isClosed &&
                 FluckEngine.currentEngineGeneration == engineGeneration
 
     override suspend fun loadUrl(url: String) {
@@ -1432,9 +1432,7 @@ internal class BrowserHandleImpl(
     }
 
     override fun dispose() {
-        if (_disposed) return
-
-        _disposed = true
+        if (!disposed.compareAndSet(false, true)) return
 
         // Stop co-browse capture so a disposed tab can never keep streaming.
         coBrowseCapturing = false

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -28,6 +28,52 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 
 /**
+ * Tracks which application window owns each plugin-created browser handle.
+ *
+ * Closing a window atomically marks it closed before draining its handles. A
+ * browser creation that finishes during teardown is therefore rejected instead
+ * of escaping cleanup and retaining the destroyed AWT window.
+ */
+internal class BrowserWindowOwnershipRegistry {
+    private val ownerByBrowserId = ConcurrentHashMap<String, String>()
+    private val closedWindowIds = ConcurrentHashMap.newKeySet<String>()
+
+    fun register(browserId: String, windowId: String): Boolean {
+        if (windowId in closedWindowIds) return false
+
+        ownerByBrowserId[browserId] = windowId
+        if (windowId in closedWindowIds) {
+            ownerByBrowserId.remove(browserId, windowId)
+            return false
+        }
+        return true
+    }
+
+    fun unregister(browserId: String) {
+        ownerByBrowserId.remove(browserId)
+    }
+
+    fun closeWindow(windowId: String): Set<String> {
+        closedWindowIds += windowId
+        return ownerByBrowserId.entries.mapNotNullTo(mutableSetOf()) { (browserId, ownerWindowId) ->
+            browserId.takeIf {
+                ownerWindowId == windowId && ownerByBrowserId.remove(browserId, windowId)
+            }
+        }
+    }
+
+    fun count(windowId: String): Int =
+        ownerByBrowserId.values.count { it == windowId }
+
+    fun closeAll(): Set<String> {
+        closedWindowIds += ownerByBrowserId.values
+        return ownerByBrowserId.keys.toSet().also {
+            ownerByBrowserId.clear()
+        }
+    }
+}
+
+/**
  * Desktop implementation of [BrowserService] that wraps [FluckEngine].
  *
  * Provides plugins with JxBrowser functionality without exposing JxBrowser types.
@@ -46,6 +92,10 @@ object BrowserServiceImpl : BrowserService {
 
     // Track active browser handles for resource management
     private val activeBrowsers = ConcurrentHashMap<String, BrowserHandleImpl>()
+
+    // BrowserService is shared process-wide, but plugin handles belong to the
+    // window whose PluginContext created them.
+    private val browserOwners = BrowserWindowOwnershipRegistry()
 
     // Managed-profile bookkeeping for handles created on an isolated profile.
     private val managedByHandle = ConcurrentHashMap<String, ManagedRef>()
@@ -139,7 +189,18 @@ object BrowserServiceImpl : BrowserService {
         }
     }
 
-    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? {
+    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? =
+        createBrowser(config, ownerWindowId = null)
+
+    internal suspend fun createBrowserForWindow(
+        windowId: String,
+        config: BrowserConfig
+    ): BrowserHandle? = createBrowser(config, ownerWindowId = windowId)
+
+    private suspend fun createBrowser(
+        config: BrowserConfig,
+        ownerWindowId: String?
+    ): BrowserHandle? {
         // Declared outside the try so the outer catch can release the managed profile
         // if anything after newBrowser() throws (see the catch below).
         var managed: ManagedRef? = null
@@ -199,6 +260,17 @@ object BrowserServiceImpl : BrowserService {
             }
             tracked = true // profile lifecycle now owned by disposeBrowser (via managedByHandle)
 
+            if (ownerWindowId != null && !browserOwners.register(handle.id, ownerWindowId)) {
+                // The window closed while browser creation was suspended. Dispose
+                // synchronously so the handle cannot retain its destroyed AWT window.
+                disposeTrackedBrowserBlocking(handle)
+                logger.debug(LogCategory.BROWSER, "Discarded browser created for closed window", mapOf(
+                    "handleId" to handle.id,
+                    "windowId" to ownerWindowId
+                ))
+                return null
+            }
+
             logger.info(LogCategory.BROWSER, "Browser created via BrowserService", mapOf(
                 "handleId" to handle.id,
                 "url" to config.url,
@@ -214,7 +286,11 @@ object BrowserServiceImpl : BrowserService {
             // stays locked for the process lifetime (deadlock) and an EPHEMERAL profile
             // leaks. Only release if we never reached the tracked point.
             if (!tracked) {
-                handleId?.let { activeBrowsers.remove(it); managedByHandle.remove(it) }
+                handleId?.let {
+                    activeBrowsers.remove(it)
+                    managedByHandle.remove(it)
+                    browserOwners.unregister(it)
+                }
                 managed?.let { releaseManaged(it) }
             }
             null
@@ -223,6 +299,7 @@ object BrowserServiceImpl : BrowserService {
 
     override suspend fun disposeBrowser(handle: BrowserHandle) {
         activeBrowsers.remove(handle.id)
+        browserOwners.unregister(handle.id)
         try {
             handle.dispose()
         } finally {
@@ -258,8 +335,39 @@ object BrowserServiceImpl : BrowserService {
         return activeBrowsers.size
     }
 
+    internal fun getActiveBrowserCountForWindow(windowId: String): Int =
+        browserOwners.count(windowId)
+
     /** Return all active browser handles for internal lookup (e.g. RPA recorder). */
     internal fun getActiveHandles(): List<BrowserHandleImpl> = activeBrowsers.values.toList()
+
+    /**
+     * Dispose plugin browsers owned by one application window.
+     *
+     * Called before that window's AWT peer is destroyed. Handles owned by other
+     * windows remain active.
+     */
+    internal fun disposeAllForWindow(windowId: String) {
+        val ownedBrowserIds = browserOwners.closeWindow(windowId)
+        var disposedCount = 0
+        ownedBrowserIds.forEach { browserId ->
+            val handle = activeBrowsers[browserId] ?: return@forEach
+            try {
+                disposeTrackedBrowserBlocking(handle)
+                disposedCount++
+            } catch (e: Exception) {
+                logger.warn(LogCategory.BROWSER, "Error disposing browser for window", mapOf(
+                    "handleId" to browserId,
+                    "windowId" to windowId
+                ), e)
+            }
+        }
+
+        logger.info(LogCategory.BROWSER, "Window browsers disposed", mapOf(
+            "windowId" to windowId,
+            "count" to disposedCount
+        ))
+    }
 
     /**
      * Dispose all active browsers.
@@ -268,9 +376,10 @@ object BrowserServiceImpl : BrowserService {
      */
     fun disposeAll() {
         val count = activeBrowsers.size
+        browserOwners.closeAll()
         activeBrowsers.values.toList().forEach { handle ->
             try {
-                handle.dispose()
+                disposeTrackedBrowserBlocking(handle)
             } catch (e: Exception) {
                 logger.warn(LogCategory.BROWSER, "Error disposing browser", error = e)
             }
@@ -278,6 +387,18 @@ object BrowserServiceImpl : BrowserService {
         activeBrowsers.clear()
 
         logger.info(LogCategory.BROWSER, "All browsers disposed", mapOf("count" to count))
+    }
+
+    private fun disposeTrackedBrowserBlocking(handle: BrowserHandleImpl) {
+        activeBrowsers.remove(handle.id, handle)
+        browserOwners.unregister(handle.id)
+        try {
+            handle.dispose()
+        } finally {
+            // Window/application teardown cannot suspend for profile accounting,
+            // but it must release profile locks and delete ephemeral profiles.
+            managedByHandle.remove(handle.id)?.let(::releaseManaged)
+        }
     }
 
     // =======================================================================

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -43,11 +43,8 @@ internal class BrowserWindowOwnershipRegistry {
     private val lock = Any()
     private val ownerByBrowserId = mutableMapOf<String, String>()
     private val creationStateByWindowId = mutableMapOf<String, WindowCreationState>()
-    private var closingAll = false
 
     fun tryBeginCreate(windowId: String): Boolean = synchronized(lock) {
-        if (closingAll) return@synchronized false
-
         val state = creationStateByWindowId.getOrPut(windowId, ::WindowCreationState)
         if (state.closing) {
             false
@@ -59,7 +56,7 @@ internal class BrowserWindowOwnershipRegistry {
 
     fun register(browserId: String, windowId: String): Boolean = synchronized(lock) {
         val state = creationStateByWindowId[windowId]
-        if (closingAll || state == null || state.closing) {
+        if (state == null || state.closing) {
             false
         } else {
             ownerByBrowserId[browserId] = windowId
@@ -67,17 +64,18 @@ internal class BrowserWindowOwnershipRegistry {
         }
     }
 
-    fun finishCreate(windowId: String) = synchronized(lock) {
-        val state = creationStateByWindowId[windowId] ?: return@synchronized
-        check(state.inFlightCreates > 0) {
-            "Browser creation finished without a matching start for window $windowId"
-        }
+    fun finishCreate(windowId: String): Boolean = synchronized(lock) {
+        val state = creationStateByWindowId[windowId] ?: return@synchronized false
+        if (state.inFlightCreates <= 0) return@synchronized false
+
         state.inFlightCreates--
         if (state.inFlightCreates == 0) {
-            // The window-scoped BrowserService permanently rejects new work after
-            // close, so no closed UUID needs to remain once admitted calls drain.
+            // The closed WindowScopedBrowserService instance rejects further work.
+            // A later service created with the same ID represents a new lifecycle,
+            // so this transient state can be discarded once admitted calls drain.
             creationStateByWindowId.remove(windowId, state)
         }
+        true
     }
 
     fun unregister(browserId: String) = synchronized(lock) {
@@ -106,17 +104,6 @@ internal class BrowserWindowOwnershipRegistry {
 
     fun count(windowId: String): Int = synchronized(lock) {
         ownerByBrowserId.values.count { it == windowId }
-    }
-
-    fun closeAll() {
-        synchronized(lock) {
-            closingAll = true
-            ownerByBrowserId.clear()
-            creationStateByWindowId.values.forEach { it.closing = true }
-            creationStateByWindowId.entries.removeAll { (_, state) ->
-                state.inFlightCreates == 0
-            }
-        }
     }
 
     internal fun trackedWindowCount(): Int = synchronized(lock) {
@@ -240,8 +227,13 @@ object BrowserServiceImpl : BrowserService {
         }
     }
 
-    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? =
-        createBrowser(config, ownerWindowId = null)
+    override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? {
+        logger.error(
+            LogCategory.BROWSER,
+            "Unscoped browser creation rejected; use a window-scoped BrowserService"
+        )
+        return null
+    }
 
     internal fun tryBeginBrowserCreation(windowId: String): Boolean =
         browserOwners.tryBeginCreate(windowId)
@@ -252,12 +244,16 @@ object BrowserServiceImpl : BrowserService {
     ): BrowserHandle? = createBrowser(config, ownerWindowId = windowId)
 
     internal fun finishBrowserCreation(windowId: String) {
-        browserOwners.finishCreate(windowId)
+        if (!browserOwners.finishCreate(windowId)) {
+            logger.error(LogCategory.BROWSER, "Unbalanced browser creation finish ignored", mapOf(
+                "windowId" to windowId
+            ))
+        }
     }
 
     private suspend fun createBrowser(
         config: BrowserConfig,
-        ownerWindowId: String?
+        ownerWindowId: String
     ): BrowserHandle? {
         // Declared outside the try so the outer catch can release the managed profile
         // if anything after newBrowser() throws (see the catch below).
@@ -318,7 +314,7 @@ object BrowserServiceImpl : BrowserService {
             }
             tracked = true // profile lifecycle now owned by disposeBrowser (via managedByHandle)
 
-            if (ownerWindowId != null && !browserOwners.register(handle.id, ownerWindowId)) {
+            if (!browserOwners.register(handle.id, ownerWindowId)) {
                 // The window closed while browser creation was suspended. Dispose
                 // synchronously so the handle cannot retain its destroyed AWT window.
                 disposeTrackedBrowserBlocking(handle)
@@ -426,26 +422,6 @@ object BrowserServiceImpl : BrowserService {
             "windowId" to windowId,
             "count" to disposedCount
         ))
-    }
-
-    /**
-     * Dispose all active browsers.
-     *
-     * Called during application shutdown to ensure clean cleanup.
-     */
-    fun disposeAll() {
-        val count = activeBrowsers.size
-        browserOwners.closeAll()
-        activeBrowsers.values.toList().forEach { handle ->
-            try {
-                disposeTrackedBrowserBlocking(handle)
-            } catch (e: Exception) {
-                logger.warn(LogCategory.BROWSER, "Error disposing browser", error = e)
-            }
-        }
-        activeBrowsers.clear()
-
-        logger.info(LogCategory.BROWSER, "All browsers disposed", mapOf("count" to count))
     }
 
     private fun disposeTrackedBrowserBlocking(handle: BrowserHandleImpl): Boolean {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -35,41 +35,92 @@ import java.util.concurrent.ConcurrentLinkedDeque
  * of escaping cleanup and retaining the destroyed AWT window.
  */
 internal class BrowserWindowOwnershipRegistry {
-    private val ownerByBrowserId = ConcurrentHashMap<String, String>()
-    private val closedWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private data class WindowCreationState(
+        var inFlightCreates: Int = 0,
+        var closing: Boolean = false
+    )
 
-    fun register(browserId: String, windowId: String): Boolean {
-        if (windowId in closedWindowIds) return false
+    private val lock = Any()
+    private val ownerByBrowserId = mutableMapOf<String, String>()
+    private val creationStateByWindowId = mutableMapOf<String, WindowCreationState>()
+    private var closingAll = false
 
-        ownerByBrowserId[browserId] = windowId
-        if (windowId in closedWindowIds) {
-            ownerByBrowserId.remove(browserId, windowId)
-            return false
+    fun tryBeginCreate(windowId: String): Boolean = synchronized(lock) {
+        if (closingAll) return@synchronized false
+
+        val state = creationStateByWindowId.getOrPut(windowId, ::WindowCreationState)
+        if (state.closing) {
+            false
+        } else {
+            state.inFlightCreates++
+            true
         }
-        return true
     }
 
-    fun unregister(browserId: String) {
+    fun register(browserId: String, windowId: String): Boolean = synchronized(lock) {
+        val state = creationStateByWindowId[windowId]
+        if (closingAll || state == null || state.closing) {
+            false
+        } else {
+            ownerByBrowserId[browserId] = windowId
+            true
+        }
+    }
+
+    fun finishCreate(windowId: String) = synchronized(lock) {
+        val state = creationStateByWindowId[windowId] ?: return@synchronized
+        check(state.inFlightCreates > 0) {
+            "Browser creation finished without a matching start for window $windowId"
+        }
+        state.inFlightCreates--
+        if (state.inFlightCreates == 0) {
+            // The window-scoped BrowserService permanently rejects new work after
+            // close, so no closed UUID needs to remain once admitted calls drain.
+            creationStateByWindowId.remove(windowId, state)
+        }
+    }
+
+    fun unregister(browserId: String) = synchronized(lock) {
         ownerByBrowserId.remove(browserId)
     }
 
-    fun closeWindow(windowId: String): Set<String> {
-        closedWindowIds += windowId
-        return ownerByBrowserId.entries.mapNotNullTo(mutableSetOf()) { (browserId, ownerWindowId) ->
-            browserId.takeIf {
-                ownerWindowId == windowId && ownerByBrowserId.remove(browserId, windowId)
+    fun closeWindow(windowId: String): Set<String> = synchronized(lock) {
+        val state = creationStateByWindowId.getOrPut(windowId, ::WindowCreationState)
+        state.closing = true
+
+        val ownedBrowserIds = mutableSetOf<String>()
+        val owners = ownerByBrowserId.iterator()
+        while (owners.hasNext()) {
+            val (browserId, ownerWindowId) = owners.next()
+            if (ownerWindowId == windowId) {
+                ownedBrowserIds += browserId
+                owners.remove()
+            }
+        }
+
+        if (state.inFlightCreates == 0) {
+            creationStateByWindowId.remove(windowId, state)
+        }
+        ownedBrowserIds
+    }
+
+    fun count(windowId: String): Int = synchronized(lock) {
+        ownerByBrowserId.values.count { it == windowId }
+    }
+
+    fun closeAll() {
+        synchronized(lock) {
+            closingAll = true
+            ownerByBrowserId.clear()
+            creationStateByWindowId.values.forEach { it.closing = true }
+            creationStateByWindowId.entries.removeAll { (_, state) ->
+                state.inFlightCreates == 0
             }
         }
     }
 
-    fun count(windowId: String): Int =
-        ownerByBrowserId.values.count { it == windowId }
-
-    fun closeAll(): Set<String> {
-        closedWindowIds += ownerByBrowserId.values
-        return ownerByBrowserId.keys.toSet().also {
-            ownerByBrowserId.clear()
-        }
+    internal fun trackedWindowCount(): Int = synchronized(lock) {
+        creationStateByWindowId.size
     }
 }
 
@@ -192,10 +243,17 @@ object BrowserServiceImpl : BrowserService {
     override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? =
         createBrowser(config, ownerWindowId = null)
 
+    internal fun tryBeginBrowserCreation(windowId: String): Boolean =
+        browserOwners.tryBeginCreate(windowId)
+
     internal suspend fun createBrowserForWindow(
         windowId: String,
         config: BrowserConfig
     ): BrowserHandle? = createBrowser(config, ownerWindowId = windowId)
+
+    internal fun finishBrowserCreation(windowId: String) {
+        browserOwners.finishCreate(windowId)
+    }
 
     private suspend fun createBrowser(
         config: BrowserConfig,
@@ -353,8 +411,9 @@ object BrowserServiceImpl : BrowserService {
         ownedBrowserIds.forEach { browserId ->
             val handle = activeBrowsers[browserId] ?: return@forEach
             try {
-                disposeTrackedBrowserBlocking(handle)
-                disposedCount++
+                if (disposeTrackedBrowserBlocking(handle)) {
+                    disposedCount++
+                }
             } catch (e: Exception) {
                 logger.warn(LogCategory.BROWSER, "Error disposing browser for window", mapOf(
                     "handleId" to browserId,
@@ -389,8 +448,9 @@ object BrowserServiceImpl : BrowserService {
         logger.info(LogCategory.BROWSER, "All browsers disposed", mapOf("count" to count))
     }
 
-    private fun disposeTrackedBrowserBlocking(handle: BrowserHandleImpl) {
-        activeBrowsers.remove(handle.id, handle)
+    private fun disposeTrackedBrowserBlocking(handle: BrowserHandleImpl): Boolean {
+        if (!activeBrowsers.remove(handle.id, handle)) return false
+
         browserOwners.unregister(handle.id)
         try {
             handle.dispose()
@@ -399,6 +459,7 @@ object BrowserServiceImpl : BrowserService {
             // but it must release profile locks and delete ephemeral profiles.
             managedByHandle.remove(handle.id)?.let(::releaseManaged)
         }
+        return true
     }
 
     // =======================================================================

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.browser
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -13,6 +14,28 @@ import kotlin.test.assertTrue
  * named-profile metadata persistence.
  */
 class BrowserServiceImplTest {
+
+    @Test
+    fun `closing one window drains only its browser handles`() {
+        val registry = BrowserWindowOwnershipRegistry()
+        assertTrue(registry.register("first-1", "first-window"))
+        assertTrue(registry.register("first-2", "first-window"))
+        assertTrue(registry.register("second-1", "second-window"))
+
+        assertEquals(setOf("second-1"), registry.closeWindow("second-window"))
+        assertEquals(2, registry.count("first-window"))
+        assertEquals(0, registry.count("second-window"))
+        assertEquals(setOf("first-1", "first-2"), registry.closeWindow("first-window"))
+    }
+
+    @Test
+    fun `browser finishing creation after window close is rejected`() {
+        val registry = BrowserWindowOwnershipRegistry()
+
+        assertTrue(registry.closeWindow("closing-window").isEmpty())
+        assertFalse(registry.register("late-browser", "closing-window"))
+        assertEquals(0, registry.count("closing-window"))
+    }
 
     @Test
     fun `cookieDomain strips scheme, path, query, fragment and port`() {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
@@ -1,8 +1,11 @@
 package ai.rever.boss.plugin.browser
 
+import ai.rever.boss.components.plugin.getBrowserServiceInstance
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -47,6 +50,20 @@ class BrowserServiceImplTest {
 
         assertEquals(0, registry.count("closing-window"))
         assertEquals(0, registry.trackedWindowCount())
+    }
+
+    @Test
+    fun `unbalanced browser creation finish is ignored`() {
+        val registry = BrowserWindowOwnershipRegistry()
+
+        assertFalse(registry.finishCreate("unknown-window"))
+        assertEquals(0, registry.trackedWindowCount())
+    }
+
+    @Test
+    fun `browser creation requires a window cleanup owner`() = runBlocking {
+        assertNull(getBrowserServiceInstance(null))
+        assertNull(BrowserServiceImpl.createBrowser(BrowserConfig()))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
@@ -18,9 +18,15 @@ class BrowserServiceImplTest {
     @Test
     fun `closing one window drains only its browser handles`() {
         val registry = BrowserWindowOwnershipRegistry()
+        assertTrue(registry.tryBeginCreate("first-window"))
         assertTrue(registry.register("first-1", "first-window"))
+        registry.finishCreate("first-window")
+        assertTrue(registry.tryBeginCreate("first-window"))
         assertTrue(registry.register("first-2", "first-window"))
+        registry.finishCreate("first-window")
+        assertTrue(registry.tryBeginCreate("second-window"))
         assertTrue(registry.register("second-1", "second-window"))
+        registry.finishCreate("second-window")
 
         assertEquals(setOf("second-1"), registry.closeWindow("second-window"))
         assertEquals(2, registry.count("first-window"))
@@ -32,9 +38,15 @@ class BrowserServiceImplTest {
     fun `browser finishing creation after window close is rejected`() {
         val registry = BrowserWindowOwnershipRegistry()
 
+        assertTrue(registry.tryBeginCreate("closing-window"))
         assertTrue(registry.closeWindow("closing-window").isEmpty())
         assertFalse(registry.register("late-browser", "closing-window"))
+        assertFalse(registry.tryBeginCreate("closing-window"))
+        assertEquals(1, registry.trackedWindowCount())
+        registry.finishCreate("closing-window")
+
         assertEquals(0, registry.count("closing-window"))
+        assertEquals(0, registry.trackedWindowCount())
     }
 
     @Test

--- a/composeApp/src/iosMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/iosMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -7,6 +7,6 @@ import ai.rever.boss.plugin.browser.BrowserService
  *
  * JxBrowser is not available on iOS, so this returns null.
  */
-actual fun getBrowserServiceInstance(): BrowserService? = null
+actual fun getBrowserServiceInstance(windowId: String?): BrowserService? = null
 
-internal actual fun disposePluginBrowsers() {}
+internal actual fun disposePluginBrowsers(windowId: String) {}

--- a/composeApp/src/wasmJsMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/wasmJsMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -7,6 +7,6 @@ import ai.rever.boss.plugin.browser.BrowserService
  *
  * JxBrowser is not available in WASM, so this returns null.
  */
-actual fun getBrowserServiceInstance(): BrowserService? = null
+actual fun getBrowserServiceInstance(windowId: String?): BrowserService? = null
 
-internal actual fun disposePluginBrowsers() {}
+internal actual fun disposePluginBrowsers(windowId: String) {}


### PR DESCRIPTION
## What changed

- Scope plugin-created browser ownership and disposal to the BossConsole window that created each browser.
- Reject browser handles that finish creation after their owning window has begun closing.
- Move the browser cleanup fallback to the window-level split view teardown so it runs once after tab lifecycles are destroyed.
- Add a window-specific dynamic plugin manager disposal path that does not invoke cross-window tab teardown.
- Preserve global tab teardown for explicit plugin update, reload, uninstall, and application-wide disposal.

## Why

Closing a secondary BossConsole window also closed tabs in the first window. Two process-wide cleanup paths were being used during per-window composition teardown:

1. `BrowserServiceImpl.disposeAll()` disposed plugin browsers across every window.
2. `DynamicPluginManager.dispose()` force-uninstalled plugins and invoked the global plugin-tab teardown callback, which intentionally closes that plugin's tabs across all windows.

Window shutdown now cleans up only resources owned by the closing window, while explicit global plugin lifecycle operations retain their existing behavior.

## Impact

Closing one BossConsole window no longer tears down plugin tabs or browser handles belonging to other open windows.

## Validation

- `./gradlew :composeApp:desktopTest`
- `git diff --check`
- Launched the rebased worktree with `./gradlew composeApp:run` using the local development configuration for manual multi-window verification.
