### PR TITLE
Scope browser keyboard input to its owner window

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -13,10 +13,12 @@ private val windowBrowserServices = ConcurrentHashMap<String, WindowScopedBrowse
  *
  * Returns a window-scoped view of the BrowserServiceImpl singleton that wraps
  * FluckEngine. The wrapper keeps plugin browser ownership isolated per window.
- * A null window ID has no cleanup owner, so no browser service is exposed.
+ * A null or blank window ID has no valid cleanup owner, so no service is exposed.
  */
 actual fun getBrowserServiceInstance(windowId: String?): BrowserService? =
-    windowId?.let { windowBrowserServices.computeIfAbsent(it, ::WindowScopedBrowserService) }
+    windowId
+        ?.takeIf(String::isNotBlank)
+        ?.let { windowBrowserServices.computeIfAbsent(it, ::WindowScopedBrowserService) }
 
 private class WindowScopedBrowserService(
     private val windowId: String

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -96,7 +96,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 internal class BrowserHandleImpl(
     private val browser: Browser,
     private val config: BrowserConfig,
-    private val engineGeneration: Long
+    private val engineGeneration: Long,
+    private val ownerWindowId: String
 ) : BrowserHandle {
 
     private val logger = BossLogger.forComponent("BrowserHandleImpl")
@@ -338,7 +339,7 @@ internal class BrowserHandleImpl(
         }
 
         // Setup keyboard interceptor for menu shortcuts
-        FluckEngine.setupKeyboardInterceptor(browser)
+        FluckEngine.setupKeyboardInterceptor(browser, ownerWindowId)
 
         // Setup screen capture handler
         FluckEngine.setupCaptureSessionHandler(browser)
@@ -676,7 +677,7 @@ internal class BrowserHandleImpl(
                     )
                     "keydown", "keyup" -> {
                         val keyCode = jsKeyToKeyCode(str("key"), str("code"))
-                        val ch = str("ch").firstOrNull() ?: ' '
+                        val ch = str("ch").firstOrNull() ?: '\u0000'
                         val mods = KeyModifiers.newBuilder()
                             .shiftDown(bool("shift"))
                             .controlDown(bool("ctrl"))
@@ -687,7 +688,7 @@ internal class BrowserHandleImpl(
                             browser.dispatch(KeyPressed.newBuilder(keyCode).keyChar(ch).keyModifiers(mods).build())
                             // KeyTyped delivers the character to the focused field; only for
                             // printable input (modifier chords and control keys must not type).
-                            if (ch != ' ' && !ch.isISOControl() && !bool("ctrl") && !bool("meta")) {
+                            if (ch != '\u0000' && !ch.isISOControl() && !bool("ctrl") && !bool("meta")) {
                                 browser.dispatch(KeyTyped.newBuilder(keyCode).keyChar(ch).keyModifiers(mods).build())
                             }
                         } else {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -238,6 +238,11 @@ object BrowserServiceImpl : BrowserService {
     internal fun tryBeginBrowserCreation(windowId: String): Boolean =
         browserOwners.tryBeginCreate(windowId)
 
+    /**
+     * Internal defensive boundary used after the public provider has already
+     * rejected null or blank owner IDs. Direct callers receive an exception
+     * because creating an unowned browser would bypass window-scoped cleanup.
+     */
     internal suspend fun createBrowserForWindow(
         windowId: String,
         config: BrowserConfig

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -241,7 +241,10 @@ object BrowserServiceImpl : BrowserService {
     internal suspend fun createBrowserForWindow(
         windowId: String,
         config: BrowserConfig
-    ): BrowserHandle? = createBrowser(config, ownerWindowId = windowId)
+    ): BrowserHandle? {
+        require(windowId.isNotBlank()) { "Browser owner windowId must not be blank" }
+        return createBrowser(config, ownerWindowId = windowId)
+    }
 
     internal fun finishBrowserCreation(windowId: String) {
         if (!browserOwners.finishCreate(windowId)) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -301,7 +301,12 @@ object BrowserServiceImpl : BrowserService {
                 config
             }
 
-            val handle = BrowserHandleImpl(browser, effectiveConfig, generation)
+            val handle = BrowserHandleImpl(
+                browser = browser,
+                config = effectiveConfig,
+                engineGeneration = generation,
+                ownerWindowId = ownerWindowId
+            )
             handleId = handle.id
             activeBrowsers[handle.id] = handle
             m?.let {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1564,12 +1564,34 @@ object FluckEngine {
         }
     }
 
+    internal data class BrowserKeyEventRoute(
+        val acceptsInput: Boolean,
+        val shortcutWindowId: String?
+    )
+
     /**
-     * Null focus represents the legacy unowned browser path; only an explicitly
-     * inactive owner is rejected.
+     * Resolves both input acceptance and the destination for application shortcuts.
+     * A window-owned browser is accepted only while its owner is focused, and its
+     * stable owner always wins over the legacy process-focused fallback.
      */
-    internal fun shouldAcceptBrowserKeyEvent(ownerWindowIsFocused: Boolean?): Boolean =
-        ownerWindowIsFocused != false
+    internal fun resolveBrowserKeyEventRoute(
+        ownerWindowId: String?,
+        ownerWindowIsFocused: Boolean?,
+        fallbackFocusedWindowId: String?
+    ): BrowserKeyEventRoute = when {
+        ownerWindowId == null -> BrowserKeyEventRoute(
+            acceptsInput = true,
+            shortcutWindowId = fallbackFocusedWindowId
+        )
+        ownerWindowIsFocused == true -> BrowserKeyEventRoute(
+            acceptsInput = true,
+            shortcutWindowId = ownerWindowId
+        )
+        else -> BrowserKeyEventRoute(
+            acceptsInput = false,
+            shortcutWindowId = null
+        )
+    }
 
     /**
      * Sets up keyboard interceptor for a browser to forward menu shortcuts to the native menu bar.
@@ -1590,11 +1612,19 @@ object FluckEngine {
                 val modifiers = event.keyModifiers()
                 val keyCode = event.keyCode()
 
-                val ownerWindowIsFocused = ownerWindowId?.let(WindowFocusManager::isWindowFocused)
-                if (!shouldAcceptBrowserKeyEvent(ownerWindowIsFocused)) {
+                val route = resolveBrowserKeyEventRoute(
+                    ownerWindowId = ownerWindowId,
+                    ownerWindowIsFocused = ownerWindowId?.let(WindowFocusManager::isWindowFocused),
+                    fallbackFocusedWindowId = if (ownerWindowId == null) {
+                        WindowFocusManager.focusedWindowFlow.value
+                    } else {
+                        null
+                    }
+                )
+                if (!route.acceptsInput) {
                     return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                 }
-                val shortcutWindowId = ownerWindowId ?: WindowFocusManager.focusedWindowFlow.value
+                val shortcutWindowId = route.shortcutWindowId
 
                 // Platform-aware main modifier: Cmd on macOS, Ctrl on Windows/Linux
                 val isMainModifierDown = if (SystemUtils.isMacOS) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -41,6 +41,7 @@ import java.awt.Toolkit
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.*
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Classification of engine initialization errors for better user feedback.
@@ -1576,14 +1577,14 @@ object FluckEngine {
      */
     internal fun resolveBrowserKeyEventRoute(
         ownerWindowId: String?,
-        ownerWindowIsFocused: Boolean?,
+        ownerWindowIsFocused: Boolean,
         fallbackFocusedWindowId: String?
     ): BrowserKeyEventRoute = when {
         ownerWindowId == null -> BrowserKeyEventRoute(
             acceptsInput = true,
             shortcutWindowId = fallbackFocusedWindowId
         )
-        ownerWindowIsFocused == true -> BrowserKeyEventRoute(
+        ownerWindowIsFocused -> BrowserKeyEventRoute(
             acceptsInput = true,
             shortcutWindowId = ownerWindowId
         )
@@ -1606,6 +1607,7 @@ object FluckEngine {
         browser: com.teamdev.jxbrowser.browser.Browser,
         ownerWindowId: String? = null
     ) {
+        val suppressionLogged = AtomicBoolean(false)
         browser.set(com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback::class.java,
             com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback { params ->
                 val event = params.event()
@@ -1614,7 +1616,7 @@ object FluckEngine {
 
                 val route = resolveBrowserKeyEventRoute(
                     ownerWindowId = ownerWindowId,
-                    ownerWindowIsFocused = ownerWindowId?.let(WindowFocusManager::isWindowFocused),
+                    ownerWindowIsFocused = ownerWindowId?.let(WindowFocusManager::isWindowFocused) == true,
                     fallbackFocusedWindowId = if (ownerWindowId == null) {
                         WindowFocusManager.focusedWindowFlow.value
                     } else {
@@ -1622,8 +1624,21 @@ object FluckEngine {
                     }
                 )
                 if (!route.acceptsInput) {
+                    ownerWindowId?.let { windowId ->
+                        if (suppressionLogged.compareAndSet(false, true)) {
+                            logger.debug(
+                                LogCategory.BROWSER,
+                                "Browser key input suppressed because owner window is not focused",
+                                mapOf(
+                                    "ownerWindowId" to windowId,
+                                    "ownerRegistered" to (WindowFocusManager.getWindow(windowId) != null)
+                                )
+                            )
+                        }
+                    }
                     return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                 }
+                suppressionLogged.set(false)
                 val shortcutWindowId = route.shortcutWindowId
 
                 // Platform-aware main modifier: Cmd on macOS, Ctrl on Windows/Linux

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1565,13 +1565,11 @@ object FluckEngine {
     }
 
     /**
-     * Browser handles created outside the window-scoped service retain their legacy behavior.
-     * Window-owned handles accept input only while their owning AWT window is focused.
+     * Null focus represents the legacy unowned browser path; only an explicitly
+     * inactive owner is rejected.
      */
-    internal fun shouldAcceptBrowserKeyEvent(
-        ownerWindowId: String?,
-        ownerWindowIsFocused: Boolean
-    ): Boolean = ownerWindowId == null || ownerWindowIsFocused
+    internal fun shouldAcceptBrowserKeyEvent(ownerWindowIsFocused: Boolean?): Boolean =
+        ownerWindowIsFocused != false
 
     /**
      * Sets up keyboard interceptor for a browser to forward menu shortcuts to the native menu bar.
@@ -1592,10 +1590,8 @@ object FluckEngine {
                 val modifiers = event.keyModifiers()
                 val keyCode = event.keyCode()
 
-                val ownerWindowIsFocused = ownerWindowId
-                    ?.let(WindowFocusManager::isWindowFocused)
-                    ?: false
-                if (!shouldAcceptBrowserKeyEvent(ownerWindowId, ownerWindowIsFocused)) {
+                val ownerWindowIsFocused = ownerWindowId?.let(WindowFocusManager::isWindowFocused)
+                if (!shouldAcceptBrowserKeyEvent(ownerWindowIsFocused)) {
                     return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                 }
                 val shortcutWindowId = ownerWindowId ?: WindowFocusManager.focusedWindowFlow.value

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1565,16 +1565,40 @@ object FluckEngine {
     }
 
     /**
+     * Browser handles created outside the window-scoped service retain their legacy behavior.
+     * Window-owned handles accept input only while their owning AWT window is focused.
+     */
+    internal fun shouldAcceptBrowserKeyEvent(
+        ownerWindowId: String?,
+        ownerWindowIsFocused: Boolean
+    ): Boolean = ownerWindowId == null || ownerWindowIsFocused
+
+    /**
      * Sets up keyboard interceptor for a browser to forward menu shortcuts to the native menu bar.
      * This intercepts Cmd+R, Cmd+N, Cmd+T, Cmd+W, etc. (on macOS) or Ctrl+R, Ctrl+N, etc. (on Windows/Linux)
      * before JxBrowser consumes them, and manually triggers the corresponding MenuActionsHandler methods.
+     * Window-owned browsers suppress every key event while their AWT window is inactive.
+     *
+     * @param ownerWindowId stable owner used for focus gating and shortcut dispatch; null preserves
+     * legacy behavior for the old unscoped browser helper.
      */
-    fun setupKeyboardInterceptor(browser: com.teamdev.jxbrowser.browser.Browser) {
+    fun setupKeyboardInterceptor(
+        browser: com.teamdev.jxbrowser.browser.Browser,
+        ownerWindowId: String? = null
+    ) {
         browser.set(com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback::class.java,
             com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback { params ->
                 val event = params.event()
                 val modifiers = event.keyModifiers()
                 val keyCode = event.keyCode()
+
+                val ownerWindowIsFocused = ownerWindowId
+                    ?.let(WindowFocusManager::isWindowFocused)
+                    ?: false
+                if (!shouldAcceptBrowserKeyEvent(ownerWindowId, ownerWindowIsFocused)) {
+                    return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
+                }
+                val shortcutWindowId = ownerWindowId ?: WindowFocusManager.focusedWindowFlow.value
 
                 // Platform-aware main modifier: Cmd on macOS, Ctrl on Windows/Linux
                 val isMainModifierDown = if (SystemUtils.isMacOS) {
@@ -1586,24 +1610,22 @@ object FluckEngine {
 
                 // Intercept main modifier + key shortcuts
                 if (isMainModifierDown && !modifiers.isShiftDown && !modifiers.isAltDown) {
-                    // Read focusedWindowId here to minimize race window between read and use
-                    val focusedWindowId = WindowFocusManager.focusedWindowFlow.value
-                    if (focusedWindowId != null) {
+                    if (shortcutWindowId != null) {
                         when (keyCode) {
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_R -> {
-                                ai.rever.boss.window.MenuActionsHandler.triggerReloadBrowser(focusedWindowId)
+                                ai.rever.boss.window.MenuActionsHandler.triggerReloadBrowser(shortcutWindowId)
                                 return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                             }
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_N -> {
-                                ai.rever.boss.window.MenuActionsHandler.triggerNewTab(focusedWindowId)
+                                ai.rever.boss.window.MenuActionsHandler.triggerNewTab(shortcutWindowId)
                                 return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                             }
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_T -> {
-                                ai.rever.boss.window.MenuActionsHandler.triggerNewTab(focusedWindowId)
+                                ai.rever.boss.window.MenuActionsHandler.triggerNewTab(shortcutWindowId)
                                 return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                             }
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_W -> {
-                                ai.rever.boss.window.MenuActionsHandler.triggerCloseTab(focusedWindowId)
+                                ai.rever.boss.window.MenuActionsHandler.triggerCloseTab(shortcutWindowId)
                                 return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                             }
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F -> {
@@ -1633,16 +1655,14 @@ object FluckEngine {
 
                 // Intercept main modifier + Shift + key shortcuts
                 if (isMainModifierDown && modifiers.isShiftDown && !modifiers.isAltDown) {
-                    // Read focusedWindowId here to minimize race window between read and use
-                    val focusedWindowId = WindowFocusManager.focusedWindowFlow.value
-                    if (focusedWindowId != null) {
+                    if (shortcutWindowId != null) {
                         when (keyCode) {
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F -> {
-                                ai.rever.boss.window.MenuActionsHandler.triggerToggleFocusMode(focusedWindowId)
+                                ai.rever.boss.window.MenuActionsHandler.triggerToggleFocusMode(shortcutWindowId)
                                 return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                             }
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_S -> {
-                                ai.rever.boss.window.MenuActionsHandler.triggerSaveWorkspace(focusedWindowId)
+                                ai.rever.boss.window.MenuActionsHandler.triggerSaveWorkspace(shortcutWindowId)
                                 return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response.suppress()
                             }
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_V -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -49,14 +49,14 @@ internal class AwtWindowFocusTracker {
 }
 
 /**
- * WindowFocusManager - Handles multi-window focus tracking
- *
- * Tracks all application windows and their focus state to ensure
- * external events (deep links, file opens) are handled by the focused window only.
+ * Handles multi-window focus tracking with two intentionally different views:
+ * [isWindowFocused] is the live AWT focus used to gate browser input, while
+ * [focusedWindowFlow] retains last-focused semantics for external actions such
+ * as deep links and file opens.
  */
 actual object WindowFocusManager {
     private val windows = ConcurrentHashMap<String, Window>()
-    // Listener installation and removal are EDT-confined.
+    // EDT-confined; registerWindow/unregisterWindow enforce this before mutation.
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
     private val awtFocusTracker = AwtWindowFocusTracker()
     private var focusedWindowId: String? = null
@@ -67,12 +67,17 @@ actual object WindowFocusManager {
     actual val focusedWindowFlow: StateFlow<String?> = _focusedWindowFlow.asStateFlow()
 
     /**
-     * Register an application window with focus tracking.
+     * Registers an application window with focus tracking. Must run on the EDT.
+     * A window registered before it is focused remains absent from the live
+     * snapshot until its first focus-gained event, so browser input fails closed.
      *
      * @param windowId Unique identifier for the window
      * @param window The AWT window instance
      */
     fun registerWindow(windowId: String, window: Window) {
+        check(SwingUtilities.isEventDispatchThread()) {
+            "WindowFocusManager.registerWindow must run on the EDT"
+        }
         windows[windowId] = window
 
         // First window becomes the main window (backward compatibility).
@@ -114,11 +119,14 @@ actual object WindowFocusManager {
     fun getWindow(windowId: String): Window? = windows[windowId]
 
     /**
-     * Unregister a window when it closes.
+     * Unregisters a window when it closes. Must run on the EDT.
      *
      * @param windowId The window ID to unregister
      */
     fun unregisterWindow(windowId: String) {
+        check(SwingUtilities.isEventDispatchThread()) {
+            "WindowFocusManager.unregisterWindow must run on the EDT"
+        }
         windowListeners.remove(windowId)?.let { listener ->
             windows[windowId]?.removeWindowFocusListener(listener)
         }
@@ -136,6 +144,8 @@ actual object WindowFocusManager {
     /**
      * Returns the current AWT focus snapshot maintained by EDT focus events.
      * The volatile snapshot is safe to read from JxBrowser callback threads.
+     * It intentionally returns false before the first focus-gained event and
+     * after unregister, keeping orphaned owner-scoped browsers fail-closed.
      */
     actual fun isWindowFocused(windowId: String): Boolean =
         awtFocusTracker.isFocused(windowId)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -10,6 +10,45 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
+ * Captures AWT focus lifecycle events on the EDT and exposes a volatile
+ * snapshot that JxBrowser callback threads can safely read.
+ */
+internal class AwtWindowFocusTracker {
+    @Volatile
+    private var focusedWindowId: String? = null
+
+    fun snapshotRegistration(windowId: String, isFocused: Boolean) {
+        if (isFocused) {
+            focusedWindowId = windowId
+        }
+    }
+
+    fun createListener(
+        windowId: String,
+        onFocusGained: () -> Unit = {}
+    ): WindowAdapter = object : WindowAdapter() {
+        override fun windowGainedFocus(e: WindowEvent?) {
+            focusedWindowId = windowId
+            onFocusGained()
+        }
+
+        override fun windowLostFocus(e: WindowEvent?) {
+            if (focusedWindowId == windowId) {
+                focusedWindowId = null
+            }
+        }
+    }
+
+    fun onUnregistered(windowId: String) {
+        if (focusedWindowId == windowId) {
+            focusedWindowId = null
+        }
+    }
+
+    fun isFocused(windowId: String): Boolean = focusedWindowId == windowId
+}
+
+/**
  * WindowFocusManager - Handles multi-window focus tracking
  *
  * Tracks all application windows and their focus state to ensure
@@ -17,10 +56,10 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 actual object WindowFocusManager {
     private val windows = ConcurrentHashMap<String, Window>()
+    // Listener installation and removal are EDT-confined.
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
+    private val awtFocusTracker = AwtWindowFocusTracker()
     private var focusedWindowId: String? = null
-    @Volatile
-    private var awtFocusedWindowId: String? = null
     private var mainWindow: Window? = null  // Kept for backward compatibility
 
     // StateFlow to observe focus changes (for elegant focus restoration)
@@ -44,22 +83,11 @@ actual object WindowFocusManager {
 
         // Registration runs on the EDT. Snapshot an already-focused window in
         // case its focus-gained event happened before the listener was attached.
-        if (window.isFocused) {
-            awtFocusedWindowId = windowId
-        }
+        awtFocusTracker.snapshotRegistration(windowId, window.isFocused)
 
-        val listener = object : WindowAdapter() {
-            override fun windowGainedFocus(e: WindowEvent?) {
-                awtFocusedWindowId = windowId
-                focusedWindowId = windowId
-                _focusedWindowFlow.value = windowId
-            }
-
-            override fun windowLostFocus(e: WindowEvent?) {
-                if (awtFocusedWindowId == windowId) {
-                    awtFocusedWindowId = null
-                }
-            }
+        val listener = awtFocusTracker.createListener(windowId) {
+            focusedWindowId = windowId
+            _focusedWindowFlow.value = windowId
         }
 
         windowListeners[windowId] = listener
@@ -96,9 +124,7 @@ actual object WindowFocusManager {
         }
 
         windows.remove(windowId)
-        if (awtFocusedWindowId == windowId) {
-            awtFocusedWindowId = null
-        }
+        awtFocusTracker.onUnregistered(windowId)
         if (focusedWindowId == windowId) {
             // Preserve the existing last-focused flow contract for external
             // actions; another window will publish itself when it gains focus.
@@ -112,7 +138,7 @@ actual object WindowFocusManager {
      * The volatile snapshot is safe to read from JxBrowser callback threads.
      */
     actual fun isWindowFocused(windowId: String): Boolean =
-        awtFocusedWindowId == windowId
+        awtFocusTracker.isFocused(windowId)
 
     /**
      * Best-effort window id for actions that need "the" active window but may run

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -19,6 +19,8 @@ actual object WindowFocusManager {
     private val windows = ConcurrentHashMap<String, Window>()
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
     private var focusedWindowId: String? = null
+    @Volatile
+    private var awtFocusedWindowId: String? = null
     private var mainWindow: Window? = null  // Kept for backward compatibility
 
     // StateFlow to observe focus changes (for elegant focus restoration)
@@ -26,7 +28,7 @@ actual object WindowFocusManager {
     actual val focusedWindowFlow: StateFlow<String?> = _focusedWindowFlow.asStateFlow()
 
     /**
-     * Register an application window with focus tracking
+     * Register an application window with focus tracking.
      *
      * @param windowId Unique identifier for the window
      * @param window The AWT window instance
@@ -34,28 +36,33 @@ actual object WindowFocusManager {
     fun registerWindow(windowId: String, window: Window) {
         windows[windowId] = window
 
-        // First window becomes the main window (backward compatibility)
+        // First window becomes the main window (backward compatibility).
         if (mainWindow == null) {
             mainWindow = window
             focusedWindowId = windowId
         }
 
-        // Create focus listener to track window focus changes
+        // Registration runs on the EDT. Snapshot an already-focused window in
+        // case its focus-gained event happened before the listener was attached.
+        if (window.isFocused) {
+            awtFocusedWindowId = windowId
+        }
+
         val listener = object : WindowAdapter() {
             override fun windowGainedFocus(e: WindowEvent?) {
+                awtFocusedWindowId = windowId
                 focusedWindowId = windowId
-                _focusedWindowFlow.value = windowId  // Emit to Flow for observers
+                _focusedWindowFlow.value = windowId
             }
 
             override fun windowLostFocus(e: WindowEvent?) {
-                // Focus tracking handled by windowGainedFocus
+                if (awtFocusedWindowId == windowId) {
+                    awtFocusedWindowId = null
+                }
             }
         }
 
-        // Store listener reference for cleanup
         windowListeners[windowId] = listener
-
-        // Add listener to window
         window.addWindowFocusListener(listener)
     }
 
@@ -79,31 +86,33 @@ actual object WindowFocusManager {
     fun getWindow(windowId: String): Window? = windows[windowId]
 
     /**
-     * Unregister a window when it closes
+     * Unregister a window when it closes.
      *
      * @param windowId The window ID to unregister
      */
     fun unregisterWindow(windowId: String) {
-        // Remove the focus listener to prevent memory leak
         windowListeners.remove(windowId)?.let { listener ->
             windows[windowId]?.removeWindowFocusListener(listener)
         }
 
         windows.remove(windowId)
+        if (awtFocusedWindowId == windowId) {
+            awtFocusedWindowId = null
+        }
         if (focusedWindowId == windowId) {
-            // If the focused window closed, clear focus (another window will gain focus via listener)
+            // Preserve the existing last-focused flow contract for external
+            // actions; another window will publish itself when it gains focus.
             focusedWindowId = null
-            _focusedWindowFlow.value = null  // Keep flow in sync
+            _focusedWindowFlow.value = null
         }
     }
 
     /**
-     * Returns the AWT focus state of the registered window rather than the last
-     * window observed by the process-wide focus listener.
+     * Returns the current AWT focus snapshot maintained by EDT focus events.
+     * The volatile snapshot is safe to read from JxBrowser callback threads.
      */
-    actual fun isWindowFocused(windowId: String): Boolean {
-        return windows[windowId]?.isFocused == true
-    }
+    actual fun isWindowFocused(windowId: String): Boolean =
+        awtFocusedWindowId == windowId
 
     /**
      * Best-effort window id for actions that need "the" active window but may run

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.utils
 import java.awt.Window
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.util.concurrent.ConcurrentHashMap
 import javax.swing.SwingUtilities
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
  * external events (deep links, file opens) are handled by the focused window only.
  */
 actual object WindowFocusManager {
-    private val windows = mutableMapOf<String, Window>()
+    private val windows = ConcurrentHashMap<String, Window>()
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
     private var focusedWindowId: String? = null
     private var mainWindow: Window? = null  // Kept for backward compatibility

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -97,13 +97,11 @@ actual object WindowFocusManager {
     }
 
     /**
-     * Check if a specific window is currently focused
-     *
-     * @param windowId The window ID to check
-     * @return true if the window is focused, false otherwise
+     * Returns the AWT focus state of the registered window rather than the last
+     * window observed by the process-wide focus listener.
      */
     actual fun isWindowFocused(windowId: String): Boolean {
-        return focusedWindowId == windowId
+        return windows[windowId]?.isFocused == true
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImplTest.kt
@@ -63,6 +63,8 @@ class BrowserServiceImplTest {
     @Test
     fun `browser creation requires a window cleanup owner`() = runBlocking {
         assertNull(getBrowserServiceInstance(null))
+        assertNull(getBrowserServiceInstance(""))
+        assertNull(getBrowserServiceInstance("   "))
         assertNull(BrowserServiceImpl.createBrowser(BrowserConfig()))
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
@@ -142,27 +142,12 @@ class FluckEngineSwitchesTest {
 
     @Test
     fun `window-owned browser accepts keys only while its owner is focused`() {
-        assertTrue(
-            FluckEngine.shouldAcceptBrowserKeyEvent(
-                ownerWindowId = "window-a",
-                ownerWindowIsFocused = true
-            )
-        )
-        assertFalse(
-            FluckEngine.shouldAcceptBrowserKeyEvent(
-                ownerWindowId = "window-a",
-                ownerWindowIsFocused = false
-            )
-        )
+        assertTrue(FluckEngine.shouldAcceptBrowserKeyEvent(ownerWindowIsFocused = true))
+        assertFalse(FluckEngine.shouldAcceptBrowserKeyEvent(ownerWindowIsFocused = false))
     }
 
     @Test
     fun `legacy unowned browser keeps accepting keys`() {
-        assertTrue(
-            FluckEngine.shouldAcceptBrowserKeyEvent(
-                ownerWindowId = null,
-                ownerWindowIsFocused = false
-            )
-        )
+        assertTrue(FluckEngine.shouldAcceptBrowserKeyEvent(ownerWindowIsFocused = null))
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
@@ -139,4 +139,30 @@ class FluckEngineSwitchesTest {
         assertFalse(FluckEngine.cgroupIndicatesContainer("0::/"))
         assertFalse(FluckEngine.cgroupIndicatesContainer("12:pids:/user.slice/user-501.slice"))
     }
+
+    @Test
+    fun `window-owned browser accepts keys only while its owner is focused`() {
+        assertTrue(
+            FluckEngine.shouldAcceptBrowserKeyEvent(
+                ownerWindowId = "window-a",
+                ownerWindowIsFocused = true
+            )
+        )
+        assertFalse(
+            FluckEngine.shouldAcceptBrowserKeyEvent(
+                ownerWindowId = "window-a",
+                ownerWindowIsFocused = false
+            )
+        )
+    }
+
+    @Test
+    fun `legacy unowned browser keeps accepting keys`() {
+        assertTrue(
+            FluckEngine.shouldAcceptBrowserKeyEvent(
+                ownerWindowId = null,
+                ownerWindowIsFocused = false
+            )
+        )
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
@@ -141,13 +141,41 @@ class FluckEngineSwitchesTest {
     }
 
     @Test
-    fun `window-owned browser accepts keys only while its owner is focused`() {
-        assertTrue(FluckEngine.shouldAcceptBrowserKeyEvent(ownerWindowIsFocused = true))
-        assertFalse(FluckEngine.shouldAcceptBrowserKeyEvent(ownerWindowIsFocused = false))
+    fun `window-owned browser input routes only to its focused owner`() {
+        val focusedRoute = FluckEngine.resolveBrowserKeyEventRoute(
+            ownerWindowId = "window-a",
+            ownerWindowIsFocused = true,
+            fallbackFocusedWindowId = "window-b"
+        )
+        assertTrue(focusedRoute.acceptsInput)
+        assertEquals("window-a", focusedRoute.shortcutWindowId)
+
+        val inactiveRoute = FluckEngine.resolveBrowserKeyEventRoute(
+            ownerWindowId = "window-a",
+            ownerWindowIsFocused = false,
+            fallbackFocusedWindowId = "window-b"
+        )
+        assertFalse(inactiveRoute.acceptsInput)
+        assertEquals(null, inactiveRoute.shortcutWindowId)
+
+        val unregisteredRoute = FluckEngine.resolveBrowserKeyEventRoute(
+            ownerWindowId = "window-a",
+            ownerWindowIsFocused = null,
+            fallbackFocusedWindowId = "window-b"
+        )
+        assertFalse(unregisteredRoute.acceptsInput)
+        assertEquals(null, unregisteredRoute.shortcutWindowId)
     }
 
     @Test
-    fun `legacy unowned browser keeps accepting keys`() {
-        assertTrue(FluckEngine.shouldAcceptBrowserKeyEvent(ownerWindowIsFocused = null))
+    fun `legacy unowned browser routes shortcuts to the focused window`() {
+        val route = FluckEngine.resolveBrowserKeyEventRoute(
+            ownerWindowId = null,
+            ownerWindowIsFocused = null,
+            fallbackFocusedWindowId = "window-b"
+        )
+
+        assertTrue(route.acceptsInput)
+        assertEquals("window-b", route.shortcutWindowId)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineSwitchesTest.kt
@@ -150,28 +150,21 @@ class FluckEngineSwitchesTest {
         assertTrue(focusedRoute.acceptsInput)
         assertEquals("window-a", focusedRoute.shortcutWindowId)
 
-        val inactiveRoute = FluckEngine.resolveBrowserKeyEventRoute(
+        // isWindowFocused returns false for both inactive and unregistered owners.
+        val unfocusedOrUnregisteredRoute = FluckEngine.resolveBrowserKeyEventRoute(
             ownerWindowId = "window-a",
             ownerWindowIsFocused = false,
             fallbackFocusedWindowId = "window-b"
         )
-        assertFalse(inactiveRoute.acceptsInput)
-        assertEquals(null, inactiveRoute.shortcutWindowId)
-
-        val unregisteredRoute = FluckEngine.resolveBrowserKeyEventRoute(
-            ownerWindowId = "window-a",
-            ownerWindowIsFocused = null,
-            fallbackFocusedWindowId = "window-b"
-        )
-        assertFalse(unregisteredRoute.acceptsInput)
-        assertEquals(null, unregisteredRoute.shortcutWindowId)
+        assertFalse(unfocusedOrUnregisteredRoute.acceptsInput)
+        assertEquals(null, unfocusedOrUnregisteredRoute.shortcutWindowId)
     }
 
     @Test
     fun `legacy unowned browser routes shortcuts to the focused window`() {
         val route = FluckEngine.resolveBrowserKeyEventRoute(
             ownerWindowId = null,
-            ownerWindowIsFocused = null,
+            ownerWindowIsFocused = false,
             fallbackFocusedWindowId = "window-b"
         )
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -1,0 +1,57 @@
+package ai.rever.boss.utils
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowFocusManagerTest {
+
+    @Test
+    fun `registration snapshots an already focused window`() {
+        val tracker = AwtWindowFocusTracker()
+
+        tracker.snapshotRegistration("window-a", isFocused = false)
+        assertFalse(tracker.isFocused("window-a"))
+
+        tracker.snapshotRegistration("window-a", isFocused = true)
+        assertTrue(tracker.isFocused("window-a"))
+    }
+
+    @Test
+    fun `late loss from previous window does not clear newer focus gain`() {
+        val tracker = AwtWindowFocusTracker()
+        val windowAListener = tracker.createListener("window-a")
+        val windowBListener = tracker.createListener("window-b")
+
+        windowAListener.windowGainedFocus(null)
+        windowBListener.windowGainedFocus(null)
+        windowAListener.windowLostFocus(null)
+
+        assertFalse(tracker.isFocused("window-a"))
+        assertTrue(tracker.isFocused("window-b"))
+    }
+
+    @Test
+    fun `losing the focused window clears the snapshot`() {
+        val tracker = AwtWindowFocusTracker()
+        val listener = tracker.createListener("window-a")
+
+        listener.windowGainedFocus(null)
+        listener.windowLostFocus(null)
+
+        assertFalse(tracker.isFocused("window-a"))
+    }
+
+    @Test
+    fun `unregister clears only the matching focused window`() {
+        val tracker = AwtWindowFocusTracker()
+        val listener = tracker.createListener("window-b")
+
+        listener.windowGainedFocus(null)
+        tracker.onUnregistered("window-a")
+        assertTrue(tracker.isFocused("window-b"))
+
+        tracker.onUnregistered("window-b")
+        assertFalse(tracker.isFocused("window-b"))
+    }
+}


### PR DESCRIPTION
## What changed

- Propagate the stable owner window ID of each browser handle into the JxBrowser keyboard interceptor.
- Suppress browser key events while the owning AWT window is inactive.
- Dispatch browser shortcuts to the owner window instead of process-global focused-window state.
- Snapshot current AWT focus from EDT focus events into a volatile tracker that JxBrowser callbacks can safely read.
- Cover registration snapshots, gain/loss ordering, focused-window loss, and unregister cleanup through actual `WindowAdapter` callbacks.
- Keep registered-window lookup thread-safe with `ConcurrentHashMap` and enforce EDT confinement for listener registration and removal.
- Document the intentional split between live AWT focus for browser input and last-focused state for external actions.
- Log the first suppressed key event per browser focus-loss streak, including whether its owner window is still registered.
- Reject null or blank browser owner window IDs at the service boundary and document the stricter internal creation boundary.
- Replace existing literal NUL bytes in `BrowserHandleImpl.kt` with equivalent escaped Kotlin char literals so the source remains reviewable as text.

## Root cause

Every browser installed a `PressKeyCallback`, but the callback selected its target from process-global focus state and did not reject input received by browsers belonging to inactive windows. With multiple windows, keyboard input or shortcuts could therefore be observed or routed across window boundaries.

## Impact

Browser input and Cmd/Ctrl shortcuts are now isolated to the owning browser window. The hot JxBrowser input path no longer reads AWT focus properties off the EDT, and lifecycle mutation fails fast if a future caller violates EDT confinement. Unfocused, not-yet-focused, and orphaned owners intentionally fail closed. Suppressed input is diagnosable without per-keystroke log spam. The legacy unscoped browser helper retains its existing routing behavior.

## Validation

- `./gradlew :composeApp:desktopTest --tests ai.rever.boss.utils.WindowFocusManagerTest --tests ai.rever.boss.plugin.browser.FluckEngineSwitchesTest --tests ai.rever.boss.plugin.browser.BrowserServiceImplTest`
- `./gradlew :composeApp:desktopTest`
- `./gradlew composeApp:run` launched successfully with the Fluck Browser plugin loaded for manual multi-window verification.
