### PR TITLE
chore: zero-warning runtime — last 8 compiler warnings + startup log noise

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -438,7 +438,9 @@ fun BossTabsComponent.BossMainTabBar(
                                 }
 
                                 // Bookmark current tab
-                                // Reference collections to ensure recomposition on bookmark changes
+                                // Deliberate bare snapshot read: subscribes this scope to
+                                // recomposition on bookmark-collection changes.
+                                @Suppress("UNUSED_EXPRESSION")
                                 collections
 
                                 val tabConfig = convertTabInfoToTabConfig(config)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
@@ -118,7 +118,6 @@ fun BossDraggableComponent.SidePanel(
                         StatusMessageManager.showMessage("$failLabel failed: ${result.text}", durationMs = 5000)
                     }
                 }
-                Unit
             }
         }
         val openEvolver: (() -> Unit)? =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/CoreAuthService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/CoreAuthService.kt
@@ -186,6 +186,11 @@ internal object CoreAuthService {
                         }
 
                         is SessionStatus.RefreshFailure -> {
+                            // supabase-kt deprecated RefreshFailure.cause in favor of a
+                            // separate AuthEvent.RefreshFailure flow; migrating means
+                            // restructuring the recovery path (#855), so read it here
+                            // until that refactor - suppressed, not ignored.
+                            @Suppress("DEPRECATION")
                             val detail =
                                 when (val cause = sessionStatus.cause) {
                                     is RefreshFailureCause.NetworkError -> {
@@ -194,10 +199,6 @@ internal object CoreAuthService {
 
                                     is RefreshFailureCause.InternalServerError -> {
                                         "server: HTTP ${cause.exception.statusCode} ${cause.exception.error}"
-                                    }
-
-                                    else -> {
-                                        cause::class.simpleName ?: "unknown"
                                     }
                                 }
                             logger.warn(LogCategory.AUTH, "Session refresh failed", mapOf("cause" to detail))

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -292,10 +292,9 @@ fun main(args: Array<String>) {
         }
     }
 
-    // Initialize deep link handler
-    DeepLinkHandler
-
-    // Process command line arguments for deep links (Windows)
+    // Process command line arguments for deep links (Windows).
+    // This first member access also triggers DeepLinkHandler's object init,
+    // so no separate bare-reference "initialization" line is needed.
     DeepLinkHandler.processCommandLineArgs(args)
 
     // Install AWT keyboard interceptor to capture shortcuts before BossTerm

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/SystemPluginManifestService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/SystemPluginManifestService.kt
@@ -231,7 +231,10 @@ object SystemPluginManifestService {
         subscribeToChanges()
     }
 
-    private suspend fun refreshFromRemote() =
+    // Block body, not expression body: the early `return`s inside withLock are
+    // non-local returns from this function, which Kotlin 2.5 forbids in
+    // expression-bodied functions without an explicit return type (KTLC-288).
+    private suspend fun refreshFromRemote() {
         refreshMutex.withLock {
             val fetched =
                 try {
@@ -296,6 +299,7 @@ object SystemPluginManifestService {
                 ),
             )
         }
+    }
 
     private fun subscribeToChanges() {
         scope.launch {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -233,7 +233,7 @@ object BrowserServiceImpl : BrowserService {
                     LogCategory.BROWSER,
                     "BrowserService not available",
                     mapOf(
-                        "initError" to (initErr?.toString() ?: "none"),
+                        "initError" to initErr.toString(),
                     ),
                 )
             }

--- a/composeApp/src/desktopMain/resources/simplelogger.properties
+++ b/composeApp/src/desktopMain/resources/simplelogger.properties
@@ -29,3 +29,8 @@ org.slf4j.simpleLogger.log.io.ktor=warn
 org.slf4j.simpleLogger.log.io.netty=warn
 org.slf4j.simpleLogger.log.com.teamdev=warn
 org.slf4j.simpleLogger.log.kotlinx.coroutines=warn
+
+# gRPC's NettyServer unconditionally sets SO_KEEPALIVE on child channels;
+# unix-domain-socket channels don't support it, so ServerBootstrap warns on
+# every kernel IPC connection. Library behavior, not ours - errors still show.
+org.slf4j.simpleLogger.log.io.netty.bootstrap.ServerBootstrap=error


### PR DESCRIPTION
Follow-up spotted while checking the debug logs of the fully-merged main running live: the compile had 8 residual warnings (the tail left after #22 zeroed the 842 BossDark deprecations) and the runtime log carried three kinds of avoidable noise.

## Compiler: 8 → 0
- **`SystemPluginManifestService.refreshFromRemote`** — expression body with non-local returns becomes a **hard error in Kotlin 2.5** (KTLC-288); now a block body.
- **`CoreAuthService`** — removed the redundant `else` from the exhaustive `RefreshFailureCause` when; the deprecated `RefreshFailure.cause` read is narrowly `@Suppress`ed with rationale — the real migration to supabase-kt's `AuthEvent.RefreshFailure` flow restructures the recovery path (#855 territory) and deserves its own change.
- **`BossMainWindowPanel`** — the bare `collections` read is a deliberate snapshot subscription (recomposition on bookmark changes); documented and suppressed rather than deleted.
- **`SidePanel`** / **`main.kt`** / **`BrowserServiceImpl`** — redundant trailing `Unit`, redundant bare object reference (the call two lines later initializes the same object), unnecessary safe call.

## Runtime log noise → clean
- **`[HOST-DEBUG]` printlns** (NavigationTargetProviderImpl + SandboxedPluginContext) violated the repo's own BossLogger rule — now `logger.debug` with the EDITOR category; the sandbox getter is back to plain delegation.
- **Netty `SO_KEEPALIVE` warnings on every kernel IPC connection** — gRPC's `NettyServer` sets the option unconditionally and unix-domain-socket channels don't support it. Library behavior, so the `io.netty.bootstrap.ServerBootstrap` logger is scoped to `error` in `simplelogger.properties` (errors still surface).

## Verification
- `:composeApp:compileKotlinDesktop --rerun-tasks`: **0 warnings** (was 8).
- `:composeApp:desktopTest`, `:plugin-platform:plugin-sandbox` compile, `:boss-ipc:build`, `detekt`, `ktlintCheck` — all green.

With this, a clean build of BossConsole emits zero compiler warnings and a normal startup emits zero avoidable WARN/println noise (remaining WARNs are real signals: signature-enforcement notices and genuine network events).