### PR TITLE
Fix browser video fullscreen from fullscreen windows

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -860,9 +860,9 @@ compose.desktop {
                     add("--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED")
                     add("--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED")
                     add("--add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED")
-                    // Required for macOS native fullscreen via com.apple.eawt.Application reflection
-                    // Used by FullscreenBrowserWindow.kt. Tested on Java 17+.
-                    // Fallback to MAXIMIZED_BOTH if API unavailable.
+                    // Required for native fullscreen toggling and FullScreenUtilities tracking.
+                    // Used by FullscreenBrowserWindow/WindowFocusManager; tested on Java 17+.
+                    // Falls back to a display-sized borderless overlay if unavailable.
                     add("--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED")
                     add("-Dapple.awt.application.appearance=system")
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -6,11 +6,16 @@ import ai.rever.boss.plugin.browser.BrowserService
 import ai.rever.boss.plugin.browser.BrowserServiceImpl
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.SwingUtilities
 
 private val windowBrowserServices = ConcurrentHashMap<String, WindowScopedBrowserService>()
+private const val BROWSER_DISPOSAL_TIMEOUT_MS = 2_000L
 
 /**
  * Desktop implementation of BrowserService provider.
@@ -29,6 +34,7 @@ private class WindowScopedBrowserService(
 ) : BrowserService by BrowserServiceImpl {
     private val logger = BossLogger.forComponent("WindowScopedBrowserService")
     private val lifecycleLock = Any()
+    private val disposalStarted = AtomicBoolean(false)
     private var closed = false
 
     override suspend fun createBrowser(config: BrowserConfig): BrowserHandle? {
@@ -55,27 +61,72 @@ private class WindowScopedBrowserService(
     override fun getActiveBrowserCount(): Int = BrowserServiceImpl.getActiveBrowserCountForWindow(windowId)
 
     fun close() {
-        if (!SwingUtilities.isEventDispatchThread()) {
-            logger.warn(
-                LogCategory.BROWSER,
-                "Browser service close called off-EDT; marshalling before disposal",
-                mapOf("windowId" to windowId),
-            )
-            try {
-                SwingUtilities.invokeAndWait { close() }
-            } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
-                logger.warn(LogCategory.BROWSER, "Interrupted while closing browser service", error = e)
-            } catch (e: InvocationTargetException) {
-                logger.warn(LogCategory.BROWSER, "Could not close browser service on the EDT", error = e.cause ?: e)
+        val shouldDispose =
+            synchronized(lifecycleLock) {
+                if (closed) {
+                    false
+                } else {
+                    closed = true
+                    true
+                }
             }
+        if (!shouldDispose) return
+
+        if (SwingUtilities.isEventDispatchThread()) {
+            disposeOwnedBrowsersOnce()
             return
         }
 
-        synchronized(lifecycleLock) {
-            if (closed) return
-            closed = true
+        logger.debug(
+            LogCategory.BROWSER,
+            "Browser service close called off-EDT; marshalling before disposal",
+            mapOf("windowId" to windowId),
+        )
+        val task =
+            FutureTask<Unit> {
+                disposeOwnedBrowsersOnce()
+            }
+        SwingUtilities.invokeLater(task)
+        try {
+            task.get(BROWSER_DISPOSAL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            disposeAfterMarshalFailure(task, "Interrupted while closing browser service", e)
+        } catch (e: TimeoutException) {
+            disposeAfterMarshalFailure(task, "Timed out closing browser service on the EDT", e)
+        } catch (e: ExecutionException) {
+            disposeAfterMarshalFailure(task, "Could not close browser service on the EDT", e.cause ?: e)
+        }
+    }
+
+    private fun disposeAfterMarshalFailure(
+        task: FutureTask<Unit>,
+        message: String,
+        error: Throwable,
+    ) {
+        task.cancel(false)
+        logger.warn(LogCategory.BROWSER, message, mapOf("windowId" to windowId), error)
+        runCatching(::disposeOwnedBrowsersOnce)
+            .onFailure { fallbackError ->
+                logger.error(
+                    LogCategory.BROWSER,
+                    "Browser service fallback disposal failed",
+                    mapOf("windowId" to windowId),
+                    fallbackError,
+                )
+            }
+    }
+
+    private fun disposeOwnedBrowsersOnce() {
+        if (!disposalStarted.compareAndSet(false, true)) return
+        var completed = false
+        try {
             BrowserServiceImpl.disposeAllForWindow(windowId)
+            completed = true
+        } finally {
+            if (!completed) {
+                disposalStarted.set(false)
+            }
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -91,30 +91,35 @@ private class WindowScopedBrowserService(
             task.get(BROWSER_DISPOSAL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
-            disposeAfterMarshalFailure(task, "Interrupted while closing browser service", e)
+            disposeAfterMarshalFailure(
+                message = "Interrupted while waiting for browser service disposal; cleanup remains queued",
+                error = e,
+                retryOnEdt = false,
+            )
         } catch (e: TimeoutException) {
-            disposeAfterMarshalFailure(task, "Timed out closing browser service on the EDT", e)
+            disposeAfterMarshalFailure(
+                message = "Timed out waiting for browser service disposal; cleanup remains queued",
+                error = e,
+                retryOnEdt = false,
+            )
         } catch (e: ExecutionException) {
-            disposeAfterMarshalFailure(task, "Could not close browser service on the EDT", e.cause ?: e)
+            disposeAfterMarshalFailure(
+                message = "Browser service disposal failed on the EDT; scheduling one retry",
+                error = e.cause ?: e,
+                retryOnEdt = true,
+            )
         }
     }
 
     private fun disposeAfterMarshalFailure(
-        task: FutureTask<Unit>,
         message: String,
         error: Throwable,
+        retryOnEdt: Boolean,
     ) {
-        task.cancel(false)
         logger.warn(LogCategory.BROWSER, message, mapOf("windowId" to windowId), error)
-        runCatching(::disposeOwnedBrowsersOnce)
-            .onFailure { fallbackError ->
-                logger.error(
-                    LogCategory.BROWSER,
-                    "Browser service fallback disposal failed",
-                    mapOf("windowId" to windowId),
-                    fallbackError,
-                )
-            }
+        if (retryOnEdt) {
+            SwingUtilities.invokeLater(::disposeOwnedBrowsersOnce)
+        }
     }
 
     private fun disposeOwnedBrowsersOnce() {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.browser.BrowserHandle
 import ai.rever.boss.plugin.browser.BrowserService
 import ai.rever.boss.plugin.browser.BrowserServiceImpl
 import java.util.concurrent.ConcurrentHashMap
+import javax.swing.SwingUtilities
 
 private val windowBrowserServices = ConcurrentHashMap<String, WindowScopedBrowserService>()
 
@@ -53,6 +54,9 @@ private class WindowScopedBrowserService(
         // Window-close routing calls this on the EDT. Keep that invariant while
         // holding lifecycleLock: fullscreen BrowserView disposal may marshal to
         // the EDT and must never wait for a lock owned by a background caller.
+        check(SwingUtilities.isEventDispatchThread()) {
+            "WindowScopedBrowserService.close must run on the EDT"
+        }
         synchronized(lifecycleLock) {
             if (closed) return
             closed = true

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -50,6 +50,9 @@ private class WindowScopedBrowserService(
     override fun getActiveBrowserCount(): Int = BrowserServiceImpl.getActiveBrowserCountForWindow(windowId)
 
     fun close() {
+        // Window-close routing calls this on the EDT. Keep that invariant while
+        // holding lifecycleLock: fullscreen BrowserView disposal may marshal to
+        // the EDT and must never wait for a lock owned by a background caller.
         synchronized(lifecycleLock) {
             if (closed) return
             closed = true

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/BrowserServiceProvider.kt
@@ -4,6 +4,9 @@ import ai.rever.boss.plugin.browser.BrowserConfig
 import ai.rever.boss.plugin.browser.BrowserHandle
 import ai.rever.boss.plugin.browser.BrowserService
 import ai.rever.boss.plugin.browser.BrowserServiceImpl
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.SwingUtilities
 
@@ -24,6 +27,7 @@ actual fun getBrowserServiceInstance(windowId: String?): BrowserService? =
 private class WindowScopedBrowserService(
     private val windowId: String,
 ) : BrowserService by BrowserServiceImpl {
+    private val logger = BossLogger.forComponent("WindowScopedBrowserService")
     private val lifecycleLock = Any()
     private var closed = false
 
@@ -51,12 +55,23 @@ private class WindowScopedBrowserService(
     override fun getActiveBrowserCount(): Int = BrowserServiceImpl.getActiveBrowserCountForWindow(windowId)
 
     fun close() {
-        // Window-close routing calls this on the EDT. Keep that invariant while
-        // holding lifecycleLock: fullscreen BrowserView disposal may marshal to
-        // the EDT and must never wait for a lock owned by a background caller.
-        check(SwingUtilities.isEventDispatchThread()) {
-            "WindowScopedBrowserService.close must run on the EDT"
+        if (!SwingUtilities.isEventDispatchThread()) {
+            logger.warn(
+                LogCategory.BROWSER,
+                "Browser service close called off-EDT; marshalling before disposal",
+                mapOf("windowId" to windowId),
+            )
+            try {
+                SwingUtilities.invokeAndWait { close() }
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                logger.warn(LogCategory.BROWSER, "Interrupted while closing browser service", error = e)
+            } catch (e: InvocationTargetException) {
+                logger.warn(LogCategory.BROWSER, "Could not close browser service on the EDT", error = e.cause ?: e)
+            }
+            return
         }
+
         synchronized(lifecycleLock) {
             if (closed) return
             closed = true

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1328,7 +1328,7 @@ internal class BrowserHandleImpl(
     }
 
     override fun requestExitFullscreen() {
-        FullscreenBrowserWindow.requestExit()
+        FullscreenBrowserWindow.requestExit(browser)
     }
 
     // ============================================================

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1313,6 +1313,7 @@ internal class BrowserHandleImpl(
         FluckEngine.setupFullscreenHandler(
             browser = browser,
             tabId = tabId,
+            ownerWindowId = ownerWindowId,
             onFullscreenEnter = {
                 logger.info(LogCategory.BROWSER, "Tab entered fullscreen", mapOf("tabId" to tabId, "handleId" to id))
                 onEnterFullscreen()
@@ -1595,6 +1596,7 @@ internal class BrowserHandleImpl(
 
     override fun dispose() {
         if (!disposed.compareAndSet(false, true)) return
+        FullscreenBrowserWindow.exitFullscreen(browser)
 
         // Stop co-browse capture so a disposed tab can never keep streaming.
         coBrowseCapturing = false

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1795,7 +1795,7 @@ object FluckEngine {
 
             // Close fullscreen window
             ai.rever.boss.tabfullscreen.FullscreenBrowserWindow
-                .exitFullscreen()
+                .exitFullscreenAsync(browser)
 
             onFullscreenExit()
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1781,12 +1781,13 @@ object FluckEngine {
             logger.info(LogCategory.BROWSER, "Web content requested fullscreen", mapOf("tabId" to tabId))
 
             // Show fullscreen window
-            ai.rever.boss.tabfullscreen.FullscreenBrowserWindow.showFullscreen(browser, tabId, ownerWindowId) {
-                // This is called when exiting fullscreen via ESC or clicking placeholder
-                onFullscreenExit()
-            }
-
-            onFullscreenEnter()
+            ai.rever.boss.tabfullscreen.FullscreenBrowserWindow.showFullscreen(
+                browser = browser,
+                tabId = tabId,
+                ownerWindowId = ownerWindowId,
+                onEnter = onFullscreenEnter,
+                onExit = onFullscreenExit,
+            )
         }
 
         // Handle fullscreen exit using event listener

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1796,9 +1796,7 @@ object FluckEngine {
 
             // Close fullscreen window
             ai.rever.boss.tabfullscreen.FullscreenBrowserWindow
-                .exitFullscreenAsync(browser)
-
-            onFullscreenExit()
+                .exitFullscreenAsync(browser, onFullscreenExit)
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1765,12 +1765,14 @@ object FluckEngine {
      *
      * @param browser The browser instance to configure
      * @param tabId The unique ID of the tab containing this browser
+     * @param ownerWindowId The Boss window that owns the browser tab
      * @param onFullscreenEnter Callback when fullscreen mode is entered
      * @param onFullscreenExit Callback when fullscreen mode is exited
      */
     fun setupFullscreenHandler(
         browser: com.teamdev.jxbrowser.browser.Browser,
         tabId: String,
+        ownerWindowId: String,
         onFullscreenEnter: () -> Unit,
         onFullscreenExit: () -> Unit,
     ) {
@@ -1779,7 +1781,7 @@ object FluckEngine {
             logger.info(LogCategory.BROWSER, "Web content requested fullscreen", mapOf("tabId" to tabId))
 
             // Show fullscreen window
-            ai.rever.boss.tabfullscreen.FullscreenBrowserWindow.showFullscreen(browser, tabId) {
+            ai.rever.boss.tabfullscreen.FullscreenBrowserWindow.showFullscreen(browser, tabId, ownerWindowId) {
                 // This is called when exiting fullscreen via ESC or clicking placeholder
                 onFullscreenExit()
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -138,18 +138,13 @@ object FullscreenBrowserWindow {
                 object : ComponentAdapter() {
                     override fun componentResized(e: ComponentEvent?) {
                         // Only check for exit after we've confirmed fullscreen was reached
-                        if (
-                            usesNativeMacOSFullscreen &&
-                            hasReachedFullscreen &&
-                            isInFullscreenMode &&
-                            !isExiting &&
-                            fullscreenFrame != null
-                        ) {
-                            SwingUtilities.invokeLater {
-                                if (!isWindowInFullscreen(frame) && !isExiting) {
-                                    logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
-                                    performExit()
-                                }
+                        if (!usesNativeMacOSFullscreen || !hasReachedFullscreen) return
+                        if (!isInFullscreenMode || isExiting || fullscreenFrame == null) return
+
+                        SwingUtilities.invokeLater {
+                            if (!isWindowInFullscreen(frame) && !isExiting) {
+                                logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
+                                performExit()
                             }
                         }
                     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -1,10 +1,8 @@
 package ai.rever.boss.tabfullscreen
 
 import ai.rever.boss.utils.WindowFocusManager
-import ai.rever.boss.utils.addWindowFullscreenExitListener
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import ai.rever.boss.utils.removeWindowFullscreenExitListener
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.BorderLayout
@@ -35,6 +33,18 @@ internal fun fillsScreen(
         windowBounds.y <= screenBounds.y &&
         windowBounds.maxX >= screenBounds.maxX &&
         windowBounds.maxY >= screenBounds.maxY
+
+internal fun shouldUseComposeFullscreenOverlay(
+    composeSignalActive: Boolean,
+    isShowing: Boolean,
+    isMaximized: Boolean,
+    windowBounds: Rectangle,
+    screenBounds: Rectangle,
+): Boolean =
+    composeSignalActive &&
+        isShowing &&
+        !isMaximized &&
+        fillsScreen(windowBounds, screenBounds)
 
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
@@ -129,7 +139,8 @@ object FullscreenBrowserWindow {
                 return
             }
 
-            val frame = JFrame()
+            val ownerWindow = currentOwnerWindowId?.let(WindowFocusManager::getWindow)
+            val frame = ownerWindow?.graphicsConfiguration?.let(::JFrame) ?: JFrame()
             frame.defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
             frame.background = Color.BLACK
             frame.contentPane.background = Color.BLACK
@@ -182,13 +193,11 @@ object FullscreenBrowserWindow {
                     // macOS can ignore a second native fullscreen-Space request while another
                     // window from this app already owns a fullscreen Space. Keep the video in
                     // that Space and cover it with an undecorated screen-sized window instead.
-                    frame.isUndecorated = true
-                    frame.isAlwaysOnTop = true
-                    frame.setBounds(fullscreenHostBounds)
-                    frame.isVisible = true
-                    usesNativeMacOSFullscreen = false
-                    hasReachedFullscreen = true
-                    watchOwnerFullscreenExit(currentOwnerWindowId)
+                    showBorderlessOverlay(
+                        frame = frame,
+                        bounds = fullscreenHostBounds,
+                        watchOwnerExit = true,
+                    )
                     logger.info(
                         LogCategory.BROWSER,
                         "Opened fullscreen video as borderless overlay in existing fullscreen Space",
@@ -207,20 +216,34 @@ object FullscreenBrowserWindow {
                             // Wait for fullscreen animation to complete before enabling exit detection
                             Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
                                 if (fullscreenFrame != null && isInFullscreenMode) {
-                                    hasReachedFullscreen = true
-                                    logger.info(
-                                        LogCategory.BROWSER,
-                                        "Fullscreen animation completed, exit detection enabled",
-                                    )
+                                    if (isWindowInFullscreen(frame)) {
+                                        hasReachedFullscreen = true
+                                        logger.info(
+                                            LogCategory.BROWSER,
+                                            "Fullscreen animation completed, exit detection enabled",
+                                        )
+                                    } else {
+                                        logger.warn(
+                                            LogCategory.BROWSER,
+                                            "macOS ignored native fullscreen toggle; using borderless overlay",
+                                        )
+                                        showBorderlessOverlay(
+                                            frame = frame,
+                                            bounds = frame.graphicsConfiguration.bounds,
+                                            watchOwnerExit = false,
+                                        )
+                                    }
                                 }
                             }.apply {
                                 isRepeats = false
                                 start()
                             }
                         } else {
-                            usesNativeMacOSFullscreen = false
-                            frame.extendedState = JFrame.MAXIMIZED_BOTH
-                            hasReachedFullscreen = true
+                            showBorderlessOverlay(
+                                frame = frame,
+                                bounds = frame.graphicsConfiguration.bounds,
+                                watchOwnerExit = false,
+                            )
                         }
                     }
                 }
@@ -247,31 +270,75 @@ object FullscreenBrowserWindow {
         }
     }
 
+    private fun showBorderlessOverlay(
+        frame: JFrame,
+        bounds: Rectangle,
+        watchOwnerExit: Boolean,
+    ) {
+        if (frame.isDisplayable) {
+            frame.dispose()
+        }
+        frame.isUndecorated = true
+        frame.isAlwaysOnTop = true
+        frame.extendedState = JFrame.NORMAL
+        frame.setBounds(bounds)
+        frame.isVisible = true
+        frame.toFront()
+        usesNativeMacOSFullscreen = false
+        hasReachedFullscreen = true
+        if (watchOwnerExit) {
+            watchOwnerFullscreenExit(currentOwnerWindowId)
+        }
+    }
+
     /**
      * Returns the display bounds of an already-fullscreen window in this process.
      * A new undecorated video window can cover that same fullscreen Space without
      * asking macOS to create a second native fullscreen Space.
      */
-    private fun existingFullscreenWindowBounds(ownerWindowId: String): Rectangle? =
-        WindowFocusManager
-            .getFullscreenWindow(ownerWindowId)
-            ?.graphicsConfiguration
-            ?.bounds
-            ?: ownerWindowBoundsFallback(ownerWindowId)
+    private fun existingFullscreenWindowBounds(ownerWindowId: String): Rectangle? {
+        val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId)
+        return when {
+            state == null -> {
+                null
+            }
 
-    private fun ownerWindowBoundsFallback(ownerWindowId: String): Rectangle? {
+            state.nativeTrackingAvailable -> {
+                state.window.graphicsConfiguration
+                    ?.bounds
+                    .takeIf { state.nativeFullscreen }
+            }
+
+            else -> {
+                ownerWindowBoundsFallback(
+                    ownerWindowId = ownerWindowId,
+                    ownerWindow = state.window,
+                    composeSignalActive = state.composeFullscreen,
+                )
+            }
+        }
+    }
+
+    private fun ownerWindowBoundsFallback(
+        ownerWindowId: String,
+        ownerWindow: Window,
+        composeSignalActive: Boolean,
+    ): Rectangle? {
         // Best-effort fallback only for the browser's owning window. Never scan
         // another Boss window or treat an ordinary maximized frame as fullscreen.
-        val ownerWindow = WindowFocusManager.getWindow(ownerWindowId)
-        val screenBounds = ownerWindow?.graphicsConfiguration?.bounds
+        val screenBounds = ownerWindow.graphicsConfiguration?.bounds
         val isMaximized =
             ownerWindow is Frame &&
                 ownerWindow.extendedState and Frame.MAXIMIZED_BOTH != 0
         val fallbackBounds =
             screenBounds?.takeIf {
-                ownerWindow.isShowing &&
-                    !isMaximized &&
-                    fillsScreen(ownerWindow.bounds, screenBounds)
+                shouldUseComposeFullscreenOverlay(
+                    composeSignalActive = composeSignalActive,
+                    isShowing = ownerWindow.isShowing,
+                    isMaximized = isMaximized,
+                    windowBounds = ownerWindow.bounds,
+                    screenBounds = screenBounds,
+                )
             }
 
         if (fallbackBounds != null) {
@@ -330,6 +397,7 @@ object FullscreenBrowserWindow {
 
     private fun watchOwnerFullscreenExit(ownerWindowId: String?) {
         if (ownerWindowId == null) return
+        ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
         val listener: (String) -> Unit = { exitedWindowId ->
             if (exitedWindowId == ownerWindowId) {
                 SwingUtilities.invokeLater {
@@ -348,14 +416,14 @@ object FullscreenBrowserWindow {
             }
         }
         ownerFullscreenExitListener = listener
-        addWindowFullscreenExitListener(listener)
+        WindowFocusManager.fullscreenExitNotifier.add(listener)
     }
 
     /**
      * Reset all state variables.
      */
     private fun resetState() {
-        ownerFullscreenExitListener?.let(::removeWindowFullscreenExitListener)
+        ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
         ownerFullscreenExitListener = null
         fullscreenFrame = null
         currentBrowserView = null
@@ -481,6 +549,15 @@ object FullscreenBrowserWindow {
         }
     }
 
+    /** Requests exit only if fullscreen belongs to this browser, without blocking its callback thread. */
+    fun requestExit(browser: Browser) {
+        SwingUtilities.invokeLater {
+            if (currentBrowser === browser) {
+                requestExit()
+            }
+        }
+    }
+
     /**
      * Direct exit without relying on fullscreen toggle.
      */
@@ -512,10 +589,21 @@ object FullscreenBrowserWindow {
         cleanupAndExit(frame, browserView, null)
     }
 
+    /** Closes fullscreen asynchronously only when it belongs to the browser emitting the event. */
+    fun exitFullscreenAsync(browser: Browser) {
+        SwingUtilities.invokeLater {
+            if (currentBrowser === browser) {
+                exitFullscreen()
+            }
+        }
+    }
+
     /**
      * Closes fullscreen only when it belongs to the browser being disposed.
      * Blocks a background disposer until the Swing view has been detached, so
      * the browser cannot close underneath the fullscreen window's cleanup.
+     * Callers must not hold a lock that the EDT could need; current disposal
+     * paths either already run on the EDT or hold only owner-local lifecycle state.
      */
     fun exitFullscreen(browser: Browser) {
         runOnEventDispatchThreadAndWait {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -69,6 +69,7 @@ object FullscreenBrowserWindow {
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
     private var usesNativeMacOSFullscreen = false
     private var isExiting = false // Prevent multiple exit calls
+    private var lifecycleEpoch = 0L
 
     private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
 
@@ -91,24 +92,58 @@ object FullscreenBrowserWindow {
         onEnter: () -> Unit,
         onExit: () -> Unit,
     ) {
-        if (!SwingUtilities.isEventDispatchThread()) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            handleFullscreenRequest(browser, tabId, ownerWindowId, onEnter, onExit)
+        } else {
             SwingUtilities.invokeLater {
-                showFullscreen(browser, tabId, ownerWindowId, onEnter, onExit)
+                handleFullscreenRequest(browser, tabId, ownerWindowId, onEnter, onExit)
             }
-            return
         }
+    }
 
-        // Prevent duplicate calls
-        if (browser.isClosed || fullscreenFrame != null || isInFullscreenMode) {
-            logger.warn(LogCategory.BROWSER, "Fullscreen already active, ignoring duplicate request")
-            runCatching { browser.fullScreen().exit() }
-                .onFailure { error ->
-                    logger.warn(LogCategory.BROWSER, "Could not reject duplicate browser fullscreen", error = error)
-                }
-            onExit()
-            return
+    private fun handleFullscreenRequest(
+        browser: Browser,
+        tabId: String,
+        ownerWindowId: String,
+        onEnter: () -> Unit,
+        onExit: () -> Unit,
+    ) {
+        val fullscreenActive = fullscreenFrame != null || isInFullscreenMode
+        when {
+            fullscreenActive && currentBrowser === browser -> {
+                logger.warn(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
+            }
+
+            browser.isClosed || fullscreenActive -> {
+                rejectFullscreenRequest(browser, onExit)
+            }
+
+            else -> {
+                beginFullscreenSession(browser, tabId, ownerWindowId, onEnter, onExit)
+            }
         }
+    }
 
+    /** Rejects a losing browser without publishing a false enter state. */
+    private fun rejectFullscreenRequest(
+        browser: Browser,
+        onExit: () -> Unit,
+    ) {
+        logger.warn(LogCategory.BROWSER, "Fullscreen already active, ignoring duplicate request")
+        runCatching { browser.fullScreen().exit() }
+            .onFailure { error ->
+                logger.warn(LogCategory.BROWSER, "Could not reject duplicate browser fullscreen", error = error)
+            }
+        onExit()
+    }
+
+    private fun beginFullscreenSession(
+        browser: Browser,
+        tabId: String,
+        ownerWindowId: String,
+        onEnter: () -> Unit,
+        onExit: () -> Unit,
+    ) {
         // Mark fullscreen state FIRST so Compose BrowserView hides immediately
         // This triggers recomposition in JxBrowserCompose.kt, replacing BrowserView with placeholder
         isInFullscreenMode = true
@@ -117,6 +152,8 @@ object FullscreenBrowserWindow {
         onExitCallback = onExit
         isExiting = false
         hasReachedFullscreen = false
+        lifecycleEpoch++
+        val expectedEpoch = lifecycleEpoch
         TabFullscreenStateManager.enterFullscreen(tabId)
         onEnter()
 
@@ -127,7 +164,9 @@ object FullscreenBrowserWindow {
         SwingUtilities.invokeLater {
             Timer(COMPOSE_DETACH_DELAY_MS) {
                 SwingUtilities.invokeLater {
-                    createFullscreenWindow(browser, tabId)
+                    if (isCurrentSession(expectedEpoch, browser)) {
+                        createFullscreenWindow(browser, tabId, expectedEpoch)
+                    }
                 }
             }.apply {
                 isRepeats = false
@@ -136,17 +175,33 @@ object FullscreenBrowserWindow {
         }
     }
 
+    private fun isCurrentSession(
+        expectedEpoch: Long,
+        browser: Browser,
+    ): Boolean =
+        lifecycleEpoch == expectedEpoch &&
+            isInFullscreenMode &&
+            currentBrowser === browser
+
+    private fun isCurrentFrameSession(
+        expectedEpoch: Long,
+        browser: Browser,
+        frame: JFrame,
+    ): Boolean = isCurrentSession(expectedEpoch, browser) && fullscreenFrame === frame
+
     /**
      * Creates and displays the fullscreen window with a Swing BrowserView.
      * Called after Compose BrowserView has had time to detach from rendering.
      */
+    @Suppress("LongMethod")
     private fun createFullscreenWindow(
         browser: Browser,
         tabId: String,
+        expectedEpoch: Long,
     ) {
         try {
             // Check if we've been cancelled during the delay
-            if (!isInFullscreenMode) {
+            if (!isCurrentSession(expectedEpoch, browser)) {
                 logger.warn(LogCategory.BROWSER, "Fullscreen cancelled during delay")
                 return
             }
@@ -190,10 +245,13 @@ object FullscreenBrowserWindow {
                         // Overlay and Windows/Linux frames are fixed-size and exit directly;
                         // resize-based native-Space exit detection is macOS-native only.
                         if (!usesNativeMacOSFullscreen || !hasReachedFullscreen) return
-                        if (!isInFullscreenMode || isExiting || fullscreenFrame == null) return
+                        if (!isCurrentFrameSession(expectedEpoch, browser, frame) || isExiting) return
 
                         SwingUtilities.invokeLater {
-                            if (!isWindowInFullscreen(frame) && !isExiting) {
+                            if (isCurrentFrameSession(expectedEpoch, browser, frame) &&
+                                !isWindowInFullscreen(frame) &&
+                                !isExiting
+                            ) {
                                 logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
                                 performExit()
                             }
@@ -215,6 +273,7 @@ object FullscreenBrowserWindow {
                         frame = frame,
                         bounds = fullscreenHostBounds,
                         watchOwnerExit = true,
+                        expectedEpoch = expectedEpoch,
                     )
                     logger.info(
                         LogCategory.BROWSER,
@@ -230,10 +289,11 @@ object FullscreenBrowserWindow {
 
                     // Request native fullscreen toggle after window is visible
                     SwingUtilities.invokeLater {
+                        if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return@invokeLater
                         if (toggleMacOSFullscreen(frame)) {
                             // Wait for fullscreen animation to complete before enabling exit detection
                             Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                                if (fullscreenFrame != null && isInFullscreenMode) {
+                                if (isCurrentFrameSession(expectedEpoch, browser, frame)) {
                                     if (isWindowInFullscreen(frame)) {
                                         hasReachedFullscreen = true
                                         logger.info(
@@ -249,6 +309,7 @@ object FullscreenBrowserWindow {
                                             frame = frame,
                                             bounds = displayBounds(frame),
                                             watchOwnerExit = false,
+                                            expectedEpoch = expectedEpoch,
                                         )
                                     }
                                 }
@@ -261,6 +322,7 @@ object FullscreenBrowserWindow {
                                 frame = frame,
                                 bounds = displayBounds(frame),
                                 watchOwnerExit = false,
+                                expectedEpoch = expectedEpoch,
                             )
                         }
                     }
@@ -282,10 +344,12 @@ object FullscreenBrowserWindow {
             logger.info(LogCategory.BROWSER, "Fullscreen window opened", mapOf("tabId" to tabId, "isMacOS" to isMacOS))
         } catch (e: Exception) {
             logger.error(LogCategory.BROWSER, "Failed to create fullscreen window", error = e)
-            val callback = onExitCallback
-            resetState()
-            TabFullscreenStateManager.exitFullscreen()
-            callback?.invoke()
+            if (isCurrentSession(expectedEpoch, browser)) {
+                val callback = onExitCallback
+                resetState()
+                TabFullscreenStateManager.exitFullscreen()
+                callback?.invoke()
+            }
         }
     }
 
@@ -293,7 +357,9 @@ object FullscreenBrowserWindow {
         frame: JFrame,
         bounds: Rectangle,
         watchOwnerExit: Boolean,
+        expectedEpoch: Long,
     ) {
+        if (lifecycleEpoch != expectedEpoch || fullscreenFrame !== frame) return
         if (frame.isDisplayable) {
             frame.dispose()
         }
@@ -307,7 +373,7 @@ object FullscreenBrowserWindow {
         usesNativeMacOSFullscreen = false
         hasReachedFullscreen = true
         if (watchOwnerExit) {
-            watchOwnerFullscreenExit(currentOwnerWindowId)
+            watchOwnerFullscreenExit(currentOwnerWindowId, expectedEpoch)
         }
     }
 
@@ -443,22 +509,22 @@ object FullscreenBrowserWindow {
         )
     }
 
-    private fun watchOwnerFullscreenExit(ownerWindowId: String?) {
+    private fun watchOwnerFullscreenExit(
+        ownerWindowId: String?,
+        expectedEpoch: Long,
+    ) {
         if (ownerWindowId == null) return
         ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
         val listener: (String) -> Unit = { exitedWindowId ->
             if (exitedWindowId == ownerWindowId) {
                 SwingUtilities.invokeLater {
-                    if (currentOwnerWindowId == ownerWindowId &&
-                        isInFullscreenMode &&
-                        !usesNativeMacOSFullscreen
-                    ) {
+                    if (isCurrentOwnerOverlay(ownerWindowId, expectedEpoch)) {
                         logger.info(
                             LogCategory.BROWSER,
                             "Closing fullscreen video overlay because its host exited fullscreen",
                             mapOf("ownerWindowId" to ownerWindowId),
                         )
-                        performExitDirect()
+                        requestPageExit()
                     }
                 }
             }
@@ -481,10 +547,20 @@ object FullscreenBrowserWindow {
         }
     }
 
+    private fun isCurrentOwnerOverlay(
+        ownerWindowId: String,
+        expectedEpoch: Long,
+    ): Boolean =
+        currentOwnerWindowId == ownerWindowId &&
+            lifecycleEpoch == expectedEpoch &&
+            isInFullscreenMode &&
+            !usesNativeMacOSFullscreen
+
     /**
      * Reset all state variables.
      */
-    private fun resetState() {
+    private fun resetState(): Long {
+        lifecycleEpoch++
         ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
         ownerFullscreenExitListener = null
         fullscreenFrame = null
@@ -496,6 +572,7 @@ object FullscreenBrowserWindow {
         hasReachedFullscreen = false
         usesNativeMacOSFullscreen = false
         isExiting = false
+        return lifecycleEpoch
     }
 
     /**
@@ -506,11 +583,13 @@ object FullscreenBrowserWindow {
      * @param frame The JFrame to dispose
      * @param browserView The BrowserView to detach (nullable)
      * @param callback Optional callback to invoke after cleanup completes
+     * @param cleanupEpoch Reset epoch that must still be current before Compose is restored
      */
     private fun cleanupAndExit(
         frame: JFrame,
         browserView: BrowserView?,
         callback: (() -> Unit)?,
+        cleanupEpoch: Long,
     ) {
         val cleanup =
             Runnable {
@@ -539,7 +618,7 @@ object FullscreenBrowserWindow {
                 // Delay before telling Compose to show its BrowserView
                 // This gives JxBrowser time to fully release the Swing rendering surface
                 Timer(SWING_RELEASE_DELAY_MS) {
-                    SwingUtilities.invokeLater {
+                    if (lifecycleEpoch == cleanupEpoch && !isInFullscreenMode) {
                         TabFullscreenStateManager.exitFullscreen()
                         logger.info(LogCategory.BROWSER, "Fullscreen exit complete, Compose BrowserView enabled")
                         callback?.invoke()
@@ -580,7 +659,7 @@ object FullscreenBrowserWindow {
 
     /** Called when the user manually triggers exit from the host UI. */
     private fun requestExit() {
-        logger.info(LogCategory.BROWSER, "Exit requested via placeholder click")
+        logger.info(LogCategory.BROWSER, "Fullscreen exit requested from host UI")
         requestPageExit()
     }
 
@@ -593,6 +672,7 @@ object FullscreenBrowserWindow {
         if (isExiting || !isInFullscreenMode) return
         isExiting = true
         val browser = currentBrowser
+        val exitEpoch = lifecycleEpoch
         if (browser == null ||
             runCatching { browser.fullScreen().exit() }
                 .onFailure { error ->
@@ -604,7 +684,10 @@ object FullscreenBrowserWindow {
         }
 
         Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-            if (currentBrowser === browser && isInFullscreenMode) {
+            if (lifecycleEpoch == exitEpoch &&
+                currentBrowser === browser &&
+                isInFullscreenMode
+            ) {
                 logger.warn(LogCategory.BROWSER, "Browser fullscreen exit event timed out; closing host window")
                 performExitDirect()
             }
@@ -627,12 +710,17 @@ object FullscreenBrowserWindow {
      * Direct exit without relying on fullscreen toggle.
      */
     private fun performExitDirect() {
-        val frame = fullscreenFrame ?: return
+        val frame = fullscreenFrame
         val browserView = currentBrowserView
         val callback = onExitCallback
 
-        resetState()
-        cleanupAndExit(frame, browserView, callback)
+        val cleanupEpoch = resetState()
+        if (frame == null) {
+            TabFullscreenStateManager.exitFullscreen()
+            callback?.invoke()
+        } else {
+            cleanupAndExit(frame, browserView, callback, cleanupEpoch)
+        }
     }
 
     /**
@@ -652,8 +740,8 @@ object FullscreenBrowserWindow {
         }
         val browserView = currentBrowserView
 
-        resetState()
-        cleanupAndExit(frame, browserView, null)
+        val cleanupEpoch = resetState()
+        cleanupAndExit(frame, browserView, null, cleanupEpoch)
     }
 
     /** Closes fullscreen asynchronously only when it belongs to the browser emitting the event. */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -87,6 +87,14 @@ internal enum class FullscreenRequestDecision {
     REJECT_CLOSED,
     REJECT_COMPETING,
     BEGIN,
+    ;
+
+    companion object {
+        fun shouldResumeAfterDuplicateRequest(
+            decision: FullscreenRequestDecision,
+            isExiting: Boolean,
+        ): Boolean = decision == IGNORE_DUPLICATE && isExiting
+    }
 }
 
 internal fun fullscreenRequestDecision(
@@ -411,6 +419,14 @@ private class FullscreenOverlayCoordinator(
         val hostWindow = ownerWindowId?.let(WindowFocusManager::getWindow) ?: return
         val listener =
             object : WindowAdapter() {
+                override fun windowLostFocus(event: WindowEvent?) {
+                    if (isCurrentFrameOverlay(frame)) {
+                        // If the overlay never acquired focus, its own listener cannot
+                        // observe app deactivation. The owner still can, so unpin here too.
+                        frame.isAlwaysOnTop = false
+                    }
+                }
+
                 override fun windowGainedFocus(event: WindowEvent?) {
                     restoreOverlayLevel(frame)
                 }
@@ -500,6 +516,7 @@ object FullscreenBrowserWindow {
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
     private var usesNativeMacOSFullscreen = false
     private var isExiting = false // Prevent multiple exit calls
+    private var pageExitFallbackTimer: Timer? = null
     private var lifecycleEpoch = 0L
     private val exitCallbackGate = FullscreenExitCallbackGate<Browser>()
     private val videoFullscreenTracker =
@@ -592,7 +609,17 @@ object FullscreenBrowserWindow {
             }
         when (decision) {
             FullscreenRequestDecision.IGNORE_DUPLICATE -> {
-                logger.debug(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
+                if (FullscreenRequestDecision.shouldResumeAfterDuplicateRequest(decision, isExiting)) {
+                    pageExitFallbackTimer?.stop()
+                    pageExitFallbackTimer = null
+                    isExiting = false
+                    logger.info(
+                        LogCategory.BROWSER,
+                        "Keeping fullscreen active after browser re-entered during pending exit",
+                    )
+                } else {
+                    logger.debug(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
+                }
             }
 
             FullscreenRequestDecision.REJECT_CLOSED -> {
@@ -1048,6 +1075,8 @@ object FullscreenBrowserWindow {
         hasReachedFullscreen = false
         usesNativeMacOSFullscreen = false
         isExiting = false
+        pageExitFallbackTimer?.stop()
+        pageExitFallbackTimer = null
         return lifecycleEpoch
     }
 
@@ -1139,18 +1168,20 @@ object FullscreenBrowserWindow {
             return
         }
 
-        Timer(PAGE_EXIT_EVENT_TIMEOUT_MS) {
-            if (lifecycleEpoch == exitEpoch &&
-                currentBrowser === browser &&
-                isInFullscreenMode
-            ) {
-                logger.warn(LogCategory.BROWSER, "Browser fullscreen exit event timed out; closing host window")
-                performExitDirect()
+        pageExitFallbackTimer =
+            Timer(PAGE_EXIT_EVENT_TIMEOUT_MS) {
+                if (lifecycleEpoch == exitEpoch &&
+                    currentBrowser === browser
+                ) {
+                    if (isInFullscreenMode && isExiting) {
+                        logger.warn(LogCategory.BROWSER, "Browser fullscreen exit event timed out; closing host window")
+                        performExitDirect()
+                    }
+                }
+            }.apply {
+                isRepeats = false
+                start()
             }
-        }.apply {
-            isRepeats = false
-            start()
-        }
     }
 
     /** Requests exit only if fullscreen belongs to this browser, without blocking its callback thread. */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -19,7 +19,7 @@ import java.awt.event.ComponentEvent
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
-import java.util.WeakHashMap
+import java.lang.ref.WeakReference
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
@@ -64,6 +64,23 @@ internal fun shouldRestoreFullscreenTabState(
     isInFullscreenMode: Boolean,
 ): Boolean = cleanupEpoch == currentEpoch && !isInFullscreenMode
 
+private fun displayBounds(frame: JFrame): Rectangle =
+    frame.graphicsConfiguration?.bounds
+        ?: GraphicsEnvironment
+            .getLocalGraphicsEnvironment()
+            .defaultScreenDevice.defaultConfiguration.bounds
+
+private fun isWindowInFullscreen(frame: JFrame): Boolean = fillsScreen(frame.bounds, displayBounds(frame))
+
+private fun isRegisteredWindowFullscreen(ownerWindowId: String): Boolean {
+    val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId) ?: return false
+    return hasFullscreenSignal(
+        nativeStateAvailable = state.nativeStateAvailable,
+        nativeFullscreen = state.nativeFullscreen,
+        composeFullscreen = state.composeFullscreen,
+    )
+}
+
 internal enum class FullscreenRequestDecision {
     IGNORE_DUPLICATE,
     REJECT_CLOSED,
@@ -88,19 +105,60 @@ internal fun fullscreenRequestDecision(
 
 /** EDT-confined once installed in [FullscreenBrowserWindow]. */
 internal class FullscreenExitCallbackGate<T : Any> {
-    private val notifiedOwners = WeakHashMap<T, Unit>()
+    private data class Entry<T : Any>(
+        val owner: WeakReference<T>,
+        var attempt: Long,
+        var notified: Boolean,
+    )
 
-    fun begin(owner: T) {
-        notifiedOwners.remove(owner)
+    private val entries = mutableListOf<Entry<T>>()
+    private var nextAttempt = 0L
+
+    fun begin(owner: T): Long {
+        val attempt = ++nextAttempt
+        val entry = findEntry(owner)
+        if (entry == null) {
+            entries += Entry(WeakReference(owner), attempt, notified = false)
+        } else {
+            entry.attempt = attempt
+            entry.notified = false
+        }
+        return attempt
     }
 
     fun notifyOnce(
         owner: T,
         callback: () -> Unit,
+    ): Boolean = notifyOnceInternal(owner, expectedAttempt = null, callback)
+
+    fun notifyOnce(
+        owner: T,
+        expectedAttempt: Long,
+        callback: () -> Unit,
+    ): Boolean = notifyOnceInternal(owner, expectedAttempt, callback)
+
+    private fun notifyOnceInternal(
+        owner: T,
+        expectedAttempt: Long?,
+        callback: () -> Unit,
     ): Boolean {
-        if (notifiedOwners.put(owner, Unit) != null) return false
-        callback()
-        return true
+        val entry =
+            findEntry(owner)
+                ?: Entry(WeakReference(owner), ++nextAttempt, notified = false)
+                    .also(entries::add)
+        val shouldNotify =
+            (expectedAttempt == null || entry.attempt == expectedAttempt) &&
+                !entry.notified
+        if (shouldNotify) {
+            entry.notified = true
+            callback()
+        }
+        return shouldNotify
+    }
+
+    private fun findEntry(owner: T): Entry<T>? {
+        entries.removeAll { it.owner.get() == null }
+        return entries.firstOrNull { it.owner.get() === owner }
     }
 }
 
@@ -208,11 +266,14 @@ object FullscreenBrowserWindow {
                 isSameBrowser = currentBrowser === browser,
                 isBrowserClosed = browser.isClosed,
             )
-        if (decision != FullscreenRequestDecision.IGNORE_DUPLICATE) {
-            // Deduplicate within one request/exit attempt, not forever for a
-            // browser that may lose several competing requests over its life.
-            exitCallbackGate.begin(browser)
-        }
+        val exitAttempt =
+            if (decision != FullscreenRequestDecision.IGNORE_DUPLICATE) {
+                // Deduplicate within one request/exit attempt, not forever for a
+                // browser that may lose several competing requests over its life.
+                exitCallbackGate.begin(browser)
+            } else {
+                null
+            }
         when (decision) {
             FullscreenRequestDecision.IGNORE_DUPLICATE -> {
                 logger.debug(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
@@ -220,11 +281,11 @@ object FullscreenBrowserWindow {
 
             FullscreenRequestDecision.REJECT_CLOSED -> {
                 logger.warn(LogCategory.BROWSER, "Ignoring fullscreen request from closed browser")
-                exitCallbackGate.notifyOnce(browser, onExit)
+                exitCallbackGate.notifyOnce(browser, checkNotNull(exitAttempt), onExit)
             }
 
             FullscreenRequestDecision.REJECT_COMPETING -> {
-                rejectFullscreenRequest(browser, onExit)
+                rejectFullscreenRequest(browser, checkNotNull(exitAttempt), onExit)
             }
 
             FullscreenRequestDecision.BEGIN -> {
@@ -236,6 +297,7 @@ object FullscreenBrowserWindow {
     /** Rejects a losing browser without publishing a false enter state. */
     private fun rejectFullscreenRequest(
         browser: Browser,
+        exitAttempt: Long,
         onExit: () -> Unit,
     ) {
         logger.warn(LogCategory.BROWSER, "Rejecting fullscreen request while another browser is active")
@@ -245,9 +307,16 @@ object FullscreenBrowserWindow {
                     logger.warn(LogCategory.BROWSER, "Could not reject competing browser fullscreen", error = error)
                 }.isSuccess
         // A successful request emits FullScreenExited, whose normal observer
-        // publishes the callback. Fall back locally only when no event can follow.
+        // publishes the callback. Bound the wait in case that event is lost.
         if (!exitRequested) {
-            exitCallbackGate.notifyOnce(browser, onExit)
+            exitCallbackGate.notifyOnce(browser, exitAttempt, onExit)
+        } else {
+            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                exitCallbackGate.notifyOnce(browser, exitAttempt, onExit)
+            }.apply {
+                isRepeats = false
+                start()
+            }
         }
     }
 
@@ -464,7 +533,7 @@ object FullscreenBrowserWindow {
                 showBorderlessOverlay(
                     frame = frame,
                     bounds = displayBounds(frame),
-                    watchOwnerExit = false,
+                    watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
                     expectedEpoch = expectedEpoch,
                 )
                 return@invokeLater
@@ -487,7 +556,7 @@ object FullscreenBrowserWindow {
                     showBorderlessOverlay(
                         frame = frame,
                         bounds = displayBounds(frame),
-                        watchOwnerExit = false,
+                        watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
                         expectedEpoch = expectedEpoch,
                     )
                 }
@@ -650,18 +719,6 @@ object FullscreenBrowserWindow {
             false
         }
 
-    /**
-     * Check if window is currently in fullscreen state (macOS).
-     * On macOS in fullscreen, the window bounds match the screen bounds exactly.
-     */
-    private fun isWindowInFullscreen(frame: JFrame): Boolean = fillsScreen(frame.bounds, displayBounds(frame))
-
-    private fun displayBounds(frame: JFrame): Rectangle =
-        frame.graphicsConfiguration?.bounds
-            ?: GraphicsEnvironment
-                .getLocalGraphicsEnvironment()
-                .defaultScreenDevice.defaultConfiguration.bounds
-
     private fun installExitShortcut(frame: JFrame) {
         frame.rootPane
             .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
@@ -702,17 +759,12 @@ object FullscreenBrowserWindow {
 
         // The owner may have completed its exit between the state read that
         // selected overlay mode and listener registration.
-        val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId)
-        val stillFullscreen =
-            state != null &&
-                hasFullscreenSignal(
-                    nativeStateAvailable = state.nativeStateAvailable,
-                    nativeFullscreen = state.nativeFullscreen,
-                    composeFullscreen = state.composeFullscreen,
-                )
+        val stillFullscreen = isRegisteredWindowFullscreen(ownerWindowId)
         if (!stillFullscreen) {
             SwingUtilities.invokeLater {
-                requestPageExit()
+                if (isCurrentOwnerOverlay(ownerWindowId, expectedEpoch)) {
+                    requestPageExit()
+                }
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -47,6 +47,18 @@ internal fun shouldUseComposeFullscreenOverlay(
         !isMaximized &&
         fillsScreen(windowBounds, screenBounds)
 
+internal fun isCurrentFullscreenLifecycle(
+    expectedEpoch: Long,
+    currentEpoch: Long,
+    isInFullscreenMode: Boolean,
+): Boolean = expectedEpoch == currentEpoch && isInFullscreenMode
+
+internal fun shouldRestoreFullscreenTabState(
+    cleanupEpoch: Long,
+    currentEpoch: Long,
+    isInFullscreenMode: Boolean,
+): Boolean = cleanupEpoch == currentEpoch && !isInFullscreenMode
+
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
  * Uses the existing browser instance with a new BrowserView.
@@ -114,7 +126,12 @@ object FullscreenBrowserWindow {
                 logger.warn(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
             }
 
-            browser.isClosed || fullscreenActive -> {
+            browser.isClosed -> {
+                logger.warn(LogCategory.BROWSER, "Ignoring fullscreen request from closed browser")
+                onExit()
+            }
+
+            fullscreenActive -> {
                 rejectFullscreenRequest(browser, onExit)
             }
 
@@ -129,12 +146,17 @@ object FullscreenBrowserWindow {
         browser: Browser,
         onExit: () -> Unit,
     ) {
-        logger.warn(LogCategory.BROWSER, "Fullscreen already active, ignoring duplicate request")
-        runCatching { browser.fullScreen().exit() }
-            .onFailure { error ->
-                logger.warn(LogCategory.BROWSER, "Could not reject duplicate browser fullscreen", error = error)
-            }
-        onExit()
+        logger.warn(LogCategory.BROWSER, "Rejecting fullscreen request while another browser is active")
+        val exitRequested =
+            runCatching { browser.fullScreen().exit() }
+                .onFailure { error ->
+                    logger.warn(LogCategory.BROWSER, "Could not reject competing browser fullscreen", error = error)
+                }.isSuccess
+        // A successful request emits FullScreenExited, whose normal observer
+        // publishes the callback. Fall back locally only when no event can follow.
+        if (!exitRequested) {
+            onExit()
+        }
     }
 
     private fun beginFullscreenSession(
@@ -179,8 +201,7 @@ object FullscreenBrowserWindow {
         expectedEpoch: Long,
         browser: Browser,
     ): Boolean =
-        lifecycleEpoch == expectedEpoch &&
-            isInFullscreenMode &&
+        isCurrentFullscreenLifecycle(expectedEpoch, lifecycleEpoch, isInFullscreenMode) &&
             currentBrowser === browser
 
     private fun isCurrentFrameSession(
@@ -193,7 +214,6 @@ object FullscreenBrowserWindow {
      * Creates and displays the fullscreen window with a Swing BrowserView.
      * Called after Compose BrowserView has had time to detach from rendering.
      */
-    @Suppress("LongMethod")
     private fun createFullscreenWindow(
         browser: Browser,
         tabId: String,
@@ -232,7 +252,7 @@ object FullscreenBrowserWindow {
             frame.addWindowListener(
                 object : WindowAdapter() {
                     override fun windowClosing(e: WindowEvent?) {
-                        performExit()
+                        requestPageExit()
                     }
                 },
             )
@@ -253,7 +273,7 @@ object FullscreenBrowserWindow {
                                 !isExiting
                             ) {
                                 logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
-                                performExit()
+                                requestPageExit()
                             }
                         }
                     }
@@ -264,69 +284,7 @@ object FullscreenBrowserWindow {
             currentBrowserView = browserView
 
             if (isMacOS) {
-                val fullscreenHostBounds = currentOwnerWindowId?.let(::existingFullscreenWindowBounds)
-                if (fullscreenHostBounds != null) {
-                    // macOS can ignore a second native fullscreen-Space request while another
-                    // window from this app already owns a fullscreen Space. Keep the video in
-                    // that Space and cover it with an undecorated screen-sized window instead.
-                    showBorderlessOverlay(
-                        frame = frame,
-                        bounds = fullscreenHostBounds,
-                        watchOwnerExit = true,
-                        expectedEpoch = expectedEpoch,
-                    )
-                    logger.info(
-                        LogCategory.BROWSER,
-                        "Opened fullscreen video as borderless overlay in existing fullscreen Space",
-                    )
-                } else {
-                    // Use native macOS fullscreen (creates new Space)
-                    usesNativeMacOSFullscreen = true
-                    frame.rootPane.putClientProperty("apple.awt.fullscreenable", true)
-                    frame.setSize(800, 600) // Initial size before fullscreen
-                    frame.setLocationRelativeTo(null)
-                    frame.isVisible = true
-
-                    // Request native fullscreen toggle after window is visible
-                    SwingUtilities.invokeLater {
-                        if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return@invokeLater
-                        if (toggleMacOSFullscreen(frame)) {
-                            // Wait for fullscreen animation to complete before enabling exit detection
-                            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                                if (isCurrentFrameSession(expectedEpoch, browser, frame)) {
-                                    if (isWindowInFullscreen(frame)) {
-                                        hasReachedFullscreen = true
-                                        logger.info(
-                                            LogCategory.BROWSER,
-                                            "Fullscreen animation completed, exit detection enabled",
-                                        )
-                                    } else {
-                                        logger.warn(
-                                            LogCategory.BROWSER,
-                                            "macOS ignored native fullscreen toggle; using borderless overlay",
-                                        )
-                                        showBorderlessOverlay(
-                                            frame = frame,
-                                            bounds = displayBounds(frame),
-                                            watchOwnerExit = false,
-                                            expectedEpoch = expectedEpoch,
-                                        )
-                                    }
-                                }
-                            }.apply {
-                                isRepeats = false
-                                start()
-                            }
-                        } else {
-                            showBorderlessOverlay(
-                                frame = frame,
-                                bounds = displayBounds(frame),
-                                watchOwnerExit = false,
-                                expectedEpoch = expectedEpoch,
-                            )
-                        }
-                    }
-                }
+                enterMacOSFullscreen(frame, browser, expectedEpoch)
             } else {
                 // Windows/Linux: use maximized undecorated window
                 frame.isUndecorated = true
@@ -349,6 +307,82 @@ object FullscreenBrowserWindow {
                 resetState()
                 TabFullscreenStateManager.exitFullscreen()
                 callback?.invoke()
+            }
+        }
+    }
+
+    private fun enterMacOSFullscreen(
+        frame: JFrame,
+        browser: Browser,
+        expectedEpoch: Long,
+    ) {
+        val fullscreenHostBounds = currentOwnerWindowId?.let(::existingFullscreenWindowBounds)
+        if (fullscreenHostBounds != null) {
+            // macOS can ignore a second native fullscreen-Space request while another
+            // window from this app already owns a fullscreen Space. Keep the video in
+            // that Space and cover it with an undecorated screen-sized window instead.
+            showBorderlessOverlay(
+                frame = frame,
+                bounds = fullscreenHostBounds,
+                watchOwnerExit = true,
+                expectedEpoch = expectedEpoch,
+            )
+            logger.info(
+                LogCategory.BROWSER,
+                "Opened fullscreen video as borderless overlay in existing fullscreen Space",
+            )
+            return
+        }
+
+        usesNativeMacOSFullscreen = true
+        frame.rootPane.putClientProperty("apple.awt.fullscreenable", true)
+        frame.setSize(800, 600) // Initial size before fullscreen
+        frame.setLocationRelativeTo(null)
+        frame.isVisible = true
+        requestNativeMacOSFullscreen(frame, browser, expectedEpoch)
+    }
+
+    private fun requestNativeMacOSFullscreen(
+        frame: JFrame,
+        browser: Browser,
+        expectedEpoch: Long,
+    ) {
+        SwingUtilities.invokeLater {
+            if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return@invokeLater
+            if (!toggleMacOSFullscreen(frame)) {
+                showBorderlessOverlay(
+                    frame = frame,
+                    bounds = displayBounds(frame),
+                    watchOwnerExit = false,
+                    expectedEpoch = expectedEpoch,
+                )
+                return@invokeLater
+            }
+
+            // Wait for fullscreen animation to complete before enabling exit detection.
+            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return@Timer
+                if (isWindowInFullscreen(frame)) {
+                    hasReachedFullscreen = true
+                    logger.info(
+                        LogCategory.BROWSER,
+                        "Fullscreen animation completed, exit detection enabled",
+                    )
+                } else {
+                    logger.warn(
+                        LogCategory.BROWSER,
+                        "macOS ignored native fullscreen toggle; using borderless overlay",
+                    )
+                    showBorderlessOverlay(
+                        frame = frame,
+                        bounds = displayBounds(frame),
+                        watchOwnerExit = false,
+                        expectedEpoch = expectedEpoch,
+                    )
+                }
+            }.apply {
+                isRepeats = false
+                start()
             }
         }
     }
@@ -414,19 +448,14 @@ object FullscreenBrowserWindow {
         ) {
             return null
         }
-        return when {
-            state.nativeStateAvailable -> {
-                state.window.graphicsConfiguration
-                    ?.bounds
-            }
-
-            else -> {
-                ownerWindowBoundsFallback(
-                    ownerWindowId = ownerWindowId,
-                    ownerWindow = state.window,
-                    composeSignalActive = state.composeFullscreen,
-                )
-            }
+        return if (state.nativeStateAvailable) {
+            state.window.graphicsConfiguration?.bounds
+        } else {
+            ownerWindowBoundsFallback(
+                ownerWindowId = ownerWindowId,
+                ownerWindow = state.window,
+                composeSignalActive = state.composeFullscreen,
+            )
         }
     }
 
@@ -503,7 +532,8 @@ object FullscreenBrowserWindow {
             EXIT_FULLSCREEN_ACTION,
             object : AbstractAction() {
                 override fun actionPerformed(event: ActionEvent?) {
-                    requestExit()
+                    logger.info(LogCategory.BROWSER, "Fullscreen exit requested from host UI")
+                    requestPageExit()
                 }
             },
         )
@@ -583,12 +613,14 @@ object FullscreenBrowserWindow {
      * @param frame The JFrame to dispose
      * @param browserView The BrowserView to detach (nullable)
      * @param callback Optional callback to invoke after cleanup completes
+     * @param exitingBrowser Browser that owned the cleanup session
      * @param cleanupEpoch Reset epoch that must still be current before Compose is restored
      */
     private fun cleanupAndExit(
         frame: JFrame,
         browserView: BrowserView?,
         callback: (() -> Unit)?,
+        exitingBrowser: Browser?,
         cleanupEpoch: Long,
     ) {
         val cleanup =
@@ -618,9 +650,14 @@ object FullscreenBrowserWindow {
                 // Delay before telling Compose to show its BrowserView
                 // This gives JxBrowser time to fully release the Swing rendering surface
                 Timer(SWING_RELEASE_DELAY_MS) {
-                    if (lifecycleEpoch == cleanupEpoch && !isInFullscreenMode) {
+                    if (shouldRestoreFullscreenTabState(cleanupEpoch, lifecycleEpoch, isInFullscreenMode)) {
                         TabFullscreenStateManager.exitFullscreen()
                         logger.info(LogCategory.BROWSER, "Fullscreen exit complete, Compose BrowserView enabled")
+                    }
+                    // The old tab still needs its local exit notification when
+                    // another browser starts a newer global session. A re-entry
+                    // by the same browser supersedes this callback instead.
+                    if (currentBrowser !== exitingBrowser) {
                         callback?.invoke()
                     }
                 }.apply {
@@ -650,17 +687,6 @@ object FullscreenBrowserWindow {
         } catch (e: InvocationTargetException) {
             logger.warn(LogCategory.BROWSER, "Could not close fullscreen browser window", error = e.cause ?: e)
         }
-    }
-
-    /** Handles a native fullscreen window exit by reconciling the browser page first. */
-    private fun performExit() {
-        requestPageExit()
-    }
-
-    /** Called when the user manually triggers exit from the host UI. */
-    private fun requestExit() {
-        logger.info(LogCategory.BROWSER, "Fullscreen exit requested from host UI")
-        requestPageExit()
     }
 
     /**
@@ -701,7 +727,8 @@ object FullscreenBrowserWindow {
     fun requestExit(browser: Browser) {
         SwingUtilities.invokeLater {
             if (currentBrowser === browser) {
-                requestExit()
+                logger.info(LogCategory.BROWSER, "Fullscreen exit requested by owning browser")
+                requestPageExit()
             }
         }
     }
@@ -712,6 +739,7 @@ object FullscreenBrowserWindow {
     private fun performExitDirect() {
         val frame = fullscreenFrame
         val browserView = currentBrowserView
+        val browser = currentBrowser
         val callback = onExitCallback
 
         val cleanupEpoch = resetState()
@@ -719,7 +747,7 @@ object FullscreenBrowserWindow {
             TabFullscreenStateManager.exitFullscreen()
             callback?.invoke()
         } else {
-            cleanupAndExit(frame, browserView, callback, cleanupEpoch)
+            cleanupAndExit(frame, browserView, callback, browser, cleanupEpoch)
         }
     }
 
@@ -739,9 +767,10 @@ object FullscreenBrowserWindow {
             return
         }
         val browserView = currentBrowserView
+        val browser = currentBrowser
 
         val cleanupEpoch = resetState()
-        cleanupAndExit(frame, browserView, null, cleanupEpoch)
+        cleanupAndExit(frame, browserView, null, browser, cleanupEpoch)
     }
 
     /** Closes fullscreen asynchronously only when it belongs to the browser emitting the event. */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -7,6 +7,7 @@ import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.BorderLayout
 import java.awt.Color
+import java.awt.Frame
 import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
 import java.awt.Window
@@ -22,8 +23,10 @@ internal fun fillsScreen(
     windowBounds: Rectangle,
     screenBounds: Rectangle,
 ): Boolean =
-    windowBounds.width >= screenBounds.width &&
-        windowBounds.height >= screenBounds.height
+    windowBounds.x <= screenBounds.x &&
+        windowBounds.y <= screenBounds.y &&
+        windowBounds.maxX >= screenBounds.maxX &&
+        windowBounds.maxY >= screenBounds.maxY
 
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
@@ -34,6 +37,10 @@ object FullscreenBrowserWindow {
     private val logger = BossLogger.forComponent("FullscreenBrowserWindow")
     private var fullscreenFrame: JFrame? = null
     private var currentBrowserView: BrowserView? = null
+
+    @Volatile
+    private var currentBrowser: Browser? = null
+    private var currentOwnerWindowId: String? = null
     private var onExitCallback: (() -> Unit)? = null
     private var isInFullscreenMode = false
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
@@ -56,6 +63,7 @@ object FullscreenBrowserWindow {
     fun showFullscreen(
         browser: Browser,
         tabId: String,
+        ownerWindowId: String,
         onExit: () -> Unit,
     ) {
         // Prevent duplicate calls
@@ -67,6 +75,8 @@ object FullscreenBrowserWindow {
         // Mark fullscreen state FIRST so Compose BrowserView hides immediately
         // This triggers recomposition in JxBrowserCompose.kt, replacing BrowserView with placeholder
         isInFullscreenMode = true
+        currentBrowser = browser
+        currentOwnerWindowId = ownerWindowId
         onExitCallback = onExit
         isExiting = false
         hasReachedFullscreen = false
@@ -137,7 +147,8 @@ object FullscreenBrowserWindow {
             frame.addComponentListener(
                 object : ComponentAdapter() {
                     override fun componentResized(e: ComponentEvent?) {
-                        // Only check for exit after we've confirmed fullscreen was reached
+                        // Overlay and Windows/Linux frames are fixed-size and exit directly;
+                        // resize-based native-Space exit detection is macOS-native only.
                         if (!usesNativeMacOSFullscreen || !hasReachedFullscreen) return
                         if (!isInFullscreenMode || isExiting || fullscreenFrame == null) return
 
@@ -155,12 +166,13 @@ object FullscreenBrowserWindow {
             currentBrowserView = browserView
 
             if (isMacOS) {
-                val fullscreenHostBounds = existingFullscreenWindowBounds()
+                val fullscreenHostBounds = currentOwnerWindowId?.let(::existingFullscreenWindowBounds)
                 if (fullscreenHostBounds != null) {
                     // macOS can ignore a second native fullscreen-Space request while another
                     // window from this app already owns a fullscreen Space. Keep the video in
                     // that Space and cover it with an undecorated screen-sized window instead.
                     frame.isUndecorated = true
+                    frame.isAlwaysOnTop = true
                     frame.setBounds(fullscreenHostBounds)
                     frame.isVisible = true
                     usesNativeMacOSFullscreen = false
@@ -179,20 +191,24 @@ object FullscreenBrowserWindow {
 
                     // Request native fullscreen toggle after window is visible
                     SwingUtilities.invokeLater {
-                        requestMacOSFullscreen(frame)
-
-                        // Wait for fullscreen animation to complete before enabling exit detection
-                        Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                            if (fullscreenFrame != null && isInFullscreenMode) {
-                                hasReachedFullscreen = true
-                                logger.info(
-                                    LogCategory.BROWSER,
-                                    "Fullscreen animation completed, exit detection enabled",
-                                )
+                        if (toggleMacOSFullscreen(frame)) {
+                            // Wait for fullscreen animation to complete before enabling exit detection
+                            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                                if (fullscreenFrame != null && isInFullscreenMode) {
+                                    hasReachedFullscreen = true
+                                    logger.info(
+                                        LogCategory.BROWSER,
+                                        "Fullscreen animation completed, exit detection enabled",
+                                    )
+                                }
+                            }.apply {
+                                isRepeats = false
+                                start()
                             }
-                        }.apply {
-                            isRepeats = false
-                            start()
+                        } else {
+                            usesNativeMacOSFullscreen = false
+                            frame.extendedState = JFrame.MAXIMIZED_BOTH
+                            hasReachedFullscreen = true
                         }
                     }
                 }
@@ -224,20 +240,36 @@ object FullscreenBrowserWindow {
      * A new undecorated video window can cover that same fullscreen Space without
      * asking macOS to create a second native fullscreen Space.
      */
-    private fun existingFullscreenWindowBounds(): Rectangle? {
+    private fun existingFullscreenWindowBounds(ownerWindowId: String): Rectangle? =
         WindowFocusManager
-            .getFullscreenWindow()
+            .getFullscreenWindow(ownerWindowId)
             ?.graphicsConfiguration
             ?.bounds
-            ?.let { return it }
+            ?: ownerWindowBoundsFallback(ownerWindowId)
 
-        // Fallback for fullscreen windows not created by BossWindow or observed before
-        // Compose placement was published.
-        return Window.getWindows().firstNotNullOfOrNull { window ->
-            if (!window.isShowing) return@firstNotNullOfOrNull null
-            val screenBounds = window.graphicsConfiguration?.bounds ?: return@firstNotNullOfOrNull null
-            screenBounds.takeIf { fillsScreen(window.bounds, screenBounds) }
+    private fun ownerWindowBoundsFallback(ownerWindowId: String): Rectangle? {
+        // Best-effort fallback only for the browser's owning window. Never scan
+        // another Boss window or treat an ordinary maximized frame as fullscreen.
+        val ownerWindow = WindowFocusManager.getWindow(ownerWindowId)
+        val screenBounds = ownerWindow?.graphicsConfiguration?.bounds
+        val isMaximized =
+            ownerWindow is Frame &&
+                ownerWindow.extendedState and Frame.MAXIMIZED_BOTH != 0
+        val fallbackBounds =
+            screenBounds?.takeIf {
+                ownerWindow.isShowing &&
+                    !isMaximized &&
+                    fillsScreen(ownerWindow.bounds, screenBounds)
+            }
+
+        if (fallbackBounds != null) {
+            logger.info(
+                LogCategory.BROWSER,
+                "Using owner-window bounds fallback for fullscreen video overlay",
+                mapOf("ownerWindowId" to ownerWindowId),
+            )
         }
+        return fallbackBounds
     }
 
     /**
@@ -245,7 +277,7 @@ object FullscreenBrowserWindow {
      * Uses com.apple.eawt.Application.requestToggleFullScreen() which creates
      * a proper macOS fullscreen Space (like Chrome/Safari behavior).
      */
-    private fun requestMacOSFullscreen(window: Window) {
+    private fun toggleMacOSFullscreen(window: Window): Boolean =
         try {
             val appClass = Class.forName("com.apple.eawt.Application")
             val getAppMethod = appClass.getDeclaredMethod("getApplication")
@@ -255,14 +287,11 @@ object FullscreenBrowserWindow {
             requestToggleMethod.isAccessible = true
             requestToggleMethod.invoke(app, window)
             logger.info(LogCategory.BROWSER, "Requested macOS native fullscreen")
+            true
         } catch (e: Exception) {
-            logger.warn(LogCategory.BROWSER, "Could not request macOS fullscreen, using fallback", error = e)
-            usesNativeMacOSFullscreen = false
-            // Fallback: maximize window
-            (window as? JFrame)?.extendedState = JFrame.MAXIMIZED_BOTH
-            hasReachedFullscreen = true
+            logger.warn(LogCategory.BROWSER, "Could not toggle macOS fullscreen", error = e)
+            false
         }
-    }
 
     /**
      * Check if window is currently in fullscreen state (macOS).
@@ -279,6 +308,8 @@ object FullscreenBrowserWindow {
     private fun resetState() {
         fullscreenFrame = null
         currentBrowserView = null
+        currentBrowser = null
+        currentOwnerWindowId = null
         onExitCallback = null
         isInFullscreenMode = false
         hasReachedFullscreen = false
@@ -358,15 +389,18 @@ object FullscreenBrowserWindow {
         if (isMacOS && usesNativeMacOSFullscreen && hasReachedFullscreen) {
             // Toggle fullscreen off (will trigger componentResized -> performExit)
             isExiting = true
-            requestMacOSFullscreen(frame)
-            // Also schedule a direct exit in case the toggle doesn't work
-            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                if (fullscreenFrame != null) {
-                    performExitDirect()
+            if (!toggleMacOSFullscreen(frame)) {
+                performExitDirect()
+            } else {
+                // Also schedule a direct exit in case the toggle doesn't work
+                Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                    if (fullscreenFrame != null) {
+                        performExitDirect()
+                    }
+                }.apply {
+                    isRepeats = false
+                    start()
                 }
-            }.apply {
-                isRepeats = false
-                start()
             }
         } else {
             performExitDirect()
@@ -390,11 +424,27 @@ object FullscreenBrowserWindow {
      * Safe to call multiple times - will only close once.
      */
     fun exitFullscreen() {
-        val frame = fullscreenFrame ?: return
+        val frame = fullscreenFrame
+        if (frame == null) {
+            if (isInFullscreenMode) {
+                resetState()
+                TabFullscreenStateManager.exitFullscreen()
+            }
+            return
+        }
         val browserView = currentBrowserView
 
         resetState()
         cleanupAndExit(frame, browserView, null)
+    }
+
+    /** Closes fullscreen only when it belongs to the browser being disposed. */
+    fun exitFullscreen(browser: Browser) {
+        SwingUtilities.invokeLater {
+            if (currentBrowser === browser) {
+                exitFullscreen()
+            }
+        }
     }
 
     fun isFullscreenActive(): Boolean = fullscreenFrame != null && isInFullscreenMode

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -145,8 +145,12 @@ internal class FullscreenExitCallbackGate<T : Any> {
     ): Boolean {
         val entry =
             findEntry(owner)
-                ?: Entry(WeakReference(owner), ++nextAttempt, notified = false)
-                    .also(entries::add)
+                ?: run {
+                    val attempt = expectedAttempt ?: ++nextAttempt
+                    nextAttempt = maxOf(nextAttempt, attempt)
+                    Entry(WeakReference(owner), attempt, notified = false)
+                        .also(entries::add)
+                }
         val shouldNotify =
             (expectedAttempt == null || entry.attempt == expectedAttempt) &&
                 !entry.notified
@@ -184,10 +188,11 @@ private fun runOnEventDispatchThreadAndWait(
         Thread.currentThread().interrupt()
         logger.warn(LogCategory.BROWSER, "Interrupted while closing fullscreen browser window", error = e)
     } catch (e: TimeoutException) {
-        task.cancel(false)
+        // Keep the task queued: the caller may stop waiting, but the fullscreen
+        // frame still must be disposed once the EDT becomes responsive.
         logger.warn(
             LogCategory.BROWSER,
-            "Timed out waiting for fullscreen browser cleanup on the EDT",
+            "Timed out waiting for fullscreen browser cleanup on the EDT; cleanup remains queued",
             error = e,
         )
     } catch (e: ExecutionException) {
@@ -269,10 +274,13 @@ private fun prepareBorderlessOverlayFrame(
 ): FullscreenFrameView {
     if (!sourceFrame.isDisplayable) {
         sourceFrame.isUndecorated = true
+        // createFullscreenWindow assigns the view before selecting this path.
         return FullscreenFrameView(sourceFrame, checkNotNull(sourceView))
     }
 
     val graphicsConfiguration = sourceFrame.graphicsConfiguration
+    // BrowserView has no close/dispose API. Hide and detach it before disposing
+    // the peer; the Browser remains alive and is mounted into a fresh view below.
     sourceView?.let { view ->
         view.isVisible = false
         sourceFrame.contentPane.remove(view)
@@ -400,6 +408,8 @@ private class FullscreenOverlayCoordinator(
  * Creates and manages a fullscreen Swing JFrame for browser content.
  * Uses the existing browser instance with a new BrowserView.
  * Uses native macOS fullscreen mode (creates new Space) for proper fullscreen experience.
+ * Exactly one browser fullscreen session is supported process-wide; window and browser IDs
+ * scope ownership and rejection decisions for that single session.
  */
 object FullscreenBrowserWindow {
     private val logger = BossLogger.forComponent("FullscreenBrowserWindow")
@@ -448,8 +458,10 @@ object FullscreenBrowserWindow {
 
     private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
 
-    // macOS fullscreen animation takes ~500ms, wait before enabling exit detection
+    // macOS fullscreen animation takes ~500ms, wait before enabling exit detection.
     private const val FULLSCREEN_ANIMATION_DELAY_MS = 600
+    private const val COMPETING_REQUEST_EXIT_TIMEOUT_MS = 600
+    private const val PAGE_EXIT_EVENT_TIMEOUT_MS = 1_000
 
     // Delay to allow Compose BrowserView to detach before creating Swing BrowserView
     // This prevents both views from competing for rendering (which causes video freeze)
@@ -536,7 +548,7 @@ object FullscreenBrowserWindow {
         if (!exitRequested) {
             exitCallbackGate.notifyOnce(browser, exitAttempt, onExit)
         } else {
-            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+            Timer(COMPETING_REQUEST_EXIT_TIMEOUT_MS) {
                 exitCallbackGate.notifyOnce(browser, exitAttempt, onExit)
             }.apply {
                 isRepeats = false
@@ -845,6 +857,8 @@ object FullscreenBrowserWindow {
             )
         fullscreenFrame = overlay.frame
         currentBrowserView = overlay.browserView
+        usesNativeMacOSFullscreen = false
+        hasReachedFullscreen = true
         overlay.frame.isAlwaysOnTop = true
         overlay.frame.extendedState = JFrame.NORMAL
         overlay.frame.setBounds(bounds)
@@ -852,8 +866,6 @@ object FullscreenBrowserWindow {
         overlay.frame.toFront()
         overlay.browserView.requestFocusInWindow()
         overlayCoordinator.installFocusBehavior(overlay.frame, currentOwnerWindowId)
-        usesNativeMacOSFullscreen = false
-        hasReachedFullscreen = true
         if (watchOwnerExit) {
             overlayCoordinator.watchOwnerExit(currentOwnerWindowId, expectedEpoch)
         }
@@ -864,7 +876,6 @@ object FullscreenBrowserWindow {
      * A new undecorated video window can cover that same fullscreen Space without
      * asking macOS to create a second native fullscreen Space.
      */
-
     private fun existingFullscreenWindowBounds(ownerWindowId: String): Rectangle? {
         val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId)
         if (state == null ||
@@ -1062,7 +1073,7 @@ object FullscreenBrowserWindow {
             return
         }
 
-        Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+        Timer(PAGE_EXIT_EVENT_TIMEOUT_MS) {
             if (lifecycleEpoch == exitEpoch &&
                 currentBrowser === browser &&
                 isInFullscreenMode

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -1,8 +1,10 @@
 package ai.rever.boss.tabfullscreen
 
 import ai.rever.boss.utils.WindowFocusManager
+import ai.rever.boss.utils.addWindowFullscreenExitListener
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.removeWindowFullscreenExitListener
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.BorderLayout
@@ -11,11 +13,17 @@ import java.awt.Frame
 import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
 import java.awt.Window
+import java.awt.event.ActionEvent
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
+import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.lang.reflect.InvocationTargetException
+import javax.swing.AbstractAction
+import javax.swing.JComponent
 import javax.swing.JFrame
+import javax.swing.KeyStroke
 import javax.swing.SwingUtilities
 import javax.swing.Timer
 
@@ -41,6 +49,7 @@ object FullscreenBrowserWindow {
     @Volatile
     private var currentBrowser: Browser? = null
     private var currentOwnerWindowId: String? = null
+    private var ownerFullscreenExitListener: ((String) -> Unit)? = null
     private var onExitCallback: (() -> Unit)? = null
     private var isInFullscreenMode = false
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
@@ -59,6 +68,7 @@ object FullscreenBrowserWindow {
     // Delay to allow Swing BrowserView to release rendering before Compose BrowserView activates
     // Exit needs more time because we need to ensure the Swing view fully releases the surface
     private const val SWING_RELEASE_DELAY_MS = 200
+    private const val EXIT_FULLSCREEN_ACTION = "exit-fullscreen"
 
     fun showFullscreen(
         browser: Browser,
@@ -124,6 +134,7 @@ object FullscreenBrowserWindow {
             frame.background = Color.BLACK
             frame.contentPane.background = Color.BLACK
             frame.contentPane.layout = BorderLayout()
+            installExitShortcut(frame)
 
             // Create BrowserView for existing browser instance
             // At this point, the Compose BrowserView should be detached from rendering
@@ -177,6 +188,7 @@ object FullscreenBrowserWindow {
                     frame.isVisible = true
                     usesNativeMacOSFullscreen = false
                     hasReachedFullscreen = true
+                    watchOwnerFullscreenExit(currentOwnerWindowId)
                     logger.info(
                         LogCategory.BROWSER,
                         "Opened fullscreen video as borderless overlay in existing fullscreen Space",
@@ -302,10 +314,49 @@ object FullscreenBrowserWindow {
         return fillsScreen(frame.bounds, screenBounds)
     }
 
+    private fun installExitShortcut(frame: JFrame) {
+        frame.rootPane
+            .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+            .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), EXIT_FULLSCREEN_ACTION)
+        frame.rootPane.actionMap.put(
+            EXIT_FULLSCREEN_ACTION,
+            object : AbstractAction() {
+                override fun actionPerformed(event: ActionEvent?) {
+                    requestExit()
+                }
+            },
+        )
+    }
+
+    private fun watchOwnerFullscreenExit(ownerWindowId: String?) {
+        if (ownerWindowId == null) return
+        val listener: (String) -> Unit = { exitedWindowId ->
+            if (exitedWindowId == ownerWindowId) {
+                SwingUtilities.invokeLater {
+                    if (currentOwnerWindowId == ownerWindowId &&
+                        isInFullscreenMode &&
+                        !usesNativeMacOSFullscreen
+                    ) {
+                        logger.info(
+                            LogCategory.BROWSER,
+                            "Closing fullscreen video overlay because its host exited fullscreen",
+                            mapOf("ownerWindowId" to ownerWindowId),
+                        )
+                        performExitDirect()
+                    }
+                }
+            }
+        }
+        ownerFullscreenExitListener = listener
+        addWindowFullscreenExitListener(listener)
+    }
+
     /**
      * Reset all state variables.
      */
     private fun resetState() {
+        ownerFullscreenExitListener?.let(::removeWindowFullscreenExitListener)
+        ownerFullscreenExitListener = null
         fullscreenFrame = null
         currentBrowserView = null
         currentBrowser = null
@@ -331,36 +382,59 @@ object FullscreenBrowserWindow {
         browserView: BrowserView?,
         callback: (() -> Unit)?,
     ) {
-        SwingUtilities.invokeLater {
-            try {
-                // Hide and detach the Swing BrowserView to release rendering surface
-                browserView?.let { view ->
-                    view.isVisible = false
-                    view.repaint()
-                    frame.contentPane.remove(view)
-                }
-                frame.contentPane.revalidate()
-                frame.contentPane.repaint()
-                frame.dispose()
-                logger.info(LogCategory.BROWSER, "Fullscreen window disposed, waiting for rendering release")
-
-                // Delay before telling Compose to show its BrowserView
-                // This gives JxBrowser time to fully release the Swing rendering surface
-                Timer(SWING_RELEASE_DELAY_MS) {
-                    SwingUtilities.invokeLater {
-                        TabFullscreenStateManager.exitFullscreen()
-                        logger.info(LogCategory.BROWSER, "Fullscreen exit complete, Compose BrowserView enabled")
-                        callback?.invoke()
+        val cleanup =
+            Runnable {
+                try {
+                    // Hide and detach the Swing BrowserView to release rendering surface
+                    browserView?.let { view ->
+                        view.isVisible = false
+                        view.repaint()
+                        frame.contentPane.remove(view)
                     }
-                }.apply {
-                    isRepeats = false
-                    start()
+                    frame.contentPane.revalidate()
+                    frame.contentPane.repaint()
+                    frame.dispose()
+                    logger.info(LogCategory.BROWSER, "Fullscreen window disposed, waiting for rendering release")
+
+                    // Delay before telling Compose to show its BrowserView
+                    // This gives JxBrowser time to fully release the Swing rendering surface
+                    Timer(SWING_RELEASE_DELAY_MS) {
+                        SwingUtilities.invokeLater {
+                            TabFullscreenStateManager.exitFullscreen()
+                            logger.info(LogCategory.BROWSER, "Fullscreen exit complete, Compose BrowserView enabled")
+                            callback?.invoke()
+                        }
+                    }.apply {
+                        isRepeats = false
+                        start()
+                    }
+                } catch (e: Exception) {
+                    logger.error(LogCategory.BROWSER, "Error closing fullscreen window", error = e)
+                    TabFullscreenStateManager.exitFullscreen()
+                    callback?.invoke()
                 }
-            } catch (e: Exception) {
-                logger.error(LogCategory.BROWSER, "Error closing fullscreen window", error = e)
-                TabFullscreenStateManager.exitFullscreen()
-                callback?.invoke()
             }
+
+        if (SwingUtilities.isEventDispatchThread()) {
+            cleanup.run()
+        } else {
+            SwingUtilities.invokeLater(cleanup)
+        }
+    }
+
+    private fun runOnEventDispatchThreadAndWait(action: () -> Unit) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action()
+            return
+        }
+
+        try {
+            SwingUtilities.invokeAndWait { action() }
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            logger.warn(LogCategory.BROWSER, "Interrupted while closing fullscreen browser window", error = e)
+        } catch (e: InvocationTargetException) {
+            logger.warn(LogCategory.BROWSER, "Could not close fullscreen browser window", error = e.cause ?: e)
         }
     }
 
@@ -438,9 +512,13 @@ object FullscreenBrowserWindow {
         cleanupAndExit(frame, browserView, null)
     }
 
-    /** Closes fullscreen only when it belongs to the browser being disposed. */
+    /**
+     * Closes fullscreen only when it belongs to the browser being disposed.
+     * Blocks a background disposer until the Swing view has been detached, so
+     * the browser cannot close underneath the fullscreen window's cleanup.
+     */
     fun exitFullscreen(browser: Browser) {
-        SwingUtilities.invokeLater {
+        runOnEventDispatchThreadAndWait {
             if (currentBrowser === browser) {
                 exitFullscreen()
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.tabfullscreen
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.hasFullscreenSignal
 import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.ComponentLogger
 import ai.rever.boss.utils.logging.LogCategory
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.view.swing.BrowserView
@@ -18,8 +19,11 @@ import java.awt.event.ComponentEvent
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
-import java.lang.reflect.InvocationTargetException
 import java.util.WeakHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import javax.swing.AbstractAction
 import javax.swing.JComponent
 import javax.swing.JFrame
@@ -100,6 +104,38 @@ internal class FullscreenExitCallbackGate<T : Any> {
     }
 }
 
+private fun runOnEventDispatchThreadAndWait(
+    logger: ComponentLogger,
+    timeoutMs: Long,
+    action: () -> Unit,
+) {
+    if (SwingUtilities.isEventDispatchThread()) {
+        action()
+        return
+    }
+
+    val task =
+        FutureTask<Unit> {
+            action()
+        }
+    SwingUtilities.invokeLater(task)
+    try {
+        task.get(timeoutMs, TimeUnit.MILLISECONDS)
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        logger.warn(LogCategory.BROWSER, "Interrupted while closing fullscreen browser window", error = e)
+    } catch (e: TimeoutException) {
+        task.cancel(false)
+        logger.warn(
+            LogCategory.BROWSER,
+            "Timed out waiting for fullscreen browser cleanup on the EDT",
+            error = e,
+        )
+    } catch (e: ExecutionException) {
+        logger.warn(LogCategory.BROWSER, "Could not close fullscreen browser window", error = e.cause ?: e)
+    }
+}
+
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
  * Uses the existing browser instance with a new BrowserView.
@@ -139,6 +175,7 @@ object FullscreenBrowserWindow {
     // Delay to allow Swing BrowserView to release rendering before Compose BrowserView activates
     // Exit needs more time because we need to ensure the Swing view fully releases the surface
     private const val SWING_RELEASE_DELAY_MS = 200
+    private const val EDT_CLEANUP_TIMEOUT_MS = 2_000L
     private const val EXIT_FULLSCREEN_ACTION = "exit-fullscreen"
 
     fun showFullscreen(
@@ -164,14 +201,19 @@ object FullscreenBrowserWindow {
         onEnter: () -> Unit,
         onExit: () -> Unit,
     ) {
-        when (
+        val decision =
             fullscreenRequestDecision(
                 frameActive = fullscreenFrame != null,
                 isInFullscreenMode = isInFullscreenMode,
                 isSameBrowser = currentBrowser === browser,
                 isBrowserClosed = browser.isClosed,
             )
-        ) {
+        if (decision != FullscreenRequestDecision.IGNORE_DUPLICATE) {
+            // Deduplicate within one request/exit attempt, not forever for a
+            // browser that may lose several competing requests over its life.
+            exitCallbackGate.begin(browser)
+        }
+        when (decision) {
             FullscreenRequestDecision.IGNORE_DUPLICATE -> {
                 logger.debug(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
             }
@@ -226,7 +268,6 @@ object FullscreenBrowserWindow {
         hasReachedFullscreen = false
         lifecycleEpoch++
         val expectedEpoch = lifecycleEpoch
-        exitCallbackGate.begin(browser)
         TabFullscreenStateManager.enterFullscreen(tabId)
         onEnter()
 
@@ -773,22 +814,6 @@ object FullscreenBrowserWindow {
         }
     }
 
-    private fun runOnEventDispatchThreadAndWait(action: () -> Unit) {
-        if (SwingUtilities.isEventDispatchThread()) {
-            action()
-            return
-        }
-
-        try {
-            SwingUtilities.invokeAndWait { action() }
-        } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
-            logger.warn(LogCategory.BROWSER, "Interrupted while closing fullscreen browser window", error = e)
-        } catch (e: InvocationTargetException) {
-            logger.warn(LogCategory.BROWSER, "Could not close fullscreen browser window", error = e.cause ?: e)
-        }
-    }
-
     /**
      * Keep the browser page and host window in sync: ask Chromium to leave
      * HTML fullscreen first, then tear down directly only if its exit event is
@@ -895,7 +920,7 @@ object FullscreenBrowserWindow {
      */
     fun exitFullscreen(browser: Browser) {
         if (currentBrowser !== browser) return
-        runOnEventDispatchThreadAndWait {
+        runOnEventDispatchThreadAndWait(logger, EDT_CLEANUP_TIMEOUT_MS) {
             if (currentBrowser === browser) {
                 exitFullscreen()
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -19,6 +19,7 @@ import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import java.lang.reflect.InvocationTargetException
+import java.util.WeakHashMap
 import javax.swing.AbstractAction
 import javax.swing.JComponent
 import javax.swing.JFrame
@@ -59,6 +60,46 @@ internal fun shouldRestoreFullscreenTabState(
     isInFullscreenMode: Boolean,
 ): Boolean = cleanupEpoch == currentEpoch && !isInFullscreenMode
 
+internal enum class FullscreenRequestDecision {
+    IGNORE_DUPLICATE,
+    REJECT_CLOSED,
+    REJECT_COMPETING,
+    BEGIN,
+}
+
+internal fun fullscreenRequestDecision(
+    frameActive: Boolean,
+    isInFullscreenMode: Boolean,
+    isSameBrowser: Boolean,
+    isBrowserClosed: Boolean,
+): FullscreenRequestDecision {
+    val fullscreenActive = frameActive || isInFullscreenMode
+    return when {
+        fullscreenActive && isSameBrowser -> FullscreenRequestDecision.IGNORE_DUPLICATE
+        isBrowserClosed -> FullscreenRequestDecision.REJECT_CLOSED
+        fullscreenActive -> FullscreenRequestDecision.REJECT_COMPETING
+        else -> FullscreenRequestDecision.BEGIN
+    }
+}
+
+/** EDT-confined once installed in [FullscreenBrowserWindow]. */
+internal class FullscreenExitCallbackGate<T : Any> {
+    private val notifiedOwners = WeakHashMap<T, Unit>()
+
+    fun begin(owner: T) {
+        notifiedOwners.remove(owner)
+    }
+
+    fun notifyOnce(
+        owner: T,
+        callback: () -> Unit,
+    ): Boolean {
+        if (notifiedOwners.put(owner, Unit) != null) return false
+        callback()
+        return true
+    }
+}
+
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
  * Uses the existing browser instance with a new BrowserView.
@@ -76,12 +117,15 @@ object FullscreenBrowserWindow {
     private var currentBrowser: Browser? = null
     private var currentOwnerWindowId: String? = null
     private var ownerFullscreenExitListener: ((String) -> Unit)? = null
+    private var overlayOwnerWindow: Window? = null
+    private var overlayOwnerFocusListener: WindowAdapter? = null
     private var onExitCallback: (() -> Unit)? = null
     private var isInFullscreenMode = false
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
     private var usesNativeMacOSFullscreen = false
     private var isExiting = false // Prevent multiple exit calls
     private var lifecycleEpoch = 0L
+    private val exitCallbackGate = FullscreenExitCallbackGate<Browser>()
 
     private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
 
@@ -120,22 +164,28 @@ object FullscreenBrowserWindow {
         onEnter: () -> Unit,
         onExit: () -> Unit,
     ) {
-        val fullscreenActive = fullscreenFrame != null || isInFullscreenMode
-        when {
-            fullscreenActive && currentBrowser === browser -> {
-                logger.warn(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
+        when (
+            fullscreenRequestDecision(
+                frameActive = fullscreenFrame != null,
+                isInFullscreenMode = isInFullscreenMode,
+                isSameBrowser = currentBrowser === browser,
+                isBrowserClosed = browser.isClosed,
+            )
+        ) {
+            FullscreenRequestDecision.IGNORE_DUPLICATE -> {
+                logger.debug(LogCategory.BROWSER, "Ignoring duplicate fullscreen request from active browser")
             }
 
-            browser.isClosed -> {
+            FullscreenRequestDecision.REJECT_CLOSED -> {
                 logger.warn(LogCategory.BROWSER, "Ignoring fullscreen request from closed browser")
-                onExit()
+                exitCallbackGate.notifyOnce(browser, onExit)
             }
 
-            fullscreenActive -> {
+            FullscreenRequestDecision.REJECT_COMPETING -> {
                 rejectFullscreenRequest(browser, onExit)
             }
 
-            else -> {
+            FullscreenRequestDecision.BEGIN -> {
                 beginFullscreenSession(browser, tabId, ownerWindowId, onEnter, onExit)
             }
         }
@@ -155,7 +205,7 @@ object FullscreenBrowserWindow {
         // A successful request emits FullScreenExited, whose normal observer
         // publishes the callback. Fall back locally only when no event can follow.
         if (!exitRequested) {
-            onExit()
+            exitCallbackGate.notifyOnce(browser, onExit)
         }
     }
 
@@ -176,6 +226,7 @@ object FullscreenBrowserWindow {
         hasReachedFullscreen = false
         lifecycleEpoch++
         val expectedEpoch = lifecycleEpoch
+        exitCallbackGate.begin(browser)
         TabFullscreenStateManager.enterFullscreen(tabId)
         onEnter()
 
@@ -219,6 +270,7 @@ object FullscreenBrowserWindow {
         tabId: String,
         expectedEpoch: Long,
     ) {
+        var createdFrame: JFrame? = null
         try {
             // Check if we've been cancelled during the delay
             if (!isCurrentSession(expectedEpoch, browser)) {
@@ -234,6 +286,7 @@ object FullscreenBrowserWindow {
 
             val ownerWindow = currentOwnerWindowId?.let(WindowFocusManager::getWindow)
             val frame = ownerWindow?.graphicsConfiguration?.let(::JFrame) ?: JFrame()
+            createdFrame = frame
             frame.defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
             frame.background = Color.BLACK
             frame.contentPane.background = Color.BLACK
@@ -248,48 +301,17 @@ object FullscreenBrowserWindow {
 
             logger.info(LogCategory.BROWSER, "Swing BrowserView created after Compose detach delay")
 
-            // Handle window close
-            frame.addWindowListener(
-                object : WindowAdapter() {
-                    override fun windowClosing(e: WindowEvent?) {
-                        requestPageExit()
-                    }
-                },
-            )
-
-            // Detect when exiting native fullscreen (green button or ESC)
-            // Only active after fullscreen animation completes
-            frame.addComponentListener(
-                object : ComponentAdapter() {
-                    override fun componentResized(e: ComponentEvent?) {
-                        // Overlay and Windows/Linux frames are fixed-size and exit directly;
-                        // resize-based native-Space exit detection is macOS-native only.
-                        if (!usesNativeMacOSFullscreen || !hasReachedFullscreen) return
-                        if (!isCurrentFrameSession(expectedEpoch, browser, frame) || isExiting) return
-
-                        SwingUtilities.invokeLater {
-                            if (isCurrentFrameSession(expectedEpoch, browser, frame) &&
-                                !isWindowInFullscreen(frame) &&
-                                !isExiting
-                            ) {
-                                logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
-                                requestPageExit()
-                            }
-                        }
-                    }
-                },
-            )
+            installFullscreenFrameListeners(frame, browser, expectedEpoch)
 
             fullscreenFrame = frame
             currentBrowserView = browserView
 
             if (isMacOS) {
-                enterMacOSFullscreen(frame, browser, expectedEpoch)
+                enterMacOSFullscreen(frame, browser, ownerWindow, expectedEpoch)
             } else {
                 // Windows/Linux: use maximized undecorated window
                 frame.isUndecorated = true
-                val gd = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
-                val screenBounds = gd.defaultConfiguration.bounds
+                val screenBounds = displayBounds(frame)
                 frame.setBounds(screenBounds.x, screenBounds.y, screenBounds.width, screenBounds.height)
                 frame.isVisible = true
                 hasReachedFullscreen = true
@@ -302,18 +324,58 @@ object FullscreenBrowserWindow {
             logger.info(LogCategory.BROWSER, "Fullscreen window opened", mapOf("tabId" to tabId, "isMacOS" to isMacOS))
         } catch (e: Exception) {
             logger.error(LogCategory.BROWSER, "Failed to create fullscreen window", error = e)
+            runCatching { createdFrame?.dispose() }
+                .onFailure { error ->
+                    logger.warn(LogCategory.BROWSER, "Could not dispose failed fullscreen window", error = error)
+                }
             if (isCurrentSession(expectedEpoch, browser)) {
                 val callback = onExitCallback
                 resetState()
                 TabFullscreenStateManager.exitFullscreen()
-                callback?.invoke()
+                callback?.let { exitCallbackGate.notifyOnce(browser, it) }
             }
         }
+    }
+
+    private fun installFullscreenFrameListeners(
+        frame: JFrame,
+        browser: Browser,
+        expectedEpoch: Long,
+    ) {
+        frame.addWindowListener(
+            object : WindowAdapter() {
+                override fun windowClosing(e: WindowEvent?) {
+                    requestPageExit()
+                }
+            },
+        )
+
+        // Detect when exiting native fullscreen (green button or ESC).
+        // Overlay and Windows/Linux frames are fixed-size and exit directly.
+        frame.addComponentListener(
+            object : ComponentAdapter() {
+                override fun componentResized(e: ComponentEvent?) {
+                    if (!usesNativeMacOSFullscreen || !hasReachedFullscreen) return
+                    if (!isCurrentFrameSession(expectedEpoch, browser, frame) || isExiting) return
+
+                    SwingUtilities.invokeLater {
+                        if (isCurrentFrameSession(expectedEpoch, browser, frame) &&
+                            !isWindowInFullscreen(frame) &&
+                            !isExiting
+                        ) {
+                            logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
+                            requestPageExit()
+                        }
+                    }
+                }
+            },
+        )
     }
 
     private fun enterMacOSFullscreen(
         frame: JFrame,
         browser: Browser,
+        ownerWindow: Window?,
         expectedEpoch: Long,
     ) {
         val fullscreenHostBounds = currentOwnerWindowId?.let(::existingFullscreenWindowBounds)
@@ -337,7 +399,15 @@ object FullscreenBrowserWindow {
         usesNativeMacOSFullscreen = true
         frame.rootPane.putClientProperty("apple.awt.fullscreenable", true)
         frame.setSize(800, 600) // Initial size before fullscreen
-        frame.setLocationRelativeTo(null)
+        if (ownerWindow != null) {
+            frame.setLocationRelativeTo(ownerWindow)
+        } else {
+            val bounds = displayBounds(frame)
+            frame.setLocation(
+                bounds.x + (bounds.width - frame.width) / 2,
+                bounds.y + (bounds.height - frame.height) / 2,
+            )
+        }
         frame.isVisible = true
         requestNativeMacOSFullscreen(frame, browser, expectedEpoch)
     }
@@ -412,6 +482,7 @@ object FullscreenBrowserWindow {
     }
 
     private fun installOverlayFocusBehavior(frame: JFrame) {
+        clearOverlayOwnerFocusListener()
         frame.addWindowFocusListener(
             object : WindowAdapter() {
                 override fun windowLostFocus(event: WindowEvent?) {
@@ -423,13 +494,39 @@ object FullscreenBrowserWindow {
                 }
 
                 override fun windowGainedFocus(event: WindowEvent?) {
-                    if (fullscreenFrame === frame && !usesNativeMacOSFullscreen) {
-                        frame.isAlwaysOnTop = true
-                        frame.toFront()
-                    }
+                    restoreOverlayFocus(frame)
                 }
             },
         )
+
+        val ownerWindow = currentOwnerWindowId?.let(WindowFocusManager::getWindow) ?: return
+        val ownerListener =
+            object : WindowAdapter() {
+                override fun windowGainedFocus(event: WindowEvent?) {
+                    restoreOverlayFocus(frame)
+                    frame.requestFocus()
+                }
+            }
+        overlayOwnerWindow = ownerWindow
+        overlayOwnerFocusListener = ownerListener
+        ownerWindow.addWindowFocusListener(ownerListener)
+    }
+
+    private fun restoreOverlayFocus(frame: JFrame) {
+        if (fullscreenFrame === frame && !usesNativeMacOSFullscreen) {
+            frame.isAlwaysOnTop = true
+            frame.toFront()
+        }
+    }
+
+    private fun clearOverlayOwnerFocusListener() {
+        val ownerWindow = overlayOwnerWindow
+        val listener = overlayOwnerFocusListener
+        if (ownerWindow != null && listener != null) {
+            ownerWindow.removeWindowFocusListener(listener)
+        }
+        overlayOwnerWindow = null
+        overlayOwnerFocusListener = null
     }
 
     /**
@@ -573,7 +670,9 @@ object FullscreenBrowserWindow {
                     composeFullscreen = state.composeFullscreen,
                 )
         if (!stillFullscreen) {
-            requestPageExit()
+            SwingUtilities.invokeLater {
+                requestPageExit()
+            }
         }
     }
 
@@ -593,6 +692,7 @@ object FullscreenBrowserWindow {
         lifecycleEpoch++
         ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
         ownerFullscreenExitListener = null
+        clearOverlayOwnerFocusListener()
         fullscreenFrame = null
         currentBrowserView = null
         currentBrowser = null
@@ -657,8 +757,8 @@ object FullscreenBrowserWindow {
                     // The old tab still needs its local exit notification when
                     // another browser starts a newer global session. A re-entry
                     // by the same browser supersedes this callback instead.
-                    if (currentBrowser !== exitingBrowser) {
-                        callback?.invoke()
+                    if (currentBrowser !== exitingBrowser && exitingBrowser != null) {
+                        callback?.let { exitCallbackGate.notifyOnce(exitingBrowser, it) }
                     }
                 }.apply {
                     isRepeats = false
@@ -745,7 +845,9 @@ object FullscreenBrowserWindow {
         val cleanupEpoch = resetState()
         if (frame == null) {
             TabFullscreenStateManager.exitFullscreen()
-            callback?.invoke()
+            if (browser != null) {
+                callback?.let { exitCallbackGate.notifyOnce(browser, it) }
+            }
         } else {
             cleanupAndExit(frame, browserView, callback, browser, cleanupEpoch)
         }
@@ -759,10 +861,8 @@ object FullscreenBrowserWindow {
         val frame = fullscreenFrame
         if (frame == null) {
             if (isInFullscreenMode) {
-                val callback = onExitCallback
                 resetState()
                 TabFullscreenStateManager.exitFullscreen()
-                callback?.invoke()
             }
             return
         }
@@ -773,12 +873,16 @@ object FullscreenBrowserWindow {
         cleanupAndExit(frame, browserView, null, browser, cleanupEpoch)
     }
 
-    /** Closes fullscreen asynchronously only when it belongs to the browser emitting the event. */
-    fun exitFullscreenAsync(browser: Browser) {
+    /** Closes the matching session and publishes each browser's exit callback at most once. */
+    fun exitFullscreenAsync(
+        browser: Browser,
+        onExit: () -> Unit,
+    ) {
         SwingUtilities.invokeLater {
             if (currentBrowser === browser) {
                 exitFullscreen()
             }
+            exitCallbackGate.notifyOnce(browser, onExit)
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -200,6 +200,35 @@ private fun runOnEventDispatchThreadAndWait(
     }
 }
 
+internal enum class VideoFullscreenConfirmationDecision {
+    CONFIRMED,
+    EXITED_EARLY,
+    USE_OVERLAY,
+    ;
+
+    companion object {
+        fun decide(
+            trackingAvailable: Boolean,
+            stateAvailable: Boolean,
+            isFullscreen: Boolean,
+            entryObserved: Boolean,
+            geometryFullscreen: Boolean,
+        ): VideoFullscreenConfirmationDecision {
+            val fullscreenConfirmed =
+                if (trackingAvailable) {
+                    stateAvailable && isFullscreen
+                } else {
+                    geometryFullscreen
+                }
+            return when {
+                fullscreenConfirmed -> CONFIRMED
+                entryObserved -> EXITED_EARLY
+                else -> USE_OVERLAY
+            }
+        }
+    }
+}
+
 private class VideoFullscreenTracker(
     private val onEntryObserved: () -> Unit,
     private val onExitObserved: () -> Unit,
@@ -210,8 +239,9 @@ private class VideoFullscreenTracker(
             onFullscreenExitStarted = ::handleFullscreenExitStarted,
         )
     private var trackingId: String? = null
-    private var entryObserved = false
 
+    var entryObserved = false
+        private set
     var trackingAvailable = false
         private set
     var stateAvailable = false
@@ -257,6 +287,49 @@ private class VideoFullscreenTracker(
     private fun handleFullscreenExitStarted(eventTrackingId: String) {
         if (eventTrackingId != trackingId || !entryObserved) return
         onExitObserved()
+    }
+}
+
+private class VideoFullscreenConfirmationHandler(
+    private val onConfirmed: () -> Unit,
+    private val onExitedEarly: () -> Unit,
+) {
+    private val logger = BossLogger.forComponent("VideoFullscreenConfirmationHandler")
+
+    fun handle(
+        tracker: VideoFullscreenTracker,
+        geometryFullscreen: () -> Boolean,
+        useOverlay: () -> Unit,
+    ) {
+        val trackingAvailable = tracker.trackingAvailable
+        val decision =
+            VideoFullscreenConfirmationDecision.decide(
+                trackingAvailable = trackingAvailable,
+                stateAvailable = tracker.stateAvailable,
+                isFullscreen = tracker.isFullscreen,
+                entryObserved = tracker.entryObserved,
+                geometryFullscreen = !trackingAvailable && geometryFullscreen(),
+            )
+        when (decision) {
+            VideoFullscreenConfirmationDecision.CONFIRMED -> {
+                onConfirmed()
+                logger.info(
+                    LogCategory.BROWSER,
+                    "Fullscreen animation completed, exit detection enabled",
+                    mapOf("nativeSignal" to trackingAvailable),
+                )
+            }
+
+            VideoFullscreenConfirmationDecision.EXITED_EARLY -> {
+                logger.info(LogCategory.BROWSER, "Native fullscreen exited before confirmation completed")
+                onExitedEarly()
+            }
+
+            VideoFullscreenConfirmationDecision.USE_OVERLAY -> {
+                logger.warn(LogCategory.BROWSER, "macOS ignored native fullscreen toggle; using borderless overlay")
+                useOverlay()
+            }
+        }
     }
 }
 
@@ -435,11 +508,17 @@ object FullscreenBrowserWindow {
                 logger.info(LogCategory.BROWSER, "Native video fullscreen entry observed")
             },
             onExitObserved = {
-                if (usesNativeMacOSFullscreen && hasReachedFullscreen && !isExiting) {
+                // VideoFullscreenTracker only publishes this callback after entryObserved.
+                if (usesNativeMacOSFullscreen && !isExiting) {
                     logger.info(LogCategory.BROWSER, "Native video fullscreen exit observed")
                     requestPageExit()
                 }
             },
+        )
+    private val videoFullscreenConfirmationHandler =
+        VideoFullscreenConfirmationHandler(
+            onConfirmed = { hasReachedFullscreen = true },
+            onExitedEarly = ::requestPageExit,
         )
     private val overlayCoordinator =
         FullscreenOverlayCoordinator(
@@ -800,32 +879,19 @@ object FullscreenBrowserWindow {
                 // only when reflective listener registration is unavailable.
                 Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
                     runFullscreenTransition(frame, browser, expectedEpoch) {
-                        val fullscreenConfirmed =
-                            if (videoFullscreenTracker.trackingAvailable) {
-                                videoFullscreenTracker.stateAvailable && videoFullscreenTracker.isFullscreen
-                            } else {
-                                isWindowInFullscreen(frame)
-                            }
-                        if (fullscreenConfirmed) {
-                            hasReachedFullscreen = true
-                            logger.info(
-                                LogCategory.BROWSER,
-                                "Fullscreen animation completed, exit detection enabled",
-                                mapOf("nativeSignal" to videoFullscreenTracker.trackingAvailable),
-                            )
-                        } else {
-                            logger.warn(
-                                LogCategory.BROWSER,
-                                "macOS ignored native fullscreen toggle; using borderless overlay",
-                            )
-                            showBorderlessOverlay(
-                                frame = frame,
-                                browser = browser,
-                                bounds = displayBounds(frame),
-                                watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
-                                expectedEpoch = expectedEpoch,
-                            )
-                        }
+                        videoFullscreenConfirmationHandler.handle(
+                            tracker = videoFullscreenTracker,
+                            geometryFullscreen = { isWindowInFullscreen(frame) },
+                            useOverlay = {
+                                showBorderlessOverlay(
+                                    frame = frame,
+                                    browser = browser,
+                                    bounds = displayBounds(frame),
+                                    watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
+                                    expectedEpoch = expectedEpoch,
+                                )
+                            },
+                        )
                     }
                 }.apply {
                     isRepeats = false

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -215,6 +215,13 @@ internal enum class VideoFullscreenConfirmationDecision {
     ;
 
     companion object {
+        fun confirmationDelayMs(trackingAvailable: Boolean): Int =
+            if (trackingAvailable) {
+                NATIVE_FULLSCREEN_ACCEPTANCE_TIMEOUT_MS
+            } else {
+                FULLSCREEN_ANIMATION_DELAY_MS
+            }
+
         fun decide(
             trackingAvailable: Boolean,
             stateAvailable: Boolean,
@@ -234,6 +241,9 @@ internal enum class VideoFullscreenConfirmationDecision {
                 else -> USE_OVERLAY
             }
         }
+
+        private const val FULLSCREEN_ANIMATION_DELAY_MS = 600
+        private const val NATIVE_FULLSCREEN_ACCEPTANCE_TIMEOUT_MS = 1_500
     }
 }
 
@@ -404,6 +414,7 @@ private class FullscreenOverlayCoordinator(
         frame.addWindowFocusListener(
             object : WindowAdapter() {
                 override fun windowLostFocus(event: WindowEvent?) {
+                    if (event?.oppositeWindow === ownerWindow) return
                     if (isCurrentFrameOverlay(frame)) {
                         // Do not cover other applications when the user switches away from Boss.
                         frame.isAlwaysOnTop = false
@@ -420,6 +431,7 @@ private class FullscreenOverlayCoordinator(
         val listener =
             object : WindowAdapter() {
                 override fun windowLostFocus(event: WindowEvent?) {
+                    if (event?.oppositeWindow === frame) return
                     if (isCurrentFrameOverlay(frame)) {
                         // If the overlay never acquired focus, its own listener cannot
                         // observe app deactivation. The owner still can, so unpin here too.
@@ -554,8 +566,6 @@ object FullscreenBrowserWindow {
 
     private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
 
-    // macOS fullscreen animation takes ~500ms, wait before enabling exit detection.
-    private const val FULLSCREEN_ANIMATION_DELAY_MS = 600
     private const val COMPETING_REQUEST_EXIT_TIMEOUT_MS = 600
     private const val PAGE_EXIT_EVENT_TIMEOUT_MS = 1_000
 
@@ -902,9 +912,13 @@ object FullscreenBrowserWindow {
                     return@runFullscreenTransition
                 }
 
-                // Prefer the native event emitted by macOS. Geometry remains a fallback
-                // only when reflective listener registration is unavailable.
-                Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                // Geometry needs one animation interval; a tracked native toggle gets
+                // longer to publish its authoritative entry event before overlay fallback.
+                val confirmationDelayMs =
+                    VideoFullscreenConfirmationDecision.confirmationDelayMs(
+                        videoFullscreenTracker.trackingAvailable,
+                    )
+                Timer(confirmationDelayMs) {
                     runFullscreenTransition(frame, browser, expectedEpoch) {
                         videoFullscreenConfirmationHandler.handle(
                             tracker = videoFullscreenTracker,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -53,10 +53,11 @@ internal fun shouldUseComposeFullscreenOverlay(
  */
 object FullscreenBrowserWindow {
     private val logger = BossLogger.forComponent("FullscreenBrowserWindow")
+
+    // Fullscreen lifecycle state is EDT-confined. Public entry/exit methods
+    // marshal to the EDT before reading or mutating these fields.
     private var fullscreenFrame: JFrame? = null
     private var currentBrowserView: BrowserView? = null
-
-    @Volatile
     private var currentBrowser: Browser? = null
     private var currentOwnerWindowId: String? = null
     private var ownerFullscreenExitListener: ((String) -> Unit)? = null
@@ -86,6 +87,13 @@ object FullscreenBrowserWindow {
         ownerWindowId: String,
         onExit: () -> Unit,
     ) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            SwingUtilities.invokeLater {
+                showFullscreen(browser, tabId, ownerWindowId, onExit)
+            }
+            return
+        }
+
         // Prevent duplicate calls
         if (fullscreenFrame != null || isInFullscreenMode) {
             logger.warn(LogCategory.BROWSER, "Fullscreen already active, ignoring duplicate request")
@@ -284,11 +292,33 @@ object FullscreenBrowserWindow {
         frame.setBounds(bounds)
         frame.isVisible = true
         frame.toFront()
+        installOverlayFocusBehavior(frame)
         usesNativeMacOSFullscreen = false
         hasReachedFullscreen = true
         if (watchOwnerExit) {
             watchOwnerFullscreenExit(currentOwnerWindowId)
         }
+    }
+
+    private fun installOverlayFocusBehavior(frame: JFrame) {
+        frame.addWindowFocusListener(
+            object : WindowAdapter() {
+                override fun windowLostFocus(event: WindowEvent?) {
+                    if (fullscreenFrame === frame && !usesNativeMacOSFullscreen) {
+                        // Do not cover other applications when the user switches
+                        // away from Boss; restore the overlay level on return.
+                        frame.isAlwaysOnTop = false
+                    }
+                }
+
+                override fun windowGainedFocus(event: WindowEvent?) {
+                    if (fullscreenFrame === frame && !usesNativeMacOSFullscreen) {
+                        frame.isAlwaysOnTop = true
+                        frame.toFront()
+                    }
+                }
+            },
+        )
     }
 
     /**
@@ -461,25 +491,30 @@ object FullscreenBrowserWindow {
                     }
                     frame.contentPane.revalidate()
                     frame.contentPane.repaint()
-                    frame.dispose()
-                    logger.info(LogCategory.BROWSER, "Fullscreen window disposed, waiting for rendering release")
-
-                    // Delay before telling Compose to show its BrowserView
-                    // This gives JxBrowser time to fully release the Swing rendering surface
-                    Timer(SWING_RELEASE_DELAY_MS) {
-                        SwingUtilities.invokeLater {
-                            TabFullscreenStateManager.exitFullscreen()
-                            logger.info(LogCategory.BROWSER, "Fullscreen exit complete, Compose BrowserView enabled")
-                            callback?.invoke()
-                        }
-                    }.apply {
-                        isRepeats = false
-                        start()
-                    }
                 } catch (e: Exception) {
-                    logger.error(LogCategory.BROWSER, "Error closing fullscreen window", error = e)
-                    TabFullscreenStateManager.exitFullscreen()
-                    callback?.invoke()
+                    logger.error(LogCategory.BROWSER, "Error detaching fullscreen browser view", error = e)
+                } finally {
+                    try {
+                        frame.isAlwaysOnTop = false
+                        frame.dispose()
+                    } catch (e: Exception) {
+                        logger.error(LogCategory.BROWSER, "Error disposing fullscreen window", error = e)
+                    }
+                }
+
+                logger.info(LogCategory.BROWSER, "Fullscreen window disposed, waiting for rendering release")
+
+                // Delay before telling Compose to show its BrowserView
+                // This gives JxBrowser time to fully release the Swing rendering surface
+                Timer(SWING_RELEASE_DELAY_MS) {
+                    SwingUtilities.invokeLater {
+                        TabFullscreenStateManager.exitFullscreen()
+                        logger.info(LogCategory.BROWSER, "Fullscreen exit complete, Compose BrowserView enabled")
+                        callback?.invoke()
+                    }
+                }.apply {
+                    isRepeats = false
+                    start()
                 }
             }
 
@@ -522,7 +557,7 @@ object FullscreenBrowserWindow {
      * Called when user manually triggers exit (placeholder click).
      * On macOS, toggles fullscreen off which triggers the exit flow.
      */
-    fun requestExit() {
+    private fun requestExit() {
         if (isExiting) return
         logger.info(LogCategory.BROWSER, "Exit requested via placeholder click")
 
@@ -574,12 +609,14 @@ object FullscreenBrowserWindow {
      * Closes the fullscreen window.
      * Safe to call multiple times - will only close once.
      */
-    fun exitFullscreen() {
+    private fun exitFullscreen() {
         val frame = fullscreenFrame
         if (frame == null) {
             if (isInFullscreenMode) {
+                val callback = onExitCallback
                 resetState()
                 TabFullscreenStateManager.exitFullscreen()
+                callback?.invoke()
             }
             return
         }
@@ -612,6 +649,4 @@ object FullscreenBrowserWindow {
             }
         }
     }
-
-    fun isFullscreenActive(): Boolean = fullscreenFrame != null && isInFullscreenMode
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.tabfullscreen
 
+import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import com.teamdev.jxbrowser.browser.Browser
@@ -7,6 +8,7 @@ import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
 import java.awt.Window
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
@@ -15,6 +17,13 @@ import java.awt.event.WindowEvent
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import javax.swing.Timer
+
+internal fun fillsScreen(
+    windowBounds: Rectangle,
+    screenBounds: Rectangle,
+): Boolean =
+    windowBounds.width >= screenBounds.width &&
+        windowBounds.height >= screenBounds.height
 
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
@@ -28,6 +37,7 @@ object FullscreenBrowserWindow {
     private var onExitCallback: (() -> Unit)? = null
     private var isInFullscreenMode = false
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
+    private var usesNativeMacOSFullscreen = false
     private var isExiting = false // Prevent multiple exit calls
 
     private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
@@ -128,7 +138,13 @@ object FullscreenBrowserWindow {
                 object : ComponentAdapter() {
                     override fun componentResized(e: ComponentEvent?) {
                         // Only check for exit after we've confirmed fullscreen was reached
-                        if (hasReachedFullscreen && isInFullscreenMode && !isExiting && fullscreenFrame != null) {
+                        if (
+                            usesNativeMacOSFullscreen &&
+                            hasReachedFullscreen &&
+                            isInFullscreenMode &&
+                            !isExiting &&
+                            fullscreenFrame != null
+                        ) {
                             SwingUtilities.invokeLater {
                                 if (!isWindowInFullscreen(frame) && !isExiting) {
                                     logger.info(LogCategory.BROWSER, "Native fullscreen exited via resize detection")
@@ -144,25 +160,45 @@ object FullscreenBrowserWindow {
             currentBrowserView = browserView
 
             if (isMacOS) {
-                // Use native macOS fullscreen (creates new Space)
-                frame.rootPane.putClientProperty("apple.awt.fullscreenable", true)
-                frame.setSize(800, 600) // Initial size before fullscreen
-                frame.setLocationRelativeTo(null)
-                frame.isVisible = true
+                val fullscreenHostBounds = existingFullscreenWindowBounds()
+                if (fullscreenHostBounds != null) {
+                    // macOS can ignore a second native fullscreen-Space request while another
+                    // window from this app already owns a fullscreen Space. Keep the video in
+                    // that Space and cover it with an undecorated screen-sized window instead.
+                    frame.isUndecorated = true
+                    frame.setBounds(fullscreenHostBounds)
+                    frame.isVisible = true
+                    usesNativeMacOSFullscreen = false
+                    hasReachedFullscreen = true
+                    logger.info(
+                        LogCategory.BROWSER,
+                        "Opened fullscreen video as borderless overlay in existing fullscreen Space",
+                    )
+                } else {
+                    // Use native macOS fullscreen (creates new Space)
+                    usesNativeMacOSFullscreen = true
+                    frame.rootPane.putClientProperty("apple.awt.fullscreenable", true)
+                    frame.setSize(800, 600) // Initial size before fullscreen
+                    frame.setLocationRelativeTo(null)
+                    frame.isVisible = true
 
-                // Request native fullscreen toggle after window is visible
-                SwingUtilities.invokeLater {
-                    requestMacOSFullscreen(frame)
+                    // Request native fullscreen toggle after window is visible
+                    SwingUtilities.invokeLater {
+                        requestMacOSFullscreen(frame)
 
-                    // Wait for fullscreen animation to complete before enabling exit detection
-                    Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                        if (fullscreenFrame != null && isInFullscreenMode) {
-                            hasReachedFullscreen = true
-                            logger.info(LogCategory.BROWSER, "Fullscreen animation completed, exit detection enabled")
+                        // Wait for fullscreen animation to complete before enabling exit detection
+                        Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                            if (fullscreenFrame != null && isInFullscreenMode) {
+                                hasReachedFullscreen = true
+                                logger.info(
+                                    LogCategory.BROWSER,
+                                    "Fullscreen animation completed, exit detection enabled",
+                                )
+                            }
+                        }.apply {
+                            isRepeats = false
+                            start()
                         }
-                    }.apply {
-                        isRepeats = false
-                        start()
                     }
                 }
             } else {
@@ -189,6 +225,27 @@ object FullscreenBrowserWindow {
     }
 
     /**
+     * Returns the display bounds of an already-fullscreen window in this process.
+     * A new undecorated video window can cover that same fullscreen Space without
+     * asking macOS to create a second native fullscreen Space.
+     */
+    private fun existingFullscreenWindowBounds(): Rectangle? {
+        WindowFocusManager
+            .getFullscreenWindow()
+            ?.graphicsConfiguration
+            ?.bounds
+            ?.let { return it }
+
+        // Fallback for fullscreen windows not created by BossWindow or observed before
+        // Compose placement was published.
+        return Window.getWindows().firstNotNullOfOrNull { window ->
+            if (!window.isShowing) return@firstNotNullOfOrNull null
+            val screenBounds = window.graphicsConfiguration?.bounds ?: return@firstNotNullOfOrNull null
+            screenBounds.takeIf { fillsScreen(window.bounds, screenBounds) }
+        }
+    }
+
+    /**
      * Request native macOS fullscreen using reflection.
      * Uses com.apple.eawt.Application.requestToggleFullScreen() which creates
      * a proper macOS fullscreen Space (like Chrome/Safari behavior).
@@ -205,6 +262,7 @@ object FullscreenBrowserWindow {
             logger.info(LogCategory.BROWSER, "Requested macOS native fullscreen")
         } catch (e: Exception) {
             logger.warn(LogCategory.BROWSER, "Could not request macOS fullscreen, using fallback", error = e)
+            usesNativeMacOSFullscreen = false
             // Fallback: maximize window
             (window as? JFrame)?.extendedState = JFrame.MAXIMIZED_BOTH
             hasReachedFullscreen = true
@@ -216,10 +274,8 @@ object FullscreenBrowserWindow {
      * On macOS in fullscreen, the window bounds match the screen bounds exactly.
      */
     private fun isWindowInFullscreen(frame: JFrame): Boolean {
-        val gd = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
-        val screenBounds = gd.defaultConfiguration.bounds
-        val frameBounds = frame.bounds
-        return frameBounds.width >= screenBounds.width && frameBounds.height >= screenBounds.height
+        val screenBounds = frame.graphicsConfiguration?.bounds ?: return false
+        return fillsScreen(frame.bounds, screenBounds)
     }
 
     /**
@@ -231,6 +287,7 @@ object FullscreenBrowserWindow {
         onExitCallback = null
         isInFullscreenMode = false
         hasReachedFullscreen = false
+        usesNativeMacOSFullscreen = false
         isExiting = false
     }
 
@@ -303,7 +360,7 @@ object FullscreenBrowserWindow {
 
         val frame = fullscreenFrame ?: return
 
-        if (isMacOS && hasReachedFullscreen) {
+        if (isMacOS && usesNativeMacOSFullscreen && hasReachedFullscreen) {
             // Toggle fullscreen off (will trigger componentResized -> performExit)
             isExiting = true
             requestMacOSFullscreen(frame)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.tabfullscreen
 
+import ai.rever.boss.utils.MacOSFullscreenTracker
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.hasFullscreenSignal
 import ai.rever.boss.utils.logging.BossLogger
@@ -194,6 +195,207 @@ private fun runOnEventDispatchThreadAndWait(
     }
 }
 
+private class VideoFullscreenTracker(
+    private val onEntryObserved: () -> Unit,
+    private val onExitObserved: () -> Unit,
+) {
+    private val nativeTracker =
+        MacOSFullscreenTracker(
+            onFullscreenChanged = ::handleFullscreenChanged,
+            onFullscreenExitStarted = ::handleFullscreenExitStarted,
+        )
+    private var trackingId: String? = null
+    private var entryObserved = false
+
+    var trackingAvailable = false
+        private set
+    var stateAvailable = false
+        private set
+    var isFullscreen = false
+        private set
+
+    fun register(
+        frame: JFrame,
+        expectedEpoch: Long,
+    ) {
+        clear()
+        val newTrackingId = "fullscreen-video-$expectedEpoch"
+        trackingId = newTrackingId
+        trackingAvailable = nativeTracker.register(newTrackingId, frame)
+    }
+
+    fun clear() {
+        val previousTrackingId = trackingId
+        trackingId = null
+        trackingAvailable = false
+        stateAvailable = false
+        isFullscreen = false
+        entryObserved = false
+        previousTrackingId?.let(nativeTracker::unregister)
+    }
+
+    private fun handleFullscreenChanged(
+        eventTrackingId: String,
+        fullscreen: Boolean,
+    ) {
+        if (eventTrackingId != trackingId) return
+        stateAvailable = true
+        isFullscreen = fullscreen
+        if (fullscreen) {
+            entryObserved = true
+            onEntryObserved()
+        } else if (entryObserved) {
+            onExitObserved()
+        }
+    }
+
+    private fun handleFullscreenExitStarted(eventTrackingId: String) {
+        if (eventTrackingId != trackingId || !entryObserved) return
+        onExitObserved()
+    }
+}
+
+private data class FullscreenFrameView(
+    val frame: JFrame,
+    val browserView: BrowserView,
+)
+
+private fun prepareBorderlessOverlayFrame(
+    sourceFrame: JFrame,
+    sourceView: BrowserView?,
+    browser: Browser,
+    installExitShortcut: (JFrame) -> Unit,
+    installFrameListeners: (JFrame) -> Unit,
+): FullscreenFrameView {
+    if (!sourceFrame.isDisplayable) {
+        sourceFrame.isUndecorated = true
+        return FullscreenFrameView(sourceFrame, checkNotNull(sourceView))
+    }
+
+    val graphicsConfiguration = sourceFrame.graphicsConfiguration
+    sourceView?.let { view ->
+        view.isVisible = false
+        sourceFrame.contentPane.remove(view)
+    }
+    sourceFrame.contentPane.revalidate()
+    sourceFrame.contentPane.repaint()
+    sourceFrame.isVisible = false
+    sourceFrame.dispose()
+
+    val overlayFrame = graphicsConfiguration?.let(::JFrame) ?: JFrame()
+    overlayFrame.defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
+    overlayFrame.background = Color.BLACK
+    overlayFrame.contentPane.background = Color.BLACK
+    overlayFrame.contentPane.layout = BorderLayout()
+    overlayFrame.isUndecorated = true
+    installExitShortcut(overlayFrame)
+
+    val overlayView = BrowserView.newInstance(browser)
+    overlayView.background = Color.BLACK
+    overlayFrame.contentPane.add(overlayView, BorderLayout.CENTER)
+    installFrameListeners(overlayFrame)
+    return FullscreenFrameView(overlayFrame, overlayView)
+}
+
+private class FullscreenOverlayCoordinator(
+    private val isCurrentFrameOverlay: (JFrame) -> Boolean,
+    private val isCurrentOwnerOverlay: (String, Long) -> Boolean,
+    private val requestPageExit: () -> Unit,
+) {
+    private val logger = BossLogger.forComponent("FullscreenOverlayCoordinator")
+    private var ownerFullscreenExitListener: ((String) -> Unit)? = null
+    private var ownerWindow: Window? = null
+    private var ownerFocusListener: WindowAdapter? = null
+
+    fun installFocusBehavior(
+        frame: JFrame,
+        ownerWindowId: String?,
+    ) {
+        clearOwnerFocusListener()
+        frame.addWindowFocusListener(
+            object : WindowAdapter() {
+                override fun windowLostFocus(event: WindowEvent?) {
+                    if (isCurrentFrameOverlay(frame)) {
+                        // Do not cover other applications when the user switches away from Boss.
+                        frame.isAlwaysOnTop = false
+                    }
+                }
+
+                override fun windowGainedFocus(event: WindowEvent?) {
+                    restoreOverlayLevel(frame)
+                }
+            },
+        )
+
+        val hostWindow = ownerWindowId?.let(WindowFocusManager::getWindow) ?: return
+        val listener =
+            object : WindowAdapter() {
+                override fun windowGainedFocus(event: WindowEvent?) {
+                    restoreOverlayLevel(frame)
+                }
+            }
+        ownerWindow = hostWindow
+        ownerFocusListener = listener
+        hostWindow.addWindowFocusListener(listener)
+    }
+
+    fun watchOwnerExit(
+        ownerWindowId: String?,
+        expectedEpoch: Long,
+    ) {
+        if (ownerWindowId == null) return
+        ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
+        val listener: (String) -> Unit = { exitedWindowId ->
+            if (exitedWindowId == ownerWindowId) {
+                SwingUtilities.invokeLater {
+                    if (isCurrentOwnerOverlay(ownerWindowId, expectedEpoch)) {
+                        logger.info(
+                            LogCategory.BROWSER,
+                            "Closing fullscreen video overlay because its host exited fullscreen",
+                            mapOf("ownerWindowId" to ownerWindowId),
+                        )
+                        requestPageExit()
+                    }
+                }
+            }
+        }
+        ownerFullscreenExitListener = listener
+        WindowFocusManager.fullscreenExitNotifier.add(listener)
+
+        // The owner may have completed its exit between selecting overlay mode
+        // and registering this listener, so re-check after registration.
+        if (!isRegisteredWindowFullscreen(ownerWindowId)) {
+            SwingUtilities.invokeLater {
+                if (isCurrentOwnerOverlay(ownerWindowId, expectedEpoch)) {
+                    requestPageExit()
+                }
+            }
+        }
+    }
+
+    fun clear() {
+        ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
+        ownerFullscreenExitListener = null
+        clearOwnerFocusListener()
+    }
+
+    private fun restoreOverlayLevel(frame: JFrame) {
+        if (isCurrentFrameOverlay(frame)) {
+            frame.isAlwaysOnTop = true
+            frame.toFront()
+        }
+    }
+
+    private fun clearOwnerFocusListener() {
+        val listener = ownerFocusListener
+        if (ownerWindow != null && listener != null) {
+            ownerWindow?.removeWindowFocusListener(listener)
+        }
+        ownerWindow = null
+        ownerFocusListener = null
+    }
+}
+
 /**
  * Creates and manages a fullscreen Swing JFrame for browser content.
  * Uses the existing browser instance with a new BrowserView.
@@ -210,9 +412,6 @@ object FullscreenBrowserWindow {
     @Volatile // Read off-EDT only for the disposal fast path; mutated on the EDT.
     private var currentBrowser: Browser? = null
     private var currentOwnerWindowId: String? = null
-    private var ownerFullscreenExitListener: ((String) -> Unit)? = null
-    private var overlayOwnerWindow: Window? = null
-    private var overlayOwnerFocusListener: WindowAdapter? = null
     private var onExitCallback: (() -> Unit)? = null
     private var isInFullscreenMode = false
     private var hasReachedFullscreen = false // True only after fullscreen animation completes
@@ -220,6 +419,32 @@ object FullscreenBrowserWindow {
     private var isExiting = false // Prevent multiple exit calls
     private var lifecycleEpoch = 0L
     private val exitCallbackGate = FullscreenExitCallbackGate<Browser>()
+    private val videoFullscreenTracker =
+        VideoFullscreenTracker(
+            onEntryObserved = {
+                logger.info(LogCategory.BROWSER, "Native video fullscreen entry observed")
+            },
+            onExitObserved = {
+                if (usesNativeMacOSFullscreen && hasReachedFullscreen && !isExiting) {
+                    logger.info(LogCategory.BROWSER, "Native video fullscreen exit observed")
+                    requestPageExit()
+                }
+            },
+        )
+    private val overlayCoordinator =
+        FullscreenOverlayCoordinator(
+            isCurrentFrameOverlay = { frame ->
+                fullscreenFrame === frame && !usesNativeMacOSFullscreen
+            },
+            isCurrentOwnerOverlay = { ownerWindowId, expectedEpoch ->
+                if (currentOwnerWindowId != ownerWindowId) {
+                    false
+                } else {
+                    lifecycleEpoch == expectedEpoch && isInFullscreenMode && !usesNativeMacOSFullscreen
+                }
+            },
+            requestPageExit = ::requestPageExit,
+        )
 
     private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
 
@@ -371,6 +596,23 @@ object FullscreenBrowserWindow {
         frame: JFrame,
     ): Boolean = isCurrentSession(expectedEpoch, browser) && fullscreenFrame === frame
 
+    private fun runFullscreenTransition(
+        frame: JFrame,
+        browser: Browser,
+        expectedEpoch: Long,
+        action: () -> Unit,
+    ) {
+        if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return
+        try {
+            action()
+        } catch (e: Exception) {
+            logger.error(LogCategory.BROWSER, "Fullscreen transition failed", error = e)
+            if (isCurrentSession(expectedEpoch, browser)) {
+                performExitDirect()
+            }
+        }
+    }
+
     /**
      * Creates and displays the fullscreen window with a Swing BrowserView.
      * Called after Compose BrowserView has had time to detach from rendering.
@@ -495,6 +737,7 @@ object FullscreenBrowserWindow {
             // that Space and cover it with an undecorated screen-sized window instead.
             showBorderlessOverlay(
                 frame = frame,
+                browser = browser,
                 bounds = fullscreenHostBounds,
                 watchOwnerExit = true,
                 expectedEpoch = expectedEpoch,
@@ -519,6 +762,7 @@ object FullscreenBrowserWindow {
             )
         }
         frame.isVisible = true
+        videoFullscreenTracker.register(frame, expectedEpoch)
         requestNativeMacOSFullscreen(frame, browser, expectedEpoch)
     }
 
@@ -528,115 +772,91 @@ object FullscreenBrowserWindow {
         expectedEpoch: Long,
     ) {
         SwingUtilities.invokeLater {
-            if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return@invokeLater
-            if (!toggleMacOSFullscreen(frame)) {
-                showBorderlessOverlay(
-                    frame = frame,
-                    bounds = displayBounds(frame),
-                    watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
-                    expectedEpoch = expectedEpoch,
-                )
-                return@invokeLater
-            }
-
-            // Wait for fullscreen animation to complete before enabling exit detection.
-            Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return@Timer
-                if (isWindowInFullscreen(frame)) {
-                    hasReachedFullscreen = true
-                    logger.info(
-                        LogCategory.BROWSER,
-                        "Fullscreen animation completed, exit detection enabled",
-                    )
-                } else {
-                    logger.warn(
-                        LogCategory.BROWSER,
-                        "macOS ignored native fullscreen toggle; using borderless overlay",
-                    )
+            runFullscreenTransition(frame, browser, expectedEpoch) {
+                if (!toggleMacOSFullscreen(frame)) {
                     showBorderlessOverlay(
                         frame = frame,
+                        browser = browser,
                         bounds = displayBounds(frame),
                         watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
                         expectedEpoch = expectedEpoch,
                     )
+                    return@runFullscreenTransition
                 }
-            }.apply {
-                isRepeats = false
-                start()
+
+                // Prefer the native event emitted by macOS. Geometry remains a fallback
+                // only when reflective listener registration is unavailable.
+                Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+                    runFullscreenTransition(frame, browser, expectedEpoch) {
+                        val fullscreenConfirmed =
+                            if (videoFullscreenTracker.trackingAvailable) {
+                                videoFullscreenTracker.stateAvailable && videoFullscreenTracker.isFullscreen
+                            } else {
+                                isWindowInFullscreen(frame)
+                            }
+                        if (fullscreenConfirmed) {
+                            hasReachedFullscreen = true
+                            logger.info(
+                                LogCategory.BROWSER,
+                                "Fullscreen animation completed, exit detection enabled",
+                                mapOf("nativeSignal" to videoFullscreenTracker.trackingAvailable),
+                            )
+                        } else {
+                            logger.warn(
+                                LogCategory.BROWSER,
+                                "macOS ignored native fullscreen toggle; using borderless overlay",
+                            )
+                            showBorderlessOverlay(
+                                frame = frame,
+                                browser = browser,
+                                bounds = displayBounds(frame),
+                                watchOwnerExit = currentOwnerWindowId?.let(::isRegisteredWindowFullscreen) == true,
+                                expectedEpoch = expectedEpoch,
+                            )
+                        }
+                    }
+                }.apply {
+                    isRepeats = false
+                    start()
+                }
             }
         }
     }
 
     private fun showBorderlessOverlay(
         frame: JFrame,
+        browser: Browser,
         bounds: Rectangle,
         watchOwnerExit: Boolean,
         expectedEpoch: Long,
     ) {
-        if (lifecycleEpoch != expectedEpoch || fullscreenFrame !== frame) return
-        if (frame.isDisplayable) {
-            frame.dispose()
-        }
-        frame.isUndecorated = true
-        frame.isAlwaysOnTop = true
-        frame.extendedState = JFrame.NORMAL
-        frame.setBounds(bounds)
-        frame.isVisible = true
-        frame.toFront()
-        installOverlayFocusBehavior(frame)
+        if (!isCurrentFrameSession(expectedEpoch, browser, frame)) return
+        videoFullscreenTracker.clear()
+
+        val overlay =
+            prepareBorderlessOverlayFrame(
+                sourceFrame = frame,
+                sourceView = currentBrowserView,
+                browser = browser,
+                installExitShortcut = ::installExitShortcut,
+                installFrameListeners = { replacement ->
+                    installFullscreenFrameListeners(replacement, browser, expectedEpoch)
+                },
+            )
+        fullscreenFrame = overlay.frame
+        currentBrowserView = overlay.browserView
+        overlay.frame.isAlwaysOnTop = true
+        overlay.frame.extendedState = JFrame.NORMAL
+        overlay.frame.setBounds(bounds)
+        overlay.frame.isVisible = true
+        overlay.frame.toFront()
+        overlay.browserView.requestFocusInWindow()
+        overlayCoordinator.installFocusBehavior(overlay.frame, currentOwnerWindowId)
         usesNativeMacOSFullscreen = false
         hasReachedFullscreen = true
         if (watchOwnerExit) {
-            watchOwnerFullscreenExit(currentOwnerWindowId, expectedEpoch)
+            overlayCoordinator.watchOwnerExit(currentOwnerWindowId, expectedEpoch)
         }
-    }
-
-    private fun installOverlayFocusBehavior(frame: JFrame) {
-        clearOverlayOwnerFocusListener()
-        frame.addWindowFocusListener(
-            object : WindowAdapter() {
-                override fun windowLostFocus(event: WindowEvent?) {
-                    if (fullscreenFrame === frame && !usesNativeMacOSFullscreen) {
-                        // Do not cover other applications when the user switches
-                        // away from Boss; restore the overlay level on return.
-                        frame.isAlwaysOnTop = false
-                    }
-                }
-
-                override fun windowGainedFocus(event: WindowEvent?) {
-                    restoreOverlayFocus(frame)
-                }
-            },
-        )
-
-        val ownerWindow = currentOwnerWindowId?.let(WindowFocusManager::getWindow) ?: return
-        val ownerListener =
-            object : WindowAdapter() {
-                override fun windowGainedFocus(event: WindowEvent?) {
-                    restoreOverlayFocus(frame)
-                    frame.requestFocus()
-                }
-            }
-        overlayOwnerWindow = ownerWindow
-        overlayOwnerFocusListener = ownerListener
-        ownerWindow.addWindowFocusListener(ownerListener)
-    }
-
-    private fun restoreOverlayFocus(frame: JFrame) {
-        if (fullscreenFrame === frame && !usesNativeMacOSFullscreen) {
-            frame.isAlwaysOnTop = true
-            frame.toFront()
-        }
-    }
-
-    private fun clearOverlayOwnerFocusListener() {
-        val ownerWindow = overlayOwnerWindow
-        val listener = overlayOwnerFocusListener
-        if (ownerWindow != null && listener != null) {
-            ownerWindow.removeWindowFocusListener(listener)
-        }
-        overlayOwnerWindow = null
-        overlayOwnerFocusListener = null
     }
 
     /**
@@ -644,6 +864,7 @@ object FullscreenBrowserWindow {
      * A new undecorated video window can cover that same fullscreen Space without
      * asking macOS to create a second native fullscreen Space.
      */
+
     private fun existingFullscreenWindowBounds(ownerWindowId: String): Rectangle? {
         val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId)
         if (state == null ||
@@ -734,58 +955,13 @@ object FullscreenBrowserWindow {
         )
     }
 
-    private fun watchOwnerFullscreenExit(
-        ownerWindowId: String?,
-        expectedEpoch: Long,
-    ) {
-        if (ownerWindowId == null) return
-        ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
-        val listener: (String) -> Unit = { exitedWindowId ->
-            if (exitedWindowId == ownerWindowId) {
-                SwingUtilities.invokeLater {
-                    if (isCurrentOwnerOverlay(ownerWindowId, expectedEpoch)) {
-                        logger.info(
-                            LogCategory.BROWSER,
-                            "Closing fullscreen video overlay because its host exited fullscreen",
-                            mapOf("ownerWindowId" to ownerWindowId),
-                        )
-                        requestPageExit()
-                    }
-                }
-            }
-        }
-        ownerFullscreenExitListener = listener
-        WindowFocusManager.fullscreenExitNotifier.add(listener)
-
-        // The owner may have completed its exit between the state read that
-        // selected overlay mode and listener registration.
-        val stillFullscreen = isRegisteredWindowFullscreen(ownerWindowId)
-        if (!stillFullscreen) {
-            SwingUtilities.invokeLater {
-                if (isCurrentOwnerOverlay(ownerWindowId, expectedEpoch)) {
-                    requestPageExit()
-                }
-            }
-        }
-    }
-
-    private fun isCurrentOwnerOverlay(
-        ownerWindowId: String,
-        expectedEpoch: Long,
-    ): Boolean =
-        currentOwnerWindowId == ownerWindowId &&
-            lifecycleEpoch == expectedEpoch &&
-            isInFullscreenMode &&
-            !usesNativeMacOSFullscreen
-
     /**
      * Reset all state variables.
      */
     private fun resetState(): Long {
         lifecycleEpoch++
-        ownerFullscreenExitListener?.let(WindowFocusManager.fullscreenExitNotifier::remove)
-        ownerFullscreenExitListener = null
-        clearOverlayOwnerFocusListener()
+        overlayCoordinator.clear()
+        videoFullscreenTracker.clear()
         fullscreenFrame = null
         currentBrowserView = null
         currentBrowser = null

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.tabfullscreen
 
 import ai.rever.boss.utils.WindowFocusManager
+import ai.rever.boss.utils.hasFullscreenSignal
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import com.teamdev.jxbrowser.browser.Browser
@@ -58,6 +59,8 @@ object FullscreenBrowserWindow {
     // marshal to the EDT before reading or mutating these fields.
     private var fullscreenFrame: JFrame? = null
     private var currentBrowserView: BrowserView? = null
+
+    @Volatile // Read off-EDT only for the disposal fast path; mutated on the EDT.
     private var currentBrowser: Browser? = null
     private var currentOwnerWindowId: String? = null
     private var ownerFullscreenExitListener: ((String) -> Unit)? = null
@@ -85,18 +88,24 @@ object FullscreenBrowserWindow {
         browser: Browser,
         tabId: String,
         ownerWindowId: String,
+        onEnter: () -> Unit,
         onExit: () -> Unit,
     ) {
         if (!SwingUtilities.isEventDispatchThread()) {
             SwingUtilities.invokeLater {
-                showFullscreen(browser, tabId, ownerWindowId, onExit)
+                showFullscreen(browser, tabId, ownerWindowId, onEnter, onExit)
             }
             return
         }
 
         // Prevent duplicate calls
-        if (fullscreenFrame != null || isInFullscreenMode) {
+        if (browser.isClosed || fullscreenFrame != null || isInFullscreenMode) {
             logger.warn(LogCategory.BROWSER, "Fullscreen already active, ignoring duplicate request")
+            runCatching { browser.fullScreen().exit() }
+                .onFailure { error ->
+                    logger.warn(LogCategory.BROWSER, "Could not reject duplicate browser fullscreen", error = error)
+                }
+            onExit()
             return
         }
 
@@ -109,6 +118,7 @@ object FullscreenBrowserWindow {
         isExiting = false
         hasReachedFullscreen = false
         TabFullscreenStateManager.enterFullscreen(tabId)
+        onEnter()
 
         logger.info(LogCategory.BROWSER, "Fullscreen state set, waiting for Compose detach", mapOf("tabId" to tabId))
 
@@ -237,7 +247,7 @@ object FullscreenBrowserWindow {
                                         )
                                         showBorderlessOverlay(
                                             frame = frame,
-                                            bounds = frame.graphicsConfiguration.bounds,
+                                            bounds = displayBounds(frame),
                                             watchOwnerExit = false,
                                         )
                                     }
@@ -249,7 +259,7 @@ object FullscreenBrowserWindow {
                         } else {
                             showBorderlessOverlay(
                                 frame = frame,
-                                bounds = frame.graphicsConfiguration.bounds,
+                                bounds = displayBounds(frame),
                                 watchOwnerExit = false,
                             )
                         }
@@ -272,9 +282,10 @@ object FullscreenBrowserWindow {
             logger.info(LogCategory.BROWSER, "Fullscreen window opened", mapOf("tabId" to tabId, "isMacOS" to isMacOS))
         } catch (e: Exception) {
             logger.error(LogCategory.BROWSER, "Failed to create fullscreen window", error = e)
+            val callback = onExitCallback
             resetState()
             TabFullscreenStateManager.exitFullscreen()
-            onExitCallback?.invoke()
+            callback?.invoke()
         }
     }
 
@@ -328,15 +339,19 @@ object FullscreenBrowserWindow {
      */
     private fun existingFullscreenWindowBounds(ownerWindowId: String): Rectangle? {
         val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId)
+        if (state == null ||
+            !hasFullscreenSignal(
+                nativeStateAvailable = state.nativeStateAvailable,
+                nativeFullscreen = state.nativeFullscreen,
+                composeFullscreen = state.composeFullscreen,
+            )
+        ) {
+            return null
+        }
         return when {
-            state == null -> {
-                null
-            }
-
-            state.nativeTrackingAvailable -> {
+            state.nativeStateAvailable -> {
                 state.window.graphicsConfiguration
                     ?.bounds
-                    .takeIf { state.nativeFullscreen }
             }
 
             else -> {
@@ -406,10 +421,13 @@ object FullscreenBrowserWindow {
      * Check if window is currently in fullscreen state (macOS).
      * On macOS in fullscreen, the window bounds match the screen bounds exactly.
      */
-    private fun isWindowInFullscreen(frame: JFrame): Boolean {
-        val screenBounds = frame.graphicsConfiguration?.bounds ?: return false
-        return fillsScreen(frame.bounds, screenBounds)
-    }
+    private fun isWindowInFullscreen(frame: JFrame): Boolean = fillsScreen(frame.bounds, displayBounds(frame))
+
+    private fun displayBounds(frame: JFrame): Rectangle =
+        frame.graphicsConfiguration?.bounds
+            ?: GraphicsEnvironment
+                .getLocalGraphicsEnvironment()
+                .defaultScreenDevice.defaultConfiguration.bounds
 
     private fun installExitShortcut(frame: JFrame) {
         frame.rootPane
@@ -447,6 +465,20 @@ object FullscreenBrowserWindow {
         }
         ownerFullscreenExitListener = listener
         WindowFocusManager.fullscreenExitNotifier.add(listener)
+
+        // The owner may have completed its exit between the state read that
+        // selected overlay mode and listener registration.
+        val state = WindowFocusManager.getWindowFullscreenState(ownerWindowId)
+        val stillFullscreen =
+            state != null &&
+                hasFullscreenSignal(
+                    nativeStateAvailable = state.nativeStateAvailable,
+                    nativeFullscreen = state.nativeFullscreen,
+                    composeFullscreen = state.composeFullscreen,
+                )
+        if (!stillFullscreen) {
+            requestPageExit()
+        }
     }
 
     /**
@@ -541,46 +573,44 @@ object FullscreenBrowserWindow {
         }
     }
 
-    /**
-     * Internal method to perform exit and invoke callback.
-     */
+    /** Handles a native fullscreen window exit by reconciling the browser page first. */
     private fun performExit() {
-        if (isExiting || !isInFullscreenMode) return
-        isExiting = true
+        requestPageExit()
+    }
 
-        val callback = onExitCallback
-        exitFullscreen()
-        callback?.invoke()
+    /** Called when the user manually triggers exit from the host UI. */
+    private fun requestExit() {
+        logger.info(LogCategory.BROWSER, "Exit requested via placeholder click")
+        requestPageExit()
     }
 
     /**
-     * Called when user manually triggers exit (placeholder click).
-     * On macOS, toggles fullscreen off which triggers the exit flow.
+     * Keep the browser page and host window in sync: ask Chromium to leave
+     * HTML fullscreen first, then tear down directly only if its exit event is
+     * lost. JxBrowser's FullScreen.exit() covers all frames in the browser.
      */
-    private fun requestExit() {
-        if (isExiting) return
-        logger.info(LogCategory.BROWSER, "Exit requested via placeholder click")
-
-        val frame = fullscreenFrame ?: return
-
-        if (isMacOS && usesNativeMacOSFullscreen && hasReachedFullscreen) {
-            // Toggle fullscreen off (will trigger componentResized -> performExit)
-            isExiting = true
-            if (!toggleMacOSFullscreen(frame)) {
-                performExitDirect()
-            } else {
-                // Also schedule a direct exit in case the toggle doesn't work
-                Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
-                    if (fullscreenFrame != null) {
-                        performExitDirect()
-                    }
-                }.apply {
-                    isRepeats = false
-                    start()
-                }
-            }
-        } else {
+    private fun requestPageExit() {
+        if (isExiting || !isInFullscreenMode) return
+        isExiting = true
+        val browser = currentBrowser
+        if (browser == null ||
+            runCatching { browser.fullScreen().exit() }
+                .onFailure { error ->
+                    logger.warn(LogCategory.BROWSER, "Could not request browser fullscreen exit", error = error)
+                }.isFailure
+        ) {
             performExitDirect()
+            return
+        }
+
+        Timer(FULLSCREEN_ANIMATION_DELAY_MS) {
+            if (currentBrowser === browser && isInFullscreenMode) {
+                logger.warn(LogCategory.BROWSER, "Browser fullscreen exit event timed out; closing host window")
+                performExitDirect()
+            }
+        }.apply {
+            isRepeats = false
+            start()
         }
     }
 
@@ -643,6 +673,7 @@ object FullscreenBrowserWindow {
      * paths either already run on the EDT or hold only owner-local lifecycle state.
      */
     fun exitFullscreen(browser: Browser) {
+        if (currentBrowser !== browser) return
         runOnEventDispatchThreadAndWait {
             if (currentBrowser === browser) {
                 exitFullscreen()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -47,7 +47,14 @@ internal fun shouldNotifyComposeFullscreenExit(
     isNativeFullscreen: Boolean,
 ): Boolean = wasComposeFullscreen && !isNativeFullscreen
 
+internal fun shouldNotifyNativeFullscreenExit(
+    hadNativeState: Boolean,
+    wasNativeFullscreen: Boolean,
+    composeFullscreen: Boolean,
+): Boolean = wasNativeFullscreen || (!hadNativeState && composeFullscreen)
+
 internal class FullscreenExitNotifier {
+    private val logger = BossLogger.forComponent("FullscreenExitNotifier")
     private val listeners = CopyOnWriteArraySet<(String) -> Unit>()
 
     fun add(listener: (String) -> Unit) {
@@ -58,8 +65,18 @@ internal class FullscreenExitNotifier {
         listeners -= listener
     }
 
-    fun notify(windowId: String) {
-        listeners.forEach { listener -> listener(windowId) }
+    fun notifyExit(windowId: String) {
+        listeners.forEach { listener ->
+            runCatching { listener(windowId) }
+                .onFailure { error ->
+                    logger.warn(
+                        LogCategory.UI,
+                        "Fullscreen exit listener failed",
+                        mapOf("windowId" to windowId),
+                        error,
+                    )
+                }
+        }
     }
 }
 
@@ -239,6 +256,13 @@ internal data class RegisteredWindowFullscreenState(
     val composeFullscreen: Boolean,
 )
 
+private data class WindowFullscreenSignals(
+    val nativeTrackingAvailable: Boolean = false,
+    val nativeStateAvailable: Boolean = false,
+    val nativeFullscreen: Boolean = false,
+    val composeFullscreen: Boolean = false,
+)
+
 /**
  * Handles multi-window focus tracking with two intentionally different views:
  * [isWindowFocused] is the live AWT focus used to gate browser input, while
@@ -247,33 +271,41 @@ internal data class RegisteredWindowFullscreenState(
  */
 actual object WindowFocusManager {
     private val windows = ConcurrentHashMap<String, Window>()
-    private val composeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
-    private val nativeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
-    private val nativeTrackedWindowIds = ConcurrentHashMap.newKeySet<String>()
-    private val nativeStateAvailableWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private val fullscreenSignals = ConcurrentHashMap<String, WindowFullscreenSignals>()
     internal val fullscreenExitNotifier = FullscreenExitNotifier()
     private val macOSFullscreenTracker =
         MacOSFullscreenTracker(
             onFullscreenChanged = { windowId, isFullscreen ->
-                val hadNativeState = !nativeStateAvailableWindowIds.add(windowId)
-                if (isFullscreen) {
-                    nativeFullscreenWindowIds += windowId
-                } else {
-                    val wasNativeFullscreen = nativeFullscreenWindowIds.remove(windowId)
-                    if (wasNativeFullscreen ||
-                        (!hadNativeState && windowId in composeFullscreenWindowIds)
-                    ) {
-                        fullscreenExitNotifier.notify(windowId)
-                    }
+                var shouldNotifyExit = false
+                fullscreenSignals.compute(windowId) { _, current ->
+                    val previous = current ?: WindowFullscreenSignals()
+                    shouldNotifyExit =
+                        !isFullscreen &&
+                        shouldNotifyNativeFullscreenExit(
+                            hadNativeState = previous.nativeStateAvailable,
+                            wasNativeFullscreen = previous.nativeFullscreen,
+                            composeFullscreen = previous.composeFullscreen,
+                        )
+                    previous.copy(
+                        nativeStateAvailable = true,
+                        nativeFullscreen = isFullscreen,
+                    )
+                }
+                if (shouldNotifyExit) {
+                    fullscreenExitNotifier.notifyExit(windowId)
                 }
             },
             onFullscreenExitStarted = { windowId ->
                 // An exit-start event proves that the registered window still
                 // owns a native fullscreen Space even if registration missed
                 // its earlier enter transition.
-                nativeStateAvailableWindowIds += windowId
-                nativeFullscreenWindowIds += windowId
-                fullscreenExitNotifier.notify(windowId)
+                fullscreenSignals.compute(windowId) { _, current ->
+                    (current ?: WindowFullscreenSignals()).copy(
+                        nativeStateAvailable = true,
+                        nativeFullscreen = true,
+                    )
+                }
+                fullscreenExitNotifier.notifyExit(windowId)
             },
         )
 
@@ -325,12 +357,18 @@ actual object WindowFocusManager {
 
         // Native fullscreen tracking is optional and must not prevent the
         // focus listener above from being installed if EAWT is unavailable.
-        nativeFullscreenWindowIds -= windowId
-        nativeStateAvailableWindowIds -= windowId
-        if (macOSFullscreenTracker.register(windowId, window)) {
-            nativeTrackedWindowIds += windowId
-        } else {
-            nativeTrackedWindowIds -= windowId
+        fullscreenSignals.compute(windowId) { _, current ->
+            (current ?: WindowFullscreenSignals()).copy(
+                nativeTrackingAvailable = false,
+                nativeStateAvailable = false,
+                nativeFullscreen = false,
+            )
+        }
+        val nativeTrackingAvailable = macOSFullscreenTracker.register(windowId, window)
+        fullscreenSignals.compute(windowId) { _, current ->
+            (current ?: WindowFullscreenSignals()).copy(
+                nativeTrackingAvailable = nativeTrackingAvailable,
+            )
         }
     }
 
@@ -358,32 +396,38 @@ actual object WindowFocusManager {
         windowId: String,
         isFullscreen: Boolean,
     ) {
-        if (isFullscreen) {
-            composeFullscreenWindowIds += windowId
-        } else {
-            val wasComposeFullscreen = composeFullscreenWindowIds.remove(windowId)
-            if (shouldNotifyComposeFullscreenExit(
-                    wasComposeFullscreen,
-                    windowId in nativeFullscreenWindowIds,
-                )
-            ) {
-                fullscreenExitNotifier.notify(windowId)
+        var shouldNotifyExit = false
+        fullscreenSignals.compute(windowId) { _, current ->
+            if (current == null && !isFullscreen) {
+                return@compute null
             }
+            val previous = current ?: WindowFullscreenSignals()
+            shouldNotifyExit =
+                !isFullscreen &&
+                shouldNotifyComposeFullscreenExit(
+                    wasComposeFullscreen = previous.composeFullscreen,
+                    isNativeFullscreen = previous.nativeFullscreen,
+                )
+            previous.copy(composeFullscreen = isFullscreen)
+        }
+        if (shouldNotifyExit) {
+            fullscreenExitNotifier.notifyExit(windowId)
         }
     }
 
     /** Returns the requested window and its independently tracked fullscreen signals. */
     internal fun getWindowFullscreenState(windowId: String): RegisteredWindowFullscreenState? {
         val window = windows[windowId] ?: return null
+        val signals = fullscreenSignals[windowId] ?: WindowFullscreenSignals()
         return RegisteredWindowFullscreenState(
             window = window,
             // A listener reports transitions, not initial state. Compose plus
             // geometry remains the fallback until the first native event.
             nativeStateAvailable =
-                windowId in nativeTrackedWindowIds &&
-                    windowId in nativeStateAvailableWindowIds,
-            nativeFullscreen = windowId in nativeFullscreenWindowIds,
-            composeFullscreen = windowId in composeFullscreenWindowIds,
+                signals.nativeTrackingAvailable &&
+                    signals.nativeStateAvailable,
+            nativeFullscreen = signals.nativeFullscreen,
+            composeFullscreen = signals.composeFullscreen,
         )
     }
 
@@ -402,12 +446,9 @@ actual object WindowFocusManager {
         macOSFullscreenTracker.unregister(windowId)
 
         windows.remove(windowId)
-        val wasComposeFullscreen = composeFullscreenWindowIds.remove(windowId)
-        val wasNativeFullscreen = nativeFullscreenWindowIds.remove(windowId)
-        nativeTrackedWindowIds -= windowId
-        nativeStateAvailableWindowIds -= windowId
-        if (wasComposeFullscreen || wasNativeFullscreen) {
-            fullscreenExitNotifier.notify(windowId)
+        val signals = fullscreenSignals.remove(windowId)
+        if (signals?.composeFullscreen == true || signals?.nativeFullscreen == true) {
+            fullscreenExitNotifier.notifyExit(windowId)
         }
         awtFocusTracker.onUnregistered(windowId)
         if (focusedWindowId == windowId) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -20,6 +20,101 @@ internal fun nativeMacOSFullscreenStateForEvent(methodName: String): Boolean? =
         else -> null
     }
 
+private class MacOSFullscreenTracker(
+    private val onFullscreenChanged: (windowId: String, isFullscreen: Boolean) -> Unit,
+) {
+    private data class Registration(
+        val window: Window,
+        val listener: Any,
+        val listenerClass: Class<*>,
+        val removeMethod: Method,
+    )
+
+    private val logger = BossLogger.forComponent("MacOSFullscreenTracker")
+    private val registrations = mutableMapOf<String, Registration>()
+
+    fun register(
+        windowId: String,
+        window: Window,
+    ) {
+        if (!System.getProperty("os.name").lowercase().contains("mac")) return
+
+        unregister(windowId)
+        try {
+            val utilitiesClass = Class.forName("com.apple.eawt.FullScreenUtilities")
+            val listenerClass = Class.forName("com.apple.eawt.FullScreenListener")
+            val listener =
+                Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass)) { proxy, method, arguments ->
+                    when (method.name) {
+                        "equals" -> {
+                            proxy === arguments?.firstOrNull()
+                        }
+
+                        "hashCode" -> {
+                            System.identityHashCode(proxy)
+                        }
+
+                        "toString" -> {
+                            "BossMacOSFullscreenListener($windowId)"
+                        }
+
+                        else -> {
+                            nativeMacOSFullscreenStateForEvent(method.name)?.let { isFullscreen ->
+                                onFullscreenChanged(windowId, isFullscreen)
+                                logger.info(
+                                    LogCategory.UI,
+                                    "Native macOS fullscreen state changed",
+                                    mapOf("windowId" to windowId, "isFullscreen" to isFullscreen),
+                                )
+                            }
+                            null
+                        }
+                    }
+                }
+            val addMethod =
+                utilitiesClass.getMethod(
+                    "addFullScreenListenerTo",
+                    Window::class.java,
+                    listenerClass,
+                )
+            val removeMethod =
+                utilitiesClass.getMethod(
+                    "removeFullScreenListenerFrom",
+                    Window::class.java,
+                    listenerClass,
+                )
+
+            addMethod.invoke(null, window, listener)
+            registrations[windowId] = Registration(window, listener, listenerClass, removeMethod)
+        } catch (e: ReflectiveOperationException) {
+            logger.warn(
+                LogCategory.UI,
+                "Could not register native macOS fullscreen listener",
+                mapOf("windowId" to windowId),
+                e,
+            )
+        }
+    }
+
+    fun unregister(windowId: String) {
+        val registration = registrations.remove(windowId) ?: return
+        try {
+            registration.removeMethod.invoke(
+                null,
+                registration.window,
+                registration.listenerClass.cast(registration.listener),
+            )
+        } catch (e: ReflectiveOperationException) {
+            logger.warn(
+                LogCategory.UI,
+                "Could not unregister native macOS fullscreen listener",
+                mapOf("windowId" to windowId),
+                e,
+            )
+        }
+    }
+}
+
 /**
  * Captures AWT focus lifecycle events on the EDT and exposes a volatile
  * snapshot that JxBrowser callback threads can safely read.
@@ -70,17 +165,9 @@ internal class AwtWindowFocusTracker {
  * as deep links and file opens.
  */
 actual object WindowFocusManager {
-    private data class MacOSFullscreenRegistration(
-        val window: Window,
-        val listener: Any,
-        val listenerClass: Class<*>,
-        val removeMethod: Method,
-    )
-
-    private val logger = BossLogger.forComponent("WindowFocusManager")
     private val windows = ConcurrentHashMap<String, Window>()
     private val fullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
-    private val macOSFullscreenRegistrations = mutableMapOf<String, MacOSFullscreenRegistration>()
+    private val macOSFullscreenTracker = MacOSFullscreenTracker(::updateWindowFullscreen)
 
     // EDT-confined; registerWindow/unregisterWindow enforce this before mutation.
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
@@ -108,7 +195,7 @@ actual object WindowFocusManager {
             "WindowFocusManager.registerWindow must run on the EDT"
         }
         windows[windowId] = window
-        registerMacOSFullscreenListener(windowId, window)
+        macOSFullscreenTracker.register(windowId, window)
 
         // First window becomes the main window (backward compatibility).
         if (mainWindow == null) {
@@ -185,7 +272,7 @@ actual object WindowFocusManager {
         windowListeners.remove(windowId)?.let { listener ->
             windows[windowId]?.removeWindowFocusListener(listener)
         }
-        unregisterMacOSFullscreenListener(windowId)
+        macOSFullscreenTracker.unregister(windowId)
 
         windows.remove(windowId)
         fullscreenWindowIds -= windowId
@@ -217,88 +304,6 @@ actual object WindowFocusManager {
      * window is registered at all.
      */
     fun resolveActionableWindowId(): String? = focusedWindowId ?: focusedWindowFlow.value ?: windows.keys.firstOrNull()
-
-    private fun registerMacOSFullscreenListener(
-        windowId: String,
-        window: Window,
-    ) {
-        if (!System.getProperty("os.name").lowercase().contains("mac")) return
-
-        unregisterMacOSFullscreenListener(windowId)
-        try {
-            val utilitiesClass = Class.forName("com.apple.eawt.FullScreenUtilities")
-            val listenerClass = Class.forName("com.apple.eawt.FullScreenListener")
-            val listener =
-                Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass)) { proxy, method, arguments ->
-                    when (method.name) {
-                        "equals" -> {
-                            proxy === arguments?.firstOrNull()
-                        }
-
-                        "hashCode" -> {
-                            System.identityHashCode(proxy)
-                        }
-
-                        "toString" -> {
-                            "BossMacOSFullscreenListener($windowId)"
-                        }
-
-                        else -> {
-                            nativeMacOSFullscreenStateForEvent(method.name)?.let { isFullscreen ->
-                                updateWindowFullscreen(windowId, isFullscreen)
-                                logger.info(
-                                    LogCategory.UI,
-                                    "Native macOS fullscreen state changed",
-                                    mapOf("windowId" to windowId, "isFullscreen" to isFullscreen),
-                                )
-                            }
-                            null
-                        }
-                    }
-                }
-            val addMethod =
-                utilitiesClass.getMethod(
-                    "addFullScreenListenerTo",
-                    Window::class.java,
-                    listenerClass,
-                )
-            val removeMethod =
-                utilitiesClass.getMethod(
-                    "removeFullScreenListenerFrom",
-                    Window::class.java,
-                    listenerClass,
-                )
-
-            addMethod.invoke(null, window, listener)
-            macOSFullscreenRegistrations[windowId] =
-                MacOSFullscreenRegistration(window, listener, listenerClass, removeMethod)
-        } catch (e: ReflectiveOperationException) {
-            logger.warn(
-                LogCategory.UI,
-                "Could not register native macOS fullscreen listener",
-                mapOf("windowId" to windowId),
-                e,
-            )
-        }
-    }
-
-    private fun unregisterMacOSFullscreenListener(windowId: String) {
-        val registration = macOSFullscreenRegistrations.remove(windowId) ?: return
-        try {
-            registration.removeMethod.invoke(
-                null,
-                registration.window,
-                registration.listenerClass.cast(registration.listener),
-            )
-        } catch (e: ReflectiveOperationException) {
-            logger.warn(
-                LogCategory.UI,
-                "Could not unregister native macOS fullscreen listener",
-                mapOf("windowId" to windowId),
-                e,
-            )
-        }
-    }
 
     /**
      * Bring a specific window to front by its ID

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -51,7 +51,8 @@ internal fun shouldNotifyNativeFullscreenExit(
     hadNativeState: Boolean,
     wasNativeFullscreen: Boolean,
     composeFullscreen: Boolean,
-): Boolean = wasNativeFullscreen || (!hadNativeState && composeFullscreen)
+    exitAlreadyNotified: Boolean = false,
+): Boolean = !exitAlreadyNotified && (wasNativeFullscreen || (!hadNativeState && composeFullscreen))
 
 internal class FullscreenExitNotifier {
     private val logger = BossLogger.forComponent("FullscreenExitNotifier")
@@ -260,6 +261,7 @@ private data class WindowFullscreenSignals(
     val nativeTrackingAvailable: Boolean = false,
     val nativeStateAvailable: Boolean = false,
     val nativeFullscreen: Boolean = false,
+    val nativeExitAlreadyNotified: Boolean = false,
     val composeFullscreen: Boolean = false,
 )
 
@@ -285,10 +287,12 @@ actual object WindowFocusManager {
                             hadNativeState = previous.nativeStateAvailable,
                             wasNativeFullscreen = previous.nativeFullscreen,
                             composeFullscreen = previous.composeFullscreen,
+                            exitAlreadyNotified = previous.nativeExitAlreadyNotified,
                         )
                     previous.copy(
                         nativeStateAvailable = true,
                         nativeFullscreen = isFullscreen,
+                        nativeExitAlreadyNotified = false,
                     )
                 }
                 if (shouldNotifyExit) {
@@ -303,6 +307,7 @@ actual object WindowFocusManager {
                     (current ?: WindowFullscreenSignals()).copy(
                         nativeStateAvailable = true,
                         nativeFullscreen = true,
+                        nativeExitAlreadyNotified = true,
                     )
                 }
                 fullscreenExitNotifier.notifyExit(windowId)
@@ -362,6 +367,7 @@ actual object WindowFocusManager {
                 nativeTrackingAvailable = false,
                 nativeStateAvailable = false,
                 nativeFullscreen = false,
+                nativeExitAlreadyNotified = false,
             )
         }
         val nativeTrackingAvailable = macOSFullscreenTracker.register(windowId, window)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import java.awt.Window
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.lang.reflect.InaccessibleObjectException
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.util.concurrent.ConcurrentHashMap
@@ -15,10 +16,20 @@ import javax.swing.SwingUtilities
 
 internal fun nativeMacOSFullscreenStateForEvent(methodName: String): Boolean? =
     when (methodName) {
+        // Treat "entering" as fullscreen immediately so a page request during
+        // the Space animation does not issue a competing native toggle.
         "windowEnteringFullScreen", "windowEnteredFullScreen" -> true
-        "windowExitedFullScreen" -> false
+
+        "windowExitingFullScreen", "windowExitedFullScreen" -> false
+
         else -> null
     }
+
+internal fun hasFullscreenSignal(
+    windowId: String,
+    composeFullscreenIds: Set<String>,
+    nativeFullscreenIds: Set<String>,
+): Boolean = windowId in composeFullscreenIds || windowId in nativeFullscreenIds
 
 private class MacOSFullscreenTracker(
     private val onFullscreenChanged: (windowId: String, isFullscreen: Boolean) -> Unit,
@@ -87,12 +98,13 @@ private class MacOSFullscreenTracker(
             addMethod.invoke(null, window, listener)
             registrations[windowId] = Registration(window, listener, listenerClass, removeMethod)
         } catch (e: ReflectiveOperationException) {
-            logger.warn(
-                LogCategory.UI,
-                "Could not register native macOS fullscreen listener",
-                mapOf("windowId" to windowId),
-                e,
-            )
+            logFailure("register", windowId, e)
+        } catch (e: InaccessibleObjectException) {
+            logFailure("register", windowId, e)
+        } catch (e: IllegalArgumentException) {
+            logFailure("register", windowId, e)
+        } catch (e: SecurityException) {
+            logFailure("register", windowId, e)
         }
     }
 
@@ -105,13 +117,27 @@ private class MacOSFullscreenTracker(
                 registration.listenerClass.cast(registration.listener),
             )
         } catch (e: ReflectiveOperationException) {
-            logger.warn(
-                LogCategory.UI,
-                "Could not unregister native macOS fullscreen listener",
-                mapOf("windowId" to windowId),
-                e,
-            )
+            logFailure("unregister", windowId, e)
+        } catch (e: InaccessibleObjectException) {
+            logFailure("unregister", windowId, e)
+        } catch (e: IllegalArgumentException) {
+            logFailure("unregister", windowId, e)
+        } catch (e: SecurityException) {
+            logFailure("unregister", windowId, e)
         }
+    }
+
+    private fun logFailure(
+        operation: String,
+        windowId: String,
+        error: Throwable,
+    ) {
+        logger.warn(
+            LogCategory.UI,
+            "Could not $operation native macOS fullscreen listener",
+            mapOf("windowId" to windowId),
+            error,
+        )
     }
 }
 
@@ -166,8 +192,16 @@ internal class AwtWindowFocusTracker {
  */
 actual object WindowFocusManager {
     private val windows = ConcurrentHashMap<String, Window>()
-    private val fullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
-    private val macOSFullscreenTracker = MacOSFullscreenTracker(::updateWindowFullscreen)
+    private val composeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private val nativeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private val macOSFullscreenTracker =
+        MacOSFullscreenTracker { windowId, isFullscreen ->
+            if (isFullscreen) {
+                nativeFullscreenWindowIds += windowId
+            } else {
+                nativeFullscreenWindowIds -= windowId
+            }
+        }
 
     // EDT-confined; registerWindow/unregisterWindow enforce this before mutation.
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
@@ -236,29 +270,23 @@ actual object WindowFocusManager {
      */
     fun getWindow(windowId: String): Window? = windows[windowId]
 
-    /** Records the authoritative Compose placement for a registered window. */
+    /** Records Compose placement without overwriting the native macOS signal. */
     fun updateWindowFullscreen(
         windowId: String,
         isFullscreen: Boolean,
     ) {
         if (isFullscreen) {
-            fullscreenWindowIds += windowId
+            composeFullscreenWindowIds += windowId
         } else {
-            fullscreenWindowIds -= windowId
+            composeFullscreenWindowIds -= windowId
         }
     }
 
-    /**
-     * Returns a registered window whose Compose placement is fullscreen,
-     * preferring the last-focused window when multiple fullscreen Spaces exist.
-     */
-    fun getFullscreenWindow(): Window? {
-        val preferredId = resolveActionableWindowId()
-        if (preferredId != null && preferredId in fullscreenWindowIds) {
-            windows[preferredId]?.let { return it }
+    /** Returns the requested window only when either fullscreen signal is active. */
+    fun getFullscreenWindow(windowId: String): Window? =
+        windows[windowId]?.takeIf {
+            hasFullscreenSignal(windowId, composeFullscreenWindowIds, nativeFullscreenWindowIds)
         }
-        return fullscreenWindowIds.firstNotNullOfOrNull(windows::get)
-    }
 
     /**
      * Unregisters a window when it closes. Must run on the EDT.
@@ -275,7 +303,8 @@ actual object WindowFocusManager {
         macOSFullscreenTracker.unregister(windowId)
 
         windows.remove(windowId)
-        fullscreenWindowIds -= windowId
+        composeFullscreenWindowIds -= windowId
+        nativeFullscreenWindowIds -= windowId
         awtFocusTracker.onUnregistered(windowId)
         if (focusedWindowId == windowId) {
             // Preserve the existing last-focused flow contract for external

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -21,33 +21,52 @@ internal fun nativeMacOSFullscreenStateForEvent(methodName: String): Boolean? =
         // the Space animation does not issue a competing native toggle.
         "windowEnteringFullScreen", "windowEnteredFullScreen" -> true
 
-        "windowExitingFullScreen", "windowExitedFullScreen" -> false
+        // Keep the state true through the exit animation. The separate
+        // exit-start signal closes overlays immediately without allowing a
+        // competing native toggle before the Space has actually gone away.
+        "windowExitedFullScreen" -> false
 
         else -> null
     }
+
+internal fun isNativeMacOSFullscreenExitStarting(methodName: String): Boolean = methodName == "windowExitingFullScreen"
 
 internal fun hasFullscreenSignal(
     windowId: String,
     composeFullscreenIds: Set<String>,
     nativeFullscreenIds: Set<String>,
-): Boolean = windowId in composeFullscreenIds || windowId in nativeFullscreenIds
+    nativeTrackedIds: Set<String>,
+): Boolean =
+    if (windowId in nativeTrackedIds) {
+        windowId in nativeFullscreenIds
+    } else {
+        windowId in composeFullscreenIds
+    }
 
-private val fullscreenExitListeners = CopyOnWriteArraySet<(String) -> Unit>()
+internal fun shouldNotifyComposeFullscreenExit(
+    wasComposeFullscreen: Boolean,
+    isNativeFullscreen: Boolean,
+): Boolean = wasComposeFullscreen && !isNativeFullscreen
 
-internal fun addWindowFullscreenExitListener(listener: (String) -> Unit) {
-    fullscreenExitListeners += listener
-}
+internal class FullscreenExitNotifier {
+    private val listeners = CopyOnWriteArraySet<(String) -> Unit>()
 
-internal fun removeWindowFullscreenExitListener(listener: (String) -> Unit) {
-    fullscreenExitListeners -= listener
-}
+    fun add(listener: (String) -> Unit) {
+        listeners += listener
+    }
 
-private fun notifyWindowFullscreenExit(windowId: String) {
-    fullscreenExitListeners.forEach { listener -> listener(windowId) }
+    fun remove(listener: (String) -> Unit) {
+        listeners -= listener
+    }
+
+    fun notify(windowId: String) {
+        listeners.forEach { listener -> listener(windowId) }
+    }
 }
 
 private class MacOSFullscreenTracker(
     private val onFullscreenChanged: (windowId: String, isFullscreen: Boolean) -> Unit,
+    private val onFullscreenExitStarted: (windowId: String) -> Unit,
 ) {
     private data class Registration(
         val window: Window,
@@ -57,16 +76,19 @@ private class MacOSFullscreenTracker(
     )
 
     private val logger = BossLogger.forComponent("MacOSFullscreenTracker")
+    private val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
+
+    // EDT-confined through WindowFocusManager.registerWindow/unregisterWindow.
     private val registrations = mutableMapOf<String, Registration>()
 
     fun register(
         windowId: String,
         window: Window,
-    ) {
-        if (!System.getProperty("os.name").lowercase().contains("mac")) return
+    ): Boolean {
+        if (!isMacOS) return false
 
         unregister(windowId)
-        try {
+        return runReflection("register", windowId) {
             val utilitiesClass = Class.forName("com.apple.eawt.FullScreenUtilities")
             val listenerClass = Class.forName("com.apple.eawt.FullScreenListener")
             val listener =
@@ -85,6 +107,9 @@ private class MacOSFullscreenTracker(
                         }
 
                         else -> {
+                            if (isNativeMacOSFullscreenExitStarting(method.name)) {
+                                onFullscreenExitStarted(windowId)
+                            }
                             nativeMacOSFullscreenStateForEvent(method.name)?.let { isFullscreen ->
                                 onFullscreenChanged(windowId, isFullscreen)
                                 logger.info(
@@ -112,39 +137,44 @@ private class MacOSFullscreenTracker(
 
             addMethod.invoke(null, window, listener)
             registrations[windowId] = Registration(window, listener, listenerClass, removeMethod)
-        } catch (e: ReflectiveOperationException) {
-            logFailure("register", windowId, e)
-        } catch (e: InaccessibleObjectException) {
-            logFailure("register", windowId, e)
-        } catch (e: IllegalArgumentException) {
-            logFailure("register", windowId, e)
-        } catch (e: ClassCastException) {
-            logFailure("register", windowId, e)
-        } catch (e: SecurityException) {
-            logFailure("register", windowId, e)
         }
     }
 
     fun unregister(windowId: String) {
         val registration = registrations.remove(windowId) ?: return
-        try {
+        runReflection("unregister", windowId) {
             registration.removeMethod.invoke(
                 null,
                 registration.window,
                 registration.listenerClass.cast(registration.listener),
             )
-        } catch (e: ReflectiveOperationException) {
-            logFailure("unregister", windowId, e)
-        } catch (e: InaccessibleObjectException) {
-            logFailure("unregister", windowId, e)
-        } catch (e: IllegalArgumentException) {
-            logFailure("unregister", windowId, e)
-        } catch (e: ClassCastException) {
-            logFailure("unregister", windowId, e)
-        } catch (e: SecurityException) {
-            logFailure("unregister", windowId, e)
         }
     }
+
+    private fun runReflection(
+        operation: String,
+        windowId: String,
+        block: () -> Unit,
+    ): Boolean =
+        try {
+            block()
+            true
+        } catch (e: ReflectiveOperationException) {
+            logFailure(operation, windowId, e)
+            false
+        } catch (e: InaccessibleObjectException) {
+            logFailure(operation, windowId, e)
+            false
+        } catch (e: IllegalArgumentException) {
+            logFailure(operation, windowId, e)
+            false
+        } catch (e: ClassCastException) {
+            logFailure(operation, windowId, e)
+            false
+        } catch (e: SecurityException) {
+            logFailure(operation, windowId, e)
+            false
+        }
 
     private fun logFailure(
         operation: String,
@@ -203,6 +233,13 @@ internal class AwtWindowFocusTracker {
     fun isFocused(windowId: String): Boolean = focusedWindowId == windowId
 }
 
+internal data class RegisteredWindowFullscreenState(
+    val window: Window,
+    val nativeTrackingAvailable: Boolean,
+    val nativeFullscreen: Boolean,
+    val composeFullscreen: Boolean,
+)
+
 /**
  * Handles multi-window focus tracking with two intentionally different views:
  * [isWindowFocused] is the live AWT focus used to gate browser input, while
@@ -213,15 +250,19 @@ actual object WindowFocusManager {
     private val windows = ConcurrentHashMap<String, Window>()
     private val composeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
     private val nativeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private val nativeTrackedWindowIds = ConcurrentHashMap.newKeySet<String>()
+    internal val fullscreenExitNotifier = FullscreenExitNotifier()
     private val macOSFullscreenTracker =
-        MacOSFullscreenTracker { windowId, isFullscreen ->
-            if (isFullscreen) {
-                nativeFullscreenWindowIds += windowId
-            } else {
-                nativeFullscreenWindowIds -= windowId
-                notifyWindowFullscreenExit(windowId)
-            }
-        }
+        MacOSFullscreenTracker(
+            onFullscreenChanged = { windowId, isFullscreen ->
+                if (isFullscreen) {
+                    nativeFullscreenWindowIds += windowId
+                } else if (nativeFullscreenWindowIds.remove(windowId)) {
+                    fullscreenExitNotifier.notify(windowId)
+                }
+            },
+            onFullscreenExitStarted = fullscreenExitNotifier::notify,
+        )
 
     // EDT-confined; registerWindow/unregisterWindow enforce this before mutation.
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
@@ -271,7 +312,11 @@ actual object WindowFocusManager {
 
         // Native fullscreen tracking is optional and must not prevent the
         // focus listener above from being installed if EAWT is unavailable.
-        macOSFullscreenTracker.register(windowId, window)
+        if (macOSFullscreenTracker.register(windowId, window)) {
+            nativeTrackedWindowIds += windowId
+        } else {
+            nativeTrackedWindowIds -= windowId
+        }
     }
 
     /**
@@ -301,18 +346,27 @@ actual object WindowFocusManager {
         if (isFullscreen) {
             composeFullscreenWindowIds += windowId
         } else {
-            composeFullscreenWindowIds -= windowId
-            if (windowId !in nativeFullscreenWindowIds) {
-                notifyWindowFullscreenExit(windowId)
+            val wasComposeFullscreen = composeFullscreenWindowIds.remove(windowId)
+            if (shouldNotifyComposeFullscreenExit(
+                    wasComposeFullscreen,
+                    windowId in nativeFullscreenWindowIds,
+                )
+            ) {
+                fullscreenExitNotifier.notify(windowId)
             }
         }
     }
 
-    /** Returns the requested window only when either fullscreen signal is active. */
-    fun getFullscreenWindow(windowId: String): Window? =
-        windows[windowId]?.takeIf {
-            hasFullscreenSignal(windowId, composeFullscreenWindowIds, nativeFullscreenWindowIds)
-        }
+    /** Returns the requested window and its independently tracked fullscreen signals. */
+    internal fun getWindowFullscreenState(windowId: String): RegisteredWindowFullscreenState? {
+        val window = windows[windowId] ?: return null
+        return RegisteredWindowFullscreenState(
+            window = window,
+            nativeTrackingAvailable = windowId in nativeTrackedWindowIds,
+            nativeFullscreen = windowId in nativeFullscreenWindowIds,
+            composeFullscreen = windowId in composeFullscreenWindowIds,
+        )
+    }
 
     /**
      * Unregisters a window when it closes. Must run on the EDT.
@@ -329,9 +383,12 @@ actual object WindowFocusManager {
         macOSFullscreenTracker.unregister(windowId)
 
         windows.remove(windowId)
-        composeFullscreenWindowIds -= windowId
-        nativeFullscreenWindowIds -= windowId
-        notifyWindowFullscreenExit(windowId)
+        val wasComposeFullscreen = composeFullscreenWindowIds.remove(windowId)
+        val wasNativeFullscreen = nativeFullscreenWindowIds.remove(windowId)
+        nativeTrackedWindowIds -= windowId
+        if (wasComposeFullscreen || wasNativeFullscreen) {
+            fullscreenExitNotifier.notify(windowId)
+        }
         awtFocusTracker.onUnregistered(windowId)
         if (focusedWindowId == windowId) {
             // Preserve the existing last-focused flow contract for external

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -81,7 +81,7 @@ internal class FullscreenExitNotifier {
     }
 }
 
-private class MacOSFullscreenTracker(
+internal class MacOSFullscreenTracker(
     private val onFullscreenChanged: (windowId: String, isFullscreen: Boolean) -> Unit,
     private val onFullscreenExitStarted: (windowId: String) -> Unit,
 ) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -32,15 +32,14 @@ internal fun nativeMacOSFullscreenStateForEvent(methodName: String): Boolean? =
 internal fun isNativeMacOSFullscreenExitStarting(methodName: String): Boolean = methodName == "windowExitingFullScreen"
 
 internal fun hasFullscreenSignal(
-    windowId: String,
-    composeFullscreenIds: Set<String>,
-    nativeFullscreenIds: Set<String>,
-    nativeTrackedIds: Set<String>,
+    nativeStateAvailable: Boolean,
+    nativeFullscreen: Boolean,
+    composeFullscreen: Boolean,
 ): Boolean =
-    if (windowId in nativeTrackedIds) {
-        windowId in nativeFullscreenIds
+    if (nativeStateAvailable) {
+        nativeFullscreen
     } else {
-        windowId in composeFullscreenIds
+        composeFullscreen
     }
 
 internal fun shouldNotifyComposeFullscreenExit(
@@ -235,7 +234,7 @@ internal class AwtWindowFocusTracker {
 
 internal data class RegisteredWindowFullscreenState(
     val window: Window,
-    val nativeTrackingAvailable: Boolean,
+    val nativeStateAvailable: Boolean,
     val nativeFullscreen: Boolean,
     val composeFullscreen: Boolean,
 )
@@ -251,17 +250,31 @@ actual object WindowFocusManager {
     private val composeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
     private val nativeFullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
     private val nativeTrackedWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private val nativeStateAvailableWindowIds = ConcurrentHashMap.newKeySet<String>()
     internal val fullscreenExitNotifier = FullscreenExitNotifier()
     private val macOSFullscreenTracker =
         MacOSFullscreenTracker(
             onFullscreenChanged = { windowId, isFullscreen ->
+                val hadNativeState = !nativeStateAvailableWindowIds.add(windowId)
                 if (isFullscreen) {
                     nativeFullscreenWindowIds += windowId
-                } else if (nativeFullscreenWindowIds.remove(windowId)) {
-                    fullscreenExitNotifier.notify(windowId)
+                } else {
+                    val wasNativeFullscreen = nativeFullscreenWindowIds.remove(windowId)
+                    if (wasNativeFullscreen ||
+                        (!hadNativeState && windowId in composeFullscreenWindowIds)
+                    ) {
+                        fullscreenExitNotifier.notify(windowId)
+                    }
                 }
             },
-            onFullscreenExitStarted = fullscreenExitNotifier::notify,
+            onFullscreenExitStarted = { windowId ->
+                // An exit-start event proves that the registered window still
+                // owns a native fullscreen Space even if registration missed
+                // its earlier enter transition.
+                nativeStateAvailableWindowIds += windowId
+                nativeFullscreenWindowIds += windowId
+                fullscreenExitNotifier.notify(windowId)
+            },
         )
 
     // EDT-confined; registerWindow/unregisterWindow enforce this before mutation.
@@ -312,6 +325,8 @@ actual object WindowFocusManager {
 
         // Native fullscreen tracking is optional and must not prevent the
         // focus listener above from being installed if EAWT is unavailable.
+        nativeFullscreenWindowIds -= windowId
+        nativeStateAvailableWindowIds -= windowId
         if (macOSFullscreenTracker.register(windowId, window)) {
             nativeTrackedWindowIds += windowId
         } else {
@@ -362,7 +377,11 @@ actual object WindowFocusManager {
         val window = windows[windowId] ?: return null
         return RegisteredWindowFullscreenState(
             window = window,
-            nativeTrackingAvailable = windowId in nativeTrackedWindowIds,
+            // A listener reports transitions, not initial state. Compose plus
+            // geometry remains the fallback until the first native event.
+            nativeStateAvailable =
+                windowId in nativeTrackedWindowIds &&
+                    windowId in nativeStateAvailableWindowIds,
             nativeFullscreen = windowId in nativeFullscreenWindowIds,
             composeFullscreen = windowId in composeFullscreenWindowIds,
         )
@@ -386,6 +405,7 @@ actual object WindowFocusManager {
         val wasComposeFullscreen = composeFullscreenWindowIds.remove(windowId)
         val wasNativeFullscreen = nativeFullscreenWindowIds.remove(windowId)
         nativeTrackedWindowIds -= windowId
+        nativeStateAvailableWindowIds -= windowId
         if (wasComposeFullscreen || wasNativeFullscreen) {
             fullscreenExitNotifier.notify(windowId)
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -124,16 +124,20 @@ internal class MacOSFullscreenTracker(
                         }
 
                         else -> {
-                            if (isNativeMacOSFullscreenExitStarting(method.name)) {
-                                onFullscreenExitStarted(windowId)
-                            }
-                            nativeMacOSFullscreenStateForEvent(method.name)?.let { isFullscreen ->
-                                onFullscreenChanged(windowId, isFullscreen)
-                                logger.info(
-                                    LogCategory.UI,
-                                    "Native macOS fullscreen state changed",
-                                    mapOf("windowId" to windowId, "isFullscreen" to isFullscreen),
-                                )
+                            runCatching {
+                                if (isNativeMacOSFullscreenExitStarting(method.name)) {
+                                    onFullscreenExitStarted(windowId)
+                                }
+                                nativeMacOSFullscreenStateForEvent(method.name)?.let { isFullscreen ->
+                                    onFullscreenChanged(windowId, isFullscreen)
+                                    logger.info(
+                                        LogCategory.UI,
+                                        "Native macOS fullscreen state changed",
+                                        mapOf("windowId" to windowId, "isFullscreen" to isFullscreen),
+                                    )
+                                }
+                            }.onFailure { error ->
+                                logFailure("handle ${method.name}", windowId, error)
                             }
                             null
                         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -12,6 +12,7 @@ import java.lang.reflect.InaccessibleObjectException
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
 import javax.swing.SwingUtilities
 
 internal fun nativeMacOSFullscreenStateForEvent(methodName: String): Boolean? =
@@ -30,6 +31,20 @@ internal fun hasFullscreenSignal(
     composeFullscreenIds: Set<String>,
     nativeFullscreenIds: Set<String>,
 ): Boolean = windowId in composeFullscreenIds || windowId in nativeFullscreenIds
+
+private val fullscreenExitListeners = CopyOnWriteArraySet<(String) -> Unit>()
+
+internal fun addWindowFullscreenExitListener(listener: (String) -> Unit) {
+    fullscreenExitListeners += listener
+}
+
+internal fun removeWindowFullscreenExitListener(listener: (String) -> Unit) {
+    fullscreenExitListeners -= listener
+}
+
+private fun notifyWindowFullscreenExit(windowId: String) {
+    fullscreenExitListeners.forEach { listener -> listener(windowId) }
+}
 
 private class MacOSFullscreenTracker(
     private val onFullscreenChanged: (windowId: String, isFullscreen: Boolean) -> Unit,
@@ -103,6 +118,8 @@ private class MacOSFullscreenTracker(
             logFailure("register", windowId, e)
         } catch (e: IllegalArgumentException) {
             logFailure("register", windowId, e)
+        } catch (e: ClassCastException) {
+            logFailure("register", windowId, e)
         } catch (e: SecurityException) {
             logFailure("register", windowId, e)
         }
@@ -121,6 +138,8 @@ private class MacOSFullscreenTracker(
         } catch (e: InaccessibleObjectException) {
             logFailure("unregister", windowId, e)
         } catch (e: IllegalArgumentException) {
+            logFailure("unregister", windowId, e)
+        } catch (e: ClassCastException) {
             logFailure("unregister", windowId, e)
         } catch (e: SecurityException) {
             logFailure("unregister", windowId, e)
@@ -200,6 +219,7 @@ actual object WindowFocusManager {
                 nativeFullscreenWindowIds += windowId
             } else {
                 nativeFullscreenWindowIds -= windowId
+                notifyWindowFullscreenExit(windowId)
             }
         }
 
@@ -229,7 +249,6 @@ actual object WindowFocusManager {
             "WindowFocusManager.registerWindow must run on the EDT"
         }
         windows[windowId] = window
-        macOSFullscreenTracker.register(windowId, window)
 
         // First window becomes the main window (backward compatibility).
         if (mainWindow == null) {
@@ -249,6 +268,10 @@ actual object WindowFocusManager {
 
         windowListeners[windowId] = listener
         window.addWindowFocusListener(listener)
+
+        // Native fullscreen tracking is optional and must not prevent the
+        // focus listener above from being installed if EAWT is unavailable.
+        macOSFullscreenTracker.register(windowId, window)
     }
 
     /**
@@ -279,6 +302,9 @@ actual object WindowFocusManager {
             composeFullscreenWindowIds += windowId
         } else {
             composeFullscreenWindowIds -= windowId
+            if (windowId !in nativeFullscreenWindowIds) {
+                notifyWindowFullscreenExit(windowId)
+            }
         }
     }
 
@@ -305,6 +331,7 @@ actual object WindowFocusManager {
         windows.remove(windowId)
         composeFullscreenWindowIds -= windowId
         nativeFullscreenWindowIds -= windowId
+        notifyWindowFullscreenExit(windowId)
         awtFocusTracker.onUnregistered(windowId)
         if (focusedWindowId == windowId) {
             // Preserve the existing last-focused flow contract for external

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowFocusManager.kt
@@ -1,13 +1,24 @@
 package ai.rever.boss.utils
 
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.awt.Window
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.SwingUtilities
+
+internal fun nativeMacOSFullscreenStateForEvent(methodName: String): Boolean? =
+    when (methodName) {
+        "windowEnteringFullScreen", "windowEnteredFullScreen" -> true
+        "windowExitedFullScreen" -> false
+        else -> null
+    }
 
 /**
  * Captures AWT focus lifecycle events on the EDT and exposes a volatile
@@ -59,7 +70,17 @@ internal class AwtWindowFocusTracker {
  * as deep links and file opens.
  */
 actual object WindowFocusManager {
+    private data class MacOSFullscreenRegistration(
+        val window: Window,
+        val listener: Any,
+        val listenerClass: Class<*>,
+        val removeMethod: Method,
+    )
+
+    private val logger = BossLogger.forComponent("WindowFocusManager")
     private val windows = ConcurrentHashMap<String, Window>()
+    private val fullscreenWindowIds = ConcurrentHashMap.newKeySet<String>()
+    private val macOSFullscreenRegistrations = mutableMapOf<String, MacOSFullscreenRegistration>()
 
     // EDT-confined; registerWindow/unregisterWindow enforce this before mutation.
     private val windowListeners = mutableMapOf<String, WindowAdapter>()
@@ -87,6 +108,7 @@ actual object WindowFocusManager {
             "WindowFocusManager.registerWindow must run on the EDT"
         }
         windows[windowId] = window
+        registerMacOSFullscreenListener(windowId, window)
 
         // First window becomes the main window (backward compatibility).
         if (mainWindow == null) {
@@ -127,6 +149,30 @@ actual object WindowFocusManager {
      */
     fun getWindow(windowId: String): Window? = windows[windowId]
 
+    /** Records the authoritative Compose placement for a registered window. */
+    fun updateWindowFullscreen(
+        windowId: String,
+        isFullscreen: Boolean,
+    ) {
+        if (isFullscreen) {
+            fullscreenWindowIds += windowId
+        } else {
+            fullscreenWindowIds -= windowId
+        }
+    }
+
+    /**
+     * Returns a registered window whose Compose placement is fullscreen,
+     * preferring the last-focused window when multiple fullscreen Spaces exist.
+     */
+    fun getFullscreenWindow(): Window? {
+        val preferredId = resolveActionableWindowId()
+        if (preferredId != null && preferredId in fullscreenWindowIds) {
+            windows[preferredId]?.let { return it }
+        }
+        return fullscreenWindowIds.firstNotNullOfOrNull(windows::get)
+    }
+
     /**
      * Unregisters a window when it closes. Must run on the EDT.
      *
@@ -139,8 +185,10 @@ actual object WindowFocusManager {
         windowListeners.remove(windowId)?.let { listener ->
             windows[windowId]?.removeWindowFocusListener(listener)
         }
+        unregisterMacOSFullscreenListener(windowId)
 
         windows.remove(windowId)
+        fullscreenWindowIds -= windowId
         awtFocusTracker.onUnregistered(windowId)
         if (focusedWindowId == windowId) {
             // Preserve the existing last-focused flow contract for external
@@ -169,6 +217,88 @@ actual object WindowFocusManager {
      * window is registered at all.
      */
     fun resolveActionableWindowId(): String? = focusedWindowId ?: focusedWindowFlow.value ?: windows.keys.firstOrNull()
+
+    private fun registerMacOSFullscreenListener(
+        windowId: String,
+        window: Window,
+    ) {
+        if (!System.getProperty("os.name").lowercase().contains("mac")) return
+
+        unregisterMacOSFullscreenListener(windowId)
+        try {
+            val utilitiesClass = Class.forName("com.apple.eawt.FullScreenUtilities")
+            val listenerClass = Class.forName("com.apple.eawt.FullScreenListener")
+            val listener =
+                Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass)) { proxy, method, arguments ->
+                    when (method.name) {
+                        "equals" -> {
+                            proxy === arguments?.firstOrNull()
+                        }
+
+                        "hashCode" -> {
+                            System.identityHashCode(proxy)
+                        }
+
+                        "toString" -> {
+                            "BossMacOSFullscreenListener($windowId)"
+                        }
+
+                        else -> {
+                            nativeMacOSFullscreenStateForEvent(method.name)?.let { isFullscreen ->
+                                updateWindowFullscreen(windowId, isFullscreen)
+                                logger.info(
+                                    LogCategory.UI,
+                                    "Native macOS fullscreen state changed",
+                                    mapOf("windowId" to windowId, "isFullscreen" to isFullscreen),
+                                )
+                            }
+                            null
+                        }
+                    }
+                }
+            val addMethod =
+                utilitiesClass.getMethod(
+                    "addFullScreenListenerTo",
+                    Window::class.java,
+                    listenerClass,
+                )
+            val removeMethod =
+                utilitiesClass.getMethod(
+                    "removeFullScreenListenerFrom",
+                    Window::class.java,
+                    listenerClass,
+                )
+
+            addMethod.invoke(null, window, listener)
+            macOSFullscreenRegistrations[windowId] =
+                MacOSFullscreenRegistration(window, listener, listenerClass, removeMethod)
+        } catch (e: ReflectiveOperationException) {
+            logger.warn(
+                LogCategory.UI,
+                "Could not register native macOS fullscreen listener",
+                mapOf("windowId" to windowId),
+                e,
+            )
+        }
+    }
+
+    private fun unregisterMacOSFullscreenListener(windowId: String) {
+        val registration = macOSFullscreenRegistrations.remove(windowId) ?: return
+        try {
+            registration.removeMethod.invoke(
+                null,
+                registration.window,
+                registration.listenerClass.cast(registration.listener),
+            )
+        } catch (e: ReflectiveOperationException) {
+            logger.warn(
+                LogCategory.UI,
+                "Could not unregister native macOS fullscreen listener",
+                mapOf("windowId" to windowId),
+                e,
+            )
+        }
+    }
 
     /**
      * Bring a specific window to front by its ID

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -253,7 +253,7 @@ fun ApplicationScope.BossWindow(
         // Publish Compose's authoritative placement. Native macOS fullscreen does not
         // reliably report full-display AWT bounds, so browser-video fullscreen uses this
         // state to decide whether to overlay the existing fullscreen Space.
-        LaunchedEffect(windowState.id, isFullScreen) {
+        LaunchedEffect(windowState.id, window, isFullScreen) {
             WindowFocusManager.updateWindowFullscreen(windowState.id, isFullScreen)
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -250,6 +250,13 @@ fun ApplicationScope.BossWindow(
             window.rootPane.putClientProperty("apple.awt.windowTitleVisible", false)
         }
 
+        // Publish Compose's authoritative placement. Native macOS fullscreen does not
+        // reliably report full-display AWT bounds, so browser-video fullscreen uses this
+        // state to decide whether to overlay the existing fullscreen Space.
+        LaunchedEffect(windowState.id, isFullScreen) {
+            WindowFocusManager.updateWindowFullscreen(windowState.id, isFullScreen)
+        }
+
         // Register window for focus management (deep links, etc.) and keyboard interception
         DisposableEffect(windowState.id, window) {
             WindowFocusManager.registerWindow(windowState.id, window)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -158,6 +158,28 @@ class FullscreenBrowserWindowTest {
     }
 
     @Test
+    fun `same browser re-entry resumes a session with an exit pending`() {
+        assertTrue(
+            FullscreenRequestDecision.shouldResumeAfterDuplicateRequest(
+                decision = FullscreenRequestDecision.IGNORE_DUPLICATE,
+                isExiting = true,
+            ),
+        )
+        assertFalse(
+            FullscreenRequestDecision.shouldResumeAfterDuplicateRequest(
+                decision = FullscreenRequestDecision.IGNORE_DUPLICATE,
+                isExiting = false,
+            ),
+        )
+        assertFalse(
+            FullscreenRequestDecision.shouldResumeAfterDuplicateRequest(
+                decision = FullscreenRequestDecision.BEGIN,
+                isExiting = true,
+            ),
+        )
+    }
+
+    @Test
     fun `exit callback gate suppresses duplicates until a new session begins`() {
         val gate = FullscreenExitCallbackGate<String>()
         var notifications = 0

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -72,4 +72,47 @@ class FullscreenBrowserWindowTest {
             ),
         )
     }
+
+    @Test
+    fun `delayed fullscreen work is rejected after a newer lifecycle starts`() {
+        assertTrue(
+            isCurrentFullscreenLifecycle(
+                expectedEpoch = 4,
+                currentEpoch = 4,
+                isInFullscreenMode = true,
+            ),
+        )
+        assertFalse(
+            isCurrentFullscreenLifecycle(
+                expectedEpoch = 4,
+                currentEpoch = 5,
+                isInFullscreenMode = true,
+            ),
+        )
+        assertFalse(
+            isCurrentFullscreenLifecycle(
+                expectedEpoch = 4,
+                currentEpoch = 4,
+                isInFullscreenMode = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `old cleanup cannot clear a newer fullscreen tab state`() {
+        assertTrue(
+            shouldRestoreFullscreenTabState(
+                cleanupEpoch = 5,
+                currentEpoch = 5,
+                isInFullscreenMode = false,
+            ),
+        )
+        assertFalse(
+            shouldRestoreFullscreenTabState(
+                cleanupEpoch = 5,
+                currentEpoch = 6,
+                isInFullscreenMode = true,
+            ),
+        )
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -270,4 +270,10 @@ class FullscreenBrowserWindowTest {
             ),
         )
     }
+
+    @Test
+    fun `tracked native fullscreen gets a longer confirmation window`() {
+        assertEquals(1_500, VideoFullscreenConfirmationDecision.confirmationDelayMs(trackingAvailable = true))
+        assertEquals(600, VideoFullscreenConfirmationDecision.confirmationDelayMs(trackingAvailable = false))
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.tabfullscreen
 
 import java.awt.Rectangle
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -114,5 +115,58 @@ class FullscreenBrowserWindowTest {
                 isInFullscreenMode = true,
             ),
         )
+    }
+
+    @Test
+    fun `fullscreen request decisions preserve branch ordering`() {
+        assertEquals(
+            FullscreenRequestDecision.IGNORE_DUPLICATE,
+            fullscreenRequestDecision(
+                frameActive = true,
+                isInFullscreenMode = true,
+                isSameBrowser = true,
+                isBrowserClosed = true,
+            ),
+        )
+        assertEquals(
+            FullscreenRequestDecision.REJECT_CLOSED,
+            fullscreenRequestDecision(
+                frameActive = false,
+                isInFullscreenMode = false,
+                isSameBrowser = false,
+                isBrowserClosed = true,
+            ),
+        )
+        assertEquals(
+            FullscreenRequestDecision.REJECT_COMPETING,
+            fullscreenRequestDecision(
+                frameActive = true,
+                isInFullscreenMode = true,
+                isSameBrowser = false,
+                isBrowserClosed = false,
+            ),
+        )
+        assertEquals(
+            FullscreenRequestDecision.BEGIN,
+            fullscreenRequestDecision(
+                frameActive = false,
+                isInFullscreenMode = false,
+                isSameBrowser = false,
+                isBrowserClosed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `exit callback gate suppresses duplicates until a new session begins`() {
+        val gate = FullscreenExitCallbackGate<String>()
+        var notifications = 0
+
+        assertTrue(gate.notifyOnce("browser-a") { notifications++ })
+        assertFalse(gate.notifyOnce("browser-a") { notifications++ })
+        gate.begin("browser-a")
+        assertTrue(gate.notifyOnce("browser-a") { notifications++ })
+
+        assertEquals(2, notifications)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -1,0 +1,30 @@
+package ai.rever.boss.tabfullscreen
+
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FullscreenBrowserWindowTest {
+    private val screen = Rectangle(0, 0, 1728, 1117)
+
+    @Test
+    fun `matching screen bounds are fullscreen`() {
+        assertTrue(fillsScreen(Rectangle(0, 0, 1728, 1117), screen))
+    }
+
+    @Test
+    fun `native fullscreen bounds larger than the display are accepted`() {
+        assertTrue(fillsScreen(Rectangle(0, 0, 1728, 1118), screen))
+    }
+
+    @Test
+    fun `maximized window leaving menu bar space is not fullscreen`() {
+        assertFalse(fillsScreen(Rectangle(0, 25, 1728, 1092), screen))
+    }
+
+    @Test
+    fun `partial screen window is not fullscreen`() {
+        assertFalse(fillsScreen(Rectangle(200, 100, 1200, 800), screen))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -191,4 +191,17 @@ class FullscreenBrowserWindowTest {
 
         assertEquals(2, notifications)
     }
+
+    @Test
+    fun `stale competing fallback cannot notify a newer attempt`() {
+        val gate = FullscreenExitCallbackGate<String>()
+        var notifications = 0
+
+        val staleAttempt = gate.begin("browser-b")
+        val currentAttempt = gate.begin("browser-b")
+
+        assertFalse(gate.notifyOnce("browser-b", staleAttempt) { notifications++ })
+        assertTrue(gate.notifyOnce("browser-b", currentAttempt) { notifications++ })
+        assertEquals(1, notifications)
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -32,4 +32,44 @@ class FullscreenBrowserWindowTest {
     fun `full-size window offset from the display is not fullscreen`() {
         assertFalse(fillsScreen(Rectangle(1, 0, 1728, 1117), screen))
     }
+
+    @Test
+    fun `compose fallback requires signal and fullscreen geometry`() {
+        assertTrue(
+            shouldUseComposeFullscreenOverlay(
+                composeSignalActive = true,
+                isShowing = true,
+                isMaximized = false,
+                windowBounds = screen,
+                screenBounds = screen,
+            ),
+        )
+        assertFalse(
+            shouldUseComposeFullscreenOverlay(
+                composeSignalActive = false,
+                isShowing = true,
+                isMaximized = false,
+                windowBounds = screen,
+                screenBounds = screen,
+            ),
+        )
+        assertFalse(
+            shouldUseComposeFullscreenOverlay(
+                composeSignalActive = true,
+                isShowing = true,
+                isMaximized = true,
+                windowBounds = screen,
+                screenBounds = screen,
+            ),
+        )
+        assertFalse(
+            shouldUseComposeFullscreenOverlay(
+                composeSignalActive = true,
+                isShowing = true,
+                isMaximized = false,
+                windowBounds = Rectangle(200, 100, 1200, 800),
+                screenBounds = screen,
+            ),
+        )
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -169,4 +169,26 @@ class FullscreenBrowserWindowTest {
 
         assertEquals(2, notifications)
     }
+
+    @Test
+    fun `each competing fullscreen attempt receives one exit callback`() {
+        val gate = FullscreenExitCallbackGate<String>()
+        var notifications = 0
+
+        repeat(2) {
+            val decision =
+                fullscreenRequestDecision(
+                    frameActive = true,
+                    isInFullscreenMode = true,
+                    isSameBrowser = false,
+                    isBrowserClosed = false,
+                )
+            assertEquals(FullscreenRequestDecision.REJECT_COMPETING, decision)
+            gate.begin("browser-b")
+            assertTrue(gate.notifyOnce("browser-b") { notifications++ })
+            assertFalse(gate.notifyOnce("browser-b") { notifications++ })
+        }
+
+        assertEquals(2, notifications)
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -27,4 +27,9 @@ class FullscreenBrowserWindowTest {
     fun `partial screen window is not fullscreen`() {
         assertFalse(fillsScreen(Rectangle(200, 100, 1200, 800), screen))
     }
+
+    @Test
+    fun `full-size window offset from the display is not fullscreen`() {
+        assertFalse(fillsScreen(Rectangle(1, 0, 1728, 1117), screen))
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -214,4 +214,38 @@ class FullscreenBrowserWindowTest {
         assertFalse(gate.notifyOnce("browser-b", 42L) { notifications++ })
         assertEquals(1, notifications)
     }
+
+    @Test
+    fun `video fullscreen confirmation distinguishes early exit from ignored toggle`() {
+        assertEquals(
+            VideoFullscreenConfirmationDecision.CONFIRMED,
+            VideoFullscreenConfirmationDecision.decide(
+                trackingAvailable = true,
+                stateAvailable = true,
+                isFullscreen = true,
+                entryObserved = true,
+                geometryFullscreen = false,
+            ),
+        )
+        assertEquals(
+            VideoFullscreenConfirmationDecision.EXITED_EARLY,
+            VideoFullscreenConfirmationDecision.decide(
+                trackingAvailable = true,
+                stateAvailable = true,
+                isFullscreen = false,
+                entryObserved = true,
+                geometryFullscreen = false,
+            ),
+        )
+        assertEquals(
+            VideoFullscreenConfirmationDecision.USE_OVERLAY,
+            VideoFullscreenConfirmationDecision.decide(
+                trackingAvailable = true,
+                stateAvailable = false,
+                isFullscreen = false,
+                entryObserved = false,
+                geometryFullscreen = false,
+            ),
+        )
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindowTest.kt
@@ -204,4 +204,14 @@ class FullscreenBrowserWindowTest {
         assertTrue(gate.notifyOnce("browser-b", currentAttempt) { notifications++ })
         assertEquals(1, notifications)
     }
+
+    @Test
+    fun `expected attempt notifies when its weak entry is missing`() {
+        val gate = FullscreenExitCallbackGate<String>()
+        var notifications = 0
+
+        assertTrue(gate.notifyOnce("browser-b", 42L) { notifications++ })
+        assertFalse(gate.notifyOnce("browser-b", 42L) { notifications++ })
+        assertEquals(1, notifications)
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.utils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class WindowFocusManagerTest {
@@ -10,17 +11,21 @@ class WindowFocusManagerTest {
     fun `native macOS fullscreen events map to authoritative state`() {
         assertEquals(true, nativeMacOSFullscreenStateForEvent("windowEnteringFullScreen"))
         assertEquals(true, nativeMacOSFullscreenStateForEvent("windowEnteredFullScreen"))
-        assertEquals(false, nativeMacOSFullscreenStateForEvent("windowExitingFullScreen"))
+        assertNull(nativeMacOSFullscreenStateForEvent("windowExitingFullScreen"))
         assertEquals(false, nativeMacOSFullscreenStateForEvent("windowExitedFullScreen"))
+        assertNull(nativeMacOSFullscreenStateForEvent("toString"))
+        assertTrue(isNativeMacOSFullscreenExitStarting("windowExitingFullScreen"))
+        assertFalse(isNativeMacOSFullscreenExitStarting("windowExitedFullScreen"))
     }
 
     @Test
-    fun `fullscreen signals are combined without leaking across windows`() {
+    fun `native tracking is authoritative and does not leak across windows`() {
         assertTrue(
             hasFullscreenSignal(
                 windowId = "window-a",
                 composeFullscreenIds = setOf("window-a"),
                 nativeFullscreenIds = emptySet(),
+                nativeTrackedIds = emptySet(),
             ),
         )
         assertTrue(
@@ -28,6 +33,15 @@ class WindowFocusManagerTest {
                 windowId = "window-a",
                 composeFullscreenIds = emptySet(),
                 nativeFullscreenIds = setOf("window-a"),
+                nativeTrackedIds = setOf("window-a"),
+            ),
+        )
+        assertFalse(
+            hasFullscreenSignal(
+                windowId = "window-a",
+                composeFullscreenIds = setOf("window-a"),
+                nativeFullscreenIds = emptySet(),
+                nativeTrackedIds = setOf("window-a"),
             ),
         )
         assertFalse(
@@ -35,8 +49,31 @@ class WindowFocusManagerTest {
                 windowId = "window-b",
                 composeFullscreenIds = setOf("window-a"),
                 nativeFullscreenIds = setOf("window-a"),
+                nativeTrackedIds = setOf("window-a"),
             ),
         )
+    }
+
+    @Test
+    fun `fullscreen exit notifications require a real transition`() {
+        assertFalse(shouldNotifyComposeFullscreenExit(wasComposeFullscreen = false, isNativeFullscreen = false))
+        assertFalse(shouldNotifyComposeFullscreenExit(wasComposeFullscreen = true, isNativeFullscreen = true))
+        assertTrue(shouldNotifyComposeFullscreenExit(wasComposeFullscreen = true, isNativeFullscreen = false))
+    }
+
+    @Test
+    fun `fullscreen exit listener stops firing after removal`() {
+        val notifier = FullscreenExitNotifier()
+        val exitedWindows = mutableListOf<String>()
+        val listener: (String) -> Unit = exitedWindows::add
+
+        notifier.notify("before-registration")
+        notifier.add(listener)
+        notifier.notify("window-a")
+        notifier.remove(listener)
+        notifier.notify("after-removal")
+
+        assertEquals(listOf("window-a"), exitedWindows)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -90,6 +90,14 @@ class WindowFocusManagerTest {
                 composeFullscreen = true,
             ),
         )
+        assertFalse(
+            shouldNotifyNativeFullscreenExit(
+                hadNativeState = true,
+                wasNativeFullscreen = true,
+                composeFullscreen = true,
+                exitAlreadyNotified = true,
+            ),
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -62,6 +62,34 @@ class WindowFocusManagerTest {
         assertFalse(shouldNotifyComposeFullscreenExit(wasComposeFullscreen = false, isNativeFullscreen = false))
         assertFalse(shouldNotifyComposeFullscreenExit(wasComposeFullscreen = true, isNativeFullscreen = true))
         assertTrue(shouldNotifyComposeFullscreenExit(wasComposeFullscreen = true, isNativeFullscreen = false))
+        assertFalse(
+            shouldNotifyNativeFullscreenExit(
+                hadNativeState = false,
+                wasNativeFullscreen = false,
+                composeFullscreen = false,
+            ),
+        )
+        assertTrue(
+            shouldNotifyNativeFullscreenExit(
+                hadNativeState = false,
+                wasNativeFullscreen = false,
+                composeFullscreen = true,
+            ),
+        )
+        assertTrue(
+            shouldNotifyNativeFullscreenExit(
+                hadNativeState = true,
+                wasNativeFullscreen = true,
+                composeFullscreen = false,
+            ),
+        )
+        assertFalse(
+            shouldNotifyNativeFullscreenExit(
+                hadNativeState = true,
+                wasNativeFullscreen = false,
+                composeFullscreen = true,
+            ),
+        )
     }
 
     @Test
@@ -70,11 +98,23 @@ class WindowFocusManagerTest {
         val exitedWindows = mutableListOf<String>()
         val listener: (String) -> Unit = exitedWindows::add
 
-        notifier.notify("before-registration")
+        notifier.notifyExit("before-registration")
         notifier.add(listener)
-        notifier.notify("window-a")
+        notifier.notifyExit("window-a")
         notifier.remove(listener)
-        notifier.notify("after-removal")
+        notifier.notifyExit("after-removal")
+
+        assertEquals(listOf("window-a"), exitedWindows)
+    }
+
+    @Test
+    fun `failing fullscreen exit listener does not skip remaining listeners`() {
+        val notifier = FullscreenExitNotifier()
+        val exitedWindows = mutableListOf<String>()
+
+        notifier.add { error("listener failure") }
+        notifier.add(exitedWindows::add)
+        notifier.notifyExit("window-a")
 
         assertEquals(listOf("window-a"), exitedWindows)
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -3,7 +3,6 @@ package ai.rever.boss.utils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class WindowFocusManagerTest {
@@ -11,8 +10,33 @@ class WindowFocusManagerTest {
     fun `native macOS fullscreen events map to authoritative state`() {
         assertEquals(true, nativeMacOSFullscreenStateForEvent("windowEnteringFullScreen"))
         assertEquals(true, nativeMacOSFullscreenStateForEvent("windowEnteredFullScreen"))
+        assertEquals(false, nativeMacOSFullscreenStateForEvent("windowExitingFullScreen"))
         assertEquals(false, nativeMacOSFullscreenStateForEvent("windowExitedFullScreen"))
-        assertNull(nativeMacOSFullscreenStateForEvent("windowExitingFullScreen"))
+    }
+
+    @Test
+    fun `fullscreen signals are combined without leaking across windows`() {
+        assertTrue(
+            hasFullscreenSignal(
+                windowId = "window-a",
+                composeFullscreenIds = setOf("window-a"),
+                nativeFullscreenIds = emptySet(),
+            ),
+        )
+        assertTrue(
+            hasFullscreenSignal(
+                windowId = "window-a",
+                composeFullscreenIds = emptySet(),
+                nativeFullscreenIds = setOf("window-a"),
+            ),
+        )
+        assertFalse(
+            hasFullscreenSignal(
+                windowId = "window-b",
+                composeFullscreenIds = setOf("window-a"),
+                nativeFullscreenIds = setOf("window-a"),
+            ),
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -1,10 +1,20 @@
 package ai.rever.boss.utils
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class WindowFocusManagerTest {
+    @Test
+    fun `native macOS fullscreen events map to authoritative state`() {
+        assertEquals(true, nativeMacOSFullscreenStateForEvent("windowEnteringFullScreen"))
+        assertEquals(true, nativeMacOSFullscreenStateForEvent("windowEnteredFullScreen"))
+        assertEquals(false, nativeMacOSFullscreenStateForEvent("windowExitedFullScreen"))
+        assertNull(nativeMacOSFullscreenStateForEvent("windowExitingFullScreen"))
+    }
+
     @Test
     fun `registration snapshots an already focused window`() {
         val tracker = AwtWindowFocusTracker()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/WindowFocusManagerTest.kt
@@ -22,34 +22,37 @@ class WindowFocusManagerTest {
     fun `native tracking is authoritative and does not leak across windows`() {
         assertTrue(
             hasFullscreenSignal(
-                windowId = "window-a",
-                composeFullscreenIds = setOf("window-a"),
-                nativeFullscreenIds = emptySet(),
-                nativeTrackedIds = emptySet(),
+                nativeStateAvailable = false,
+                nativeFullscreen = false,
+                composeFullscreen = true,
             ),
         )
         assertTrue(
             hasFullscreenSignal(
-                windowId = "window-a",
-                composeFullscreenIds = emptySet(),
-                nativeFullscreenIds = setOf("window-a"),
-                nativeTrackedIds = setOf("window-a"),
+                nativeStateAvailable = true,
+                nativeFullscreen = true,
+                composeFullscreen = false,
             ),
         )
         assertFalse(
             hasFullscreenSignal(
-                windowId = "window-a",
-                composeFullscreenIds = setOf("window-a"),
-                nativeFullscreenIds = emptySet(),
-                nativeTrackedIds = setOf("window-a"),
+                nativeStateAvailable = true,
+                nativeFullscreen = false,
+                composeFullscreen = true,
             ),
         )
         assertFalse(
             hasFullscreenSignal(
-                windowId = "window-b",
-                composeFullscreenIds = setOf("window-a"),
-                nativeFullscreenIds = setOf("window-a"),
-                nativeTrackedIds = setOf("window-a"),
+                nativeStateAvailable = false,
+                nativeFullscreen = true,
+                composeFullscreen = false,
+            ),
+        )
+        assertFalse(
+            hasFullscreenSignal(
+                nativeStateAvailable = false,
+                nativeFullscreen = false,
+                composeFullscreen = false,
             ),
         )
     }

--- a/plugin-platform/plugin-api-browser/src/commonMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandle.kt
+++ b/plugin-platform/plugin-api-browser/src/commonMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandle.kt
@@ -569,6 +569,10 @@ interface BrowserHandle {
      *
      * After calling this, [isValid] will return false and
      * all other methods will be no-ops.
+     *
+     * If this browser owns a fullscreen rendering surface, disposal may wait
+     * briefly for UI-thread detachment. Do not call while holding a lock that
+     * the UI thread may need.
      */
     fun dispose()
 }

--- a/plugin-platform/plugin-api-browser/src/commonMain/kotlin/ai/rever/boss/plugin/browser/BrowserService.kt
+++ b/plugin-platform/plugin-api-browser/src/commonMain/kotlin/ai/rever/boss/plugin/browser/BrowserService.kt
@@ -64,6 +64,10 @@ interface BrowserService {
      * This is equivalent to calling [BrowserHandle.dispose] but allows
      * batch disposal operations.
      *
+     * If the browser owns a fullscreen rendering surface, disposal may wait
+     * briefly for UI-thread detachment. Do not call while holding a lock that
+     * the UI thread may need.
+     *
      * @param handle The browser handle to dispose
      */
     suspend fun disposeBrowser(handle: BrowserHandle)


### PR DESCRIPTION
## Summary

- Track Compose and native macOS fullscreen signals independently for every registered Boss window, using one atomic per-window snapshot and native state after its first authoritative event.
- Scope browser video fullscreen entry and exit to the window and browser that own the requesting tab.
- Keep Chromium page fullscreen and the host window synchronized by requesting JxBrowser fullscreen exit first, with a bounded direct-teardown fallback.
- Deduplicate exit callbacks per fullscreen attempt across native events, direct fallbacks, closed browsers, and competing requests; repeated entry from the active browser remains idempotent.
- Key delayed window creation, native-transition checks, exit fallbacks, and Compose restoration to a fullscreen lifecycle epoch so rapid exit/re-entry cannot affect a newer session.
- Preserve the exiting tab's local callback when a different tab starts a newer session without clearing that newer global fullscreen state.
- Keep native and overlay windows on the owning window's display, and raise an overlay again when its owner regains focus without floating above other applications while Boss is inactive.
- Verify native macOS fullscreen entry and fall back to a borderless display overlay when macOS ignores the toggle.
- Marshal window-close disposal to the Swing event thread, bound plugin-triggered EDT cleanup waits, and guarantee frame disposal even when construction or browser-view detachment fails.
- Add regression coverage for request decisions, per-attempt callback deduplication, lifecycle epochs, native event mapping, signal precedence, exit notifications, overlay selection, and screen-bound detection.

## Root cause

macOS can ignore a second native fullscreen request when another window from the same application already owns a fullscreen Space. Compose `WindowPlacement` and AWT window bounds also do not reliably report fullscreen state during native macOS transitions, so the host incorrectly attempted that second native request. Unscoped fullscreen-exit events could also tear down an overlay owned by another browser, while host-only teardown could leave the page itself logically fullscreen. Delayed Swing callbacks were not tied to the lifecycle that scheduled them, allowing a rapid exit/re-entry to reopen an old frame or tear down a newer session.

## Impact

YouTube and other browser video fullscreen requests fill the correct display whether BossConsole starts in a normal window or is already in a native macOS fullscreen Space. Multi-window and multi-tab requests stay on the correct owner, page and host exit state remain synchronized, callbacks fire once per attempt, teardown cannot leave an orphaned overlay or wait indefinitely on the EDT, rapid toggles cannot cross lifecycle boundaries, and switching applications no longer leaves the video above unrelated apps or stranded behind its owner.

## Validation

- `./gradlew detekt`
- `./gradlew ktlintCheck`
- `./gradlew :composeApp:desktopTest`
- Manual verification in BossConsole debug mode from both windowed and native-fullscreen host windows

## Related

- Companion Fluck Browser state restoration: https://github.com/risa-labs-inc/boss-plugin-fluck-browser/pull/15
