### PR TITLE
fix(tabbar): keep the "+" button next to the tabs, not pinned right

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -175,8 +175,7 @@ private fun NewTabButton(
     Box(
         modifier =
             modifier
-                .height(32.dp)
-                .width(32.dp)
+                .size(NEW_TAB_BUTTON_SIZE)
                 .padding(4.dp)
                 .background(
                     color = BossTheme.colors.raised,
@@ -334,13 +333,15 @@ fun BossTabsComponent.BossMainTabBar(
                 // scroll away). Once the tabs fill the strip this lands
                 // flush right, same as before.
                 //
-                // `padding(start = 4.dp)` keeps it off the last tab's edge;
-                // the trailing `end` padding is what separates it from
-                // whatever follows in the bar when the strip is full.
+                // Both gaps belong to the slot, not to the strip Row — see the
+                // reserve rule in BossLeftTabBar's KDoc. NEW_TAB_BUTTON_GAP on
+                // the end side plus the strip's own 8.dp inset reproduces the
+                // 12.dp right margin the pinned-right button used to have.
+                trailingReserve = if (shrinkTabsToFit || isScrollable) NEW_TAB_SLOT_WIDTH else 0.dp,
                 trailing = {
                     if (shrinkTabsToFit || isScrollable) {
                         NewTabButton(
-                            modifier = Modifier.padding(start = 4.dp, end = 12.dp),
+                            modifier = Modifier.padding(horizontal = NEW_TAB_BUTTON_GAP),
                             onClick = {
                                 showNewTabDialog = true
                                 // Track panel interaction when plus button is clicked

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -163,8 +163,9 @@ private fun BossTabButtonWithFavicon(
 
 /**
  * The "+" (new tab) button. Rendered either as a LazyRow item hugging the
- * last tab (legacy FIXED sizing while everything fits) or as a fixed sibling
- * at the right edge of the tab strip — see the call sites in BossMainTabBar.
+ * last tab (legacy FIXED sizing while everything fits) or as the tab strip's
+ * non-scrolling trailing slot, which also sits directly after the last tab —
+ * see the call sites in BossMainTabBar.
  */
 @Composable
 private fun NewTabButton(
@@ -323,7 +324,34 @@ fun BossTabsComponent.BossMainTabBar(
                     }
                 },
         ) {
-            BossLeftTabBar(listState, tabCount = tabsState.value.tabs.size) { tabWidth ->
+            BossLeftTabBar(
+                listState,
+                tabCount = tabsState.value.tabs.size,
+                // Plus button outside the LazyRow but still inside the strip,
+                // sitting directly after the last tab: always in
+                // SHRINK_TO_FIT (immune to the isScrollable race), and in
+                // FIXED mode once the row scrolls (so the button can't
+                // scroll away). Once the tabs fill the strip this lands
+                // flush right, same as before.
+                //
+                // `padding(start = 4.dp)` keeps it off the last tab's edge;
+                // the trailing `end` padding is what separates it from
+                // whatever follows in the bar when the strip is full.
+                trailing = {
+                    if (shrinkTabsToFit || isScrollable) {
+                        NewTabButton(
+                            modifier = Modifier.padding(start = 4.dp, end = 12.dp),
+                            onClick = {
+                                showNewTabDialog = true
+                                // Track panel interaction when plus button is clicked
+                                if (splitViewState != null && currentPanelId != null) {
+                                    splitViewState.setActivePanel(currentPanelId)
+                                }
+                            },
+                        )
+                    }
+                },
+            ) { tabWidth ->
                 // Render tab buttons as lazy items
                 itemsIndexed(tabsState.value.tabs) { index, config ->
                     val isSelected = index == tabsState.value.activeIndex
@@ -593,27 +621,6 @@ fun BossTabsComponent.BossMainTabBar(
                         )
                     }
                 }
-            }
-
-            // Plus button outside the LazyRow, fixed at the right edge of the
-            // strip: always in SHRINK_TO_FIT (tabs fill the bar, so this is
-            // both natural and immune to the isScrollable race), and in FIXED
-            // mode once the row scrolls (so the button can't scroll away).
-            //
-            // `padding(end = 12.dp)` reserves extra breathing room on the right
-            // edge so the icon doesn't feel jammed against the next bar
-            // element (the right tab-bar section / window-control area).
-            if (shrinkTabsToFit || isScrollable) {
-                NewTabButton(
-                    modifier = Modifier.padding(end = 12.dp),
-                    onClick = {
-                        showNewTabDialog = true
-                        // Track panel interaction when plus button is clicked
-                        if (splitViewState != null && currentPanelId != null) {
-                            splitViewState.setActivePanel(currentPanelId)
-                        }
-                    },
-                )
             }
 
             Spacer(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -36,21 +37,35 @@ private val MAX_TAB_WIDTH = 240.dp
  */
 internal val INTER_TAB_DIVIDER_PADDING = 4.dp
 
-/**
- * Width consumed between adjacent tabs by the inter-tab VDivider: padding on
- * both sides plus VDivider's fixed 1.dp line. Must be subtracted from the
- * available width before dividing, otherwise the rendered row is wider than
- * the viewport and the LazyRow scrolls even when every tab is well below
- * [MAX_TAB_WIDTH].
- */
-private val INTER_TAB_DIVIDER_WIDTH = INTER_TAB_DIVIDER_PADDING * 2 + 1.dp
+/** The line VDivider draws between two tabs (`Modifier.width(1.dp)` there). */
+private val INTER_TAB_DIVIDER_LINE = 1.dp
 
 /**
- * The strip's fixed sizing constants in pixel space: [INTER_TAB_DIVIDER_WIDTH]
- * and the [MIN_TAB_WIDTH]/[MAX_TAB_WIDTH] clamp. Converted from Dp at the call
- * site because that needs a density, and bundled rather than passed loose so
- * [computeTabWidthPx] keeps a signature that reads at a glance (and stays
- * under detekt's parameter-count threshold).
+ * Width consumed between adjacent tabs by the inter-tab VDivider: padding on
+ * both sides plus VDivider's fixed line. Must be subtracted from the available
+ * width before dividing, otherwise the rendered row is wider than the viewport
+ * and the LazyRow scrolls even when every tab is well below [MAX_TAB_WIDTH].
+ *
+ * Each of the three pieces is rounded to whole pixels SEPARATELY, exactly as
+ * Compose measures them — do not sum in Dp space and convert once. A composite
+ * `9.dp.toPx().toInt()` truncates where the three rendered pieces round up: at
+ * density 1.5 it budgets 13px against a rendered 6 + 6 + 2 = 14px, and at 1.75
+ * 15px against 7 + 7 + 2 = 16px. That 1px-per-divider shortfall is ~19px of
+ * unbudgeted overflow at 20 tabs — precisely the scrollbar flicker this whole
+ * integer-pixel design exists to prevent, and it only shows up at 150%/175%
+ * display scaling (i.e. on Windows, not on the 1x/2x Macs we develop on).
+ */
+private fun Density.interTabDividerPx(): Int {
+    val paddingPx = INTER_TAB_DIVIDER_PADDING.roundToPx()
+    return paddingPx * 2 + INTER_TAB_DIVIDER_LINE.roundToPx()
+}
+
+/**
+ * The strip's fixed sizing constants in pixel space: the inter-tab divider
+ * (see [interTabDividerPx]) and the [MIN_TAB_WIDTH]/[MAX_TAB_WIDTH] clamp.
+ * Converted from Dp at the call site because that needs a density, and bundled
+ * rather than passed loose so [computeTabWidthPx] keeps a signature that reads
+ * at a glance (and stays under detekt's parameter-count threshold).
  */
 internal data class TabStripMetrics(
     val dividerPx: Int,
@@ -58,21 +73,51 @@ internal data class TabStripMetrics(
     val maxTabPx: Int,
 )
 
+/** [TabStripMetrics] for the current density. */
+internal fun Density.tabStripMetrics(): TabStripMetrics =
+    TabStripMetrics(
+        dividerPx = interTabDividerPx(),
+        minTabPx = MIN_TAB_WIDTH.roundToPx(),
+        maxTabPx = MAX_TAB_WIDTH.roundToPx(),
+    )
+
+/**
+ * Geometry of the "+" button that occupies the strip's trailing slot, kept
+ * here rather than at the button's definition so [BossLeftTabBar] can seed its
+ * reserve with the right value on the very first frame (see
+ * [NEW_TAB_SLOT_WIDTH]).
+ *
+ * The paddings are part of the *slot*: all spacing around the trailing content
+ * must live INSIDE it, never as arrangement or padding on the strip Row, so
+ * that the slot's measured width is the whole reserve.
+ */
+internal val NEW_TAB_BUTTON_SIZE = 32.dp
+
+/** Gap between the last tab and the "+", matching [INTER_TAB_DIVIDER_PADDING]'s rhythm. */
+internal val NEW_TAB_BUTTON_GAP = 4.dp
+
+/**
+ * Total width the trailing slot occupies once it renders. Only a first-frame
+ * seed — the slot's measured width is the authority, so this going stale costs
+ * one frame of slightly-too-generous tabs, not a permanent mis-budget.
+ */
+internal val NEW_TAB_SLOT_WIDTH = NEW_TAB_BUTTON_SIZE + NEW_TAB_BUTTON_GAP * 2
+
 /**
  * Per-tab width in INTEGER PIXELS, not Dp. A Dp-space division produces a
  * fractional Dp that Compose rounds to the nearest pixel when it measures
  * each tab. With N tabs the rounding can go up, making total content >
- * [rowWidthPx] by a couple of pixels, which triggers the LazyRow scrollbar
+ * [stripWidthPx] by a couple of pixels, which triggers the LazyRow scrollbar
  * even when every tab is far below the max. Adding a tab swings the rounding
  * the other way, so the bar flickers in and out.
  *
  * Integer-pixel division floors naturally, so total tab pixels
- * (result * tabCount + dividersPx) is always ≤ [rowWidthPx], with at most
- * `tabCount - 1` pixels of slack on the right — invisible and, crucially,
- * stable.
+ * (result * tabCount + dividersPx) is always ≤ [stripWidthPx] - [trailingPx],
+ * with at most `tabCount - 1` pixels of slack on the right — invisible and,
+ * crucially, stable.
  *
  * Two distinct fallbacks:
- * - Not yet measured ([rowWidthPx] ≤ 0) or nothing to lay out
+ * - Not yet measured ([stripWidthPx] ≤ 0) or nothing to lay out
  *   ([tabCount] ≤ 0) → [TabStripMetrics.maxTabPx], the first-paint fallback.
  * - Over-cramped (so many tabs that the dividers alone exceed the row and
  *   the division goes ≤ 0) → the coercion clamps to
@@ -90,14 +135,14 @@ internal data class TabStripMetrics(
  * the lesser evil.
  */
 internal fun computeTabWidthPx(
-    rowWidthPx: Int,
+    stripWidthPx: Int,
     tabCount: Int,
     trailingPx: Int,
     metrics: TabStripMetrics,
 ): Int {
-    if (rowWidthPx <= 0 || tabCount <= 0) return metrics.maxTabPx
+    if (stripWidthPx <= 0 || tabCount <= 0) return metrics.maxTabPx
     val totalDividersPx = metrics.dividerPx * (tabCount - 1)
-    return ((rowWidthPx - trailingPx - totalDividersPx) / tabCount)
+    return ((stripWidthPx - trailingPx - totalDividersPx) / tabCount)
         .coerceIn(metrics.minTabPx, metrics.maxTabPx)
 }
 
@@ -114,9 +159,13 @@ internal fun computeTabWidthPx(
  * the inner `LazyRow` through `disposeOrReuseStartingFromIndex` and resize
  * the semantics `ScatterMap` on each reuse, pinning the EDT at 100% CPU
  * after ~10 tabs. The trade-off here is one extra frame on first paint
- * before [rowWidthPx] is populated (tabs initially render at
+ * before [stripWidthPx] is populated (tabs initially render at
  * [MAX_TAB_WIDTH], then re-measure once); after that, only tab additions
- * trigger a re-measure and there is no nested subcomposition.
+ * trigger a re-measure and there is no nested subcomposition. The trailing
+ * reserve has the same shape — measured, therefore one frame behind — which
+ * is why [trailingReserve] seeds it: without a seed the first measured frame
+ * budgets a slot-width too much, and on a full strip that overflow can flash
+ * the scrollbar for a frame before the second measure settles.
  *
  * The [trailing] slot (the "+" button) is laid out immediately after the last
  * tab rather than pinned to the far right of the bar: the strip container
@@ -132,8 +181,29 @@ internal fun computeTabWidthPx(
  * filling container instead, and the trailing slot's own measured width is
  * subtracted from the budget.
  *
+ * The reserve is therefore expressed twice — implicitly by this Row's weight
+ * distribution and explicitly as `trailingPx` — and they agree only because
+ * both come from the same measured slot. Hence the rule stated on
+ * [NEW_TAB_BUTTON_SIZE]: **all spacing around the trailing content lives
+ * inside the slot**, never as `Arrangement.spacedBy` on this Row or padding on
+ * the wrapper Box, or the explicit reserve silently under-counts and the row
+ * scrolls early.
+ *
+ * A caller that gates its [trailing] content on scroll state (FIXED mode does:
+ * "+" moves in-row while everything fits) closes a loop — slot presence
+ * depends on scrollability depends on the LazyRow's cap depends on slot width.
+ * It settles rather than oscillates. With strip width `W` and content width
+ * `C` (the in-row "+" included), no-slot is scrollable iff `C > W`, and
+ * with-slot iff `C > W - (slot - button)`; both states are self-consistent
+ * across that narrow band, so it is hysteretic, and both render exactly one
+ * "+", so the button can never blink out. The old pinned-right "+" took the
+ * same width off the weighted container, so this is no new hazard.
+ *
  * @param listState The LazyListState for controlling scroll position
  * @param tabCount Number of tabs being rendered; needed to divide the available width
+ * @param trailingReserve First-frame seed for the trailing slot's width; the
+ *   slot's measured width is the authority, so a stale value costs one frame,
+ *   not a permanent mis-budget. Pass 0.dp when [trailing] renders nothing.
  * @param trailing Rendered directly after the last tab, outside the scrollable
  *   row so it can never scroll away. Its measured width is reserved from the
  *   per-tab budget.
@@ -144,36 +214,36 @@ internal fun computeTabWidthPx(
 fun RowScope.BossLeftTabBar(
     listState: LazyListState,
     tabCount: Int,
+    trailingReserve: Dp = 0.dp,
     trailing: @Composable () -> Unit = {},
     content: LazyListScope.(tabWidth: Dp) -> Unit,
 ) {
-    var rowWidthPx by remember { mutableStateOf(0) }
-    var trailingWidthPx by remember { mutableStateOf(0) }
     val density = LocalDensity.current
+    var stripWidthPx by remember { mutableStateOf(0) }
+    var trailingWidthPx by remember { mutableStateOf(with(density) { trailingReserve.roundToPx() }) }
 
     Row(
         modifier =
             Modifier
                 .weight(1f)
                 .padding(horizontal = 8.dp)
-                .onSizeChanged { size -> rowWidthPx = size.width },
+                .onSizeChanged { size -> stripWidthPx = size.width },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // All arithmetic lives in computeTabWidthPx (pure, unit-tested);
-        // here we only convert the Dp constants to pixels and back.
+        // All arithmetic lives in computeTabWidthPx (pure, unit-tested); here
+        // we only convert the Dp constants to pixels and back. Remembered on
+        // its four inputs because this bar recomposes on hover, selection,
+        // favicon and drop-target changes, none of which move a tab edge.
         val tabWidth =
-            with(density) {
-                computeTabWidthPx(
-                    rowWidthPx = rowWidthPx,
-                    tabCount = tabCount,
-                    trailingPx = trailingWidthPx,
-                    metrics =
-                        TabStripMetrics(
-                            dividerPx = INTER_TAB_DIVIDER_WIDTH.toPx().toInt(),
-                            minTabPx = MIN_TAB_WIDTH.roundToPx(),
-                            maxTabPx = MAX_TAB_WIDTH.roundToPx(),
-                        ),
-                ).toDp()
+            remember(density, stripWidthPx, tabCount, trailingWidthPx) {
+                with(density) {
+                    computeTabWidthPx(
+                        stripWidthPx = stripWidthPx,
+                        tabCount = tabCount,
+                        trailingPx = trailingWidthPx,
+                        metrics = tabStripMetrics(),
+                    ).toDp()
+                }
             }
 
         LazyRow(
@@ -193,6 +263,8 @@ fun RowScope.BossLeftTabBar(
             content(tabWidth)
         }
 
+        // No padding or arrangement here — see the reserve rule in the KDoc:
+        // this Box's measured width must be the entire trailing reserve.
         Box(modifier = Modifier.onSizeChanged { size -> trailingWidthPx = size.width }) {
             trailing()
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
@@ -65,6 +65,11 @@ private val INTER_TAB_DIVIDER_WIDTH = INTER_TAB_DIVIDER_PADDING * 2 + 1.dp
  *   the division goes ≤ 0) → the coercion clamps to [minTabPx] and the row
  *   scrolls, same as any other below-floor result.
  *
+ * [trailingPx] is the width of the trailing slot (the "+" button) that shares
+ * the strip with the tabs. It is subtracted up front so tabs shrink to fit
+ * *beside* the button; without it the last tab would slide under the button
+ * and the row would scroll a fraction of a tab early.
+ *
  * Deliberately NOT budgeted: the 3.dp reorder indicator injected into the
  * row during a tab drag. Including it would resize every tab the moment a
  * drag starts; a transient 3px overflow near the fit boundary mid-drag is
@@ -76,10 +81,11 @@ internal fun computeTabWidthPx(
     dividerPx: Int,
     minTabPx: Int,
     maxTabPx: Int,
+    trailingPx: Int = 0,
 ): Int {
     if (rowWidthPx <= 0 || tabCount <= 0) return maxTabPx
     val totalDividersPx = dividerPx * (tabCount - 1)
-    return ((rowWidthPx - totalDividersPx) / tabCount).coerceIn(minTabPx, maxTabPx)
+    return ((rowWidthPx - trailingPx - totalDividersPx) / tabCount).coerceIn(minTabPx, maxTabPx)
 }
 
 /**
@@ -89,7 +95,7 @@ internal fun computeTabWidthPx(
  * would shrink below [MIN_TAB_WIDTH], the width is clamped and the row scrolls.
  *
  * Implementation note: the available width is captured via [onSizeChanged]
- * on the [LazyRow] itself, rather than wrapping the row in
+ * on the plain [Row] wrapping the strip, rather than with
  * [BoxWithConstraints]. Both `BoxWithConstraints` and `LazyRow` are
  * `SubcomposeLayout`s; nesting them caused every `tabCount` change to thrash
  * the inner `LazyRow` through `disposeOrReuseStartingFromIndex` and resize
@@ -99,8 +105,25 @@ internal fun computeTabWidthPx(
  * [MAX_TAB_WIDTH], then re-measure once); after that, only tab additions
  * trigger a re-measure and there is no nested subcomposition.
  *
+ * The [trailing] slot (the "+" button) is laid out immediately after the last
+ * tab rather than pinned to the far right of the bar: the strip container
+ * takes the full width (so the shrink math sees the real budget) while the
+ * [LazyRow] inside it wraps its content, leaving the empty remainder to the
+ * *right* of the trailing slot. Once the tabs fill the strip the button ends
+ * up flush right anyway, so both regimes read the same.
+ *
+ * The [LazyRow] must therefore NOT be the node that reports the available
+ * width — a wrapping row reports its content width, and feeding that back
+ * into the shrink math latches the tabs at their current size (they could
+ * never grow again when the window widens). The width is measured on the
+ * filling container instead, and the trailing slot's own measured width is
+ * subtracted from the budget.
+ *
  * @param listState The LazyListState for controlling scroll position
  * @param tabCount Number of tabs being rendered; needed to divide the available width
+ * @param trailing Rendered directly after the last tab, outside the scrollable
+ *   row so it can never scroll away. Its measured width is reserved from the
+ *   per-tab budget.
  * @param content Receives the computed per-tab width and renders the tab buttons.
  *   Each [content] body should size its tab to the supplied `tabWidth`.
  */
@@ -108,12 +131,21 @@ internal fun computeTabWidthPx(
 fun RowScope.BossLeftTabBar(
     listState: LazyListState,
     tabCount: Int,
+    trailing: @Composable () -> Unit = {},
     content: LazyListScope.(tabWidth: Dp) -> Unit,
 ) {
     var rowWidthPx by remember { mutableStateOf(0) }
+    var trailingWidthPx by remember { mutableStateOf(0) }
     val density = LocalDensity.current
 
-    Column(modifier = Modifier.weight(1f).padding(horizontal = 8.dp)) {
+    Row(
+        modifier =
+            Modifier
+                .weight(1f)
+                .padding(horizontal = 8.dp)
+                .onSizeChanged { size -> rowWidthPx = size.width },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         // All arithmetic lives in computeTabWidthPx (pure, unit-tested);
         // here we only convert the Dp constants to pixels and back.
         val tabWidth =
@@ -124,15 +156,18 @@ fun RowScope.BossLeftTabBar(
                     dividerPx = INTER_TAB_DIVIDER_WIDTH.toPx().toInt(),
                     minTabPx = MIN_TAB_WIDTH.roundToPx(),
                     maxTabPx = MAX_TAB_WIDTH.roundToPx(),
+                    trailingPx = trailingWidthPx,
                 ).toDp()
             }
 
         LazyRow(
             state = listState,
+            // fill = false lets the row wrap its tabs so [trailing] hugs the
+            // last one; the weight still caps it at everything the trailing
+            // slot doesn't need, so a full strip scrolls exactly as before.
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .onSizeChanged { size -> rowWidthPx = size.width }
+                    .weight(1f, fill = false)
                     .horizontalLazyListScrollbar(
                         listState = listState,
                         scrollbarConfig = getBarScrollbarConfig(),
@@ -140,6 +175,10 @@ fun RowScope.BossLeftTabBar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             content(tabWidth)
+        }
+
+        Box(modifier = Modifier.onSizeChanged { size -> trailingWidthPx = size.width }) {
+            trailing()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossTabBar.kt
@@ -46,6 +46,19 @@ internal val INTER_TAB_DIVIDER_PADDING = 4.dp
 private val INTER_TAB_DIVIDER_WIDTH = INTER_TAB_DIVIDER_PADDING * 2 + 1.dp
 
 /**
+ * The strip's fixed sizing constants in pixel space: [INTER_TAB_DIVIDER_WIDTH]
+ * and the [MIN_TAB_WIDTH]/[MAX_TAB_WIDTH] clamp. Converted from Dp at the call
+ * site because that needs a density, and bundled rather than passed loose so
+ * [computeTabWidthPx] keeps a signature that reads at a glance (and stays
+ * under detekt's parameter-count threshold).
+ */
+internal data class TabStripMetrics(
+    val dividerPx: Int,
+    val minTabPx: Int,
+    val maxTabPx: Int,
+)
+
+/**
  * Per-tab width in INTEGER PIXELS, not Dp. A Dp-space division produces a
  * fractional Dp that Compose rounds to the nearest pixel when it measures
  * each tab. With N tabs the rounding can go up, making total content >
@@ -60,10 +73,11 @@ private val INTER_TAB_DIVIDER_WIDTH = INTER_TAB_DIVIDER_PADDING * 2 + 1.dp
  *
  * Two distinct fallbacks:
  * - Not yet measured ([rowWidthPx] ≤ 0) or nothing to lay out
- *   ([tabCount] ≤ 0) → [maxTabPx], the first-paint fallback.
+ *   ([tabCount] ≤ 0) → [TabStripMetrics.maxTabPx], the first-paint fallback.
  * - Over-cramped (so many tabs that the dividers alone exceed the row and
- *   the division goes ≤ 0) → the coercion clamps to [minTabPx] and the row
- *   scrolls, same as any other below-floor result.
+ *   the division goes ≤ 0) → the coercion clamps to
+ *   [TabStripMetrics.minTabPx] and the row scrolls, same as any other
+ *   below-floor result.
  *
  * [trailingPx] is the width of the trailing slot (the "+" button) that shares
  * the strip with the tabs. It is subtracted up front so tabs shrink to fit
@@ -78,14 +92,13 @@ private val INTER_TAB_DIVIDER_WIDTH = INTER_TAB_DIVIDER_PADDING * 2 + 1.dp
 internal fun computeTabWidthPx(
     rowWidthPx: Int,
     tabCount: Int,
-    dividerPx: Int,
-    minTabPx: Int,
-    maxTabPx: Int,
-    trailingPx: Int = 0,
+    trailingPx: Int,
+    metrics: TabStripMetrics,
 ): Int {
-    if (rowWidthPx <= 0 || tabCount <= 0) return maxTabPx
-    val totalDividersPx = dividerPx * (tabCount - 1)
-    return ((rowWidthPx - trailingPx - totalDividersPx) / tabCount).coerceIn(minTabPx, maxTabPx)
+    if (rowWidthPx <= 0 || tabCount <= 0) return metrics.maxTabPx
+    val totalDividersPx = metrics.dividerPx * (tabCount - 1)
+    return ((rowWidthPx - trailingPx - totalDividersPx) / tabCount)
+        .coerceIn(metrics.minTabPx, metrics.maxTabPx)
 }
 
 /**
@@ -153,10 +166,13 @@ fun RowScope.BossLeftTabBar(
                 computeTabWidthPx(
                     rowWidthPx = rowWidthPx,
                     tabCount = tabCount,
-                    dividerPx = INTER_TAB_DIVIDER_WIDTH.toPx().toInt(),
-                    minTabPx = MIN_TAB_WIDTH.roundToPx(),
-                    maxTabPx = MAX_TAB_WIDTH.roundToPx(),
                     trailingPx = trailingWidthPx,
+                    metrics =
+                        TabStripMetrics(
+                            dividerPx = INTER_TAB_DIVIDER_WIDTH.toPx().toInt(),
+                            minTabPx = MIN_TAB_WIDTH.roundToPx(),
+                            maxTabPx = MAX_TAB_WIDTH.roundToPx(),
+                        ),
                 ).toDp()
             }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
@@ -18,7 +18,8 @@ class ComputeTabWidthPxTest {
     private fun compute(
         rowWidthPx: Int,
         tabCount: Int,
-    ) = computeTabWidthPx(rowWidthPx, tabCount, divider, min, max)
+        trailingPx: Int = 0,
+    ) = computeTabWidthPx(rowWidthPx, tabCount, divider, min, max, trailingPx)
 
     @Test
     fun `single tab gets max width`() {
@@ -60,6 +61,39 @@ class ComputeTabWidthPxTest {
     fun `exact fit divides evenly with no slack`() {
         // 5 tabs at 100px + 4 dividers at 9px = 536px row
         assertEquals(100, compute(rowWidthPx = 536, tabCount = 5))
+    }
+
+    @Test
+    fun `trailing slot is reserved before the tabs divide the row`() {
+        // The "+" button shares the strip with the tabs, so its 48px slot
+        // comes off the top: (1000 - 48 - 9*9) / 10 = 87.1 → 87.
+        assertEquals(87, compute(rowWidthPx = 1000, tabCount = 10, trailingPx = 48))
+    }
+
+    @Test
+    fun `tabs plus trailing slot never exceed the row`() {
+        // The scrollbar-flicker invariant again, this time with the button
+        // in the budget: it must still fit beside a full strip of tabs.
+        val row = 1234
+        val trailing = 48
+        for (tabCount in 1..20) {
+            val width = compute(row, tabCount, trailing)
+            if (width in (min + 1) until max) {
+                val total = width * tabCount + divider * (tabCount - 1) + trailing
+                assertTrue(
+                    total <= row,
+                    "tabCount=$tabCount: total ${total}px exceeds row ${row}px",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `trailing slot wider than the row clamps to min not max`() {
+        // Degenerate window (narrower than the button slot itself): the
+        // division goes negative, which must read as over-cramped → floor,
+        // never as "not measured yet" → max.
+        assertEquals(36, compute(rowWidthPx = 40, tabCount = 3, trailingPx = 48))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
@@ -2,6 +2,8 @@ package ai.rever.boss.components.window_panel
 
 import ai.rever.boss.components.window_panel.components.main_window_panels.TabStripMetrics
 import ai.rever.boss.components.window_panel.components.main_window_panels.computeTabWidthPx
+import ai.rever.boss.components.window_panel.components.main_window_panels.tabStripMetrics
+import androidx.compose.ui.unit.Density
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -19,26 +21,26 @@ class ComputeTabWidthPxTest {
     private val metrics = TabStripMetrics(dividerPx = divider, minTabPx = min, maxTabPx = max)
 
     private fun compute(
-        rowWidthPx: Int,
+        stripWidthPx: Int,
         tabCount: Int,
         trailingPx: Int = 0,
-    ) = computeTabWidthPx(rowWidthPx, tabCount, trailingPx, metrics)
+    ) = computeTabWidthPx(stripWidthPx, tabCount, trailingPx, metrics)
 
     @Test
     fun `single tab gets max width`() {
-        assertEquals(240, compute(rowWidthPx = 1000, tabCount = 1))
+        assertEquals(240, compute(stripWidthPx = 1000, tabCount = 1))
     }
 
     @Test
     fun `tabs divide available width after dividers`() {
         // (1000 - 9*9) / 10 = 91.9 → floors to 91
-        assertEquals(91, compute(rowWidthPx = 1000, tabCount = 10))
+        assertEquals(91, compute(stripWidthPx = 1000, tabCount = 10))
     }
 
     @Test
     fun `below-floor result clamps to min and row scrolls`() {
         // (1000 - 29*9) / 30 = 24.6 → 24 → clamped to 36
-        assertEquals(36, compute(rowWidthPx = 1000, tabCount = 30))
+        assertEquals(36, compute(stripWidthPx = 1000, tabCount = 30))
     }
 
     @Test
@@ -47,30 +49,46 @@ class ComputeTabWidthPxTest {
         // division goes negative. The old -1 sentinel conflated this with
         // "not measured yet" and fell back to MAX (240) — the exact opposite
         // of shrink-to-fit. Over-cramped must clamp to the floor.
-        assertEquals(36, compute(rowWidthPx = 200, tabCount = 30))
+        assertEquals(36, compute(stripWidthPx = 200, tabCount = 30))
     }
 
     @Test
     fun `unmeasured row falls back to max for first paint`() {
-        assertEquals(240, compute(rowWidthPx = 0, tabCount = 10))
+        assertEquals(240, compute(stripWidthPx = 0, tabCount = 10))
     }
 
     @Test
     fun `zero tabs falls back to max`() {
-        assertEquals(240, compute(rowWidthPx = 1000, tabCount = 0))
+        assertEquals(240, compute(stripWidthPx = 1000, tabCount = 0))
     }
 
     @Test
     fun `exact fit divides evenly with no slack`() {
         // 5 tabs at 100px + 4 dividers at 9px = 536px row
-        assertEquals(100, compute(rowWidthPx = 536, tabCount = 5))
+        assertEquals(100, compute(stripWidthPx = 536, tabCount = 5))
+    }
+
+    @Test
+    fun `divider reserve matches the three separately-rounded rendered pieces`() {
+        // The divider renders as three independently rounded pieces —
+        // INTER_TAB_DIVIDER_PADDING twice plus VDivider's 1.dp line — so the
+        // reserve has to round them the same way. Summing in Dp space and
+        // converting once (`9.dp.toPx().toInt()`) truncates where the pieces
+        // round up, under-reserving 1px per divider: ~19px of unbudgeted
+        // overflow at 20 tabs, i.e. the scrollbar flicker the integer-pixel
+        // design exists to prevent. Only visible at fractional densities,
+        // which is Windows 150%/175% scaling, not the 1x/2x Macs we build on.
+        assertEquals(14, Density(1.5f).tabStripMetrics().dividerPx, "density 1.5: rendered 6+6+2")
+        assertEquals(16, Density(1.75f).tabStripMetrics().dividerPx, "density 1.75: rendered 7+7+2")
+        assertEquals(9, Density(1f).tabStripMetrics().dividerPx, "density 1.0: rendered 4+4+1")
+        assertEquals(18, Density(2f).tabStripMetrics().dividerPx, "density 2.0: rendered 8+8+2")
     }
 
     @Test
     fun `trailing slot is reserved before the tabs divide the row`() {
         // The "+" button shares the strip with the tabs, so its 48px slot
         // comes off the top: (1000 - 48 - 9*9) / 10 = 87.1 → 87.
-        assertEquals(87, compute(rowWidthPx = 1000, tabCount = 10, trailingPx = 48))
+        assertEquals(87, compute(stripWidthPx = 1000, tabCount = 10, trailingPx = 48))
     }
 
     @Test
@@ -96,7 +114,7 @@ class ComputeTabWidthPxTest {
         // Degenerate window (narrower than the button slot itself): the
         // division goes negative, which must read as over-cramped → floor,
         // never as "not measured yet" → max.
-        assertEquals(36, compute(rowWidthPx = 40, tabCount = 3, trailingPx = 48))
+        assertEquals(36, compute(stripWidthPx = 40, tabCount = 3, trailingPx = 48))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/ComputeTabWidthPxTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.window_panel
 
+import ai.rever.boss.components.window_panel.components.main_window_panels.TabStripMetrics
 import ai.rever.boss.components.window_panel.components.main_window_panels.computeTabWidthPx
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,11 +16,13 @@ class ComputeTabWidthPxTest {
     private val min = 36
     private val max = 240
 
+    private val metrics = TabStripMetrics(dividerPx = divider, minTabPx = min, maxTabPx = max)
+
     private fun compute(
         rowWidthPx: Int,
         tabCount: Int,
         trailingPx: Int = 0,
-    ) = computeTabWidthPx(rowWidthPx, tabCount, divider, min, max, trailingPx)
+    ) = computeTabWidthPx(rowWidthPx, tabCount, trailingPx, metrics)
 
     @Test
     fun `single tab gets max width`() {


### PR DESCRIPTION
## Problem

In shrink-to-fit mode the "+" (new tab) button was pinned to the far right edge of the panel instead of sitting next to the tabs.

The tab strip claimed the whole bar (`weight(1f)` on the container **and** `fillMaxWidth()` on the `LazyRow`), and the "+" was a sibling rendered *after* it. Since tabs cap at `MAX_TAB_WIDTH` (240.dp), a handful of tabs left a wide dead gap between the last tab and the button.

## Fix

The strip container still fills the bar — the shrink math needs the real budget — but the `LazyRow` inside it now uses `weight(1f, fill = false)` so it **wraps its tabs**, and the "+" renders in a new `trailing` slot directly after the last one. The empty remainder falls to the *right* of the button. Once the tabs do fill the strip the button lands flush right exactly as before, so both regimes read the same.

Two things this had to get right:

- **The `LazyRow` can no longer be the node that reports the available width.** A wrapping `LazyRow` reports its *content* width (`layoutWidth = constrainWidth(currentMainAxisOffset)` in `LazyListMeasure.kt`), and feeding that back into the shrink math latches the tabs at their current size — they could never grow again when the window widened. The width is measured on the plain `Row` wrapping the strip instead.
- **`computeTabWidthPx` takes a `trailingPx` reserve** (the trailing slot's measured width), subtracted before dividing, so tabs shrink to fit *beside* the button rather than sliding under it and scrolling the row a fraction of a tab early.

Legacy `FIXED` mode keeps its historical in-row "+" placement untouched.

Drag-and-drop is unaffected: drop targeting reads the whole bar's bounds plus per-tab bounds, never the `LazyRow`'s width, so dropping in the empty area right of the last tab still appends.

## Testing

- `./gradlew :composeApp:ktlintCheck :composeApp:desktopTest` — green; `ComputeTabWidthPxTest` is 11/11 with three new cases covering the trailing reserve (budget subtraction, the "tabs + button never exceed the row" invariant, and a degenerate window narrower than the button slot clamping to the floor, not the max).
- Ran the app from the worktree and confirmed both regimes in one window: a shrunken 7-tab panel with the "+" tight against the last tab, and a single-tab panel where the "+" hugs the tab with the empty bar space to its right.
