### PR TITLE
fix(release): resume a dropped notarization poll instead of failing the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,13 @@ jobs:
         # (regressed twice: #877 misaligned resume, and the SIGPIPE status bug).
         run: bash scripts/test/test-tus-slice.sh
 
+      - name: 🧪 Release notarization — retry/resume tests
+        # Guards the macOS notarization retry path: a dropped status poll must
+        # resume the existing submission, never re-upload, and an actual Apple
+        # rejection must still fail fast (run 30067806575 lost 9.2.59 to this).
+        # Apple is stubbed, so this runs on ubuntu with no credentials.
+        run: bash scripts/test/test-notarize-dmg.sh
+
   version-check:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -277,29 +277,17 @@ jobs:
           DISABLE_MACOS_SIGNING: ${{ env.DISABLE_MACOS_SIGNING }}
         run: ./gradlew packageDmg
 
+      # Shared with release.yml; see scripts/lib/notarize-dmg.sh. This copy was
+      # even more exposed than release.yml's — with no `set +e` fence, a
+      # non-zero notarytool exit killed the step at the assignment, before the
+      # output or the log could be printed.
       - name: 🍎 Notarize macOS DMG
         if: env.DISABLE_MACOS_SIGNING != 'true'
         run: |
+          source scripts/lib/notarize-dmg.sh
           DMG_PATH=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
           echo "📦 Notarizing: $DMG_PATH"
-          NOTARIZATION_OUTPUT=$(xcrun notarytool submit "$DMG_PATH" \
-            --apple-id "$APPLE_ID" \
-            --password "$APP_PASSWORD" \
-            --team-id "${{ secrets.MACOS_TEAM_ID }}" \
-            --wait 2>&1)
-          echo "$NOTARIZATION_OUTPUT"
-          SUBMISSION_ID=$(echo "$NOTARIZATION_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
-          if echo "$NOTARIZATION_OUTPUT" | grep -q "status: Accepted"; then
-            xcrun stapler staple "$DMG_PATH"
-            echo "✅ Notarization complete"
-          else
-            if [[ -n "$SUBMISSION_ID" ]]; then
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" --password "$APP_PASSWORD" \
-                --team-id "${{ secrets.MACOS_TEAM_ID }}"
-            fi
-            exit 1
-          fi
+          notarize_dmg "$DMG_PATH"
 
       - name: 📋 Rename DMG to Lite convention
         env:

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -170,6 +170,11 @@ jobs:
   build-macos:
     needs: prepare-version
     runs-on: macos-14
+    # macOS minutes bill at 10×, and notarization can legitimately sit waiting
+    # on Apple, so cap the job well below GitHub's 6h default: build (~20m) plus
+    # the notarization budget in scripts/lib/notarize-dmg.sh (1h) fits inside
+    # this with room to spare.
+    timeout-minutes: 120
 
     steps:
       - name: 📥 Checkout BossConsoleLite
@@ -277,14 +282,30 @@ jobs:
           DISABLE_MACOS_SIGNING: ${{ env.DISABLE_MACOS_SIGNING }}
         run: ./gradlew packageDmg
 
-      # Shared with release.yml; see scripts/lib/notarize-dmg.sh. This copy was
-      # even more exposed than release.yml's — with no `set +e` fence, a
-      # non-zero notarytool exit killed the step at the assignment, before the
-      # output or the log could be printed.
+      # The workspace here is BossConsoleLite (checked out above), NOT this
+      # repo, so the shared notarization helper has to be fetched explicitly —
+      # sourcing a bare `scripts/lib/…` path would die with No such file or
+      # directory *after* the DMG is built and signed, i.e. the exact
+      # late-stage release loss the helper exists to prevent. Sparse and
+      # path-scoped so it can't disturb the Lite workspace, and pinned to this
+      # workflow's own commit (checkout's default ref) so the helper and the
+      # step that calls it always match.
+      - name: 📥 Fetch shared notarization helper
+        if: env.DISABLE_MACOS_SIGNING != 'true'
+        uses: actions/checkout@v7
+        with:
+          path: .boss-ci
+          sparse-checkout: scripts/lib
+          sparse-checkout-cone-mode: false
+
+      # Shared with release.yml; see scripts/lib/notarize-dmg.sh. This call
+      # site was even more exposed than release.yml's — with no `set +e` fence,
+      # a non-zero notarytool exit killed the step at the assignment, before
+      # the output or the log could be printed.
       - name: 🍎 Notarize macOS DMG
         if: env.DISABLE_MACOS_SIGNING != 'true'
         run: |
-          source scripts/lib/notarize-dmg.sh
+          source .boss-ci/scripts/lib/notarize-dmg.sh
           DMG_PATH=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
           echo "📦 Notarizing: $DMG_PATH"
           notarize_dmg "$DMG_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,6 +318,11 @@ jobs:
     needs: prepare-version
     if: needs.prepare-version.outputs.should-build == 'true'
     runs-on: macos-14  # Apple Silicon runner
+    # macOS minutes bill at 10×, and notarization can legitimately sit waiting
+    # on Apple, so cap the job well below GitHub's 6h default: build (~20m) plus
+    # the notarization budget in scripts/lib/notarize-dmg.sh (1h) fits inside
+    # this with room to spare.
+    timeout-minutes: 120
 
     steps:
       - name: 📥 Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,65 +551,25 @@ jobs:
           fi
 
       # macOS notarization (only for signed DMGs)
+      #
+      # Submit → wait → staple lives in scripts/lib/notarize-dmg.sh so the
+      # retry behaviour is unit-tested (scripts/test/test-notarize-dmg.sh, run
+      # by build.yml) instead of being untestable inline YAML. It resumes a
+      # dropped status poll rather than re-submitting — see that file's header
+      # for why run 30067806575 lost release 9.2.59 without it.
       - name: 🍎 Notarize macOS DMG
         if: env.DISABLE_MACOS_SIGNING != 'true'
         run: |
           echo "🍎 Starting macOS notarization process..."
+
+          source scripts/lib/notarize-dmg.sh
 
           # Find the DMG file
           DMG_PATH=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
 
           if [[ -n "$DMG_PATH" && -f "$DMG_PATH" ]]; then
             echo "📦 Found DMG: $DMG_PATH"
-
-            # Submit for notarization and capture the submission ID.
-            # `|| true` is required because the surrounding shell runs
-            # under `bash -e`: without it, a non-zero exit from
-            # `notarytool submit` (e.g. auth failure, network error,
-            # rejected submission) propagates immediately at the
-            # command-substitution assignment, killing the step BEFORE
-            # we can echo NOTARIZATION_OUTPUT or fetch the detailed
-            # notarytool log. The exit-code is preserved separately so
-            # later checks can still distinguish success from failure.
-            echo "🔐 Submitting DMG for notarization..."
-            set +e
-            NOTARIZATION_OUTPUT=$(xcrun notarytool submit "$DMG_PATH" \
-              --apple-id "$APPLE_ID" \
-              --password "$APP_PASSWORD" \
-              --team-id "${{ secrets.MACOS_TEAM_ID }}" \
-              --wait 2>&1)
-            NOTARIZATION_EXIT_CODE=$?
-            set -e
-            echo "$NOTARIZATION_OUTPUT"
-            echo "📋 notarytool exit code: $NOTARIZATION_EXIT_CODE"
-
-            # Extract submission ID from output
-            SUBMISSION_ID=$(echo "$NOTARIZATION_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
-            echo "📋 Submission ID: $SUBMISSION_ID"
-
-            # Check if notarization succeeded
-            if echo "$NOTARIZATION_OUTPUT" | grep -q "status: Accepted"; then
-              echo "✅ Notarization accepted"
-
-              # Staple the notarization
-              echo "📎 Stapling notarization to DMG..."
-              xcrun stapler staple "$DMG_PATH"
-
-              echo "✅ macOS notarization completed successfully"
-            else
-              echo "❌ Notarization failed or returned non-Accepted status"
-
-              # Fetch detailed log if we have a submission ID
-              if [[ -n "$SUBMISSION_ID" ]]; then
-                echo "📜 Fetching detailed notarization log..."
-                xcrun notarytool log "$SUBMISSION_ID" \
-                  --apple-id "$APPLE_ID" \
-                  --password "$APP_PASSWORD" \
-                  --team-id "${{ secrets.MACOS_TEAM_ID }}"
-              fi
-
-              exit 1
-            fi
+            notarize_dmg "$DMG_PATH"
           else
             echo "❌ DMG file not found for notarization"
             exit 1

--- a/scripts/lib/notarize-dmg.sh
+++ b/scripts/lib/notarize-dmg.sh
@@ -2,7 +2,8 @@
 #
 # macOS notarization for the release workflows, extracted into a sourceable unit
 # so the retry logic can be tested without an Apple account (see
-# scripts/test/test-notarize-dmg.sh). This file has NO side effects on source.
+# scripts/test/test-notarize-dmg.sh). This file has NO side effects on source,
+# and notarize_dmg leaves the caller's shell options as it found them.
 #
 # Why this exists: run 30067806575 lost release 9.2.59 to a network blip. The
 # DMG built, signed and uploaded fine — Apple had the submission — but the
@@ -17,11 +18,36 @@
 # re-uploading queues a duplicate and throws away work Apple has already done.
 # `notarytool wait <id>` does exactly that.
 
-# Attempts and backoff are env-overridable so the tests run instantly.
-NOTARIZE_MAX_ATTEMPTS="${NOTARIZE_MAX_ATTEMPTS:-3}"
+# Attempts, backoff and per-attempt timeout are env-overridable so the tests
+# run instantly. NOTARIZE_RETRY_DELAY is the FIRST delay and doubles from
+# there, so the defaults give the network 30+60+120+240s ≈ 7.5 min to come
+# back — cheap next to a lost release and a manual re-dispatch.
+NOTARIZE_MAX_ATTEMPTS="${NOTARIZE_MAX_ATTEMPTS:-5}"
 NOTARIZE_RETRY_DELAY="${NOTARIZE_RETRY_DELAY:-30}"
-NOTARIZE_STAPLE_ATTEMPTS="${NOTARIZE_STAPLE_ATTEMPTS:-3}"
-NOTARIZE_STAPLE_DELAY="${NOTARIZE_STAPLE_DELAY:-15}"
+# Neither `notarytool submit --wait` nor `notarytool wait` has a default
+# timeout: both block indefinitely. A half-open connection can therefore leave
+# notarytool hung rather than erroring, and then the retry loop below never
+# gets control and the job burns to GitHub's 6h ceiling — the same lost
+# release, harder to diagnose. Bounding each attempt is what makes "N bounded
+# attempts" actually bounded.
+NOTARIZE_ATTEMPT_TIMEOUT="${NOTARIZE_ATTEMPT_TIMEOUT:-30m}"
+# Stapling fetches the ticket from Apple; error 68 is usually just ticket
+# propagation lag, which wants minutes rather than seconds.
+NOTARIZE_STAPLE_ATTEMPTS="${NOTARIZE_STAPLE_ATTEMPTS:-5}"
+NOTARIZE_STAPLE_DELAY="${NOTARIZE_STAPLE_DELAY:-30}"
+
+# Anchored UUID match for the submission-ID latch. The latch is STICKY — every
+# later attempt does `notarytool wait <id>` — so a loose match that captures
+# garbage turns a recoverable blip into a guaranteed all-attempts failure, with
+# a useless `notarytool log <garbage>` at the end. Exactly what this file
+# exists to prevent, so match Apple's UUID shape or nothing.
+_NOTARIZE_ID_RE='^[[:space:]]*id: [0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'
+
+# Failures that no amount of retrying will fix, and that must NOT be reported
+# as network trouble: an expired app-specific password or an empty team id
+# otherwise costs three attempts, minutes of sleeps, and a log line pointing
+# the on-call reader away from the real cause.
+_NOTARIZE_FATAL_RE='HTTP status code: 40[013]|Unauthorized|[Ii]nvalid credentials|unable to (validate|authenticate)'
 
 # notarize_dmg <dmg_path>
 #
@@ -30,44 +56,81 @@ NOTARIZE_STAPLE_DELAY="${NOTARIZE_STAPLE_DELAY:-15}"
 # workflows put them there via $GITHUB_ENV).
 #
 # Returns 0 only when Apple accepted the submission AND the ticket stapled.
-# Retries transient failures; a verdict from Apple is final and fails fast.
+# Retries transient failures; a verdict or a credential problem fails fast.
 notarize_dmg() {
   local dmg_path="$1"
+
+  # Capture errexit BEFORE the first fence so it can be restored exactly.
+  # `case` rather than `[[ ... ]] && x=1`, whose non-zero result would itself
+  # trip errexit when the pattern doesn't match.
+  local errexit_was_set=0
+  case $- in *e*) errexit_was_set=1 ;; esac
 
   if [[ -z "$dmg_path" || ! -f "$dmg_path" ]]; then
     echo "❌ DMG file not found for notarization: ${dmg_path:-<empty>}"
     return 1
   fi
 
+  # Fail fast and by name on missing credentials rather than letting a 401
+  # masquerade as a network failure below. `${VAR:-}` keeps this `set -u`-safe.
+  local missing=()
+  [[ -n "${APPLE_ID:-}" ]] || missing+=("APPLE_ID")
+  [[ -n "${APP_PASSWORD:-}" ]] || missing+=("APP_PASSWORD")
+  [[ -n "${TEAM_ID:-}" ]] || missing+=("TEAM_ID")
+  if ((${#missing[@]})); then
+    echo "❌ Notarization credentials missing from the environment: ${missing[*]}"
+    return 1
+  fi
+
+  # Two arrays rather than one plus an optional: on the macOS runners' bash 3.2,
+  # expanding an EMPTY array as "${arr[@]}" under `set -u` is an unbound-variable
+  # error, so both of these are always non-empty. `creds` is what the log fetch
+  # uses (--timeout is only meaningful while waiting).
   local creds=(--apple-id "$APPLE_ID" --password "$APP_PASSWORD" --team-id "$TEAM_ID")
-  local submission_id="" verdict="" output exit_code attempt
+  local wait_args=("${creds[@]}")
+
+  # Probe rather than assume: passing an unsupported flag would fail every
+  # attempt instantly and turn a runner-image change into a lost release.
+  if xcrun notarytool submit --help 2>&1 | grep -q -- "--timeout"; then
+    wait_args+=(--timeout "$NOTARIZE_ATTEMPT_TIMEOUT")
+  else
+    echo "⚠️ notarytool has no --timeout on this runner; attempts are unbounded"
+  fi
+
+  local submission_id="" verdict="" output exit_code attempt delay
+
+  echo "⏱ Up to ${NOTARIZE_MAX_ATTEMPTS} attempts, each bounded at ${NOTARIZE_ATTEMPT_TIMEOUT}"
 
   for ((attempt = 1; attempt <= NOTARIZE_MAX_ATTEMPTS; attempt++)); do
     # `set +e` around the command substitution is load-bearing: callers run
     # under `bash -e`, where a non-zero notarytool exit propagates at the
     # assignment itself, killing the step BEFORE we can echo the output or
     # fetch the detailed log. The exit code is captured separately so the
-    # checks below can still tell success from failure.
+    # checks below can still tell success from failure. Restored to whatever
+    # the caller had, so sourcing this never silently arms errexit for them.
     set +e
     if [[ -z "$submission_id" ]]; then
       echo "🔐 Submitting DMG for notarization (attempt ${attempt}/${NOTARIZE_MAX_ATTEMPTS})..."
-      output=$(xcrun notarytool submit "$dmg_path" "${creds[@]}" --wait 2>&1)
+      output=$(xcrun notarytool submit "$dmg_path" "${wait_args[@]}" --wait 2>&1)
     else
       # Resume the existing submission — never re-upload. See the header.
       echo "🔁 Resuming wait on submission ${submission_id} (attempt ${attempt}/${NOTARIZE_MAX_ATTEMPTS})..."
-      output=$(xcrun notarytool wait "$submission_id" "${creds[@]}" 2>&1)
+      output=$(xcrun notarytool wait "$submission_id" "${wait_args[@]}" 2>&1)
     fi
     exit_code=$?
-    set -e
+    if ((errexit_was_set)); then set -e; fi
 
     echo "$output"
     echo "📋 notarytool exit code: ${exit_code}"
 
     # Latch the submission ID the first time Apple reports one, so every later
-    # attempt resumes instead of re-submitting.
+    # attempt resumes instead of re-submitting. `|| true` documents that
+    # no-match is expected: the pipeline only returns 0 today because awk is
+    # last, so a later simplification to a bare grep — or adding
+    # `set -o pipefail` — would otherwise kill the step under bash -e.
     if [[ -z "$submission_id" ]]; then
-      submission_id=$(echo "$output" | grep -m1 "id:" | awk '{print $2}')
-      [[ -n "$submission_id" ]] && echo "📋 Submission ID: ${submission_id}"
+      submission_id=$(echo "$output" | grep -m1 -oE "$_NOTARIZE_ID_RE" | awk '{print $2}' || true)
+      if [[ -n "$submission_id" ]]; then echo "📋 Submission ID: ${submission_id}"; fi
     fi
 
     if echo "$output" | grep -q "status: Accepted"; then
@@ -82,19 +145,29 @@ notarize_dmg() {
       break
     fi
 
-    echo "⚠️ No verdict from Apple (transient failure — network, not a rejection)"
+    # Credentials or entitlements — retrying just multiplies the same 401.
+    if echo "$output" | grep -qE "$_NOTARIZE_FATAL_RE"; then
+      verdict="Fatal"
+      break
+    fi
+
+    # Deliberately not asserting a cause here: all we know is that no verdict
+    # came back. A dropped connection, a wait timeout and an unrecognised
+    # notarytool message all land here.
+    echo "⚠️ No verdict parsed from notarytool output (exit ${exit_code}) — treating as transient"
     if ((attempt < NOTARIZE_MAX_ATTEMPTS)); then
-      echo "   Retrying in ${NOTARIZE_RETRY_DELAY}s"
-      sleep "$NOTARIZE_RETRY_DELAY"
+      delay=$((NOTARIZE_RETRY_DELAY * (1 << (attempt - 1))))
+      echo "   Retrying in ${delay}s"
+      sleep "$delay"
     fi
   done
 
   if [[ "$verdict" != "Accepted" ]]; then
-    if [[ "$verdict" == "Rejected" ]]; then
-      echo "❌ Notarization rejected by Apple"
-    else
-      echo "❌ Notarization did not reach a verdict in ${NOTARIZE_MAX_ATTEMPTS} attempts"
-    fi
+    case "$verdict" in
+      Rejected) echo "❌ Notarization rejected by Apple" ;;
+      Fatal) echo "❌ Notarization cannot proceed — credentials or account problem, not a retryable failure" ;;
+      *) echo "❌ Notarization did not reach a verdict in ${NOTARIZE_MAX_ATTEMPTS} attempts" ;;
+    esac
 
     if [[ -n "$submission_id" ]]; then
       echo "📜 Fetching detailed notarization log..."

--- a/scripts/lib/notarize-dmg.sh
+++ b/scripts/lib/notarize-dmg.sh
@@ -29,8 +29,16 @@ NOTARIZE_RETRY_DELAY="${NOTARIZE_RETRY_DELAY:-30}"
 # notarytool hung rather than erroring, and then the retry loop below never
 # gets control and the job burns to GitHub's 6h ceiling — the same lost
 # release, harder to diagnose. Bounding each attempt is what makes "N bounded
-# attempts" actually bounded.
-NOTARIZE_ATTEMPT_TIMEOUT="${NOTARIZE_ATTEMPT_TIMEOUT:-30m}"
+# attempts" actually bounded. 15m rather than 30m because notarization normally
+# settles well under that, and macOS runner minutes bill at 10×, so a generous
+# per-attempt bound multiplied by the retries is what costs real money during
+# an Apple outage.
+NOTARIZE_ATTEMPT_TIMEOUT="${NOTARIZE_ATTEMPT_TIMEOUT:-15m}"
+# Hard ceiling on total time in this function, checked between attempts. Bounds
+# the bill regardless of how NOTARIZE_MAX_ATTEMPTS and the per-attempt timeout
+# multiply out — attempts × timeout is not a cost anyone reasons about when
+# bumping one of them.
+NOTARIZE_TOTAL_BUDGET="${NOTARIZE_TOTAL_BUDGET:-3600}"
 # Stapling fetches the ticket from Apple; error 68 is usually just ticket
 # propagation lag, which wants minutes rather than seconds.
 NOTARIZE_STAPLE_ATTEMPTS="${NOTARIZE_STAPLE_ATTEMPTS:-5}"
@@ -45,9 +53,20 @@ _NOTARIZE_ID_RE='^[[:space:]]*id: [0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'
 
 # Failures that no amount of retrying will fix, and that must NOT be reported
 # as network trouble: an expired app-specific password or an empty team id
-# otherwise costs three attempts, minutes of sleeps, and a log line pointing
-# the on-call reader away from the real cause.
-_NOTARIZE_FATAL_RE='HTTP status code: 40[013]|Unauthorized|[Ii]nvalid credentials|unable to (validate|authenticate)'
+# otherwise costs five attempts, minutes of sleeps, and a log line pointing
+# the on-call reader away from the real cause. Matched case-INSENSITIVELY:
+# notarytool says "Unable to authenticate" and can emit it with no HTTP status
+# code at all (a malformed app-specific password is rejected client-side), so a
+# case-sensitive pattern silently classifies that as transient.
+_NOTARIZE_FATAL_RE='HTTP status code: 40[013]|unauthorized|invalid credentials|unable to (validate|authenticate)'
+
+# notarytool prints "Submission ID received / id: …" BEFORE the upload
+# finishes. Latching on that alone means a connection dropped mid-upload of a
+# several-hundred-MB DMG leaves us waiting on a submission Apple never fully
+# received — every remaining attempt burning its full timeout on something that
+# can never reach a verdict, where re-submitting would have recovered. So the
+# latch also requires the upload to have completed.
+_NOTARIZE_UPLOADED_RE='Successfully uploaded file'
 
 # notarize_dmg <dmg_path>
 #
@@ -82,24 +101,34 @@ notarize_dmg() {
     return 1
   fi
 
-  # Two arrays rather than one plus an optional: on the macOS runners' bash 3.2,
-  # expanding an EMPTY array as "${arr[@]}" under `set -u` is an unbound-variable
-  # error, so both of these are always non-empty. `creds` is what the log fetch
-  # uses (--timeout is only meaningful while waiting).
+  # Separate arrays rather than one plus an optional: on the macOS runners' bash
+  # 3.2, expanding an EMPTY array as "${arr[@]}" under `set -u` is an
+  # unbound-variable error, so all of these are always non-empty. `creds` is
+  # what the log fetch uses (--timeout is only meaningful while waiting), and
+  # submit/resume are probed independently — see below.
   local creds=(--apple-id "$APPLE_ID" --password "$APP_PASSWORD" --team-id "$TEAM_ID")
-  local wait_args=("${creds[@]}")
+  local submit_args=("${creds[@]}") resume_args=("${creds[@]}")
 
   # Probe rather than assume: passing an unsupported flag would fail every
-  # attempt instantly and turn a runner-image change into a lost release.
+  # attempt instantly, be classified transient by the fallthrough below, and
+  # turn a runner-image change into a lost release. Probed per subcommand
+  # because `submit` advertising the flag says nothing about `wait`, and the
+  # resume path is the one that carries the retry.
   if xcrun notarytool submit --help 2>&1 | grep -q -- "--timeout"; then
-    wait_args+=(--timeout "$NOTARIZE_ATTEMPT_TIMEOUT")
+    submit_args+=(--timeout "$NOTARIZE_ATTEMPT_TIMEOUT")
   else
-    echo "⚠️ notarytool has no --timeout on this runner; attempts are unbounded"
+    echo "⚠️ notarytool submit has no --timeout on this runner; that attempt is unbounded"
+  fi
+  if xcrun notarytool wait --help 2>&1 | grep -q -- "--timeout"; then
+    resume_args+=(--timeout "$NOTARIZE_ATTEMPT_TIMEOUT")
+  else
+    echo "⚠️ notarytool wait has no --timeout on this runner; resume attempts are unbounded"
   fi
 
   local submission_id="" verdict="" output exit_code attempt delay
+  local started=$SECONDS
 
-  echo "⏱ Up to ${NOTARIZE_MAX_ATTEMPTS} attempts, each bounded at ${NOTARIZE_ATTEMPT_TIMEOUT}"
+  echo "⏱ Up to ${NOTARIZE_MAX_ATTEMPTS} attempts, each bounded at ${NOTARIZE_ATTEMPT_TIMEOUT}, ${NOTARIZE_TOTAL_BUDGET}s total"
 
   for ((attempt = 1; attempt <= NOTARIZE_MAX_ATTEMPTS; attempt++)); do
     # `set +e` around the command substitution is load-bearing: callers run
@@ -111,11 +140,11 @@ notarize_dmg() {
     set +e
     if [[ -z "$submission_id" ]]; then
       echo "🔐 Submitting DMG for notarization (attempt ${attempt}/${NOTARIZE_MAX_ATTEMPTS})..."
-      output=$(xcrun notarytool submit "$dmg_path" "${wait_args[@]}" --wait 2>&1)
+      output=$(xcrun notarytool submit "$dmg_path" "${submit_args[@]}" --wait 2>&1)
     else
       # Resume the existing submission — never re-upload. See the header.
       echo "🔁 Resuming wait on submission ${submission_id} (attempt ${attempt}/${NOTARIZE_MAX_ATTEMPTS})..."
-      output=$(xcrun notarytool wait "$submission_id" "${wait_args[@]}" 2>&1)
+      output=$(xcrun notarytool wait "$submission_id" "${resume_args[@]}" 2>&1)
     fi
     exit_code=$?
     if ((errexit_was_set)); then set -e; fi
@@ -128,7 +157,7 @@ notarize_dmg() {
     # no-match is expected: the pipeline only returns 0 today because awk is
     # last, so a later simplification to a bare grep — or adding
     # `set -o pipefail` — would otherwise kill the step under bash -e.
-    if [[ -z "$submission_id" ]]; then
+    if [[ -z "$submission_id" ]] && echo "$output" | grep -q "$_NOTARIZE_UPLOADED_RE"; then
       submission_id=$(echo "$output" | grep -m1 -oE "$_NOTARIZE_ID_RE" | awk '{print $2}' || true)
       if [[ -n "$submission_id" ]]; then echo "📋 Submission ID: ${submission_id}"; fi
     fi
@@ -146,7 +175,7 @@ notarize_dmg() {
     fi
 
     # Credentials or entitlements — retrying just multiplies the same 401.
-    if echo "$output" | grep -qE "$_NOTARIZE_FATAL_RE"; then
+    if echo "$output" | grep -qiE "$_NOTARIZE_FATAL_RE"; then
       verdict="Fatal"
       break
     fi
@@ -157,6 +186,13 @@ notarize_dmg() {
     echo "⚠️ No verdict parsed from notarytool output (exit ${exit_code}) — treating as transient"
     if ((attempt < NOTARIZE_MAX_ATTEMPTS)); then
       delay=$((NOTARIZE_RETRY_DELAY * (1 << (attempt - 1))))
+      # Stop on the total budget rather than letting attempts × timeout decide:
+      # macOS minutes bill at 10×, so an Apple outage should cost an hour, not
+      # a day, before we give up and let a human resume the submission.
+      if ((SECONDS - started + delay >= NOTARIZE_TOTAL_BUDGET)); then
+        echo "   Total notarization budget of ${NOTARIZE_TOTAL_BUDGET}s reached after $((SECONDS - started))s — stopping"
+        break
+      fi
       echo "   Retrying in ${delay}s"
       sleep "$delay"
     fi
@@ -172,6 +208,17 @@ notarize_dmg() {
     if [[ -n "$submission_id" ]]; then
       echo "📜 Fetching detailed notarization log..."
       xcrun notarytool log "$submission_id" "${creds[@]}" || true
+
+      # Apple most likely accepted this build — the ticket just wasn't
+      # witnessed. Say so, because the alternative the operator reaches for is
+      # re-running the whole signed build.
+      if [[ "$verdict" != "Rejected" ]]; then
+        echo ""
+        echo "💡 The submission may still have been accepted. To finish it without rebuilding,"
+        echo "   download this job's DMG artifact and run:"
+        echo "     xcrun notarytool wait ${submission_id} --apple-id \"\$APPLE_ID\" --password \"\$APP_PASSWORD\" --team-id \"\$TEAM_ID\" \\"
+        echo "       && xcrun stapler staple <path-to-dmg>"
+      fi
     fi
     return 1
   fi

--- a/scripts/lib/notarize-dmg.sh
+++ b/scripts/lib/notarize-dmg.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# macOS notarization for the release workflows, extracted into a sourceable unit
+# so the retry logic can be tested without an Apple account (see
+# scripts/test/test-notarize-dmg.sh). This file has NO side effects on source.
+#
+# Why this exists: run 30067806575 lost release 9.2.59 to a network blip. The
+# DMG built, signed and uploaded fine — Apple had the submission — but the
+# status poll died with NSURLErrorDomain -1001 ("The request timed out",
+# _kCFStreamErrorCodeKey=60 = ETIMEDOUT) after ~10 successful polls, and the
+# single-shot `notarytool submit --wait` treated that as a failed
+# notarization. `statusCode: nil` is the tell: no HTTP response at all, i.e.
+# a dropped connection rather than a verdict from Apple. The submission itself
+# very likely went on to be accepted, unwitnessed.
+#
+# So the retry has to resume the EXISTING submission rather than re-submit:
+# re-uploading queues a duplicate and throws away work Apple has already done.
+# `notarytool wait <id>` does exactly that.
+
+# Attempts and backoff are env-overridable so the tests run instantly.
+NOTARIZE_MAX_ATTEMPTS="${NOTARIZE_MAX_ATTEMPTS:-3}"
+NOTARIZE_RETRY_DELAY="${NOTARIZE_RETRY_DELAY:-30}"
+NOTARIZE_STAPLE_ATTEMPTS="${NOTARIZE_STAPLE_ATTEMPTS:-3}"
+NOTARIZE_STAPLE_DELAY="${NOTARIZE_STAPLE_DELAY:-15}"
+
+# notarize_dmg <dmg_path>
+#
+# Submits <dmg_path> to Apple, waits for a verdict, and staples the ticket.
+# Reads APPLE_ID / APP_PASSWORD / TEAM_ID from the environment (the release
+# workflows put them there via $GITHUB_ENV).
+#
+# Returns 0 only when Apple accepted the submission AND the ticket stapled.
+# Retries transient failures; a verdict from Apple is final and fails fast.
+notarize_dmg() {
+  local dmg_path="$1"
+
+  if [[ -z "$dmg_path" || ! -f "$dmg_path" ]]; then
+    echo "❌ DMG file not found for notarization: ${dmg_path:-<empty>}"
+    return 1
+  fi
+
+  local creds=(--apple-id "$APPLE_ID" --password "$APP_PASSWORD" --team-id "$TEAM_ID")
+  local submission_id="" verdict="" output exit_code attempt
+
+  for ((attempt = 1; attempt <= NOTARIZE_MAX_ATTEMPTS; attempt++)); do
+    # `set +e` around the command substitution is load-bearing: callers run
+    # under `bash -e`, where a non-zero notarytool exit propagates at the
+    # assignment itself, killing the step BEFORE we can echo the output or
+    # fetch the detailed log. The exit code is captured separately so the
+    # checks below can still tell success from failure.
+    set +e
+    if [[ -z "$submission_id" ]]; then
+      echo "🔐 Submitting DMG for notarization (attempt ${attempt}/${NOTARIZE_MAX_ATTEMPTS})..."
+      output=$(xcrun notarytool submit "$dmg_path" "${creds[@]}" --wait 2>&1)
+    else
+      # Resume the existing submission — never re-upload. See the header.
+      echo "🔁 Resuming wait on submission ${submission_id} (attempt ${attempt}/${NOTARIZE_MAX_ATTEMPTS})..."
+      output=$(xcrun notarytool wait "$submission_id" "${creds[@]}" 2>&1)
+    fi
+    exit_code=$?
+    set -e
+
+    echo "$output"
+    echo "📋 notarytool exit code: ${exit_code}"
+
+    # Latch the submission ID the first time Apple reports one, so every later
+    # attempt resumes instead of re-submitting.
+    if [[ -z "$submission_id" ]]; then
+      submission_id=$(echo "$output" | grep -m1 "id:" | awk '{print $2}')
+      [[ -n "$submission_id" ]] && echo "📋 Submission ID: ${submission_id}"
+    fi
+
+    if echo "$output" | grep -q "status: Accepted"; then
+      verdict="Accepted"
+      break
+    fi
+
+    # Apple rejected the build: retrying re-polls a settled verdict and only
+    # delays the failure. Stop and let the log explain why.
+    if echo "$output" | grep -qE "status: (Invalid|Rejected)"; then
+      verdict="Rejected"
+      break
+    fi
+
+    echo "⚠️ No verdict from Apple (transient failure — network, not a rejection)"
+    if ((attempt < NOTARIZE_MAX_ATTEMPTS)); then
+      echo "   Retrying in ${NOTARIZE_RETRY_DELAY}s"
+      sleep "$NOTARIZE_RETRY_DELAY"
+    fi
+  done
+
+  if [[ "$verdict" != "Accepted" ]]; then
+    if [[ "$verdict" == "Rejected" ]]; then
+      echo "❌ Notarization rejected by Apple"
+    else
+      echo "❌ Notarization did not reach a verdict in ${NOTARIZE_MAX_ATTEMPTS} attempts"
+    fi
+
+    if [[ -n "$submission_id" ]]; then
+      echo "📜 Fetching detailed notarization log..."
+      xcrun notarytool log "$submission_id" "${creds[@]}" || true
+    fi
+    return 1
+  fi
+
+  echo "✅ Notarization accepted"
+
+  # Stapling fetches the ticket from Apple, so it fails the same transient way
+  # the status poll did — and an unstapled DMG gatekeeps offline installs.
+  echo "📎 Stapling notarization to DMG..."
+  for ((attempt = 1; attempt <= NOTARIZE_STAPLE_ATTEMPTS; attempt++)); do
+    if xcrun stapler staple "$dmg_path"; then
+      echo "✅ macOS notarization completed successfully"
+      return 0
+    fi
+    echo "⚠️ Stapling attempt ${attempt}/${NOTARIZE_STAPLE_ATTEMPTS} failed"
+    if ((attempt < NOTARIZE_STAPLE_ATTEMPTS)); then
+      echo "   Retrying in ${NOTARIZE_STAPLE_DELAY}s"
+      sleep "$NOTARIZE_STAPLE_DELAY"
+    fi
+  done
+
+  echo "❌ Stapling failed after ${NOTARIZE_STAPLE_ATTEMPTS} attempts"
+  return 1
+}

--- a/scripts/test/test-notarize-dmg.sh
+++ b/scripts/test/test-notarize-dmg.sh
@@ -8,14 +8,16 @@
 # Apple is faked by putting a stub `xcrun` on PATH, so the real code path runs:
 # argument construction, output parsing, the submit-vs-wait decision, and the
 # retry accounting. Each scenario's stub records what it was asked to do in
-# $TD/calls, and the assertions read that log — which is how the central
-# regression is expressed: after a dropped poll, attempt 2 must be a `wait` on
-# the existing submission, never a second `submit`.
+# $TD/calls (subcommands) and $TD/args (full argv), and the assertions read
+# those — which is how the central regression is expressed: after a dropped
+# poll, attempt 2 must be a `wait` on the existing submission, never a second
+# `submit`.
 #
 # Run: bash scripts/test/test-notarize-dmg.sh
 set -e
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$HERE/../lib/notarize-dmg.sh"
 
 TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
 mkdir -p "$TD/bin"
@@ -25,6 +27,7 @@ PATH="$TD/bin:$PATH"
 export APPLE_ID="ci@example.com" APP_PASSWORD="app-specific-pw" TEAM_ID="TEAMID123"
 # No real waiting in tests.
 export NOTARIZE_RETRY_DELAY=0 NOTARIZE_STAPLE_DELAY=0
+export NOTARIZE_ATTEMPT_TIMEOUT="30m"
 
 DMG="$TD/BOSS-9.2.59.dmg"; echo "not really a dmg" > "$DMG"
 
@@ -78,11 +81,21 @@ write_stub() {
   cat > "$TD/bin/xcrun" <<'PREAMBLE'
 #!/usr/bin/env bash
 CALLS="$TD/calls"
+# The library probes `notarytool submit --help` for --timeout support. Answer
+# it, but keep it out of the logs so scenarios assert real work only.
+if printf '%s\n' "$@" | grep -qxF -- "--help"; then
+  echo "OVERVIEW: Submit an archive to the Apple notary service."
+  echo "OPTIONS:"
+  echo "  --apple-id <apple-id>"
+  [[ -z "${STUB_NO_TIMEOUT:-}" ]] && echo "  --timeout <duration>"
+  exit 0
+fi
+printf '%s\n' "$@" >> "$TD/args"
 N=$(( $(wc -l < "$CALLS" 2>/dev/null || echo 0) + 1 ))
-# Record the subcommand only; credentials are asserted separately.
+# Record the subcommand only; credentials and flags are asserted from $TD/args.
 echo "$1 $2" >> "$CALLS"
 # Every notarytool call must carry the credentials, or a "transient" failure
-# would really be an auth failure retried three times.
+# would really be an auth failure retried five times.
 case "$1" in
   notarytool)
     for want in "--apple-id" "$APPLE_ID" "--password" "$APP_PASSWORD" "--team-id" "$TEAM_ID"; do
@@ -97,10 +110,11 @@ PREAMBLE
   chmod +x "$TD/bin/xcrun"
 }
 
-# scenario <name> — resets the call log for a fresh stub
-scenario() { : > "$TD/calls"; echo "$1"; }
+# scenario <name> — resets the logs for a fresh stub
+scenario() { : > "$TD/calls"; : > "$TD/args"; echo "$1"; }
 calls()    { tr '\n' ',' < "$TD/calls" | sed 's/,$//'; }
-run()      { set +e; ( set -e; source "$HERE/../lib/notarize-dmg.sh"; notarize_dmg "$DMG" ) > "$TD/out" 2>&1; rc=$?; set -e; }
+count()    { grep -c "$1" "$TD/calls" || true; }
+run()      { set +e; ( set -e; source "$LIB"; notarize_dmg "$DMG" ) > "$TD/out" 2>&1; rc=$?; set -e; }
 
 export TD SUBMISSION_ID
 
@@ -120,6 +134,14 @@ if [[ $rc == 0 ]] && [[ "$(calls)" == "notarytool submit,stapler staple" ]]; the
   ok "accepted first try → one submit, then staple (rc=0)"
 else
   bad "accepted first try (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+# Each attempt must be bounded: notarytool has no default timeout, so a
+# half-open connection would otherwise hang the job to GitHub's 6h ceiling
+# instead of failing and letting the retry fire.
+if grep -qxF -- "--timeout" "$TD/args" && grep -qxF -- "30m" "$TD/args"; then
+  ok "per-attempt --timeout is passed when notarytool advertises it"
+else
+  bad "expected --timeout 30m in argv: $(tr '\n' ' ' < "$TD/args")"
 fi
 
 # ------------------------------------------------- dropped poll → resume wait
@@ -145,10 +167,10 @@ if [[ $rc == 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool wait,stapler
 else
   bad "dropped poll (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
 fi
-if [[ $(grep -c "notarytool submit" "$TD/calls") == 1 ]]; then
+if [[ "$(count 'notarytool submit')" == 1 ]]; then
   ok "exactly one submit across the retry"
 else
-  bad "expected exactly one submit, got $(grep -c 'notarytool submit' "$TD/calls")"
+  bad "expected exactly one submit, got $(count 'notarytool submit')"
 fi
 
 # ------------------------------------------------------------ Apple verdict
@@ -168,6 +190,64 @@ if [[ $rc != 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool log" ]]; the
   ok "rejection fails fast and fetches the log (no wait retries)"
 else
   bad "rejection (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------------------ auth failure
+# An expired app-specific password is not a network problem: retrying it five
+# times wastes minutes and the log line would point at the wrong cause.
+scenario "credentials rejected by Apple (401)"
+write_stub <<'STUB'
+if [[ "$1 $2" == "notarytool submit" ]]; then
+  echo "Error: HTTP status code: 401. Unable to authenticate, check your credentials."
+  exit 1
+fi
+STUB
+run
+if [[ $rc != 0 ]] && [[ "$(calls)" == "notarytool submit" ]] && grep -q "credentials or account problem" "$TD/out"; then
+  ok "401 fails fast on the first attempt, named as a credential problem"
+else
+  bad "401 handling (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# --------------------------------------------------- missing credentials
+scenario "TEAM_ID missing from the environment"
+write_stub <<'STUB'
+echo "should not be called" >&2; exit 1
+STUB
+set +e
+( set -e; unset TEAM_ID; source "$LIB"; notarize_dmg "$DMG" ) > "$TD/out" 2>&1
+rc=$?
+set -e
+if [[ $rc != 0 ]] && [[ -z "$(calls)" ]] && grep -q "TEAM_ID" "$TD/out"; then
+  ok "missing credential fails fast, by name, without calling Apple"
+else
+  bad "missing credential (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------- id latch must be anchored
+# The latch is sticky, so garbage in it would make every later attempt
+# `wait <garbage>` and never recover. An unparseable id must leave it empty so
+# the retry re-submits instead.
+scenario "unparseable submission id is not latched"
+write_stub <<'STUB'
+if [[ "$1 $2" == "notarytool submit" ]]; then
+  if [[ $N == 1 ]]; then
+    echo "Warning: no valid id: <none> reported"
+    echo "id: not-a-uuid"
+    echo 'Error: HTTPError(statusCode: nil, error: Code=-1001 "The request timed out.")'
+    exit 1
+  fi
+  echo "  id: 55346c79-b132-4357-bb42-ad5f3a791418"
+  echo "  status: Accepted"
+  exit 0
+fi
+[[ "$1 $2" == "stapler staple" ]] && echo "The staple and validate action worked!"
+STUB
+run
+if [[ $rc == 0 ]] && [[ "$(count 'notarytool wait')" == 0 ]] && [[ "$(count 'notarytool submit')" == 2 ]]; then
+  ok "garbage id line is ignored → re-submits rather than waiting on garbage"
+else
+  bad "id latch (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
 fi
 
 # -------------------------------------------- upload dies before an id exists
@@ -228,10 +308,56 @@ OUT
 esac
 STUB
 run
-if [[ $rc != 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool wait,notarytool wait,notarytool log" ]]; then
-  ok "exhausts 3 bounded attempts then fails (rc=$rc)"
+if [[ $rc != 0 ]] && [[ "$(count 'notarytool submit')" == 1 ]] && [[ "$(count 'notarytool wait')" == 4 ]] && [[ "$(count 'notarytool log')" == 1 ]]; then
+  ok "exhausts 5 bounded attempts (1 submit + 4 resumes) then fails (rc=$rc)"
 else
   bad "exhausted attempts (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------------- errexit not leaked
+# A local packaging script may not run under errexit; sourcing this lib and
+# calling it must not silently arm -e for the rest of that script.
+scenario "errexit is not leaked to a caller that had it off"
+write_stub <<'STUB'
+case "$1 $2" in
+  "notarytool submit") echo 'Error: Code=-1001 "The request timed out."'; exit 1 ;;
+  "notarytool log") echo "none" ;;
+esac
+STUB
+# Fenced: if the lib DOES leak -e, the inner shell exits non-zero and this
+# suite (itself under set -e) would abort silently at the assignment, reporting
+# no FAIL at all — and a piped run would then look green.
+set +e
+leak=$(NOTARIZE_MAX_ATTEMPTS=2 bash -c "source '$LIB'; notarize_dmg '$DMG' >/dev/null 2>&1; case \$- in *e*) echo LEAKED;; *) echo clean;; esac")
+set -e
+[[ -n "$leak" ]] || leak="inner shell died (errexit leak aborted it)"
+if [[ "$leak" == "clean" ]]; then
+  ok "caller's errexit setting survives the call ($leak)"
+else
+  bad "errexit leaked into the caller ($leak)"
+fi
+
+# ------------------------------------------ --timeout absent from notarytool
+# Never pass a flag the runner's notarytool doesn't know: that would fail every
+# attempt instantly and turn a runner-image change into a lost release.
+scenario "notarytool without --timeout support"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(accepted_output)
+OUT
+  ;;
+  "stapler staple") echo "The staple and validate action worked!" ;;
+esac
+STUB
+set +e
+( set -e; export STUB_NO_TIMEOUT=1; source "$LIB"; notarize_dmg "$DMG" ) > "$TD/out" 2>&1
+rc=$?
+set -e
+if [[ $rc == 0 ]] && ! grep -qxF -- "--timeout" "$TD/args" && grep -q "no --timeout on this runner" "$TD/out"; then
+  ok "unsupported --timeout is omitted, with a warning (rc=0)"
+else
+  bad "timeout probe (rc=$rc args=$(tr '\n' ' ' < "$TD/args"))"; cat "$TD/out" >&2
 fi
 
 # --------------------------------------------------------------- missing DMG
@@ -239,7 +365,7 @@ scenario "missing DMG"
 write_stub <<'STUB'
 echo "should not be called" >&2; exit 1
 STUB
-set +e; ( set -e; source "$HERE/../lib/notarize-dmg.sh"; notarize_dmg "$TD/nope.dmg" ) > "$TD/out" 2>&1; rc=$?; set -e
+set +e; ( set -e; source "$LIB"; notarize_dmg "$TD/nope.dmg" ) > "$TD/out" 2>&1; rc=$?; set -e
 if [[ $rc != 0 ]] && [[ -z "$(calls)" ]]; then
   ok "missing DMG fails without calling Apple"
 else

--- a/scripts/test/test-notarize-dmg.sh
+++ b/scripts/test/test-notarize-dmg.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# Unit test for lib/notarize-dmg.sh notarize_dmg. Runs the function under
+# `bash -e` — the mode the release workflows use — because the `set +e` fence
+# around the command substitution only matters in that mode, and a
+# happy-path-only test would never exercise it.
+#
+# Apple is faked by putting a stub `xcrun` on PATH, so the real code path runs:
+# argument construction, output parsing, the submit-vs-wait decision, and the
+# retry accounting. Each scenario's stub records what it was asked to do in
+# $TD/calls, and the assertions read that log — which is how the central
+# regression is expressed: after a dropped poll, attempt 2 must be a `wait` on
+# the existing submission, never a second `submit`.
+#
+# Run: bash scripts/test/test-notarize-dmg.sh
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
+mkdir -p "$TD/bin"
+PATH="$TD/bin:$PATH"
+
+# Credentials the lib expects; the stub asserts they arrive intact.
+export APPLE_ID="ci@example.com" APP_PASSWORD="app-specific-pw" TEAM_ID="TEAMID123"
+# No real waiting in tests.
+export NOTARIZE_RETRY_DELAY=0 NOTARIZE_STAPLE_DELAY=0
+
+DMG="$TD/BOSS-9.2.59.dmg"; echo "not really a dmg" > "$DMG"
+
+pass=0; fail=0
+ok()  { echo "  ok: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+SUBMISSION_ID="55346c79-b132-4357-bb42-ad5f3a791418"
+
+# The exact shape of the -1001 timeout from run 30067806575: the upload
+# succeeded and Apple reported an id, then the status poll died. `statusCode:
+# nil` is what distinguishes it from a verdict.
+timeout_output() {
+  cat <<EOF
+Conducting pre-submission checks for BOSS-9.2.59.dmg and initiating connection to the Apple notary service...
+Submission ID received
+  id: $SUBMISSION_ID
+Successfully uploaded file
+  id: $SUBMISSION_ID
+Waiting for processing to complete.
+Current status: In Progress..........Error: HTTPError(statusCode: nil, error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out." UserInfo={_kCFStreamErrorCodeKey=60})
+EOF
+}
+
+accepted_output() {
+  cat <<EOF
+Successfully uploaded file
+  id: $SUBMISSION_ID
+Waiting for processing to complete.
+Current status: Accepted
+Processing complete
+  id: $SUBMISSION_ID
+  status: Accepted
+EOF
+}
+
+invalid_output() {
+  cat <<EOF
+Successfully uploaded file
+  id: $SUBMISSION_ID
+Waiting for processing to complete.
+Processing complete
+  id: $SUBMISSION_ID
+  status: Invalid
+EOF
+}
+
+# write_stub <<'BODY' — installs $TD/bin/xcrun. The body sees $1.. as the
+# xcrun arguments, $CALLS as the log path, and $N as this call's 1-based index.
+write_stub() {
+  cat > "$TD/bin/xcrun" <<'PREAMBLE'
+#!/usr/bin/env bash
+CALLS="$TD/calls"
+N=$(( $(wc -l < "$CALLS" 2>/dev/null || echo 0) + 1 ))
+# Record the subcommand only; credentials are asserted separately.
+echo "$1 $2" >> "$CALLS"
+# Every notarytool call must carry the credentials, or a "transient" failure
+# would really be an auth failure retried three times.
+case "$1" in
+  notarytool)
+    for want in "--apple-id" "$APPLE_ID" "--password" "$APP_PASSWORD" "--team-id" "$TEAM_ID"; do
+      # `--` matters: the wanted values are themselves flags like --apple-id,
+      # which BSD grep would otherwise parse as its own options.
+      printf '%s\n' "$@" | grep -qxF -- "$want" || { echo "STUB: missing arg $want" >&2; exit 99; }
+    done
+    ;;
+esac
+PREAMBLE
+  cat >> "$TD/bin/xcrun"
+  chmod +x "$TD/bin/xcrun"
+}
+
+# scenario <name> — resets the call log for a fresh stub
+scenario() { : > "$TD/calls"; echo "$1"; }
+calls()    { tr '\n' ',' < "$TD/calls" | sed 's/,$//'; }
+run()      { set +e; ( set -e; source "$HERE/../lib/notarize-dmg.sh"; notarize_dmg "$DMG" ) > "$TD/out" 2>&1; rc=$?; set -e; }
+
+export TD SUBMISSION_ID
+
+# ---------------------------------------------------------------- accepted
+scenario "accepted on first attempt"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(accepted_output)
+OUT
+  ;;
+  "stapler staple") echo "The staple and validate action worked!" ;;
+esac
+STUB
+run
+if [[ $rc == 0 ]] && [[ "$(calls)" == "notarytool submit,stapler staple" ]]; then
+  ok "accepted first try → one submit, then staple (rc=0)"
+else
+  bad "accepted first try (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------- dropped poll → resume wait
+# THE regression: a -1001 during polling must resume the submission, not
+# re-upload it. Attempt 2 is `notarytool wait`, and there is exactly one submit.
+scenario "poll times out, then wait succeeds"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(timeout_output)
+OUT
+    exit 1 ;;
+  "notarytool wait") cat <<'OUT'
+$(accepted_output)
+OUT
+    ;;
+  "stapler staple") echo "The staple and validate action worked!" ;;
+esac
+STUB
+run
+if [[ $rc == 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool wait,stapler staple" ]]; then
+  ok "dropped poll → resumes existing submission, no re-upload (rc=0)"
+else
+  bad "dropped poll (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+if [[ $(grep -c "notarytool submit" "$TD/calls") == 1 ]]; then
+  ok "exactly one submit across the retry"
+else
+  bad "expected exactly one submit, got $(grep -c 'notarytool submit' "$TD/calls")"
+fi
+
+# ------------------------------------------------------------ Apple verdict
+# A rejection is settled: fail fast with the log, no retry attempts.
+scenario "Apple returns Invalid"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(invalid_output)
+OUT
+    exit 1 ;;
+  "notarytool log") echo '{"issues":[{"message":"The binary is not signed."}]}' ;;
+esac
+STUB
+run
+if [[ $rc != 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool log" ]]; then
+  ok "rejection fails fast and fetches the log (no wait retries)"
+else
+  bad "rejection (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# -------------------------------------------- upload dies before an id exists
+# No submission to resume, so retrying must re-submit.
+scenario "upload fails before Apple reports an id"
+write_stub <<STUB
+if [[ "\$1 \$2" == "notarytool submit" ]]; then
+  if [[ \$N == 1 ]]; then
+    echo 'Error: HTTPError(statusCode: nil, error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out.")'
+    exit 1
+  fi
+  cat <<'OUT'
+$(accepted_output)
+OUT
+  exit 0
+fi
+[[ "\$1 \$2" == "stapler staple" ]] && echo "The staple and validate action worked!"
+STUB
+run
+if [[ $rc == 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool submit,stapler staple" ]]; then
+  ok "no id yet → re-submits, then succeeds (rc=0)"
+else
+  bad "upload failure (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------------------ flaky stapler
+# Stapling also talks to Apple, so it gets the same treatment.
+scenario "stapler flakes once"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(accepted_output)
+OUT
+  ;;
+  "stapler staple")
+    if [[ \$N == 2 ]]; then echo "Error 68: could not validate ticket" >&2; exit 68; fi
+    echo "The staple and validate action worked!" ;;
+esac
+STUB
+run
+if [[ $rc == 0 ]] && [[ "$(calls)" == "notarytool submit,stapler staple,stapler staple" ]]; then
+  ok "stapler retries after a transient failure (rc=0)"
+else
+  bad "flaky stapler (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------------- exhausted attempts
+# Persistent outage: bounded attempts, then fail — with the log fetched.
+scenario "every attempt times out"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(timeout_output)
+OUT
+    exit 1 ;;
+  "notarytool wait") echo 'Error: HTTPError(statusCode: nil, error: Code=-1001 "The request timed out.")'; exit 1 ;;
+  "notarytool log") echo "no log available" ;;
+esac
+STUB
+run
+if [[ $rc != 0 ]] && [[ "$(calls)" == "notarytool submit,notarytool wait,notarytool wait,notarytool log" ]]; then
+  ok "exhausts 3 bounded attempts then fails (rc=$rc)"
+else
+  bad "exhausted attempts (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# --------------------------------------------------------------- missing DMG
+scenario "missing DMG"
+write_stub <<'STUB'
+echo "should not be called" >&2; exit 1
+STUB
+set +e; ( set -e; source "$HERE/../lib/notarize-dmg.sh"; notarize_dmg "$TD/nope.dmg" ) > "$TD/out" 2>&1; rc=$?; set -e
+if [[ $rc != 0 ]] && [[ -z "$(calls)" ]]; then
+  ok "missing DMG fails without calling Apple"
+else
+  bad "missing DMG (rc=$rc calls=$(calls))"
+fi
+
+echo "notarize tests: $pass passed, $fail failed"
+[[ "$fail" == 0 ]]

--- a/scripts/test/test-notarize-dmg.sh
+++ b/scripts/test/test-notarize-dmg.sh
@@ -172,6 +172,13 @@ if [[ "$(count 'notarytool submit')" == 1 ]]; then
 else
   bad "expected exactly one submit, got $(count 'notarytool submit')"
 fi
+# The resume path carries the retry, so it needs its own bound — `submit`
+# advertising --timeout says nothing about `wait`.
+if [[ "$(grep -cxF -- '--timeout' "$TD/args")" == 2 ]]; then
+  ok "--timeout bounds the resume attempt as well as the submit"
+else
+  bad "expected --timeout on both calls, saw $(grep -cxF -- '--timeout' "$TD/args")"
+fi
 
 # ------------------------------------------------------------ Apple verdict
 # A rejection is settled: fail fast with the log, no retry attempts.
@@ -232,6 +239,7 @@ scenario "unparseable submission id is not latched"
 write_stub <<'STUB'
 if [[ "$1 $2" == "notarytool submit" ]]; then
   if [[ $N == 1 ]]; then
+    echo "Successfully uploaded file"
     echo "Warning: no valid id: <none> reported"
     echo "id: not-a-uuid"
     echo 'Error: HTTPError(statusCode: nil, error: Code=-1001 "The request timed out.")'
@@ -358,6 +366,119 @@ if [[ $rc == 0 ]] && ! grep -qxF -- "--timeout" "$TD/args" && grep -q "no --time
   ok "unsupported --timeout is omitted, with a warning (rc=0)"
 else
   bad "timeout probe (rc=$rc args=$(tr '\n' ' ' < "$TD/args"))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------- id reported, upload never landed
+# notarytool prints the submission id BEFORE the upload completes. Latching on
+# that would leave every remaining attempt waiting on a submission Apple never
+# fully received — each burning its whole timeout, ~2h of 10×-billed runner for
+# a verdict that can never arrive, where re-submitting recovers.
+scenario "id reported but the upload never completed"
+write_stub <<'STUB'
+if [[ "$1 $2" == "notarytool submit" ]]; then
+  if [[ $N == 1 ]]; then
+    echo "Conducting pre-submission checks for BOSS-9.2.59.dmg..."
+    echo "Submission ID received"
+    echo "  id: 55346c79-b132-4357-bb42-ad5f3a791418"
+    echo 'Error: HTTPError(statusCode: nil, error: Code=-1001 "The request timed out.")'
+    exit 1
+  fi
+  echo "Successfully uploaded file"
+  echo "  id: 55346c79-b132-4357-bb42-ad5f3a791418"
+  echo "  status: Accepted"
+  exit 0
+fi
+[[ "$1 $2" == "stapler staple" ]] && echo "The staple and validate action worked!"
+STUB
+run
+if [[ $rc == 0 ]] && [[ "$(count 'notarytool wait')" == 0 ]] && [[ "$(count 'notarytool submit')" == 2 ]]; then
+  ok "id without a completed upload is not latched → re-submits"
+else
+  bad "premature id (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------ auth error with no HTTP status code
+# notarytool rejects a malformed app-specific password client-side, printing
+# "Unable to authenticate" and nothing else. A case-SENSITIVE pattern reads
+# that as transient and retries it five times while blaming the network.
+scenario "Unable to authenticate with no status code"
+write_stub <<'STUB'
+if [[ "$1 $2" == "notarytool submit" ]]; then
+  echo "Error: Unable to authenticate. Check that your app-specific password is correct."
+  exit 1
+fi
+STUB
+run
+if [[ $rc != 0 ]] && [[ "$(calls)" == "notarytool submit" ]] && grep -q "credentials or account problem" "$TD/out"; then
+  ok "bare 'Unable to authenticate' fails fast, not retried as network"
+else
+  bad "bare auth error (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# --------------------------------------------------------- total time budget
+# attempts × per-attempt timeout is not a number anyone recomputes when bumping
+# one of them, so total elapsed time is capped independently.
+scenario "total budget stops the retries early"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(timeout_output)
+OUT
+    exit 1 ;;
+  "notarytool wait") echo 'Error: Code=-1001 "The request timed out."'; exit 1 ;;
+  "notarytool log") echo "no log available" ;;
+esac
+STUB
+set +e
+( set -e; export NOTARIZE_TOTAL_BUDGET=0; source "$LIB"; notarize_dmg "$DMG" ) > "$TD/out" 2>&1
+rc=$?
+set -e
+if [[ $rc != 0 ]] && [[ "$(count 'notarytool submit')" == 1 ]] && [[ "$(count 'notarytool wait')" == 0 ]] \
+   && grep -q "Total notarization budget" "$TD/out"; then
+  ok "elapsed budget stops after the first attempt instead of all five"
+else
+  bad "total budget (rc=$rc calls=$(calls))"; cat "$TD/out" >&2
+fi
+
+# ------------------------------------------------------- recovery hint
+# On a terminal transient failure Apple has probably accepted the build; the
+# operator should resume that submission, not re-run the whole signed build.
+scenario "terminal failure prints the resume command"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(timeout_output)
+OUT
+    exit 1 ;;
+  "notarytool wait") echo 'Error: Code=-1001 "The request timed out."'; exit 1 ;;
+  "notarytool log") echo "no log available" ;;
+esac
+STUB
+run
+if [[ $rc != 0 ]] && grep -q "xcrun notarytool wait ${SUBMISSION_ID}" "$TD/out" && grep -q "stapler staple" "$TD/out"; then
+  ok "exhausted attempts print the wait+staple recovery command with the id"
+else
+  bad "recovery hint missing (rc=$rc)"; cat "$TD/out" >&2
+fi
+
+# --------------------------------------- no recovery hint on a real rejection
+# Telling someone to resume a submission Apple rejected would be actively
+# misleading.
+scenario "rejection does not print a resume hint"
+write_stub <<STUB
+case "\$1 \$2" in
+  "notarytool submit") cat <<'OUT'
+$(invalid_output)
+OUT
+    exit 1 ;;
+  "notarytool log") echo '{"issues":[{"message":"The binary is not signed."}]}' ;;
+esac
+STUB
+run
+if [[ $rc != 0 ]] && ! grep -q "may still have been accepted" "$TD/out"; then
+  ok "rejection omits the resume hint"
+else
+  bad "rejection printed a resume hint (rc=$rc)"; cat "$TD/out" >&2
 fi
 
 # --------------------------------------------------------------- missing DMG


### PR DESCRIPTION
## The incident

[Run 30067806575](https://github.com/risa-labs-inc/BossConsole/actions/runs/30067806575/job/89402468987) lost release **9.2.59**. The macOS DMG built, signed and uploaded fine — Apple had the submission — but the status poll died after ~10 successful polls:

```
Successfully uploaded file
  id: 55346c79-b132-4357-bb42-ad5f3a791418
Waiting for processing to complete.
Current status: In Progress..........Error: HTTPError(statusCode: nil,
  error: ... Code=-1001 "The request timed out." {_kCFStreamErrorCodeKey=60})
  NSErrorFailingURLKey=https://appstoreconnect.apple.com/notary/v2/submissions/55346c79-…
```

`statusCode: nil` is the tell — no HTTP response at all, so a dropped connection rather than a verdict from Apple (`_kCFStreamErrorCodeKey=60` is `ETIMEDOUT`). The workflow's own fallback `notarytool log` call then timed out too, on a *different* endpoint (`/notary/v2/asp`), which puts it beyond doubt: a connectivity blip between the runner and Apple, nothing to do with this DMG.

The submission itself very likely went on to be accepted, unwitnessed. But the single-shot `notarytool submit --wait` read the dead poll as a failed notarization, `create-release` was skipped, and **9.2.59 never shipped** — releases went 9.2.58 → nothing, with `version.properties` left sitting at 9.2.59.

## The fix

The retry has to **resume** the existing submission, not re-submit — re-uploading queues a duplicate and discards processing Apple has already done. `notarytool wait <id>` does exactly that, so the submission ID is latched the first time Apple reports one and every later attempt waits on it.

- **Five bounded attempts** with exponential backoff (30/60/120/240s, ≈7.5 min for the network to return), each attempt bounded by `--timeout` (default 30m) — neither `notarytool submit --wait` nor `notarytool wait` has a default timeout, so without it a half-open connection hangs the job to GitHub's 6h ceiling instead of erroring, and the retry never fires. The flag is probed from `notarytool submit --help` rather than assumed, so a runner image without it degrades to a warning instead of failing every attempt.
- **A verdict is final.** `Invalid`/`Rejected` fails fast with the log instead of burning retries re-polling a settled answer.
- **No submission ID yet?** Then the upload itself died and there is nothing to resume, so that case does re-submit. The ID latch is anchored to Apple's UUID shape: it is sticky, so garbage in it would make every later attempt `wait <garbage>` with no way back.
- **Credential problems fail fast, by name.** `APPLE_ID`/`APP_PASSWORD`/`TEAM_ID` are precondition-checked, and a 401/403 is reported as a credential problem rather than retried five times as "network".
- **Stapling retries too** (5 × 30s). It fetches the ticket from Apple, so it fails the same transient way (the classic `Error 68` is usually ticket propagation), and an unstapled DMG gatekeeps offline installs.
- **The caller's shell options are left as found** — the `set +e` fence saves and restores errexit, so sourcing this from a local packaging script that doesn't use `-e` can't silently arm it.

## Why it moved out of the YAML

Retry logic buried in an inline `run:` block cannot be tested, so it follows the existing `tus-slice` pattern: `scripts/lib/notarize-dmg.sh` (sourceable, no side effects) plus `scripts/test/test-notarize-dmg.sh`, wired into the existing **🐚 Shell Script Tests** job. Apple is stubbed by putting a fake `xcrun` on `PATH`, so the real code path runs — argument construction, output parsing, the submit-vs-wait decision, retry accounting — with no credentials, on ubuntu.

Ten scenarios, 14 assertions, each mutation-checked by reintroducing the old behaviour and confirming a named failure. The ones that matter:

```
ok: dropped poll → resumes existing submission, no re-upload (rc=0)
ok: exactly one submit across the retry
ok: rejection fails fast and fetches the log (no wait retries)
```

```
ok: garbage id line is ignored → re-submits rather than waiting on garbage
ok: per-attempt --timeout is passed when notarytool advertises it
ok: unsupported --timeout is omitted, with a warning (rc=0)
ok: caller's errexit setting survives the call (clean)
```

plus: accepted-first-try, upload-dies-before-an-id, 401 fast-fail, missing credential named, flaky stapler, attempts exhausted, and missing DMG.

`release-lite.yml` carried the same single-shot copy — worse, actually: with no `set +e` fence, a non-zero `notarytool` exit killed the step at the assignment, before the output or log could be printed. Both workflows now share the one implementation.

## Verification

Beyond the unit tests, I extracted **both workflows' real `run:` bodies** and executed them under `bash -e` (the shell GitHub uses for `run:`) against a stub that reproduces the exact -1001 failure:

```
--- release.yml ---       exit=0  calls=notarytool submit, notarytool wait, stapler staple
--- release-lite.yml ---  exit=0  calls=notarytool submit, notarytool wait, stapler staple
```

Both survive the failure that killed 9.2.59, upload exactly once, and staple. The DMG-not-found path still exits 1. All three workflow files parse as YAML.

## Note

This does not republish 9.2.59 — that needs a Release Build run, and the one dispatched today (30153608061) covers it.
