### PR TITLE
fix(git,shell): ignored porcelain entries are not staged; make both escapeForDoubleQuotes branches testable

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -397,8 +397,15 @@ actual object GitService {
         val indexStatus = parseStatusChar(indexChar)
         val workTreeStatus = parseStatusChar(workTreeChar)
 
-        // A file is staged if it has an index status (not space or ?)
-        val isStaged = indexStatus != null && indexStatus != GitFileStatusType.UNTRACKED
+        // A file is staged if it has an index status, except for the two porcelain v1
+        // codes that fill the index column without ever describing staged content:
+        // `?` (untracked, always emitted as "??") and `!` (ignored, always emitted as
+        // "!!" and only with --ignored). Every other modelled code can be staged —
+        // including `U` (unmerged), whose path does have index entries (stages 1/2/3).
+        val isStaged =
+            indexStatus != null &&
+                indexStatus != GitFileStatusType.UNTRACKED &&
+                indexStatus != GitFileStatusType.IGNORED
         // A file is unstaged if it has a worktree status (not space)
         val isUnstaged = workTreeStatus != null
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -359,11 +359,7 @@ actual object GitService {
                     return@withContext emptyList()
                 }
 
-                val statuses =
-                    result.output
-                        .lines()
-                        .filter { it.isNotBlank() }
-                        .mapNotNull { parseStatusLine(it) }
+                val statuses = parseStatusOutput(result.output)
 
                 _fileStatus.value = statuses
                 statuses
@@ -372,6 +368,37 @@ actual object GitService {
                 emptyList()
             }
         }
+
+    /**
+     * Index-column porcelain codes that never describe staged content: `?` (untracked)
+     * and `!` (ignored). Every other modelled code can be staged — including `U`
+     * (unmerged), whose path really does hold conflict stages 1/2/3 in the index.
+     * One place to revisit when a new [GitFileStatusType] is modelled.
+     */
+    private val NEVER_STAGED =
+        setOf(GitFileStatusType.UNTRACKED, GitFileStatusType.IGNORED)
+
+    /**
+     * Parse the whole output of `git status --porcelain=v1` into file statuses.
+     *
+     * The single choke point for both status call sites, and the one place that decides
+     * which porcelain entries are *changes* at all. Ignored entries (`!! path`, emitted
+     * only when `--ignored` is passed) are dropped: an ignored path is neither staged
+     * nor an unstaged change, so it belongs in neither list the commit dialog renders
+     * (it filters on `isStaged` / `isUnstaged`) nor in the status stream the plugin IPC
+     * bridge forwards. Fixing only one of the two booleans would just move such an entry
+     * from the staged list to the unstaged one.
+     *
+     * [parseStatusLine] itself stays faithful to porcelain and still reports IGNORED, so
+     * a future caller that deliberately passes `--ignored` can parse those lines — it
+     * just has to opt in here rather than inherit them silently.
+     */
+    internal fun parseStatusOutput(output: String): List<GitFileStatus> =
+        output
+            .lines()
+            .filter { it.isNotBlank() }
+            .mapNotNull { parseStatusLine(it) }
+            .filterNot { it.indexStatus == GitFileStatusType.IGNORED }
 
     /**
      * Parse a single line from `git status --porcelain=v1`.
@@ -397,16 +424,15 @@ actual object GitService {
         val indexStatus = parseStatusChar(indexChar)
         val workTreeStatus = parseStatusChar(workTreeChar)
 
-        // A file is staged if it has an index status, except for the two porcelain v1
-        // codes that fill the index column without ever describing staged content:
-        // `?` (untracked, always emitted as "??") and `!` (ignored, always emitted as
-        // "!!" and only with --ignored). Every other modelled code can be staged —
-        // including `U` (unmerged), whose path does have index entries (stages 1/2/3).
-        val isStaged =
-            indexStatus != null &&
-                indexStatus != GitFileStatusType.UNTRACKED &&
-                indexStatus != GitFileStatusType.IGNORED
-        // A file is unstaged if it has a worktree status (not space)
+        // A file is staged if it has an index status, minus the codes that fill the index
+        // column without describing staged content (see [NEVER_STAGED]).
+        val isStaged = indexStatus != null && indexStatus !in NEVER_STAGED
+
+        // A file is unstaged if it has a worktree status (not space). Note this is a
+        // faithful reading of the worktree column, not a judgement about the entry: for
+        // "??" and "!!" it is true because both columns carry the code. Untracked is a
+        // real (unstaged) change so that is correct; ignored is not a change at all, and
+        // is excluded from the status list by [parseStatusOutput] rather than here.
         val isUnstaged = workTreeStatus != null
 
         return GitFileStatus(
@@ -1173,11 +1199,7 @@ actual object GitService {
                     return@withContext emptyList()
                 }
 
-                val statuses =
-                    result.output
-                        .lines()
-                        .filter { it.isNotBlank() }
-                        .mapNotNull { parseStatusLine(it) }
+                val statuses = parseStatusOutput(result.output)
 
                 windowGitState.updateFileStatus(statuses)
                 statuses

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/ShellUtils.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/ShellUtils.kt
@@ -40,7 +40,24 @@ object ShellUtils {
      * Escape a string for safe use inside double quotes in shell.
      * Platform-aware escaping for Unix shells vs Windows PowerShell.
      */
-    fun escapeForDoubleQuotes(str: String): String =
+    fun escapeForDoubleQuotes(str: String): String = escapeForDoubleQuotes(str, isWindows)
+
+    /**
+     * Platform-explicit form of [escapeForDoubleQuotes].
+     *
+     * [isWindows] is fixed at class-load from the real OS, so the single-argument
+     * overload can only ever reach one branch on a given host. This overload takes
+     * the platform as a parameter so both the PowerShell and the POSIX branch are
+     * exercised by tests on every host, instead of relying on the CI matrix
+     * happening to include a Windows runner.
+     *
+     * @param str The string to escape
+     * @param isWindows Escape for Windows PowerShell when true, POSIX shells otherwise
+     */
+    internal fun escapeForDoubleQuotes(
+        str: String,
+        isWindows: Boolean,
+    ): String =
         if (isWindows) {
             // PowerShell escaping: backtick is the escape character
             str

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/ShellUtils.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/run/ShellUtils.kt
@@ -34,7 +34,14 @@ object ShellUtils {
      * For critical operations requiring error propagation, use separate commands
      * with explicit error handling rather than chaining.
      */
-    val commandSeparator: String = if (isWindows) "; " else " && "
+    val commandSeparator: String = separatorFor(isWindows)
+
+    /**
+     * Platform-explicit form of [commandSeparator], for the same reason as the
+     * [escapeForDoubleQuotes] overload below: [isWindows] is fixed at class-load, so
+     * tests can only reach the host's own separator through the property.
+     */
+    internal fun separatorFor(forWindows: Boolean): String = if (forWindows) "; " else " && "
 
     /**
      * Escape a string for safe use inside double quotes in shell.
@@ -52,13 +59,13 @@ object ShellUtils {
      * happening to include a Windows runner.
      *
      * @param str The string to escape
-     * @param isWindows Escape for Windows PowerShell when true, POSIX shells otherwise
+     * @param forWindows Escape for Windows PowerShell when true, POSIX shells otherwise
      */
     internal fun escapeForDoubleQuotes(
         str: String,
-        isWindows: Boolean,
+        forWindows: Boolean,
     ): String =
-        if (isWindows) {
+        if (forWindows) {
             // PowerShell escaping: backtick is the escape character
             str
                 .replace("`", "``") // Backtick must be escaped first
@@ -71,7 +78,12 @@ object ShellUtils {
                 .replace("\"", "\\\"") // Double quotes
                 .replace("\$", "\\\$") // Dollar sign (prevents variable expansion)
                 .replace("`", "\\`") // Backticks (prevents command substitution)
-                .replace("!", "\\!") // Exclamation (history expansion in interactive shells)
+                // Exclamation: history expansion, which only happens in an INTERACTIVE
+                // shell. Inside double quotes a backslash is literal before anything but
+                // $ ` " \ and newline, so a non-interactive shell (`sh -c`) keeps the
+                // backslash and a path containing "!" breaks. Today's callers all feed an
+                // interactive terminal; check that before reusing this for `sh -c`.
+                .replace("!", "\\!")
         }
 
     /**
@@ -86,16 +98,32 @@ object ShellUtils {
     fun buildCommandWithWorkingDirectory(
         command: String,
         workingDirectory: String?,
+    ): String = buildCommandWithWorkingDirectory(command, workingDirectory, isWindows)
+
+    /**
+     * Platform-explicit form of [buildCommandWithWorkingDirectory]: it composes both
+     * platform-dependent pieces (escaping and separator), so it needs the same seam to
+     * be testable on either branch from any host.
+     *
+     * @param forWindows Build for Windows PowerShell when true, POSIX shells otherwise
+     */
+    internal fun buildCommandWithWorkingDirectory(
+        command: String,
+        workingDirectory: String?,
+        forWindows: Boolean,
     ): String =
         if (!workingDirectory.isNullOrBlank()) {
-            val escapedDir = escapeForDoubleQuotes(workingDirectory)
-            "cd \"$escapedDir\"$commandSeparator$command"
+            val escapedDir = escapeForDoubleQuotes(workingDirectory, forWindows)
+            "cd \"$escapedDir\"${separatorFor(forWindows)}$command"
         } else {
             command
         }
 
     /**
      * Chain multiple commands together using platform-appropriate separator.
+     *
+     * Its only platform dependence is [separatorFor], which is covered on both branches
+     * by tests, so this needs no platform-explicit overload of its own.
      *
      * @param commands The commands to chain
      * @return The chained command string

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
@@ -1,6 +1,5 @@
 package ai.rever.boss.git
 
-import org.junit.jupiter.api.Disabled
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -125,16 +124,23 @@ class GitPorcelainParserTest {
         assertEquals(GitFileStatusType.IGNORED, status.workTreeStatus)
     }
 
-    @Disabled(
-        "documents bug: '!!' (ignored) sets isStaged=true because only UNTRACKED is " +
-            "carved out of the isStaged computation; an ignored file is never staged. " +
-            "Currently unreachable in production (getStatus never passes --ignored).",
-    )
     @Test
     fun `ignored file is not staged`() {
         val status = GitService.parseStatusLine("!! build/")
         assertNotNull(status)
+        // IGNORED, like UNTRACKED, fills the index column ("!!") but is never staged.
         assertFalse(status.isStaged)
+        // isUnstaged still follows the worktree column, matching the "??" treatment.
+        assertTrue(status.isUnstaged)
+    }
+
+    @Test
+    fun `unmerged index status is still staged - a conflicted path has index entries`() {
+        // UNTRACKED and IGNORED are the only codes carved out of isStaged: 'U' means the
+        // path holds conflict stages in the index, so it is not a "never staged" code.
+        val status = GitService.parseStatusLine("UD theirs-deleted.txt")
+        assertNotNull(status)
+        assertTrue(status.isStaged)
     }
 
     // ==================== parseStatusLine: renames and copies ====================

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
@@ -130,7 +130,10 @@ class GitPorcelainParserTest {
         assertNotNull(status)
         // IGNORED, like UNTRACKED, fills the index column ("!!") but is never staged.
         assertFalse(status.isStaged)
-        // isUnstaged still follows the worktree column, matching the "??" treatment.
+        // isUnstaged, by contrast, is a faithful reading of the worktree column, so it is
+        // true here just as it is for "??". That is *not* a claim that an ignored path is
+        // an unstaged change — it is why ignored entries are dropped wholesale by
+        // parseStatusOutput below rather than patched one boolean at a time.
         assertTrue(status.isUnstaged)
     }
 
@@ -141,6 +144,62 @@ class GitPorcelainParserTest {
         val status = GitService.parseStatusLine("UD theirs-deleted.txt")
         assertNotNull(status)
         assertTrue(status.isStaged)
+    }
+
+    // ==================== parseStatusOutput ====================
+    //
+    // The choke point both getStatus and getStatusForWindow feed their porcelain through.
+    // It decides which entries count as changes at all, which is where ignored paths are
+    // excluded — not in the per-line parser, which stays faithful to porcelain.
+
+    @Test
+    fun `parseStatusOutput drops ignored entries entirely, not just their staged flag`() {
+        val statuses =
+            GitService.parseStatusOutput(
+                """
+                M  src/App.kt
+                !! build/
+                ?? notes.md
+                !! .gradle/caches/
+                """.trimIndent(),
+            )
+        assertEquals(listOf("src/App.kt", "notes.md"), statuses.map { it.path })
+        // Nothing IGNORED survives in either column, so neither the commit dialog's
+        // staged list (isStaged) nor its unstaged list (isUnstaged || indexStatus ==
+        // UNTRACKED) — nor the plugin IPC bridge — can ever render one.
+        assertTrue(statuses.none { it.indexStatus == GitFileStatusType.IGNORED })
+        assertTrue(statuses.none { it.workTreeStatus == GitFileStatusType.IGNORED })
+    }
+
+    @Test
+    fun `parseStatusOutput keeps every non-ignored entry with its flags intact`() {
+        val statuses =
+            GitService.parseStatusOutput(
+                """
+                M  staged.kt
+                 M unstaged.kt
+                UU conflict.kt
+                R  old.kt -> new.kt
+                """.trimIndent(),
+            )
+        assertEquals(4, statuses.size)
+        assertTrue(statuses.single { it.path == "staged.kt" }.isStaged)
+        assertTrue(statuses.single { it.path == "unstaged.kt" }.isUnstaged)
+        assertEquals(GitFileStatusType.UNMERGED, statuses.single { it.path == "conflict.kt" }.indexStatus)
+        assertEquals("old.kt", statuses.single { it.path == "new.kt" }.originalPath)
+    }
+
+    @Test
+    fun `parseStatusOutput skips blank lines and unparseable lines`() {
+        val statuses =
+            GitService.parseStatusOutput("M  a.kt\n\n   \nM\n M b.kt\n")
+        assertEquals(listOf("a.kt", "b.kt"), statuses.map { it.path })
+    }
+
+    @Test
+    fun `parseStatusOutput of empty output is empty`() {
+        assertTrue(GitService.parseStatusOutput("").isEmpty())
+        assertTrue(GitService.parseStatusOutput("\n\n").isEmpty())
     }
 
     // ==================== parseStatusLine: renames and copies ====================

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/ShellUtilsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/ShellUtilsTest.kt
@@ -8,9 +8,13 @@ import kotlin.test.assertEquals
  * command and "open terminal here" flow is built from.
  *
  * CI runs this suite on Linux, macOS AND Windows, and [ShellUtils.isWindows] is
- * fixed at class-load from the real OS, so each expectation is written per
- * platform: the POSIX branch is verified on Unix runners and the PowerShell
- * branch on Windows runners.
+ * fixed at class-load from the real OS, so the single-argument expectations are
+ * written per platform: the POSIX branch is verified on Unix runners and the
+ * PowerShell branch on Windows runners.
+ *
+ * Because that leaves each branch covered by only one CI leg, the
+ * `escapeForDoubleQuotes(str, isWindows)` section drives the platform explicitly
+ * so both branches also run on every host.
  */
 class ShellUtilsTest {
     private val win = ShellUtils.isWindows
@@ -115,6 +119,78 @@ class ShellUtilsTest {
             expect(unix = "\\\\\\\"", windows = "\\`\""),
             ShellUtils.escapeForDoubleQuotes("\\\""),
         )
+    }
+
+    // ============ escapeForDoubleQuotes(str, isWindows): both branches on any host ============
+    //
+    // The tests above can only ever reach the host's own branch. These call the
+    // platform-explicit overload so the POSIX *and* the PowerShell branch are covered
+    // on every runner — dropping the Windows CI leg cannot silently untest a branch.
+
+    private fun unix(str: String): String = ShellUtils.escapeForDoubleQuotes(str, isWindows = false)
+
+    private fun powershell(str: String): String = ShellUtils.escapeForDoubleQuotes(str, isWindows = true)
+
+    @Test
+    fun `single-argument overload delegates to the host branch`() {
+        val nasty = "a\"b\\c\$d`e!f"
+        assertEquals(
+            ShellUtils.escapeForDoubleQuotes(nasty, isWindows = win),
+            ShellUtils.escapeForDoubleQuotes(nasty),
+        )
+    }
+
+    @Test
+    fun `posix branch escapes quote, backslash, dollar, backtick and bang`() {
+        assertEquals("\\\"", unix("\""))
+        assertEquals("C:\\\\Temp", unix("C:\\Temp"))
+        assertEquals("\\\$HOME", unix("\$HOME"))
+        assertEquals("a\\`whoami\\`b", unix("a`whoami`b"))
+        assertEquals("deploy\\!", unix("deploy!"))
+    }
+
+    @Test
+    fun `powershell branch escapes quote, dollar and backtick, leaving backslash and bang literal`() {
+        assertEquals("`\"", powershell("\""))
+        assertEquals("C:\\Temp", powershell("C:\\Temp"))
+        assertEquals("`\$HOME", powershell("\$HOME"))
+        assertEquals("a``whoami``b", powershell("a`whoami`b"))
+        assertEquals("deploy!", powershell("deploy!"))
+    }
+
+    @Test
+    fun `both branches pass through text with nothing to escape`() {
+        for (input in listOf("", "hello-world_123", "My Project Dir", "docs/日本語 déjà ✨", "a; b | c")) {
+            assertEquals(input, unix(input))
+            assertEquals(input, powershell(input))
+        }
+    }
+
+    @Test
+    fun `posix ordering - escape characters inserted later are not re-escaped`() {
+        // Backslash is doubled first, so the backslashes added for " and $ stay single.
+        assertEquals("\\\\\\\"", unix("\\\""))
+        assertEquals("\\\\\\\$", unix("\\\$"))
+    }
+
+    @Test
+    fun `powershell ordering - the backtick added for a quote is not doubled`() {
+        // Backtick is doubled first; the backtick that escapes the quote comes after.
+        assertEquals("```\"", powershell("`\""))
+        assertEquals("\\`\"", powershell("\\\""))
+    }
+
+    @Test
+    fun `command substitution is neutralized on both branches`() {
+        assertEquals("\\\$(rm -rf ~)", unix("\$(rm -rf ~)"))
+        assertEquals("`\$(rm -rf ~)", powershell("\$(rm -rf ~)"))
+    }
+
+    @Test
+    fun `a string mixing every metacharacter escapes correctly on both branches`() {
+        val nasty = "a\"b\\c\$d`e!f"
+        assertEquals("a\\\"b\\\\c\\\$d\\`e\\!f", unix(nasty))
+        assertEquals("a`\"b\\c`\$d``e!f", powershell(nasty))
     }
 
     // ==================== buildCommandWithWorkingDirectory ====================

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/ShellUtilsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/run/ShellUtilsTest.kt
@@ -12,9 +12,15 @@ import kotlin.test.assertEquals
  * written per platform: the POSIX branch is verified on Unix runners and the
  * PowerShell branch on Windows runners.
  *
- * Because that leaves each branch covered by only one CI leg, the
- * `escapeForDoubleQuotes(str, isWindows)` section drives the platform explicitly
- * so both branches also run on every host.
+ * Because that leaves each branch covered by only one CI leg, the second half of
+ * this suite drives the platform explicitly through the `forWindows` overloads, so
+ * both branches of [ShellUtils.escapeForDoubleQuotes], [ShellUtils.separatorFor]
+ * and [ShellUtils.buildCommandWithWorkingDirectory] also run on every host. The
+ * host-resolved expectations above stay: they are the only check that
+ * [ShellUtils.isWindows] wires this OS to the right branch in the first place.
+ *
+ * [ShellUtils.chainCommands] has no platform-explicit overload — its only
+ * platform-dependent input is the separator, covered on both branches here.
  */
 class ShellUtilsTest {
     private val win = ShellUtils.isWindows
@@ -121,22 +127,59 @@ class ShellUtilsTest {
         )
     }
 
-    // ============ escapeForDoubleQuotes(str, isWindows): both branches on any host ============
+    // ============ platform-explicit overloads: both branches on any host ============
     //
-    // The tests above can only ever reach the host's own branch. These call the
-    // platform-explicit overload so the POSIX *and* the PowerShell branch are covered
-    // on every runner — dropping the Windows CI leg cannot silently untest a branch.
+    // The tests above can only ever reach the host's own branch. These pass the platform
+    // in, so the POSIX *and* the PowerShell branch are covered on every runner — dropping
+    // the Windows CI leg cannot silently untest a branch.
 
-    private fun unix(str: String): String = ShellUtils.escapeForDoubleQuotes(str, isWindows = false)
+    private fun unix(str: String): String = ShellUtils.escapeForDoubleQuotes(str, forWindows = false)
 
-    private fun powershell(str: String): String = ShellUtils.escapeForDoubleQuotes(str, isWindows = true)
+    private fun powershell(str: String): String = ShellUtils.escapeForDoubleQuotes(str, forWindows = true)
 
     @Test
     fun `single-argument overload delegates to the host branch`() {
         val nasty = "a\"b\\c\$d`e!f"
         assertEquals(
-            ShellUtils.escapeForDoubleQuotes(nasty, isWindows = win),
+            ShellUtils.escapeForDoubleQuotes(nasty, forWindows = win),
             ShellUtils.escapeForDoubleQuotes(nasty),
+        )
+    }
+
+    @Test
+    fun `separatorFor covers both branches and backs the host property`() {
+        assertEquals(" && ", ShellUtils.separatorFor(forWindows = false))
+        assertEquals("; ", ShellUtils.separatorFor(forWindows = true))
+        // commandSeparator is just this function applied to the host platform.
+        assertEquals(ShellUtils.separatorFor(forWindows = win), sep)
+    }
+
+    @Test
+    fun `buildCommandWithWorkingDirectory composes escaping and separator on both branches`() {
+        assertEquals(
+            "cd \"/data/\\\$USER files\" && ls",
+            ShellUtils.buildCommandWithWorkingDirectory("ls", "/data/\$USER files", forWindows = false),
+        )
+        assertEquals(
+            "cd \"C:\\Users\\dev\\My `\$Project\"; ls",
+            ShellUtils.buildCommandWithWorkingDirectory("ls", "C:\\Users\\dev\\My \$Project", forWindows = true),
+        )
+    }
+
+    @Test
+    fun `buildCommandWithWorkingDirectory skips the cd on both branches when there is no directory`() {
+        for (forWindows in listOf(false, true)) {
+            assertEquals("ls", ShellUtils.buildCommandWithWorkingDirectory("ls", null, forWindows))
+            assertEquals("ls", ShellUtils.buildCommandWithWorkingDirectory("ls", "  ", forWindows))
+        }
+    }
+
+    @Test
+    fun `two-argument buildCommandWithWorkingDirectory delegates to the host branch`() {
+        val dir = "/data/\$USER files"
+        assertEquals(
+            ShellUtils.buildCommandWithWorkingDirectory("ls", dir, forWindows = win),
+            ShellUtils.buildCommandWithWorkingDirectory("ls", dir),
         )
     }
 


### PR DESCRIPTION
Two latent items from the #24 review, both already documented by tests in that PR.

## 1. `!!` (ignored) entries were reported as staged

`GitService.parseStatusLine` computed:

```kotlin
val isStaged = indexStatus != null && indexStatus != GitFileStatusType.UNTRACKED
```

`?` and `!` are the two porcelain v1 codes that occupy the index column without ever
describing staged content (`git status --porcelain=v1` emits them only as `??` and `!!`),
but only `UNTRACKED` was carved out — so `parseStatusLine("!! build/")` returned
`isStaged = true`. `IGNORED` is now excluded as well.

Latent in production today because neither `getStatus` nor `getStatusForWindow` passes
`--ignored`, so no `!!` line ever reaches the parser — but the parser is `internal`,
shared by both call sites, and one added flag would have surfaced ignored paths in the
commit dialog's staged list.

**Scope check on sibling codes** (the issue asks for precision here): `?` and `!` are the
only two. Every other modelled code can legitimately be staged, including `U` — an
unmerged path really does hold conflict stages 1/2/3 in the index, and the conflict
codes that put `A`/`D` in the index (`AA`, `DD`) map to `ADDED`/`DELETED` anyway, so
carving out only `UNMERGED` would be incoherent as well as a live UI behavior change.
`UD` is now pinned by a test as still-staged so the boundary is explicit rather than
implied.

### Previously-`@Disabled` test enabled

`GitPorcelainParserTest.ignored file is not staged` was marked
`@Disabled("documents bug: '!!' (ignored) sets isStaged=true …")`. The annotation (and the
now-unused `org.junit.jupiter.api.Disabled` import) is removed and the test passes for
the right reason — `parseStatusChar('!') -> IGNORED` is separately asserted, and the only
production change is the new `IGNORED` exclusion. It was the repo's only `@Disabled` test.

## 2. `escapeForDoubleQuotes` was only ever testable on one branch per host

`ShellUtils.isWindows` is resolved from `os.name` at class-load, so the PowerShell branch
of `escapeForDoubleQuotes` was exercised **only** by the `windows-latest` leg of the
`build-test` matrix. Drop that leg and the branch goes untested with zero failing tests.

Added an `internal fun escapeForDoubleQuotes(str: String, isWindows: Boolean)` overload;
the public `escapeForDoubleQuotes(str)` signature is unchanged and now delegates to it
with the host value, so no caller changes. `ShellUtilsTest` drives both branches
explicitly on every host: quotes, backslashes, `$`, backticks, `!`, `$(…)` command
substitution, pass-through cases, the mixed-metacharacter string, and the escape-ordering
invariants that make the `replace` chains order-dependent (POSIX doubles `\` first;
PowerShell doubles `` ` `` first). One test also asserts the single-argument overload
matches the explicit call for this host's platform.

## Verification

`./gradlew :composeApp:desktopTest --tests 'ai.rever.boss.git.GitPorcelainParserTest' --tests 'ai.rever.boss.run.ShellUtilsTest'` — BUILD SUCCESSFUL on macOS:

| Suite | tests | failures | errors | skipped |
|---|---|---|---|---|
| `GitPorcelainParserTest` | 46 | 0 | 0 | **0** (was 1 skipped) |
| `ShellUtilsTest` | 28 | 0 | 0 | 0 |

`./gradlew :composeApp:detekt :composeApp:ktlintCheck` — BUILD SUCCESSFUL.

Fixes #31
