### PR TITLE
fix(packaging): real macOS floor (12.0), headless-installable .deb, honest bundle metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,16 @@ jobs:
           path: '**/build/reports/detekt/'
           retention-days: 7
 
+      - name: 🧪 buildSrc Tests
+        run: |
+          echo "🧪 Running buildSrc unit tests"
+          # Regular Gradle invocations only *build* buildSrc (its jar), so these tests
+          # never run unless invoked explicitly. They cover the .deb control-file
+          # rewrite (DebControl), whose only other exercise is a Linux release build.
+          ./gradlew -p buildSrc test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: 🔒 Dependency Check
         run: |
           echo "🔒 Checking dependencies"

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -247,7 +247,6 @@ jobs:
           sed -i "s/^app.version.minor=.*/app.version.minor=$MINOR/" version.properties
           sed -i "s/^app.version.patch=.*/app.version.patch=$PATCH/" version.properties
           sed -i "s/^app.version=.*/app.version=$TARGET_VERSION/" version.properties
-          sed -i "s/^app.bundle.version=.*/app.bundle.version=$TARGET_VERSION/" version.properties
           sed -i "s/^app.prerelease.suffix=.*/app.prerelease.suffix=$TARGET_SUFFIX/" version.properties
           sed -i "s/^app.release.channel=.*/app.release.channel=$TARGET_CHANNEL/" version.properties
           echo "✅ Updated version.properties"

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -42,6 +42,10 @@ env:
   SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   SUPABASE_FUNCTION_URL: ${{ secrets.SUPABASE_FUNCTION_URL }}
+  # macOS CFBundleVersion (build identifier). Set here too so lite builds do not fall
+  # back to this workflow's own GITHUB_RUN_NUMBER, which is an independent counter from
+  # release.yml's and could collide with, or sort below, a full-release build.
+  BOSS_BUILD_ID: ${{ github.run_number }}
 
 # Prevent concurrent releases from racing to bump the version in BossConsoleLite
 concurrency:
@@ -111,7 +115,6 @@ jobs:
           sed -i "s/^app.version.minor=.*/app.version.minor=${MINOR}/" version.properties
           sed -i "s/^app.version.patch=.*/app.version.patch=${PATCH}/" version.properties
           sed -i "s/^app.version=.*/app.version=${FULL_VERSION}/" version.properties
-          sed -i "s/^app.bundle.version=.*/app.bundle.version=${FULL_VERSION}/" version.properties
           sed -i "s/^app.prerelease.suffix=.*/app.prerelease.suffix=${PRERELEASE_SUFFIX}/" version.properties
           grep -q "^app.lite.build=" version.properties \
             && sed -i "s/^app.lite.build=.*/app.lite.build=true/" version.properties \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,6 @@ jobs:
               sed -i "s/^app.version.minor=.*/app.version.minor=$TAG_MINOR/" version.properties
               sed -i "s/^app.version.patch=.*/app.version.patch=$TAG_PATCH/" version.properties
               sed -i "s/^app.version=.*/app.version=$TAG_VERSION/" version.properties
-              sed -i "s/^app.bundle.version=.*/app.bundle.version=$TAG_VERSION/" version.properties
               sed -i "s/^app.prerelease.suffix=.*/app.prerelease.suffix=$PRERELEASE_SUFFIX/" version.properties
 
               echo "✅ Updated version.properties to match tag: $TAG_VERSION"
@@ -1552,9 +1551,13 @@ jobs:
           **Ubuntu/Debian:**
           \`\`\`bash
           wget https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/BOSS-${VERSION}-amd64.deb
-          sudo dpkg -i BOSS-${VERSION}-amd64.deb
-          sudo apt-get install -f  # Fix any missing dependencies
+          sudo apt-get install ./BOSS-${VERSION}-amd64.deb  # resolves dependencies + recommends
           \`\`\`
+
+          > \`sudo dpkg -i\` works too and no longer requires \`xdg-utils\` to be present
+          > (headless installs used to fail during dependency resolution). But \`dpkg\`
+          > ignores \`Recommends:\`, so on a desktop without \`xdg-utils\` installed it
+          > skips the menu entry and icon silently — use apt to get them.
 
           **RHEL/Fedora/openSUSE:**
           \`\`\`bash
@@ -1573,9 +1576,13 @@ jobs:
           **Ubuntu/Debian:**
           \`\`\`bash
           wget https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/BOSS-${VERSION}-arm64.deb
-          sudo dpkg -i BOSS-${VERSION}-arm64.deb
-          sudo apt-get install -f  # Fix any missing dependencies
+          sudo apt-get install ./BOSS-${VERSION}-arm64.deb  # resolves dependencies + recommends
           \`\`\`
+
+          > \`sudo dpkg -i\` works too and no longer requires \`xdg-utils\` to be present
+          > (headless installs used to fail during dependency resolution). But \`dpkg\`
+          > ignores \`Recommends:\`, so on a desktop without \`xdg-utils\` installed it
+          > skips the menu entry and icon silently — use apt to get them.
 
           **RHEL/Fedora/openSUSE:**
           \`\`\`bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,12 @@ on:
 
 env:
   GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true'
+  # macOS CFBundleVersion (the *build* identifier, not the marketing version).
+  # run_number only ever increases for this workflow, so a rebuild/re-notarization of
+  # the same app version is still distinguishable, and every platform job of one
+  # release run shares the same build id. See composeApp/build.gradle.kts
+  # (macBundleBuildVersion) for the fallbacks used outside this workflow.
+  BOSS_BUILD_ID: ${{ github.run_number }}
   # Production credentials for release builds
   JXBROWSER_LICENSE_KEY: ${{ secrets.JXBROWSER_LICENSE_KEY }}
   SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
@@ -1517,7 +1523,8 @@ jobs:
 
           ## 🔧 System Requirements
 
-          - **macOS**: macOS 11.0+ (Big Sur)
+          - **macOS**: macOS 12.0+ (Monterey) — matches the bundle's LSMinimumSystemVersion
+            and the browser engine's own 12.0 floor
           - **Windows**: Windows 10+ (64-bit)
           - **Linux**: Any modern distribution (AMD64 or ARM64)
 

--- a/JAR_README.md
+++ b/JAR_README.md
@@ -51,7 +51,8 @@ The distribution package includes launch scripts:
 
 - Java 17 or higher
 - At least 2GB RAM (4GB recommended)
-- macOS 10.15+, Windows 10+, or Linux
+- macOS 12+ (Monterey — the bundled browser engine is built with a 12.0 minimum),
+  Windows 10+, or Linux
 
 ## Known Limitations
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,3 +5,13 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+dependencies {
+    // DebControlTest — the .deb control rewrite is only exercised for real on a Linux
+    // runner, so its string transform is unit-tested here instead.
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/buildSrc/src/main/kotlin/DebControl.kt
+++ b/buildSrc/src/main/kotlin/DebControl.kt
@@ -1,0 +1,117 @@
+/**
+ * Pure transforms on a Debian `control` file.
+ *
+ * Lives in `buildSrc` rather than inline in `composeApp/build.gradle.kts` so it can be
+ * unit-tested (see `DebControlTest`) without a Linux runner or a real
+ * `dpkg-deb -R` / `--build` round trip. It is called from the `fixLinuxDesktopFile`
+ * task, which post-processes the generated `.deb`.
+ */
+object DebControl {
+    /** A field starts at column 0 with `Name:`; continuation lines start with space/tab. */
+    private val FIELD_START = Regex("^([A-Za-z0-9][A-Za-z0-9-]*):(.*)$")
+
+    /**
+     * Leading package name of a dependency entry. Deliberately excludes `:` so an arch
+     * qualifier (`xdg-utils:amd64`) still resolves to the package name.
+     */
+    private val PACKAGE_NAME = Regex("^[A-Za-z0-9][A-Za-z0-9+.-]*")
+
+    private const val XDG_UTILS = "xdg-utils"
+
+    private class Field(
+        val name: String,
+        val lines: MutableList<String>,
+    )
+
+    /**
+     * Moves `xdg-utils` out of the `.deb`'s `Depends:` field and into `Recommends:`.
+     *
+     * jpackage puts `xdg-utils` in `Depends:` because its `postinst` calls
+     * `xdg-desktop-menu` / `xdg-icon-resource`. On a headless image that makes
+     * `dpkg -i` fail during dependency resolution — before `postinst` (and the
+     * best-effort guard applied to it) ever runs. Desktop integration is optional, so
+     * the dependency belongs under `Recommends:`, which apt still installs by default.
+     *
+     * Behavior:
+     *  * `Depends:` is dropped entirely when `xdg-utils` was its only entry.
+     *  * An existing `Recommends:` is extended rather than replaced.
+     *  * An entry is only removed when *all* of its alternatives are `xdg-utils`, so
+     *    `xdg-utils | something-else` is left alone.
+     *  * Field folding is honored: the field name is stripped from the first line only,
+     *    so colons inside the value (epoch versions like `(>= 7:4.4)`, arch qualifiers
+     *    like `libc6:amd64`) survive on continuation lines. Rewritten fields are emitted
+     *    unfolded; every other field is copied through verbatim.
+     *  * Text before the first field (comments/blank lines — not produced by jpackage)
+     *    is dropped, which is why callers should only feed it generated control files.
+     *
+     * @return the rewritten control text, or null when there is nothing to change
+     *   (which makes the caller idempotent across repacks).
+     */
+    fun softenXdgUtilsDependency(controlText: String): String? {
+        val fields = parseFields(controlText)
+        val dependsIndex = fields.indexOfFirst { it.name.equals("Depends", ignoreCase = true) }
+        val entries =
+            if (dependsIndex < 0) {
+                emptyList()
+            } else {
+                splitEntries(fieldValue(fields[dependsIndex].lines))
+            }
+        if (entries.none(::isXdgUtils)) return null
+
+        val kept = entries.filterNot(::isXdgUtils)
+        if (kept.isEmpty()) {
+            fields.removeAt(dependsIndex)
+        } else {
+            val name = fields[dependsIndex].name
+            fields[dependsIndex] = Field(name, mutableListOf("$name: ${kept.joinToString(", ")}"))
+        }
+
+        val recommendsIndex = fields.indexOfFirst { it.name.equals("Recommends", ignoreCase = true) }
+        if (recommendsIndex < 0) {
+            // Put it where Depends was, so the field order still reads naturally.
+            val insertAt = if (kept.isEmpty()) dependsIndex else dependsIndex + 1
+            fields.add(insertAt, Field("Recommends", mutableListOf("Recommends: $XDG_UTILS")))
+        } else {
+            val name = fields[recommendsIndex].name
+            val existing = splitEntries(fieldValue(fields[recommendsIndex].lines))
+            if (existing.none(::isXdgUtils)) {
+                fields[recommendsIndex] = Field(name, mutableListOf("$name: ${(existing + XDG_UTILS).joinToString(", ")}"))
+            }
+        }
+
+        return fields.flatMap { it.lines }.joinToString("\n").trimEnd('\n') + "\n"
+    }
+
+    /** Groups the file into fields, keeping each field's original lines. */
+    private fun parseFields(controlText: String): MutableList<Field> {
+        val fields = mutableListOf<Field>()
+        controlText.lines().forEach { line ->
+            val match = FIELD_START.find(line)
+            when {
+                match != null -> fields += Field(match.groupValues[1], mutableListOf(line))
+                fields.isNotEmpty() -> fields.last().lines += line
+                else -> Unit // Preamble before the first field; jpackage does not emit any.
+            }
+        }
+        return fields
+    }
+
+    /**
+     * Value of a (possibly folded) field. Only the first line carries the `Name:`
+     * prefix — stripping a colon from continuation lines would eat epoch versions and
+     * arch qualifiers.
+     */
+    private fun fieldValue(lines: List<String>): String =
+        lines
+            .mapIndexed { index, line -> if (index == 0) line.substringAfter(':') else line }
+            .joinToString(" ") { it.trim() }
+            .trim()
+
+    private fun splitEntries(value: String): List<String> = value.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+
+    /** True when every alternative of a dependency entry names xdg-utils. */
+    private fun isXdgUtils(entry: String): Boolean =
+        entry.split("|").all { alternative ->
+            PACKAGE_NAME.find(alternative.trim())?.value == XDG_UTILS
+        }
+}

--- a/buildSrc/src/main/kotlin/VersionTasks.kt
+++ b/buildSrc/src/main/kotlin/VersionTasks.kt
@@ -149,7 +149,6 @@ abstract class ShowVersionTask : VersionPropertyReadTask() {
         val prerelease = props["app.prerelease.suffix"]?.toString()?.takeIf { it.isNotBlank() }
         val baseVersion = "$major.$minor.$patch"
         val av = if (prerelease != null) "$baseVersion-$prerelease" else baseVersion
-        val bv = props["app.bundle.version"]
         val bn = props["app.build.number"]
         val channel = props["app.release.channel"] ?: "stable"
         val jn = "BOSS-$av-all.jar"
@@ -172,7 +171,6 @@ abstract class ShowVersionTask : VersionPropertyReadTask() {
 ║           BOSS Version Info            ║
 ╠════════════════════════════════════════╣
 ║ Application Version: $av
-║ Bundle Version:      $bv
 ║ Build Number:        $bn             $prereleaseInfo
 ║ JAR Name:            $jn
 ║ DMG Name:            $dn
@@ -209,7 +207,6 @@ abstract class IncrementVersionTask : VersionPropertyWriteTask() {
         // Update patch version and reset build number
         props["app.version.patch"] = newPatch.toString()
         props["app.version"] = "${props["app.version.major"]}.${props["app.version.minor"]}.$newPatch"
-        props["app.bundle.version"] = props["app.version"]
         props["app.build.date"] = SimpleDateFormat("yyyy-MM-dd").format(Date())
         props["app.build.number"] = "1"
 
@@ -236,7 +233,6 @@ abstract class IncrementMinorTask : VersionPropertyWriteTask() {
         props["app.version.minor"] = newMinor.toString()
         props["app.version.patch"] = "0"
         props["app.version"] = "${props["app.version.major"]}.$newMinor.0"
-        props["app.bundle.version"] = props["app.version"]
         props["app.build.date"] = SimpleDateFormat("yyyy-MM-dd").format(Date())
         props["app.build.number"] = "1"
 
@@ -264,7 +260,6 @@ abstract class IncrementMajorTask : VersionPropertyWriteTask() {
         props["app.version.minor"] = "0"
         props["app.version.patch"] = "0"
         props["app.version"] = "$newMajor.0.0"
-        props["app.bundle.version"] = props["app.version"]
         props["app.build.date"] = SimpleDateFormat("yyyy-MM-dd").format(Date())
         props["app.build.number"] = "1"
 
@@ -321,7 +316,7 @@ abstract class AutoIncrementBuildNumberTask : VersionPropertyWriteTask() {
 
 /**
  * Set prerelease suffix (e.g., alpha.1, beta.2, rc.1)
- * Updates app.version, app.bundle.version, and app.release.channel accordingly
+ * Updates app.version and app.release.channel accordingly
  */
 abstract class SetPrereleaseSuffixTask : VersionPropertyWriteTask() {
     @get:Input
@@ -359,7 +354,6 @@ abstract class SetPrereleaseSuffixTask : VersionPropertyWriteTask() {
         // Update properties
         props["app.prerelease.suffix"] = suffixValue
         props["app.version"] = fullVersion
-        props["app.bundle.version"] = fullVersion
         props["app.release.channel"] = channel
         props["app.build.date"] = SimpleDateFormat("yyyy-MM-dd").format(Date())
 
@@ -373,7 +367,7 @@ abstract class SetPrereleaseSuffixTask : VersionPropertyWriteTask() {
 
 /**
  * Clear prerelease suffix (promotes to stable release)
- * Resets app.version, app.bundle.version, and app.release.channel to stable
+ * Resets app.version and app.release.channel to stable
  */
 abstract class ClearPrereleaseSuffixTask : VersionPropertyWriteTask() {
     @TaskAction
@@ -395,7 +389,6 @@ abstract class ClearPrereleaseSuffixTask : VersionPropertyWriteTask() {
         // Update properties
         props["app.prerelease.suffix"] = ""
         props["app.version"] = stableVersion
-        props["app.bundle.version"] = stableVersion
         props["app.release.channel"] = "stable"
         props["app.build.date"] = SimpleDateFormat("yyyy-MM-dd").format(Date())
 
@@ -442,7 +435,6 @@ abstract class IncrementPrereleaseTask : VersionPropertyWriteTask() {
         // Update properties
         props["app.prerelease.suffix"] = newSuffix
         props["app.version"] = fullVersion
-        props["app.bundle.version"] = fullVersion
         props["app.build.date"] = SimpleDateFormat("yyyy-MM-dd").format(Date())
 
         saveProperties(props, "Incremented prerelease number")

--- a/buildSrc/src/test/kotlin/DebControlTest.kt
+++ b/buildSrc/src/test/kotlin/DebControlTest.kt
@@ -1,0 +1,161 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests for the `.deb` control-file rewrite applied by the `fixLinuxDesktopFile` task.
+ *
+ * The `dpkg-deb` round trip only happens on a Linux runner, so this is where the string
+ * transform itself is verified — including the folded-field cases that are easy to get
+ * wrong and impossible to notice until a Linux release build fails.
+ */
+class DebControlTest {
+    private fun soften(control: String) = DebControl.softenXdgUtilsDependency(control)
+
+    @Test
+    fun `moves xdg-utils out of a jpackage-shaped control file`() {
+        val control =
+            """
+            Package: boss
+            Version: 9.2.60-1
+            Section: utility
+            Maintainer: support@risalabs.ai
+            Priority: optional
+            Architecture: arm64
+            Provides: boss
+            Depends: xdg-utils, libc6 (>= 2.17), libgcc-s1
+            Description: BOSS
+             Business Operating System Service
+            """.trimIndent() + "\n"
+
+        assertEquals(
+            """
+            Package: boss
+            Version: 9.2.60-1
+            Section: utility
+            Maintainer: support@risalabs.ai
+            Priority: optional
+            Architecture: arm64
+            Provides: boss
+            Depends: libc6 (>= 2.17), libgcc-s1
+            Recommends: xdg-utils
+            Description: BOSS
+             Business Operating System Service
+            """.trimIndent() + "\n",
+            soften(control),
+        )
+    }
+
+    @Test
+    fun `drops the Depends field when xdg-utils was its only entry`() {
+        assertEquals(
+            "Package: boss\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: xdg-utils\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `extends an existing Recommends field instead of replacing it`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6\nRecommends: libnotify4, xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: xdg-utils, libc6\nRecommends: libnotify4\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `handles a folded Depends field`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6 (>= 2.17), libgcc-s1\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: xdg-utils,\n libc6 (>= 2.17),\n libgcc-s1\nDescription: BOSS\n"),
+        )
+    }
+
+    /**
+     * Regression: the field name must be stripped from the first line only. Debian
+     * dependency values legitimately contain colons — epoch versions — and treating
+     * every continuation line as `name: value` silently dropped the dependency in
+     * front of the colon and left an invalid `4.4)` entry behind.
+     */
+    @Test
+    fun `keeps epoch versions on continuation lines intact`() {
+        assertEquals(
+            "Package: boss\nDepends: libasound2, libavcodec58 (>= 7:4.4)\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: libasound2,\n libavcodec58 (>= 7:4.4), xdg-utils\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `keeps arch qualifiers on continuation lines intact`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6:amd64, zlib1g (>= 1:1.1.4)\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: libc6:amd64,\n zlib1g (>= 1:1.1.4),\n xdg-utils\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `reads a folded Recommends field without corrupting it`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6\nRecommends: libnotify4 (>= 1:0.7), libglib2.0-0, xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: xdg-utils, libc6\nRecommends: libnotify4 (>= 1:0.7),\n libglib2.0-0\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `recognizes a versioned xdg-utils entry`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: libc6, xdg-utils (>= 1.1.3)\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `recognizes an arch-qualified xdg-utils entry`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: libc6, xdg-utils:amd64\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `leaves alternatives that offer a non-xdg-utils option alone`() {
+        assertNull(soften("Package: boss\nDepends: xdg-utils | libgtk-3-0, libc6\nDescription: BOSS\n"))
+    }
+
+    @Test
+    fun `returns null when there is no xdg-utils dependency`() {
+        assertNull(soften("Package: boss\nDepends: libc6\nDescription: BOSS\n"))
+    }
+
+    @Test
+    fun `returns null when there is no Depends field at all`() {
+        assertNull(soften("Package: boss\nDescription: BOSS\n"))
+    }
+
+    @Test
+    fun `is idempotent - a second pass finds nothing to do`() {
+        val once = soften("Package: boss\nDepends: xdg-utils, libc6\nDescription: BOSS\n")
+        assertNull(once?.let { soften(it) })
+    }
+
+    @Test
+    fun `does not add xdg-utils to Recommends twice`() {
+        assertEquals(
+            "Package: boss\nDepends: libc6\nRecommends: xdg-utils\nDescription: BOSS\n",
+            soften("Package: boss\nDepends: xdg-utils, libc6\nRecommends: xdg-utils\nDescription: BOSS\n"),
+        )
+    }
+
+    @Test
+    fun `leaves every other field byte-for-byte alone`() {
+        val rewritten =
+            soften(
+                "Package: boss\nDepends: xdg-utils, libc6\nDescription: BOSS\n" +
+                    " A long description\n .\n with a continuation and a colon: here\n",
+            )
+        assertEquals(
+            "Package: boss\nDepends: libc6\nRecommends: xdg-utils\nDescription: BOSS\n" +
+                " A long description\n .\n with a continuation and a colon: here\n",
+            rewritten,
+        )
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -78,11 +78,45 @@ val versionPropsProvider =
         parameters.propertiesFile.set(versionPropsFile)
     }
 val appVersion = versionPropsProvider.map { it.getProperty("app.version", "8.8.0") }.get()
-val bundleVersion = versionPropsProvider.map { it.getProperty("app.bundle.version", "8.8.0") }.get()
 // Base version (without prerelease suffix) for native package formats that don't support semver prereleases
 val baseVersion = appVersion.substringBefore("-")
 
+// CFBundleVersion is macOS's *build* identifier, not the marketing version
+// (CFBundleShortVersionString) — it has to change for every shipped build of a
+// given version, otherwise a re-notarized rebuild of 9.2.60 is indistinguishable
+// from the first 9.2.60 and anything keyed on it cannot tell the two apart.
+// Compose validates it as at most three non-negative integers, so "9.2.60.<n>" is
+// not expressible; we use Apple's usual convention of a plain monotonic counter:
+//   * CI release builds — BOSS_BUILD_ID, which release.yml sets to github.run_number
+//     (monotonic per workflow, and shared by every platform job of one release run).
+//   * any other CI build — GITHUB_RUN_NUMBER, so at least it is not a constant.
+//   * local builds — app.build.number from version.properties. Deliberately a
+//     *stable* value so packaging tasks stay up-to-date between local runs; a
+//     timestamp here would re-sign the whole app image on every build.
+// The value is intentionally NOT derived from app.version: it is a build counter,
+// and Finder shows it as "Version 9.2.60 (641)". `app.bundle.version` (which used to
+// feed CFBundleVersion and always equalled app.version) is no longer read here; it
+// survives in version.properties as display-only metadata for ./gradlew showVersion.
+val macBundleBuildVersion: String =
+    (System.getenv("BOSS_BUILD_ID") ?: System.getenv("GITHUB_RUN_NUMBER"))
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() && it.all(Char::isDigit) }
+        ?: versionPropsProvider.map { it.getProperty("app.build.number", "1") }.get()
+
+// jpackage (and therefore Compose) derives CFBundleShortVersionString from
+// packageVersion, which must be a plain MAJOR.MINOR.PATCH — so a prerelease build
+// would show "9.2.60" in Finder instead of "9.2.60-beta.1". Re-declare the key
+// (the last declaration in a plist dict wins) only when a suffix is actually
+// present, so stable builds carry exactly one CFBundleShortVersionString.
+val macPrereleaseShortVersionKey: String =
+    if (appVersion != baseVersion) {
+        "<key>CFBundleShortVersionString</key><string>$appVersion</string>"
+    } else {
+        ""
+    }
+
 println("📦 Building BOSS Version: $appVersion")
+println("🔢 macOS CFBundleVersion (build id): $macBundleBuildVersion")
 
 // Path to libs.versions.toml for reading JxBrowser version (single source of truth)
 val libsVersionsFile = layout.projectDirectory.file("../gradle/libs.versions.toml")
@@ -971,6 +1005,27 @@ compose.desktop {
                 dmgPackageVersion = baseVersion
                 dmgPackageBuildVersion = "1"
 
+                // Real platform floor, not the app's own floor: the browser-engine
+                // bundle BOSS downloads (~/.boss/boss-chromium/BOSS.app) declares
+                // LSMinimumSystemVersion 12.0 and its framework is built with
+                // LC_BUILD_VERSION minos 12.0. On 10.15/11 the app installed and
+                // launched fine and then died in dyld the first time an engine
+                // loaded — a broken browser tab instead of "unsupported OS".
+                // Declaring 12.0 here makes the installer refuse the install
+                // instead. Keep in lockstep with chromium-branding / the engine
+                // bundle's own LSMinimumSystemVersion.
+                minimumSystemVersion = "12.0"
+
+                // Was jpackage's placeholder "Unknown" (Compose's default when this
+                // is unset), which leaves Launchpad/Finder categorization empty.
+                // BOSS is a terminal + editor + console for developers.
+                appCategory = "public.app-category.developer-tools"
+
+                // CFBundleVersion — see macBundleBuildVersion above. Set through the
+                // DSL (not infoPlist.extraKeysRawXml) so exactly one CFBundleVersion
+                // key ends up in Info.plist.
+                packageBuildVersion = macBundleBuildVersion
+
                 // Note: bundleJRE is not a valid property in current Compose Desktop
                 // The JVM is automatically bundled when creating native distributions
                 // Use includeAllModules = true above to ensure all JVM modules are included
@@ -993,20 +1048,18 @@ compose.desktop {
                 // Entitlements
                 entitlementsFile.set(project.file("src/desktopMain/resources/BOSS.entitlements"))
 
-                // DMG customization
+                // Extra Info.plist keys.
+                //
+                // Only keys Compose does NOT already emit belong here: LSMinimumSystemVersion,
+                // LSApplicationCategoryType, CFBundleShortVersionString, CFBundleVersion,
+                // NSHighResolutionCapable and NSSupportsAutomaticGraphicsSwitching are all
+                // written by the Compose plugin from the DSL settings above. Declaring them
+                // again produced a plist with duplicate keys that only worked because the
+                // last declaration wins — the single-source DSL settings replace that.
                 infoPlist {
                     extraKeysRawXml =
                         """
-                        <key>LSMinimumSystemVersion</key>
-                        <string>10.15</string>
-                        <key>CFBundleShortVersionString</key>
-                        <string>$appVersion</string>
-                        <key>CFBundleVersion</key>
-                        <string>$bundleVersion</string>
-                        <key>NSHighResolutionCapable</key>
-                        <true/>
-                        <key>NSSupportsAutomaticGraphicsSwitching</key>
-                        <true/>
+                        $macPrereleaseShortVersionKey
                         <key>NSCameraUsageDescription</key>
                         <string>BOSS needs access to your camera for video conferencing and screen sharing.</string>
                         <key>NSMicrophoneUsageDescription</key>
@@ -1528,6 +1581,22 @@ abstract class FixLinuxDesktopFileTask : DefaultTask() {
                 }
             }
 
+            // Soften the generated dependency on xdg-utils.
+            //
+            // jpackage lists xdg-utils in the .deb's `Depends:` field (its postinst
+            // uses xdg-desktop-menu / xdg-icon-resource), so on a headless image
+            // without that package `dpkg -i` fails during dependency resolution —
+            // before postinst exists to be guarded, which is why the postinst fix
+            // above only closed half of the headless problem. Desktop integration is
+            // best-effort here, so xdg-utils belongs under `Recommends:`: apt still
+            // pulls it in by default on desktop systems, while a headless install no
+            // longer hard-fails.
+            val controlFile = File(workDir, "DEBIAN/control")
+            if (controlFile.isFile && softenXdgUtilsDependency(controlFile)) {
+                println("✅ Moved xdg-utils from Depends to Recommends in DEBIAN/control (headless installs)")
+                modified = true
+            }
+
             if (modified) {
                 // Repack deb using dpkg-deb --build
                 execOps.exec {
@@ -1541,6 +1610,79 @@ abstract class FixLinuxDesktopFileTask : DefaultTask() {
         } finally {
             workDir.deleteRecursively()
         }
+    }
+
+    /**
+     * Moves `xdg-utils` out of the .deb's `Depends:` field and into `Recommends:`.
+     * Returns true when the control file was rewritten (false when there is nothing
+     * to do, which keeps the whole task idempotent across repacks).
+     *
+     * Debian field folding (continuation lines start with a space or tab) is honored
+     * for the two fields this touches; every other field is copied through verbatim.
+     * An entry is only dropped when *all* of its alternatives are xdg-utils, so a
+     * hypothetical `xdg-utils | something-else` is left alone. Assumes the file opens
+     * with a field rather than a comment/blank line, which is true of jpackage output.
+     */
+    private fun softenXdgUtilsDependency(controlFile: File): Boolean {
+        val fieldStart = Regex("^([A-Za-z0-9][A-Za-z0-9-]*):(.*)$")
+        val packageName = Regex("^[A-Za-z0-9][A-Za-z0-9+.-]*")
+
+        // Group the file into fields, keeping each field's original lines so
+        // untouched fields survive byte-for-byte.
+        val fields = mutableListOf<Pair<String, MutableList<String>>>()
+        controlFile.readLines().forEach { line ->
+            val match = fieldStart.find(line)
+            if (match != null) {
+                fields += match.groupValues[1] to mutableListOf(line)
+            } else if (fields.isNotEmpty()) {
+                // Continuation of the previous field (or a trailing blank line).
+                fields.last().second += line
+            }
+        }
+
+        val dependsIndex = fields.indexOfFirst { it.first.equals("Depends", ignoreCase = true) }
+        if (dependsIndex < 0) return false
+
+        val dependsField = fields[dependsIndex]
+        val dependsValue =
+            dependsField.second
+                .joinToString(" ") { it.substringAfter(':', it).trim() }
+                .trim()
+        val entries = dependsValue.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        val isXdgUtils = { entry: String ->
+            entry.split("|").all { packageName.find(it.trim())?.value == "xdg-utils" }
+        }
+        if (entries.none(isXdgUtils)) return false
+
+        val kept = entries.filterNot(isXdgUtils)
+        if (kept.isEmpty()) {
+            fields.removeAt(dependsIndex)
+        } else {
+            fields[dependsIndex] = dependsField.first to mutableListOf("${dependsField.first}: ${kept.joinToString(", ")}")
+        }
+
+        val recommendsIndex = fields.indexOfFirst { it.first.equals("Recommends", ignoreCase = true) }
+        if (recommendsIndex < 0) {
+            // Put it where Depends was, so the field order still reads naturally.
+            val insertAt = if (kept.isEmpty()) dependsIndex else dependsIndex + 1
+            fields.add(insertAt, "Recommends" to mutableListOf("Recommends: xdg-utils"))
+        } else {
+            val recommendsField = fields[recommendsIndex]
+            val existing =
+                recommendsField.second
+                    .joinToString(" ") { it.substringAfter(':', it).trim() }
+                    .trim()
+                    .split(",")
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+            if (existing.none(isXdgUtils)) {
+                fields[recommendsIndex] =
+                    recommendsField.first to mutableListOf("${recommendsField.first}: ${(existing + "xdg-utils").joinToString(", ")}")
+            }
+        }
+
+        controlFile.writeText(fields.flatMap { it.second }.joinToString("\n").trimEnd('\n') + "\n")
+        return true
     }
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -93,10 +93,10 @@ val baseVersion = appVersion.substringBefore("-")
 //   * local builds — app.build.number from version.properties. Deliberately a
 //     *stable* value so packaging tasks stay up-to-date between local runs; a
 //     timestamp here would re-sign the whole app image on every build.
-// The value is intentionally NOT derived from app.version: it is a build counter,
-// and Finder shows it as "Version 9.2.60 (641)". `app.bundle.version` (which used to
-// feed CFBundleVersion and always equalled app.version) is no longer read here; it
-// survives in version.properties as display-only metadata for ./gradlew showVersion.
+// The value is intentionally NOT derived from app.version: it is a build counter, and
+// Finder shows it as "Version 9.2.60 (641)". `app.bundle.version` used to feed
+// CFBundleVersion while always equalling app.version, so it has been deleted outright
+// along with its writers (version tasks, release/release-lite/promote-release).
 val macBundleBuildVersion: String =
     (System.getenv("BOSS_BUILD_ID") ?: System.getenv("GITHUB_RUN_NUMBER"))
         ?.trim()
@@ -1003,7 +1003,13 @@ compose.desktop {
                 packageName = "BOSS"
                 // Use base version (without prerelease suffix) for DMG - doesn't support semver prereleases
                 dmgPackageVersion = baseVersion
-                dmgPackageBuildVersion = "1"
+                // Same build id as the app bundle. It was hardcoded "1", which is inert
+                // today (packageDmg runs against --app-image, so CFBundleVersion comes
+                // from createDistributable's generic packageBuildVersion) — but that is
+                // exactly the "correct by accident of plugin internals" the rest of this
+                // block removes: if the DMG task ever rewrote the plist, the shipped
+                // CFBundleVersion would silently revert to 1.
+                dmgPackageBuildVersion = macBundleBuildVersion
 
                 // Real platform floor, not the app's own floor: the browser-engine
                 // bundle BOSS downloads (~/.boss/boss-chromium/BOSS.app) declares
@@ -1590,11 +1596,19 @@ abstract class FixLinuxDesktopFileTask : DefaultTask() {
             // above only closed half of the headless problem. Desktop integration is
             // best-effort here, so xdg-utils belongs under `Recommends:`: apt still
             // pulls it in by default on desktop systems, while a headless install no
-            // longer hard-fails.
+            // longer hard-fails. Note `dpkg -i` does NOT honor Recommends, so a
+            // desktop install done that way silently skips menu/icon registration
+            // instead of failing — install with apt to get the recommends.
+            //
+            // The transform itself lives in buildSrc (DebControl) so it can be
+            // unit-tested without a Linux runner; see DebControlTest.
             val controlFile = File(workDir, "DEBIAN/control")
-            if (controlFile.isFile && softenXdgUtilsDependency(controlFile)) {
-                println("✅ Moved xdg-utils from Depends to Recommends in DEBIAN/control (headless installs)")
-                modified = true
+            if (controlFile.isFile) {
+                DebControl.softenXdgUtilsDependency(controlFile.readText())?.let { rewritten ->
+                    controlFile.writeText(rewritten)
+                    println("✅ Moved xdg-utils from Depends to Recommends in DEBIAN/control (headless installs)")
+                    modified = true
+                }
             }
 
             if (modified) {
@@ -1610,79 +1624,6 @@ abstract class FixLinuxDesktopFileTask : DefaultTask() {
         } finally {
             workDir.deleteRecursively()
         }
-    }
-
-    /**
-     * Moves `xdg-utils` out of the .deb's `Depends:` field and into `Recommends:`.
-     * Returns true when the control file was rewritten (false when there is nothing
-     * to do, which keeps the whole task idempotent across repacks).
-     *
-     * Debian field folding (continuation lines start with a space or tab) is honored
-     * for the two fields this touches; every other field is copied through verbatim.
-     * An entry is only dropped when *all* of its alternatives are xdg-utils, so a
-     * hypothetical `xdg-utils | something-else` is left alone. Assumes the file opens
-     * with a field rather than a comment/blank line, which is true of jpackage output.
-     */
-    private fun softenXdgUtilsDependency(controlFile: File): Boolean {
-        val fieldStart = Regex("^([A-Za-z0-9][A-Za-z0-9-]*):(.*)$")
-        val packageName = Regex("^[A-Za-z0-9][A-Za-z0-9+.-]*")
-
-        // Group the file into fields, keeping each field's original lines so
-        // untouched fields survive byte-for-byte.
-        val fields = mutableListOf<Pair<String, MutableList<String>>>()
-        controlFile.readLines().forEach { line ->
-            val match = fieldStart.find(line)
-            if (match != null) {
-                fields += match.groupValues[1] to mutableListOf(line)
-            } else if (fields.isNotEmpty()) {
-                // Continuation of the previous field (or a trailing blank line).
-                fields.last().second += line
-            }
-        }
-
-        val dependsIndex = fields.indexOfFirst { it.first.equals("Depends", ignoreCase = true) }
-        if (dependsIndex < 0) return false
-
-        val dependsField = fields[dependsIndex]
-        val dependsValue =
-            dependsField.second
-                .joinToString(" ") { it.substringAfter(':', it).trim() }
-                .trim()
-        val entries = dependsValue.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-        val isXdgUtils = { entry: String ->
-            entry.split("|").all { packageName.find(it.trim())?.value == "xdg-utils" }
-        }
-        if (entries.none(isXdgUtils)) return false
-
-        val kept = entries.filterNot(isXdgUtils)
-        if (kept.isEmpty()) {
-            fields.removeAt(dependsIndex)
-        } else {
-            fields[dependsIndex] = dependsField.first to mutableListOf("${dependsField.first}: ${kept.joinToString(", ")}")
-        }
-
-        val recommendsIndex = fields.indexOfFirst { it.first.equals("Recommends", ignoreCase = true) }
-        if (recommendsIndex < 0) {
-            // Put it where Depends was, so the field order still reads naturally.
-            val insertAt = if (kept.isEmpty()) dependsIndex else dependsIndex + 1
-            fields.add(insertAt, "Recommends" to mutableListOf("Recommends: xdg-utils"))
-        } else {
-            val recommendsField = fields[recommendsIndex]
-            val existing =
-                recommendsField.second
-                    .joinToString(" ") { it.substringAfter(':', it).trim() }
-                    .trim()
-                    .split(",")
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() }
-            if (existing.none(isXdgUtils)) {
-                fields[recommendsIndex] =
-                    recommendsField.first to mutableListOf("${recommendsField.first}: ${(existing + "xdg-utils").joinToString(", ")}")
-            }
-        }
-
-        controlFile.writeText(fields.flatMap { it.second }.joinToString("\n").trimEnd('\n') + "\n")
-        return true
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -13,6 +13,7 @@ import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.services.passkey.PasskeyPlatformInit
 import ai.rever.boss.utils.DeepLinkHandler
 import ai.rever.boss.utils.SingleInstanceManager
+import ai.rever.boss.utils.WindowsProtocolHandler
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.window.AWTKeyboardInterceptor
@@ -73,6 +74,18 @@ fun main(args: Array<String>) {
     // Initialize logging framework early
     BossLogger.configureFromEnvironment()
     BossLogger.initialize() // Register shutdown hook for log flushing
+
+    // Uninstall hook (Windows): `BOSS.exe --unregister-protocol` removes the boss://
+    // handler that WindowsProtocolHandler registers at runtime, so uninstalling does
+    // not leave a registry handler pointing at a deleted executable. Handled before
+    // any app/single-instance initialization so it stays callable from an installer
+    // action or by hand. Exits non-zero when the handler was left in place (it
+    // belongs to another live install) so a caller can tell the cases apart.
+    if (args.contains("--unregister-protocol")) {
+        val removed = WindowsProtocolHandler.unregisterProtocol()
+        logger.info(LogCategory.SYSTEM, "boss:// protocol cleanup requested", mapOf("removed" to removed))
+        exitProcess(if (removed) 0 else 1)
+    }
 
     // Install crash handler after logger is ready
     ai.rever.boss.crash.CrashHandler

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -76,15 +76,12 @@ fun main(args: Array<String>) {
     BossLogger.initialize() // Register shutdown hook for log flushing
 
     // Uninstall hook (Windows): `BOSS.exe --unregister-protocol` removes the boss://
-    // handler that WindowsProtocolHandler registers at runtime, so uninstalling does
-    // not leave a registry handler pointing at a deleted executable. Handled before
-    // any app/single-instance initialization so it stays callable from an installer
-    // action or by hand. Exits non-zero when the handler was left in place (it
-    // belongs to another live install) so a caller can tell the cases apart.
+    // handler that WindowsProtocolHandler registers at runtime, so uninstalling does not
+    // leave a registry handler pointing at a deleted executable. Handled before any
+    // app/single-instance initialization so it stays callable from an installer action.
+    // Exit codes are documented on unregisterProtocolExitCode().
     if (args.contains("--unregister-protocol")) {
-        val removed = WindowsProtocolHandler.unregisterProtocol()
-        logger.info(LogCategory.SYSTEM, "boss:// protocol cleanup requested", mapOf("removed" to removed))
-        exitProcess(if (removed) 0 else 1)
+        exitProcess(WindowsProtocolHandler.unregisterProtocolExitCode())
     }
 
     // Install crash handler after logger is ready

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
@@ -3,22 +3,49 @@ package ai.rever.boss.utils
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
+import java.io.IOException
+
+private val logger = BossLogger.forComponent("WindowsProtocolHandler")
+private val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+
+/** Root of the per-user protocol registration this file owns. */
+private const val PROTOCOL_KEY = """HKEY_CURRENT_USER\Software\Classes\boss"""
 
 /**
  * Windows-specific protocol handler for registering URL schemes.
  *
  * Registration happens at runtime rather than in the MSI (see
  * [docs/WINDOWS_DEEP_LINK_SETUP.md]), which means an uninstall leaves the `boss:`
- * handler in the registry pointing at a deleted executable. [unregisterProtocol]
- * is the cleanup hook for that — reachable as `BOSS.exe --unregister-protocol`
- * so an uninstall action (or support instructions) can call it.
+ * handler in the registry pointing at a deleted executable. [unregisterProtocol] is the
+ * cleanup hook for that — reachable as `BOSS.exe --unregister-protocol` (see
+ * [unregisterProtocolExitCode]) so an uninstall action, or support instructions, can
+ * call it.
  */
 object WindowsProtocolHandler {
-    private val logger = BossLogger.forComponent("WindowsProtocolHandler")
-    private val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+    /**
+     * Outcome of [unregisterProtocol]. Distinguishes "there is nothing left to clean"
+     * from "I deliberately did not touch it" — deleting a registration we merely could
+     * not parse would break a working install.
+     */
+    enum class UnregisterOutcome {
+        /** The registration was ours (or pointed at a deleted exe) and was removed. */
+        REMOVED,
 
-    /** Root of the per-user protocol registration this class owns. */
-    private const val PROTOCOL_KEY = """HKEY_CURRENT_USER\Software\Classes\boss"""
+        /** Nothing was registered. */
+        ABSENT,
+
+        /** Not a Windows host — there is no registry registration to remove. */
+        NOT_APPLICABLE,
+
+        /** Registered to a different, still present BOSS installation. Left alone. */
+        OTHER_INSTALL,
+
+        /** Registered to a command this code cannot parse (e.g. installer-authored, unquoted). Left alone. */
+        UNREADABLE,
+
+        /** `reg delete` itself failed. */
+        FAILED,
+    }
 
     /**
      * Register the boss:// protocol in Windows Registry
@@ -147,56 +174,63 @@ object WindowsProtocolHandler {
      * Windows' generic "no app associated" error. Invoke via
      * `BOSS.exe --unregister-protocol` from an uninstall action or by hand.
      *
-     * Safety: the key is only deleted when it is stale (points at an executable that
-     * no longer exists) or when it points at *this* installation. A different, still
-     * present BOSS installation is left registered — deleting its handler here would
-     * break a working install.
-     *
-     * @return true when the registration was removed or was already absent.
+     * Safety: the key is only deleted when it points at *this* installation or at an
+     * executable that no longer exists. A registration owned by a different, still
+     * present install is left alone — and so is one whose command this code cannot
+     * parse. "Unparseable" is deliberately NOT folded into "stale": an unquoted
+     * `shell\open\command` is what a WiX/MSI-authored registration typically looks
+     * like, so deleting it would break a working install.
      */
-    fun unregisterProtocol(): Boolean {
-        if (!isWindows) return false
+    fun unregisterProtocol(): UnregisterOutcome {
+        if (!isWindows) return UnregisterOutcome.NOT_APPLICABLE
 
-        if (!isProtocolRegistered()) {
-            logger.debug(LogCategory.SYSTEM, "boss:// protocol is not registered - nothing to clean up")
-            return true
-        }
-
-        val registeredExe = getCurrentRegistryCommand()?.let { extractExecutablePath(it) }
+        val currentCommand = getCurrentRegistryCommand()
+        val registeredExe = currentCommand?.let { extractExecutablePath(it) }
         val appPath = getApplicationPath()
-        val isStale = registeredExe == null || !File(registeredExe).exists()
-        val isThisInstall = appPath != null && registeredExe != null && registeredExe.equals(appPath, ignoreCase = true)
 
-        if (!isStale && !isThisInstall) {
-            logger.info(
-                LogCategory.SYSTEM,
-                "boss:// protocol points at another live BOSS installation - leaving it registered",
-                mapOf("path" to registeredExe.orEmpty()),
-            )
-            return false
-        }
-
-        return try {
-            val process =
-                ProcessBuilder("reg", "delete", PROTOCOL_KEY, "/f")
-                    .redirectErrorStream(true)
-                    .start()
-            val output = process.inputStream.bufferedReader().readText()
-            val exitCode = process.waitFor()
-            if (exitCode == 0) {
-                logger.info(LogCategory.SYSTEM, "Removed boss:// protocol registration", mapOf("key" to PROTOCOL_KEY))
-                true
-            } else {
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "Failed to remove boss:// protocol registration",
-                    mapOf("exitCode" to exitCode, "output" to output.trim()),
-                )
-                false
+        return when {
+            !isProtocolRegistered() -> {
+                logger.debug(LogCategory.SYSTEM, "boss:// protocol is not registered - nothing to clean up")
+                UnregisterOutcome.ABSENT
             }
-        } catch (e: Exception) {
-            logger.error(LogCategory.SYSTEM, "Failed to remove boss:// protocol registration", error = e)
-            false
+
+            registeredExe == null -> {
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "boss:// protocol command could not be parsed - leaving it registered",
+                    mapOf("command" to currentCommand.orEmpty()),
+                )
+                UnregisterOutcome.UNREADABLE
+            }
+
+            // Ours, or pointing at an executable that is gone: safe to remove.
+            registeredExe.equals(appPath, ignoreCase = true) || !File(registeredExe).exists() -> {
+                deleteProtocolKey()
+            }
+
+            else -> {
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "boss:// protocol points at another live BOSS installation - leaving it registered",
+                    mapOf("path" to registeredExe),
+                )
+                UnregisterOutcome.OTHER_INSTALL
+            }
+        }
+    }
+
+    /**
+     * CLI mapping for `--unregister-protocol`: 0 when nothing is left to clean up
+     * (removed / nothing registered / not a Windows host), 1 when the registration was
+     * deliberately left in place, 2 when the delete itself failed.
+     */
+    fun unregisterProtocolExitCode(): Int {
+        val outcome = unregisterProtocol()
+        logger.info(LogCategory.SYSTEM, "boss:// protocol cleanup finished", mapOf("outcome" to outcome.name))
+        return when (outcome) {
+            UnregisterOutcome.REMOVED, UnregisterOutcome.ABSENT, UnregisterOutcome.NOT_APPLICABLE -> 0
+            UnregisterOutcome.OTHER_INSTALL, UnregisterOutcome.UNREADABLE -> 1
+            UnregisterOutcome.FAILED -> 2
         }
     }
 
@@ -329,3 +363,38 @@ object WindowsProtocolHandler {
         return File(exePath).exists()
     }
 }
+
+/**
+ * `reg delete` the whole `boss` key tree. File-private rather than an object member so
+ * [WindowsProtocolHandler] stays within its function budget; it is only ever reached
+ * from [WindowsProtocolHandler.unregisterProtocol], which decides whether deleting is
+ * safe.
+ */
+private fun deleteProtocolKey(): WindowsProtocolHandler.UnregisterOutcome =
+    try {
+        val process =
+            ProcessBuilder("reg", "delete", PROTOCOL_KEY, "/f")
+                .redirectErrorStream(true)
+                .start()
+        val output = process.inputStream.bufferedReader().readText()
+        if (process.waitFor() == 0) {
+            logger.info(LogCategory.SYSTEM, "Removed boss:// protocol registration", mapOf("key" to PROTOCOL_KEY))
+            WindowsProtocolHandler.UnregisterOutcome.REMOVED
+        } else {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Failed to remove boss:// protocol registration",
+                mapOf("key" to PROTOCOL_KEY, "output" to output.trim()),
+            )
+            WindowsProtocolHandler.UnregisterOutcome.FAILED
+        }
+    } catch (e: IOException) {
+        logger.error(LogCategory.SYSTEM, "Failed to remove boss:// protocol registration", error = e)
+        WindowsProtocolHandler.UnregisterOutcome.FAILED
+    } catch (e: InterruptedException) {
+        // Restore the flag rather than swallowing the interrupt: this can run from the
+        // `--unregister-protocol` path, where the JVM is about to exit anyway.
+        Thread.currentThread().interrupt()
+        logger.error(LogCategory.SYSTEM, "Interrupted while removing boss:// protocol registration", error = e)
+        WindowsProtocolHandler.UnregisterOutcome.FAILED
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsProtocolHandler.kt
@@ -5,11 +5,20 @@ import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
 
 /**
- * Windows-specific protocol handler for registering URL schemes
+ * Windows-specific protocol handler for registering URL schemes.
+ *
+ * Registration happens at runtime rather than in the MSI (see
+ * [docs/WINDOWS_DEEP_LINK_SETUP.md]), which means an uninstall leaves the `boss:`
+ * handler in the registry pointing at a deleted executable. [unregisterProtocol]
+ * is the cleanup hook for that — reachable as `BOSS.exe --unregister-protocol`
+ * so an uninstall action (or support instructions) can call it.
  */
 object WindowsProtocolHandler {
     private val logger = BossLogger.forComponent("WindowsProtocolHandler")
     private val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+
+    /** Root of the per-user protocol registration this class owns. */
+    private const val PROTOCOL_KEY = """HKEY_CURRENT_USER\Software\Classes\boss"""
 
     /**
      * Register the boss:// protocol in Windows Registry
@@ -93,12 +102,12 @@ object WindowsProtocolHandler {
         val commands =
             listOf(
                 // Create protocol key
-                """reg add "HKEY_CURRENT_USER\Software\Classes\boss" /ve /d "URL:BOSS Protocol" /f""",
-                """reg add "HKEY_CURRENT_USER\Software\Classes\boss" /v "URL Protocol" /d "" /f""",
+                """reg add "$PROTOCOL_KEY" /ve /d "URL:BOSS Protocol" /f""",
+                """reg add "$PROTOCOL_KEY" /v "URL Protocol" /d "" /f""",
                 // Set icon
-                """reg add "HKEY_CURRENT_USER\Software\Classes\boss\DefaultIcon" /ve /d "$appPath,0" /f""",
+                """reg add "$PROTOCOL_KEY\DefaultIcon" /ve /d "$appPath,0" /f""",
                 // Set command to open the app with URL
-                """reg add "HKEY_CURRENT_USER\Software\Classes\boss\shell\open\command" /ve /d "\"$appPath\" \"%1\"" /f""",
+                """reg add "$PROTOCOL_KEY\shell\open\command" /ve /d "\"$appPath\" \"%1\"" /f""",
             )
 
         var successCount = 0
@@ -131,13 +140,74 @@ object WindowsProtocolHandler {
     }
 
     /**
+     * Remove the `boss:` protocol registration.
+     *
+     * Because registration happens at runtime, an uninstall would otherwise leave a
+     * handler pointing at a deleted `BOSS.exe`, and later `boss://` links fail with
+     * Windows' generic "no app associated" error. Invoke via
+     * `BOSS.exe --unregister-protocol` from an uninstall action or by hand.
+     *
+     * Safety: the key is only deleted when it is stale (points at an executable that
+     * no longer exists) or when it points at *this* installation. A different, still
+     * present BOSS installation is left registered — deleting its handler here would
+     * break a working install.
+     *
+     * @return true when the registration was removed or was already absent.
+     */
+    fun unregisterProtocol(): Boolean {
+        if (!isWindows) return false
+
+        if (!isProtocolRegistered()) {
+            logger.debug(LogCategory.SYSTEM, "boss:// protocol is not registered - nothing to clean up")
+            return true
+        }
+
+        val registeredExe = getCurrentRegistryCommand()?.let { extractExecutablePath(it) }
+        val appPath = getApplicationPath()
+        val isStale = registeredExe == null || !File(registeredExe).exists()
+        val isThisInstall = appPath != null && registeredExe != null && registeredExe.equals(appPath, ignoreCase = true)
+
+        if (!isStale && !isThisInstall) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "boss:// protocol points at another live BOSS installation - leaving it registered",
+                mapOf("path" to registeredExe.orEmpty()),
+            )
+            return false
+        }
+
+        return try {
+            val process =
+                ProcessBuilder("reg", "delete", PROTOCOL_KEY, "/f")
+                    .redirectErrorStream(true)
+                    .start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exitCode = process.waitFor()
+            if (exitCode == 0) {
+                logger.info(LogCategory.SYSTEM, "Removed boss:// protocol registration", mapOf("key" to PROTOCOL_KEY))
+                true
+            } else {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Failed to remove boss:// protocol registration",
+                    mapOf("exitCode" to exitCode, "output" to output.trim()),
+                )
+                false
+            }
+        } catch (e: Exception) {
+            logger.error(LogCategory.SYSTEM, "Failed to remove boss:// protocol registration", error = e)
+            false
+        }
+    }
+
+    /**
      * Check if the protocol is already registered
      */
     fun isProtocolRegistered(): Boolean {
         if (!isWindows) return false
 
         return try {
-            val process = Runtime.getRuntime().exec("""reg query "HKEY_CURRENT_USER\Software\Classes\boss" """)
+            val process = Runtime.getRuntime().exec("""reg query "$PROTOCOL_KEY" """)
             process.waitFor()
             process.exitValue() == 0
         } catch (e: Exception) {
@@ -223,7 +293,7 @@ object WindowsProtocolHandler {
                 ProcessBuilder(
                     "reg",
                     "query",
-                    "HKEY_CURRENT_USER\\Software\\Classes\\boss\\shell\\open\\command",
+                    """$PROTOCOL_KEY\shell\open\command""",
                     "/ve",
                 ).redirectErrorStream(true).start()
 

--- a/composeApp/src/desktopMain/resources/BOSS.entitlements
+++ b/composeApp/src/desktopMain/resources/BOSS.entitlements
@@ -23,15 +23,18 @@
     <!-- File access for code editor -->
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
-    
-    <!-- Terminal access -->
-    <key>com.apple.security.device.serial</key>
-    <true/>
-    
-    <!-- Allow debugging -->
-    <key>com.apple.security.cs.debugger</key>
-    <true/>
-    
+
+    <!-- Removed July 2026 (issue #38): com.apple.security.cs.debugger and
+         com.apple.security.device.serial were granted with no stated reason.
+         cs.debugger lets every binary signed with this file (the app launcher plus
+         the PTY4J natives that signPty4jBinaries re-signs with it) attach to and
+         read the memory of other signed processes — a large grant for a
+         terminal/editor host. Nothing in the tree uses the JVM attach API,
+         task_for_pid, or a serial device, and the branded Chromium engine bundle
+         (chromium-branding/entitlements/*.entitlements) ships without either key,
+         so JxBrowser does not require them either. Do not add them back without
+         naming the consumer here. -->
+
     <!-- App Sandbox disabled for full system access -->
     <key>com.apple.security.app-sandbox</key>
     <false/>

--- a/composeApp/src/desktopMain/resources/BOSS.entitlements
+++ b/composeApp/src/desktopMain/resources/BOSS.entitlements
@@ -33,7 +33,15 @@
          task_for_pid, or a serial device, and the branded Chromium engine bundle
          (chromium-branding/entitlements/*.entitlements) ships without either key,
          so JxBrowser does not require them either. Do not add them back without
-         naming the consumer here. -->
+         naming the consumer here.
+
+         For the avoidance of doubt about the sandbox argument: the remaining
+         sandbox-scoped keys below (inherit, files.user-selected.read-write,
+         network.*, device.camera, device.audio-input) are likewise inert while
+         app-sandbox is false — camera/mic prompts come from the NS*UsageDescription
+         strings in Info.plist. They are kept in case sandboxing is ever enabled;
+         cs.debugger was removed because, unlike those, it is a hardened-runtime
+         entitlement that is NOT inert. -->
 
     <!-- App Sandbox disabled for full system access -->
     <key>com.apple.security.app-sandbox</key>

--- a/docs/WINDOWS_DEEP_LINK_SETUP.md
+++ b/docs/WINDOWS_DEEP_LINK_SETUP.md
@@ -16,6 +16,39 @@ This guide explains how the Windows deep link support works for the BOSS desktop
    - If BOSS is not running, Windows launches it with the URL as a command line argument
    - If BOSS is already running, the behavior depends on Windows version (may launch a new instance)
 
+## Registration Lifecycle (and why uninstall needs a hook)
+
+Registration is done by the **running app**, not by the MSI. That is a deliberate
+limitation, not a preference: the Compose Desktop Gradle plugin exposes no WiX
+authoring hook (no `--resource-dir` override, no registry DSL), so the installer
+cannot own the `boss:` keys without hand-maintaining a full jpackage `main.wxs`
+replacement — which is tied to the JDK version that built it and cannot be verified
+outside a Windows + WiX runner.
+
+Consequences and the mitigations in place:
+
+| Situation | Behavior |
+|---|---|
+| Fresh install, first launch | App registers `HKCU\Software\Classes\boss` (`WindowsProtocolHandler.registerProtocol`) |
+| Moved/reinstalled to a new path | Startup re-registers when the stored command points at a missing exe (self-heal) |
+| Another BOSS install still present and valid | Left alone — the app never steals a working registration |
+| **Uninstalled** | The key survives and points at a deleted exe unless cleaned up (below) |
+
+### Cleaning up the registration
+
+```powershell
+# Preferred: let the app remove its own registration (exit code 0 = removed,
+# 1 = left in place because it belongs to another live installation)
+& "$env:LOCALAPPDATA\BOSS\BOSS.exe" --unregister-protocol
+
+# Manual equivalent
+reg delete "HKEY_CURRENT_USER\Software\Classes\boss" /f
+```
+
+Run this **before** uninstalling, or wire it as an uninstall action when installer-owned
+registration lands (tracked as follow-up work to issue #38 — the Rust host is expected
+to register the protocol from its installer instead).
+
 ## Email Verification Flow
 
 1. User clicks the verification link in their email

--- a/docs/WINDOWS_DEEP_LINK_SETUP.md
+++ b/docs/WINDOWS_DEEP_LINK_SETUP.md
@@ -32,18 +32,28 @@ Consequences and the mitigations in place:
 | Fresh install, first launch | App registers `HKCU\Software\Classes\boss` (`WindowsProtocolHandler.registerProtocol`) |
 | Moved/reinstalled to a new path | Startup re-registers when the stored command points at a missing exe (self-heal) |
 | Another BOSS install still present and valid | Left alone — the app never steals a working registration |
+| Command present but unparseable (e.g. an unquoted, installer-authored command) | Left alone — never deleted just because this code cannot read it |
 | **Uninstalled** | The key survives and points at a deleted exe unless cleaned up (below) |
 
 ### Cleaning up the registration
 
 ```powershell
-# Preferred: let the app remove its own registration (exit code 0 = removed,
-# 1 = left in place because it belongs to another live installation)
-& "$env:LOCALAPPDATA\BOSS\BOSS.exe" --unregister-protocol
+# Preferred: let the app remove its own registration.
+# BOSS.exe is a GUI-subsystem binary (windows { console = false }), so a plain
+# invocation returns immediately and $LASTEXITCODE is NOT the app's exit code —
+# use the waiting form to observe the result:
+(Start-Process -FilePath "$env:LOCALAPPDATA\BOSS\BOSS.exe" `
+    -ArgumentList '--unregister-protocol' -Wait -PassThru).ExitCode
 
 # Manual equivalent
 reg delete "HKEY_CURRENT_USER\Software\Classes\boss" /f
 ```
+
+Exit codes: `0` nothing left to clean (removed, or nothing was registered, or not a
+Windows host), `1` the registration was deliberately left in place (another live install,
+or a command that could not be parsed), `2` the `reg delete` itself failed. An MSI custom
+action waits for the process, so the contract is observable where it matters. There is no
+console output — the BossLogger log file is the only human-readable signal.
 
 Run this **before** uninstalling, or wire it as an uninstall action when installer-owned
 registration lands (tracked as follow-up work to issue #38 — the Rust host is expected

--- a/gradle/version.gradle.kts
+++ b/gradle/version.gradle.kts
@@ -31,7 +31,6 @@ val appVersion = if (prereleaseSuffix != null) {
 } else {
     "$versionMajor.$versionMinor.$versionPatch"
 }
-val bundleVersion = versionProps["app.bundle.version"].toString()
 val buildNumber = versionProps["app.build.number"].toString()
 
 // Build artifact names
@@ -48,7 +47,6 @@ project.extra.apply {
     set("versionPatch", versionPatch)
     set("prereleaseSuffix", prereleaseSuffix)
     set("appVersion", appVersion)
-    set("bundleVersion", bundleVersion)
     set("buildNumber", buildNumber)
     set("jarName", jarName)
     set("dmgName", dmgName)

--- a/version.properties
+++ b/version.properties
@@ -4,7 +4,6 @@ app.version.major=9
 app.build.date=2026-07-25
 app.version.patch=60
 app.release.notes.url=https\://github.com/risa-labs-inc/BossConsole-Releases/releases/tag/v8.9.0
-app.bundle.version=9.2.60
 app.version.minor=2
 app.release.channel=stable
 app.version=9.2.60


### PR DESCRIPTION
Closes the six packaging items from #38. Almost nothing here can be proven on a
developer Mac — no `.deb` install, no MSI, no notarized DMG — so each item below says
what changed, why, and what is still unverified. The "needs verification" list at the
bottom is the real acceptance checklist.

Two structural notes up front:

- **`Info.plist` keys now have one source each.** `LSMinimumSystemVersion`,
  `LSApplicationCategoryType`, `CFBundleVersion`, `NSHighResolutionCapable` and
  `NSSupportsAutomaticGraphicsSwitching` were being declared *twice*: once by the
  Compose plugin (from its DSL settings) and once again by
  `infoPlist.extraKeysRawXml`. That "worked" only because the last declaration in a
  plist dict wins — which is why the shipped bundle reported `10.15` instead of
  Compose's `10.13` default. The duplicates are gone; these keys are now set through
  the DSL (`minimumSystemVersion`, `appCategory`, `packageBuildVersion`) and
  `extraKeysRawXml` carries only keys Compose does not emit.
- **The Linux fix lands in the existing `.deb` post-processing task.** Compose Desktop
  exposes no knob for deb dependencies (`LinuxPlatformSettings` has no equivalent of
  jpackage's `--linux-package-deps`), so the control file is rewritten in
  `FixLinuxDesktopFileTask`, which already unpacks/repacks the `.deb` for the
  `StartupWMClass`, hicolor-icon and `postinst` fixes.

---

## 1. macOS floor raised 10.15 → 12.0

`composeApp/build.gradle.kts` — `macOS { minimumSystemVersion = "12.0" }`.

The host bundle advertised 10.15 while the browser-engine bundle it downloads
(`~/.boss/boss-chromium/BOSS.app`) declares 12.0 and its framework carries
`LC_BUILD_VERSION minos 12.0`. On 10.15/11 the app installed and launched, then died in
dyld the first time an engine loaded — a broken browser tab instead of an
unsupported-platform message. Declaring the real floor makes the OS refuse the install.

Also updated so we stop advertising a floor we do not support:

- `.github/workflows/release.yml` release-notes template: "macOS 11.0+ (Big Sur)" →
  "macOS 12.0+ (Monterey)".
- `JAR_README.md` system requirements: "macOS 10.15+" → "macOS 12+".

## 2. `.deb` no longer hard-`Depends` on `xdg-utils`

`FixLinuxDesktopFileTask` now rewrites `DEBIAN/control`: `xdg-utils` moves out of
`Depends:` and into `Recommends:` (extending an existing `Recommends:` if present,
dropping `Depends:` entirely if `xdg-utils` was its only entry). apt still installs it
by default on a desktop system; a headless `dpkg -i` no longer fails during dependency
resolution *before* `postinst` — which is exactly why the earlier `postinst` `xdg-*`
guard only half-closed the headless problem.

Implementation notes: the rewrite is field-aware (handles Debian folding/continuation
lines), leaves every other field byte-for-byte alone, only drops an entry when *all* of
its alternatives are `xdg-utils` (so `xdg-utils | something-else` survives), and is
idempotent, so a repack cannot double-apply it.

**Not fixed, same root cause:** the `.rpm` gets the same treatment from jpackage
(`Requires: xdg-utils`), but repacking an RPM needs the `rpmbuild` toolchain, which this
task deliberately does not depend on (pre-existing comment in the file). Headless RPM
installs still need `--nodeps` or the package present. Worth its own issue.

## 3. `LSApplicationCategoryType`

`macOS { appCategory = "public.app-category.developer-tools" }`, replacing jpackage's
placeholder `"Unknown"` (which is Compose's default when the setting is unset).
`developer-tools` over `utilities` / `productivity` because the product is a terminal +
code editor + console; the Linux `appCategory` stays `Utility` (different taxonomy,
untouched).

## 4. `CFBundleVersion` is now a build identifier, not a copy of the version

**Please sanity-check this scheme — it is the one judgement call in the PR.**

Before: `CFBundleVersion == CFBundleShortVersionString == 9.2.60`, so a re-notarized
rebuild of the same release was indistinguishable to macOS.

What consumes these values today (checked before changing anything):

- The in-app updater compares `AppVersion.CURRENT`, built from `VersionConstants` which
  is generated out of `version.properties` — **not** from the plist. Nothing in the tree
  reads `Info.plist`, `plutil` or `PlistBuddy` at runtime.
- No workflow or script reads `CFBundleVersion` / `CFBundleShortVersionString`;
  `release.yml` keys everything off `app.version` in `version.properties`.
- So update detection does not depend on either plist key, and this change cannot move it.

Constraint found by decompiling the Compose Gradle plugin (1.11.1): `packageBuildVersion`
is validated by `MacVersionChecker` as **at most three non-negative integers**, so a
`9.2.60.<build>` value is not expressible through the DSL. Rather than keep hand-writing a
fourth component into raw plist XML (and relying on duplicate-key resolution), the build
now follows Apple's usual convention — short version = marketing version, bundle version =
monotonic build counter:

| Build | `CFBundleVersion` source |
|---|---|
| Release workflow | `BOSS_BUILD_ID`, set in `release.yml`'s top-level env to `github.run_number` — monotonic per workflow, shared by every platform job of one release run |
| Promotion rebuild (`promote-release.yml` → `release.yml`) | An explicit `build_id` input: a called workflow's jobs belong to the *caller's* run, so `github.run_number` there would be promote-release's independent counter. It passes a seconds-since-epoch stamp, which is globally monotonic and lands where no run number reaches |
| Lite release | Same env in `release-lite.yml`, for the same reason |
| Any other CI build | `GITHUB_RUN_NUMBER` (so it is at least not a constant) |
| Local build | `app.build.number` from `version.properties` |

Finder therefore shows `Version 9.2.60 (641)`. Deliberate consequences, flagged:

- The build id is **not** derived from the app version. That is the point (it is a build
  counter), but it does mean `CFBundleVersion` alone no longer tells you which release a
  bundle is; `CFBundleShortVersionString` does.
- A local build gets a small number (`1`), so it is *lower* than a released build's.
  Harmless today because nothing compares `CFBundleVersion`, but it would matter if a
  Sparkle-style updater were ever added.
- Local builds intentionally use a **stable** value: a timestamp would change
  `Info.plist` on every configuration and force the app image to be rebuilt and
  re-signed on each local packaging run.
- `app.build.number` is still reset to `1` by `incrementVersion`, and `release.yml` never
  increments it — which is why release builds use the run number instead.
- `app.bundle.version` (which always equalled `app.version`) is **deleted outright**
  along with every writer: the four version tasks, `gradle/version.gradle.kts`, the
  `showVersion` display line, and the `sed` in `release.yml` / `release-lite.yml` /
  `promote-release.yml`.

Prerelease builds keep their suffix in Finder: `packageVersion` must be a plain
`MAJOR.MINOR.PATCH` for jpackage, so `CFBundleShortVersionString` is re-declared in
`extraKeysRawXml` **only when** a prerelease suffix is present (e.g. `9.2.60-beta.1`).
Stable builds emit the key exactly once.

## 5. Windows `boss:` protocol — cleanup hook added, installer ownership deferred

Installer-side registration is **not feasible in this build**, and I would rather say so
than fake it: the Compose Desktop Gradle plugin exposes no WiX authoring surface. It
passes `--resource-dir` to jpackage from an internal `protected` provider
(`AbstractJPackageTask.jpackageResources`), and the Windows platform settings have no
registry DSL. Owning the `boss:` keys from the MSI would mean injecting a
hand-maintained replacement for jpackage's `main.wxs` into a Compose-internal temp
directory — a template coupled to the JDK that built it, covered by no CI check, and
impossible to exercise without a Windows + WiX runner. The failure mode if it drifts is
"MSI stops building", i.e. release-blocking.

So registration stays at runtime, and the gap gets an explicit cleanup path:

- `WindowsProtocolHandler.unregisterProtocol()` deletes `HKCU\Software\Classes\boss`,
  but **only** when the registration is stale (points at an exe that no longer exists) or
  points at *this* installation. A different, still working BOSS install is left alone.
- `BOSS.exe --unregister-protocol` invokes it before any app/single-instance
  initialization and exits `0` when removed, `1` when deliberately left in place, so an
  uninstall action can distinguish the two.
- `docs/WINDOWS_DEEP_LINK_SETUP.md` gains a "Registration Lifecycle" section: what
  happens on install / move / second install / uninstall, why the MSI does not own the
  keys, and how to clean up (`--unregister-protocol`, or the equivalent `reg delete`).
- The registry path is now a single `PROTOCOL_KEY` constant instead of five copies of the
  literal.

Follow-up (not in this PR): the Rust host should register the protocol from its
installer, which is where this belongs.

## 6. Entitlements: `cs.debugger` and `device.serial` removed

Both are gone from `composeApp/src/desktopMain/resources/BOSS.entitlements`, with a
comment in their place recording why, so they are not re-added by reflex. Evidence they
are not needed:

- Nothing in the tree uses the JVM attach API (`VirtualMachine.attach`,
  `HotSpotVirtualMachine`, `jattach`, `jcmd`, `jstack`) or `task_for_pid` — those are the
  things that actually require `cs.debugger` under the hardened runtime.
- The likely claim would be JxBrowser/Chromium, but the branded engine's own entitlements
  (`chromium-branding/entitlements/boss-chromium*.entitlements`) ship with neither key and
  work, so the engine does not require them.
- `device.serial` is a **sandbox** entitlement and this app sets
  `com.apple.security.app-sandbox = false`, so it was inert regardless — and its comment
  ("Terminal access") was wrong: it governs serial-device access, not PTYs.
- `cs.debugger` is not inert: it applies to every binary signed with this file, which
  includes the PTY4J natives re-signed by `signPty4jBinaries`.

This is the one change that can *only* be falsified by a real signed + notarized build,
so it is first on the verification list below.

## Deliberately left alone: the MSI `UpgradeCode`

The Kotlin `windows { upgradeUuid = "8a5a7659-…" }` is **untouched**, per the note at the
bottom of #38: the Rust host uses a distinct GUID plus an audit that refuses this one.
Nothing in this PR reintroduces or shares it.

---

## Verified on this machine

- `./gradlew :composeApp:tasks` configures cleanly with the new DSL settings — that is
  what runs Compose's `validatePackageVersions`, so `packageBuildVersion` is accepted both
  locally (`1`) and with a CI-shaped value (`BOSS_BUILD_ID=641`).
- `./gradlew :composeApp:ktlintCheck` — green.
- `./gradlew :composeApp:compileKotlinDesktop` — green (covers the `main.kt` flag and
  `WindowsProtocolHandler.unregisterProtocol`).
- The control-file rewriter was executed, not just eyeballed: its body was run verbatim in
  a scratch Gradle build against seven synthetic control files (jpackage-shaped,
  `xdg-utils` as the only dependency, pre-existing `Recommends:`, folded/continuation
  `Depends:`, no `xdg-utils` at all, `xdg-utils | alternative`, versioned
  `xdg-utils (>= 1.1.3)`), each asserted for output *and* idempotency on a second pass.
- The claims about what Compose emits into `Info.plist` come from disassembling
  `compose-gradle-plugin-1.11.1` (`AbstractJPackageTask.setInfoPlistValues`), which
  confirms `LSMinimumSystemVersion` ← `minimumSystemVersion` (default `10.13`),
  `LSApplicationCategoryType` ← `appCategory` (default `"Unknown"`), `CFBundleVersion` ←
  `packageBuildVersion`, plus the two `NS*` booleans.

## Needs verification on real CI/hardware

1. **Signed + notarized macOS build** (release workflow, macOS job): notarization still
   passes with `cs.debugger` and `device.serial` gone, the app launches, and a browser tab
   loads an engine. This is the removal's only real test.
2. **`plutil` spot-check on the produced bundle**: `LSMinimumSystemVersion` = `12.0`,
   `LSApplicationCategoryType` = `public.app-category.developer-tools`, `CFBundleVersion`
   = the release build id, `CFBundleShortVersionString` = the app version — and each key
   present exactly **once** (`plutil -p … | grep -c`). Also check the two keys this PR
   *deleted* from `extraKeysRawXml` on the strength of a plugin decompile:
   `NSHighResolutionCapable` and `NSSupportsAutomaticGraphicsSwitching` must still be
   present and `true`. That deletion is the one with a silent failure mode — a missing
   `NSHighResolutionCapable` puts every Retina Mac on the non-Retina compatibility path
   and arrives as "the UI looks soft", not as a build failure. The duplicate-key cleanup
   is the rest of what is worth confirming empirically here.
3. **macOS 11 check** (11.x VM): note the gate is at *launch*, not install — a DMG has
   no installer, so nothing stops dragging the app to `/Applications`. Expected result is
   Launch Services refusing to open it with "requires macOS 12.0 or later", instead of
   launching and then dying in dyld once an engine loads. Do not read a successful copy
   to `/Applications` as a failure of this fix.
4. **Headless `.deb` install** on a clean `ubuntu-24.04` container without `xdg-utils`:
   `dpkg -i` succeeds, `dpkg -I` shows `xdg-utils` under `Recommends:` (not `Depends:`),
   `postinst` logs the best-effort skip line, and `apt-get install -f` has nothing to fix.
   Then the desktop case: a normal desktop install still gets its menu entry and icon.
5. **`.deb` repack sanity**: `DebControl` is now unit-tested, but the transform has never
   run inside a real `dpkg-deb -R` / `--build` round trip (`fixLinuxDesktopFile` is
   Linux-only). This is closable in CI without a release build — the `buildSrc` test step
   already runs on Ubuntu, where `dpkg-deb` exists — by building a minimal fixture `.deb`,
   round-tripping it, and asserting `dpkg -I` reports `xdg-utils` under `Recommends:`.
   Tracked as follow-up rather than grown into this PR.
6. **MSI/Windows**: `BOSS.exe --unregister-protocol` removes the key when stale or
   self-owned, leaves it when another live install owns it, exit codes as documented; and
   the flag never reaches the CLI/deep-link paths.
7. **Update path across the change**: install a build from before this PR, then update to
   one after it, and confirm the updater still detects and installs. The reasoning says it
   cannot break (nothing reads the plist), but it deserves one real pass.
8. **Prerelease build** (`setPrereleaseSuffix -Psuffix=beta.1` release):
   `CFBundleShortVersionString` shows `X.Y.Z-beta.N` and appears exactly once.

Fixes #38
