### PR TITLE
fix(remote-ui): repair the boss-ui-sdk ⇄ RemoteWidgetRenderer contract (8 defects from the Rust port)

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -129,7 +129,7 @@
     <ID>CyclomaticComplexMethod:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun downloadSystemPluginFromGitHub(plugin: SystemPluginInfo): Boolean</ID>
     <ID>CyclomaticComplexMethod:PluginStoreSetup.kt$PluginStoreSetup$private suspend fun ensureSystemPluginsInstalled()</ID>
     <ID>CyclomaticComplexMethod:ReleaseNotesMarkdown.kt$internal fun parseReleaseNotes(source: String): List&lt;NotesBlock&gt;</ID>
-    <ID>CyclomaticComplexMethod:RemoteWidgetRenderer.kt$@Composable private fun RenderNode( node: WidgetNode, tree: WidgetTree, onEvent: (nodeId: String, eventType: String, eventData: String) -&gt; Unit, )</ID>
+    <ID>CyclomaticComplexMethod:RemoteWidgetRenderer.kt$@Composable private fun RenderNode( node: WidgetNode, tree: WidgetTree, onEvent: (nodeId: String, event: WidgetEvent) -&gt; Unit, )</ID>
     <ID>CyclomaticComplexMethod:ScreenCaptureNotifier.kt$ScreenCaptureNotifier$fun requestCapture( requestId: String, sources: CaptureSources, tell: StartCaptureSessionCallback.Action, )</ID>
     <ID>CyclomaticComplexMethod:SecuritySettings.kt$@Composable fun SecuritySettings()</ID>
     <ID>CyclomaticComplexMethod:SecuritySettings.kt$private suspend fun detectWebAuthnCapabilities(): WebAuthnCapabilities</ID>
@@ -365,7 +365,7 @@
     <ID>LongMethod:ProjectSelectionDialog.kt$@Composable fun ProjectSelectionDialog( onDismiss: () -&gt; Unit, onOpenDirectoryPicker: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:ReleaseNotesMarkdown.kt$@Composable internal fun NotesBlockView(block: NotesBlock)</ID>
     <ID>LongMethod:ReleaseNotesMarkdown.kt$internal fun parseReleaseNotes(source: String): List&lt;NotesBlock&gt;</ID>
-    <ID>LongMethod:RemoteWidgetRenderer.kt$@Composable private fun RenderNode( node: WidgetNode, tree: WidgetTree, onEvent: (nodeId: String, eventType: String, eventData: String) -&gt; Unit, )</ID>
+    <ID>LongMethod:RemoteWidgetRenderer.kt$@Composable private fun RenderNode( node: WidgetNode, tree: WidgetTree, onEvent: (nodeId: String, event: WidgetEvent) -&gt; Unit, )</ID>
     <ID>LongMethod:RemoveBookmarkConfirmationDialog.kt$@Composable fun RemoveBookmarkConfirmationDialog( bookmarkTitle: String, onDismiss: () -&gt; Unit, onConfirm: () -&gt; Unit, )</ID>
     <ID>LongMethod:RenameDialog.kt$@Composable fun RenameDialog( title: String, currentName: String, label: String, onDismiss: () -&gt; Unit, onRename: (newName: String) -&gt; Unit, )</ID>
     <ID>LongMethod:RunnerSettings.kt$@Composable fun RunnerSettings()</ID>

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemotePanelComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemotePanelComponent.kt
@@ -1,10 +1,9 @@
 package ai.rever.boss.components.plugin.remote
 
-import ai.rever.boss.ipc.proto.ClickEvent
 import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
-import ai.rever.boss.ipc.proto.TextChangeEvent
-import ai.rever.boss.ipc.proto.ToggleEvent
 import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ui.sdk.UIEventMapper
+import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetTree
 import androidx.compose.runtime.*
 import io.grpc.ManagedChannel
@@ -53,17 +52,17 @@ class RemotePanelComponent(
         tree?.let { widgetTree ->
             RemoteWidgetRenderer(
                 tree = widgetTree,
-                onEvent = { nodeId, eventType, eventData ->
+                onEvent = { nodeId, event ->
+                    // Payloads can contain what the user typed — log the shape, not the content.
                     logger.debug(
-                        "Panel UI event: panel={}, node={}, type={}, data={}",
+                        "Panel UI event: panel={}, node={}, type={}",
                         panelId,
                         nodeId,
-                        eventType,
-                        eventData,
+                        event::class.simpleName,
                     )
                     // Forward event to plugin process via gRPC
                     scope.launch {
-                        sendUIEvent(nodeId, eventType, eventData)
+                        sendUIEvent(nodeId, event)
                     }
                 },
             )
@@ -152,38 +151,17 @@ class RemotePanelComponent(
         }
     }
 
+    /**
+     * Forward one interaction to the plugin process.
+     *
+     * The `WidgetEvent` → proto `UIEvent` mapping lives in [UIEventMapper] (boss-ui-sdk): it is total
+     * over the sealed event type, so no oneof case can be silently skipped — which is exactly how
+     * dropdown selections used to cross the wire as events with no payload at all.
+     */
     private suspend fun sendUIEvent(
         nodeId: String,
-        eventType: String,
-        eventData: String,
+        event: WidgetEvent,
     ) {
-        val eventBuilder =
-            UIEvent
-                .newBuilder()
-                .setSurfaceId(panelId)
-                .setTargetNodeId(nodeId)
-                .setTimestamp(System.currentTimeMillis())
-
-        when (eventType) {
-            "click" -> {
-                eventBuilder.setClick(
-                    ClickEvent.newBuilder().setEventId(eventData).build(),
-                )
-            }
-
-            "textChange" -> {
-                eventBuilder.setTextChange(
-                    TextChangeEvent.newBuilder().setNewValue(eventData).build(),
-                )
-            }
-
-            "toggle" -> {
-                eventBuilder.setToggle(
-                    ToggleEvent.newBuilder().setChecked(eventData.toBoolean()).build(),
-                )
-            }
-        }
-
-        outgoingEvents.emit(eventBuilder.build())
+        outgoingEvents.emit(UIEventMapper.toProto(panelId, nodeId, event, System.currentTimeMillis()))
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemotePanelComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemotePanelComponent.kt
@@ -5,16 +5,18 @@ import ai.rever.boss.ipc.proto.UIEvent
 import ai.rever.boss.ui.sdk.UIEventMapper
 import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetTree
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.*
 import io.grpc.ManagedChannel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
-import org.slf4j.LoggerFactory
 
 /**
  * Host-side panel component that renders a remote plugin's UI.
@@ -31,14 +33,21 @@ class RemotePanelComponent(
     private val processId: String,
     private val uiAddress: String,
 ) {
-    private val logger = LoggerFactory.getLogger(RemotePanelComponent::class.java)
+    private val logger = BossLogger.forComponent("RemotePanelComponent")
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val _widgetTree = mutableStateOf<WidgetTree?>(null)
     private val _connected = mutableStateOf(false)
 
-    /** Outgoing UI events from kernel to plugin process. */
-    private val outgoingEvents = MutableSharedFlow<UIEvent>(extraBufferCapacity = 256)
+    /**
+     * Outgoing UI events from kernel to plugin process.
+     *
+     * A queue, not a shared flow: `TextChange` carries the *whole* field value with
+     * last-write-wins semantics, so two fast keystrokes that each got their own coroutine could
+     * race to the stream and land reversed, silently reverting a character. An unlimited channel
+     * written straight from the Compose callback keeps emission order = interaction order.
+     */
+    private val outgoingEvents = Channel<UIEvent>(Channel.UNLIMITED)
 
     /** Whether the component is connected to the plugin process. */
     val connected: State<Boolean> get() = _connected
@@ -52,19 +61,7 @@ class RemotePanelComponent(
         tree?.let { widgetTree ->
             RemoteWidgetRenderer(
                 tree = widgetTree,
-                onEvent = { nodeId, event ->
-                    // Payloads can contain what the user typed — log the shape, not the content.
-                    logger.debug(
-                        "Panel UI event: panel={}, node={}, type={}",
-                        panelId,
-                        nodeId,
-                        event::class.simpleName,
-                    )
-                    // Forward event to plugin process via gRPC
-                    scope.launch {
-                        sendUIEvent(nodeId, event)
-                    }
-                },
+                onEvent = { nodeId, event -> sendUIEvent(nodeId, event) },
             )
         }
     }
@@ -74,7 +71,11 @@ class RemotePanelComponent(
      * Call this when the panel is first displayed.
      */
     fun connect() {
-        logger.info("Connecting to remote panel: panelId={}, process={}, address={}", panelId, processId, uiAddress)
+        logger.info(
+            LogCategory.UI,
+            "Connecting to remote panel",
+            mapOf("panelId" to panelId, "process" to processId, "address" to uiAddress),
+        )
         scope.launch {
             connectToPluginProcess()
         }
@@ -85,7 +86,11 @@ class RemotePanelComponent(
      * Uses the provided gRPC channel instead of creating one from the address.
      */
     fun connect(channel: ManagedChannel) {
-        logger.info("Connecting to remote panel via channel: panelId={}, process={}", panelId, processId)
+        logger.info(
+            LogCategory.UI,
+            "Connecting to remote panel via channel",
+            mapOf("panelId" to panelId, "process" to processId),
+        )
         scope.launch {
             connectWithChannel(channel)
         }
@@ -100,8 +105,9 @@ class RemotePanelComponent(
 
     fun dispose() {
         scope.cancel()
+        outgoingEvents.close()
         _connected.value = false
-        logger.info("Remote panel disposed: panelId={}", panelId)
+        logger.info(LogCategory.UI, "Remote panel disposed", mapOf("panelId" to panelId))
     }
 
     // ---- Internal ----
@@ -113,7 +119,12 @@ class RemotePanelComponent(
                     .BossIpcClient(uiAddress)
             connectWithChannel(client.channel)
         } catch (e: Exception) {
-            logger.error("Failed to connect to plugin process: panelId={}", panelId, e)
+            logger.error(
+                LogCategory.UI,
+                "Failed to connect to plugin process",
+                mapOf("panelId" to panelId),
+                error = e,
+            )
             _connected.value = false
         }
     }
@@ -130,7 +141,7 @@ class RemotePanelComponent(
             val widgetUpdateStream =
                 channelFlow {
                     // Forward UI events from kernel to plugin process as WidgetUpdate wrappers
-                    outgoingEvents.collect { event ->
+                    outgoingEvents.consumeAsFlow().collect { event ->
                         val update =
                             ai.rever.boss.ipc.proto.WidgetUpdate
                                 .newBuilder()
@@ -141,27 +152,44 @@ class RemotePanelComponent(
                 }
 
             stub.streamUI(widgetUpdateStream).collect { uiEvent ->
-                logger.debug("Received UI event from plugin: surface={}", uiEvent.surfaceId)
+                logger.debug(LogCategory.UI, "Received UI event from plugin", mapOf("surface" to uiEvent.surfaceId))
             }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
             _connected.value = false
-            logger.warn("Connection to plugin process lost: panelId={}, error={}", panelId, e.message)
+            logger.warn(
+                LogCategory.UI,
+                "Connection to plugin process lost",
+                mapOf("panelId" to panelId, "error" to e.message),
+            )
         }
     }
 
     /**
-     * Forward one interaction to the plugin process.
+     * Queue one interaction for the plugin process.
+     *
+     * Not `suspend`, and deliberately called straight from the Compose callback: the send is a
+     * non-blocking enqueue onto an unlimited channel, so interactions reach the stream in the order
+     * the user made them. Handing each event to its own `scope.launch` let two keystrokes race.
      *
      * The `WidgetEvent` → proto `UIEvent` mapping lives in [UIEventMapper] (boss-ui-sdk): it is total
      * over the sealed event type, so no oneof case can be silently skipped — which is exactly how
      * dropdown selections used to cross the wire as events with no payload at all.
      */
-    private suspend fun sendUIEvent(
+    private fun sendUIEvent(
         nodeId: String,
         event: WidgetEvent,
     ) {
-        outgoingEvents.emit(UIEventMapper.toProto(panelId, nodeId, event, System.currentTimeMillis()))
+        // Payloads can contain what the user typed — log the shape, not the content.
+        logger.debug(
+            LogCategory.UI,
+            "Panel UI event",
+            mapOf("panelId" to panelId, "node" to nodeId, "type" to event::class.simpleName),
+        )
+        val queued = outgoingEvents.trySend(UIEventMapper.toProto(panelId, nodeId, event, System.currentTimeMillis()))
+        if (queued.isFailure) {
+            logger.debug(LogCategory.UI, "Dropped UI event: surface is closed", mapOf("panelId" to panelId))
+        }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteTabComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteTabComponent.kt
@@ -1,10 +1,9 @@
 package ai.rever.boss.components.plugin.remote
 
-import ai.rever.boss.ipc.proto.ClickEvent
 import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
-import ai.rever.boss.ipc.proto.TextChangeEvent
-import ai.rever.boss.ipc.proto.ToggleEvent
 import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ui.sdk.UIEventMapper
+import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetTree
 import androidx.compose.runtime.*
 import io.grpc.ManagedChannel
@@ -53,16 +52,16 @@ class RemoteTabComponent(
         tree?.let { widgetTree ->
             RemoteWidgetRenderer(
                 tree = widgetTree,
-                onEvent = { nodeId, eventType, eventData ->
+                onEvent = { nodeId, event ->
+                    // Payloads can contain what the user typed — log the shape, not the content.
                     logger.debug(
-                        "Tab UI event: tab={}, node={}, type={}, data={}",
+                        "Tab UI event: tab={}, node={}, type={}",
                         tabId,
                         nodeId,
-                        eventType,
-                        eventData,
+                        event::class.simpleName,
                     )
                     scope.launch {
-                        sendUIEvent(nodeId, eventType, eventData)
+                        sendUIEvent(nodeId, event)
                     }
                 },
             )
@@ -153,38 +152,14 @@ class RemoteTabComponent(
         }
     }
 
+    /**
+     * Forward one interaction to the plugin process, mapped by [UIEventMapper] — a total mapping over
+     * the sealed [WidgetEvent] type, so no proto oneof case can be silently skipped.
+     */
     private suspend fun sendUIEvent(
         nodeId: String,
-        eventType: String,
-        eventData: String,
+        event: WidgetEvent,
     ) {
-        val eventBuilder =
-            UIEvent
-                .newBuilder()
-                .setSurfaceId(tabId)
-                .setTargetNodeId(nodeId)
-                .setTimestamp(System.currentTimeMillis())
-
-        when (eventType) {
-            "click" -> {
-                eventBuilder.setClick(
-                    ClickEvent.newBuilder().setEventId(eventData).build(),
-                )
-            }
-
-            "textChange" -> {
-                eventBuilder.setTextChange(
-                    TextChangeEvent.newBuilder().setNewValue(eventData).build(),
-                )
-            }
-
-            "toggle" -> {
-                eventBuilder.setToggle(
-                    ToggleEvent.newBuilder().setChecked(eventData.toBoolean()).build(),
-                )
-            }
-        }
-
-        outgoingEvents.emit(eventBuilder.build())
+        outgoingEvents.emit(UIEventMapper.toProto(tabId, nodeId, event, System.currentTimeMillis()))
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteTabComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteTabComponent.kt
@@ -5,16 +5,18 @@ import ai.rever.boss.ipc.proto.UIEvent
 import ai.rever.boss.ui.sdk.UIEventMapper
 import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetTree
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.*
 import io.grpc.ManagedChannel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
-import org.slf4j.LoggerFactory
 
 /**
  * Host-side tab component that renders a remote plugin's tab UI.
@@ -28,7 +30,7 @@ class RemoteTabComponent(
     private val processId: String,
     private val uiAddress: String,
 ) {
-    private val logger = LoggerFactory.getLogger(RemoteTabComponent::class.java)
+    private val logger = BossLogger.forComponent("RemoteTabComponent")
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val _widgetTree = mutableStateOf<WidgetTree?>(null)
@@ -36,8 +38,15 @@ class RemoteTabComponent(
     private val _isLoading = mutableStateOf(false)
     private val _connected = mutableStateOf(false)
 
-    /** Outgoing UI events from kernel to plugin process. */
-    private val outgoingEvents = MutableSharedFlow<UIEvent>(extraBufferCapacity = 256)
+    /**
+     * Outgoing UI events from kernel to plugin process.
+     *
+     * A queue, not a shared flow: `TextChange` carries the *whole* field value with
+     * last-write-wins semantics, so two fast keystrokes that each got their own coroutine could
+     * race to the stream and land reversed, silently reverting a character. An unlimited channel
+     * written straight from the Compose callback keeps emission order = interaction order.
+     */
+    private val outgoingEvents = Channel<UIEvent>(Channel.UNLIMITED)
 
     val title: State<String> get() = _title
     val isLoading: State<Boolean> get() = _isLoading
@@ -52,18 +61,7 @@ class RemoteTabComponent(
         tree?.let { widgetTree ->
             RemoteWidgetRenderer(
                 tree = widgetTree,
-                onEvent = { nodeId, event ->
-                    // Payloads can contain what the user typed — log the shape, not the content.
-                    logger.debug(
-                        "Tab UI event: tab={}, node={}, type={}",
-                        tabId,
-                        nodeId,
-                        event::class.simpleName,
-                    )
-                    scope.launch {
-                        sendUIEvent(nodeId, event)
-                    }
-                },
+                onEvent = { nodeId, event -> sendUIEvent(nodeId, event) },
             )
         }
     }
@@ -72,7 +70,11 @@ class RemoteTabComponent(
      * Connect to the plugin process and start streaming widget updates.
      */
     fun connect() {
-        logger.info("Connecting to remote tab: tabId={}, process={}, address={}", tabId, processId, uiAddress)
+        logger.info(
+            LogCategory.UI,
+            "Connecting to remote tab",
+            mapOf("tabId" to tabId, "process" to processId, "address" to uiAddress),
+        )
         scope.launch {
             connectToPluginProcess()
         }
@@ -82,7 +84,11 @@ class RemoteTabComponent(
      * Connect using a pre-existing gRPC channel.
      */
     fun connect(channel: ManagedChannel) {
-        logger.info("Connecting to remote tab via channel: tabId={}, process={}", tabId, processId)
+        logger.info(
+            LogCategory.UI,
+            "Connecting to remote tab via channel",
+            mapOf("tabId" to tabId, "process" to processId),
+        )
         scope.launch {
             connectWithChannel(channel)
         }
@@ -105,8 +111,9 @@ class RemoteTabComponent(
 
     fun dispose() {
         scope.cancel()
+        outgoingEvents.close()
         _connected.value = false
-        logger.info("Remote tab disposed: tabId={}", tabId)
+        logger.info(LogCategory.UI, "Remote tab disposed", mapOf("tabId" to tabId))
     }
 
     // ---- Internal ----
@@ -118,7 +125,12 @@ class RemoteTabComponent(
                     .BossIpcClient(uiAddress)
             connectWithChannel(client.channel)
         } catch (e: Exception) {
-            logger.error("Failed to connect to plugin process: tabId={}", tabId, e)
+            logger.error(
+                LogCategory.UI,
+                "Failed to connect to plugin process",
+                mapOf("tabId" to tabId),
+                error = e,
+            )
             _connected.value = false
         }
     }
@@ -131,7 +143,7 @@ class RemoteTabComponent(
 
             val widgetUpdateStream =
                 channelFlow {
-                    outgoingEvents.collect { event ->
+                    outgoingEvents.consumeAsFlow().collect { event ->
                         val update =
                             ai.rever.boss.ipc.proto.WidgetUpdate
                                 .newBuilder()
@@ -142,24 +154,38 @@ class RemoteTabComponent(
                 }
 
             stub.streamUI(widgetUpdateStream).collect { uiEvent ->
-                logger.debug("Received UI event from plugin tab: surface={}", uiEvent.surfaceId)
+                logger.debug(LogCategory.UI, "Received UI event from plugin tab", mapOf("surface" to uiEvent.surfaceId))
             }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
             _connected.value = false
-            logger.warn("Connection to plugin tab lost: tabId={}, error={}", tabId, e.message)
+            logger.warn(
+                LogCategory.UI,
+                "Connection to plugin tab lost",
+                mapOf("tabId" to tabId, "error" to e.message),
+            )
         }
     }
 
     /**
-     * Forward one interaction to the plugin process, mapped by [UIEventMapper] — a total mapping over
-     * the sealed [WidgetEvent] type, so no proto oneof case can be silently skipped.
+     * Queue one interaction for the plugin process — see [RemotePanelComponent] for why this is an
+     * ordered channel written from the callback rather than a coroutine per event, and why
+     * [UIEventMapper] owns the proto mapping.
      */
-    private suspend fun sendUIEvent(
+    private fun sendUIEvent(
         nodeId: String,
         event: WidgetEvent,
     ) {
-        outgoingEvents.emit(UIEventMapper.toProto(tabId, nodeId, event, System.currentTimeMillis()))
+        // Payloads can contain what the user typed — log the shape, not the content.
+        logger.debug(
+            LogCategory.UI,
+            "Tab UI event",
+            mapOf("tabId" to tabId, "node" to nodeId, "type" to event::class.simpleName),
+        )
+        val queued = outgoingEvents.trySend(UIEventMapper.toProto(tabId, nodeId, event, System.currentTimeMillis()))
+        if (queued.isFailure) {
+            logger.debug(LogCategory.UI, "Dropped UI event: surface is closed", mapOf("tabId" to tabId))
+        }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
@@ -53,26 +53,29 @@ private fun RenderNode(
     when (node.type) {
         WidgetType.COLUMN -> {
             Column(modifier = modifier) {
-                RenderChildren(node = node, tree = tree, onEvent = onEvent)
+                RenderChildren(node, tree, onEvent)
             }
         }
 
         WidgetType.ROW -> {
             Row(modifier = modifier) {
-                RenderChildren(node = node, tree = tree, onEvent = onEvent)
+                RenderChildren(node, tree, onEvent)
             }
         }
 
         WidgetType.BOX -> {
             Box(modifier = modifier) {
-                RenderChildren(node = node, tree = tree, onEvent = onEvent)
+                RenderChildren(node, tree, onEvent)
             }
         }
 
         WidgetType.SCROLL -> {
             val scrollState = rememberScrollState()
             Column(modifier = modifier.verticalScroll(scrollState)) {
-                RenderChildren(node = node, tree = tree, onEvent = onEvent)
+                // Everything below is measured with an unbounded max height — see the LIST branch.
+                CompositionLocalProvider(LocalUnboundedHeight provides true) {
+                    RenderChildren(node, tree, onEvent)
+                }
             }
         }
 
@@ -98,10 +101,8 @@ private fun RenderNode(
         }
 
         WidgetType.TEXT_FIELD -> {
-            // Keyed by node id: the plugin's `value` seeds the buffer, and the buffer survives tree
-            // updates that keep the node's identity (see WidgetTreeBuilder's deterministic ids).
-            var value by remember(node.id) { mutableStateOf(node.properties["value"] ?: "") }
             val placeholder = node.properties["placeholder"] ?: ""
+            var value by rememberPushableState(node.id, node.properties["value"] ?: "")
             OutlinedTextField(
                 value = value,
                 onValueChange = { newValue ->
@@ -109,15 +110,12 @@ private fun RenderNode(
                     onEvent(node.id, WidgetEvent.TextChange(newValue))
                 },
                 placeholder = { Text(placeholder) },
-                modifier =
-                    modifier.onFocusChanged { focusState ->
-                        onEvent(node.id, WidgetEvent.Focus(focusState.isFocused))
-                    },
+                modifier = modifier.notifyFocusChanges(node.id, onEvent),
             )
         }
 
         WidgetType.CHECKBOX -> {
-            var checked by remember(node.id) { mutableStateOf(node.properties["checked"]?.toBoolean() ?: false) }
+            var checked by rememberPushableState(node.id, node.properties["checked"].toBossBoolean())
             val label = node.properties["label"] ?: ""
             Row(modifier = modifier, verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
                 Checkbox(
@@ -135,7 +133,7 @@ private fun RenderNode(
         }
 
         WidgetType.TOGGLE -> {
-            var checked by remember(node.id) { mutableStateOf(node.properties["checked"]?.toBoolean() ?: false) }
+            var checked by rememberPushableState(node.id, node.properties["checked"].toBossBoolean())
             Switch(
                 checked = checked,
                 onCheckedChange = { newChecked ->
@@ -166,16 +164,29 @@ private fun RenderNode(
         }
 
         WidgetType.LIST -> {
+            // A LazyColumn measured with an unbounded max height throws, so a plugin could crash the
+            // host surface purely by nesting LIST inside SCROLL (or inside another LIST). Inside such
+            // a parent, fall back to a plain Column: no virtualization, but the surface survives
+            // whatever tree shape arrives over IPC.
+            // Read the ambient value BEFORE providing our own, or every list looks nested.
+            val unboundedParent = LocalUnboundedHeight.current
             val children = node.childIds.mapNotNull { tree.nodes[it] }
-            LazyColumn(modifier = modifier) {
-                if (children.isNotEmpty()) {
-                    items(items = children, key = { it.id }) { child ->
-                        RenderNode(node = child, tree = tree, onEvent = onEvent)
+            // WidgetTreeBuilder.list() carries rows as an `items` property rather than child nodes;
+            // walking childIds alone drew an empty list.
+            val rows = if (children.isEmpty()) node.resolveListItems() else emptyList()
+            CompositionLocalProvider(LocalUnboundedHeight provides true) {
+                if (unboundedParent) {
+                    Column(modifier = modifier) {
+                        children.forEach { child -> key(child.id) { RenderNode(child, tree, onEvent) } }
+                        rows.forEach { row -> Text(text = row) }
                     }
                 } else {
-                    // WidgetTreeBuilder.list() carries rows as an `items` property rather than child
-                    // nodes; walking childIds alone drew an empty list.
-                    items(node.resolveListItems()) { row -> Text(text = row) }
+                    LazyColumn(modifier = modifier) {
+                        items(items = children, key = { it.id }) { child ->
+                            RenderNode(child, tree, onEvent)
+                        }
+                        items(rows) { row -> Text(text = row) }
+                    }
                 }
             }
         }
@@ -256,17 +267,80 @@ private fun RenderChildren(
     node.childIds.forEach { childId ->
         tree.nodes[childId]?.let { child ->
             key(child.id) {
-                RenderNode(node = child, tree = tree, onEvent = onEvent)
+                RenderNode(child, tree, onEvent)
             }
         }
     }
 }
 
 /**
+ * Whether the surrounding layout measures its children with an unbounded max height.
+ *
+ * `LazyColumn` throws when measured that way, so a plugin could crash the host surface purely by
+ * nesting `LIST` inside `SCROLL` (or inside another `LIST`) — tree *shape* arriving over IPC, not a
+ * host bug. Ambient rather than a parameter: it describes the enclosing layout, and threading it
+ * through every branch would put it in `RenderNode`'s signature for one consumer.
+ */
+private val LocalUnboundedHeight = compositionLocalOf { false }
+
+/**
+ * Local widget state that the user edits and the **plugin can still push to**.
+ *
+ * A plain `remember(nodeId) { mutableStateOf(incoming) }` seeds once per node identity and then
+ * ignores the property forever, which means a plugin cannot drive its own widgets: no clearing a
+ * search box after submit, no echoing back a normalized value, no rejecting a toggle. Tracking the
+ * last value seen on the wire separates "the user typed" (leave the buffer alone) from "the plugin
+ * sent something new" (the plugin wins). An unchanged property re-sent on every tree update does
+ * *not* clobber in-flight typing.
+ */
+@Composable
+private fun <T> rememberPushableState(
+    nodeId: String,
+    incoming: T,
+): MutableState<T> {
+    val state = remember(nodeId) { mutableStateOf(incoming) }
+    val lastIncoming = remember(nodeId) { mutableStateOf(incoming) }
+    LaunchedEffect(nodeId, incoming) {
+        if (lastIncoming.value != incoming) {
+            lastIncoming.value = incoming
+            state.value = incoming
+        }
+    }
+    return state
+}
+
+/**
+ * Report focus transitions, and only transitions.
+ *
+ * `onFocusChanged` also fires when a node's focus state is first resolved on attach, so wiring it
+ * straight through made every text field announce focus *loss* the moment it rendered — a plugin
+ * could not tell that from a real blur. Gate on the previous value, seeded to `false` because a
+ * freshly composed (or re-keyed) node genuinely starts unfocused: that attach callback is not a
+ * transition, while an auto-focused field's `true` is one and still reports.
+ */
+@Composable
+private fun Modifier.notifyFocusChanges(
+    nodeId: String,
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
+): Modifier {
+    val lastFocused = remember(nodeId) { mutableStateOf(false) }
+    return onFocusChanged { focusState ->
+        val isFocused = focusState.isFocused
+        if (lastFocused.value != isFocused) {
+            lastFocused.value = isFocused
+            onEvent(nodeId, WidgetEvent.Focus(isFocused))
+        }
+    }
+}
+
+/** `String.toBoolean()` semantics for an absent property, matching the SDK's wire conventions. */
+private fun String?.toBossBoolean(): Boolean = this?.toBoolean() ?: false
+
+/**
  * Resolve a design-system token to a color from the host's active scheme.
  *
  * A table rather than a `when` so [ThemeToken] coverage is asserted by
- * `RemoteWidgetRendererThemeTokenTest` instead of being spread across the renderer.
+ * `RemoteWidgetRendererColorTest` instead of being spread across the renderer.
  */
 internal val themeTokenColors: Map<ThemeToken, BossColorScheme.() -> Color> =
     mapOf(
@@ -339,10 +413,12 @@ private fun WidgetModifier.toComposeModifier(
             )
     }
 
-    if (backgroundColor.isNotEmpty()) {
-        resolveBackgroundColor(backgroundColor, BossTheme.colors)?.let { color ->
-            m = m.background(color)
-        }
+    // Memoized: this runs for every node on every recomposition, and resolving a spec allocates
+    // (token normalization builds two strings, hex parsing more).
+    val colors = BossTheme.colors
+    val background = remember(backgroundColor, colors) { resolveBackgroundColor(backgroundColor, colors) }
+    if (background != null) {
+        m = m.background(background)
     }
 
     // After background, so a translucent widget keeps its own backdrop crisp — matches the native

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin.remote
 
+import ai.rever.boss.plugin.ui.BossColorScheme
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.ui.sdk.*
 import androidx.compose.foundation.background
@@ -12,6 +13,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -22,13 +25,18 @@ import androidx.compose.ui.unit.sp
  * This is the kernel-side renderer for Phase 4/7: plugins in separate JVM processes
  * send declarative widget trees over IPC, which the kernel renders using this component.
  *
+ * How a node's properties and modifier are interpreted lives in `boss-ui-sdk`
+ * ([resolveClickEventId], [resolveListItems], [resolveDropdownOptions], [effectiveAlpha],
+ * [parseBackgroundColor]) so that this renderer and the native `boss-remote-ui` renderer in the Rust
+ * shell agree by construction, and so the rules are testable without a UI toolkit.
+ *
  * @param tree      The widget tree to render
- * @param onEvent   Callback for UI events: (nodeId, eventType, eventData) -> Unit
+ * @param onEvent   Callback for UI events, forwarded to the owning plugin as proto `UIEvent`s
  */
 @Composable
 fun RemoteWidgetRenderer(
     tree: WidgetTree,
-    onEvent: (nodeId: String, eventType: String, eventData: String) -> Unit = { _, _, _ -> },
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit = { _, _ -> },
 ) {
     val root = tree.nodes[tree.rootId] ?: return
     RenderNode(node = root, tree = tree, onEvent = onEvent)
@@ -38,49 +46,33 @@ fun RemoteWidgetRenderer(
 private fun RenderNode(
     node: WidgetNode,
     tree: WidgetTree,
-    onEvent: (nodeId: String, eventType: String, eventData: String) -> Unit,
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
 ) {
     val modifier = node.modifier.toComposeModifier(node, onEvent)
 
     when (node.type) {
         WidgetType.COLUMN -> {
             Column(modifier = modifier) {
-                node.childIds.forEach { childId ->
-                    tree.nodes[childId]?.let { child ->
-                        RenderNode(node = child, tree = tree, onEvent = onEvent)
-                    }
-                }
+                RenderChildren(node = node, tree = tree, onEvent = onEvent)
             }
         }
 
         WidgetType.ROW -> {
             Row(modifier = modifier) {
-                node.childIds.forEach { childId ->
-                    tree.nodes[childId]?.let { child ->
-                        RenderNode(node = child, tree = tree, onEvent = onEvent)
-                    }
-                }
+                RenderChildren(node = node, tree = tree, onEvent = onEvent)
             }
         }
 
         WidgetType.BOX -> {
             Box(modifier = modifier) {
-                node.childIds.forEach { childId ->
-                    tree.nodes[childId]?.let { child ->
-                        RenderNode(node = child, tree = tree, onEvent = onEvent)
-                    }
-                }
+                RenderChildren(node = node, tree = tree, onEvent = onEvent)
             }
         }
 
         WidgetType.SCROLL -> {
             val scrollState = rememberScrollState()
             Column(modifier = modifier.verticalScroll(scrollState)) {
-                node.childIds.forEach { childId ->
-                    tree.nodes[childId]?.let { child ->
-                        RenderNode(node = child, tree = tree, onEvent = onEvent)
-                    }
-                }
+                RenderChildren(node = node, tree = tree, onEvent = onEvent)
             }
         }
 
@@ -95,39 +87,44 @@ private fun RenderNode(
         }
 
         WidgetType.BUTTON -> {
-            val label = node.properties["label"] ?: ""
-            val clickEventId = node.properties["clickEventId"] ?: node.modifier.clickEventId
+            // Accepts both spellings of the event id — see resolveClickEventId.
+            val clickEventId = node.resolveClickEventId()
             Button(
-                onClick = { onEvent(node.id, "click", clickEventId) },
+                onClick = { onEvent(node.id, WidgetEvent.Click(clickEventId)) },
                 modifier = modifier,
             ) {
-                Text(label)
+                Text(node.properties["label"] ?: "")
             }
         }
 
         WidgetType.TEXT_FIELD -> {
-            var value by remember { mutableStateOf(node.properties["value"] ?: "") }
+            // Keyed by node id: the plugin's `value` seeds the buffer, and the buffer survives tree
+            // updates that keep the node's identity (see WidgetTreeBuilder's deterministic ids).
+            var value by remember(node.id) { mutableStateOf(node.properties["value"] ?: "") }
             val placeholder = node.properties["placeholder"] ?: ""
             OutlinedTextField(
                 value = value,
                 onValueChange = { newValue ->
                     value = newValue
-                    onEvent(node.id, "textChange", newValue)
+                    onEvent(node.id, WidgetEvent.TextChange(newValue))
                 },
                 placeholder = { Text(placeholder) },
-                modifier = modifier,
+                modifier =
+                    modifier.onFocusChanged { focusState ->
+                        onEvent(node.id, WidgetEvent.Focus(focusState.isFocused))
+                    },
             )
         }
 
         WidgetType.CHECKBOX -> {
-            var checked by remember { mutableStateOf(node.properties["checked"]?.toBoolean() ?: false) }
+            var checked by remember(node.id) { mutableStateOf(node.properties["checked"]?.toBoolean() ?: false) }
             val label = node.properties["label"] ?: ""
             Row(modifier = modifier, verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
                 Checkbox(
                     checked = checked,
                     onCheckedChange = { newChecked ->
                         checked = newChecked
-                        onEvent(node.id, "toggle", newChecked.toString())
+                        onEvent(node.id, WidgetEvent.Toggle(newChecked))
                     },
                 )
                 if (label.isNotEmpty()) {
@@ -138,12 +135,12 @@ private fun RenderNode(
         }
 
         WidgetType.TOGGLE -> {
-            var checked by remember { mutableStateOf(node.properties["checked"]?.toBoolean() ?: false) }
+            var checked by remember(node.id) { mutableStateOf(node.properties["checked"]?.toBoolean() ?: false) }
             Switch(
                 checked = checked,
                 onCheckedChange = { newChecked ->
                     checked = newChecked
-                    onEvent(node.id, "toggle", newChecked.toString())
+                    onEvent(node.id, WidgetEvent.Toggle(newChecked))
                 },
                 modifier = modifier,
             )
@@ -169,10 +166,16 @@ private fun RenderNode(
         }
 
         WidgetType.LIST -> {
-            val items = node.childIds.mapNotNull { tree.nodes[it] }
+            val children = node.childIds.mapNotNull { tree.nodes[it] }
             LazyColumn(modifier = modifier) {
-                items(items) { item ->
-                    RenderNode(node = item, tree = tree, onEvent = onEvent)
+                if (children.isNotEmpty()) {
+                    items(items = children, key = { it.id }) { child ->
+                        RenderNode(node = child, tree = tree, onEvent = onEvent)
+                    }
+                } else {
+                    // WidgetTreeBuilder.list() carries rows as an `items` property rather than child
+                    // nodes; walking childIds alone drew an empty list.
+                    items(node.resolveListItems()) { row -> Text(text = row) }
                 }
             }
         }
@@ -190,19 +193,19 @@ private fun RenderNode(
         }
 
         WidgetType.DROPDOWN -> {
-            var expanded by remember { mutableStateOf(false) }
+            var expanded by remember(node.id) { mutableStateOf(false) }
             val selected = node.properties["selected"] ?: ""
-            val options = node.properties["options"]?.split(",") ?: emptyList()
+            val options = node.resolveDropdownOptions()
             Box(modifier = modifier) {
                 Text(
                     text = selected,
                     modifier = Modifier.clickable { expanded = true },
                 )
                 DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                    options.forEach { option ->
+                    options.forEachIndexed { index, option ->
                         DropdownMenuItem(onClick = {
                             expanded = false
-                            onEvent(node.id, "selection", option)
+                            onEvent(node.id, WidgetEvent.Selection(option, index))
                         }) {
                             Text(option)
                         }
@@ -238,41 +241,78 @@ private fun RenderNode(
 }
 
 /**
- * Parse a CSS hex color string (#RGB, #RRGGBB, or #AARRGGBB) into a Compose [Color].
+ * Render a container's children, giving each one a Compose identity keyed by its node id.
+ *
+ * Without the [key], Compose identifies children *positionally*, so inserting or reordering a
+ * sibling shifts every `remember`ed state (a text field's buffer, a dropdown's expanded flag) onto
+ * the wrong node.
  */
-private fun parseHexColor(hex: String): Color? =
-    runCatching {
-        val clean = hex.trimStart('#')
-        when (clean.length) {
-            6 -> {
-                Color(
-                    red = clean.substring(0, 2).toInt(16) / 255f,
-                    green = clean.substring(2, 4).toInt(16) / 255f,
-                    blue = clean.substring(4, 6).toInt(16) / 255f,
-                )
-            }
-
-            8 -> {
-                Color(
-                    alpha = clean.substring(0, 2).toInt(16) / 255f,
-                    red = clean.substring(2, 4).toInt(16) / 255f,
-                    green = clean.substring(4, 6).toInt(16) / 255f,
-                    blue = clean.substring(6, 8).toInt(16) / 255f,
-                )
-            }
-
-            else -> {
-                null
+@Composable
+private fun RenderChildren(
+    node: WidgetNode,
+    tree: WidgetTree,
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
+) {
+    node.childIds.forEach { childId ->
+        tree.nodes[childId]?.let { child ->
+            key(child.id) {
+                RenderNode(node = child, tree = tree, onEvent = onEvent)
             }
         }
-    }.getOrNull()
+    }
+}
+
+/**
+ * Resolve a design-system token to a color from the host's active scheme.
+ *
+ * A table rather than a `when` so [ThemeToken] coverage is asserted by
+ * `RemoteWidgetRendererThemeTokenTest` instead of being spread across the renderer.
+ */
+internal val themeTokenColors: Map<ThemeToken, BossColorScheme.() -> Color> =
+    mapOf(
+        ThemeToken.INK to { ink },
+        ThemeToken.PANEL to { panel },
+        ThemeToken.RAISED to { raised },
+        ThemeToken.LINE to { line },
+        ThemeToken.LINE_STRONG to { lineStrong },
+        ThemeToken.TEXT_PRIMARY to { textPrimary },
+        ThemeToken.TEXT_SECONDARY to { textSecondary },
+        ThemeToken.TEXT_MUTED to { textMuted },
+        ThemeToken.SIGNAL to { signal },
+        ThemeToken.SIGNAL_DIM to { signalDim },
+        ThemeToken.SIGNAL_WASH to { signalWash },
+        ThemeToken.DATA to { data },
+        ThemeToken.OK to { ok },
+        ThemeToken.WARN to { warn },
+        ThemeToken.ALERT to { alert },
+        ThemeToken.ON_SIGNAL to { onSignal },
+        ThemeToken.ON_DATA to { onData },
+    )
+
+/**
+ * Resolve a `WidgetModifier.background_color` spec against [scheme].
+ *
+ * `ui_protocol.proto` promises "hex color string … or theme token"; only hex was ever parsed, so
+ * every token value was silently dropped. Tokens resolve through the host's *active* theme, so a
+ * plugin asking for `panel` re-skins with the app.
+ */
+internal fun resolveBackgroundColor(
+    spec: String,
+    scheme: BossColorScheme,
+): Color? =
+    when (val parsed = parseBackgroundColor(spec)) {
+        is BackgroundSpec.Token -> themeTokenColors[parsed.token]?.invoke(scheme)
+        is BackgroundSpec.Hex -> Color(parsed.argb)
+        BackgroundSpec.None -> null
+    }
 
 /**
  * Convert [WidgetModifier] to a Compose [Modifier].
  */
+@Composable
 private fun WidgetModifier.toComposeModifier(
     node: WidgetNode,
-    onEvent: (nodeId: String, eventType: String, eventData: String) -> Unit,
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
 ): Modifier {
     var m: Modifier = Modifier
 
@@ -300,13 +340,19 @@ private fun WidgetModifier.toComposeModifier(
     }
 
     if (backgroundColor.isNotEmpty()) {
-        parseHexColor(backgroundColor)?.let { color ->
+        resolveBackgroundColor(backgroundColor, BossTheme.colors)?.let { color ->
             m = m.background(color)
         }
     }
 
+    // After background, so a translucent widget keeps its own backdrop crisp — matches the native
+    // renderer. `effectiveAlpha()` resolves proto3's "unset is 0.0" trap; see WidgetModifier.alpha.
+    effectiveAlpha()?.let { resolved ->
+        m = m.alpha(resolved)
+    }
+
     if (clickable && clickEventId.isNotEmpty()) {
-        m = m.clickable { onEvent(node.id, "click", clickEventId) }
+        m = m.clickable { onEvent(node.id, WidgetEvent.Click(clickEventId)) }
     }
 
     return m

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererColorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererColorTest.kt
@@ -29,6 +29,24 @@ class RemoteWidgetRendererColorTest {
     }
 
     @Test
+    fun `the token vocabulary covers the whole color scheme`() {
+        // `ui_protocol.proto` now publishes the token list as part of the contract, so a colour added
+        // to BossColorScheme must not silently stay unaddressable. Counting the data class's
+        // componentN accessors avoids a kotlin-reflect dependency (Color is a value class, so the
+        // backing fields are primitives and would not be recognizable by type).
+        val schemeProperties =
+            ai.rever.boss.plugin.ui.BossColorScheme::class.java.declaredMethods
+                .count { it.name.startsWith("component") }
+
+        assertEquals(
+            schemeProperties,
+            ThemeToken.entries.size,
+            "BossColorScheme has $schemeProperties colours but ThemeToken names ${ThemeToken.entries.size}; " +
+                "add the missing token (and its row in themeTokenColors + the proto comment)",
+        )
+    }
+
+    @Test
     fun `tokens resolve against the active scheme`() {
         assertEquals(BossDarkColorScheme.panel, resolveBackgroundColor("panel", BossDarkColorScheme))
         assertEquals(BossLightColorScheme.panel, resolveBackgroundColor("panel", BossLightColorScheme))

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererColorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererColorTest.kt
@@ -1,0 +1,50 @@
+package ai.rever.boss.components.plugin.remote
+
+import ai.rever.boss.plugin.ui.BossDarkColorScheme
+import ai.rever.boss.plugin.ui.BossLightColorScheme
+import ai.rever.boss.ui.sdk.ThemeToken
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * `WidgetModifier.background_color` resolution (issue #34 item 5).
+ *
+ * `ui_protocol.proto` promises "hex color string … or theme token", but the renderer only ever parsed
+ * hex, so every token value a plugin sent was dropped on the floor.
+ */
+class RemoteWidgetRendererColorTest {
+    @Test
+    fun `every theme token resolves to a color`() {
+        // A token the table forgets would silently fall back to "no background".
+        assertEquals(ThemeToken.entries.toSet(), themeTokenColors.keys)
+        for (token in ThemeToken.entries) {
+            assertNotNull(
+                resolveBackgroundColor(token.tokenName, BossDarkColorScheme),
+                "token ${token.tokenName} must resolve",
+            )
+        }
+    }
+
+    @Test
+    fun `tokens resolve against the active scheme`() {
+        assertEquals(BossDarkColorScheme.panel, resolveBackgroundColor("panel", BossDarkColorScheme))
+        assertEquals(BossLightColorScheme.panel, resolveBackgroundColor("panel", BossLightColorScheme))
+        assertEquals(BossDarkColorScheme.signalWash, resolveBackgroundColor("signal_wash", BossDarkColorScheme))
+    }
+
+    @Test
+    fun `hex specs still resolve`() {
+        assertEquals(Color(0xFFFF0000), resolveBackgroundColor("#FF0000", BossDarkColorScheme))
+        assertEquals(Color(0x80FF0000), resolveBackgroundColor("#80FF0000", BossDarkColorScheme))
+    }
+
+    @Test
+    fun `unknown specs resolve to no background`() {
+        assertNull(resolveBackgroundColor("", BossDarkColorScheme))
+        assertNull(resolveBackgroundColor("rebeccapurple", BossDarkColorScheme))
+        assertNull(resolveBackgroundColor("#F00", BossDarkColorScheme))
+    }
+}

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -53,9 +53,28 @@ message WidgetTree {
 }
 
 message WidgetNode {
+  // Node identity. Renderers key per-node state (text-field buffers, scroll
+  // offsets) on this, and WidgetDiff operations address nodes by it, so senders
+  // must keep ids STABLE across rebuilds of the same logical widget. Freshly
+  // random ids per build turn every update into remove-all/add-all and discard
+  // whatever the user was typing.
   string id = 1;
+
   WidgetType type = 2;
-  map<string, string> properties = 3;    // Type-specific properties (all as strings)
+
+  // Type-specific properties (all values as strings). Notable keys:
+  //   BUTTON:      "label", "clickEventId" (also accepted: "onClickEvent")
+  //   TEXT:        "value", "fontSize", "style"
+  //   TEXT_FIELD:  "value", "placeholder", "onChangeEvent"
+  //   CHECKBOX /
+  //   TOGGLE:      "checked", "label", "onToggleEvent"
+  //   DROPDOWN:    "selected", "options" (comma-joined), "onSelectEvent"
+  //   LIST:        "items" (comma-joined rows, used when child_ids is empty)
+  //   ICON:        "name", "size"
+  //   PROGRESS:    "value", "indeterminate"
+  //   SPACER:      "height"
+  map<string, string> properties = 3;
+
   repeated string child_ids = 4;         // Ordered child node IDs
   WidgetModifier modifier = 5;           // Layout/style modifiers
 }
@@ -100,8 +119,22 @@ message WidgetModifier {
   int32 padding_top = 4;
   int32 padding_end = 5;
   int32 padding_bottom = 6;
-  string background_color = 7;  // Hex color string (e.g., "#FF0000") or theme token
-  float alpha = 8;              // 0.0-1.0
+
+  // Hex color ("#RRGGBB" / "#AARRGGBB") or a design-system theme token resolved
+  // against the host's ACTIVE theme, so the widget re-skins with the app:
+  // ink, panel, raised, line, lineStrong, textPrimary, textSecondary,
+  // textMuted, signal, signalDim, signalWash, data, ok, warn, alert, onSignal,
+  // onData. Token names are matched case-insensitively, ignoring '_' and '-'.
+  // Empty, or anything that is neither a token nor valid hex: no background.
+  string background_color = 7;
+
+  // Opacity 0.0-1.0. NOTE: 0.0 means "unset", NOT "invisible". proto3 has no
+  // presence for scalars, so a sender that never touches this field sends 0.0;
+  // honouring that literally would make every widget from every such plugin
+  // disappear. Renderers apply the value only when it lies strictly inside
+  // (0.0, 1.0). A widget that should not be visible must not be sent.
+  float alpha = 8;
+
   bool clickable = 9;
   string click_event_id = 10;   // Event ID sent back on click
 }

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -73,6 +73,19 @@ message WidgetNode {
   //   ICON:        "name", "size"
   //   PROGRESS:    "value", "indeterminate"
   //   SPACER:      "height"
+  //
+  // Comma-joined values ("options", "items") split on ',' with NO escaping and
+  // NO trimming: "Buy milk, eggs" is two entries, the second " eggs". Send
+  // values that may contain a comma as child nodes instead. An absent or empty
+  // property means zero entries; "a,,b" is three entries with a blank middle
+  // one. Boolean values follow Kotlin's String.toBoolean: case-insensitive
+  // "true", everything else false.
+  //
+  // A widget's local state (a text field's buffer, a checkbox's flag) is seeded
+  // from these properties and thereafter owned by the user — but a NEW value on
+  // an update replaces it, which is how a plugin clears a field after submit or
+  // pushes back a normalized/rejected value. Re-sending an unchanged value does
+  // not disturb in-flight editing.
   map<string, string> properties = 3;
 
   repeated string child_ids = 4;         // Ordered child node IDs

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/UIEventMapper.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/UIEventMapper.kt
@@ -1,0 +1,151 @@
+package ai.rever.boss.ui.sdk
+
+import ai.rever.boss.ipc.proto.ClickEvent as ProtoClickEvent
+import ai.rever.boss.ipc.proto.FocusEvent as ProtoFocusEvent
+import ai.rever.boss.ipc.proto.KeyEvent as ProtoKeyEvent
+import ai.rever.boss.ipc.proto.LifecycleEvent as ProtoLifecycleEvent
+import ai.rever.boss.ipc.proto.ScrollEvent as ProtoScrollEvent
+import ai.rever.boss.ipc.proto.SelectionEvent as ProtoSelectionEvent
+import ai.rever.boss.ipc.proto.TextChangeEvent as ProtoTextChangeEvent
+import ai.rever.boss.ipc.proto.ToggleEvent as ProtoToggleEvent
+import ai.rever.boss.ipc.proto.UIEvent as ProtoUIEvent
+
+/**
+ * Maps [WidgetEvent]s onto the `UIEvent` wire type and back.
+ *
+ * Every case of the proto oneof is covered in both directions. The host used to build these events
+ * inline (duplicated in each surface component) from a `(eventType, eventData)` string pair, and the
+ * `when` had no branch for `"selection"` — dropdown picks crossed the wire as a `UIEvent` with an
+ * *unset* oneof, i.e. an event the plugin cannot interpret. A total mapping over a sealed type makes
+ * that class of gap a compile error instead of silence.
+ */
+object UIEventMapper {
+    /** Wrap a single event for the wire. */
+    fun toProto(
+        surfaceId: String,
+        nodeId: String,
+        event: WidgetEvent,
+        timestampMs: Long,
+    ): ProtoUIEvent =
+        ProtoUIEvent
+            .newBuilder()
+            .setSurfaceId(surfaceId)
+            .setTargetNodeId(nodeId)
+            .setTimestamp(timestampMs)
+            .applyEvent(event)
+            .build()
+
+    /** Wrap an already-tagged event for the wire. */
+    fun toProto(
+        surfaceId: String,
+        emitted: EmittedEvent,
+        timestampMs: Long,
+    ): ProtoUIEvent = toProto(surfaceId, emitted.nodeId, emitted.event, timestampMs)
+
+    /**
+     * Read a wire event back. `null` when the oneof is unset — either a malformed sender or a case
+     * added to the proto after this build, which callers must skip rather than misinterpret.
+     */
+    fun fromProto(event: ProtoUIEvent): EmittedEvent? {
+        val widgetEvent = toWidgetEvent(event) ?: return null
+        return EmittedEvent(event.targetNodeId, widgetEvent)
+    }
+
+    private fun ProtoUIEvent.Builder.applyEvent(event: WidgetEvent): ProtoUIEvent.Builder =
+        when (event) {
+            is WidgetEvent.Click -> {
+                setClick(ProtoClickEvent.newBuilder().setEventId(event.eventId))
+            }
+
+            is WidgetEvent.TextChange -> {
+                setTextChange(ProtoTextChangeEvent.newBuilder().setNewValue(event.newValue))
+            }
+
+            is WidgetEvent.Toggle -> {
+                setToggle(ProtoToggleEvent.newBuilder().setChecked(event.checked))
+            }
+
+            is WidgetEvent.Selection -> {
+                setSelection(
+                    ProtoSelectionEvent
+                        .newBuilder()
+                        .setSelectedValue(event.value)
+                        .setSelectedIndex(event.index),
+                )
+            }
+
+            is WidgetEvent.Key -> {
+                setKey(
+                    ProtoKeyEvent
+                        .newBuilder()
+                        .setKeyCode(event.keyCode)
+                        .setCtrl(event.ctrl)
+                        .setAlt(event.alt)
+                        .setShift(event.shift)
+                        .setMeta(event.meta),
+                )
+            }
+
+            is WidgetEvent.Scroll -> {
+                setScroll(
+                    ProtoScrollEvent
+                        .newBuilder()
+                        .setDeltaX(event.deltaX)
+                        .setDeltaY(event.deltaY),
+                )
+            }
+
+            is WidgetEvent.Focus -> {
+                setFocus(ProtoFocusEvent.newBuilder().setHasFocus(event.hasFocus))
+            }
+
+            is WidgetEvent.Lifecycle -> {
+                setLifecycle(ProtoLifecycleEvent.newBuilder().setLifecycleState(event.state))
+            }
+        }
+
+    private fun toWidgetEvent(event: ProtoUIEvent): WidgetEvent? =
+        when (event.eventCase) {
+            ProtoUIEvent.EventCase.CLICK -> {
+                WidgetEvent.Click(event.click.eventId)
+            }
+
+            ProtoUIEvent.EventCase.TEXT_CHANGE -> {
+                WidgetEvent.TextChange(event.textChange.newValue)
+            }
+
+            ProtoUIEvent.EventCase.TOGGLE -> {
+                WidgetEvent.Toggle(event.toggle.checked)
+            }
+
+            ProtoUIEvent.EventCase.SELECTION -> {
+                WidgetEvent.Selection(event.selection.selectedValue, event.selection.selectedIndex)
+            }
+
+            ProtoUIEvent.EventCase.KEY -> {
+                WidgetEvent.Key(
+                    keyCode = event.key.keyCode,
+                    ctrl = event.key.ctrl,
+                    alt = event.key.alt,
+                    shift = event.key.shift,
+                    meta = event.key.meta,
+                )
+            }
+
+            ProtoUIEvent.EventCase.SCROLL -> {
+                WidgetEvent.Scroll(event.scroll.deltaX, event.scroll.deltaY)
+            }
+
+            ProtoUIEvent.EventCase.FOCUS -> {
+                WidgetEvent.Focus(event.focus.hasFocus)
+            }
+
+            ProtoUIEvent.EventCase.LIFECYCLE -> {
+                WidgetEvent.Lifecycle(event.lifecycle.lifecycleState)
+            }
+
+            ProtoUIEvent.EventCase.EVENT_NOT_SET, null -> {
+                null
+            }
+        }
+}

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngine.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngine.kt
@@ -90,34 +90,86 @@ object WidgetDiffEngine {
             }
         }
 
+        // Sibling reorders, last: they must apply after the parent-change moves above, because a
+        // NodeMoved re-inserts at an absolute index in the parent's list.
+        ops.addAll(reorderOps(old, new, oldParents, newParents))
+
         return ops
     }
+
+    /**
+     * Emit the moves that fix sibling order *within* a parent.
+     *
+     * `NodeMoved` used to be emitted only when a node changed parent, and common nodes were never
+     * compared on `childIds` — so swapping two siblings produced **no operations at all** and
+     * `apply(old, diff(old, new)) != new`. `apply` has always handled a same-parent move; nothing
+     * generated one. (It was masked while builder ids were positional, since a reorder then looked
+     * like a pile of property changes. Stable ids — now a documented requirement in the proto — are
+     * exactly what makes it reachable.)
+     *
+     * Only children that exist in both trees *and* kept this parent participate: additions,
+     * removals and cross-parent moves are already covered by their own ops, and their positions fall
+     * out of applying those. When the surviving order differs, the whole surviving sequence is
+     * re-emitted in its new order rather than a minimal move set — correct and independent of how a
+     * receiver orders the ops, at the cost of up to `k` ops for a `k`-child reorder. A minimal
+     * (longest-increasing-subsequence) set would be a pure optimization.
+     */
+    private fun reorderOps(
+        old: WidgetTree,
+        new: WidgetTree,
+        oldParents: Map<String, String>,
+        newParents: Map<String, String>,
+    ): List<DiffOperation> =
+        new.nodes.entries.flatMap { (parentId, newParent) ->
+            // Parents absent from the old tree arrive whole; their children need no moves.
+            val keptOldOrder =
+                old.nodes[parentId]?.childIds?.filter { it.keepsParent(parentId, oldParents, newParents) }
+            val keptNewOrder = newParent.childIds.filter { it.keepsParent(parentId, oldParents, newParents) }
+
+            if (keptOldOrder == null || keptOldOrder == keptNewOrder) {
+                emptyList()
+            } else {
+                keptNewOrder.map { childId ->
+                    DiffOperation.NodeMoved(childId, parentId, newParent.childIds.indexOf(childId))
+                }
+            }
+        }
+
+    /** True when this child is linked to [parentId] in both the old and the new tree. */
+    private fun String.keepsParent(
+        parentId: String,
+        oldParents: Map<String, String>,
+        newParents: Map<String, String>,
+    ): Boolean = oldParents[this] == parentId && newParents[this] == parentId
 
     fun apply(
         base: WidgetTree,
         operations: List<DiffOperation>,
     ): WidgetTree {
         val nodes = base.nodes.toMutableMap()
+        // child id → parent id, maintained as ops mutate the links. Unlinking used to scan every node
+        // for whoever listed the child (O(n) per remove/move, O(n²) for a list turnover) on the
+        // per-update path.
+        val parentOf = buildParentMap(base).toMutableMap()
 
         for (op in operations) {
             when (op) {
                 is DiffOperation.NodeAdded -> {
                     nodes[op.node.id] = op.node
+                    // The payload carries the node's own children, so they are linked from here on.
+                    for (childId in op.node.childIds) parentOf[childId] = op.node.id
                     if (op.parentId.isNotEmpty()) {
                         val parent = nodes[op.parentId]
                         if (parent != null) {
                             nodes[op.parentId] = parent.copy(childIds = parent.childIds.withChild(op.node.id, op.index))
+                            parentOf[op.node.id] = op.parentId
                         }
                     }
                 }
 
                 is DiffOperation.NodeRemoved -> {
-                    val parentEntry = nodes.entries.firstOrNull { op.nodeId in it.value.childIds }
                     nodes.remove(op.nodeId)
-                    if (parentEntry != null) {
-                        val (parentId, parentNode) = parentEntry
-                        nodes[parentId] = parentNode.copy(childIds = parentNode.childIds - op.nodeId)
-                    }
+                    nodes.unlink(op.nodeId, parentOf)
                 }
 
                 is DiffOperation.NodeUpdated -> {
@@ -131,26 +183,28 @@ object WidgetDiffEngine {
                 }
 
                 is DiffOperation.NodeMoved -> {
-                    // Remove from old parent
-                    val oldParentEntry = nodes.entries.firstOrNull { op.nodeId in it.value.childIds }
-                    if (oldParentEntry != null) {
-                        val (oldParentId, oldParentNode) = oldParentEntry
-                        nodes[oldParentId] =
-                            oldParentNode.copy(
-                                childIds = oldParentNode.childIds - op.nodeId,
-                            )
-                    }
-                    // Add to new parent
+                    nodes.unlink(op.nodeId, parentOf)
                     val newParent = nodes[op.newParentId]
                     if (newParent != null) {
                         nodes[op.newParentId] =
                             newParent.copy(childIds = newParent.childIds.withChild(op.nodeId, op.newIndex))
+                        parentOf[op.nodeId] = op.newParentId
                     }
                 }
             }
         }
 
         return base.copy(nodes = nodes, version = base.version + 1)
+    }
+
+    /** Drop [nodeId] from whichever parent currently lists it, keeping [parentOf] in step. */
+    private fun MutableMap<String, WidgetNode>.unlink(
+        nodeId: String,
+        parentOf: MutableMap<String, String>,
+    ) {
+        val parentId = parentOf.remove(nodeId) ?: return
+        val parent = this[parentId] ?: return
+        this[parentId] = parent.copy(childIds = parent.childIds - nodeId)
     }
 
     /**

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngine.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngine.kt
@@ -106,9 +106,7 @@ object WidgetDiffEngine {
                     if (op.parentId.isNotEmpty()) {
                         val parent = nodes[op.parentId]
                         if (parent != null) {
-                            val children = parent.childIds.toMutableList()
-                            children.add(op.index.coerceIn(0, children.size), op.node.id)
-                            nodes[op.parentId] = parent.copy(childIds = children)
+                            nodes[op.parentId] = parent.copy(childIds = parent.childIds.withChild(op.node.id, op.index))
                         }
                     }
                 }
@@ -145,9 +143,8 @@ object WidgetDiffEngine {
                     // Add to new parent
                     val newParent = nodes[op.newParentId]
                     if (newParent != null) {
-                        val children = newParent.childIds.toMutableList()
-                        children.add(op.newIndex.coerceIn(0, children.size), op.nodeId)
-                        nodes[op.newParentId] = newParent.copy(childIds = children)
+                        nodes[op.newParentId] =
+                            newParent.copy(childIds = newParent.childIds.withChild(op.nodeId, op.newIndex))
                     }
                 }
             }
@@ -155,6 +152,24 @@ object WidgetDiffEngine {
 
         return base.copy(nodes = nodes, version = base.version + 1)
     }
+
+    /**
+     * Insert [childId] at [index], or leave the list untouched if it already links that child.
+     *
+     * A `NodeAdded` payload carries the added node's own `childIds`, so when a whole subtree is added
+     * the parent arrives already linked to children that then get their own `NodeAdded` ops. Applying
+     * those parent-first (map iteration order decides, so it happens in practice) linked each child
+     * twice, and the renderer drew the subtree twice. Idempotent insertion makes op order irrelevant.
+     */
+    private fun List<String>.withChild(
+        childId: String,
+        index: Int,
+    ): List<String> =
+        if (contains(childId)) {
+            this
+        } else {
+            toMutableList().apply { add(index.coerceIn(0, size), childId) }
+        }
 
     private fun buildParentMap(tree: WidgetTree): Map<String, String> {
         val parentOf = mutableMapOf<String, String>()

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetEvent.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetEvent.kt
@@ -1,0 +1,81 @@
+package ai.rever.boss.ui.sdk
+
+/**
+ * A user interaction a renderer reports back to the plugin that owns the surface.
+ *
+ * One variant per `UIEvent` oneof case in `ui_protocol.proto`, so the mapping to the wire
+ * ([UIEventMapper]) is total and a renderer cannot express an event the protocol can't carry.
+ * Renderers previously reported events as a `(nodeId, eventType: String, eventData: String)` triple,
+ * which silently lost the fields that don't fit one string (a selection's index, a key's modifiers)
+ * and made "did anyone map this case?" invisible to the compiler.
+ */
+sealed interface WidgetEvent {
+    /** A button press, or a click on a node with `clickable` set. */
+    data class Click(
+        val eventId: String,
+    ) : WidgetEvent
+
+    /** A text-field edit, carrying the full new value. */
+    data class TextChange(
+        val newValue: String,
+    ) : WidgetEvent
+
+    /** A checkbox or switch flip. */
+    data class Toggle(
+        val checked: Boolean,
+    ) : WidgetEvent
+
+    /** A dropdown selection: the chosen label and its index in the node's `options`. */
+    data class Selection(
+        val value: String,
+        val index: Int,
+    ) : WidgetEvent
+
+    /** A key press on a focused widget. [keyCode] is the platform key code. */
+    data class Key(
+        val keyCode: Int,
+        val ctrl: Boolean = false,
+        val alt: Boolean = false,
+        val shift: Boolean = false,
+        val meta: Boolean = false,
+    ) : WidgetEvent
+
+    /** A scroll gesture delta, in logical pixels. */
+    data class Scroll(
+        val deltaX: Float,
+        val deltaY: Float,
+    ) : WidgetEvent
+
+    /** Focus gained ([hasFocus] `true`) or lost. */
+    data class Focus(
+        val hasFocus: Boolean,
+    ) : WidgetEvent
+
+    /**
+     * A surface lifecycle transition. [state] is one of [LifecycleStates]; it stays a free string
+     * because the proto field is one, and an unknown state must survive the round trip rather than
+     * being dropped.
+     */
+    data class Lifecycle(
+        val state: String,
+    ) : WidgetEvent
+}
+
+/** The lifecycle states `ui_protocol.proto` documents for `LifecycleEvent.lifecycle_state`. */
+object LifecycleStates {
+    const val CREATED: String = "created"
+    const val RESUMED: String = "resumed"
+    const val PAUSED: String = "paused"
+    const val DESTROYED: String = "destroyed"
+}
+
+/**
+ * A [WidgetEvent] tagged with the node that produced it.
+ *
+ * Surface-level events (lifecycle) carry an empty [nodeId] — they belong to the surface, not to a
+ * node in its tree.
+ */
+data class EmittedEvent(
+    val nodeId: String,
+    val event: WidgetEvent,
+)

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
@@ -130,7 +130,10 @@ object WidgetProtoConverter {
             paddingEnd = paddingEnd,
             paddingBottom = paddingBottom,
             backgroundColor = backgroundColor,
-            alpha = alpha,
+            // Canonicalized, NOT copied verbatim: proto3's unset 0.0 and the Kotlin default 1f both
+            // mean "opaque", and WidgetDiffEngine compares modifiers structurally. See
+            // normalizeWireAlpha.
+            alpha = normalizeWireAlpha(alpha),
             clickable = clickable,
             clickEventId = clickEventId,
         )

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetSemantics.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetSemantics.kt
@@ -1,0 +1,173 @@
+package ai.rever.boss.ui.sdk
+
+/**
+ * Property/modifier interpretation rules shared by every widget-tree renderer.
+ *
+ * These live in the SDK rather than inside a renderer on purpose: they are the *contract* between
+ * [WidgetTreeBuilder] (plugin side) and whatever draws the tree (host side, Compose today, the
+ * native `boss-remote-ui` renderer in the Rust shell). Keeping them here means both ends resolve a
+ * node identically and the rules are unit-testable without a UI toolkit.
+ */
+
+// ---- Property names -------------------------------------------------------
+
+/** Canonical spelling of a button's click event id — what renderers read first. */
+const val PROP_CLICK_EVENT_ID: String = "clickEventId"
+
+/** Legacy spelling written by [WidgetTreeBuilder.button]; accepted as a fallback. */
+const val PROP_ON_CLICK_EVENT: String = "onClickEvent"
+
+/** Comma-joined row labels written by [WidgetTreeBuilder.list]. */
+const val PROP_ITEMS: String = "items"
+
+/** Comma-joined option labels written by [WidgetTreeBuilder.dropdown]. */
+const val PROP_OPTIONS: String = "options"
+
+private const val UNSET_ALPHA = 0f
+private const val OPAQUE_ALPHA = 1f
+
+/**
+ * Resolve the event id a click on this node should report.
+ *
+ * Precedence: [PROP_CLICK_EVENT_ID], then [PROP_ON_CLICK_EVENT], then [WidgetModifier.clickEventId];
+ * empty values fall through. Both spellings are accepted because
+ * `WidgetTreeBuilder.button()` historically wrote only `onClickEvent` while renderers read only
+ * `clickEventId` — every builder-built button clicked with an empty id. The builder now writes both
+ * (so already-shipped hosts work) and renderers accept either (so already-shipped plugins work).
+ */
+fun WidgetNode.resolveClickEventId(): String =
+    sequenceOf(
+        properties[PROP_CLICK_EVENT_ID],
+        properties[PROP_ON_CLICK_EVENT],
+        modifier.clickEventId,
+    ).firstOrNull { !it.isNullOrEmpty() } ?: ""
+
+/**
+ * Row labels for a `LIST` node that carries no child nodes.
+ *
+ * [WidgetTreeBuilder.list] writes a comma-joined `items` property instead of child nodes, so a
+ * renderer that only walks `childIds` draws an empty list. Renderers should prefer children and
+ * fall back to this.
+ */
+fun WidgetNode.resolveListItems(): List<String> = splitCommaProperty(PROP_ITEMS)
+
+/** Option labels for a `DROPDOWN` node. Empty (not `[""]`) when the property is absent or blank. */
+fun WidgetNode.resolveDropdownOptions(): List<String> = splitCommaProperty(PROP_OPTIONS)
+
+private fun WidgetNode.splitCommaProperty(key: String): List<String> =
+    properties[key]?.takeIf { it.isNotEmpty() }?.split(",") ?: emptyList()
+
+/**
+ * The opacity a renderer should actually apply, or `null` when there is nothing to apply.
+ *
+ * Resolves the proto3 presence gap documented on [WidgetModifier.alpha]: `<= 0` means "unset"
+ * (proto3's default for an untouched float), `>= 1` means fully opaque, and `NaN` is garbage.
+ * Only a value strictly inside `(0, 1)` is a real request.
+ */
+fun WidgetModifier.effectiveAlpha(): Float? =
+    when {
+        alpha.isNaN() -> null
+        alpha <= UNSET_ALPHA -> null
+        alpha >= OPAQUE_ALPHA -> null
+        else -> alpha
+    }
+
+// ---- Background color -----------------------------------------------------
+
+/**
+ * The BOSS design-system color tokens a plugin may name in [WidgetModifier.backgroundColor].
+ *
+ * One entry per `BossColorScheme` field. Token names resolve against the *host's* active theme, so
+ * a plugin that asks for `panel` re-skins with the app instead of pinning a hex value.
+ */
+enum class ThemeToken(
+    val tokenName: String,
+) {
+    INK("ink"),
+    PANEL("panel"),
+    RAISED("raised"),
+    LINE("line"),
+    LINE_STRONG("lineStrong"),
+    TEXT_PRIMARY("textPrimary"),
+    TEXT_SECONDARY("textSecondary"),
+    TEXT_MUTED("textMuted"),
+    SIGNAL("signal"),
+    SIGNAL_DIM("signalDim"),
+    SIGNAL_WASH("signalWash"),
+    DATA("data"),
+    OK("ok"),
+    WARN("warn"),
+    ALERT("alert"),
+    ON_SIGNAL("onSignal"),
+    ON_DATA("onData"),
+    ;
+
+    companion object {
+        private val byNormalizedName: Map<String, ThemeToken> =
+            entries.associateBy { normalize(it.tokenName) }
+
+        private fun normalize(spec: String): String = spec.filter { it != '_' && it != '-' }.lowercase()
+
+        /** Match a wire spec against the token names, accepting `camelCase`, `snake_case` and `kebab-case`. */
+        fun fromSpec(spec: String): ThemeToken? = byNormalizedName[normalize(spec)]
+    }
+}
+
+/** What a [WidgetModifier.backgroundColor] string resolves to. */
+sealed interface BackgroundSpec {
+    /** A design-system token; the renderer looks it up in the host's active color scheme. */
+    data class Token(
+        val token: ThemeToken,
+    ) : BackgroundSpec
+
+    /** A literal color as packed `0xAARRGGBB` (opaque alpha filled in for the `#RRGGBB` form). */
+    data class Hex(
+        val argb: Long,
+    ) : BackgroundSpec
+
+    /** Absent, or a spec that is neither a known token nor valid hex — draw no background. */
+    data object None : BackgroundSpec
+}
+
+private const val RGB_HEX_LENGTH = 6
+private const val ARGB_HEX_LENGTH = 8
+private const val OPAQUE_ALPHA_BITS = 0xFF000000L
+
+/**
+ * Resolve a [WidgetModifier.backgroundColor] spec.
+ *
+ * Tokens win over hex (they cannot collide: no token name is valid hex). Unknown specs resolve to
+ * [BackgroundSpec.None] rather than throwing — a plugin typo must not take the surface down.
+ */
+fun parseBackgroundColor(spec: String): BackgroundSpec =
+    when {
+        spec.isEmpty() -> {
+            BackgroundSpec.None
+        }
+
+        else -> {
+            ThemeToken.fromSpec(spec)?.let(BackgroundSpec::Token)
+                ?: parseHexArgb(spec)?.let(BackgroundSpec::Hex)
+                ?: BackgroundSpec.None
+        }
+    }
+
+/** Shorthand for `parseBackgroundColor(backgroundColor)`. */
+fun WidgetModifier.resolveBackground(): BackgroundSpec = parseBackgroundColor(backgroundColor)
+
+/**
+ * Parse `#RRGGBB` / `#AARRGGBB` (with or without the leading `#`) into packed `0xAARRGGBB`.
+ * `null` for anything else — including the 3-digit `#RGB` shorthand, which this protocol has never
+ * accepted.
+ */
+private fun parseHexArgb(hex: String): Long? {
+    val clean = hex.trimStart('#')
+    return when {
+        !clean.all { it.isHexDigit() } -> null
+        clean.length == RGB_HEX_LENGTH -> OPAQUE_ALPHA_BITS or clean.toLong(16)
+        clean.length == ARGB_HEX_LENGTH -> clean.toLong(16)
+        else -> null
+    }
+}
+
+private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetSemantics.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetSemantics.kt
@@ -36,11 +36,9 @@ private const val OPAQUE_ALPHA = 1f
  * (so already-shipped hosts work) and renderers accept either (so already-shipped plugins work).
  */
 fun WidgetNode.resolveClickEventId(): String =
-    sequenceOf(
-        properties[PROP_CLICK_EVENT_ID],
-        properties[PROP_ON_CLICK_EVENT],
-        modifier.clickEventId,
-    ).firstOrNull { !it.isNullOrEmpty() } ?: ""
+    properties[PROP_CLICK_EVENT_ID]?.takeIf(String::isNotEmpty)
+        ?: properties[PROP_ON_CLICK_EVENT]?.takeIf(String::isNotEmpty)
+        ?: modifier.clickEventId
 
 /**
  * Row labels for a `LIST` node that carries no child nodes.
@@ -54,6 +52,16 @@ fun WidgetNode.resolveListItems(): List<String> = splitCommaProperty(PROP_ITEMS)
 /** Option labels for a `DROPDOWN` node. Empty (not `[""]`) when the property is absent or blank. */
 fun WidgetNode.resolveDropdownOptions(): List<String> = splitCommaProperty(PROP_OPTIONS)
 
+/**
+ * Split a comma-joined property. The rule, stated once so both renderers agree (and repeated in
+ * `ui_protocol.proto`):
+ *
+ * - split on `,`; **no escaping, no trimming** — `"Buy milk, eggs"` is two entries, the second
+ *   being `" eggs"`. A value that contains a comma must be sent as child nodes instead.
+ * - an *absent or empty* property yields no entries. This is not the same as an intentionally empty
+ *   element: `"a,,b"` is three entries, the middle one blank. Kotlin's `"".split(",")` would
+ *   otherwise hand a renderer one blank entry for a property nobody set.
+ */
 private fun WidgetNode.splitCommaProperty(key: String): List<String> =
     properties[key]?.takeIf { it.isNotEmpty() }?.split(",") ?: emptyList()
 
@@ -69,6 +77,27 @@ fun WidgetModifier.effectiveAlpha(): Float? =
         alpha.isNaN() -> null
         alpha <= UNSET_ALPHA -> null
         alpha >= OPAQUE_ALPHA -> null
+        else -> alpha
+    }
+
+/**
+ * Canonicalize an `alpha` value arriving off the wire: everything the sentinel treats as "nothing to
+ * apply" becomes [OPAQUE_ALPHA], the Kotlin default.
+ *
+ * Without this, the *same* widget is unequal to itself depending on where it came from — a builder
+ * modifier carries `alpha = 1f` while an untouched proto field arrives as `0f`, and both mean
+ * "opaque". [WidgetDiffEngine] compares whole [WidgetModifier]s, so a diff whose old side came off
+ * the wire reported a modifier change for **every node** on the first update. Normalizing at the
+ * boundary keeps the sentinel and makes structural equality mean semantic equality.
+ *
+ * The cost is that `toProto(toKotlin(p))` rewrites an unset `0.0` as `1.0`. Those encode the same
+ * rendering, so the round trip is semantics-preserving rather than byte-preserving.
+ */
+fun normalizeWireAlpha(alpha: Float): Float =
+    when {
+        alpha.isNaN() -> OPAQUE_ALPHA
+        alpha <= UNSET_ALPHA -> OPAQUE_ALPHA
+        alpha > OPAQUE_ALPHA -> OPAQUE_ALPHA
         else -> alpha
     }
 

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetTree.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetTree.kt
@@ -14,6 +14,19 @@ data class WidgetNode(
     val modifier: WidgetModifier = WidgetModifier(),
 )
 
+/**
+ * Layout/style modifiers. Mirrors proto `WidgetModifier`.
+ *
+ * @param width `0` wraps content, positive values are dp, `-1` fills the available space.
+ * @param height same encoding as [width].
+ * @param backgroundColor a hex string (`#RRGGBB` / `#AARRGGBB`) **or** a theme-token name
+ *   (`panel`, `raised`, `signalWash`, …) — see [ThemeToken] and [parseBackgroundColor].
+ * @param alpha opacity in `0.0..1.0`. **`0.0` means "unset", not "invisible"**: proto3 has no
+ *   presence for scalars, so an unset `alpha` arrives as `0.0` and honouring it literally would
+ *   make every widget from every existing plugin disappear. Renderers must resolve it through
+ *   [effectiveAlpha], which treats `<= 0` (and `>= 1`) as "nothing to apply". A widget that
+ *   should be invisible must simply not be sent.
+ */
 data class WidgetModifier(
     val width: Int = 0,
     val height: Int = 0,

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetTreeBuilder.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetTreeBuilder.kt
@@ -22,9 +22,20 @@ fun widgetTree(block: WidgetTreeBuilder.() -> Unit): WidgetTree {
  * away — the visible symptom being a text field that lost what the user was typing whenever the
  * plugin refreshed its tree.
  *
- * The consequence to be aware of: ids track *position*, so inserting a widget renumbers the ones
- * after it. That is the same trade-off Compose's positional memoization makes and keeps the common
- * "rebuild the same shape with new values" case free.
+ * ## The limit of positional ids
+ *
+ * Ids track *position*, so **inserting or removing a widget renumbers everything after it in
+ * creation order**. For that suffix the diff degenerates to remove-all/add-all and any host-side
+ * state keyed by node id is discarded — the same symptom this addresses, triggered structurally
+ * instead of on every rebuild. Deterministic ids fix the common case (rebuild the same shape with
+ * new values, which is what a plugin does on nearly every update) and leave structural edits no
+ * worse than before.
+ *
+ * Real stability under insertion needs a caller-supplied key
+ * (`button(label, event, key = "search")`), where the id derives from the key rather than the
+ * counter. That is a follow-up: it touches every builder entry point, and adding a defaulted
+ * parameter to each would change their JVM descriptors — a binary break for plugins that pin an
+ * older `boss-ui-sdk` jar. It wants overloads and a deprecation window, not a drive-by parameter.
  */
 class WidgetTreeBuilder {
     private val allNodes = mutableMapOf<String, WidgetNode>()

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetTreeBuilder.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetTreeBuilder.kt
@@ -1,20 +1,39 @@
 package ai.rever.boss.ui.sdk
 
-import java.util.UUID
-
 fun widgetTree(block: WidgetTreeBuilder.() -> Unit): WidgetTree {
     val builder = WidgetTreeBuilder()
     builder.block()
     return builder.buildTree()
 }
 
+/**
+ * DSL for building a [WidgetTree]. The first widget created becomes the root.
+ *
+ * ## Node identity
+ *
+ * Ids are **deterministic**: `w0`, `w1`, … in creation (pre-)order, assigned by a counter that is
+ * private to one builder instance. Rebuilding a structurally unchanged tree therefore yields the
+ * same ids.
+ *
+ * That is load-bearing, not cosmetic. Node ids *are* node identity for [WidgetDiffEngine] and for
+ * host-side per-node state (a text field's edit buffer, a scroll offset). With the random UUIDs this
+ * builder used to mint, every rebuild produced an all-new set of ids, so each update degenerated
+ * into remove-everything/add-everything and any state the host held against a node id was thrown
+ * away — the visible symptom being a text field that lost what the user was typing whenever the
+ * plugin refreshed its tree.
+ *
+ * The consequence to be aware of: ids track *position*, so inserting a widget renumbers the ones
+ * after it. That is the same trade-off Compose's positional memoization makes and keeps the common
+ * "rebuild the same shape with new values" case free.
+ */
 class WidgetTreeBuilder {
     private val allNodes = mutableMapOf<String, WidgetNode>()
     private val childrenOf = mutableMapOf<String, MutableList<String>>()
     private val parentStack = ArrayDeque<String>()
     private var rootId: String? = null
+    private var nextId = 0
 
-    private fun genId(): String = UUID.randomUUID().toString()
+    private fun genId(): String = "w${nextId++}"
 
     private fun container(
         type: WidgetType,
@@ -77,10 +96,27 @@ class WidgetTreeBuilder {
             },
         )
 
+    /**
+     * A button that reports [onClickEvent] when clicked.
+     *
+     * The event id is written under **both** [PROP_CLICK_EVENT_ID] (the spelling renderers read) and
+     * [PROP_ON_CLICK_EVENT] (the spelling this builder has always written). Writing only
+     * `onClickEvent` meant every builder-built button clicked with an empty event id; writing only
+     * `clickEventId` would break hosts that were shipped reading the old spelling. Renderers resolve
+     * either via [resolveClickEventId].
+     */
     fun button(
         label: String,
         onClickEvent: String,
-    ): String = leaf(WidgetType.BUTTON, mapOf("label" to label, "onClickEvent" to onClickEvent))
+    ): String =
+        leaf(
+            WidgetType.BUTTON,
+            mapOf(
+                "label" to label,
+                PROP_CLICK_EVENT_ID to onClickEvent,
+                PROP_ON_CLICK_EVENT to onClickEvent,
+            ),
+        )
 
     fun textField(
         value: String,
@@ -124,7 +160,7 @@ class WidgetTreeBuilder {
             WidgetType.DROPDOWN,
             mapOf(
                 "selected" to selected,
-                "options" to options.joinToString(","),
+                PROP_OPTIONS to options.joinToString(","),
                 "onSelectEvent" to onSelectEvent,
             ),
         )
@@ -145,7 +181,12 @@ class WidgetTreeBuilder {
 
     fun divider(): String = leaf(WidgetType.DIVIDER)
 
-    fun list(items: List<String>): String = leaf(WidgetType.LIST, mapOf("items" to items.joinToString(",")))
+    /**
+     * A list of plain text rows, carried as a comma-joined [PROP_ITEMS] property rather than child
+     * nodes. Renderers draw child nodes when present and fall back to these rows
+     * (see [resolveListItems]) — a renderer that only walked `childIds` drew nothing at all.
+     */
+    fun list(items: List<String>): String = leaf(WidgetType.LIST, mapOf(PROP_ITEMS to items.joinToString(",")))
 
     internal fun buildTree(): WidgetTree {
         val root = rootId ?: throw IllegalStateException("No root widget defined")

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/RemoteUiInteractionWireTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/RemoteUiInteractionWireTest.kt
@@ -1,0 +1,237 @@
+package ai.rever.boss.ui.sdk
+
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toKotlin
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProto
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import ai.rever.boss.ipc.proto.UIEvent as ProtoUIEvent
+import ai.rever.boss.ipc.proto.WidgetModifier as ProtoWidgetModifier
+import ai.rever.boss.ipc.proto.WidgetNode as ProtoWidgetNode
+import ai.rever.boss.ipc.proto.WidgetTree as ProtoWidgetTree
+import ai.rever.boss.ipc.proto.WidgetType as ProtoWidgetType
+
+/**
+ * End-to-end coverage of the interactive path for issue #34 items 1 and 2:
+ * **builder → wire → renderer resolution → event back over the wire**.
+ *
+ * The renderer step is represented by the SDK resolution rules the Compose renderer now calls
+ * ([resolveClickEventId], [resolveDropdownOptions]) — that is where the mismatch lived: the builder
+ * wrote `onClickEvent`, the renderer read `clickEventId`, and nothing failed loudly. Everything
+ * except the Compose call itself is exercised here.
+ */
+class RemoteUiInteractionWireTest {
+    private val surface = "panel-1"
+
+    /** A tree as it arrives at a host: built by the plugin SDK, serialized, deserialized. */
+    private fun overTheWire(tree: WidgetTree): WidgetTree = tree.toProto().toKotlin()
+
+    private fun WidgetTree.only(type: WidgetType): WidgetNode = nodes.values.single { it.type == type }
+
+    @Test
+    fun `a builder-built button click reaches the plugin with its event id`() {
+        val sent =
+            widgetTree {
+                column {
+                    text("Settings")
+                    button("Save", "save_settings")
+                }
+            }
+
+        val received = overTheWire(sent)
+        val button = received.only(WidgetType.BUTTON)
+
+        // Renderer step: what event id does a click on this node report?
+        val eventId = button.resolveClickEventId()
+        assertEquals("save_settings", eventId, "builder-built buttons used to click with an empty id")
+
+        // Back over the wire to the plugin.
+        val wire = UIEventMapper.toProto(surface, button.id, WidgetEvent.Click(eventId), 42L)
+        assertEquals(ProtoUIEvent.EventCase.CLICK, wire.eventCase)
+        assertEquals("save_settings", wire.click.eventId)
+        assertEquals(button.id, wire.targetNodeId)
+        assertEquals(surface, wire.surfaceId)
+
+        assertEquals(EmittedEvent(button.id, WidgetEvent.Click("save_settings")), UIEventMapper.fromProto(wire))
+    }
+
+    @Test
+    fun `a dropdown selection reaches the plugin with its value and index`() {
+        val sent =
+            widgetTree {
+                column {
+                    dropdown("beta", listOf("alpha", "beta", "gamma"), "pick_channel")
+                }
+            }
+
+        val received = overTheWire(sent)
+        val dropdown = received.only(WidgetType.DROPDOWN)
+
+        // Renderer step: the options it draws, and the pick it turns into an event.
+        val options = dropdown.resolveDropdownOptions()
+        assertEquals(listOf("alpha", "beta", "gamma"), options)
+        val picked = 2
+        val event = WidgetEvent.Selection(options[picked], picked)
+
+        val wire = UIEventMapper.toProto(surface, dropdown.id, event, 42L)
+        assertEquals(ProtoUIEvent.EventCase.SELECTION, wire.eventCase)
+        assertEquals("gamma", wire.selection.selectedValue)
+        assertEquals(picked, wire.selection.selectedIndex)
+
+        assertEquals(EmittedEvent(dropdown.id, event), UIEventMapper.fromProto(wire))
+    }
+
+    @Test
+    fun `a text field edit reaches the plugin with the full new value`() {
+        val received = overTheWire(widgetTree { textField("", "name_changed", "Name") })
+        val field = received.only(WidgetType.TEXT_FIELD)
+
+        val wire = UIEventMapper.toProto(surface, field.id, WidgetEvent.TextChange("Ada"), 42L)
+        assertEquals(EmittedEvent(field.id, WidgetEvent.TextChange("Ada")), UIEventMapper.fromProto(wire))
+    }
+
+    @Test
+    fun `a plugin built against the old SDK still clicks`() {
+        // Trees from already-shipped plugins carry only the legacy spelling.
+        val legacy =
+            WidgetTree(
+                rootId = "b1",
+                nodes =
+                    mapOf(
+                        "b1" to
+                            WidgetNode(
+                                "b1",
+                                WidgetType.BUTTON,
+                                properties = mapOf("label" to "Save", PROP_ON_CLICK_EVENT to "save_settings"),
+                            ),
+                    ),
+            )
+
+        assertEquals("save_settings", overTheWire(legacy).only(WidgetType.BUTTON).resolveClickEventId())
+    }
+
+    @Test
+    fun `a host that only writes the canonical spelling still clicks`() {
+        val canonical =
+            WidgetTree(
+                rootId = "b1",
+                nodes =
+                    mapOf(
+                        "b1" to
+                            WidgetNode(
+                                "b1",
+                                WidgetType.BUTTON,
+                                properties = mapOf("label" to "Save", PROP_CLICK_EVENT_ID to "save_settings"),
+                            ),
+                    ),
+            )
+
+        assertEquals("save_settings", overTheWire(canonical).only(WidgetType.BUTTON).resolveClickEventId())
+    }
+
+    @Test
+    fun `a clickable modifier click reaches the plugin`() {
+        val tree =
+            WidgetTree(
+                rootId = "box1",
+                nodes =
+                    mapOf(
+                        "box1" to
+                            WidgetNode(
+                                "box1",
+                                WidgetType.BOX,
+                                modifier = WidgetModifier(clickable = true, clickEventId = "surface_tapped"),
+                            ),
+                    ),
+            )
+
+        val box = overTheWire(tree).nodes.getValue("box1")
+        assertTrue(box.modifier.clickable)
+        assertEquals("surface_tapped", box.resolveClickEventId())
+    }
+
+    @Test
+    fun `list rows survive the wire so the renderer can draw them`() {
+        val received = overTheWire(widgetTree { list(listOf("first", "second", "third")) })
+        val list = received.only(WidgetType.LIST)
+
+        assertTrue(list.childIds.isEmpty(), "the builder emits rows as a property, not child nodes")
+        assertEquals(listOf("first", "second", "third"), list.resolveListItems())
+    }
+
+    @Test
+    fun `a sender that never touches alpha is treated as unset, not invisible`() {
+        // The real-world shape of issue #34 item 4: any plugin that builds the proto directly (or in
+        // another language) leaves `alpha` at proto3's default 0.0, which must not mean "transparent".
+        val protoTree =
+            ProtoWidgetTree
+                .newBuilder()
+                .setRootId("t1")
+                .addNodes(
+                    ProtoWidgetNode
+                        .newBuilder()
+                        .setId("t1")
+                        .setType(ProtoWidgetType.WIDGET_TYPE_TEXT)
+                        .putProperties("value", "Hello")
+                        // Modifier present, alpha never set.
+                        .setModifier(ProtoWidgetModifier.newBuilder().setPaddingTop(4)),
+                ).build()
+
+        val text = protoTree.toKotlin().nodes.getValue("t1")
+        assertEquals(0f, text.modifier.alpha)
+        assertNull(text.modifier.effectiveAlpha(), "0f must not be rendered as fully transparent")
+    }
+
+    @Test
+    fun `the Kotlin default alpha needs no compositing`() {
+        val text = overTheWire(widgetTree { text("Hello") }).only(WidgetType.TEXT)
+
+        assertEquals(1f, text.modifier.alpha)
+        assertNull(text.modifier.effectiveAlpha())
+    }
+
+    @Test
+    fun `a real alpha survives the wire`() {
+        val tree =
+            WidgetTree(
+                rootId = "t1",
+                nodes = mapOf("t1" to WidgetNode("t1", WidgetType.TEXT, modifier = WidgetModifier(alpha = 0.25f))),
+            )
+
+        assertEquals(
+            0.25f,
+            overTheWire(tree)
+                .nodes
+                .getValue("t1")
+                .modifier
+                .effectiveAlpha(),
+        )
+    }
+
+    @Test
+    fun `a theme-token background survives the wire`() {
+        val tree =
+            WidgetTree(
+                rootId = "c1",
+                nodes =
+                    mapOf(
+                        "c1" to
+                            WidgetNode(
+                                "c1",
+                                WidgetType.COLUMN,
+                                modifier = WidgetModifier(backgroundColor = "raised"),
+                            ),
+                    ),
+            )
+
+        assertEquals(
+            BackgroundSpec.Token(ThemeToken.RAISED),
+            overTheWire(tree)
+                .nodes
+                .getValue("c1")
+                .modifier
+                .resolveBackground(),
+        )
+    }
+}

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/RemoteUiInteractionWireTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/RemoteUiInteractionWireTest.kt
@@ -160,27 +160,56 @@ class RemoteUiInteractionWireTest {
         assertEquals(listOf("first", "second", "third"), list.resolveListItems())
     }
 
+    /** A tree as a plugin that builds the proto directly would send it: `alpha` never touched. */
+    private fun protoTextTree(): ProtoWidgetTree =
+        ProtoWidgetTree
+            .newBuilder()
+            .setRootId("t1")
+            .addNodes(
+                ProtoWidgetNode
+                    .newBuilder()
+                    .setId("t1")
+                    .setType(ProtoWidgetType.WIDGET_TYPE_TEXT)
+                    .putProperties("value", "Hello")
+                    // Modifier present, alpha never set.
+                    .setModifier(ProtoWidgetModifier.newBuilder().setPaddingTop(4)),
+            ).build()
+
     @Test
     fun `a sender that never touches alpha is treated as unset, not invisible`() {
-        // The real-world shape of issue #34 item 4: any plugin that builds the proto directly (or in
-        // another language) leaves `alpha` at proto3's default 0.0, which must not mean "transparent".
-        val protoTree =
-            ProtoWidgetTree
-                .newBuilder()
-                .setRootId("t1")
-                .addNodes(
-                    ProtoWidgetNode
-                        .newBuilder()
-                        .setId("t1")
-                        .setType(ProtoWidgetType.WIDGET_TYPE_TEXT)
-                        .putProperties("value", "Hello")
-                        // Modifier present, alpha never set.
-                        .setModifier(ProtoWidgetModifier.newBuilder().setPaddingTop(4)),
-                ).build()
+        // The real-world shape of issue #34 item 4: proto3's default 0.0 must not mean "transparent".
+        val text = protoTextTree().toKotlin().nodes.getValue("t1")
 
-        val text = protoTree.toKotlin().nodes.getValue("t1")
-        assertEquals(0f, text.modifier.alpha)
-        assertNull(text.modifier.effectiveAlpha(), "0f must not be rendered as fully transparent")
+        assertEquals(1f, text.modifier.alpha, "an unset wire alpha is canonicalized to opaque")
+        assertNull(text.modifier.effectiveAlpha(), "and composites nothing")
+    }
+
+    @Test
+    fun `a wire-originated tree diffs clean against an identical local one`() {
+        // Before alpha was canonicalized at the boundary, the wire side carried 0f and the local side
+        // 1f for the same opaque widget, so WidgetModifier equality failed and the FIRST diff after a
+        // tree arrived reported a modifier change for every single node.
+        val fromWire = protoTextTree().toKotlin()
+        val local =
+            WidgetTree(
+                rootId = "t1",
+                nodes =
+                    mapOf(
+                        "t1" to
+                            WidgetNode(
+                                "t1",
+                                WidgetType.TEXT,
+                                properties = mapOf("value" to "Hello"),
+                                modifier = WidgetModifier(paddingTop = 4),
+                            ),
+                    ),
+            )
+
+        assertEquals(local.nodes, fromWire.nodes)
+        assertTrue(
+            WidgetDiffEngine.diff(fromWire, local).isEmpty(),
+            "expected no ops, got: ${WidgetDiffEngine.diff(fromWire, local)}",
+        )
     }
 
     @Test

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/UIEventMapperTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/UIEventMapperTest.kt
@@ -1,0 +1,155 @@
+package ai.rever.boss.ui.sdk
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import ai.rever.boss.ipc.proto.UIEvent as ProtoUIEvent
+
+/**
+ * Every `UIEvent` oneof case must map in both directions (issue #34 items 2 and 8).
+ *
+ * The host previously built these events inline from a `(eventType, eventData)` string pair with no
+ * `"selection"` branch, so dropdown picks reached the plugin as a `UIEvent` with an unset oneof, and
+ * the four families the proto declares but nothing mapped (`key`, `scroll`, `focus`, `lifecycle`)
+ * had no representation at all.
+ */
+class UIEventMapperTest {
+    private val surface = "surface-1"
+    private val node = "w7"
+    private val timestamp = 1_234_567L
+
+    private fun roundTrip(event: WidgetEvent): ProtoUIEvent {
+        val wire = UIEventMapper.toProto(surface, node, event, timestamp)
+
+        assertEquals(surface, wire.surfaceId)
+        assertEquals(node, wire.targetNodeId)
+        assertEquals(timestamp, wire.timestamp)
+        assertOneofSet(wire)
+        assertEquals(EmittedEvent(node, event), UIEventMapper.fromProto(wire))
+        return wire
+    }
+
+    private fun assertOneofSet(wire: ProtoUIEvent) {
+        assertTrue(
+            wire.eventCase != ProtoUIEvent.EventCase.EVENT_NOT_SET,
+            "oneof must be set, else the plugin receives an uninterpretable event",
+        )
+    }
+
+    @Test
+    fun `click maps onto the click case`() {
+        val wire = roundTrip(WidgetEvent.Click("save_event"))
+        assertEquals(ProtoUIEvent.EventCase.CLICK, wire.eventCase)
+        assertEquals("save_event", wire.click.eventId)
+    }
+
+    @Test
+    fun `text change maps onto the text change case`() {
+        val wire = roundTrip(WidgetEvent.TextChange("typed value"))
+        assertEquals(ProtoUIEvent.EventCase.TEXT_CHANGE, wire.eventCase)
+        assertEquals("typed value", wire.textChange.newValue)
+    }
+
+    @Test
+    fun `toggle maps onto the toggle case`() {
+        val wire = roundTrip(WidgetEvent.Toggle(checked = true))
+        assertEquals(ProtoUIEvent.EventCase.TOGGLE, wire.eventCase)
+        assertEquals(true, wire.toggle.checked)
+    }
+
+    @Test
+    fun `selection carries both the value and its index`() {
+        val wire = roundTrip(WidgetEvent.Selection("beta", 1))
+        assertEquals(ProtoUIEvent.EventCase.SELECTION, wire.eventCase)
+        assertEquals("beta", wire.selection.selectedValue)
+        assertEquals(1, wire.selection.selectedIndex)
+    }
+
+    @Test
+    fun `key carries the code and every modifier`() {
+        val wire =
+            roundTrip(
+                WidgetEvent.Key(keyCode = 65, ctrl = true, alt = false, shift = true, meta = false),
+            )
+        assertEquals(ProtoUIEvent.EventCase.KEY, wire.eventCase)
+        assertEquals(65, wire.key.keyCode)
+        assertEquals(true, wire.key.ctrl)
+        assertEquals(false, wire.key.alt)
+        assertEquals(true, wire.key.shift)
+        assertEquals(false, wire.key.meta)
+    }
+
+    @Test
+    fun `scroll carries both deltas`() {
+        val wire = roundTrip(WidgetEvent.Scroll(deltaX = -3.5f, deltaY = 12f))
+        assertEquals(ProtoUIEvent.EventCase.SCROLL, wire.eventCase)
+        assertEquals(-3.5f, wire.scroll.deltaX)
+        assertEquals(12f, wire.scroll.deltaY)
+    }
+
+    @Test
+    fun `focus maps onto the focus case`() {
+        val gained = roundTrip(WidgetEvent.Focus(hasFocus = true))
+        assertEquals(ProtoUIEvent.EventCase.FOCUS, gained.eventCase)
+        assertEquals(true, gained.focus.hasFocus)
+        // `false` is a meaningful value, not an absent one: focus loss must still map.
+        val lost = roundTrip(WidgetEvent.Focus(hasFocus = false))
+        assertEquals(ProtoUIEvent.EventCase.FOCUS, lost.eventCase)
+    }
+
+    @Test
+    fun `lifecycle maps onto the lifecycle case`() {
+        val wire = roundTrip(WidgetEvent.Lifecycle(LifecycleStates.CREATED))
+        assertEquals(ProtoUIEvent.EventCase.LIFECYCLE, wire.eventCase)
+        assertEquals("created", wire.lifecycle.lifecycleState)
+    }
+
+    @Test
+    fun `unknown lifecycle states survive the round trip`() {
+        roundTrip(WidgetEvent.Lifecycle("some-future-state"))
+    }
+
+    @Test
+    fun `surface-level events may carry an empty node id`() {
+        val emitted = EmittedEvent("", WidgetEvent.Lifecycle(LifecycleStates.CREATED))
+        val wire = UIEventMapper.toProto(surface, emitted, timestamp)
+        assertEquals("", wire.targetNodeId)
+        assertEquals(EmittedEvent("", WidgetEvent.Lifecycle("created")), UIEventMapper.fromProto(wire))
+    }
+
+    @Test
+    fun `an unset oneof reads back as null rather than a fabricated event`() {
+        val empty =
+            ProtoUIEvent
+                .newBuilder()
+                .setSurfaceId(surface)
+                .setTargetNodeId(node)
+                .build()
+        assertNull(UIEventMapper.fromProto(empty))
+    }
+
+    @Test
+    fun `every widget event variant is mapped`() {
+        val allVariants =
+            listOf(
+                WidgetEvent.Click(""),
+                WidgetEvent.TextChange(""),
+                WidgetEvent.Toggle(false),
+                WidgetEvent.Selection("", 0),
+                WidgetEvent.Key(0),
+                WidgetEvent.Scroll(0f, 0f),
+                WidgetEvent.Focus(false),
+                WidgetEvent.Lifecycle(""),
+            )
+        // One per proto oneof case (EVENT_NOT_SET excluded): a new sealed variant without a mapping is
+        // a compile error, and a new proto case without a variant shows up here as a count mismatch.
+        assertEquals(ProtoUIEvent.EventCase.values().size - 1, allVariants.size)
+        for (event in allVariants) {
+            val wire = UIEventMapper.toProto(surface, node, event, timestamp)
+            assertOneofSet(wire)
+            assertNotNull(UIEventMapper.fromProto(wire))
+        }
+    }
+}

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/UIEventMapperTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/UIEventMapperTest.kt
@@ -145,7 +145,7 @@ class UIEventMapperTest {
             )
         // One per proto oneof case (EVENT_NOT_SET excluded): a new sealed variant without a mapping is
         // a compile error, and a new proto case without a variant shows up here as a count mismatch.
-        assertEquals(ProtoUIEvent.EventCase.values().size - 1, allVariants.size)
+        assertEquals(ProtoUIEvent.EventCase.entries.size - 1, allVariants.size)
         for (event in allVariants) {
             val wire = UIEventMapper.toProto(surface, node, event, timestamp)
             assertOneofSet(wire)

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngineTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngineTest.kt
@@ -229,6 +229,143 @@ class WidgetDiffEngineTest {
     }
 
     @Test
+    fun `two siblings added to the same existing parent converge in either order`() {
+        val base = simpleTree()
+        val expected =
+            WidgetTree(
+                rootId = "col1",
+                nodes =
+                    mapOf(
+                        "col1" to WidgetNode("col1", WidgetType.COLUMN, childIds = listOf("text1", "a", "b")),
+                        "text1" to WidgetNode("text1", WidgetType.TEXT, properties = mapOf("value" to "Hello")),
+                        "a" to WidgetNode("a", WidgetType.TEXT, properties = mapOf("value" to "A")),
+                        "b" to WidgetNode("b", WidgetType.TEXT, properties = mapOf("value" to "B")),
+                    ),
+            )
+
+        val ops = WidgetDiffEngine.diff(base, expected)
+        val forward = WidgetDiffEngine.apply(base, ops)
+        val reversed = WidgetDiffEngine.apply(base, ops.reversed())
+
+        assertEquals(expected.nodes, forward.nodes)
+        assertEquals(listOf("text1", "a", "b"), reversed.nodes["col1"]!!.childIds)
+    }
+
+    // ---- Sibling reorder (review finding 4) ----
+
+    private fun columnOf(vararg children: String): WidgetTree =
+        WidgetTree(
+            rootId = "col1",
+            nodes =
+                buildMap {
+                    put("col1", WidgetNode("col1", WidgetType.COLUMN, childIds = children.toList()))
+                    for (child in children) {
+                        put(child, WidgetNode(child, WidgetType.TEXT, properties = mapOf("value" to child)))
+                    }
+                },
+        )
+
+    @Test
+    fun `swapping two siblings produces operations`() {
+        val before = columnOf("a", "b")
+        val after = columnOf("b", "a")
+
+        val ops = WidgetDiffEngine.diff(before, after)
+
+        // Used to be empty: NodeMoved was only emitted when the PARENT changed, so a reorder was
+        // invisible and apply(old, diff(old, new)) != new.
+        assertTrue(ops.isNotEmpty(), "a reorder must be expressible")
+        assertEquals(after.nodes, WidgetDiffEngine.apply(before, ops).nodes)
+    }
+
+    @Test
+    fun `reorder round-trips for every permutation of three siblings`() {
+        val before = columnOf("a", "b", "c")
+        val permutations =
+            listOf(
+                listOf("a", "b", "c"),
+                listOf("a", "c", "b"),
+                listOf("b", "a", "c"),
+                listOf("b", "c", "a"),
+                listOf("c", "a", "b"),
+                listOf("c", "b", "a"),
+            )
+
+        for (order in permutations) {
+            val after = columnOf(*order.toTypedArray())
+            val result = WidgetDiffEngine.apply(before, WidgetDiffEngine.diff(before, after))
+            assertEquals(order, result.nodes["col1"]!!.childIds, "reorder to $order")
+        }
+    }
+
+    @Test
+    fun `an insertion alone is not reported as a reorder`() {
+        val before = columnOf("a", "b")
+        val after = columnOf("a", "x", "b")
+
+        val ops = WidgetDiffEngine.diff(before, after)
+
+        // `a` and `b` shift index but keep their relative order, so the add is the whole story.
+        assertEquals(1, ops.size, "expected only the add, got: $ops")
+        assertIs<DiffOperation.NodeAdded>(ops.single())
+        assertEquals(after.nodes, WidgetDiffEngine.apply(before, ops).nodes)
+    }
+
+    @Test
+    fun `reorder combined with an insertion round-trips`() {
+        val before = columnOf("a", "b")
+        val after = columnOf("x", "b", "a")
+
+        val result = WidgetDiffEngine.apply(before, WidgetDiffEngine.diff(before, after))
+
+        assertEquals(after.nodes, result.nodes)
+    }
+
+    @Test
+    fun `reorder combined with a removal round-trips`() {
+        val before = columnOf("a", "b", "c")
+        val after = columnOf("c", "a")
+
+        val result = WidgetDiffEngine.apply(before, WidgetDiffEngine.diff(before, after))
+
+        assertEquals(after.nodes, result.nodes)
+    }
+
+    @Test
+    fun `a cross-parent move alongside a reorder round-trips`() {
+        val before =
+            WidgetTree(
+                rootId = "root",
+                nodes =
+                    mapOf(
+                        "root" to WidgetNode("root", WidgetType.COLUMN, childIds = listOf("p1", "p2")),
+                        "p1" to WidgetNode("p1", WidgetType.ROW, childIds = listOf("a", "b", "c")),
+                        "p2" to WidgetNode("p2", WidgetType.ROW, childIds = emptyList()),
+                        "a" to WidgetNode("a", WidgetType.TEXT),
+                        "b" to WidgetNode("b", WidgetType.TEXT),
+                        "c" to WidgetNode("c", WidgetType.TEXT),
+                    ),
+            )
+        val after =
+            WidgetTree(
+                rootId = "root",
+                nodes =
+                    mapOf(
+                        "root" to WidgetNode("root", WidgetType.COLUMN, childIds = listOf("p1", "p2")),
+                        "p1" to WidgetNode("p1", WidgetType.ROW, childIds = listOf("c", "b")),
+                        "p2" to WidgetNode("p2", WidgetType.ROW, childIds = listOf("a")),
+                        "a" to WidgetNode("a", WidgetType.TEXT),
+                        "b" to WidgetNode("b", WidgetType.TEXT),
+                        "c" to WidgetNode("c", WidgetType.TEXT),
+                    ),
+            )
+
+        val result = WidgetDiffEngine.apply(before, WidgetDiffEngine.diff(before, after))
+
+        assertEquals(after.nodes, result.nodes)
+    }
+
+    @Test
     fun `apply NodeMoved within the same parent re-indexes without duplicating`() {
         val base =
             WidgetTree(

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngineTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffEngineTest.kt
@@ -173,6 +173,79 @@ class WidgetDiffEngineTest {
         assertEquals("Updated", result.nodes[textId]!!.properties["value"])
     }
 
+    // ---- Subtree adds must not double-link children (issue #34 item 7) ----
+
+    /**
+     * A `NodeAdded` payload carries the added node's own `childIds`, so a subtree add links the
+     * child from the parent's payload *and* from the child's own op. Applying them parent-first used
+     * to link the child twice (and the renderer drew the subtree twice); insertion is now idempotent,
+     * so both orders converge.
+     */
+    private fun subtreeAddOps(): List<DiffOperation> {
+        val rowId = "row1"
+        val innerId = "inner1"
+        val row = WidgetNode(rowId, WidgetType.ROW, childIds = listOf(innerId))
+        val inner = WidgetNode(innerId, WidgetType.TEXT, properties = mapOf("value" to "Nested"))
+        return listOf(
+            DiffOperation.NodeAdded(row, "col1", 1),
+            DiffOperation.NodeAdded(inner, rowId, 0),
+        )
+    }
+
+    @Test
+    fun `apply subtree add parent-first does not duplicate child links`() {
+        val result = WidgetDiffEngine.apply(simpleTree(), subtreeAddOps())
+
+        assertEquals(listOf("inner1"), result.nodes["row1"]!!.childIds)
+        assertEquals(listOf("text1", "row1"), result.nodes["col1"]!!.childIds)
+    }
+
+    @Test
+    fun `apply subtree add child-first matches parent-first`() {
+        val parentFirst = WidgetDiffEngine.apply(simpleTree(), subtreeAddOps())
+        val childFirst = WidgetDiffEngine.apply(simpleTree(), subtreeAddOps().reversed())
+
+        assertEquals(parentFirst.nodes, childFirst.nodes)
+    }
+
+    @Test
+    fun `diff then apply of a subtree add matches the new tree exactly`() {
+        val base = simpleTree()
+        val expected =
+            WidgetTree(
+                rootId = "col1",
+                nodes =
+                    mapOf(
+                        "col1" to WidgetNode("col1", WidgetType.COLUMN, childIds = listOf("text1", "row1")),
+                        "text1" to WidgetNode("text1", WidgetType.TEXT, properties = mapOf("value" to "Hello")),
+                        "row1" to WidgetNode("row1", WidgetType.ROW, childIds = listOf("inner1")),
+                        "inner1" to WidgetNode("inner1", WidgetType.TEXT, properties = mapOf("value" to "Nested")),
+                    ),
+            )
+
+        val result = WidgetDiffEngine.apply(base, WidgetDiffEngine.diff(base, expected))
+
+        assertEquals(expected.nodes, result.nodes)
+    }
+
+    @Test
+    fun `apply NodeMoved within the same parent re-indexes without duplicating`() {
+        val base =
+            WidgetTree(
+                rootId = "col1",
+                nodes =
+                    mapOf(
+                        "col1" to WidgetNode("col1", WidgetType.COLUMN, childIds = listOf("a", "b")),
+                        "a" to WidgetNode("a", WidgetType.TEXT),
+                        "b" to WidgetNode("b", WidgetType.TEXT),
+                    ),
+            )
+
+        val result = WidgetDiffEngine.apply(base, listOf(DiffOperation.NodeMoved("a", "col1", 1)))
+
+        assertEquals(listOf("b", "a"), result.nodes["col1"]!!.childIds)
+    }
+
     @Test
     fun `apply diff round-trip matches new tree`() {
         val base = simpleTree()

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetSemanticsTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetSemanticsTest.kt
@@ -101,6 +101,30 @@ class WidgetSemanticsTest {
         assertNull(WidgetModifier(alpha = Float.NaN).effectiveAlpha())
     }
 
+    @Test
+    fun `wire alpha canonicalizes everything that composites nothing to opaque`() {
+        // So that structural equality means semantic equality — WidgetDiffEngine compares whole
+        // modifiers, and the wire's unset 0f vs the Kotlin default 1f otherwise look like a change.
+        assertEquals(1f, normalizeWireAlpha(0f))
+        assertEquals(1f, normalizeWireAlpha(-1f))
+        assertEquals(1f, normalizeWireAlpha(1f))
+        assertEquals(1f, normalizeWireAlpha(2f))
+        assertEquals(1f, normalizeWireAlpha(Float.NaN))
+        // Real values pass through untouched.
+        assertEquals(0.25f, normalizeWireAlpha(0.25f))
+    }
+
+    @Test
+    fun `canonicalized alphas agree with the sentinel`() {
+        for (raw in listOf(-1f, 0f, 0.5f, 1f, 2f, Float.NaN)) {
+            assertEquals(
+                WidgetModifier(alpha = raw).effectiveAlpha(),
+                WidgetModifier(alpha = normalizeWireAlpha(raw)).effectiveAlpha(),
+                "normalizing must not change what gets composited (raw=$raw)",
+            )
+        }
+    }
+
     // ---- Item 5: background color ----
 
     @Test

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetSemanticsTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetSemanticsTest.kt
@@ -1,0 +1,149 @@
+package ai.rever.boss.ui.sdk
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the property/modifier interpretation rules every renderer must agree on.
+ *
+ * These are the rules the Rust renderer port (BossConsoleRust `crates/boss-remote-ui`) disagreed
+ * with the JVM stack about — issue #34 items 1, 3, 4 and 5.
+ */
+class WidgetSemanticsTest {
+    private fun button(
+        properties: Map<String, String>,
+        modifier: WidgetModifier = WidgetModifier(),
+    ) = WidgetNode("n1", WidgetType.BUTTON, properties = properties, modifier = modifier)
+
+    // ---- Item 1: click event id ----
+
+    @Test
+    fun `canonical spelling wins`() {
+        val node =
+            button(
+                mapOf(PROP_CLICK_EVENT_ID to "canonical", PROP_ON_CLICK_EVENT to "legacy"),
+                WidgetModifier(clickEventId = "modifier"),
+            )
+        assertEquals("canonical", node.resolveClickEventId())
+    }
+
+    @Test
+    fun `builder spelling is accepted when the canonical one is absent`() {
+        assertEquals("legacy", button(mapOf(PROP_ON_CLICK_EVENT to "legacy")).resolveClickEventId())
+    }
+
+    @Test
+    fun `empty values fall through to the next source`() {
+        val node =
+            button(
+                mapOf(PROP_CLICK_EVENT_ID to "", PROP_ON_CLICK_EVENT to ""),
+                WidgetModifier(clickEventId = "modifier"),
+            )
+        assertEquals("modifier", node.resolveClickEventId())
+    }
+
+    @Test
+    fun `no event id anywhere resolves to empty`() {
+        assertEquals("", button(mapOf("label" to "Go")).resolveClickEventId())
+    }
+
+    // ---- Item 3: list items ----
+
+    @Test
+    fun `list items split on commas`() {
+        val node = WidgetNode("n1", WidgetType.LIST, properties = mapOf(PROP_ITEMS to "a,b,c"))
+        assertEquals(listOf("a", "b", "c"), node.resolveListItems())
+    }
+
+    @Test
+    fun `blank or absent items yield no rows`() {
+        assertEquals(emptyList(), WidgetNode("n1", WidgetType.LIST).resolveListItems())
+        assertEquals(
+            emptyList(),
+            WidgetNode("n1", WidgetType.LIST, properties = mapOf(PROP_ITEMS to "")).resolveListItems(),
+        )
+    }
+
+    @Test
+    fun `blank options yield no dropdown entries`() {
+        // Naive `split(",")` would produce a single empty option here.
+        val node = WidgetNode("n1", WidgetType.DROPDOWN, properties = mapOf(PROP_OPTIONS to ""))
+        assertEquals(emptyList(), node.resolveDropdownOptions())
+        assertEquals(
+            listOf("one", "two"),
+            WidgetNode("n1", WidgetType.DROPDOWN, properties = mapOf(PROP_OPTIONS to "one,two"))
+                .resolveDropdownOptions(),
+        )
+    }
+
+    // ---- Item 4: alpha ----
+
+    @Test
+    fun `alpha inside the open unit interval is honoured`() {
+        assertEquals(0.5f, WidgetModifier(alpha = 0.5f).effectiveAlpha())
+        assertEquals(0.01f, WidgetModifier(alpha = 0.01f).effectiveAlpha())
+    }
+
+    @Test
+    fun `proto3 default alpha means unset, not invisible`() {
+        // The whole point: an out-of-process plugin that never touches `alpha` sends 0.0, and
+        // honouring that literally would make every widget it renders disappear.
+        assertNull(WidgetModifier(alpha = 0f).effectiveAlpha())
+        assertNull(WidgetModifier(alpha = -1f).effectiveAlpha())
+    }
+
+    @Test
+    fun `opaque and out-of-range alphas need no compositing`() {
+        assertNull(WidgetModifier().effectiveAlpha())
+        assertNull(WidgetModifier(alpha = 1f).effectiveAlpha())
+        assertNull(WidgetModifier(alpha = 2f).effectiveAlpha())
+        assertNull(WidgetModifier(alpha = Float.NaN).effectiveAlpha())
+    }
+
+    // ---- Item 5: background color ----
+
+    @Test
+    fun `theme tokens resolve`() {
+        assertEquals(BackgroundSpec.Token(ThemeToken.PANEL), parseBackgroundColor("panel"))
+        assertEquals(BackgroundSpec.Token(ThemeToken.SIGNAL_WASH), parseBackgroundColor("signalWash"))
+        assertEquals(BackgroundSpec.Token(ThemeToken.SIGNAL_WASH), parseBackgroundColor("signal_wash"))
+        assertEquals(BackgroundSpec.Token(ThemeToken.SIGNAL_WASH), parseBackgroundColor("SIGNAL-WASH"))
+        assertEquals(BackgroundSpec.Token(ThemeToken.ON_SIGNAL), parseBackgroundColor("onSignal"))
+    }
+
+    @Test
+    fun `every design-system token is addressable by name`() {
+        for (token in ThemeToken.entries) {
+            assertEquals(BackgroundSpec.Token(token), parseBackgroundColor(token.tokenName))
+        }
+        assertEquals(17, ThemeToken.entries.size)
+    }
+
+    @Test
+    fun `hex forms parse to packed argb`() {
+        assertEquals(BackgroundSpec.Hex(0xFFFF0000), parseBackgroundColor("#FF0000"))
+        assertEquals(BackgroundSpec.Hex(0xFFFF0000), parseBackgroundColor("FF0000"))
+        assertEquals(BackgroundSpec.Hex(0x80FF0000), parseBackgroundColor("#80FF0000"))
+        assertEquals(BackgroundSpec.Hex(0xFF00FF00), parseBackgroundColor("#00ff00"))
+    }
+
+    @Test
+    fun `unparseable specs draw no background instead of throwing`() {
+        assertEquals(BackgroundSpec.None, parseBackgroundColor(""))
+        // Three-digit shorthand has never been supported by this protocol.
+        assertEquals(BackgroundSpec.None, parseBackgroundColor("#F00"))
+        assertEquals(BackgroundSpec.None, parseBackgroundColor("#GGGGGG"))
+        assertEquals(BackgroundSpec.None, parseBackgroundColor("rebeccapurple"))
+        assertEquals(BackgroundSpec.None, parseBackgroundColor("#"))
+    }
+
+    @Test
+    fun `modifier shorthand delegates to the parser`() {
+        assertEquals(
+            BackgroundSpec.Token(ThemeToken.RAISED),
+            WidgetModifier(backgroundColor = "raised").resolveBackground(),
+        )
+        assertEquals(BackgroundSpec.None, WidgetModifier().resolveBackground())
+    }
+}

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetTreeBuilderTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetTreeBuilderTest.kt
@@ -2,7 +2,9 @@ package ai.rever.boss.ui.sdk
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class WidgetTreeBuilderTest {
     @Test
@@ -52,7 +54,7 @@ class WidgetTreeBuilderTest {
 
         assertEquals(WidgetType.BUTTON, tree.nodes[buttonId]!!.type)
         assertEquals("Click me", tree.nodes[buttonId]!!.properties["label"])
-        assertEquals("click1", tree.nodes[buttonId]!!.properties["onClickEvent"])
+        assertEquals("click1", tree.nodes[buttonId]!!.properties[PROP_ON_CLICK_EVENT])
 
         val rowNode = tree.nodes[rowId]!!
         assertEquals(WidgetType.ROW, rowNode.type)
@@ -101,5 +103,77 @@ class WidgetTreeBuilderTest {
         val root = tree.nodes[tree.rootId]!!
         assertEquals(WidgetType.SCROLL, root.type)
         assertEquals(2, root.childIds.size)
+    }
+
+    // ---- Node identity (issue #34 item 6) ----
+
+    private fun sampleTree(label: String = "Hello"): WidgetTree =
+        widgetTree {
+            column {
+                text(label)
+                textField("", "name_changed", "Name")
+                row {
+                    icon("star", 24)
+                    button("Save", "save")
+                }
+            }
+        }
+
+    @Test
+    fun `ids are deterministic in creation order`() {
+        val tree = sampleTree()
+
+        assertEquals("w0", tree.rootId)
+        assertEquals(listOf("w1", "w2", "w3"), tree.nodes["w0"]!!.childIds)
+        assertEquals(listOf("w4", "w5"), tree.nodes["w3"]!!.childIds)
+        assertEquals(setOf("w0", "w1", "w2", "w3", "w4", "w5"), tree.nodes.keys)
+    }
+
+    @Test
+    fun `rebuilding the same shape reuses the same ids`() {
+        val first = sampleTree()
+        val second = sampleTree()
+
+        assertEquals(first.rootId, second.rootId)
+        assertEquals(first.nodes.keys, second.nodes.keys)
+        // Structurally identical rebuild ⇒ nothing to send, and every host-side per-node state
+        // (text-field buffers, scroll offsets) keyed by node id stays valid.
+        assertTrue(
+            WidgetDiffEngine.diff(first, second).isEmpty(),
+            "Expected an empty diff for an identical rebuild, got: ${WidgetDiffEngine.diff(first, second)}",
+        )
+    }
+
+    @Test
+    fun `rebuilding with changed values keeps ids and diffs to just the value`() {
+        val before = sampleTree("Hello")
+        val after = sampleTree("Goodbye")
+
+        val ops = WidgetDiffEngine.diff(before, after)
+        assertEquals(1, ops.size, "Expected a single property update, got: $ops")
+        val updated = assertIs<DiffOperation.NodeUpdated>(ops.single())
+        assertEquals("w1", updated.nodeId)
+        assertEquals("Goodbye", updated.changedProperties["value"])
+    }
+
+    @Test
+    fun `separate builders do not share the id counter`() {
+        val a = widgetTree { text("a") }
+        val b = widgetTree { text("b") }
+
+        assertEquals("w0", a.rootId)
+        assertEquals("w0", b.rootId)
+    }
+
+    // ---- Click event ids (issue #34 item 1) ----
+
+    @Test
+    fun `button writes both event id spellings`() {
+        val tree = widgetTree { button("Save", "save_event") }
+        val button = tree.nodes[tree.rootId]!!
+
+        assertEquals("save_event", button.properties[PROP_CLICK_EVENT_ID])
+        assertEquals("save_event", button.properties[PROP_ON_CLICK_EVENT])
+        assertEquals("save_event", button.resolveClickEventId())
     }
 }


### PR DESCRIPTION
Porting the widget-tree renderer to Rust (BossConsoleRust `crates/boss-remote-ui`) used `modules/boss-ui-sdk` + `RemoteWidgetRenderer.kt` as the behavioral spec and found eight latent defects. This fixes seven of them and closes item 8 on the wire while deliberately deferring part of its emission side.

Where a fix had a choice, it mirrors the Rust renderer so the two hosts agree by construction. The interpretation rules themselves moved **into the SDK** (`WidgetSemantics.kt`, `WidgetEvent.kt`, `UIEventMapper.kt`) instead of living inside a Compose renderer — that is what makes them testable without a UI toolkit, and it is what turns "did anyone map this case?" into a compile error.

## The eight items

| # | Defect | Status | What was done |
|---|---|---|---|
| 1 | Builder writes `onClickEvent`, renderer reads `clickEventId` | **Fixed** | Builder now writes **both** spellings; renderers resolve via `resolveClickEventId()` (canonical → legacy → `modifier.clickEventId`, empty values fall through). Writing both means already-shipped hosts start working with new plugins; accepting both means already-shipped plugins work on new hosts. |
| 2 | `sendUIEvent` never maps `"selection"` | **Fixed** | The `(eventType, eventData)` string pair is gone. `UIEventMapper` maps a sealed `WidgetEvent` onto the `UIEvent` oneof — **total in both directions, all 8 families** — and both surface components share it instead of duplicating a `when`. The typed event also carries a selection's *index*, which one data string could not express. |
| 3 | `WidgetTreeBuilder.list(items)` renders empty | **Fixed** | Renderer draws child nodes when present, else the comma-joined `items` rows (`resolveListItems()`). `resolveDropdownOptions()` gets the same treatment, and blank `options` no longer yields one empty entry. |
| 4 | `alpha` ignored; proto default `0.0` vs Kotlin `1.0` ambiguous | **Fixed** (ambiguity resolved as a documented sentinel) | `effectiveAlpha()`: `<= 0` = **unset**, `>= 1` = opaque, `NaN` = garbage — only a value strictly inside `(0, 1)` is applied, and the renderer composites it. Documented on `WidgetModifier.alpha` and in `ui_protocol.proto`. Trade-off note below. |
| 5 | Theme-token `background_color` values dropped | **Fixed** | 17 tokens (one per `BossColorScheme` field) resolve against the host's **active** theme, so a plugin asking for `panel` re-skins with the app. Names match case-insensitively, ignoring `_`/`-`. Hex parsing unchanged; unknown specs still draw no background rather than throwing. |
| 6 | UUID-per-build ids defeat state retention | **Fixed** | Builder ids are deterministic (`w0`, `w1`, … in creation order), so a rebuilt tree keeps its identities. The renderer also keys Compose identity on the node id (`key(child.id)`, `remember(node.id)`) so state follows the node rather than its position. |
| 7 | `WidgetDiffEngine` duplicates child links on parent-first adds | **Fixed** | Child insertion is idempotent. A `NodeAdded` payload carries the added node's own `childIds`, so a subtree add linked each child twice when the parent's op landed first; both op orders now converge on the same tree. |
| 8 | Key/scroll/focus/lifecycle emitted by neither side | **Partially fixed — see below** | Wire mapping complete for all four, both directions. Renderer now emits **focus** for text fields. **Key, scroll and lifecycle emission deferred.** |

### Item 4: why a sentinel and not real presence

The clean fix for "is `0.0` unset or transparent?" is `optional float alpha`, which gives proto3 explicit presence. Rejected: it changes generated code in every binding (prost turns the field into `Option<f32>`, breaking the Rust consumer's compile) for a field whose only sane unset behavior is "don't composite". The sentinel is documented in the proto so both implementations state the same rule, and `alpha = 0` as "invisible" is unreachable by design — a widget that should not be visible must not be sent.

### Item 8: what is deferred and why

Emitting an event family well means deciding *when* it fires, and three of the four need a design decision rather than a few lines:

- **Key** — needs a routing policy: which widgets receive keys, whether the surface consumes them, and how that coexists with the host's own keymap interception. Guessing would ship a protocol nobody can rely on.
- **Scroll** — `ScrollEvent` is a delta, and a naive `snapshotFlow` on the scroll offset emits one event per pixel. It needs a throttle/coalescing policy before it is safe to put on the stream.
- **Lifecycle** — `created` is easy, but `destroyed` cannot be delivered today: the surface's outgoing flow is torn down with its scope, so a teardown event never gets flushed. An asymmetric lifecycle (create without destroy) is a footgun for plugin authors, so the whole family stays out until `StreamUI` has a graceful drain. Emitting only the easy half is exactly the half-wiring worth avoiding.

All four are already mapped and round-trip tested, so the follow-up is purely emission-side.

## Blocker worth flagging: the surface transport does not actually deliver events

Independent of this issue, `RemotePanelComponent`/`RemoteTabComponent` cannot deliver a UI event to a plugin at all today:

- the host connects as the gRPC **client** of `PluginUIService`, so it *sends* `WidgetUpdate` and *receives* `UIEvent` — inverted from the service's own contract ("plugin sends widget updates, kernel sends user events"), which puts the host on the serving side;
- each outgoing `UIEvent` is converted into a `WidgetUpdate` carrying only `surface_id`, i.e. the payload is dropped on the floor;
- incoming `UIEvent`s are only logged, and the stream never applies a tree (`updateTree` is only ever called from outside).

So items 1, 2 and 8 are correct at the mapping layer and unit-tested end to end, but **nothing is observable at runtime until the surface transport is implemented**. That is a feature (host-side `PluginUIService` + surface registry), not a defect fix, so it is not in this PR — it wants its own issue, and it is the reason this PR does not claim "interactive remote UI now works".

## Wire compatibility

**No structural proto change.** Messages, fields and field numbers are untouched; the `ui_protocol.proto` diff is comments only (alpha sentinel, token vocabulary, per-type property keys, node-id stability). The IPC version therefore correctly stays `1.0.0` — `assembleUpstreamJars` stamps the **wire-format** version, and the wire format did not change. **No plugin needs rebuilding.**

`boss-ui-sdk`'s public API is additive (`WidgetEvent`, `EmittedEvent`, `UIEventMapper`, `ThemeToken`, `BackgroundSpec`, the `resolve*`/`effectiveAlpha` helpers, the `PROP_*` constants); nothing was removed or re-signed, so the jar stays binary compatible for the standalone microkernel-runtime consumer.

Two behavior changes are visible to plugins that build trees with the SDK, both intended:

1. **Node ids are `w0…wN` instead of UUIDs.** Ids are opaque and scoped per surface, and the diff engine wants exactly this stability. Anything that persisted a UUID *across* SDK versions and expected it to still resolve would notice — nothing in this repo does, and per-surface scoping means the reused short ids cannot collide.
2. **Buttons carry an extra `clickEventId` property** alongside `onClickEvent` (a few bytes). This is what makes an already-shipped host click correctly; no host regresses, since the old spelling is still written.

One host-internal signature changed: `RemoteWidgetRenderer`'s `onEvent` is now `(nodeId, WidgetEvent)` instead of three strings. Only `composeApp` calls it — it is not part of the plugin ABI.

## Tests

New/extended, all pinning behavior the two implementations disagreed about:

- `RemoteUiInteractionWireTest` (11) — the priority path for items 1 and 2, end to end: **builder → proto → back → renderer resolution → `UIEvent` → back**. Covers builder-built buttons, legacy-spelling-only trees from old plugins, canonical-only trees, `clickable` modifiers, dropdown value+index, list rows, and a proto-built tree that never set `alpha`.
- `UIEventMapperTest` (12) — every oneof case round-trips; an unset oneof reads back as `null` instead of a fabricated event; a count check fails if the proto grows a case with no `WidgetEvent` variant.
- `WidgetSemanticsTest` (15) — click-id precedence, list/dropdown splitting, the alpha sentinel, and background specs (all 17 tokens, three spellings, both hex forms, `#RGB`/garbage rejected).
- `WidgetTreeBuilderTest` (+5, 9 total) — deterministic ids, identical rebuild ⇒ empty diff, value-only rebuild ⇒ one `NodeUpdated`, independent counters per builder, both button spellings.
- `WidgetDiffEngineTest` (+4, 13 total) — parent-first subtree add does not double-link, parent-first ≡ child-first, `diff`→`apply` reproduces the tree exactly, same-parent `NodeMoved` re-indexes without duplicating.
- `RemoteWidgetRendererColorTest` (4, composeApp) — every `ThemeToken` resolves, tokens follow the active scheme, hex still works, unknown → no background.

Gradle (narrow tasks, `--max-workers=2`):

```
:boss-ui-sdk:ktlintCheck :boss-ui-sdk:detekt :boss-ui-sdk:test   BUILD SUCCESSFUL — 60 tests, 0 failures
:composeApp:compileKotlinDesktop                                 BUILD SUCCESSFUL
:composeApp:ktlintCheck :composeApp:detekt                       BUILD SUCCESSFUL
:composeApp:desktopTest (full suite)                             BUILD SUCCESSFUL — 846 tests, 0 failures, 1 skipped
```

The two detekt baseline IDs for `RenderNode` are re-keyed to its new signature (the pre-existing `LongMethod`/`CyclomaticComplexMethod` debt on the widget-type dispatcher); no new suppressions were added.

The Compose renderer itself has no UI test: `composeApp:desktopTest` runs on JUnit 5 and `createComposeRule` is JUnit 4, so covering it means adding `compose.desktop.uiTestJUnit4` plus the vintage engine. That is why the interpretation rules live in the SDK where they are covered directly, leaving the renderer a thin caller — but it does mean the Compose wiring (focus emission, `key()`/`remember` identity, alpha compositing) is reviewed, not asserted.

`Refs #34` — deliberately not auto-closing: item 8's key, scroll and lifecycle **emission** remain open, and the transport blocker above deserves its own issue.
