### PR TITLE
feat(remote-ui): invert the PluginUIService transport so plugin UI works both ways

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -787,8 +787,14 @@ kotlin {
             // behaviour can be asserted against a real composition instead of
             // reasoned about. The API is JUnit 4 only; this module runs on the
             // JUnit Platform, so the vintage engine is what actually executes
-            // those rules. Both engines are discovered side by side — the Jupiter
-            // suite is untouched.
+            // those rules.
+            //
+            // Adding vintage WIDENS what runs: any pre-existing org.junit.Test in
+            // desktopTest that the platform previously ignored now executes. When
+            // it was introduced the source set held 67 test classes and 67 were
+            // executed, on all three CI platforms — nothing was silently skipped
+            // before and nothing appeared. Re-check that count if these deps
+            // change; a suite that quietly stops running is worse than no suite.
             implementation(compose.desktop.uiTestJUnit4)
             runtimeOnly(libs.junit.vintage.engine)
             // Test-only: lets the suite assert the IPC proxy's skip-list stays

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -783,6 +783,14 @@ kotlin {
         desktopTest.dependencies {
             implementation(kotlin("test-junit5"))
             implementation(libs.junit.jupiter)
+            // Compose UI testing (createComposeRule / onNodeWithText), so renderer
+            // behaviour can be asserted against a real composition instead of
+            // reasoned about. The API is JUnit 4 only; this module runs on the
+            // JUnit Platform, so the vintage engine is what actually executes
+            // those rules. Both engines are discovered side by side — the Jupiter
+            // suite is untouched.
+            implementation(compose.desktop.uiTestJUnit4)
+            runtimeOnly(libs.junit.vintage.engine)
             // Test-only: lets the suite assert the IPC proxy's skip-list stays
             // equal to the in-process scanner's (no production coupling).
             // Resolved by path with a presence guard, NOT the type-safe
@@ -801,10 +809,14 @@ kotlin {
         if (findProject(":plugin-platform:plugin-api-ipc") == null) {
             desktopTest.kotlin.exclude("**/SkipListDriftTest.kt")
         }
-        // Mirror of the desktopMain exclusion above: **/kernel/** isn't compiled on
-        // Windows ARM64 (no boss-ipc), so tests naming kernel types can't be either.
+        // Mirror of the desktopMain exclusions above: **/kernel/** and
+        // **/plugin/remote/** aren't compiled on Windows ARM64 (no boss-ipc, no
+        // boss-ui-sdk), so tests naming those types can't be either. The
+        // plugin/remote half was missed when the kernel one was added, which left
+        // RemoteWidgetRendererColorTest (it reads resolveBackgroundColor out of the
+        // excluded renderer) unable to compile on that platform.
         if (isWindowsArm64Build) {
-            desktopTest.kotlin.exclude("**/kernel/**")
+            desktopTest.kotlin.exclude("**/kernel/**", "**/plugin/remote/**")
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -229,12 +229,6 @@ class OutOfProcessPluginSpawnerImpl(
         }
 
     /**
-     * Get the gRPC channel to a plugin process.
-     * Used by RemotePanelComponent/RemoteTabComponent for UI streaming.
-     */
-    fun getChannel(pluginId: String): ManagedChannel? = pluginChannels[pluginId]
-
-    /**
      * Get the state bridge for a plugin.
      */
     fun getStateBridge(pluginId: String): PluginStateBridge? = stateBridges[pluginId]

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemotePanelComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemotePanelComponent.kt
@@ -1,55 +1,57 @@
 package ai.rever.boss.components.plugin.remote
 
-import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
-import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceHost
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.ui.sdk.UIEventMapper
 import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetTree
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.*
-import io.grpc.ManagedChannel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.launch
 
 /**
  * Host-side panel component that renders a remote plugin's UI.
  *
- * Connects to the plugin process via gRPC [PluginUIService], collects
- * widget tree updates, and re-renders using [RemoteWidgetRenderer].
+ * The panel is one half of a surface; the plugin process is the other. It does **not** connect to the
+ * plugin: `ui_protocol.proto` makes the plugin the gRPC client and the host the server, so inbound
+ * trees arrive at [PluginUIServiceBridge][ai.rever.boss.kernel.services.PluginUIServiceBridge] and
+ * outbound events leave through it. This class meets that transport at
+ * [RemoteUiSurfaceRegistry], keyed by [panelId], which is what lets the panel and its plugin start,
+ * stop and restart in any order.
  *
- * UI events from user interactions are forwarded back to the plugin process
- * via the bidirectional stream.
+ * (Before this existed, the component dialled *out* to the plugin and packed each user event into a
+ * `WidgetUpdate` — a message with nowhere to put one — so every interaction crossed the wire as a bare
+ * `surface_id`. Nothing the user did could reach a plugin.)
  */
 class RemotePanelComponent(
     val panelId: String,
     val displayName: String,
     private val processId: String,
-    private val uiAddress: String,
+    private val registry: RemoteUiSurfaceRegistry = RemoteUiSurfaceRegistry.shared,
 ) {
     private val logger = BossLogger.forComponent("RemotePanelComponent")
-    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val _widgetTree = mutableStateOf<WidgetTree?>(null)
     private val _connected = mutableStateOf(false)
 
     /**
-     * Outgoing UI events from kernel to plugin process.
+     * The transport's view of this panel.
      *
-     * A queue, not a shared flow: `TextChange` carries the *whole* field value with
-     * last-write-wins semantics, so two fast keystrokes that each got their own coroutine could
-     * race to the stream and land reversed, silently reverting a character. An unlimited channel
-     * written straight from the Compose callback keeps emission order = interaction order.
+     * Kept private rather than implemented by the class: these are calls the registry makes *into* the
+     * panel from an IPC thread, not API for the rest of the host.
      */
-    private val outgoingEvents = Channel<UIEvent>(Channel.UNLIMITED)
+    private val surfaceHost =
+        object : RemoteUiSurfaceHost {
+            override fun onTreeUpdated(tree: WidgetTree) {
+                updateTree(tree)
+            }
 
-    /** Whether the component is connected to the plugin process. */
+            override fun onConnectionChanged(connected: Boolean) {
+                _connected.value = connected
+            }
+        }
+
+    /** Whether a plugin process is currently streaming this panel's surface. */
     val connected: State<Boolean> get() = _connected
 
     /**
@@ -67,111 +69,42 @@ class RemotePanelComponent(
     }
 
     /**
-     * Connect to the plugin process and start streaming widget updates.
-     * Call this when the panel is first displayed.
+     * Bind this panel to its surface. Call this when the panel is first displayed.
+     *
+     * Safe before the plugin exists: the registry replays the surface's retained tree and connection
+     * state if there already is one, and delivers the first update if there is not yet.
      */
-    fun connect() {
+    fun attach() {
         logger.info(
             LogCategory.UI,
-            "Connecting to remote panel",
-            mapOf("panelId" to panelId, "process" to processId, "address" to uiAddress),
-        )
-        scope.launch {
-            connectToPluginProcess()
-        }
-    }
-
-    /**
-     * Connect to the plugin process and start streaming widget updates.
-     * Uses the provided gRPC channel instead of creating one from the address.
-     */
-    fun connect(channel: ManagedChannel) {
-        logger.info(
-            LogCategory.UI,
-            "Connecting to remote panel via channel",
+            "Attaching remote panel to its surface",
             mapOf("panelId" to panelId, "process" to processId),
         )
-        scope.launch {
-            connectWithChannel(channel)
-        }
+        registry.attach(panelId, surfaceHost)
     }
 
     /**
-     * Update the displayed widget tree (called from IPC handler or direct test).
+     * Update the displayed widget tree (called from the transport, or directly in tests).
      */
     fun updateTree(tree: WidgetTree) {
         _widgetTree.value = tree
     }
 
     fun dispose() {
-        scope.cancel()
-        outgoingEvents.close()
+        registry.detach(panelId, surfaceHost)
         _connected.value = false
         logger.info(LogCategory.UI, "Remote panel disposed", mapOf("panelId" to panelId))
     }
 
     // ---- Internal ----
 
-    private suspend fun connectToPluginProcess() {
-        try {
-            val client =
-                ai.rever.boss.ipc
-                    .BossIpcClient(uiAddress)
-            connectWithChannel(client.channel)
-        } catch (e: Exception) {
-            logger.error(
-                LogCategory.UI,
-                "Failed to connect to plugin process",
-                mapOf("panelId" to panelId),
-                error = e,
-            )
-            _connected.value = false
-        }
-    }
-
-    private suspend fun connectWithChannel(channel: ManagedChannel) {
-        val stub = PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub(channel)
-
-        try {
-            _connected.value = true
-
-            // StreamUI is bidirectional: kernel sends WidgetUpdates, plugin sends UIEvents.
-            // We wrap outgoing UIEvents as the request stream and collect incoming UIEvents
-            // from the response stream.
-            val widgetUpdateStream =
-                channelFlow {
-                    // Forward UI events from kernel to plugin process as WidgetUpdate wrappers
-                    outgoingEvents.consumeAsFlow().collect { event ->
-                        val update =
-                            ai.rever.boss.ipc.proto.WidgetUpdate
-                                .newBuilder()
-                                .setSurfaceId(event.surfaceId)
-                                .build()
-                        send(update)
-                    }
-                }
-
-            stub.streamUI(widgetUpdateStream).collect { uiEvent ->
-                logger.debug(LogCategory.UI, "Received UI event from plugin", mapOf("surface" to uiEvent.surfaceId))
-            }
-        } catch (e: kotlinx.coroutines.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            _connected.value = false
-            logger.warn(
-                LogCategory.UI,
-                "Connection to plugin process lost",
-                mapOf("panelId" to panelId, "error" to e.message),
-            )
-        }
-    }
-
     /**
-     * Queue one interaction for the plugin process.
+     * Hand one interaction to the surface's outgoing queue.
      *
      * Not `suspend`, and deliberately called straight from the Compose callback: the send is a
-     * non-blocking enqueue onto an unlimited channel, so interactions reach the stream in the order
-     * the user made them. Handing each event to its own `scope.launch` let two keystrokes race.
+     * non-blocking enqueue, so interactions reach the wire in the order the user made them. Handing each
+     * event to its own coroutine let two keystrokes race, and `TextChange` carries the *whole* field
+     * value with last-write-wins semantics — reversed, two fast keystrokes silently revert a character.
      *
      * The `WidgetEvent` → proto `UIEvent` mapping lives in [UIEventMapper] (boss-ui-sdk): it is total
      * over the sealed event type, so no oneof case can be silently skipped — which is exactly how
@@ -187,9 +120,13 @@ class RemotePanelComponent(
             "Panel UI event",
             mapOf("panelId" to panelId, "node" to nodeId, "type" to event::class.simpleName),
         )
-        val queued = outgoingEvents.trySend(UIEventMapper.toProto(panelId, nodeId, event, System.currentTimeMillis()))
-        if (queued.isFailure) {
-            logger.debug(LogCategory.UI, "Dropped UI event: surface is closed", mapOf("panelId" to panelId))
+        val proto = UIEventMapper.toProto(panelId, nodeId, event, System.currentTimeMillis())
+        if (!registry.emit(panelId, proto)) {
+            logger.debug(
+                LogCategory.UI,
+                "Dropped UI event: no plugin holds this surface",
+                mapOf("panelId" to panelId),
+            )
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteTabComponent.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteTabComponent.kt
@@ -1,55 +1,49 @@
 package ai.rever.boss.components.plugin.remote
 
-import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
-import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceHost
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.ui.sdk.UIEventMapper
 import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetTree
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.*
-import io.grpc.ManagedChannel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.launch
 
 /**
  * Host-side tab component that renders a remote plugin's tab UI.
  *
- * Same pattern as [RemotePanelComponent] but for tab-type surfaces,
- * with additional title and loading state management.
+ * Same shape as [RemotePanelComponent] — a surface half that meets the plugin's stream at
+ * [RemoteUiSurfaceRegistry] rather than dialling out to it — plus title and loading state.
  */
 class RemoteTabComponent(
     val tabId: String,
     val displayName: String,
     private val processId: String,
-    private val uiAddress: String,
+    private val registry: RemoteUiSurfaceRegistry = RemoteUiSurfaceRegistry.shared,
 ) {
     private val logger = BossLogger.forComponent("RemoteTabComponent")
-    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val _widgetTree = mutableStateOf<WidgetTree?>(null)
     private val _title = mutableStateOf(displayName)
     private val _isLoading = mutableStateOf(false)
     private val _connected = mutableStateOf(false)
 
-    /**
-     * Outgoing UI events from kernel to plugin process.
-     *
-     * A queue, not a shared flow: `TextChange` carries the *whole* field value with
-     * last-write-wins semantics, so two fast keystrokes that each got their own coroutine could
-     * race to the stream and land reversed, silently reverting a character. An unlimited channel
-     * written straight from the Compose callback keeps emission order = interaction order.
-     */
-    private val outgoingEvents = Channel<UIEvent>(Channel.UNLIMITED)
+    /** The transport's view of this tab — see [RemotePanelComponent] for why it is not the class itself. */
+    private val surfaceHost =
+        object : RemoteUiSurfaceHost {
+            override fun onTreeUpdated(tree: WidgetTree) {
+                updateTree(tree)
+            }
+
+            override fun onConnectionChanged(connected: Boolean) {
+                _connected.value = connected
+            }
+        }
 
     val title: State<String> get() = _title
     val isLoading: State<Boolean> get() = _isLoading
+
+    /** Whether a plugin process is currently streaming this tab's surface. */
     val connected: State<Boolean> get() = _connected
 
     /**
@@ -66,36 +60,18 @@ class RemoteTabComponent(
         }
     }
 
-    /**
-     * Connect to the plugin process and start streaming widget updates.
-     */
-    fun connect() {
+    /** Bind this tab to its surface. Safe before the plugin exists — see [RemotePanelComponent.attach]. */
+    fun attach() {
         logger.info(
             LogCategory.UI,
-            "Connecting to remote tab",
-            mapOf("tabId" to tabId, "process" to processId, "address" to uiAddress),
-        )
-        scope.launch {
-            connectToPluginProcess()
-        }
-    }
-
-    /**
-     * Connect using a pre-existing gRPC channel.
-     */
-    fun connect(channel: ManagedChannel) {
-        logger.info(
-            LogCategory.UI,
-            "Connecting to remote tab via channel",
+            "Attaching remote tab to its surface",
             mapOf("tabId" to tabId, "process" to processId),
         )
-        scope.launch {
-            connectWithChannel(channel)
-        }
+        registry.attach(tabId, surfaceHost)
     }
 
     /**
-     * Update the displayed widget tree (called from IPC handler).
+     * Update the displayed widget tree (called from the transport, or directly in tests).
      */
     fun updateTree(tree: WidgetTree) {
         _widgetTree.value = tree
@@ -110,68 +86,16 @@ class RemoteTabComponent(
     }
 
     fun dispose() {
-        scope.cancel()
-        outgoingEvents.close()
+        registry.detach(tabId, surfaceHost)
         _connected.value = false
         logger.info(LogCategory.UI, "Remote tab disposed", mapOf("tabId" to tabId))
     }
 
     // ---- Internal ----
 
-    private suspend fun connectToPluginProcess() {
-        try {
-            val client =
-                ai.rever.boss.ipc
-                    .BossIpcClient(uiAddress)
-            connectWithChannel(client.channel)
-        } catch (e: Exception) {
-            logger.error(
-                LogCategory.UI,
-                "Failed to connect to plugin process",
-                mapOf("tabId" to tabId),
-                error = e,
-            )
-            _connected.value = false
-        }
-    }
-
-    private suspend fun connectWithChannel(channel: ManagedChannel) {
-        val stub = PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub(channel)
-
-        try {
-            _connected.value = true
-
-            val widgetUpdateStream =
-                channelFlow {
-                    outgoingEvents.consumeAsFlow().collect { event ->
-                        val update =
-                            ai.rever.boss.ipc.proto.WidgetUpdate
-                                .newBuilder()
-                                .setSurfaceId(event.surfaceId)
-                                .build()
-                        send(update)
-                    }
-                }
-
-            stub.streamUI(widgetUpdateStream).collect { uiEvent ->
-                logger.debug(LogCategory.UI, "Received UI event from plugin tab", mapOf("surface" to uiEvent.surfaceId))
-            }
-        } catch (e: kotlinx.coroutines.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            _connected.value = false
-            logger.warn(
-                LogCategory.UI,
-                "Connection to plugin tab lost",
-                mapOf("tabId" to tabId, "error" to e.message),
-            )
-        }
-    }
-
     /**
-     * Queue one interaction for the plugin process — see [RemotePanelComponent] for why this is an
-     * ordered channel written from the callback rather than a coroutine per event, and why
-     * [UIEventMapper] owns the proto mapping.
+     * Hand one interaction to the surface's outgoing queue — see [RemotePanelComponent] for why this is
+     * an ordered non-suspending enqueue, and why [UIEventMapper] owns the proto mapping.
      */
     private fun sendUIEvent(
         nodeId: String,
@@ -183,9 +107,13 @@ class RemoteTabComponent(
             "Tab UI event",
             mapOf("tabId" to tabId, "node" to nodeId, "type" to event::class.simpleName),
         )
-        val queued = outgoingEvents.trySend(UIEventMapper.toProto(tabId, nodeId, event, System.currentTimeMillis()))
-        if (queued.isFailure) {
-            logger.debug(LogCategory.UI, "Dropped UI event: surface is closed", mapOf("tabId" to tabId))
+        val proto = UIEventMapper.toProto(tabId, nodeId, event, System.currentTimeMillis())
+        if (!registry.emit(tabId, proto)) {
+            logger.debug(
+                LogCategory.UI,
+                "Dropped UI event: no plugin holds this surface",
+                mapOf("tabId" to tabId),
+            )
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -453,6 +453,10 @@ class KernelBootstrap(
         // 6. Stop IPC server
         ipcServer?.stop()
 
+        // 6b. Close remote UI surfaces. The registry is process-wide and outlives this bootstrap, so a
+        // restart would otherwise come up still holding claims from processes that are now dead.
+        RemoteUiSurfaceRegistry.shared.clear()
+
         // 7. Cancel scope
         scope.cancel()
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.ipc.services.EventBusServiceImpl
 import ai.rever.boss.ipc.services.KernelServiceImpl
 import ai.rever.boss.ipc.services.StateServiceImpl
 import ai.rever.boss.kernel.services.*
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.plugin.api.*
 import ai.rever.boss.process.ManagedProcess
 import ai.rever.boss.process.ProcessConfig
@@ -129,12 +130,22 @@ class KernelBootstrap(
         eventBusService = EventBusServiceImpl()
         stateService = StateServiceImpl()
 
-        // Start gRPC server
+        // Start gRPC server.
+        //
+        // PluginUIServiceBridge goes in here rather than in registerPluginServices() below, for two
+        // reasons. It has to exist before any plugin connects — processes are spawned immediately after
+        // this, and a plugin whose RegisterUI lands on a server that has no PluginUIService gets
+        // UNIMPLEMENTED and no UI at all. And BossIpcServer.addService() on a *running* server rebuilds
+        // it, which means tearing down the socket: harmless for the unary services registered that way,
+        // fatal for StreamUI, whose whole job is to stay open. registerPluginServices() also exists to
+        // gate each bridge on a host provider being present, and this one has no provider to gate on —
+        // its dependency is the surface registry, which the host owns for its whole lifetime.
         ipcServer =
             BossIpcServer(kernelAddress!!)
                 .addService(kernelService!!)
                 .addService(eventBusService!!)
                 .addService(stateService!!)
+                .addService(PluginUIServiceBridge(RemoteUiSurfaceRegistry.shared))
                 .start()
 
         // Wire IPC event bridge to forward events cross-process (M8 fix)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -132,14 +132,18 @@ class KernelBootstrap(
 
         // Start gRPC server.
         //
-        // PluginUIServiceBridge goes in here rather than in registerPluginServices() below, for two
+        // PluginUIServiceBridge goes in here rather than in registerPluginServices() below for two
         // reasons. It has to exist before any plugin connects — processes are spawned immediately after
-        // this, and a plugin whose RegisterUI lands on a server that has no PluginUIService gets
-        // UNIMPLEMENTED and no UI at all. And BossIpcServer.addService() on a *running* server rebuilds
-        // it, which means tearing down the socket: harmless for the unary services registered that way,
-        // fatal for StreamUI, whose whole job is to stay open. registerPluginServices() also exists to
-        // gate each bridge on a host provider being present, and this one has no provider to gate on —
-        // its dependency is the surface registry, which the host owns for its whole lifetime.
+        // this, and a plugin whose RegisterUI lands on a server with no PluginUIService gets UNIMPLEMENTED
+        // and no UI at all. And registerPluginServices() exists to gate each bridge on a host provider
+        // being present, which this one has nothing to gate on: its dependency is the surface registry,
+        // which the host owns for its whole lifetime.
+        //
+        // Note it is NOT because late registration is destructive. It used to be — addService() on a
+        // running server rebuilt it, tearing down the socket, which was survivable for unary bridges and
+        // fatal for StreamUI — but BossIpcServer now routes late services through a MutableHandlerRegistry
+        // and never touches the socket. Adding a service to a running server is safe; the ordering above
+        // is about existence, not about protecting streams.
         ipcServer =
             BossIpcServer(kernelAddress!!)
                 .addService(kernelService!!)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.ipc.proto.UIRegistrationResponse
 import ai.rever.boss.ipc.proto.UIUnregistration
 import ai.rever.boss.ipc.proto.WidgetUpdate
 import ai.rever.boss.kernel.ui.RemoteUiSurface
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceDescriptor
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.kernel.ui.SurfaceRegistration
 import ai.rever.boss.kernel.ui.SurfaceStream
@@ -48,7 +49,7 @@ class PluginUIServiceBridge(
     private val registry: RemoteUiSurfaceRegistry = RemoteUiSurfaceRegistry.shared,
 ) : PluginUIServiceGrpcKt.PluginUIServiceCoroutineImplBase() {
     override suspend fun registerUI(request: UIRegistration): UIRegistrationResponse =
-        when (val outcome = registry.register(request.surfaceId, request.processId)) {
+        when (val outcome = registry.register(request.surfaceId, request.processId, request.descriptor())) {
             is SurfaceRegistration.Rejected -> {
                 logger.warn(
                     LogCategory.UI,
@@ -178,6 +179,20 @@ class PluginUIServiceBridge(
                 }
             }.collect()
     }
+
+    /**
+     * Everything a registration declares beyond identity.
+     *
+     * Kept on the surface for the follow-up that places it in the window, which is what needs
+     * `surface_type` to choose panel vs tab and `default_slot` to position a panel.
+     */
+    private fun UIRegistration.descriptor(): RemoteUiSurfaceDescriptor =
+        RemoteUiSurfaceDescriptor(
+            surfaceType = surfaceType,
+            displayName = displayName,
+            iconName = iconName,
+            defaultSlot = defaultSlot,
+        )
 
     private fun registrationResponse(
         success: Boolean,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -155,6 +155,7 @@ class PluginUIServiceBridge(
     ) {
         var surface: RemoteUiSurface? = null
         var refused = false
+        var broken = false
         requests
             .onEach { update ->
                 val target = surface
@@ -166,7 +167,8 @@ class PluginUIServiceBridge(
                     target != null -> {
                         logger.warn(
                             LogCategory.UI,
-                            "Ignoring a WidgetUpdate for a surface this stream is not bound to",
+                            "Ignoring a WidgetUpdate for a surface this stream is not bound to — " +
+                                "use one StreamUI call per surface",
                             mapOf("streamSurfaceId" to target.surfaceId, "updateSurfaceId" to update.surfaceId),
                         )
                     }
@@ -196,15 +198,25 @@ class PluginUIServiceBridge(
                     }
                 }
             }.catch { cause ->
-                logger.debug(
+                broken = true
+                logger.warn(
                     LogCategory.UI,
-                    "Plugin widget-update stream ended abnormally",
+                    "Plugin widget-update stream ended abnormally — closing the surface",
                     mapOf("surfaceId" to surface?.surfaceId, "error" to cause.message),
                 )
+                // Whatever the reason — a dead wire, or a failure applying an update — this pump has
+                // stopped reading the request stream, and the call cannot usefully continue. Leaving the
+                // response side running would keep the surface claimed and reading *connected* while the
+                // plugin's next send blocked on flow control forever. Closing the surface completes the
+                // event queue, which completes the response flow, which ends the RPC.
+                surface?.let(registry::closeStream)
             }.onCompletion { cause ->
-                // Only when the stream ended of its own accord: a cancellation is not an unbindable
-                // stream, and reporting it as one puts a misleading status on a dead RPC.
-                if (cause == null && surface == null && !refused) {
+                // An unbindable stream is one that ended of its own accord without ever naming a surface.
+                // A cancellation is not that, and neither is a broken wire — `catch` above swallows the
+                // cause to keep one status on the call, so `broken` is what distinguishes them here.
+                val endedCleanly = cause == null && !broken
+                val neverBound = surface == null && !refused
+                if (endedCleanly && neverBound) {
                     bound.completeExceptionally(
                         StatusException(Status.INVALID_ARGUMENT.withDescription(UNIDENTIFIED_STREAM)),
                     )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -19,6 +19,7 @@ import io.grpc.Status
 import io.grpc.StatusException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -28,7 +29,9 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Kernel-side implementation of `PluginUIService` — the transport that makes out-of-process plugin UI
@@ -48,9 +51,13 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * @param registry the surface directory to route through. Defaults to the host-wide one; tests pass
  *   their own so two suites cannot see each other's surfaces.
+ * @param bindTimeoutMs how long a `StreamUI` call may stay open without naming a surface — see
+ *   [DEFAULT_BIND_TIMEOUT_MS]. A parameter only so a test can assert the reaping in milliseconds instead of
+ *   spending the production deadline doing it.
  */
 class PluginUIServiceBridge(
     private val registry: RemoteUiSurfaceRegistry = RemoteUiSurfaceRegistry.shared,
+    private val bindTimeoutMs: Long = DEFAULT_BIND_TIMEOUT_MS,
 ) : PluginUIServiceGrpcKt.PluginUIServiceCoroutineImplBase() {
     override suspend fun registerUI(request: UIRegistration): UIRegistrationResponse =
         when (val outcome = registry.register(request.surfaceId, request.processId, request.descriptor())) {
@@ -101,10 +108,21 @@ class PluginUIServiceBridge(
             val pump = launch { pumpUpdates(requests, bound, claimed) }
             try {
                 // Throws the StatusException the pump resolved this with when the id is unusable.
-                val surface = bound.await()
+                //
+                // Bounded, because the INVALID_ARGUMENT below is raised from onCompletion and so needs the
+                // request stream to actually end. A plugin that opens the call and then neither sends nor
+                // half-closes would otherwise park here forever with the pump on a stream that never
+                // completes, and there is no server deadline to reap it.
+                val surface = withTimeout(bindTimeoutMs) { bound.await() }
                 // One collector for one queue: this is the hop that turns interaction order into wire
                 // order, so it must stay single — see RemoteUiSurface.claimStream.
                 surface.events().collect { event -> send(event) }
+            } catch (timeout: TimeoutCancellationException) {
+                // Our own timeout, not the caller's cancellation, so converting it to a status is right:
+                // otherwise the plugin sees CANCELLED with a Kotlin message and no idea what it did wrong.
+                throw StatusException(
+                    Status.DEADLINE_EXCEEDED.withCause(timeout).withDescription(SILENT_STREAM),
+                )
             } finally {
                 // channelFlow does not complete until its children do, and the pump is collecting a
                 // request stream the plugin may keep open indefinitely. Without this cancel, closing a
@@ -248,10 +266,22 @@ class PluginUIServiceBridge(
             .setErrorMessage(error)
             .build()
 
-    private companion object {
-        val logger = BossLogger.forComponent("PluginUIServiceBridge")
+    companion object {
+        /**
+         * How long a `StreamUI` call may stay open without naming a surface.
+         *
+         * Generous on purpose: it bounds a stuck call, it is not a latency budget. A plugin sends its first
+         * update immediately after opening the stream, so reaching this means the plugin is not going to.
+         */
+        val DEFAULT_BIND_TIMEOUT_MS = 30.seconds.inWholeMilliseconds
 
-        const val UNIDENTIFIED_STREAM =
+        private val logger = BossLogger.forComponent("PluginUIServiceBridge")
+
+        private const val SILENT_STREAM =
+            "StreamUI takes its surface identity from the surface_id of its first WidgetUpdate; " +
+                "none arrived, and the request stream stayed open"
+
+        private const val UNIDENTIFIED_STREAM =
             "StreamUI takes its surface identity from the surface_id of its first WidgetUpdate; " +
                 "the request stream ended without sending one"
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -174,6 +174,7 @@ class PluginUIServiceBridge(
         var surface: RemoteUiSurface? = null
         var refused = false
         var broken = false
+        var strays = 0L
         requests
             .onEach { update ->
                 val target = surface
@@ -183,12 +184,8 @@ class PluginUIServiceBridge(
                     }
 
                     target != null -> {
-                        logger.warn(
-                            LogCategory.UI,
-                            "Ignoring a WidgetUpdate for a surface this stream is not bound to — " +
-                                "use one StreamUI call per surface",
-                            mapOf("streamSurfaceId" to target.surfaceId, "updateSurfaceId" to update.surfaceId),
-                        )
+                        strays++
+                        noteStrayUpdate(target.surfaceId, update.surfaceId, strays)
                     }
 
                     !refused -> {
@@ -243,6 +240,30 @@ class PluginUIServiceBridge(
     }
 
     /**
+     * Report an update for a surface this stream is not bound to, first and then every Nth.
+     *
+     * Throttled because a plugin that multiplexes two surfaces onto one call sends these at its own update
+     * rate, and an unthrottled warning is a log-flooding primitive handed across the boundary.
+     */
+    private fun noteStrayUpdate(
+        streamSurfaceId: String,
+        updateSurfaceId: String,
+        occurrences: Long,
+    ) {
+        if (occurrences != 1L && occurrences % STRAY_LOG_INTERVAL != 0L) return
+        logger.warn(
+            LogCategory.UI,
+            "Ignoring a WidgetUpdate for a surface this stream is not bound to — " +
+                "use one StreamUI call per surface",
+            mapOf(
+                "streamSurfaceId" to streamSurfaceId,
+                "updateSurfaceId" to updateSurfaceId,
+                "occurrences" to occurrences,
+            ),
+        )
+    }
+
+    /**
      * Everything a registration declares beyond identity.
      *
      * Kept on the surface for the follow-up that places it in the window, which is what needs
@@ -276,6 +297,9 @@ class PluginUIServiceBridge(
         val DEFAULT_BIND_TIMEOUT_MS = 30.seconds.inWholeMilliseconds
 
         private val logger = BossLogger.forComponent("PluginUIServiceBridge")
+
+        /** Log the first stray update on a stream, then every Nth. See the throttle in pumpUpdates. */
+        private const val STRAY_LOG_INTERVAL = 256L
 
         private const val SILENT_STREAM =
             "StreamUI takes its surface identity from the surface_id of its first WidgetUpdate; " +

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -1,0 +1,199 @@
+package ai.rever.boss.kernel.services
+
+import ai.rever.boss.ipc.proto.Empty
+import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ipc.proto.UIRegistration
+import ai.rever.boss.ipc.proto.UIRegistrationResponse
+import ai.rever.boss.ipc.proto.UIUnregistration
+import ai.rever.boss.ipc.proto.WidgetUpdate
+import ai.rever.boss.kernel.ui.RemoteUiSurface
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
+import ai.rever.boss.kernel.ui.SurfaceRegistration
+import ai.rever.boss.kernel.ui.SurfaceStream
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toKotlin
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+/**
+ * Kernel-side implementation of `PluginUIService` — the transport that makes out-of-process plugin UI
+ * actually work in both directions.
+ *
+ * **The host used to have this backwards.** `ui_protocol.proto` makes the plugin the client (it streams
+ * `WidgetUpdate`s) and the kernel the server (it streams `UIEvent`s back), but `RemotePanelComponent`
+ * and `RemoteTabComponent` each opened a `PluginUIServiceCoroutineStub` and dialled *out* to the plugin.
+ * Because the request stream of `StreamUI` is typed `WidgetUpdate`, every outgoing `UIEvent` had to be
+ * repacked as a `WidgetUpdate` — a message with no room for an event — so what crossed the wire was a
+ * `surface_id` and nothing else. Inbound `UIEvent`s, arriving on the response stream where the host was
+ * pretending to be a plugin, were logged at debug and discarded. No click, keystroke or selection could
+ * reach a plugin, and no plugin-pushed tree could reach the host: the whole path was decorative.
+ *
+ * This class is the correct half of that inversion, and [RemoteUiSurfaceRegistry] is where it meets the
+ * components. Nothing in the host dials a plugin's UI service any more.
+ *
+ * @param registry the surface directory to route through. Defaults to the host-wide one; tests pass
+ *   their own so two suites cannot see each other's surfaces.
+ */
+class PluginUIServiceBridge(
+    private val registry: RemoteUiSurfaceRegistry = RemoteUiSurfaceRegistry.shared,
+) : PluginUIServiceGrpcKt.PluginUIServiceCoroutineImplBase() {
+    override suspend fun registerUI(request: UIRegistration): UIRegistrationResponse =
+        when (val outcome = registry.register(request.surfaceId, request.processId)) {
+            is SurfaceRegistration.Rejected -> {
+                logger.warn(
+                    LogCategory.UI,
+                    "Refused a UI surface registration",
+                    mapOf("surfaceId" to request.surfaceId, "reason" to outcome.reason),
+                )
+                registrationResponse(success = false, error = outcome.reason)
+            }
+
+            is SurfaceRegistration.Accepted -> {
+                // Applied before the stream exists so a surface renders from the moment it is opened,
+                // rather than staying blank until the plugin's first update.
+                if (request.hasInitialTree()) {
+                    outcome.surface.pushTree(request.initialTree.toKotlin())
+                }
+                registrationResponse(success = true, error = "")
+            }
+        }
+
+    /**
+     * Bidirectional stream: inbound `WidgetUpdate`s are routed to their surface, outbound `UIEvent`s are
+     * drained from that surface's ordered queue.
+     *
+     * The two halves are deliberately independent. A plugin that has sent its tree and has nothing more
+     * to say may half-close its request stream and keep listening for events forever — so the response
+     * flow outlives the request flow and ends only when the surface closes or the plugin goes away.
+     *
+     * `StreamUI` carries no surface id of its own, so the stream is bound by the `surface_id` of its
+     * first `WidgetUpdate` and pinned to it. That is a limitation of the protocol, not a choice: a
+     * plugin that registers a surface and then streams nothing cannot be matched to it, and gets
+     * `INVALID_ARGUMENT` when its request stream ends rather than an RPC that hangs open.
+     */
+    override fun streamUI(requests: Flow<WidgetUpdate>): Flow<UIEvent> =
+        channelFlow {
+            val bound = CompletableDeferred<RemoteUiSurface>()
+            val pump = launch { pumpUpdates(requests, bound) }
+            // Throws the StatusException the pump resolved this with when the id is unusable.
+            val surface = bound.await()
+            try {
+                // One collector for one queue: this is the hop that turns interaction order into wire
+                // order, so it must stay single — see RemoteUiSurface.claimStream.
+                surface.events().collect { event -> send(event) }
+            } finally {
+                // channelFlow does not complete until its children do, and the pump is collecting a
+                // request stream the plugin may keep open indefinitely. Without this cancel, closing a
+                // surface completed the event queue but left the RPC hanging: the plugin's response flow
+                // never ended, so `UnregisterUI` looked like it had silently frozen the stream. The
+                // surface is gone by now, so there is nothing left for the pump to route.
+                pump.cancel()
+                registry.closeStream(surface)
+            }
+        }
+
+    override suspend fun unregisterUI(request: UIUnregistration): Empty {
+        val removed = registry.unregister(request.surfaceId)
+        if (!removed) {
+            logger.debug(
+                LogCategory.UI,
+                "Ignoring UnregisterUI for an unknown surface",
+                mapOf("surfaceId" to request.surfaceId),
+            )
+        }
+        return Empty.getDefaultInstance()
+    }
+
+    /**
+     * Drain the plugin's update stream into its surface.
+     *
+     * Never fails the call by throwing: a broken request stream means the transport is already gone, and
+     * letting that escape would race the response flow's own teardown for which error the plugin sees.
+     * Binding problems are reported through [bound] instead, so exactly one status describes them.
+     */
+    private suspend fun pumpUpdates(
+        requests: Flow<WidgetUpdate>,
+        bound: CompletableDeferred<RemoteUiSurface>,
+    ) {
+        var surface: RemoteUiSurface? = null
+        var refused = false
+        requests
+            .onEach { update ->
+                val target = surface
+                when {
+                    target != null && target.surfaceId == update.surfaceId -> {
+                        target.applyUpdate(update)
+                    }
+
+                    target != null -> {
+                        logger.warn(
+                            LogCategory.UI,
+                            "Ignoring a WidgetUpdate for a surface this stream is not bound to",
+                            mapOf("streamSurfaceId" to target.surfaceId, "updateSurfaceId" to update.surfaceId),
+                        )
+                    }
+
+                    !refused -> {
+                        when (val opened = registry.openStream(update.surfaceId)) {
+                            is SurfaceStream.Bound -> {
+                                surface = opened.surface
+                                bound.complete(opened.surface)
+                                opened.surface.applyUpdate(update)
+                            }
+
+                            is SurfaceStream.Refused -> {
+                                refused = true
+                                bound.completeExceptionally(
+                                    StatusException(Status.FAILED_PRECONDITION.withDescription(opened.reason)),
+                                )
+                            }
+                        }
+                    }
+
+                    else -> {
+                        Unit
+                    }
+                }
+            }.catch { cause ->
+                logger.debug(
+                    LogCategory.UI,
+                    "Plugin widget-update stream ended abnormally",
+                    mapOf("surfaceId" to surface?.surfaceId, "error" to cause.message),
+                )
+            }.onCompletion {
+                if (surface == null && !refused) {
+                    bound.completeExceptionally(
+                        StatusException(Status.INVALID_ARGUMENT.withDescription(UNIDENTIFIED_STREAM)),
+                    )
+                }
+            }.collect()
+    }
+
+    private fun registrationResponse(
+        success: Boolean,
+        error: String,
+    ): UIRegistrationResponse =
+        UIRegistrationResponse
+            .newBuilder()
+            .setSuccess(success)
+            .setErrorMessage(error)
+            .build()
+
+    private companion object {
+        val logger = BossLogger.forComponent("PluginUIServiceBridge")
+
+        const val UNIDENTIFIED_STREAM =
+            "StreamUI takes its surface identity from the surface_id of its first WidgetUpdate; " +
+                "the request stream ended without sending one"
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Kernel-side implementation of `PluginUIService` — the transport that makes out-of-process plugin UI
@@ -85,10 +86,19 @@ class PluginUIServiceBridge(
     override fun streamUI(requests: Flow<WidgetUpdate>): Flow<UIEvent> =
         channelFlow {
             val bound = CompletableDeferred<RemoteUiSurface>()
-            val pump = launch { pumpUpdates(requests, bound) }
-            // Throws the StatusException the pump resolved this with when the id is unusable.
-            val surface = bound.await()
+            // Written by the pump the instant it claims, and read by the finally below. The claim happens
+            // inside the pump, so a `finally` guarding only the collect would miss it: an RPC cancelled
+            // between `openStream()` returning Bound and this coroutine resuming from `await()` would
+            // leave the surface in the registry with `streaming == true` forever — the component reading
+            // *connected* for a dead plugin, and every respawn's RegisterUI refused for the rest of the
+            // session, because the reclaim rule only takes over claims that are not streaming. That is
+            // precisely the frozen-not-disconnected state this transport exists to avoid, and it is the
+            // likeliest crash: a plugin dying right after its first WidgetUpdate.
+            val claimed = AtomicReference<RemoteUiSurface>(null)
+            val pump = launch { pumpUpdates(requests, bound, claimed) }
             try {
+                // Throws the StatusException the pump resolved this with when the id is unusable.
+                val surface = bound.await()
                 // One collector for one queue: this is the hop that turns interaction order into wire
                 // order, so it must stay single — see RemoteUiSurface.claimStream.
                 surface.events().collect { event -> send(event) }
@@ -99,7 +109,8 @@ class PluginUIServiceBridge(
                 // never ended, so `UnregisterUI` looked like it had silently frozen the stream. The
                 // surface is gone by now, so there is nothing left for the pump to route.
                 pump.cancel()
-                registry.closeStream(surface)
+                // Safe to reach twice — closeStream removes by identity and close() is idempotent.
+                claimed.get()?.let(registry::closeStream)
             }
         }
 
@@ -125,6 +136,7 @@ class PluginUIServiceBridge(
     private suspend fun pumpUpdates(
         requests: Flow<WidgetUpdate>,
         bound: CompletableDeferred<RemoteUiSurface>,
+        claimed: AtomicReference<RemoteUiSurface>,
     ) {
         var surface: RemoteUiSurface? = null
         var refused = false
@@ -148,6 +160,9 @@ class PluginUIServiceBridge(
                         when (val opened = registry.openStream(update.surfaceId)) {
                             is SurfaceStream.Bound -> {
                                 surface = opened.surface
+                                // Recorded before anything can suspend, so the claim is never held by a
+                                // coroutine that no longer has a way to release it.
+                                claimed.set(opened.surface)
                                 bound.complete(opened.surface)
                                 opened.surface.applyUpdate(update)
                             }
@@ -171,8 +186,10 @@ class PluginUIServiceBridge(
                     "Plugin widget-update stream ended abnormally",
                     mapOf("surfaceId" to surface?.surfaceId, "error" to cause.message),
                 )
-            }.onCompletion {
-                if (surface == null && !refused) {
+            }.onCompletion { cause ->
+                // Only when the stream ended of its own accord: a cancellation is not an unbindable
+                // stream, and reporting it as one puts a misleading status on a dead RPC.
+                if (cause == null && surface == null && !refused) {
                     bound.completeExceptionally(
                         StatusException(Status.INVALID_ARGUMENT.withDescription(UNIDENTIFIED_STREAM)),
                     )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -201,9 +201,7 @@ class PluginUIServiceBridge(
 
                             is SurfaceStream.Refused -> {
                                 refused = true
-                                bound.completeExceptionally(
-                                    StatusException(Status.FAILED_PRECONDITION.withDescription(opened.reason)),
-                                )
+                                bound.completeExceptionally(StatusException(opened.status()))
                             }
                         }
                     }
@@ -238,6 +236,19 @@ class PluginUIServiceBridge(
                 }
             }.collect()
     }
+
+    /**
+     * The status a refusal goes out as.
+     *
+     * Distinct codes because the recoveries differ: `NOT_FOUND` means "register the surface and open a new
+     * stream", `FAILED_PRECONDITION` means "someone else already owns this one, and always will". A plugin
+     * should not have to parse a description to tell those apart.
+     */
+    private fun SurfaceStream.Refused.status(): Status =
+        when (this) {
+            is SurfaceStream.Unregistered -> Status.NOT_FOUND.withDescription(reason)
+            is SurfaceStream.AlreadyStreaming -> Status.FAILED_PRECONDITION.withDescription(reason)
+        }
 
     /**
      * Report an update for a surface this stream is not bound to, first and then every Nth.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridge.kt
@@ -18,6 +18,8 @@ import ai.rever.boss.ui.sdk.WidgetProtoConverter.toKotlin
 import io.grpc.Status
 import io.grpc.StatusException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
@@ -25,6 +27,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -108,7 +111,19 @@ class PluginUIServiceBridge(
                 // surface completed the event queue but left the RPC hanging: the plugin's response flow
                 // never ended, so `UnregisterUI` looked like it had silently frozen the stream. The
                 // surface is gone by now, so there is nothing left for the pump to route.
-                pump.cancel()
+                //
+                // cancelAndJoin, not cancel: cancel() only *requests* it and returns, so the read below
+                // could race the pump sitting between `openStream()` (which has already set
+                // streaming = true) and its write to `claimed` — two adjacent statements with no
+                // suspension point between them, executing on a different thread, since grpc-kotlin
+                // builds its RPC scope from EmptyCoroutineContext and an RPC cancellation cancels both
+                // coroutines at once. Losing that read would strand the claim exactly as above.
+                // NonCancellable because arriving here *via* cancellation is the common case.
+                //
+                // Joining is also why this cannot be pump.invokeOnCompletion: the pump completes when a
+                // plugin merely half-closes its request stream, which is legal and must not tear the
+                // surface down.
+                withContext(NonCancellable) { pump.cancelAndJoin() }
                 // Safe to reach twice — closeStream removes by identity and close() is idempotent.
                 claimed.get()?.let(registry::closeStream)
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -38,9 +38,31 @@ import ai.rever.boss.ipc.proto.WidgetDiff as ProtoWidgetDiff
 class RemoteUiSurface internal constructor(
     val surfaceId: String,
     val processId: String,
+    /**
+     * What the plugin declared about this surface at registration.
+     *
+     * Retained but unused today: placing a remote surface in the window is the follow-up this transport
+     * unblocks, and that is what will need `surface_type` to pick panel vs tab, `default_slot` to place a
+     * panel, and the name and icon to label it. Dropping them here would mean re-plumbing the protocol
+     * later for data it already carries.
+     */
+    val descriptor: RemoteUiSurfaceDescriptor = RemoteUiSurfaceDescriptor(),
     private val publishTree: (WidgetTree) -> Unit,
     private val publishConnected: (Boolean) -> Unit,
 ) {
+    /**
+     * Serializes publication against a host component attaching.
+     *
+     * Without it, [RemoteUiSurfaceRegistry.attach] could install a host, have a gRPC thread deliver tree
+     * *N+1* through it, and then replay the *N* it had already read — leaving the component rendering an
+     * older tree than the surface holds, with nothing but the plugin's next update to correct it. Taking
+     * this lock while reading the state to replay makes the sequence a host sees monotonic.
+     *
+     * Held across a callback into the host component, which is safe because those callbacks only write
+     * Compose snapshot state and never re-enter the surface.
+     */
+    private val publishLock = Any()
+
     /**
      * User events queued for the plugin process.
      *
@@ -60,7 +82,7 @@ class RemoteUiSurface internal constructor(
      * newest inverts last-write-wins: the plugin would end up holding a stale text value with no later
      * event to correct it, and host and plugin would disagree about the field forever. Dropping from
      * the head keeps the queue converging on the current truth, and preserves the order of what
-     * survives. Sheds are counted in [shedEventCount] rather than being silent.
+     * survives. Sheds are approximated in [shedEventCount] rather than being silent.
      */
     private val outgoing = Channel<UIEvent>(OUTGOING_BUFFER, BufferOverflow.DROP_OLDEST)
 
@@ -77,7 +99,15 @@ class RemoteUiSurface internal constructor(
     /** Whether a plugin process currently holds this surface's `StreamUI` call. */
     val streaming: Boolean get() = streamClaimed.get()
 
-    /** How many outgoing events have been shed because the plugin stopped reading. */
+    /**
+     * Roughly how many outgoing events have been shed because the plugin stopped reading.
+     *
+     * **Approximate by construction.** `DROP_OLDEST` evicts inside the channel, so occupancy has to be
+     * inferred from outside it, and the collector's decrement lands just after its receive — so a
+     * concurrent drain can make an ordinary send look like an eviction (or hide a real one). Exact while
+     * nothing is collecting, which is the case that matters: a plugin that has stopped reading. Treat it
+     * as a health signal, not a count.
+     */
     val shedEventCount: Long get() = shed.get()
 
     /**
@@ -89,8 +119,21 @@ class RemoteUiSurface internal constructor(
      */
     internal fun claimStream(): Boolean {
         val claimed = streamClaimed.compareAndSet(false, true)
-        if (claimed) publishConnected(true)
+        if (claimed) synchronized(publishLock) { publishConnected(true) }
         return claimed
+    }
+
+    /**
+     * Hand a freshly attached host component the state this surface already holds.
+     *
+     * Under [publishLock], so the state read here is the state as of the last delivery — a live update
+     * cannot slip in between the read and the callback and be overwritten by an older tree.
+     */
+    internal fun replayTo(host: RemoteUiSurfaceHost) {
+        synchronized(publishLock) {
+            host.onConnectionChanged(streaming)
+            tree?.let(host::onTreeUpdated)
+        }
     }
 
     /** The outgoing event stream. Consumable exactly once — see [claimStream]. */
@@ -107,16 +150,18 @@ class RemoteUiSurface internal constructor(
      */
     internal fun emit(event: UIEvent): Boolean {
         if (outgoing.trySend(event).isFailure) return false
-        // DROP_OLDEST makes trySend always succeed, so overflow has to be inferred: the buffer cannot
-        // hold more than its capacity, so a count above it means an eviction happened on this send.
+        // DROP_OLDEST evicts inside the channel, so overflow has to be inferred from outside it: the
+        // buffer cannot hold more than its capacity, so a count above it means this send probably
+        // evicted. "Probably" because the collector decrements just after its receive — see
+        // shedEventCount for why that is acceptable for a health signal.
         if (buffered.incrementAndGet() > OUTGOING_BUFFER) {
             buffered.decrementAndGet()
             val total = shed.incrementAndGet()
             if (total == 1L || total % SHED_LOG_INTERVAL == 0L) {
                 logger.warn(
                     LogCategory.UI,
-                    "Plugin is not reading its UI events — shedding the oldest",
-                    mapOf("surfaceId" to surfaceId, "processId" to processId, "shed" to total),
+                    "Plugin appears not to be reading its UI events — shedding the oldest",
+                    mapOf("surfaceId" to surfaceId, "processId" to processId, "shedApprox" to total),
                 )
             }
         }
@@ -125,8 +170,10 @@ class RemoteUiSurface internal constructor(
 
     /** Publish a tree the host already holds in SDK form (a registration's `initial_tree`, or a test). */
     internal fun pushTree(next: WidgetTree) {
-        tree = next
-        publishTree(next)
+        synchronized(publishLock) {
+            tree = next
+            publishTree(next)
+        }
     }
 
     /** Route one inbound `WidgetUpdate` into this surface's tree. */
@@ -168,7 +215,7 @@ class RemoteUiSurface internal constructor(
         if (!closed.compareAndSet(false, true)) return
         outgoing.close()
         streamClaimed.set(false)
-        publishConnected(false)
+        synchronized(publishLock) { publishConnected(false) }
     }
 
     private fun applyDiff(diff: ProtoWidgetDiff) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -5,7 +5,7 @@ import ai.rever.boss.ipc.proto.WidgetUpdate
 import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
 import ai.rever.boss.ui.sdk.WidgetDiffEngine
-import ai.rever.boss.ui.sdk.WidgetProtoConverter.toDiffOperations
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.decodeOperations
 import ai.rever.boss.ui.sdk.WidgetProtoConverter.toKotlin
 import ai.rever.boss.ui.sdk.WidgetTree
 import kotlinx.coroutines.channels.BufferOverflow
@@ -47,8 +47,15 @@ class RemoteUiSurface internal constructor(
      * later for data it already carries.
      */
     val descriptor: RemoteUiSurfaceDescriptor = RemoteUiSurfaceDescriptor(),
-    private val publishTree: (WidgetTree) -> Unit,
-    private val publishConnected: (Boolean) -> Unit,
+    /**
+     * Deliver to whichever host component currently owns this surface's id.
+     *
+     * Both take the surface as their first argument so the registry can drop a publication from a surface
+     * that has already been replaced — a reclaimed predecessor's `close()` would otherwise report
+     * "disconnected" over its successor's live stream.
+     */
+    private val publishTree: (RemoteUiSurface, WidgetTree) -> Unit,
+    private val publishConnected: (RemoteUiSurface, Boolean) -> Unit,
 ) {
     /**
      * Serializes publication against a host component attaching.
@@ -88,6 +95,7 @@ class RemoteUiSurface internal constructor(
 
     private val streamClaimed = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
+    private val eventsTaken = AtomicBoolean(false)
     private val buffered = AtomicInteger(0)
     private val shed = AtomicLong(0)
 
@@ -119,7 +127,7 @@ class RemoteUiSurface internal constructor(
      */
     internal fun claimStream(): Boolean {
         val claimed = streamClaimed.compareAndSet(false, true)
-        if (claimed) synchronized(publishLock) { publishConnected(true) }
+        if (claimed) synchronized(publishLock) { publishConnected(this, true) }
         return claimed
     }
 
@@ -136,8 +144,19 @@ class RemoteUiSurface internal constructor(
         }
     }
 
-    /** The outgoing event stream. Consumable exactly once — see [claimStream]. */
-    internal fun events(): Flow<UIEvent> = outgoing.consumeAsFlow().onEach { buffered.decrementAndGet() }
+    /**
+     * The outgoing event stream, consumable exactly once.
+     *
+     * Enforced here rather than left to [claimStream]'s convention: a second consumer would drain part of
+     * [outgoing] and split one ordered event sequence across two readers, which is the failure the queue
+     * exists to prevent, and the underlying channel's own error for that says nothing about surfaces.
+     */
+    internal fun events(): Flow<UIEvent> {
+        check(eventsTaken.compareAndSet(false, true)) {
+            "surface '$surfaceId' already has an event consumer — one StreamUI call per surface"
+        }
+        return outgoing.consumeAsFlow().onEach { buffered.decrementAndGet() }
+    }
 
     /**
      * Queue one user event for the plugin.
@@ -172,7 +191,7 @@ class RemoteUiSurface internal constructor(
     internal fun pushTree(next: WidgetTree) {
         synchronized(publishLock) {
             tree = next
-            publishTree(next)
+            publishTree(this, next)
         }
     }
 
@@ -215,7 +234,7 @@ class RemoteUiSurface internal constructor(
         if (!closed.compareAndSet(false, true)) return
         outgoing.close()
         streamClaimed.set(false)
-        synchronized(publishLock) { publishConnected(false) }
+        synchronized(publishLock) { publishConnected(this, false) }
     }
 
     private fun applyDiff(diff: ProtoWidgetDiff) {
@@ -230,19 +249,34 @@ class RemoteUiSurface internal constructor(
             )
             return
         }
-        if (diff.baseVersion != 0L && diff.baseVersion != base.version) {
-            // Best-effort rather than fatal: refusing would freeze the surface permanently, whereas the
-            // next full tree from the plugin repairs whatever this misapplies.
+        val stale = diff.baseVersion != 0L && diff.baseVersion != base.version
+        if (stale) {
+            // Best-effort rather than fatal: refusing would freeze the surface permanently, whereas any
+            // later full tree from the plugin repairs whatever this misapplies.
             logger.warn(
                 LogCategory.UI,
                 "Widget diff base version does not match the surface's tree — applying anyway",
                 mapOf("surfaceId" to surfaceId, "expected" to base.version, "actual" to diff.baseVersion),
             )
         }
-        val applied = WidgetDiffEngine.apply(base, diff.toDiffOperations())
-        // WidgetDiffEngine bumps the version by one; honour the sender's numbering when it supplied
-        // some, so the next diff's base_version check compares against what the plugin believes.
-        pushTree(if (diff.newVersion != 0L) applied.copy(version = diff.newVersion) else applied)
+        val decoded = diff.decodeOperations()
+        if (decoded.skipped > 0) {
+            // Structural ops that could not be decoded cannot be reconstructed from their neighbours, so
+            // the tree below is knowingly not the one the plugin has.
+            logger.warn(
+                LogCategory.UI,
+                "Widget diff contained operations this build cannot decode — the tree may now diverge",
+                mapOf("surfaceId" to surfaceId, "skipped" to decoded.skipped, "applied" to decoded.operations.size),
+            )
+        }
+        val applied = WidgetDiffEngine.apply(base, decoded.operations)
+        // WidgetDiffEngine bumps the version by one; adopt the sender's numbering only when we believe we
+        // applied the diff faithfully. Adopting it after a divergence would make every SUBSEQUENT
+        // base_version check pass and the surface permanently, invisibly wrong — and "the next full tree
+        // repairs it" is no comfort to a plugin that sends one full tree and then only diffs, which is
+        // the intended steady state. Keeping the local version instead makes the next diff trip too.
+        val faithful = !stale && decoded.skipped == 0
+        pushTree(if (faithful && diff.newVersion != 0L) applied.copy(version = diff.newVersion) else applied)
     }
 
     companion object {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -249,7 +249,14 @@ class RemoteUiSurface internal constructor(
         synchronized(publishLock) { publishConnected(this, false) }
     }
 
-    private fun applyDiff(diff: ProtoWidgetDiff) {
+    private fun applyDiff(diff: ProtoWidgetDiff) =
+        // The whole read-modify-write, not just the write. One stream per surface rules out concurrent
+        // diffs, but a registration's `initial_tree` is pushed from a different coroutine and nothing makes
+        // a plugin await the RegisterUI response before opening StreamUI — so an initial tree and a first
+        // diff can interleave and lose one. The monitor is reentrant, so pushTree taking it again is free.
+        synchronized(publishLock) { applyDiffLocked(diff) }
+
+    private fun applyDiffLocked(diff: ProtoWidgetDiff) {
         val base = tree
         if (base == null) {
             // A diff is meaningless without the tree it was computed against, and the protocol has no

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -126,6 +126,13 @@ class RemoteUiSurface internal constructor(
      * guarantee the queue exists to provide.
      */
     internal fun claimStream(): Boolean {
+        // The closed check is not redundant with the CAS. `close()` resets streamClaimed, so a claim that
+        // raced a concurrent `unregister`/`clear` — the registry reads the map, then the surface is removed
+        // and closed, then the claim lands — would succeed on a dead surface and publish connected = true.
+        // Nothing ever takes that back: `events()` completes immediately over the closed channel, and the
+        // compensating close() returns early because it has already run. The component would sit reading
+        // *connected* for a surface that no longer exists.
+        if (closed.get()) return false
         val claimed = streamClaimed.compareAndSet(false, true)
         if (claimed) synchronized(publishLock) { publishConnected(this, true) }
         return claimed
@@ -225,6 +232,11 @@ class RemoteUiSurface internal constructor(
      * cleanly, so this is also the anti-leak path. The last tree is deliberately **kept**: a surface
      * whose plugin died shows its final state with `connected == false` rather than going blank, which
      * is the difference between "disconnected" and "frozen" from the user's side.
+     *
+     * That applies to a component that was *already* attached — the tree it last rendered stays in its own
+     * state. A component that attaches *after* the plugin is gone gets nothing, because the surface is out
+     * of the registry by then and there is nothing to replay. Deliberate: a tree from a process that died
+     * some time ago is stale, and showing it as if it were live would be the more misleading of the two.
      *
      * Idempotent, because it is legitimately reached twice on a graceful shutdown: `UnregisterUI` closes
      * the surface, which ends the event queue, which ends the `StreamUI` call, whose teardown closes the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -96,6 +96,8 @@ class RemoteUiSurface internal constructor(
     private val streamClaimed = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
     private val eventsTaken = AtomicBoolean(false)
+    private val diverged = AtomicBoolean(false)
+    private val malformed = AtomicLong(0)
     private val buffered = AtomicInteger(0)
     private val shed = AtomicLong(0)
 
@@ -126,16 +128,24 @@ class RemoteUiSurface internal constructor(
      * guarantee the queue exists to provide.
      */
     internal fun claimStream(): Boolean {
-        // The closed check is not redundant with the CAS. `close()` resets streamClaimed, so a claim that
-        // raced a concurrent `unregister`/`clear` — the registry reads the map, then the surface is removed
-        // and closed, then the claim lands — would succeed on a dead surface and publish connected = true.
-        // Nothing ever takes that back: `events()` completes immediately over the closed channel, and the
-        // compensating close() returns early because it has already run. The component would sit reading
-        // *connected* for a surface that no longer exists.
-        if (closed.get()) return false
-        val claimed = streamClaimed.compareAndSet(false, true)
-        if (claimed) synchronized(publishLock) { publishConnected(this, true) }
-        return claimed
+        // Order matters, and checking `closed` first is not enough. `close()` *resets* streamClaimed, so a
+        // check-then-CAS still admits: read closed (false) → close() runs fully, resetting the flag → CAS
+        // succeeds → publish connected = true on a dead surface. Nothing takes that back, because
+        // stillOwnedBy passes for a removed id, events() completes at once over the closed channel, and the
+        // compensating close() returns early. The component would sit reading *connected* for a surface
+        // that no longer exists — the frozen state this transport exists to avoid.
+        //
+        // Claiming first and re-checking closes it: either close()'s write is visible to the re-check, or
+        // the CAS landed before close() reset the flag and the re-check sees closed anyway. Not reachable
+        // from a test, which is why the ordering carries the weight here.
+        if (!streamClaimed.compareAndSet(false, true)) return false
+        val alive = !closed.get()
+        if (alive) {
+            synchronized(publishLock) { publishConnected(this, true) }
+        } else {
+            streamClaimed.set(false)
+        }
+        return alive
     }
 
     /**
@@ -206,6 +216,9 @@ class RemoteUiSurface internal constructor(
     internal fun applyUpdate(update: WidgetUpdate) {
         when (update.updateCase) {
             WidgetUpdate.UpdateCase.FULL_TREE -> {
+                // A full tree is the only thing that repairs a diverged surface, so it also clears the flag
+                // that suppresses repeat divergence warnings.
+                diverged.set(false)
                 pushTree(update.fullTree.toKotlin())
             }
 
@@ -216,11 +229,7 @@ class RemoteUiSurface internal constructor(
             WidgetUpdate.UpdateCase.UPDATE_NOT_SET, null -> {
                 // Neither oneof arm set: a sender bug, or a proto case newer than this build. Either
                 // way there is nothing to render, and guessing would corrupt the tree.
-                logger.warn(
-                    LogCategory.UI,
-                    "Ignoring a WidgetUpdate that carries neither a full tree nor a diff",
-                    mapOf("surfaceId" to surfaceId, "processId" to processId),
-                )
+                noteMalformed("Ignoring a WidgetUpdate that carries neither a full tree nor a diff")
             }
         }
     }
@@ -249,6 +258,23 @@ class RemoteUiSurface internal constructor(
         synchronized(publishLock) { publishConnected(this, false) }
     }
 
+    /**
+     * Report a malformed update, first and then every [MALFORMED_LOG_INTERVAL]th.
+     *
+     * These paths are all reachable by a misbehaving plugin on the once-per-update path, so an unthrottled
+     * warning is a log-flooding primitive handed to the other side of the boundary.
+     */
+    private fun noteMalformed(message: String) {
+        val total = malformed.incrementAndGet()
+        if (total == 1L || total % MALFORMED_LOG_INTERVAL == 0L) {
+            logger.warn(
+                LogCategory.UI,
+                message,
+                mapOf("surfaceId" to surfaceId, "processId" to processId, "occurrences" to total),
+            )
+        }
+    }
+
     private fun applyDiff(diff: ProtoWidgetDiff) =
         // The whole read-modify-write, not just the write. One stream per surface rules out concurrent
         // diffs, but a registration's `initial_tree` is pushed from a different coroutine and nothing makes
@@ -259,33 +285,29 @@ class RemoteUiSurface internal constructor(
     private fun applyDiffLocked(diff: ProtoWidgetDiff) {
         val base = tree
         if (base == null) {
-            // A diff is meaningless without the tree it was computed against, and the protocol has no
-            // way to ask for a resync — so say so loudly instead of inventing an empty base.
-            logger.warn(
-                LogCategory.UI,
-                "Dropping a widget diff for a surface with no tree yet — the plugin must send a full tree first",
-                mapOf("surfaceId" to surfaceId, "processId" to processId),
-            )
+            // A diff is meaningless without the tree it was computed against, and the protocol has no way to
+            // ask for a resync — so say so instead of inventing an empty base. Throttled, because a plugin
+            // that only ever sends diffs would otherwise log one per update forever.
+            noteMalformed("Dropping a widget diff for a surface with no tree — the plugin must send one first")
             return
         }
         val stale = diff.baseVersion != 0L && diff.baseVersion != base.version
-        if (stale) {
-            // Best-effort rather than fatal: refusing would freeze the surface permanently, whereas any
-            // later full tree from the plugin repairs whatever this misapplies.
-            logger.warn(
-                LogCategory.UI,
-                "Widget diff base version does not match the surface's tree — applying anyway",
-                mapOf("surfaceId" to surfaceId, "expected" to base.version, "actual" to diff.baseVersion),
-            )
-        }
         val decoded = diff.decodeOperations()
-        if (decoded.skipped > 0) {
-            // Structural ops that could not be decoded cannot be reconstructed from their neighbours, so
-            // the tree below is knowingly not the one the plugin has.
+        // Reported on the TRANSITION into divergence, not per update. Keeping the local version means every
+        // subsequent diff mismatches by design — that is what makes the next one trip — so warning each
+        // time would turn one bad diff into a warning per frame for the life of the surface. Cleared when a
+        // full tree arrives, because that is the thing that actually repairs it.
+        if ((stale || decoded.skipped > 0) && diverged.compareAndSet(false, true)) {
             logger.warn(
                 LogCategory.UI,
-                "Widget diff contained operations this build cannot decode — the tree may now diverge",
-                mapOf("surfaceId" to surfaceId, "skipped" to decoded.skipped, "applied" to decoded.operations.size),
+                "Widget diff cannot be applied faithfully — this surface's tree may now diverge from the " +
+                    "plugin's until it sends a full tree",
+                mapOf(
+                    "surfaceId" to surfaceId,
+                    "expectedBaseVersion" to base.version,
+                    "actualBaseVersion" to diff.baseVersion,
+                    "undecodableOperations" to decoded.skipped,
+                ),
             )
         }
         val applied = WidgetDiffEngine.apply(base, decoded.operations)
@@ -309,6 +331,9 @@ class RemoteUiSurface internal constructor(
 
         /** Log the first shed event, then every Nth, so a wedged plugin cannot flood the log. */
         private const val SHED_LOG_INTERVAL = 256L
+
+        /** Same restraint for malformed updates, which are equally plugin-controlled. */
+        private const val MALFORMED_LOG_INTERVAL = 256L
 
         private val logger = BossLogger.forComponent("RemoteUiSurface")
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -1,0 +1,215 @@
+package ai.rever.boss.kernel.ui
+
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ipc.proto.WidgetUpdate
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.ui.sdk.WidgetDiffEngine
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toDiffOperations
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toKotlin
+import ai.rever.boss.ui.sdk.WidgetTree
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onEach
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import ai.rever.boss.ipc.proto.WidgetDiff as ProtoWidgetDiff
+
+/**
+ * One remote UI surface, from the host's side of the IPC boundary.
+ *
+ * A surface is the meeting point of two independent lifetimes: an out-of-process plugin that streams
+ * widget trees in, and a host component ([ai.rever.boss.components.plugin.remote.RemotePanelComponent]
+ * or `RemoteTabComponent`) that renders them and hands back user events. Neither one holds the other
+ * — both address the surface by `surfaceId` through [RemoteUiSurfaceRegistry], so they can appear in
+ * either order and either can go away without stranding the other.
+ *
+ * This object owns the two pieces of per-surface transport state:
+ * - the last widget tree the plugin published (retained, so a component attaching later renders
+ *   immediately instead of waiting for the next update), and
+ * - the queue of user events waiting to go out to the plugin.
+ *
+ * Instances come from [RemoteUiSurfaceRegistry.register]; the constructor is internal because a
+ * surface that is not in the registry is unreachable by definition.
+ */
+class RemoteUiSurface internal constructor(
+    val surfaceId: String,
+    val processId: String,
+    private val publishTree: (WidgetTree) -> Unit,
+    private val publishConnected: (Boolean) -> Unit,
+) {
+    /**
+     * User events queued for the plugin process.
+     *
+     * **Ordered, and bounded.** Ordering is the load-bearing property: `TextChange` carries the whole
+     * field value with last-write-wins semantics, so two keystrokes that arrive out of order silently
+     * revert a character. A single channel written straight from the Compose callback makes emission
+     * order equal interaction order, and one collector drains it into one gRPC stream, which preserves
+     * that order on the wire.
+     *
+     * The bound is the part that differs from a purely in-process queue. Across a process boundary the
+     * reader can stop reading — a wedged or paused plugin leaves gRPC flow control blocking our
+     * collector, and an unlimited queue would then grow without limit inside the *host* for a fault
+     * that is entirely the plugin's. [OUTGOING_BUFFER] events is over ten seconds of continuous human
+     * interaction; a surface that falls that far behind is not "busy", it is gone.
+     *
+     * Overflow drops the **oldest** event, not the newest. Both lose information, but dropping the
+     * newest inverts last-write-wins: the plugin would end up holding a stale text value with no later
+     * event to correct it, and host and plugin would disagree about the field forever. Dropping from
+     * the head keeps the queue converging on the current truth, and preserves the order of what
+     * survives. Sheds are counted in [shedEventCount] rather than being silent.
+     */
+    private val outgoing = Channel<UIEvent>(OUTGOING_BUFFER, BufferOverflow.DROP_OLDEST)
+
+    private val streamClaimed = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
+    private val buffered = AtomicInteger(0)
+    private val shed = AtomicLong(0)
+
+    /** The last tree the plugin published, or `null` before its first update. */
+    @Volatile
+    var tree: WidgetTree? = null
+        private set
+
+    /** Whether a plugin process currently holds this surface's `StreamUI` call. */
+    val streaming: Boolean get() = streamClaimed.get()
+
+    /** How many outgoing events have been shed because the plugin stopped reading. */
+    val shedEventCount: Long get() = shed.get()
+
+    /**
+     * Take ownership of this surface's outgoing stream, or fail if someone already has it.
+     *
+     * One stream per surface is not a detail: two concurrent `StreamUI` calls would each drain part of
+     * [outgoing], splitting one ordered event sequence across two readers and losing the ordering
+     * guarantee the queue exists to provide.
+     */
+    internal fun claimStream(): Boolean {
+        val claimed = streamClaimed.compareAndSet(false, true)
+        if (claimed) publishConnected(true)
+        return claimed
+    }
+
+    /** The outgoing event stream. Consumable exactly once — see [claimStream]. */
+    internal fun events(): Flow<UIEvent> = outgoing.consumeAsFlow().onEach { buffered.decrementAndGet() }
+
+    /**
+     * Queue one user event for the plugin.
+     *
+     * Non-suspending on purpose: it is called straight from a Compose callback, where suspending would
+     * mean either blocking the frame or handing the event to a coroutine that can be reordered against
+     * its neighbours.
+     *
+     * @return `false` when the surface is closed — a late event is dropped, never thrown at the caller.
+     */
+    internal fun emit(event: UIEvent): Boolean {
+        if (outgoing.trySend(event).isFailure) return false
+        // DROP_OLDEST makes trySend always succeed, so overflow has to be inferred: the buffer cannot
+        // hold more than its capacity, so a count above it means an eviction happened on this send.
+        if (buffered.incrementAndGet() > OUTGOING_BUFFER) {
+            buffered.decrementAndGet()
+            val total = shed.incrementAndGet()
+            if (total == 1L || total % SHED_LOG_INTERVAL == 0L) {
+                logger.warn(
+                    LogCategory.UI,
+                    "Plugin is not reading its UI events — shedding the oldest",
+                    mapOf("surfaceId" to surfaceId, "processId" to processId, "shed" to total),
+                )
+            }
+        }
+        return true
+    }
+
+    /** Publish a tree the host already holds in SDK form (a registration's `initial_tree`, or a test). */
+    internal fun pushTree(next: WidgetTree) {
+        tree = next
+        publishTree(next)
+    }
+
+    /** Route one inbound `WidgetUpdate` into this surface's tree. */
+    internal fun applyUpdate(update: WidgetUpdate) {
+        when (update.updateCase) {
+            WidgetUpdate.UpdateCase.FULL_TREE -> {
+                pushTree(update.fullTree.toKotlin())
+            }
+
+            WidgetUpdate.UpdateCase.DIFF -> {
+                applyDiff(update.diff)
+            }
+
+            WidgetUpdate.UpdateCase.UPDATE_NOT_SET, null -> {
+                // Neither oneof arm set: a sender bug, or a proto case newer than this build. Either
+                // way there is nothing to render, and guessing would corrupt the tree.
+                logger.warn(
+                    LogCategory.UI,
+                    "Ignoring a WidgetUpdate that carries neither a full tree nor a diff",
+                    mapOf("surfaceId" to surfaceId, "processId" to processId),
+                )
+            }
+        }
+    }
+
+    /**
+     * Close the surface: complete the outgoing stream and report the surface disconnected.
+     *
+     * Completing the channel is what unblocks the `StreamUI` collector and lets gRPC finish the call
+     * cleanly, so this is also the anti-leak path. The last tree is deliberately **kept**: a surface
+     * whose plugin died shows its final state with `connected == false` rather than going blank, which
+     * is the difference between "disconnected" and "frozen" from the user's side.
+     *
+     * Idempotent, because it is legitimately reached twice on a graceful shutdown: `UnregisterUI` closes
+     * the surface, which ends the event queue, which ends the `StreamUI` call, whose teardown closes the
+     * surface again. Without the guard the host component would be told it disconnected twice.
+     */
+    internal fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        outgoing.close()
+        streamClaimed.set(false)
+        publishConnected(false)
+    }
+
+    private fun applyDiff(diff: ProtoWidgetDiff) {
+        val base = tree
+        if (base == null) {
+            // A diff is meaningless without the tree it was computed against, and the protocol has no
+            // way to ask for a resync — so say so loudly instead of inventing an empty base.
+            logger.warn(
+                LogCategory.UI,
+                "Dropping a widget diff for a surface with no tree yet — the plugin must send a full tree first",
+                mapOf("surfaceId" to surfaceId, "processId" to processId),
+            )
+            return
+        }
+        if (diff.baseVersion != 0L && diff.baseVersion != base.version) {
+            // Best-effort rather than fatal: refusing would freeze the surface permanently, whereas the
+            // next full tree from the plugin repairs whatever this misapplies.
+            logger.warn(
+                LogCategory.UI,
+                "Widget diff base version does not match the surface's tree — applying anyway",
+                mapOf("surfaceId" to surfaceId, "expected" to base.version, "actual" to diff.baseVersion),
+            )
+        }
+        val applied = WidgetDiffEngine.apply(base, diff.toDiffOperations())
+        // WidgetDiffEngine bumps the version by one; honour the sender's numbering when it supplied
+        // some, so the next diff's base_version check compares against what the plugin believes.
+        pushTree(if (diff.newVersion != 0L) applied.copy(version = diff.newVersion) else applied)
+    }
+
+    companion object {
+        /**
+         * How many outgoing events a surface holds for a plugin that has stopped reading.
+         *
+         * Public because it is a documented property of the transport, not a tuning detail: it is the
+         * point past which the host starts shedding a plugin's events. See [outgoing].
+         */
+        const val OUTGOING_BUFFER = 256
+
+        /** Log the first shed event, then every Nth, so a wedged plugin cannot flood the log. */
+        private const val SHED_LOG_INTERVAL = 256L
+
+        private val logger = BossLogger.forComponent("RemoteUiSurface")
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -1,0 +1,198 @@
+package ai.rever.boss.kernel.ui
+
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.ui.sdk.WidgetTree
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The host-side renderer of one remote surface, as the transport sees it.
+ *
+ * Implemented by `RemotePanelComponent` / `RemoteTabComponent`. Both callbacks arrive on whichever
+ * thread gRPC delivered the message on, never the UI thread — implementations must only touch
+ * thread-safe state (Compose snapshot state is).
+ */
+interface RemoteUiSurfaceHost {
+    /** A new widget tree to render. */
+    fun onTreeUpdated(tree: WidgetTree)
+
+    /** Whether a plugin process is currently streaming this surface. */
+    fun onConnectionChanged(connected: Boolean)
+}
+
+/** Outcome of a plugin's `RegisterUI`. */
+sealed interface SurfaceRegistration {
+    data class Accepted(
+        val surface: RemoteUiSurface,
+    ) : SurfaceRegistration
+
+    /** [reason] is written to be readable by a plugin author — it goes out as `error_message`. */
+    data class Rejected(
+        val reason: String,
+    ) : SurfaceRegistration
+}
+
+/** Outcome of a plugin's `StreamUI` binding to a surface. */
+sealed interface SurfaceStream {
+    data class Bound(
+        val surface: RemoteUiSurface,
+    ) : SurfaceStream
+
+    data class Refused(
+        val reason: String,
+    ) : SurfaceStream
+}
+
+/**
+ * Directory of live remote UI surfaces, and the seam the two sides of a surface meet at.
+ *
+ * The problem this solves is that a surface's two halves start independently: the plugin process
+ * registers and streams whenever it happens to come up, while the host component is constructed when
+ * the user opens the panel or tab. Either order is normal, and a plugin can crash and respawn under a
+ * component that never went away.
+ *
+ * So neither half holds a reference to the other. Both are indexed by `surfaceId` in separate maps —
+ * plugin-side surfaces here, host-side renderers in [hosts] — and every delivery is a lookup at the
+ * moment it happens. A tree that arrives with nobody attached is retained on the surface for whoever
+ * attaches next; an event emitted with no plugin registered is reported undeliverable to its caller
+ * rather than queued into a void or thrown; and a component that attaches to an already-streaming
+ * surface is immediately given the current tree and connection state, so it does not render blank
+ * until the plugin's next update.
+ */
+class RemoteUiSurfaceRegistry {
+    private val surfaces = ConcurrentHashMap<String, RemoteUiSurface>()
+    private val hosts = ConcurrentHashMap<String, RemoteUiSurfaceHost>()
+
+    /**
+     * Claim [surfaceId] for a plugin process.
+     *
+     * A duplicate id is refused rather than silently taken over: two plugins rendering into one surface
+     * would interleave trees, and the second one's events would be delivered to the first's stream.
+     */
+    fun register(
+        surfaceId: String,
+        processId: String,
+    ): SurfaceRegistration {
+        if (surfaceId.isBlank()) {
+            return SurfaceRegistration.Rejected("surface_id is required")
+        }
+        val created =
+            RemoteUiSurface(
+                surfaceId = surfaceId,
+                processId = processId,
+                publishTree = { tree -> hosts[surfaceId]?.onTreeUpdated(tree) },
+                publishConnected = { connected -> hosts[surfaceId]?.onConnectionChanged(connected) },
+            )
+        val existing = surfaces.putIfAbsent(surfaceId, created)
+        return if (existing != null) {
+            SurfaceRegistration.Rejected(
+                "surface_id '$surfaceId' is already registered by process '${existing.processId}'",
+            )
+        } else {
+            logger.info(
+                LogCategory.UI,
+                "Remote UI surface registered",
+                mapOf("surfaceId" to surfaceId, "processId" to processId, "attached" to hosts.containsKey(surfaceId)),
+            )
+            SurfaceRegistration.Accepted(created)
+        }
+    }
+
+    /** Tear a surface down at the plugin's request. @return `false` if it was not registered. */
+    fun unregister(surfaceId: String): Boolean {
+        val surface = surfaces.remove(surfaceId) ?: return false
+        surface.close()
+        logger.info(LogCategory.UI, "Remote UI surface unregistered", mapOf("surfaceId" to surfaceId))
+        return true
+    }
+
+    /**
+     * Bind a plugin's `StreamUI` call to its surface.
+     *
+     * Registration first, deliberately: a stream for an unknown id is a protocol error worth reporting,
+     * and accepting it would mean inventing a surface with no `surface_type`, `display_name` or slot —
+     * i.e. one the host could never place.
+     */
+    fun openStream(surfaceId: String): SurfaceStream {
+        val surface = surfaces[surfaceId]
+        return when {
+            surface == null -> {
+                SurfaceStream.Refused("surface_id '$surfaceId' is not registered — call RegisterUI first")
+            }
+
+            !surface.claimStream() -> {
+                SurfaceStream.Refused("surface_id '$surfaceId' already has an open StreamUI call")
+            }
+
+            else -> {
+                SurfaceStream.Bound(surface)
+            }
+        }
+    }
+
+    /**
+     * Release a stream that has ended, for any reason.
+     *
+     * This also drops the registration. A dying stream is the *only* signal the host gets that a plugin
+     * process is gone — there is no `UnregisterUI` from a process that crashed — so holding the claim
+     * would lock the id out and a respawned plugin could never re-register it. Any attached component
+     * stays attached and simply sees `connected == false`, ready for the replacement process.
+     */
+    fun closeStream(surface: RemoteUiSurface) {
+        surfaces.remove(surface.surfaceId, surface)
+        surface.close()
+        logger.info(
+            LogCategory.UI,
+            "Remote UI stream closed",
+            mapOf("surfaceId" to surface.surfaceId, "processId" to surface.processId, "shed" to surface.shedEventCount),
+        )
+    }
+
+    /** Bind a host component to [surfaceId], replaying whatever the surface already holds. */
+    fun attach(
+        surfaceId: String,
+        host: RemoteUiSurfaceHost,
+    ) {
+        hosts[surfaceId] = host
+        val surface = surfaces[surfaceId]
+        host.onConnectionChanged(surface?.streaming == true)
+        surface?.tree?.let(host::onTreeUpdated)
+    }
+
+    /** Unbind a host component. Scoped to [host] so a component disposed late cannot evict its successor. */
+    fun detach(
+        surfaceId: String,
+        host: RemoteUiSurfaceHost,
+    ) {
+        hosts.remove(surfaceId, host)
+    }
+
+    /**
+     * Queue a user event for the plugin behind [surfaceId].
+     *
+     * @return `false` when there is nothing to deliver to — no registered surface, or one already closed.
+     *   Callers log and move on; a click that lands during teardown is not an error condition.
+     */
+    fun emit(
+        surfaceId: String,
+        event: UIEvent,
+    ): Boolean = surfaces[surfaceId]?.emit(event) == true
+
+    /** The live surface for [surfaceId], if a plugin currently holds it. */
+    fun surfaceOf(surfaceId: String): RemoteUiSurface? = surfaces[surfaceId]
+
+    companion object {
+        /**
+         * The host-wide registry.
+         *
+         * One per process, because the surfaces it indexes are process-wide: the single IPC server every
+         * plugin connects to is on one side and the single window's components on the other. Tests build
+         * their own instances instead, which is why every collaborator takes one as a parameter rather
+         * than reaching for this.
+         */
+        val shared = RemoteUiSurfaceRegistry()
+
+        private val logger = BossLogger.forComponent("RemoteUiSurfaceRegistry")
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -58,6 +58,26 @@ sealed interface SurfaceStream {
 }
 
 /**
+ * Whether [surface] may still publish under its id, given the currently registered surfaces.
+ *
+ * `claim()` installs a replacement *before* closing the surface it reclaimed, and the publish lock is
+ * per-instance, so those two do not serialize against each other: without this check a predecessor's
+ * `close()` could announce "disconnected" *after* its successor had already announced a live stream,
+ * leaving the component reading disconnected while trees kept arriving.
+ *
+ * A surface whose id is now **free** still publishes — that is `closeStream`'s remove-then-close order
+ * delivering the legitimate "your plugin died" notice, and suppressing it would recreate the frozen
+ * surface this transport exists to avoid.
+ *
+ * A file-level predicate rather than a member: it needs nothing but the map, and reads as a question
+ * about the map.
+ */
+private fun Map<String, RemoteUiSurface>.stillOwnedBy(surface: RemoteUiSurface): Boolean {
+    val current = this[surface.surfaceId]
+    return current == null || current === surface
+}
+
+/**
  * Directory of live remote UI surfaces, and the seam the two sides of a surface meet at.
  *
  * The problem this solves is that a surface's two halves start independently: the plugin process
@@ -104,8 +124,12 @@ class RemoteUiSurfaceRegistry {
                 surfaceId = surfaceId,
                 processId = processId,
                 descriptor = descriptor,
-                publishTree = { tree -> hosts[surfaceId]?.onTreeUpdated(tree) },
-                publishConnected = { connected -> hosts[surfaceId]?.onConnectionChanged(connected) },
+                publishTree = { from, tree ->
+                    if (surfaces.stillOwnedBy(from)) hosts[surfaceId]?.onTreeUpdated(tree)
+                },
+                publishConnected = { from, connected ->
+                    if (surfaces.stillOwnedBy(from)) hosts[surfaceId]?.onConnectionChanged(connected)
+                },
             )
         val stale = claim(surfaceId, created)
         return if (stale != null) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -58,9 +58,22 @@ sealed interface SurfaceStream {
         val surface: RemoteUiSurface,
     ) : SurfaceStream
 
-    data class Refused(
-        val reason: String,
-    ) : SurfaceStream
+    /**
+     * Split by recovery, not just by message: an unregistered surface is fixable by calling `RegisterUI`,
+     * an already-streaming one never is. Collapsing them left a plugin string-matching a description to
+     * tell "retry after registering" from "give up", which the proto now documents as contract.
+     */
+    sealed interface Refused : SurfaceStream {
+        val reason: String
+    }
+
+    data class Unregistered(
+        override val reason: String,
+    ) : Refused
+
+    data class AlreadyStreaming(
+        override val reason: String,
+    ) : Refused
 }
 
 /**
@@ -224,11 +237,11 @@ class RemoteUiSurfaceRegistry {
         val surface = surfaces[surfaceId]
         return when {
             surface == null -> {
-                SurfaceStream.Refused("surface_id '$surfaceId' is not registered — call RegisterUI first")
+                SurfaceStream.Unregistered("surface_id '$surfaceId' is not registered — call RegisterUI first")
             }
 
             !surface.claimStream() -> {
-                SurfaceStream.Refused("surface_id '$surfaceId' already has an open StreamUI call")
+                SurfaceStream.AlreadyStreaming("surface_id '$surfaceId' already has an open StreamUI call")
             }
 
             else -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -21,6 +21,19 @@ interface RemoteUiSurfaceHost {
     fun onConnectionChanged(connected: Boolean)
 }
 
+/**
+ * What a plugin declared about a surface when it registered it.
+ *
+ * Carried, not acted on: placing a remote surface in the window is the follow-up this transport unblocks,
+ * and it is what will read these. Mirrors the corresponding `UIRegistration` fields.
+ */
+data class RemoteUiSurfaceDescriptor(
+    val surfaceType: String = "",
+    val displayName: String = "",
+    val iconName: String = "",
+    val defaultSlot: String = "",
+)
+
 /** Outcome of a plugin's `RegisterUI`. */
 sealed interface SurfaceRegistration {
     data class Accepted(
@@ -67,12 +80,21 @@ class RemoteUiSurfaceRegistry {
     /**
      * Claim [surfaceId] for a plugin process.
      *
-     * A duplicate id is refused rather than silently taken over: two plugins rendering into one surface
-     * would interleave trees, and the second one's events would be delivered to the first's stream.
+     * A claim held by a *different* process is refused rather than taken over: two plugins rendering into
+     * one surface would interleave trees, and the second one's events would be delivered to the first's
+     * stream.
+     *
+     * A claim held by the **same** process with no stream open is taken over, because that is what a
+     * respawn looks like. [closeStream] releases the id when a stream dies, but a plugin can also die in
+     * the window between `RegisterUI` returning and `StreamUI` binding, or hold claims on more surfaces
+     * than it streams — and there is no notification for either. Refusing those would lock a plugin out of
+     * its own `surface_id` forever, leaving the attached component permanently disconnected: exactly the
+     * lockout `closeStream` exists to prevent, reached by a path it cannot see.
      */
     fun register(
         surfaceId: String,
         processId: String,
+        descriptor: RemoteUiSurfaceDescriptor = RemoteUiSurfaceDescriptor(),
     ): SurfaceRegistration {
         if (surfaceId.isBlank()) {
             return SurfaceRegistration.Rejected("surface_id is required")
@@ -81,13 +103,14 @@ class RemoteUiSurfaceRegistry {
             RemoteUiSurface(
                 surfaceId = surfaceId,
                 processId = processId,
+                descriptor = descriptor,
                 publishTree = { tree -> hosts[surfaceId]?.onTreeUpdated(tree) },
                 publishConnected = { connected -> hosts[surfaceId]?.onConnectionChanged(connected) },
             )
-        val existing = surfaces.putIfAbsent(surfaceId, created)
-        return if (existing != null) {
+        val stale = claim(surfaceId, created)
+        return if (stale != null) {
             SurfaceRegistration.Rejected(
-                "surface_id '$surfaceId' is already registered by process '${existing.processId}'",
+                "surface_id '$surfaceId' is already registered by process '${stale.processId}'",
             )
         } else {
             logger.info(
@@ -99,7 +122,44 @@ class RemoteUiSurfaceRegistry {
         }
     }
 
-    /** Tear a surface down at the plugin's request. @return `false` if it was not registered. */
+    /**
+     * Install [created], returning the surface that blocked it, or `null` on success.
+     *
+     * Loops because the abandoned-claim replacement is a compare-and-set: another `RegisterUI` for the
+     * same id can win the race, and the loser has to re-read rather than assume its own view.
+     */
+    private fun claim(
+        surfaceId: String,
+        created: RemoteUiSurface,
+    ): RemoteUiSurface? {
+        var blocker = surfaces.putIfAbsent(surfaceId, created)
+        while (blocker != null) {
+            val abandoned = blocker.processId == created.processId && !blocker.streaming
+            if (!abandoned) break
+            if (surfaces.replace(surfaceId, blocker, created)) {
+                logger.info(
+                    LogCategory.UI,
+                    "Reclaimed an abandoned UI surface for its own process — treating it as a respawn",
+                    mapOf("surfaceId" to surfaceId, "processId" to created.processId),
+                )
+                blocker.close()
+                blocker = null
+            } else {
+                // Another RegisterUI for this id won the swap; re-read rather than trust our own view.
+                blocker = surfaces.putIfAbsent(surfaceId, created)
+            }
+        }
+        return blocker
+    }
+
+    /**
+     * Tear a surface down at the plugin's request. @return `false` if it was not registered.
+     *
+     * Unattributed, unlike [closeStream]'s two-argument removal: `UIUnregistration` carries only a
+     * `surface_id`, so a late call from a dying incarnation can evict a respawn's fresh surface. That
+     * plugin's next `RegisterUI` recovers, and the window needs an `UnregisterUI` to arrive after a
+     * respawn has already registered — narrow enough to accept rather than to widen the proto for.
+     */
     fun unregister(surfaceId: String): Boolean {
         val surface = surfaces.remove(surfaceId) ?: return false
         surface.close()
@@ -149,15 +209,24 @@ class RemoteUiSurfaceRegistry {
         )
     }
 
-    /** Bind a host component to [surfaceId], replaying whatever the surface already holds. */
+    /**
+     * Bind a host component to [surfaceId], replaying whatever the surface already holds.
+     *
+     * Ordered so no update can fall between the two steps: the host goes into [hosts] *first*, so a
+     * surface that registers a microsecond later delivers straight to it, and the replay then happens
+     * under that surface's publish lock, so it cannot hand back a tree older than one already delivered.
+     */
     fun attach(
         surfaceId: String,
         host: RemoteUiSurfaceHost,
     ) {
         hosts[surfaceId] = host
         val surface = surfaces[surfaceId]
-        host.onConnectionChanged(surface?.streaming == true)
-        surface?.tree?.let(host::onTreeUpdated)
+        if (surface == null) {
+            host.onConnectionChanged(false)
+        } else {
+            surface.replayTo(host)
+        }
     }
 
     /** Unbind a host component. Scoped to [host] so a component disposed late cannot evict its successor. */
@@ -181,6 +250,21 @@ class RemoteUiSurfaceRegistry {
 
     /** The live surface for [surfaceId], if a plugin currently holds it. */
     fun surfaceOf(surfaceId: String): RemoteUiSurface? = surfaces[surfaceId]
+
+    /**
+     * Close and forget every surface.
+     *
+     * For kernel shutdown. [shared] outlives a single `KernelBootstrap`, so without this a restart would
+     * come up holding claims from processes that no longer exist. Attached components are left attached
+     * and simply see `connected == false` — they belong to the window, not to the kernel.
+     */
+    fun clear() {
+        val closing = surfaces.keys.toList()
+        closing.forEach { surfaceId -> surfaces.remove(surfaceId)?.close() }
+        if (closing.isNotEmpty()) {
+            logger.info(LogCategory.UI, "Closed all remote UI surfaces", mapOf("count" to closing.size))
+        }
+    }
 
     companion object {
         /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -207,7 +207,9 @@ class RemoteUiSurfaceRegistry {
     fun unregister(surfaceId: String): Boolean {
         val surface = surfaces.remove(surfaceId) ?: return false
         surface.close()
-        logger.info(LogCategory.UI, "Remote UI surface unregistered", mapOf("surfaceId" to surfaceId))
+        // debug, not info: register + unregister + closeStream at info is three lines per restart of a
+        // crash-looping plugin. The registration itself is the event worth seeing at info.
+        logger.debug(LogCategory.UI, "Remote UI surface unregistered", mapOf("surfaceId" to surfaceId))
         return true
     }
 
@@ -246,7 +248,7 @@ class RemoteUiSurfaceRegistry {
     fun closeStream(surface: RemoteUiSurface) {
         surfaces.remove(surface.surfaceId, surface)
         surface.close()
-        logger.info(
+        logger.debug(
             LogCategory.UI,
             "Remote UI stream closed",
             mapOf("surfaceId" to surface.surfaceId, "processId" to surface.processId, "shed" to surface.shedEventCount),
@@ -286,7 +288,15 @@ class RemoteUiSurfaceRegistry {
         }
     }
 
-    /** Unbind a host component. Scoped to [host] so a component disposed late cannot evict its successor. */
+    /**
+     * Unbind a host component. Scoped to [host] so a component disposed late cannot evict its successor.
+     *
+     * The only path that removes from [hosts] — `clear()` deliberately leaves them, since components belong
+     * to the window rather than the kernel. So a component collected without `dispose()` leaves an entry
+     * behind for its surface id. Bounded by the number of surfaces a user opens, and the entry is a dead
+     * reference rather than a live subscription, but binding `attach`/`dispose` to the component's
+     * composition is what makes it structural — for the change that gives these components a caller.
+     */
     fun detach(
         surfaceId: String,
         host: RemoteUiSurfaceHost,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -122,8 +122,18 @@ class RemoteUiSurfaceRegistry {
         processId: String,
         descriptor: RemoteUiSurfaceDescriptor = RemoteUiSurfaceDescriptor(),
     ): SurfaceRegistration {
-        if (surfaceId.isBlank()) {
-            return SurfaceRegistration.Rejected("surface_id is required")
+        // process_id is not cosmetic: `claim()` compares it to decide whether a claim may be taken over, so
+        // a blank one is an authorization key every plugin shares. proto3 makes the empty string the
+        // default, so a runtime that simply forgets the field would let any plugin reclaim any other
+        // plugin's registered-but-not-yet-streaming surface — and then receive its TextChangeEvents.
+        val missing =
+            when {
+                surfaceId.isBlank() -> "surface_id"
+                processId.isBlank() -> "process_id"
+                else -> null
+            }
+        if (missing != null) {
+            return SurfaceRegistration.Rejected("$missing is required")
         }
         val created =
             RemoteUiSurface(
@@ -186,9 +196,13 @@ class RemoteUiSurfaceRegistry {
      * Tear a surface down at the plugin's request. @return `false` if it was not registered.
      *
      * Unattributed, unlike [closeStream]'s two-argument removal: `UIUnregistration` carries only a
-     * `surface_id`, so a late call from a dying incarnation can evict a respawn's fresh surface. That
-     * plugin's next `RegisterUI` recovers, and the window needs an `UnregisterUI` to arrive after a
-     * respawn has already registered — narrow enough to accept rather than to widen the proto for.
+     * `surface_id`. Accidentally, that means a late call from a dying incarnation can evict a respawn's
+     * fresh surface — narrow (it must arrive after the respawn registered) and self-healing (the plugin's
+     * next `RegisterUI` recovers), so not worth widening the proto for.
+     *
+     * Deliberately, it means **any** connected plugin can tear down any other plugin's live surface, since
+     * there is nothing in the request to attribute it to. That is not fixable here: it needs per-connection
+     * identity rather than a body field, which is the same root cause as `StreamUI` having no owner check.
      */
     fun unregister(surfaceId: String): Boolean {
         val surface = surfaces.remove(surfaceId) ?: return false
@@ -250,7 +264,20 @@ class RemoteUiSurfaceRegistry {
         surfaceId: String,
         host: RemoteUiSurfaceHost,
     ) {
-        hosts[surfaceId] = host
+        val displaced = hosts.put(surfaceId, host)
+        if (displaced != null && displaced !== host) {
+            // The registry routes to one host per id, and it is process-wide while the app is
+            // multi-window — so this is reachable, and silence would leave the displaced component
+            // rendering its last tree and still reporting `connected`, frozen from the host side rather
+            // than the plugin side. One surface renders in one place; saying so is better than the
+            // follow-up discovering it.
+            logger.warn(
+                LogCategory.UI,
+                "A second component attached to a surface already being rendered — the first is detached",
+                mapOf("surfaceId" to surfaceId),
+            )
+            displaced.onConnectionChanged(false)
+        }
         val surface = surfaces[surfaceId]
         if (surface == null) {
             host.onConnectionChanged(false)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -9,9 +9,15 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * The host-side renderer of one remote surface, as the transport sees it.
  *
- * Implemented by `RemotePanelComponent` / `RemoteTabComponent`. Both callbacks arrive on whichever
- * thread gRPC delivered the message on, never the UI thread — implementations must only touch
- * thread-safe state (Compose snapshot state is).
+ * Implemented by `RemotePanelComponent` / `RemoteTabComponent`. Both callbacks arrive on whichever thread
+ * gRPC delivered the message on, never the UI thread, and both are invoked **while the surface's publish
+ * lock is held** — which is what makes the sequence a host observes monotonic. So an implementation must:
+ *
+ * - touch only thread-safe state (Compose snapshot state is — writing it from any thread is fine);
+ * - not block, and not dispatch and wait; and
+ * - never call back into [RemoteUiSurfaceRegistry] or its surface from inside the callback.
+ *
+ * Anything heavier belongs on the far side of a state write the UI observes.
  */
 interface RemoteUiSurfaceHost {
     /** A new widget tree to render. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponentTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceComponentTest.kt
@@ -1,0 +1,111 @@
+package ai.rever.boss.components.plugin.remote
+
+import ai.rever.boss.kernel.ui.RemoteUiSurface
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
+import ai.rever.boss.kernel.ui.SurfaceRegistration
+import ai.rever.boss.kernel.ui.SurfaceStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * How the two surface components bind themselves to the transport, observed through their public state.
+ *
+ * Tree delivery and event tagging are asserted end to end with a real composition in
+ * [RemoteWidgetRendererComposeTest] — a rendered widget is the only honest evidence that a tree arrived,
+ * and a real click the only honest evidence that an event left with the right `surface_id`. What is left
+ * for here is the binding itself: that each component follows *its own* surface, that `dispose()` actually
+ * unbinds, and that neither hears about the other's plugin.
+ */
+class RemoteSurfaceComponentTest {
+    private val registry = RemoteUiSurfaceRegistry()
+
+    @Test
+    fun `a panel follows its own surface's connection state`() {
+        val panel = RemotePanelComponent(PANEL, "Inbox", PROCESS, registry)
+
+        panel.attach()
+        assertFalse(panel.connected.value, "no plugin has claimed the surface yet")
+
+        registry.register(PANEL, PROCESS).accepted()
+        assertFalse(panel.connected.value, "registered is not streaming")
+
+        assertIs<SurfaceStream.Bound>(registry.openStream(PANEL))
+        assertTrue(panel.connected.value)
+
+        assertTrue(registry.unregister(PANEL))
+        assertFalse(panel.connected.value, "a surface whose plugin left reads as disconnected")
+    }
+
+    @Test
+    fun `a disposed panel stops hearing about its surface`() {
+        val panel = RemotePanelComponent(PANEL, "Inbox", PROCESS, registry)
+        panel.attach()
+
+        panel.dispose()
+
+        registry.register(PANEL, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(PANEL))
+        assertFalse(panel.connected.value, "dispose must detach, not merely stop rendering")
+    }
+
+    @Test
+    fun `a panel ignores a plugin that streams a different surface`() {
+        val panel = RemotePanelComponent(PANEL, "Inbox", PROCESS, registry)
+        panel.attach()
+
+        registry.register(TAB, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(TAB))
+
+        assertFalse(panel.connected.value)
+    }
+
+    @Test
+    fun `a tab follows its own surface and keeps its own title and loading state`() {
+        val tab = RemoteTabComponent(TAB, "Notebook", PROCESS, registry)
+        tab.attach()
+        assertEquals("Notebook", tab.title.value, "the title seeds from the display name")
+
+        registry.register(TAB, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(TAB))
+        tab.updateTitle("Notebook — running")
+        tab.setLoading(true)
+
+        assertTrue(tab.connected.value)
+        assertEquals("Notebook — running", tab.title.value)
+        assertTrue(tab.isLoading.value)
+    }
+
+    @Test
+    fun `a disposed tab stops hearing about its surface`() {
+        val tab = RemoteTabComponent(TAB, "Notebook", PROCESS, registry)
+        tab.attach()
+
+        tab.dispose()
+
+        registry.register(TAB, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(TAB))
+        assertFalse(tab.connected.value)
+    }
+
+    @Test
+    fun `a component attached to an already-streaming surface picks up the connection immediately`() {
+        registry.register(PANEL, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(PANEL))
+
+        val panel = RemotePanelComponent(PANEL, "Inbox", PROCESS, registry)
+        panel.attach()
+
+        assertTrue(panel.connected.value, "the surface was already live when the panel opened")
+    }
+
+    private fun SurfaceRegistration.accepted(): RemoteUiSurface = assertIs<SurfaceRegistration.Accepted>(this).surface
+
+    private companion object {
+        const val PANEL = "panel-1"
+        const val TAB = "tab-1"
+        const val PROCESS = "plugin-a"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
@@ -1,9 +1,14 @@
 package ai.rever.boss.components.plugin.remote
 
+import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
+import ai.rever.boss.ipc.proto.UIRegistration
+import ai.rever.boss.ipc.proto.WidgetUpdate
+import ai.rever.boss.kernel.services.PluginUIServiceBridge
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.kernel.ui.SurfaceRegistration
 import ai.rever.boss.ui.sdk.WidgetEvent
 import ai.rever.boss.ui.sdk.WidgetNode
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProto
 import ai.rever.boss.ui.sdk.WidgetTree
 import ai.rever.boss.ui.sdk.WidgetType
 import androidx.compose.runtime.getValue
@@ -14,6 +19,14 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
+import io.grpc.ManagedChannelBuilder
+import io.grpc.ServerBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -164,6 +177,71 @@ class RemoteWidgetRendererComposeTest {
         tab.dispose()
     }
 
+    @Test
+    fun `a plugin over real gRPC renders into a real composition and gets the click back`() {
+        // The one combination nothing else covers: the round-trip tests use a recording host, and the other
+        // Compose tests drive the registry directly, so gRPC threads writing Compose snapshot state through
+        // RemoteUiSurfaceHost — the actual production threading — was never exercised. Everything here is
+        // real: a gRPC server, the generated plugin-side stub, a composition, and a click.
+        //
+        // The plugin side runs on its own scope rather than inside runBlocking around the Compose calls:
+        // runBlocking owns this thread's event loop, and the Compose test rule needs it to advance frames,
+        // so nesting the two deadlocks (`waitUntil` times out with the tree sitting undelivered).
+        val registry = RemoteUiSurfaceRegistry()
+        val server =
+            ServerBuilder
+                .forPort(0)
+                .addService(PluginUIServiceBridge(registry))
+                .build()
+                .start()
+        val channel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+        val plugin = PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub(channel)
+        val pluginScope = CoroutineScope(Dispatchers.Default)
+        val panel = RemotePanelComponent(PANEL, "Test Panel", "plugin-a", registry)
+        panel.attach()
+        compose.setContent { panel.Content() }
+
+        try {
+            val registration =
+                UIRegistration
+                    .newBuilder()
+                    .setSurfaceId(PANEL)
+                    .setSurfaceType("panel")
+                    .setProcessId("plugin-a")
+                    .build()
+            assertTrue(runBlocking { plugin.registerUI(registration).success })
+
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+            val events = pluginScope.async { plugin.streamUI(updates.consumeAsFlow()).take(1).toList() }
+            val fullTree =
+                WidgetUpdate
+                    .newBuilder()
+                    .setSurfaceId(PANEL)
+                    .setFullTree(buttonTree().toProto())
+                    .build()
+            assertTrue(updates.trySend(fullTree).isSuccess)
+
+            // The tree crosses the wire on a gRPC thread and has to land in the composition.
+            compose.waitUntil(WAIT_TIMEOUT_MS) {
+                runCatching { compose.onNodeWithText("Save").assertExists() }.isSuccess
+            }
+            assertTrue(panel.connected.value, "a streaming plugin must read as connected")
+
+            compose.onNodeWithText("Save").performClick()
+            compose.waitForIdle()
+
+            val received = runBlocking { events.await() }.single()
+            assertEquals(PANEL, received.surfaceId)
+            assertEquals(BUTTON, received.targetNodeId)
+            assertEquals("save_settings", received.click.eventId)
+        } finally {
+            panel.dispose()
+            pluginScope.cancel()
+            channel.shutdownNow()
+            server.shutdownNow()
+        }
+    }
+
     private fun textFieldTree(value: String): WidgetTree =
         WidgetTree(
             rootId = FIELD,
@@ -197,5 +275,6 @@ class RemoteWidgetRendererComposeTest {
         const val BUTTON = "button-1"
         const val PANEL = "panel-1"
         const val TAB = "tab-1"
+        const val WAIT_TIMEOUT_MS = 10_000L
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
@@ -1,9 +1,11 @@
 package ai.rever.boss.components.plugin.remote
 
 import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
+import ai.rever.boss.ipc.proto.UIEvent
 import ai.rever.boss.ipc.proto.UIRegistration
 import ai.rever.boss.ipc.proto.WidgetUpdate
 import ai.rever.boss.kernel.services.PluginUIServiceBridge
+import ai.rever.boss.kernel.ui.RemoteUiSurface
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.kernel.ui.SurfaceRegistration
 import ai.rever.boss.ui.sdk.WidgetEvent
@@ -30,6 +32,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -148,7 +151,7 @@ class RemoteWidgetRendererComposeTest {
         compose.onNodeWithText("Save").performClick()
         compose.waitForIdle()
 
-        val queued = runBlocking { surface.events().take(1).toList() }.single()
+        val queued = surface.firstEvent()
         // The panel's id is used twice — to attach and emit, and to stamp the event — and the two uses
         // must agree or the plugin receives events for a surface it does not own.
         assertEquals(PANEL, queued.surfaceId)
@@ -170,7 +173,7 @@ class RemoteWidgetRendererComposeTest {
         compose.onNodeWithText("Save").performClick()
         compose.waitForIdle()
 
-        val queued = runBlocking { surface.events().take(1).toList() }.single()
+        val queued = surface.firstEvent()
         assertEquals(TAB, queued.surfaceId)
         assertEquals(BUTTON, queued.targetNodeId)
         assertEquals("save_settings", queued.click.eventId)
@@ -230,7 +233,7 @@ class RemoteWidgetRendererComposeTest {
             compose.onNodeWithText("Save").performClick()
             compose.waitForIdle()
 
-            val received = runBlocking { events.await() }.single()
+            val received = runBlocking { withTimeout(WAIT_TIMEOUT_MS) { events.await() } }.single()
             assertEquals(PANEL, received.surfaceId)
             assertEquals(BUTTON, received.targetNodeId)
             assertEquals("save_settings", received.click.eventId)
@@ -241,6 +244,17 @@ class RemoteWidgetRendererComposeTest {
             server.shutdownNow()
         }
     }
+
+    /**
+     * The first event queued for a surface.
+     *
+     * Bounded: an unbounded `runBlocking` here would make a regression *hang the build* instead of failing
+     * a test, which is a far worse failure mode on CI than a red assertion.
+     */
+    private fun RemoteUiSurface.firstEvent(): UIEvent =
+        runBlocking {
+            withTimeout(WAIT_TIMEOUT_MS) { events().take(1).toList() }.single()
+        }
 
     private fun textFieldTree(value: String): WidgetTree =
         WidgetTree(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
@@ -123,7 +123,7 @@ class RemoteWidgetRendererComposeTest {
     }
 
     @Test
-    fun `a click on a rendered button reaches the surface's outgoing queue with its event id`() {
+    fun `a click on a rendered button reaches the panel's surface with its event id`() {
         val registry = RemoteUiSurfaceRegistry()
         val surface = (registry.register(PANEL, "plugin-a") as SurfaceRegistration.Accepted).surface
         val panel = RemotePanelComponent(PANEL, "Test Panel", "plugin-a", registry)
@@ -136,10 +136,32 @@ class RemoteWidgetRendererComposeTest {
         compose.waitForIdle()
 
         val queued = runBlocking { surface.events().take(1).toList() }.single()
+        // The panel's id is used twice — to attach and emit, and to stamp the event — and the two uses
+        // must agree or the plugin receives events for a surface it does not own.
         assertEquals(PANEL, queued.surfaceId)
         assertEquals(BUTTON, queued.targetNodeId)
         assertEquals("save_settings", queued.click.eventId)
         panel.dispose()
+    }
+
+    @Test
+    fun `a click on a rendered button reaches the tab's surface with its event id`() {
+        // Same wiring, separately implemented in RemoteTabComponent — so separately asserted.
+        val registry = RemoteUiSurfaceRegistry()
+        val surface = (registry.register(TAB, "plugin-a") as SurfaceRegistration.Accepted).surface
+        val tab = RemoteTabComponent(TAB, "Test Tab", "plugin-a", registry)
+        tab.attach()
+        surface.pushTree(buttonTree())
+
+        compose.setContent { tab.Content() }
+        compose.onNodeWithText("Save").performClick()
+        compose.waitForIdle()
+
+        val queued = runBlocking { surface.events().take(1).toList() }.single()
+        assertEquals(TAB, queued.surfaceId)
+        assertEquals(BUTTON, queued.targetNodeId)
+        assertEquals("save_settings", queued.click.eventId)
+        tab.dispose()
     }
 
     private fun textFieldTree(value: String): WidgetTree =
@@ -174,5 +196,6 @@ class RemoteWidgetRendererComposeTest {
         const val FIELD = "field-1"
         const val BUTTON = "button-1"
         const val PANEL = "panel-1"
+        const val TAB = "tab-1"
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
@@ -1,0 +1,178 @@
+package ai.rever.boss.components.plugin.remote
+
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
+import ai.rever.boss.kernel.ui.SurfaceRegistration
+import ai.rever.boss.ui.sdk.WidgetEvent
+import ai.rever.boss.ui.sdk.WidgetNode
+import ai.rever.boss.ui.sdk.WidgetTree
+import ai.rever.boss.ui.sdk.WidgetType
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Renderer behaviour asserted against a real composition.
+ *
+ * These three rules were fixed with care and documented in prose, but nothing executed them: focus was
+ * only reported on a *transition*, a widget's local state was made pushable by the plugin without
+ * clobbering in-flight typing, and `LIST` inside `SCROLL` fell back to a plain column because a
+ * `LazyColumn` measured with an unbounded max height throws. Each is a claim about what happens across
+ * two compositions, which is exactly what cannot be checked by reading the tree or the wire.
+ *
+ * The last test closes the loop the rest of this PR opens: a real click on a rendered widget, landing in
+ * the surface's outgoing queue as a `UIEvent` with its payload.
+ */
+class RemoteWidgetRendererComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `a text field reports no focus event on its first composition`() {
+        // onFocusChanged also fires when a node's focus state is first resolved on attach. Wired straight
+        // through, every field announced focus *loss* the moment it rendered, and a plugin could not tell
+        // that from a real blur.
+        val events = mutableListOf<Pair<String, WidgetEvent>>()
+        compose.setContent {
+            RemoteWidgetRenderer(textFieldTree("seed"), onEvent = { id, event -> events += id to event })
+        }
+        compose.waitForIdle()
+
+        assertTrue(
+            events.none { it.second is WidgetEvent.Focus },
+            "first composition must not report a focus transition, got $events",
+        )
+    }
+
+    @Test
+    fun `focusing a text field reports the transition`() {
+        val events = mutableListOf<Pair<String, WidgetEvent>>()
+        compose.setContent {
+            RemoteWidgetRenderer(textFieldTree("seed"), onEvent = { id, event -> events += id to event })
+        }
+
+        compose.onNode(hasSetTextAction()).performTextReplacement("typed")
+        compose.waitForIdle()
+
+        assertEquals(
+            listOf(WidgetEvent.Focus(hasFocus = true)),
+            events.map { it.second }.filterIsInstance<WidgetEvent.Focus>(),
+            "gaining focus is a real transition and must be reported exactly once",
+        )
+        assertEquals(FIELD, events.first().first, "events must be tagged with the node that raised them")
+    }
+
+    @Test
+    fun `a plugin can push a new value into a field without clobbering what the user is typing`() {
+        var tree by mutableStateOf(textFieldTree("seed"))
+        compose.setContent { RemoteWidgetRenderer(tree) }
+        compose.onNodeWithText("seed").assertExists()
+
+        compose.onNode(hasSetTextAction()).performTextReplacement("typed")
+        compose.waitForIdle()
+        compose.onNodeWithText("typed").assertExists()
+
+        // A tree update that repeats the value the plugin already sent is the common case — it happens on
+        // every unrelated change — and must leave the buffer alone.
+        tree = textFieldTree("seed").copy(version = 2)
+        compose.waitForIdle()
+        compose.onNodeWithText("typed").assertExists()
+
+        // A genuinely new value is the plugin driving its own widget: clearing a box after submit,
+        // echoing back a normalized value, rejecting an edit. The plugin wins.
+        tree = textFieldTree("pushed-back")
+        compose.waitForIdle()
+        compose.onNodeWithText("pushed-back").assertExists()
+    }
+
+    @Test
+    fun `a list nested inside a scroll renders its rows instead of throwing`() {
+        // A LazyColumn measured with an unbounded max height throws, so this tree shape — which a plugin
+        // can send at any time — used to take the whole surface down.
+        val tree =
+            WidgetTree(
+                rootId = "scroll",
+                nodes =
+                    mapOf(
+                        "scroll" to WidgetNode("scroll", WidgetType.SCROLL, childIds = listOf("list")),
+                        "list" to
+                            WidgetNode(
+                                id = "list",
+                                type = WidgetType.LIST,
+                                properties = mapOf("items" to "alpha,beta"),
+                            ),
+                    ),
+            )
+
+        compose.setContent { RemoteWidgetRenderer(tree) }
+        compose.waitForIdle()
+
+        compose.onNodeWithText("alpha").assertExists()
+        compose.onNodeWithText("beta").assertExists()
+    }
+
+    @Test
+    fun `a click on a rendered button reaches the surface's outgoing queue with its event id`() {
+        val registry = RemoteUiSurfaceRegistry()
+        val surface = (registry.register(PANEL, "plugin-a") as SurfaceRegistration.Accepted).surface
+        val panel = RemotePanelComponent(PANEL, "Test Panel", "plugin-a", registry)
+        surface.pushTree(buttonTree())
+        // Attached after the tree arrived: the surface retains it, so the panel renders immediately.
+        panel.attach()
+
+        compose.setContent { panel.Content() }
+        compose.onNodeWithText("Save").performClick()
+        compose.waitForIdle()
+
+        val queued = runBlocking { surface.events().take(1).toList() }.single()
+        assertEquals(PANEL, queued.surfaceId)
+        assertEquals(BUTTON, queued.targetNodeId)
+        assertEquals("save_settings", queued.click.eventId)
+        panel.dispose()
+    }
+
+    private fun textFieldTree(value: String): WidgetTree =
+        WidgetTree(
+            rootId = FIELD,
+            nodes =
+                mapOf(
+                    FIELD to
+                        WidgetNode(
+                            id = FIELD,
+                            type = WidgetType.TEXT_FIELD,
+                            properties = mapOf("value" to value, "onChangeEvent" to "changed"),
+                        ),
+                ),
+        )
+
+    private fun buttonTree(): WidgetTree =
+        WidgetTree(
+            rootId = BUTTON,
+            nodes =
+                mapOf(
+                    BUTTON to
+                        WidgetNode(
+                            id = BUTTON,
+                            type = WidgetType.BUTTON,
+                            properties = mapOf("label" to "Save", "clickEventId" to "save_settings"),
+                        ),
+                ),
+        )
+
+    private companion object {
+        const val FIELD = "field-1"
+        const val BUTTON = "button-1"
+        const val PANEL = "panel-1"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
@@ -1,0 +1,431 @@
+package ai.rever.boss.kernel.services
+
+import ai.rever.boss.ipc.proto.ClickEvent
+import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
+import ai.rever.boss.ipc.proto.TextChangeEvent
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ipc.proto.UIRegistration
+import ai.rever.boss.ipc.proto.UIUnregistration
+import ai.rever.boss.ipc.proto.WidgetNode
+import ai.rever.boss.ipc.proto.WidgetType
+import ai.rever.boss.ipc.proto.WidgetUpdate
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceHost
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Server
+import io.grpc.ServerBuilder
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import ai.rever.boss.ipc.proto.WidgetTree as ProtoWidgetTree
+import ai.rever.boss.ui.sdk.WidgetTree as SdkWidgetTree
+
+/**
+ * The remote-UI transport, exercised over a real gRPC server with a real plugin-side client.
+ *
+ * This is the path that did not exist. `ui_protocol.proto` makes the plugin the client and the kernel
+ * the server, and the host had it inverted: it dialled *out* with a `PluginUIServiceCoroutineStub` and,
+ * because `StreamUI`'s request stream is typed `WidgetUpdate`, repacked every outgoing `UIEvent` as a
+ * `WidgetUpdate` carrying only `surface_id`. Whatever the user did — the click id, the typed value, the
+ * dropdown index — was discarded at that repack, and inbound `UIEvent`s were logged and dropped.
+ *
+ * So the assertion that matters throughout is not "an event arrived" but "an event arrived **with its
+ * payload**". Everything here goes over localhost TCP through the generated stubs; nothing is faked at
+ * the transport.
+ */
+class PluginUIServiceBridgeTest {
+    private lateinit var registry: RemoteUiSurfaceRegistry
+    private lateinit var server: Server
+    private lateinit var channel: ManagedChannel
+    private lateinit var plugin: PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub
+
+    @BeforeTest
+    fun setUp() {
+        // Port 0: the OS picks a free one, which cannot race a concurrently starting test the way
+        // "find a free port, then bind it" can.
+        registry = RemoteUiSurfaceRegistry()
+        server =
+            ServerBuilder
+                .forPort(0)
+                .addService(PluginUIServiceBridge(registry))
+                .build()
+                .start()
+        channel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+        plugin = PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub(channel)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        channel.shutdownNow()
+        channel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        server.shutdownNow()
+        server.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun `a widget tree streamed by a plugin reaches the attached host component`() =
+        runBlocking {
+            val host = RecordingHost()
+            registry.attach(PANEL, host)
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = holdStream(updates)
+                updates.send(fullTree(PANEL, label = "Save"))
+
+                awaitTrue { host.trees.isNotEmpty() }
+                assertEquals(
+                    "Save",
+                    host.trees
+                        .last()
+                        .nodes
+                        .getValue(BUTTON_NODE)
+                        .properties["label"],
+                )
+                assertTrue(host.connections.last(), "a streaming surface must report itself connected")
+                stream.cancel()
+            }
+        }
+
+    @Test
+    fun `a click the host emits reaches the plugin with its event id intact`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = async { plugin.streamUI(updates.consumeAsFlow()).take(1).toList() }
+                updates.send(fullTree(PANEL))
+                awaitTrue { registry.surfaceOf(PANEL)?.streaming == true }
+
+                assertTrue(registry.emit(PANEL, click(PANEL, "save_settings")))
+
+                val event = stream.await().single()
+                // The old transport could carry exactly the first of these five.
+                assertEquals(PANEL, event.surfaceId)
+                assertEquals(BUTTON_NODE, event.targetNodeId)
+                assertEquals(UIEvent.EventCase.CLICK, event.eventCase)
+                assertEquals("save_settings", event.click.eventId)
+                assertTrue(event.timestamp > 0, "timestamp must survive the wire")
+            }
+        }
+
+    @Test
+    fun `a burst of text changes arrives in the order the user typed it`() =
+        runBlocking {
+            // TextChange carries the whole field value with last-write-wins semantics, so a reordered
+            // pair silently reverts a character. Ordering is a correctness property, not a nicety.
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val typed = (1..BURST).map { "value-$it" }
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = async { plugin.streamUI(updates.consumeAsFlow()).take(typed.size).toList() }
+                updates.send(fullTree(PANEL))
+                awaitTrue { registry.surfaceOf(PANEL)?.streaming == true }
+
+                typed.forEach { value -> assertTrue(registry.emit(PANEL, textChange(PANEL, value))) }
+
+                assertEquals(typed, stream.await().map { it.textChange.newValue })
+            }
+        }
+
+    @Test
+    fun `two surfaces never see each other's events`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            assertTrue(plugin.registerUI(registration(TAB)).success)
+            val panelUpdates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+            val tabUpdates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val panelStream = async { plugin.streamUI(panelUpdates.consumeAsFlow()).take(1).toList() }
+                val tabStream = async { plugin.streamUI(tabUpdates.consumeAsFlow()).take(1).toList() }
+                panelUpdates.send(fullTree(PANEL))
+                tabUpdates.send(fullTree(TAB))
+                awaitTrue {
+                    registry.surfaceOf(PANEL)?.streaming == true && registry.surfaceOf(TAB)?.streaming == true
+                }
+
+                assertTrue(registry.emit(PANEL, textChange(PANEL, "panel-only")))
+                assertTrue(registry.emit(TAB, textChange(TAB, "tab-only")))
+
+                assertEquals(listOf("panel-only"), panelStream.await().map { it.textChange.newValue })
+                assertEquals(listOf("tab-only"), tabStream.await().map { it.textChange.newValue })
+            }
+        }
+
+    @Test
+    fun `unregistering completes the plugin's event stream and drops later events`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                // No take(): the flow must end because the surface closed, not because we stopped reading.
+                val stream = async { plugin.streamUI(updates.consumeAsFlow()).toList() }
+                updates.send(fullTree(PANEL))
+                awaitTrue { registry.surfaceOf(PANEL)?.streaming == true }
+                assertTrue(registry.emit(PANEL, textChange(PANEL, "before-teardown")))
+
+                plugin.unregisterUI(UIUnregistration.newBuilder().setSurfaceId(PANEL).build())
+
+                assertEquals(listOf("before-teardown"), stream.await().map { it.textChange.newValue })
+                assertNull(registry.surfaceOf(PANEL), "an unregistered surface must not stay in the registry")
+                // The interesting half: a click that lands during teardown is dropped, not thrown.
+                assertFalse(registry.emit(PANEL, click(PANEL, "too_late")))
+            }
+        }
+
+    @Test
+    fun `a plugin that disappears leaves its surface visibly disconnected, not frozen`() =
+        runBlocking {
+            val host = RecordingHost()
+            registry.attach(PANEL, host)
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = holdStream(updates)
+                updates.send(fullTree(PANEL))
+                awaitTrue { host.connections.lastOrNull() == true }
+
+                // A crash, not a graceful UnregisterUI: the transport dying is the only notice the host
+                // gets that a plugin process is gone.
+                channel.shutdownNow()
+                stream.join()
+            }
+
+            awaitTrue { host.connections.lastOrNull() == false }
+            assertNull(registry.surfaceOf(PANEL), "a dead stream must release the surface id for a respawn")
+            assertTrue(host.trees.isNotEmpty(), "the last tree stays on screen — disconnected, not blank")
+        }
+
+    @Test
+    fun `a duplicate surface id is rejected and says why`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL, process = "plugin-a")).success)
+
+            val second = plugin.registerUI(registration(PANEL, process = "plugin-b"))
+
+            assertFalse(second.success)
+            assertContains(second.errorMessage, PANEL)
+            assertContains(second.errorMessage, "plugin-a")
+        }
+
+    @Test
+    fun `a blank surface id is rejected`() =
+        runBlocking {
+            val response = plugin.registerUI(registration(""))
+
+            assertFalse(response.success)
+            assertContains(response.errorMessage, "surface_id")
+        }
+
+    @Test
+    fun `streaming a surface that was never registered fails with a usable reason`() =
+        runBlocking {
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+            val stream = plugin.streamUI(updates.consumeAsFlow())
+            updates.send(fullTree("never-registered"))
+
+            val failure = assertFailsWith<StatusException> { stream.toList() }
+
+            assertEquals(Status.Code.FAILED_PRECONDITION, failure.status.code)
+            assertContains(failure.status.description.orEmpty(), "RegisterUI")
+        }
+
+    @Test
+    fun `a stream that never names a surface is refused rather than left hanging`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+
+            // StreamUI has no surface_id of its own; the request stream closing without one leaves the
+            // call unbindable, and the plugin deserves an error instead of an RPC that never returns.
+            val failure = assertFailsWith<StatusException> { plugin.streamUI(emptyFlow()).toList() }
+
+            assertEquals(Status.Code.INVALID_ARGUMENT, failure.status.code)
+            assertContains(failure.status.description.orEmpty(), "first WidgetUpdate")
+        }
+
+    @Test
+    fun `a second stream for the same surface is refused so ordering stays intact`() =
+        runBlocking {
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val first = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val held = async { plugin.streamUI(first.consumeAsFlow()).toList() }
+                first.send(fullTree(PANEL))
+                awaitTrue { registry.surfaceOf(PANEL)?.streaming == true }
+
+                val second = Channel<WidgetUpdate>(Channel.UNLIMITED)
+                val rival = plugin.streamUI(second.consumeAsFlow())
+                second.send(fullTree(PANEL))
+                val failure = assertFailsWith<StatusException> { rival.toList() }
+
+                assertEquals(Status.Code.FAILED_PRECONDITION, failure.status.code)
+                assertContains(failure.status.description.orEmpty(), "StreamUI")
+
+                // The original stream is untouched by the rejection.
+                assertTrue(registry.emit(PANEL, textChange(PANEL, "still-mine")))
+                assertTrue(registry.unregister(PANEL))
+                assertEquals(listOf("still-mine"), held.await().map { it.textChange.newValue })
+            }
+        }
+
+    @Test
+    fun `a registration's initial tree renders before any stream exists`() =
+        runBlocking {
+            val host = RecordingHost()
+            registry.attach(PANEL, host)
+
+            val response =
+                plugin.registerUI(
+                    registration(PANEL)
+                        .toBuilder()
+                        .setInitialTree(protoTree(label = "Ready"))
+                        .build(),
+                )
+
+            assertTrue(response.success)
+            assertEquals(
+                "Ready",
+                host.trees
+                    .single()
+                    .nodes
+                    .getValue(BUTTON_NODE)
+                    .properties["label"],
+            )
+            assertFalse(host.connections.last(), "no stream yet, so the surface is not connected")
+        }
+
+    // ---- Helpers ----
+
+    private class RecordingHost : RemoteUiSurfaceHost {
+        val trees = mutableListOf<SdkWidgetTree>()
+        val connections = mutableListOf<Boolean>()
+
+        override fun onTreeUpdated(tree: SdkWidgetTree) {
+            trees += tree
+        }
+
+        override fun onConnectionChanged(connected: Boolean) {
+            connections += connected
+        }
+    }
+
+    /**
+     * Open a `StreamUI` call and keep it open, discarding events.
+     *
+     * The returned RPC only runs while something collects the response flow, so tests that assert on the
+     * *inbound* direction still have to hold the call open.
+     */
+    private fun kotlinx.coroutines.CoroutineScope.holdStream(updates: Channel<WidgetUpdate>): Job =
+        launch {
+            runCatching { plugin.streamUI(updates.consumeAsFlow()).toList() }
+        }
+
+    /** Poll until [condition] holds. The host applies inbound updates on a gRPC thread. */
+    private suspend fun awaitTrue(condition: () -> Boolean) {
+        withTimeout(AWAIT_TIMEOUT_MS) {
+            while (!condition()) {
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun registration(
+        surfaceId: String,
+        process: String = "plugin-a",
+    ): UIRegistration =
+        UIRegistration
+            .newBuilder()
+            .setSurfaceId(surfaceId)
+            .setSurfaceType("panel")
+            .setDisplayName("Test Surface")
+            .setProcessId(process)
+            .build()
+
+    private fun protoTree(label: String): ProtoWidgetTree =
+        ProtoWidgetTree
+            .newBuilder()
+            .setRootId(BUTTON_NODE)
+            .setVersion(1)
+            .addNodes(
+                WidgetNode
+                    .newBuilder()
+                    .setId(BUTTON_NODE)
+                    .setType(WidgetType.WIDGET_TYPE_BUTTON)
+                    .putProperties("label", label)
+                    .putProperties("clickEventId", "save_settings"),
+            ).build()
+
+    private fun fullTree(
+        surfaceId: String,
+        label: String = "Save",
+    ): WidgetUpdate =
+        WidgetUpdate
+            .newBuilder()
+            .setSurfaceId(surfaceId)
+            .setFullTree(protoTree(label))
+            .build()
+
+    private fun click(
+        surfaceId: String,
+        eventId: String,
+    ): UIEvent =
+        UIEvent
+            .newBuilder()
+            .setSurfaceId(surfaceId)
+            .setTargetNodeId(BUTTON_NODE)
+            .setTimestamp(System.currentTimeMillis())
+            .setClick(ClickEvent.newBuilder().setEventId(eventId))
+            .build()
+
+    private fun textChange(
+        surfaceId: String,
+        value: String,
+    ): UIEvent =
+        UIEvent
+            .newBuilder()
+            .setSurfaceId(surfaceId)
+            .setTargetNodeId(FIELD_NODE)
+            .setTimestamp(System.currentTimeMillis())
+            .setTextChange(TextChangeEvent.newBuilder().setNewValue(value))
+            .build()
+
+    private companion object {
+        const val PANEL = "panel-1"
+        const val TAB = "tab-1"
+        const val BUTTON_NODE = "button-7"
+        const val FIELD_NODE = "field-3"
+        const val BURST = 50
+        const val AWAIT_TIMEOUT_MS = 10_000L
+        const val POLL_INTERVAL_MS = 5L
+        const val SHUTDOWN_TIMEOUT_MS = 5_000L
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
@@ -11,6 +11,9 @@ import ai.rever.boss.ipc.proto.WidgetType
 import ai.rever.boss.ipc.proto.WidgetUpdate
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceHost
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
+import ai.rever.boss.kernel.ui.SurfaceRegistration
+import ai.rever.boss.ui.sdk.DiffOperation
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProtoDiff
 import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.grpc.Server
@@ -37,6 +40,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import ai.rever.boss.ipc.proto.WidgetTree as ProtoWidgetTree
@@ -225,6 +229,103 @@ class PluginUIServiceBridgeTest {
         }
 
     @Test
+    fun `a plugin that dies right after binding leaves no stuck claim behind`() =
+        runBlocking {
+            // The claim happens inside the request pump, so a `finally` guarding only the event collection
+            // missed it: an RPC cancelled between `openStream()` returning Bound and the response side
+            // resuming from `await()` left the surface streaming forever — the component reading
+            // *connected* for a dead plugin, and every respawn refused for the rest of the session, since
+            // reclaiming only takes over surfaces that are not streaming.
+            //
+            // Which side of the `await()` the cancellation lands on is not forceable from out here, so the
+            // assertion is the invariant rather than the interleaving: after the plugin is gone, nothing
+            // is left claiming a stream and the id is usable again.
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = holdStream(updates)
+                updates.send(fullTree(PANEL))
+                awaitTrue { registry.surfaceOf(PANEL)?.streaming == true }
+                channel.shutdownNow()
+                stream.join()
+            }
+
+            awaitTrue { registry.surfaceOf(PANEL)?.streaming != true }
+            assertIs<SurfaceRegistration.Accepted>(registry.register(PANEL, "plugin-a"))
+        }
+
+    @Test
+    fun `a diff sent over the wire is applied to the surface's tree`() =
+        runBlocking {
+            // Diffs are the intended steady state after the first full tree, and until this PR the host
+            // could not decode one at all. Exercised over the wire, not just through applyUpdate.
+            val host = RecordingHost()
+            registry.attach(PANEL, host)
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = holdStream(updates)
+                updates.send(fullTree(PANEL, label = "Save"))
+                awaitTrue { host.trees.isNotEmpty() }
+
+                updates.send(
+                    WidgetUpdate
+                        .newBuilder()
+                        .setSurfaceId(PANEL)
+                        .setDiff(
+                            listOf<DiffOperation>(
+                                DiffOperation.NodeUpdated(BUTTON_NODE, mapOf("label" to "Saving…"), null),
+                            ).toProtoDiff(baseVersion = 1, newVersion = 2),
+                        ).build(),
+                )
+
+                awaitTrue { host.trees.size > 1 }
+                assertEquals(
+                    "Saving…",
+                    host.trees
+                        .last()
+                        .nodes
+                        .getValue(BUTTON_NODE)
+                        .properties["label"],
+                )
+                assertEquals(2L, registry.surfaceOf(PANEL)?.tree?.version)
+                stream.cancel()
+            }
+        }
+
+    @Test
+    fun `an update naming a surface this stream is not bound to is ignored`() =
+        runBlocking {
+            // One call, one surface. A second surface_id on the same stream must not reach the other
+            // surface — that would be the cross-delivery the per-surface routing exists to prevent.
+            val panelHost = RecordingHost()
+            val tabHost = RecordingHost()
+            registry.attach(PANEL, panelHost)
+            registry.attach(TAB, tabHost)
+            assertTrue(plugin.registerUI(registration(PANEL)).success)
+            assertTrue(plugin.registerUI(registration(TAB)).success)
+            val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+
+            coroutineScope {
+                val stream = holdStream(updates)
+                updates.send(fullTree(PANEL, label = "Mine"))
+                awaitTrue { panelHost.trees.isNotEmpty() }
+
+                updates.send(fullTree(TAB, label = "Not mine"))
+                // The stream stays healthy — the stray update is dropped, not fatal.
+                updates.send(fullTree(PANEL, label = "Still mine"))
+                awaitTrue { panelHost.trees.size > 1 }
+
+                assertEquals(listOf("Mine", "Still mine"), panelHost.trees.map { it.label() })
+                assertTrue(tabHost.trees.isEmpty(), "the other surface must not have been written to")
+                assertNull(registry.surfaceOf(TAB)?.tree)
+                stream.cancel()
+            }
+        }
+
+    @Test
     fun `a duplicate surface id is rejected and says why`() =
         runBlocking {
             assertTrue(plugin.registerUI(registration(PANEL, process = "plugin-a")).success)
@@ -348,6 +449,8 @@ class PluginUIServiceBridgeTest {
         launch {
             runCatching { plugin.streamUI(updates.consumeAsFlow()).toList() }
         }
+
+    private fun SdkWidgetTree.label(): String? = nodes[BUTTON_NODE]?.properties?.get("label")
 
     /** Poll until [condition] holds. The host applies inbound updates on a gRPC thread. */
     private suspend fun awaitTrue(condition: () -> Boolean) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
@@ -374,6 +374,35 @@ class PluginUIServiceBridgeTest {
         }
 
     @Test
+    fun `a stream that sends nothing and never closes is reaped rather than held open`() =
+        runBlocking {
+            // The INVALID_ARGUMENT case above needs the request stream to END. A plugin that opens the call
+            // and then neither sends nor half-closes gives no such completion, and gRPC applies no server
+            // deadline of its own — so without the bind timeout the RPC and its pump would sit there for the
+            // life of the process. Runs against its own server so the deadline can be milliseconds.
+            val brief =
+                ServerBuilder
+                    .forPort(0)
+                    .addService(quickBridge())
+                    .build()
+                    .start()
+            val briefChannel = ManagedChannelBuilder.forAddress("localhost", brief.port).usePlaintext().build()
+            try {
+                val silent = Channel<WidgetUpdate>(Channel.UNLIMITED)
+                val stub = PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub(briefChannel)
+                assertTrue(stub.registerUI(registration(PANEL)).success)
+
+                val failure = assertFailsWith<StatusException> { stub.streamUI(silent.consumeAsFlow()).toList() }
+
+                assertEquals(Status.Code.DEADLINE_EXCEEDED, failure.status.code)
+                assertContains(failure.status.description.orEmpty(), "first WidgetUpdate")
+            } finally {
+                briefChannel.shutdownNow()
+                brief.shutdownNow()
+            }
+        }
+
+    @Test
     fun `a second stream for the same surface is refused so ordering stays intact`() =
         runBlocking {
             assertTrue(plugin.registerUI(registration(PANEL)).success)
@@ -467,6 +496,9 @@ class PluginUIServiceBridgeTest {
         }
     }
 
+    /** A bridge over the same registry whose bind deadline fires in milliseconds. */
+    private fun quickBridge() = PluginUIServiceBridge(registry, bindTimeoutMs = BRIEF_BIND_TIMEOUT_MS)
+
     private fun registration(
         surfaceId: String,
         process: String = "plugin-a",
@@ -536,5 +568,8 @@ class PluginUIServiceBridgeTest {
         const val AWAIT_TIMEOUT_MS = 10_000L
         const val POLL_INTERVAL_MS = 5L
         const val SHUTDOWN_TIMEOUT_MS = 5_000L
+
+        /** Long enough not to be flaky, short enough that the reaping test costs nothing. */
+        const val BRIEF_BIND_TIMEOUT_MS = 250L
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
@@ -356,7 +356,9 @@ class PluginUIServiceBridgeTest {
 
             val failure = assertFailsWith<StatusException> { stream.toList() }
 
-            assertEquals(Status.Code.FAILED_PRECONDITION, failure.status.code)
+            // NOT_FOUND, not FAILED_PRECONDITION: this one is recoverable by registering the surface and
+            // opening a new stream, and a plugin should not have to parse the description to know that.
+            assertEquals(Status.Code.NOT_FOUND, failure.status.code)
             assertContains(failure.status.description.orEmpty(), "RegisterUI")
         }
 
@@ -418,6 +420,7 @@ class PluginUIServiceBridgeTest {
                 second.send(fullTree(PANEL))
                 val failure = assertFailsWith<StatusException> { rival.toList() }
 
+                // FAILED_PRECONDITION: unlike an unregistered surface, this one never becomes available.
                 assertEquals(Status.Code.FAILED_PRECONDITION, failure.status.code)
                 assertContains(failure.status.description.orEmpty(), "StreamUI")
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/services/PluginUIServiceBridgeTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -426,9 +427,14 @@ class PluginUIServiceBridgeTest {
 
     // ---- Helpers ----
 
+    /**
+     * Thread-safe on purpose: the transport publishes from a gRPC thread while the test thread polls and
+     * reads these, so a plain ArrayList would be a data race — the kind that survives a laptop and flakes
+     * on a loaded CI runner.
+     */
     private class RecordingHost : RemoteUiSurfaceHost {
-        val trees = mutableListOf<SdkWidgetTree>()
-        val connections = mutableListOf<Boolean>()
+        val trees = CopyOnWriteArrayList<SdkWidgetTree>()
+        val connections = CopyOnWriteArrayList<Boolean>()
 
         override fun onTreeUpdated(tree: SdkWidgetTree) {
             trees += tree

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -17,7 +17,9 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -75,6 +77,68 @@ class RemoteUiSurfaceRegistryTest {
         val second = registry.register(SURFACE, "plugin-a-respawned")
 
         assertIs<SurfaceRegistration.Accepted>(second)
+    }
+
+    @Test
+    fun `a surface claimed but never streamed is reclaimable by its own process`() {
+        // The gap closeStream cannot see: a plugin can die between RegisterUI returning and StreamUI
+        // binding, or claim more surfaces than it streams. Refusing the respawn's claim would leave that
+        // panel permanently disconnected with no way back.
+        val abandoned = registry.register(SURFACE, PROCESS).accepted()
+
+        val respawn = registry.register(SURFACE, PROCESS)
+
+        val surface = assertIs<SurfaceRegistration.Accepted>(respawn).surface
+        assertNotSame(abandoned, surface)
+        assertSame(surface, registry.surfaceOf(SURFACE))
+        assertFalse(abandoned.emit(textChange("to-the-dead-one")), "the reclaimed surface is closed")
+    }
+
+    @Test
+    fun `a different process cannot take over a claim, streamed or not`() {
+        registry.register(SURFACE, "plugin-a").accepted()
+
+        val intruder = registry.register(SURFACE, "plugin-b")
+
+        assertIs<SurfaceRegistration.Rejected>(intruder)
+    }
+
+    @Test
+    fun `a streaming surface is not reclaimable even by its own process`() {
+        // Otherwise a buggy plugin that re-registers mid-session would silently cut its own live stream.
+        registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        assertIs<SurfaceRegistration.Rejected>(registry.register(SURFACE, PROCESS))
+    }
+
+    @Test
+    fun `clear closes every surface and reports the disconnection`() {
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        registry.clear()
+
+        assertNull(registry.surfaceOf(SURFACE))
+        assertFalse(surface.emit(textChange("after-clear")))
+        assertEquals(listOf(false, true, false), host.connections)
+    }
+
+    @Test
+    fun `a registration's descriptor is retained on the surface`() {
+        val descriptor =
+            RemoteUiSurfaceDescriptor(
+                surfaceType = "panel",
+                displayName = "Inbox",
+                iconName = "mail",
+                defaultSlot = "left.top.top",
+            )
+
+        val surface = registry.register(SURFACE, PROCESS, descriptor).accepted()
+
+        assertEquals(descriptor, surface.descriptor)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -118,6 +119,40 @@ class RemoteUiSurfaceRegistryTest {
         assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
 
         assertIs<SurfaceRegistration.Rejected>(registry.register(SURFACE, PROCESS))
+    }
+
+    @Test
+    fun `a closed surface refuses a stream, so a racing claim cannot report a dead plugin as connected`() {
+        // openStream reads the map, then unregister/clear can remove and close the surface, and only then
+        // does the claim land. Without the closed check that claim succeeded and published connected = true
+        // — and nothing took it back, because events() completes at once over the closed channel and the
+        // compensating close() has already run. The component would sit reading *connected* forever.
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertTrue(registry.unregister(SURFACE))
+
+        assertFalse(surface.claimStream(), "a closed surface has no stream to give")
+        assertFalse(
+            host.connections.any { it },
+            "and must never announce a connection it cannot honour, got ${host.connections}",
+        )
+    }
+
+    @Test
+    fun `a component that opens after its plugin died gets no stale tree`() {
+        // The other side of close()'s "keep the last tree": a component already attached keeps what it
+        // rendered, but one opening later has nothing replayed to it. A tree from a process that died some
+        // time ago is stale, and showing it as though it were live would be the worse of the two.
+        val gone = registry.register(SURFACE, PROCESS).accepted()
+        gone.pushTree(tree("from-the-dead-plugin"))
+        registry.closeStream(gone)
+
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+
+        assertTrue(host.trees.isEmpty())
+        assertEquals(listOf(false), host.connections)
     }
 
     @Test
@@ -443,9 +478,13 @@ class RemoteUiSurfaceRegistryTest {
 
     // ---- Helpers ----
 
+    /**
+     * Thread-safe on purpose: publication happens on whichever thread delivered the update, and the test
+     * thread reads these without taking the surface's publish lock.
+     */
     private class RecordingHost : RemoteUiSurfaceHost {
-        val trees = mutableListOf<WidgetTree>()
-        val connections = mutableListOf<Boolean>()
+        val trees = CopyOnWriteArrayList<WidgetTree>()
+        val connections = CopyOnWriteArrayList<Boolean>()
 
         override fun onTreeUpdated(tree: WidgetTree) {
             trees += tree

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -15,12 +15,14 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import ai.rever.boss.ipc.proto.DiffOperation as ProtoDiffOp
 
 /**
  * The rendezvous rules that let a surface's two halves start, stop and restart independently.
@@ -263,6 +265,70 @@ class RemoteUiSurfaceRegistryTest {
     }
 
     @Test
+    fun `a diff whose base version does not match keeps the local numbering so the next one trips too`() {
+        // Adopting the sender's newVersion after a divergence would make every SUBSEQUENT base_version
+        // check pass, and the surface would be permanently, invisibly wrong. "The next full tree repairs
+        // it" is no comfort to a plugin that sends one full tree and then only diffs — the steady state.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.pushTree(tree("before").copy(version = 4))
+
+        surface.applyUpdate(diffUpdate("after", baseVersion = 9, newVersion = 10))
+
+        assertEquals("after", surface.tree?.label(), "still applied — refusing would freeze the surface")
+        assertEquals(5L, surface.tree?.version, "but the sender's numbering is not adopted")
+    }
+
+    @Test
+    fun `a diff carrying operations this build cannot decode keeps the local numbering`() {
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.pushTree(tree("before").copy(version = 4))
+
+        // A structural op that cannot be decoded cannot be reconstructed from its neighbours, so the tree
+        // below is knowingly not the plugin's — and must not claim to be at the plugin's version.
+        val undecodable =
+            diffUpdate("after", baseVersion = 4, newVersion = 5)
+                .toBuilder()
+                .apply { diffBuilder.addOperations(ProtoDiffOp.getDefaultInstance()) }
+                .build()
+        surface.applyUpdate(undecodable)
+
+        assertEquals("after", surface.tree?.label())
+        assertEquals(5L, surface.tree?.version)
+        assertEquals(4L + 1, surface.tree?.version, "local increment, not the sender's newVersion")
+    }
+
+    @Test
+    fun `a reclaimed surface cannot publish over the one that replaced it`() {
+        // claim() installs the replacement before closing what it reclaimed, and the publish lock is
+        // per-instance — so without an ownership check a predecessor's close() could report "disconnected"
+        // after its successor had already reported a live stream, with trees still arriving.
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val abandoned = registry.register(SURFACE, PROCESS).accepted()
+        val replacement = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        val connectionsAfterHandover = host.connections.toList()
+
+        abandoned.pushTree(tree("from-the-dead-one"))
+
+        assertTrue(host.trees.isEmpty(), "a replaced surface must not publish")
+        assertEquals(connectionsAfterHandover, host.connections, "nor report the connection state")
+        replacement.pushTree(tree("from-the-live-one"))
+        assertEquals(listOf("from-the-live-one"), host.trees.map { it.label() })
+    }
+
+    @Test
+    fun `a surface refuses a second event consumer`() {
+        // Two consumers would each drain part of the queue, splitting one ordered event sequence.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.events()
+
+        val failure = assertFailsWith<IllegalStateException> { surface.events() }
+
+        assertContains(failure.message.orEmpty(), SURFACE)
+    }
+
+    @Test
     fun `a diff arriving before any full tree is dropped rather than applied to nothing`() {
         val host = RecordingHost()
         registry.attach(SURFACE, host)
@@ -337,6 +403,20 @@ class RemoteUiSurfaceRegistryTest {
         )
 
     private fun WidgetTree.label(): String? = nodes[NODE]?.properties?.get("label")
+
+    private fun diffUpdate(
+        label: String,
+        baseVersion: Long,
+        newVersion: Long,
+    ): WidgetUpdate =
+        WidgetUpdate
+            .newBuilder()
+            .setSurfaceId(SURFACE)
+            .setDiff(
+                listOf<DiffOperation>(
+                    DiffOperation.NodeUpdated(NODE, mapOf("label" to label), null),
+                ).toProtoDiff(baseVersion, newVersion),
+            ).build()
 
     private fun textChange(value: String): UIEvent =
         UIEvent

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -9,8 +9,13 @@ import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProto
 import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProtoDiff
 import ai.rever.boss.ui.sdk.WidgetTree
 import ai.rever.boss.ui.sdk.WidgetType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -18,6 +23,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -221,6 +227,62 @@ class RemoteUiSurfaceRegistryTest {
             assertEquals(overflow.toLong(), surface.shedEventCount)
             val drained = surface.events().take(RemoteUiSurface.OUTGOING_BUFFER).toList()
             assertEquals(sent.drop(overflow), drained.map { it.textChange.newValue })
+        }
+
+    @Test
+    fun `concurrent registrations for one id produce exactly one winner`() =
+        runBlocking {
+            // The reclaim path is a compare-and-set precisely because this can happen; the retry loop it
+            // needs was otherwise untested. Every caller must either win or be told who holds the id, and
+            // the registry must end up agreeing with exactly one of them.
+            val attempts = 32
+            val outcomes =
+                (1..attempts)
+                    .map { async(Dispatchers.Default) { registry.register(SURFACE, PROCESS) } }
+                    .awaitAll()
+
+            val accepted = outcomes.filterIsInstance<SurfaceRegistration.Accepted>()
+            assertTrue(accepted.isNotEmpty(), "someone must win")
+            assertEquals(attempts, outcomes.size, "no caller may be left without an outcome")
+            val live = registry.surfaceOf(SURFACE)
+            assertNotNull(live)
+            assertEquals(1, accepted.count { it.surface === live }, "the registry must agree with one winner")
+            // Everyone who lost lost to this plugin, and every surface that is not the live one is closed.
+            outcomes.filterIsInstance<SurfaceRegistration.Rejected>().forEach {
+                assertContains(it.reason, PROCESS)
+            }
+            accepted.filter { it.surface !== live }.forEach {
+                assertFalse(it.surface.emit(textChange("loser")), "a superseded surface must be closed")
+            }
+        }
+
+    @Test
+    fun `draining concurrently with a burst of events leaves the queue accounting sane`() =
+        runBlocking {
+            // shedEventCount is documented as approximate under a concurrent drain; "approximate" must
+            // still mean non-negative and never more than what was sent.
+            val surface = registry.register(SURFACE, PROCESS).accepted()
+            val sent = RemoteUiSurface.OUTGOING_BUFFER * 4
+
+            val drained =
+                coroutineScope {
+                    val collector =
+                        async(Dispatchers.Default) {
+                            surface
+                                .events()
+                                .take(RemoteUiSurface.OUTGOING_BUFFER)
+                                .toList()
+                                .size
+                        }
+                    launch(Dispatchers.Default) {
+                        repeat(sent) { surface.emit(textChange("value-$it")) }
+                    }
+                    collector.await()
+                }
+
+            assertEquals(RemoteUiSurface.OUTGOING_BUFFER, drained)
+            assertTrue(surface.shedEventCount >= 0, "the counter must never go negative")
+            assertTrue(surface.shedEventCount <= sent, "nor exceed what was sent, got ${surface.shedEventCount}")
         }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -489,8 +489,10 @@ class RemoteUiSurfaceRegistryTest {
     }
 
     @Test
-    fun `a stream for an unregistered surface is refused with an actionable reason`() {
-        val refused = assertIs<SurfaceStream.Refused>(registry.openStream("never-registered"))
+    fun `a stream for an unregistered surface is refused as recoverable`() {
+        // Typed apart from AlreadyStreaming because the recoveries differ: this one is fixable by calling
+        // RegisterUI, and the bridge turns the distinction into NOT_FOUND vs FAILED_PRECONDITION.
+        val refused = assertIs<SurfaceStream.Unregistered>(registry.openStream("never-registered"))
 
         assertContains(refused.reason, "RegisterUI")
     }
@@ -500,7 +502,7 @@ class RemoteUiSurfaceRegistryTest {
         registry.register(SURFACE, PROCESS).accepted()
         assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
 
-        val refused = assertIs<SurfaceStream.Refused>(registry.openStream(SURFACE))
+        val refused = assertIs<SurfaceStream.AlreadyStreaming>(registry.openStream(SURFACE))
 
         assertContains(refused.reason, "StreamUI")
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -1,0 +1,290 @@
+package ai.rever.boss.kernel.ui
+
+import ai.rever.boss.ipc.proto.TextChangeEvent
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ipc.proto.WidgetUpdate
+import ai.rever.boss.ui.sdk.DiffOperation
+import ai.rever.boss.ui.sdk.WidgetNode
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProto
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProtoDiff
+import ai.rever.boss.ui.sdk.WidgetTree
+import ai.rever.boss.ui.sdk.WidgetType
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The rendezvous rules that let a surface's two halves start, stop and restart independently.
+ *
+ * A plugin process and the panel or tab it draws into have unrelated lifetimes: the plugin registers
+ * whenever it comes up, the component is built when the user opens the surface, and a plugin can crash
+ * and respawn under a component that never went away. Every ordering here is therefore normal, and none
+ * of them may lose a tree, misroute an event, or throw at a caller.
+ */
+class RemoteUiSurfaceRegistryTest {
+    private val registry = RemoteUiSurfaceRegistry()
+
+    @Test
+    fun `a component attached before the plugin exists still gets the first tree`() {
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.pushTree(tree("first"))
+
+        assertEquals(listOf("first"), host.trees.map { it.label() })
+    }
+
+    @Test
+    fun `a component attached after the plugin is replayed the current state instead of rendering blank`() {
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.pushTree(tree("already-here"))
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+
+        assertEquals(listOf("already-here"), host.trees.map { it.label() })
+        assertEquals(listOf(true), host.connections, "the surface was already streaming when we attached")
+    }
+
+    @Test
+    fun `a duplicate registration is refused and names the process holding the id`() {
+        registry.register(SURFACE, "plugin-a").accepted()
+
+        val second = registry.register(SURFACE, "plugin-b")
+
+        val rejected = assertIs<SurfaceRegistration.Rejected>(second)
+        assertContains(rejected.reason, SURFACE)
+        assertContains(rejected.reason, "plugin-a")
+    }
+
+    @Test
+    fun `a surface id is reusable once its stream dies, so a respawned plugin can take it back`() {
+        val first = registry.register(SURFACE, "plugin-a").accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.closeStream(first)
+
+        val second = registry.register(SURFACE, "plugin-a-respawned")
+
+        assertIs<SurfaceRegistration.Accepted>(second)
+    }
+
+    @Test
+    fun `an attached component follows a plugin across a crash and respawn`() {
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val crashed = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.closeStream(crashed)
+
+        val respawned = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        respawned.pushTree(tree("after-respawn"))
+
+        assertEquals(listOf("after-respawn"), host.trees.map { it.label() })
+        assertEquals(listOf(false, true, false, true), host.connections)
+    }
+
+    @Test
+    fun `an event emitted with no plugin behind the surface is reported undeliverable, not thrown`() {
+        assertFalse(registry.emit(SURFACE, textChange("nobody-home")))
+    }
+
+    @Test
+    fun `an event emitted after the surface closes is dropped`() {
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertTrue(registry.emit(SURFACE, textChange("in-time")))
+
+        assertTrue(registry.unregister(SURFACE))
+
+        assertFalse(registry.emit(SURFACE, textChange("too-late")))
+        assertFalse(surface.emit(textChange("too-late-direct")), "a closed surface refuses directly too")
+        assertNull(registry.surfaceOf(SURFACE))
+    }
+
+    @Test
+    fun `a graceful shutdown reports the disconnection once, not once per teardown path`() {
+        // UnregisterUI closes the surface, which ends the event queue, which ends the StreamUI call, whose
+        // own teardown closes the surface again. The component must not be told twice.
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        assertTrue(registry.unregister(SURFACE))
+        registry.closeStream(surface)
+
+        assertEquals(listOf(false, true, false), host.connections)
+    }
+
+    @Test
+    fun `detaching is scoped to the component that owns the attachment`() {
+        val replaced = RecordingHost()
+        val current = RecordingHost()
+        registry.attach(SURFACE, replaced)
+        registry.attach(SURFACE, current)
+
+        // A component disposed after its successor attached must not take the successor's slot with it.
+        registry.detach(SURFACE, replaced)
+        registry.register(SURFACE, PROCESS).accepted().pushTree(tree("still-delivered"))
+
+        assertEquals(listOf("still-delivered"), current.trees.map { it.label() })
+        assertTrue(replaced.trees.isEmpty())
+    }
+
+    @Test
+    fun `a plugin that stops reading sheds the oldest events and keeps the newest in order`() =
+        runBlocking {
+            // Bounded, not unlimited: the reader is in another process and can stop reading, and the
+            // queue lives in the host. Shedding from the head keeps last-write-wins pointing at the
+            // current value — dropping the newest would leave the plugin holding a stale one forever.
+            val surface = registry.register(SURFACE, PROCESS).accepted()
+            val overflow = 5
+            val sent = (1..RemoteUiSurface.OUTGOING_BUFFER + overflow).map { "value-$it" }
+
+            sent.forEach { value -> assertTrue(surface.emit(textChange(value))) }
+
+            assertEquals(overflow.toLong(), surface.shedEventCount)
+            val drained = surface.events().take(RemoteUiSurface.OUTGOING_BUFFER).toList()
+            assertEquals(sent.drop(overflow), drained.map { it.textChange.newValue })
+        }
+
+    @Test
+    fun `a full tree replaces the surface's tree`() {
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+
+        surface.applyUpdate(
+            WidgetUpdate
+                .newBuilder()
+                .setSurfaceId(SURFACE)
+                .setFullTree(tree("from-wire").toProto())
+                .build(),
+        )
+
+        assertEquals("from-wire", surface.tree?.label())
+        assertEquals(listOf("from-wire"), host.trees.map { it.label() })
+    }
+
+    @Test
+    fun `a diff applies on top of the surface's current tree`() {
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.pushTree(tree("before").copy(version = 4))
+
+        surface.applyUpdate(
+            WidgetUpdate
+                .newBuilder()
+                .setSurfaceId(SURFACE)
+                .setDiff(
+                    listOf<DiffOperation>(
+                        DiffOperation.NodeUpdated(NODE, mapOf("label" to "after"), null),
+                    ).toProtoDiff(baseVersion = 4, newVersion = 5),
+                ).build(),
+        )
+
+        assertEquals("after", surface.tree?.label())
+        assertEquals(5L, surface.tree?.version, "the sender's version must be kept so the next base check works")
+        assertEquals(listOf("before", "after"), host.trees.map { it.label() })
+    }
+
+    @Test
+    fun `a diff arriving before any full tree is dropped rather than applied to nothing`() {
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+
+        surface.applyUpdate(
+            WidgetUpdate
+                .newBuilder()
+                .setSurfaceId(SURFACE)
+                .setDiff(
+                    listOf<DiffOperation>(DiffOperation.NodeRemoved(NODE)).toProtoDiff(baseVersion = 1, newVersion = 2),
+                ).build(),
+        )
+
+        assertNull(surface.tree)
+        assertTrue(host.trees.isEmpty(), "nothing to render, so nothing is published")
+    }
+
+    @Test
+    fun `an update with neither a tree nor a diff leaves the surface alone`() {
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.pushTree(tree("kept"))
+
+        surface.applyUpdate(WidgetUpdate.newBuilder().setSurfaceId(SURFACE).build())
+
+        assertEquals("kept", surface.tree?.label())
+    }
+
+    @Test
+    fun `a stream for an unregistered surface is refused with an actionable reason`() {
+        val refused = assertIs<SurfaceStream.Refused>(registry.openStream("never-registered"))
+
+        assertContains(refused.reason, "RegisterUI")
+    }
+
+    @Test
+    fun `only one stream may hold a surface at a time`() {
+        registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        val refused = assertIs<SurfaceStream.Refused>(registry.openStream(SURFACE))
+
+        assertContains(refused.reason, "StreamUI")
+    }
+
+    @Test
+    fun `unregistering a surface nobody registered is not an error`() {
+        assertFalse(registry.unregister("never-registered"))
+    }
+
+    // ---- Helpers ----
+
+    private class RecordingHost : RemoteUiSurfaceHost {
+        val trees = mutableListOf<WidgetTree>()
+        val connections = mutableListOf<Boolean>()
+
+        override fun onTreeUpdated(tree: WidgetTree) {
+            trees += tree
+        }
+
+        override fun onConnectionChanged(connected: Boolean) {
+            connections += connected
+        }
+    }
+
+    private fun SurfaceRegistration.accepted(): RemoteUiSurface = assertIs<SurfaceRegistration.Accepted>(this).surface
+
+    private fun tree(label: String): WidgetTree =
+        WidgetTree(
+            rootId = NODE,
+            nodes = mapOf(NODE to WidgetNode(NODE, WidgetType.TEXT, mapOf("label" to label))),
+        )
+
+    private fun WidgetTree.label(): String? = nodes[NODE]?.properties?.get("label")
+
+    private fun textChange(value: String): UIEvent =
+        UIEvent
+            .newBuilder()
+            .setSurfaceId(SURFACE)
+            .setTargetNodeId(NODE)
+            .setTextChange(TextChangeEvent.newBuilder().setNewValue(value))
+            .build()
+
+    private companion object {
+        const val SURFACE = "panel-1"
+        const val PROCESS = "plugin-a"
+        const val NODE = "node-1"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistryTest.kt
@@ -104,6 +104,37 @@ class RemoteUiSurfaceRegistryTest {
     }
 
     @Test
+    fun `a blank process id is refused, because the reclaim rule treats it as an identity`() {
+        // proto3 makes the empty string the default, so a runtime that forgets the field would hand every
+        // plugin the same identity — and with it the right to reclaim any other plugin's un-streamed
+        // surface, and then receive that surface's keystrokes.
+        val rejected = assertIs<SurfaceRegistration.Rejected>(registry.register(SURFACE, ""))
+
+        assertContains(rejected.reason, "process_id")
+    }
+
+    @Test
+    fun `a second component attaching to one surface detaches the first instead of freezing it`() {
+        // The registry routes to one host per id and is process-wide while the app is multi-window, so this
+        // is reachable. Silence would leave the displaced component rendering its last tree and still
+        // reporting connected — frozen from the host side rather than the plugin side.
+        val first = RecordingHost()
+        val second = RecordingHost()
+        registry.attach(SURFACE, first)
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        assertEquals(listOf(false, true), first.connections)
+
+        registry.attach(SURFACE, second)
+        surface.pushTree(tree("for-the-second"))
+
+        assertEquals(false, first.connections.last(), "the displaced component must be told it is detached")
+        assertTrue(first.trees.isEmpty(), "and must stop receiving trees")
+        assertEquals(listOf("for-the-second"), second.trees.map { it.label() })
+        assertEquals(true, second.connections.first(), "the new one is replayed the live connection")
+    }
+
+    @Test
     fun `a different process cannot take over a claim, streamed or not`() {
         registry.register(SURFACE, "plugin-a").accepted()
 
@@ -382,16 +413,19 @@ class RemoteUiSurfaceRegistryTest {
 
         // A structural op that cannot be decoded cannot be reconstructed from its neighbours, so the tree
         // below is knowingly not the plugin's — and must not claim to be at the plugin's version.
+        //
+        // newVersion is deliberately far from base + 1: with newVersion = 5 on a base-4 tree both branches
+        // produce 5 (the sender's number and the local increment coincide), so the assertion would pass
+        // with the skipped-operations guard removed and prove nothing.
         val undecodable =
-            diffUpdate("after", baseVersion = 4, newVersion = 5)
+            diffUpdate("after", baseVersion = 4, newVersion = 9)
                 .toBuilder()
                 .apply { diffBuilder.addOperations(ProtoDiffOp.getDefaultInstance()) }
                 .build()
         surface.applyUpdate(undecodable)
 
         assertEquals("after", surface.tree?.label())
-        assertEquals(5L, surface.tree?.version)
-        assertEquals(4L + 1, surface.tree?.version, "local increment, not the sender's newVersion")
+        assertEquals(4L + 1, surface.tree?.version, "local increment, not the sender's newVersion of 9")
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,10 @@ boss-plugin-api = "1.0.68"
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+# Runs the JUnit 4 rules Compose UI testing is built on (createComposeRule) on the
+# JUnit Platform, alongside Jupiter. Versioned with junit-jupiter: both come out of
+# the same JUnit release train.
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-jupiter" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,9 @@ grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpc-kotlin" }
 grpc-services = { module = "io.grpc:grpc-services", version.ref = "grpc" }
+# MutableHandlerRegistry — lets BossIpcServer register a service on a running
+# server without rebuilding it (which would kill every in-flight streaming RPC).
+grpc-util = { module = "io.grpc:grpc-util", version.ref = "grpc" }
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 # Netty transport for Unix domain sockets

--- a/modules/boss-ipc/build.gradle.kts
+++ b/modules/boss-ipc/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
 
     // gRPC Netty transport (supports Unix domain sockets)
     implementation(libs.grpc.netty)
+
+    // MutableHandlerRegistry, for adding a service to an already-running server
+    implementation(libs.grpc.util)
     implementation(libs.netty.transport.native.unix.common)
 
     // Platform-specific UDS transports (all included — unused platforms are harmless)

--- a/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
+++ b/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.ipc
 
 import io.grpc.BindableService
 import io.grpc.Server
+import io.grpc.util.MutableHandlerRegistry
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
@@ -14,19 +15,31 @@ import java.util.concurrent.TimeUnit
  *     .addService(MyServiceImpl())
  *     .start()
  * ```
+ *
+ * Services may also be added *after* [start]; they go into a [MutableHandlerRegistry] installed as the
+ * fallback registry, so the socket is never touched. This used to stop the running server and rebuild it
+ * on the same address, which is destructive in a way that only shows up once something streams:
+ * `KernelBootstrap.registerPluginServices()` adds up to fifteen bridges one at a time, and a bidirectional
+ * RPC never completes gracefully, so each rebuild burned the full 2s shutdown grace period and then killed
+ * every in-flight call — with the address unbound in between. Unary bridges survived that by luck of
+ * timing; `PluginUIService.StreamUI`, whose whole job is to stay open, cannot.
  */
 class BossIpcServer(
     private val address: String,
 ) {
     private val logger = LoggerFactory.getLogger(BossIpcServer::class.java)
     private val services = mutableListOf<BindableService>()
+
+    /** Services added after the server started. Resolved per-call, so adding one disturbs nothing. */
+    private val lateServices = MutableHandlerRegistry()
     private var server: Server? = null
 
     fun addService(service: BindableService): BossIpcServer {
-        services.add(service)
-        // If server is already running, rebuild it with the new service
-        if (server != null && server?.isShutdown == false) {
-            rebuildServer()
+        if (isRunning) {
+            lateServices.addService(service)
+            logger.info("Registered service on the running IPC server: {}", service::class.java.simpleName)
+        } else {
+            services.add(service)
         }
         return this
     }
@@ -36,26 +49,12 @@ class BossIpcServer(
         return this
     }
 
-    /**
-     * Rebuild the running server with the current service list.
-     * Must stop old server first to release the Unix socket address.
-     */
-    private fun rebuildServer() {
-        val oldServer = server
-        // Stop old server FIRST to release the socket address
-        oldServer?.let { s ->
-            s.shutdown()
-            if (!s.awaitTermination(2, TimeUnit.SECONDS)) {
-                s.shutdownNow()
-            }
-        }
-        buildAndStart()
-        logger.info("IPC server rebuilt with {} services on: {}", services.size, address)
-    }
-
     private fun buildAndStart() {
         val builder = IpcAddressResolver.configureServerBuilder(address)
         services.forEach { builder.addService(it) }
+        // Consulted only for methods no directly-registered service claims, so build-time registration
+        // keeps taking precedence.
+        builder.fallbackHandlerRegistry(lateServices)
         server = builder.build().start()
         logger.info("IPC server started on: {}", address)
         IpcAddressResolver.secureSocketFile(address)

--- a/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
+++ b/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
@@ -53,7 +53,9 @@ class BossIpcServer(
         val builder = IpcAddressResolver.configureServerBuilder(address)
         services.forEach { builder.addService(it) }
         // Consulted only for methods no directly-registered service claims, so build-time registration
-        // keeps taking precedence.
+        // takes precedence. That is a CHANGE: a rebuild put everything in the primary registry, where the
+        // last one added won, so re-adding a service after start used to replace the build-time one and
+        // now silently does nothing. Nothing in the tree relies on either behaviour.
         builder.fallbackHandlerRegistry(lateServices)
         server = builder.build().start()
         logger.info("IPC server started on: {}", address)
@@ -70,6 +72,9 @@ class BossIpcServer(
             }
         }
         IpcAddressResolver.cleanupAddress(address)
+        // Cleared with the server, so a stopped-and-restarted instance does not silently resurrect every
+        // service registered during its previous lifetime.
+        lateServices.services.forEach { lateServices.removeService(it) }
         server = null
     }
 

--- a/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
+++ b/modules/boss-ipc/src/main/kotlin/ai/rever/boss/ipc/BossIpcServer.kt
@@ -73,7 +73,8 @@ class BossIpcServer(
         }
         IpcAddressResolver.cleanupAddress(address)
         // Cleared with the server, so a stopped-and-restarted instance does not silently resurrect every
-        // service registered during its previous lifetime.
+        // service registered during its previous lifetime. `services` is deliberately NOT cleared: it is
+        // the build-time set, and a restart is expected to bring the same server back up.
         lateServices.services.forEach { lateServices.removeService(it) }
         server = null
     }

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -33,14 +33,14 @@ service PluginUIService {
   // The call carries no surface id of its own, so it is bound to the surface_id of its FIRST
   // WidgetUpdate and pinned to it for its lifetime — send one (normally the full tree) to open the
   // stream, or the call fails with INVALID_ARGUMENT when the request stream ends. Later updates for a
-  // different surface_id are ignored; use one call per surface. A second concurrent call for a surface
-  // already streaming is refused with FAILED_PRECONDITION, because two readers would split one ordered
-  // event sequence.
+  // different surface_id are ignored; use one call per surface.
   //
-  // The first update is the only attempt: if it names a surface that is not registered, the call fails and
-  // later updates on it are ignored, so recover by opening a NEW StreamUI after RegisterUI rather than by
-  // retrying on the same call. A call that sends nothing at all and does not half-close fails with
-  // DEADLINE_EXCEEDED rather than staying open.
+  // The first update is the only attempt at binding, and the status says what to do about it:
+  //   NOT_FOUND            the surface_id is not registered — call RegisterUI, then open a NEW StreamUI
+  //                        (later updates on this call are ignored, so retrying on it will not work)
+  //   FAILED_PRECONDITION  another call already streams that surface, and always will
+  //   INVALID_ARGUMENT     the request stream ended without ever sending a WidgetUpdate
+  //   DEADLINE_EXCEEDED    the call sent nothing and did not half-close, so it was reaped
   //
   // The two directions are independent. Half-closing the request stream is fine and keeps receiving
   // events. But the call ENDING — cancelled, dropped, or the process dying — also unregisters the

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -10,14 +10,40 @@ option java_multiple_files = true;
 // PluginUIService enables out-of-process plugins to render UI in the kernel's Compose window.
 // Plugins send declarative widget trees; the kernel renders them as Compose components.
 // User events flow back from kernel to plugin for handling.
+//
+// The PLUGIN is the client here and the KERNEL is the server, in both directions: a plugin dials the
+// kernel, streams WidgetUpdates up, and reads UIEvents back down off the same call. A host that
+// implements this as a client of the plugin cannot work — the request stream is typed WidgetUpdate, so
+// there is nowhere to put an outgoing event.
 service PluginUIService {
-  // Register a UI surface (panel or tab) with the kernel
+  // Register a UI surface (panel or tab) with the kernel.
+  //
+  // Required before StreamUI. A surface_id already held by a *different* process is refused, with the
+  // holder named in error_message. A surface_id held by the SAME process with no stream open is taken
+  // over, which is what a respawn after a crash looks like.
   rpc RegisterUI(UIRegistration) returns (UIRegistrationResponse);
 
-  // Bidirectional stream: plugin sends widget updates, kernel sends user events
+  // Bidirectional stream: plugin sends widget updates, kernel sends user events.
+  //
+  // The call carries no surface id of its own, so it is bound to the surface_id of its FIRST
+  // WidgetUpdate and pinned to it for its lifetime — send one (normally the full tree) to open the
+  // stream, or the call fails with INVALID_ARGUMENT when the request stream ends. Later updates for a
+  // different surface_id are ignored; use one call per surface. A second concurrent call for a surface
+  // already streaming is refused with FAILED_PRECONDITION, because two readers would split one ordered
+  // event sequence.
+  //
+  // The two directions are independent. Half-closing the request stream is fine and keeps receiving
+  // events. But the call ENDING — cancelled, dropped, or the process dying — also unregisters the
+  // surface, since a dead stream is the only notice the kernel gets that a plugin is gone; reopening
+  // therefore needs a fresh RegisterUI.
+  //
+  // Events raised while a surface is registered but not yet streaming are buffered, and the buffer is
+  // bounded (256 events). Past that the kernel sheds from the HEAD, keeping the newest: TextChangeEvent
+  // carries a whole field value with last-write-wins semantics, so the newest is the one that must
+  // survive. A plugin that stops reading loses its oldest events, not its current state.
   rpc StreamUI(stream WidgetUpdate) returns (stream UIEvent);
 
-  // Unregister a UI surface
+  // Unregister a UI surface. Completes any open StreamUI call for it.
   rpc UnregisterUI(UIUnregistration) returns (Empty);
 }
 

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -21,6 +21,11 @@ service PluginUIService {
   // Required before StreamUI. A surface_id already held by a *different* process is refused, with the
   // holder named in error_message. A surface_id held by the SAME process with no stream open is taken
   // over, which is what a respawn after a crash looks like.
+  //
+  // That reclaim rule compares process_id as a string, so process_id must be STABLE FOR A PLUGIN ACROSS
+  // RESTARTS — an identity for the plugin, not for the OS process. A pid or a per-launch UUID silently
+  // costs a plugin its own surfaces: crash in the window between RegisterUI and StreamUI and the id is
+  // refused for the rest of the session, with no error to point at.
   rpc RegisterUI(UIRegistration) returns (UIRegistrationResponse);
 
   // Bidirectional stream: plugin sends widget updates, kernel sends user events.

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -37,6 +37,11 @@ service PluginUIService {
   // already streaming is refused with FAILED_PRECONDITION, because two readers would split one ordered
   // event sequence.
   //
+  // The first update is the only attempt: if it names a surface that is not registered, the call fails and
+  // later updates on it are ignored, so recover by opening a NEW StreamUI after RegisterUI rather than by
+  // retrying on the same call. A call that sends nothing at all and does not half-close fails with
+  // DEADLINE_EXCEEDED rather than staying open.
+  //
   // The two directions are independent. Half-closing the request stream is fine and keeps receiving
   // events. But the call ENDING — cancelled, dropped, or the process dying — also unregisters the
   // surface, since a dead stream is the only notice the kernel gets that a plugin is gone; reopening

--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.ipc.services.EventBusServiceImpl
 import com.google.protobuf.ByteString
 import io.grpc.ManagedChannelBuilder
 import io.grpc.ServerBuilder
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -20,6 +22,11 @@ import kotlin.test.assertTrue
  * Integration tests for EventBusService — publish/subscribe round-trip.
  */
 class EventBusServiceTest {
+    private companion object {
+        const val POLL_MS = 25L
+        const val SETTLE_MS = 100L
+    }
+
     private var server: io.grpc.Server? = null
     private var channel: io.grpc.ManagedChannel? = null
     private var port: Int = 0
@@ -48,6 +55,39 @@ class EventBusServiceTest {
         server?.shutdownNow()
     }
 
+    /**
+     * Publish until the subscriber has actually received something.
+     *
+     * These tests used to `delay(100)` and publish once. The service's `MutableSharedFlow` has **no
+     * replay**, so a publish that lands before the subscription is registered is lost for good — and then
+     * `subscriberJob.join()` waits out the enclosing 10s timeout. Latent on a fast machine, and it fails on
+     * the Windows CI runner, which is the slowest leg. Republishing is safe because every caller asserts on
+     * the *first* event it receives.
+     */
+    private suspend fun publishUntilDelivered(
+        subscriber: Job,
+        publish: suspend () -> Unit,
+    ) {
+        while (subscriber.isActive) {
+            publish()
+            delay(POLL_MS)
+        }
+    }
+
+    /**
+     * Wait until a subscription has been registered with the service.
+     *
+     * Weaker than [publishUntilDelivered] — the count increments when the RPC handler runs, which is still
+     * ahead of the flow being collected — but it is what a test asserting an exact event count can use,
+     * since republishing would change the count it asserts. Still strictly better than a fixed sleep.
+     */
+    private suspend fun awaitSubscriberRegistered() {
+        while (eventBusService.activeSubscribers < 1) {
+            delay(POLL_MS)
+        }
+        delay(SETTLE_MS)
+    }
+
     @Test
     fun `publish event is received by subscriber`() =
         runBlocking {
@@ -69,8 +109,6 @@ class EventBusServiceTest {
                     }
 
                 // Give subscriber time to connect
-                kotlinx.coroutines.delay(100)
-
                 // Publish event
                 val envelope =
                     EventEnvelope
@@ -81,7 +119,8 @@ class EventBusServiceTest {
                         .setTimestamp(System.currentTimeMillis())
                         .build()
 
-                val publishResponse = stub.publish(envelope)
+                var publishResponse = stub.publish(envelope)
+                publishUntilDelivered(subscriberJob) { publishResponse = stub.publish(envelope) }
 
                 subscriberJob.join()
 
@@ -111,8 +150,6 @@ class EventBusServiceTest {
                         receivedEnvelope = stub.subscribe(subscribeRequest).first()
                     }
 
-                kotlinx.coroutines.delay(100)
-
                 // Publish unmatched event first
                 stub.publish(
                     EventEnvelope
@@ -124,14 +161,14 @@ class EventBusServiceTest {
                 )
 
                 // Publish matching event
-                stub.publish(
+                val matching =
                     EventEnvelope
                         .newBuilder()
                         .setEventType("FilteredEvent")
                         .setPayload(ByteString.copyFromUtf8("should receive this"))
                         .setTimestamp(System.currentTimeMillis())
-                        .build(),
-                )
+                        .build()
+                publishUntilDelivered(subscriberJob) { stub.publish(matching) }
 
                 subscriberJob.join()
 
@@ -162,7 +199,7 @@ class EventBusServiceTest {
                         }
                     }
 
-                kotlinx.coroutines.delay(100)
+                awaitSubscriberRegistered()
 
                 val batchRequest =
                     PublishBatchRequest
@@ -206,16 +243,14 @@ class EventBusServiceTest {
                         receivedEnvelope = stub.subscribe(subscribeRequest).first()
                     }
 
-                kotlinx.coroutines.delay(100)
-
-                eventBusService.publishLocal(
+                val event =
                     EventEnvelope
                         .newBuilder()
                         .setEventType("LocalEvent")
                         .setPayload(ByteString.copyFromUtf8("local-payload"))
                         .setTimestamp(System.currentTimeMillis())
-                        .build(),
-                )
+                        .build()
+                publishUntilDelivered(subscriberJob) { eventBusService.publishLocal(event) }
 
                 subscriberJob.join()
                 assertEquals("LocalEvent", receivedEnvelope?.eventType)

--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/EventBusServiceTest.kt
@@ -25,6 +25,7 @@ class EventBusServiceTest {
     private companion object {
         const val POLL_MS = 25L
         const val SETTLE_MS = 100L
+        const val BATCH_SIZE = 3
     }
 
     private var server: io.grpc.Server? = null
@@ -195,7 +196,7 @@ class EventBusServiceTest {
                     launch {
                         stub.subscribe(subscribeRequest).collect { envelope ->
                             received.add(envelope)
-                            if (received.size == 3) return@collect
+                            if (received.size == BATCH_SIZE) return@collect
                         }
                     }
 
@@ -217,10 +218,15 @@ class EventBusServiceTest {
 
                 stub.publishBatch(batchRequest)
 
-                kotlinx.coroutines.delay(500)
+                // Wait for the three, rather than sleeping long enough that they have probably arrived. The
+                // enclosing withTimeout is the bound if they never do, so a real failure reports as a
+                // timeout instead of an off-by-a-few count that reads like a delivery bug.
+                while (received.size < BATCH_SIZE) {
+                    delay(POLL_MS)
+                }
                 subscriberJob.cancel()
 
-                assertEquals(3, received.size, "Should receive all 3 batch events")
+                assertEquals(BATCH_SIZE, received.size, "Should receive all 3 batch events")
             }
         }
 

--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/LateServiceRegistrationTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/LateServiceRegistrationTest.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.net.ServerSocket
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -36,12 +35,14 @@ class LateServiceRegistrationTest {
 
     @Before
     fun setUp() {
-        port = ServerSocket(0).use { it.localPort }
+        // Port 0, then read back what was bound: "find a free port, then bind it" can lose the port to
+        // another process in between, which is the race the sibling suites avoid by construction.
         // Only the kernel service at build time; everything else arrives late, as in KERNEL bootstrap.
         ipcServer =
-            BossIpcServer("tcp://localhost:$port")
+            BossIpcServer("tcp://localhost:0")
                 .addService(KernelServiceImpl())
                 .start()
+        port = ipcServer!!.port
         channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
     }
 

--- a/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/LateServiceRegistrationTest.kt
+++ b/modules/boss-ipc/src/test/kotlin/ai/rever/boss/ipc/LateServiceRegistrationTest.kt
@@ -1,0 +1,119 @@
+package ai.rever.boss.ipc
+
+import ai.rever.boss.ipc.proto.EventBusServiceGrpcKt
+import ai.rever.boss.ipc.proto.EventEnvelope
+import ai.rever.boss.ipc.proto.SubscribeRequest
+import ai.rever.boss.ipc.services.EventBusServiceImpl
+import ai.rever.boss.ipc.services.KernelServiceImpl
+import ai.rever.boss.ipc.services.StateServiceImpl
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.net.ServerSocket
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Adding a service to an already-running [BossIpcServer] must not disturb the server.
+ *
+ * It used to stop the running server and rebuild it on the same address. That is destructive in a way only
+ * a long-lived call notices: `KernelBootstrap.registerPluginServices()` adds up to fifteen bridges one at a
+ * time, and since a streaming RPC does not complete on demand, each rebuild burned the full 2s shutdown
+ * grace period and then killed every in-flight call — with the address unbound in between. Unary bridges
+ * survived on timing; `PluginUIService.StreamUI`, whose whole job is to stay open, could not.
+ */
+class LateServiceRegistrationTest {
+    private var ipcServer: BossIpcServer? = null
+    private var channel: ManagedChannel? = null
+    private var port: Int = 0
+
+    @Before
+    fun setUp() {
+        port = ServerSocket(0).use { it.localPort }
+        // Only the kernel service at build time; everything else arrives late, as in KERNEL bootstrap.
+        ipcServer =
+            BossIpcServer("tcp://localhost:$port")
+                .addService(KernelServiceImpl())
+                .start()
+        channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()
+    }
+
+    @After
+    fun tearDown() {
+        channel?.shutdownNow()
+        ipcServer?.stop(timeoutMs = 2_000)
+    }
+
+    @Test
+    fun `a service added after the server started is reachable`() =
+        runBlocking {
+            withTimeout(TIMEOUT_MS) {
+                ipcServer!!.addService(EventBusServiceImpl())
+
+                val response = stub().publish(envelope("Reachable"))
+
+                assertTrue(response.success, "a late-registered service must answer")
+            }
+        }
+
+    @Test
+    fun `an open streaming call survives fifteen services being added underneath it`() =
+        runBlocking {
+            withTimeout(TIMEOUT_MS) {
+                ipcServer!!.addService(EventBusServiceImpl())
+                val received = Channel<EventEnvelope>(Channel.UNLIMITED)
+                val subscriber =
+                    launch {
+                        stub()
+                            .subscribe(
+                                SubscribeRequest
+                                    .newBuilder()
+                                    .setSubscriberId("late-registration")
+                                    .addEventTypes("Ping")
+                                    .build(),
+                            ).collect { received.trySend(it) }
+                    }
+                // Wait until the subscription is genuinely live, not merely launched.
+                while (received.isEmpty) {
+                    stub().publish(envelope("Ping"))
+                    delay(POLL_MS)
+                }
+                received.tryReceive()
+
+                // What registerPluginServices() does, while the stream is open.
+                repeat(LATE_SERVICES) { ipcServer!!.addService(StateServiceImpl()) }
+
+                // The same stream still delivers, on the same address.
+                stub().publish(envelope("Ping"))
+                val next = received.receive()
+
+                assertEquals("Ping", next.eventType)
+                assertTrue(ipcServer!!.isRunning)
+                assertEquals(port, ipcServer!!.port, "a rebuild would have rebound the address")
+                subscriber.cancel()
+            }
+        }
+
+    private fun stub() = EventBusServiceGrpcKt.EventBusServiceCoroutineStub(channel!!)
+
+    private fun envelope(type: String): EventEnvelope =
+        EventEnvelope
+            .newBuilder()
+            .setEventType(type)
+            .setSourceProcess("late-registration-test")
+            .setTimestamp(System.currentTimeMillis())
+            .build()
+
+    private companion object {
+        const val LATE_SERVICES = 15
+        const val TIMEOUT_MS = 20_000L
+        const val POLL_MS = 25L
+    }
+}

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
@@ -55,11 +55,14 @@ object WidgetProtoConverter {
      * happened has no way to stop trusting its own copy.
      */
     fun ProtoWidgetDiff.decodeOperations(): DecodedWidgetDiff {
-        // Inlined rather than a named helper: WidgetProtoConverter sits one function below detekt's
-        // TooManyFunctions threshold for objects, and splitting the whole converter to name this would
-        // trade a real seam for a cosmetic one.
-        val decoded: List<DiffOperation?> =
-            operationsList.map { op ->
+        // One pass, no intermediate nullable list: the proto documents diffs as the steady state after a
+        // surface's first full tree, so this runs on every update. Inlined rather than a named helper
+        // because WidgetProtoConverter sits one function below detekt's TooManyFunctions threshold for
+        // objects, and splitting the converter to name this would trade a real seam for a cosmetic one.
+        var skipped = 0
+        val operations = ArrayList<DiffOperation>(operationsCount)
+        operationsList.forEach { op ->
+            val decoded =
                 when (op.opCase) {
                     ProtoDiffOp.OpCase.ADDED -> {
                         DiffOperation.NodeAdded(op.added.node.toKotlin(), op.added.parentId, op.added.index)
@@ -89,11 +92,9 @@ object WidgetProtoConverter {
                         null
                     }
                 }
-            }
-        return DecodedWidgetDiff(
-            operations = decoded.filterNotNull(),
-            skipped = decoded.count { it == null },
-        )
+            if (decoded == null) skipped++ else operations += decoded
+        }
+        return DecodedWidgetDiff(operations = operations, skipped = skipped)
     }
 
     private fun ProtoWidgetNode.toKotlin(): WidgetNode =

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
@@ -20,20 +20,63 @@ object WidgetProtoConverter {
             .setVersion(version)
             .build()
 
-    fun ProtoWidgetTree.toKotlin(): WidgetTree {
-        val nodeMap =
-            nodesList.associate { protoNode ->
-                protoNode.id to
-                    WidgetNode(
-                        id = protoNode.id,
-                        type = protoNode.type.toKotlin(),
-                        properties = protoNode.propertiesMap.toMap(),
-                        childIds = protoNode.childIdsList.toList(),
-                        modifier = protoNode.modifier.toKotlin(),
+    fun ProtoWidgetTree.toKotlin(): WidgetTree =
+        WidgetTree(
+            rootId = rootId,
+            nodes = nodesList.associate { it.id to it.toKotlin() },
+            version = version,
+        )
+
+    /**
+     * Read a wire diff back into SDK operations, ready for [WidgetDiffEngine.apply].
+     *
+     * The forward direction ([toProtoDiff]) shipped without an inverse, so `WidgetUpdate.diff` was a
+     * write-only half of the protocol: a receiver could decode `full_tree` and nothing else, which is
+     * why the host transport only ever handled full trees. Operations whose `oneof` is unset are
+     * skipped rather than guessed at — a sender built against a newer proto is not a reason to
+     * misapply the ops around it.
+     */
+    fun ProtoWidgetDiff.toDiffOperations(): List<DiffOperation> =
+        operationsList.mapNotNull { op ->
+            when (op.opCase) {
+                ProtoDiffOp.OpCase.ADDED -> {
+                    DiffOperation.NodeAdded(op.added.node.toKotlin(), op.added.parentId, op.added.index)
+                }
+
+                ProtoDiffOp.OpCase.REMOVED -> {
+                    DiffOperation.NodeRemoved(op.removed.nodeId)
+                }
+
+                ProtoDiffOp.OpCase.UPDATED -> {
+                    DiffOperation.NodeUpdated(
+                        nodeId = op.updated.nodeId,
+                        changedProperties = op.updated.changedPropertiesMap.toMap(),
+                        // `NodeUpdated.modifier` documents "null = no change", and proto3 message presence
+                        // is the only thing that distinguishes that from "reset every field to its
+                        // default" — reading the field unconditionally would silently wipe a node's
+                        // layout on any property-only update.
+                        newModifier = if (op.updated.hasModifier()) op.updated.modifier.toKotlin() else null,
                     )
+                }
+
+                ProtoDiffOp.OpCase.MOVED -> {
+                    DiffOperation.NodeMoved(op.moved.nodeId, op.moved.newParentId, op.moved.newIndex)
+                }
+
+                ProtoDiffOp.OpCase.OP_NOT_SET, null -> {
+                    null
+                }
             }
-        return WidgetTree(rootId, nodeMap, version)
-    }
+        }
+
+    private fun ProtoWidgetNode.toKotlin(): WidgetNode =
+        WidgetNode(
+            id = id,
+            type = type.toKotlin(),
+            properties = propertiesMap.toMap(),
+            childIds = childIdsList.toList(),
+            modifier = modifier.toKotlin(),
+        )
 
     fun List<DiffOperation>.toProtoDiff(
         baseVersion: Long,

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetProtoConverter.kt
@@ -11,6 +11,20 @@ import ai.rever.boss.ipc.proto.WidgetNode as ProtoWidgetNode
 import ai.rever.boss.ipc.proto.WidgetTree as ProtoWidgetTree
 import ai.rever.boss.ipc.proto.WidgetType as ProtoWidgetType
 
+/**
+ * A wire diff read back into SDK operations.
+ *
+ * @property skipped operations whose `oneof` was unset — a sender built against a newer proto, or a
+ *   malformed one. **Non-zero means the receiver's tree may now differ structurally from the sender's**:
+ *   a dropped `NodeAdded` or `NodeRemoved` cannot be reconstructed from the operations around it, so a
+ *   caller that applies the rest should stop trusting its own version numbering rather than pretend the
+ *   diff landed whole.
+ */
+data class DecodedWidgetDiff(
+    val operations: List<DiffOperation>,
+    val skipped: Int,
+)
+
 object WidgetProtoConverter {
     fun WidgetTree.toProto(): ProtoWidgetTree =
         ProtoWidgetTree
@@ -35,39 +49,52 @@ object WidgetProtoConverter {
      * why the host transport only ever handled full trees. Operations whose `oneof` is unset are
      * skipped rather than guessed at — a sender built against a newer proto is not a reason to
      * misapply the ops around it.
+     *
+     * The skipped count is returned rather than swallowed: a dropped `NodeAdded` or `NodeRemoved` leaves
+     * the receiver's tree structurally different from the sender's, and a caller that cannot see that
+     * happened has no way to stop trusting its own copy.
      */
-    fun ProtoWidgetDiff.toDiffOperations(): List<DiffOperation> =
-        operationsList.mapNotNull { op ->
-            when (op.opCase) {
-                ProtoDiffOp.OpCase.ADDED -> {
-                    DiffOperation.NodeAdded(op.added.node.toKotlin(), op.added.parentId, op.added.index)
-                }
+    fun ProtoWidgetDiff.decodeOperations(): DecodedWidgetDiff {
+        // Inlined rather than a named helper: WidgetProtoConverter sits one function below detekt's
+        // TooManyFunctions threshold for objects, and splitting the whole converter to name this would
+        // trade a real seam for a cosmetic one.
+        val decoded: List<DiffOperation?> =
+            operationsList.map { op ->
+                when (op.opCase) {
+                    ProtoDiffOp.OpCase.ADDED -> {
+                        DiffOperation.NodeAdded(op.added.node.toKotlin(), op.added.parentId, op.added.index)
+                    }
 
-                ProtoDiffOp.OpCase.REMOVED -> {
-                    DiffOperation.NodeRemoved(op.removed.nodeId)
-                }
+                    ProtoDiffOp.OpCase.REMOVED -> {
+                        DiffOperation.NodeRemoved(op.removed.nodeId)
+                    }
 
-                ProtoDiffOp.OpCase.UPDATED -> {
-                    DiffOperation.NodeUpdated(
-                        nodeId = op.updated.nodeId,
-                        changedProperties = op.updated.changedPropertiesMap.toMap(),
-                        // `NodeUpdated.modifier` documents "null = no change", and proto3 message presence
-                        // is the only thing that distinguishes that from "reset every field to its
-                        // default" — reading the field unconditionally would silently wipe a node's
-                        // layout on any property-only update.
-                        newModifier = if (op.updated.hasModifier()) op.updated.modifier.toKotlin() else null,
-                    )
-                }
+                    ProtoDiffOp.OpCase.UPDATED -> {
+                        DiffOperation.NodeUpdated(
+                            nodeId = op.updated.nodeId,
+                            changedProperties = op.updated.changedPropertiesMap.toMap(),
+                            // `NodeUpdated.modifier` documents "null = no change", and proto3 message presence
+                            // is the only thing that distinguishes that from "reset every field to its
+                            // default" — reading the field unconditionally would silently wipe a node's
+                            // layout on any property-only update.
+                            newModifier = if (op.updated.hasModifier()) op.updated.modifier.toKotlin() else null,
+                        )
+                    }
 
-                ProtoDiffOp.OpCase.MOVED -> {
-                    DiffOperation.NodeMoved(op.moved.nodeId, op.moved.newParentId, op.moved.newIndex)
-                }
+                    ProtoDiffOp.OpCase.MOVED -> {
+                        DiffOperation.NodeMoved(op.moved.nodeId, op.moved.newParentId, op.moved.newIndex)
+                    }
 
-                ProtoDiffOp.OpCase.OP_NOT_SET, null -> {
-                    null
+                    ProtoDiffOp.OpCase.OP_NOT_SET, null -> {
+                        null
+                    }
                 }
             }
-        }
+        return DecodedWidgetDiff(
+            operations = decoded.filterNotNull(),
+            skipped = decoded.count { it == null },
+        )
+    }
 
     private fun ProtoWidgetNode.toKotlin(): WidgetNode =
         WidgetNode(

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffWireTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffWireTest.kt
@@ -1,0 +1,117 @@
+package ai.rever.boss.ui.sdk
+
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toDiffOperations
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProtoDiff
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import ai.rever.boss.ipc.proto.DiffOperation as ProtoDiffOp
+import ai.rever.boss.ipc.proto.WidgetDiff as ProtoWidgetDiff
+
+/**
+ * `WidgetDiff` in the receiving direction.
+ *
+ * `toProtoDiff` shipped without an inverse, which made `WidgetUpdate.diff` a write-only half of the
+ * protocol: a receiver could decode `full_tree` and nothing else. The host transport consequently only
+ * ever handled full trees, so a plugin sending incremental updates — the reason diffs exist — drew
+ * nothing at all.
+ */
+class WidgetDiffWireTest {
+    @Test
+    fun `every operation kind survives a round trip`() {
+        val operations =
+            listOf(
+                DiffOperation.NodeAdded(
+                    node =
+                        WidgetNode(
+                            id = "added",
+                            type = WidgetType.BUTTON,
+                            properties = mapOf("label" to "Save", "clickEventId" to "save"),
+                            childIds = listOf("child-a", "child-b"),
+                            modifier = WidgetModifier(width = -1, paddingTop = 8, backgroundColor = "panel"),
+                        ),
+                    parentId = "root",
+                    index = 2,
+                ),
+                DiffOperation.NodeRemoved("gone"),
+                DiffOperation.NodeUpdated(
+                    nodeId = "updated",
+                    changedProperties = mapOf("value" to "typed", "placeholder" to ""),
+                    newModifier = WidgetModifier(height = 24, clickable = true, clickEventId = "row"),
+                ),
+                DiffOperation.NodeMoved("moved", "new-parent", 1),
+            )
+
+        val decoded = operations.toProtoDiff(baseVersion = 7, newVersion = 8).toDiffOperations()
+
+        assertEquals(operations, decoded)
+    }
+
+    @Test
+    fun `an update with no modifier decodes as no modifier change`() {
+        // `NodeUpdated.modifier` documents "null = no change"; reading proto3's zero value instead would
+        // reset a node's whole layout on every property-only update.
+        val operations = listOf<DiffOperation>(DiffOperation.NodeUpdated("n", mapOf("value" to "x"), null))
+
+        val decoded = operations.toDiffOperations(baseVersion = 1, newVersion = 2).single()
+
+        assertNull((decoded as DiffOperation.NodeUpdated).newModifier)
+    }
+
+    @Test
+    fun `versions are carried on the diff itself`() {
+        val diff = listOf<DiffOperation>(DiffOperation.NodeRemoved("n")).toProtoDiff(baseVersion = 3, newVersion = 4)
+
+        assertEquals(3L, diff.baseVersion)
+        assertEquals(4L, diff.newVersion)
+    }
+
+    @Test
+    fun `an operation with no oneof set is skipped, not guessed at`() {
+        // What a sender built against a newer proto looks like from here.
+        val diff =
+            ProtoWidgetDiff
+                .newBuilder()
+                .addOperations(ProtoDiffOp.getDefaultInstance())
+                .addOperations(
+                    listOf<DiffOperation>(DiffOperation.NodeRemoved("real")).toProtoDiff(0, 0).getOperations(0),
+                ).build()
+
+        val decoded = diff.toDiffOperations()
+
+        assertEquals(listOf<DiffOperation>(DiffOperation.NodeRemoved("real")), decoded)
+    }
+
+    @Test
+    fun `a diff round trip reproduces the tree the sender diffed to`() {
+        // The property that makes diffs usable at all: decode ∘ encode ∘ diff, applied to the old tree,
+        // must equal the new one.
+        val before =
+            widgetTree {
+                column {
+                    text("Inbox")
+                    button("Refresh", "refresh")
+                }
+            }
+        val after =
+            widgetTree {
+                column {
+                    text("Inbox (3)")
+                    button("Refresh", "refresh")
+                    text("newest first")
+                }
+            }
+
+        val wire = WidgetDiffEngine.diff(before, after).toProtoDiff(before.version, after.version)
+        val applied = WidgetDiffEngine.apply(before, wire.toDiffOperations())
+
+        assertEquals(after.nodes, applied.nodes)
+        assertTrue(wire.operationsCount > 0, "a changed tree must produce operations")
+    }
+
+    private fun List<DiffOperation>.toDiffOperations(
+        baseVersion: Long,
+        newVersion: Long,
+    ): List<DiffOperation> = toProtoDiff(baseVersion, newVersion).toDiffOperations()
+}

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffWireTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/WidgetDiffWireTest.kt
@@ -1,6 +1,6 @@
 package ai.rever.boss.ui.sdk
 
-import ai.rever.boss.ui.sdk.WidgetProtoConverter.toDiffOperations
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.decodeOperations
 import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProtoDiff
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -43,9 +43,10 @@ class WidgetDiffWireTest {
                 DiffOperation.NodeMoved("moved", "new-parent", 1),
             )
 
-        val decoded = operations.toProtoDiff(baseVersion = 7, newVersion = 8).toDiffOperations()
+        val decoded = operations.toProtoDiff(baseVersion = 7, newVersion = 8).decodeOperations()
 
-        assertEquals(operations, decoded)
+        assertEquals(operations, decoded.operations)
+        assertEquals(0, decoded.skipped)
     }
 
     @Test
@@ -54,7 +55,7 @@ class WidgetDiffWireTest {
         // reset a node's whole layout on every property-only update.
         val operations = listOf<DiffOperation>(DiffOperation.NodeUpdated("n", mapOf("value" to "x"), null))
 
-        val decoded = operations.toDiffOperations(baseVersion = 1, newVersion = 2).single()
+        val decoded = operations.roundTrip(baseVersion = 1, newVersion = 2).operations.single()
 
         assertNull((decoded as DiffOperation.NodeUpdated).newModifier)
     }
@@ -78,9 +79,10 @@ class WidgetDiffWireTest {
                     listOf<DiffOperation>(DiffOperation.NodeRemoved("real")).toProtoDiff(0, 0).getOperations(0),
                 ).build()
 
-        val decoded = diff.toDiffOperations()
+        val decoded = diff.decodeOperations()
 
-        assertEquals(listOf<DiffOperation>(DiffOperation.NodeRemoved("real")), decoded)
+        assertEquals(listOf<DiffOperation>(DiffOperation.NodeRemoved("real")), decoded.operations)
+        assertEquals(1, decoded.skipped, "a caller must be able to see that the tree may now diverge")
     }
 
     @Test
@@ -104,14 +106,14 @@ class WidgetDiffWireTest {
             }
 
         val wire = WidgetDiffEngine.diff(before, after).toProtoDiff(before.version, after.version)
-        val applied = WidgetDiffEngine.apply(before, wire.toDiffOperations())
+        val applied = WidgetDiffEngine.apply(before, wire.decodeOperations().operations)
 
         assertEquals(after.nodes, applied.nodes)
         assertTrue(wire.operationsCount > 0, "a changed tree must produce operations")
     }
 
-    private fun List<DiffOperation>.toDiffOperations(
+    private fun List<DiffOperation>.roundTrip(
         baseVersion: Long,
         newVersion: Long,
-    ): List<DiffOperation> = toProtoDiff(baseVersion, newVersion).toDiffOperations()
+    ): DecodedWidgetDiff = toProtoDiff(baseVersion, newVersion).decodeOperations()
 }


### PR DESCRIPTION
## The inversion

`modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto` is unambiguous about who is who:

```proto
service PluginUIService {
  rpc RegisterUI(UIRegistration) returns (UIRegistrationResponse);
  // Bidirectional stream: plugin sends widget updates, kernel sends user events
  rpc StreamUI(stream WidgetUpdate) returns (stream UIEvent);
  rpc UnregisterUI(UIUnregistration) returns (Empty);
}
```

The **plugin is the client** (it streams `WidgetUpdate`s) and the **kernel is the server** (it streams `UIEvent`s back). The host did the opposite. `RemotePanelComponent` and `RemoteTabComponent` each opened a `PluginUIServiceCoroutineStub` and dialled *out* to the plugin, and because `StreamUI`'s request stream is typed `WidgetUpdate`, every outgoing `UIEvent` had to be repacked as a `WidgetUpdate` — a message with nowhere to put an event:

```kotlin
val update = WidgetUpdate.newBuilder().setSurfaceId(event.surfaceId).build()
send(update)
```

A `surface_id` and nothing else. The click id, the typed value, the dropdown index, the target node — all discarded at that repack. Inbound `UIEvent`s, arriving on the response stream where the host was pretending to be a plugin, were `logger.debug`'d and dropped.

Net effect: no user interaction could reach an out-of-process plugin, and no plugin-pushed widget tree could reach the host through this path. #48 correctly fixed the click id, selection mapping, focus emission, pushable state and diff behaviour at the mapping layer, but none of it had a path to run on. This PR is the missing server half.

There was also no way for the host to consume half the inbound protocol: `WidgetProtoConverter` had `List<DiffOperation>.toProtoDiff()` with no inverse, so a receiver could decode `full_tree` and nothing else. `WidgetUpdate.diff` was write-only.

## What this builds

**`PluginUIServiceBridge`** (`kernel/services/`, alongside its 15 siblings) — `RegisterUI` claims a surface and rejects a duplicate `surface_id` with a reason naming the process that holds it; a registration's `initial_tree` is applied immediately so a surface renders from the moment it opens. `StreamUI` routes each inbound update to its surface by `surface_id` and returns that surface's ordered event flow. `UnregisterUI` tears the surface down and completes the flow.

**`RemoteUiSurfaceRegistry` + `RemoteUiSurface`** (`kernel/ui/`) — the seam. Plugin-side surfaces and host-side renderers live in **separate maps** keyed by `surface_id`, and every delivery is a lookup at the moment it happens. That is what makes the ordering question go away: a surface's two halves start independently (the plugin when its process comes up, the component when the user opens the panel), so a tree that arrives with nobody attached is retained for whoever attaches next, and a component attaching to a live surface is replayed the current tree *and* connection state rather than rendering blank until the plugin's next update. A plugin can crash and respawn under a component that never went away.

**Rewired components** — they publish events to the registry and receive trees from it; `updateTree()` still works for direct/test use. The `WidgetUpdate`-wrapping code is gone, along with the `uiAddress`/`ManagedChannel` plumbing. Nothing in the host dials a plugin's UI service any more.

**`WidgetProtoConverter.toDiffOperations()`** — the missing inverse. `NodeUpdated.modifier` is read through `hasModifier()`, since proto3 message presence is the only thing separating the documented "null = no change" from "reset every field to its default".

### Where it is registered, and why

At **build time**, in the `.addService(…)` chain before `.start()` — not through `registerPluginServices()`:

- Plugin processes spawn immediately after bootstrap. A plugin whose `RegisterUI` lands on a server with no `PluginUIService` gets `UNIMPLEMENTED` and no UI at all.
- `registerPluginServices()` exists to gate each bridge on a host provider being present, and this one has no provider to gate on — its dependency is the registry, which the host owns for its whole lifetime.

**Corrected during review:** this originally also argued that `addService()` on a running server rebuilds it and tears the socket down, fatal for `StreamUI`. That was true, and it turned out not to be escapable by registering early — it just moved the hazard to the fifteen bridges that arrive later, after processes are already streaming. So `BossIpcServer` now routes late services through a `MutableHandlerRegistry` and never touches the socket (`6acbb76e`, mutation-checked: restoring the rebuild kills an open stream with `CANCELLED: RST_STREAM`). Late registration is safe; the ordering above is about existence, not about protecting streams.

## Decisions worth arguing with

**Backpressure — bounded at 256, shedding the oldest.** #48 chose `Channel(UNLIMITED)` + `trySend` to guarantee ordering, and ordering is preserved end to end here (one queue written from the Compose callback, one collector draining it into one gRPC stream — hence "one stream per surface", enforced by a CAS). But unlimited is the wrong bound across a process boundary: the reader is in another process and can stop reading, gRPC flow control then blocks our collector, and the queue that grows lives in the *host* for a fault that is entirely the plugin's. 256 events is over ten seconds of continuous human interaction.

Overflow drops the **oldest**, not the newest, and that direction matters: dropping the newest inverts `TextChange`'s last-write-wins, leaving the plugin holding a stale value with no later event to correct it — host and plugin disagree about that field forever. Dropping from the head keeps the queue converging on the current truth and preserves the order of what survives. Sheds are counted (`shedEventCount`) and logged (first, then every 256th) rather than being silent.

**Lifecycle — a dying stream releases the registration.** A crashed plugin never sends `UnregisterUI`, so the stream dying is the only notice the host gets that a process is gone. Holding the claim would lock a plugin's own `surface_id` out from its respawn. The surface keeps its **last tree** and reports `connected == false`, so a dead plugin reads as *disconnected* rather than *frozen*. A late event after teardown returns `false` to its caller — dropped and logged, never thrown. `close()` is idempotent because a graceful shutdown legitimately reaches it twice (`UnregisterUI` → queue ends → `StreamUI` ends → teardown closes again), and without the guard the component would be told it disconnected twice.

**`StreamUI` binds on its first update.** The RPC carries no surface id of its own, so the stream is pinned to the `surface_id` of its first `WidgetUpdate`. That is a protocol limitation, not a preference — and a plugin that registers a surface then streams nothing gets `INVALID_ARGUMENT` when its request stream ends, rather than an RPC that hangs open forever. **Client-side note for `boss-microkernel-runtime`:** a plugin must send at least one `WidgetUpdate` (normally its full tree) to bind the stream.

One non-obvious bug found while testing: `channelFlow` does not complete until its children do, and the request pump collects a stream the plugin may keep open indefinitely. Without cancelling the pump on teardown, closing a surface completed the event queue but left the RPC hanging — `UnregisterUI` looked like it had silently frozen the stream. Caught by the teardown test, which is exactly what it is for.

## Tested

**34 new transport tests, 5 new renderer tests.** Full suite: 1015 tests, 0 failures (`:composeApp:desktopTest` 940 + `:boss-ui-sdk:test` 75).

- **Round trip over a real in-process gRPC server** with a real plugin-side client (12 tests, following `IpcRoundTripTest`/`StateServiceTest`): a click arrives with `surfaceId` + `targetNodeId` + `eventCase` + `click.eventId` + `timestamp` — the old code could carry exactly the first of those five. Plus a plugin-streamed tree reaching the attached component, a registration's `initial_tree`, and the duplicate / blank / unregistered / unbindable / second-stream refusals each asserting their status code *and* that the message says something actionable.
- **Ordering**: a 50-deep `TextChange` burst arrives in the order it was emitted.
- **Isolation**: two surfaces with two streams; neither sees the other's events.
- **Teardown**: `UnregisterUI` completes the plugin's flow (asserted without `take()`, so completion has to come from the surface closing), removes the surface, and a later click returns `false`. Separately, a plugin that vanishes (channel `shutdownNow`) leaves the surface visibly disconnected, releases the id for a respawn, and keeps its last tree.
- **Rendezvous** (17 registry tests): attach-before-register and register-before-attach, crash-and-respawn under a live component, detach scoped to its owner, shedding, diff-on-top-of-tree, diff-with-no-base dropped, empty update ignored.
- **Proto diffs** (5 tests): every operation kind round-trips, absent modifier decodes as "no change", and `apply(old, decode(encode(diff(old, new))))` reproduces `new`.
- **Compose UI tests** (5) against a real composition, per the decision to add `compose.desktop.uiTestJUnit4` + the JUnit vintage engine: #48's focus gating (no spurious `Focus(false)` on first composition; a real focus gain reported exactly once), pushable state (typing survives an unchanged re-send, a genuinely new value wins), `LIST` inside `SCROLL` rendering its rows instead of throwing, and a real click on a rendered button landing in the surface's outgoing queue with its event id.

The Compose tests were **mutation-checked**: reverting the focus gate, the pushable state and the `LIST` fallback in `RemoteWidgetRenderer` fails exactly those 4 tests and no others. The vintage engine coexists with the existing Jupiter suite — 67 test classes in `desktopTest`, 67 executed, none lost to discovery.

**Not tested / not built:** item 8's `key`/`scroll`/`lifecycle` emission is untouched (`UIEventMapper` already handles all three; nothing raises them yet) — hence `Refs`, not `Fixes`. No host code constructs `RemotePanelComponent`/`RemoteTabComponent` yet, so placing a remote surface in the window is still open; this PR makes the transport under it real and exercisable. Compose UI tests are unverified under a headless Linux runner — CI's ubuntu leg will be the first word on that.

## Incidental

`desktopTest`'s Windows-ARM64 exclusion now mirrors `desktopMain` for `**/plugin/remote/**` as well as `**/kernel/**`. The kernel half was added in #43; the renderer half was missed, which left `RemoteWidgetRendererColorTest` (it reads `resolveBackgroundColor` out of the excluded renderer) unable to compile on that platform.

Gates: full-repo `./gradlew detekt ktlintCheck` green.

Refs #34

