### PR TITLE
feat(remote-ui): emit key, scroll and lifecycle — the three families #34 deferred

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapMatcher.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/keymap/handler/KeymapMatcher.kt
@@ -85,8 +85,16 @@ class KeymapMatcher(
      *
      * This follows JxBrowser's pattern: only intercept known system shortcuts,
      * let the component handle everything else (including Shift-only like '?').
+     *
+     * Public because it is also the honest answer to "would the host actually act on this key?", which
+     * is not the same question as "is this key in the keymap". `AWTKeyboardInterceptor` returns before
+     * it ever consults the keymap unless Meta, Ctrl or Alt is down, so a bound-but-modifier-less binding
+     * — `Shift+/` for the shortcut sheet, say — is never dispatched. Anything deciding whether a key is
+     * still available to something else (see `Modifier.forwardUnclaimedKeys` in the remote-UI renderer)
+     * must ask this too, or it will decline a key the host was never going to take and the key is lost
+     * to everyone.
      */
-    private fun hasSystemModifier(binding: KeyBinding): Boolean =
+    fun hasSystemModifier(binding: KeyBinding): Boolean =
         binding.modifiers.any { mod ->
             mod.equals("Cmd", true) || mod.equals("Meta", true) ||
                 mod.equals("Ctrl", true) || mod.equals("Control", true) ||

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -1,0 +1,175 @@
+package ai.rever.boss.components.plugin.remote
+
+import ai.rever.boss.keymap.KeymapSettingsManager
+import ai.rever.boss.keymap.handler.KeymapMatcher
+import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.ui.sdk.ScrollCoalescer
+import ai.rever.boss.ui.sdk.ScrollOffset
+import ai.rever.boss.ui.sdk.WidgetEvent
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.focusable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
+import java.awt.event.KeyEvent as AwtKeyEvent
+
+/**
+ * The two input families a remote surface raises for itself rather than for one of its widgets:
+ * unclaimed key presses, and coalesced scrolling.
+ *
+ * Both were mapped onto the wire by #48 and emitted by nobody, each deferred for a policy decision.
+ * The decisions are documented on [toForwardedKey] and in
+ * [ScrollCoalescer][ai.rever.boss.ui.sdk.ScrollCoalescer]; this file is where they meet Compose.
+ */
+
+/**
+ * Forward keys the host did not want to the plugin behind this surface, **without ever consuming one**.
+ *
+ * ## The policy: the host keymap wins, the plugin gets what is left
+ *
+ * An out-of-process plugin must not be able to swallow `Cmd+W` and trap the user in a panel. Three
+ * things make that impossible here, and only the second is code in this function:
+ *
+ * 1. **The host keymap runs strictly upstream, at the AWT layer.**
+ *    [AWTKeyboardInterceptor][ai.rever.boss.window.AWTKeyboardInterceptor] installs a
+ *    `KeyEventDispatcher` on the `KeyboardFocusManager`, which sees every key *before* AWT routes it
+ *    to the focused component — i.e. before Compose exists as far as the event is concerned. When a
+ *    binding matches and its action dispatches, the interceptor calls `event.consume()` and returns
+ *    `true`, and the event is never delivered onward. So a key that reaches a Compose modifier is, by
+ *    construction, one the host keymap already declined; `false // Let event propagate normally` at
+ *    the end of that dispatcher is the exact point this tap sits after. Nothing needed to change there
+ *    — and deliberately so, because the interceptor cannot answer "which remote surface has focus"
+ *    (it routes by AWT window, and remote surfaces are not placed in a window yet), while Compose's
+ *    own focus system answers it for free.
+ *
+ * 2. **The tap re-checks the live keymap anyway.** The interceptor has early exits that skip matching
+ *    entirely — an unregistered focused window returns before it consults the keymap — and this
+ *    modifier would happily forward a `Cmd+T` that arrived down one of those paths. Asking
+ *    [KeymapMatcher] the same question the interceptor asks makes "the host keymap wins" a property of
+ *    the forwarding rule itself rather than an emergent property of dispatch order, and it is what
+ *    makes the rule testable without driving AWT.
+ *
+ * 3. **This handler always returns `false`.** It is a tap, not a handler: the key continues to
+ *    whatever the host has above the surface exactly as if the plugin were not there. A plugin can
+ *    *observe* what is left over; it can never claim it. Even a plugin process that hangs cannot
+ *    delay a host shortcut, because the shortcut never entered this path.
+ *
+ * ## What gets forwarded
+ *
+ * Keys the *focused widget* did not take, because `onKeyEvent` fires on the way up from the focus
+ * target: typing into a remote text field produces `TextChange`, not a `Key` per character, and only
+ * what the field ignores bubbles this far. That is the same "host first, then the specific thing, then
+ * the surface" ordering one level down.
+ *
+ * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
+ *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
+ *   Same convention as lifecycle, per `EmittedEvent`.
+ * @param hostKeymap the keymap to check against; the live user settings in production, injected in
+ *   tests so an assertion about a shortcut does not depend on whoever's `~/.boss/keymap-settings.json`
+ *   the suite happens to run beside.
+ */
+internal fun Modifier.forwardUnclaimedKeys(
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
+    hostKeymap: () -> KeymapSettings = { KeymapSettingsManager.currentSettings.value },
+): Modifier =
+    onKeyEvent { keyEvent ->
+        keyEvent.toForwardedKey(hostKeymap())?.let { forwarded -> onEvent("", forwarded) }
+        // Never true. See point 3 above — this is the anti-trap guarantee, and it is one word.
+        false
+    }.focusable()
+
+/**
+ * The `Key` event a plugin should see for this key press, or `null` if it must not be forwarded.
+ *
+ * Three refusals:
+ *
+ * - **Anything that is not a key *down*.** `KeyEvent` on the wire has a key code and modifiers and no
+ *   up/down discriminator, so forwarding both edges would deliver every press twice with no way for a
+ *   plugin to tell them apart. Down is the edge that means "the user pressed this".
+ * - **A modifier pressed on its own.** Holding Shift to type a capital letter would otherwise deliver a
+ *   bare `VK_SHIFT` ahead of the letter, and a plugin listening for keys would see two events for one
+ *   keystroke. The modifier is not lost — it arrives as a flag on the key it modifies, which is the
+ *   only form the wire type can express. Same set the AWT interceptor skips, for the same reason.
+ * - **Anything bound in the host keymap.** Checked in [ShortcutContext.GLOBAL], which is what
+ *   [KeymapMatcher] resolves for a surface that is neither a browser, a terminal nor an editor — the
+ *   same context the AWT interceptor derives for one — and which also covers `WORKSPACE` bindings.
+ *
+ * `Key.nativeKeyCode` rather than the packed `Key.keyCode`: the proto field is an `int32` and the
+ * documented meaning is a platform key code, which on this host is the AWT `VK_` constant. The packed
+ * Compose value would neither fit nor mean anything to a plugin.
+ */
+internal fun ComposeKeyEvent.toForwardedKey(hostKeymap: KeymapSettings): WidgetEvent.Key? {
+    // One conjunction rather than three guard clauses: `&&` short-circuits, so the keymap lookup — the
+    // only expensive test of the three — still runs at most once per real key press.
+    val forwardable =
+        type == KeyEventType.KeyDown &&
+            key.nativeKeyCode !in MODIFIER_ONLY_KEYS &&
+            KeymapMatcher(hostKeymap).match(this, ShortcutContext.GLOBAL) == null
+    return if (!forwardable) {
+        null
+    } else {
+        WidgetEvent.Key(
+            keyCode = key.nativeKeyCode,
+            ctrl = isCtrlPressed,
+            alt = isAltPressed,
+            shift = isShiftPressed,
+            meta = isMetaPressed,
+        )
+    }
+}
+
+/**
+ * Keys that only ever qualify another key.
+ *
+ * Mirrors `AWTKeyboardInterceptor.isModifierOnlyKey`. Kept as its own list rather than shared with the
+ * interceptor because the two answer different questions — the interceptor asks "can this be a
+ * shortcut", this asks "is this an event a plugin wants" — and they happen to agree.
+ */
+private val MODIFIER_ONLY_KEYS =
+    setOf(
+        AwtKeyEvent.VK_SHIFT,
+        AwtKeyEvent.VK_CONTROL,
+        AwtKeyEvent.VK_ALT,
+        AwtKeyEvent.VK_ALT_GRAPH,
+        AwtKeyEvent.VK_META,
+        AwtKeyEvent.VK_CAPS_LOCK,
+        AwtKeyEvent.VK_NUM_LOCK,
+        AwtKeyEvent.VK_SCROLL_LOCK,
+    )
+
+/**
+ * Report [scrollState]'s movement to the plugin as coalesced deltas.
+ *
+ * The whole policy is in [ScrollCoalescer] — one event per window, and the resting position always
+ * delivered — so that it is testable without a UI toolkit and so the Rust renderer has one spec to
+ * mirror. This is only the wiring: a `snapshotFlow` over the offset, which already emits at most once
+ * per frame, feeding the coalescer.
+ *
+ * Keyed on the node id so a tree update that replaces the node restarts the reporter against its new
+ * state instead of publishing another node's offsets, and scoped to the composition so a closed
+ * surface leaves nothing running.
+ */
+@Composable
+internal fun ReportScrollPosition(
+    nodeId: String,
+    scrollState: ScrollState,
+    onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
+) {
+    LaunchedEffect(nodeId, scrollState) {
+        ScrollCoalescer
+            .coalesce(snapshotFlow { ScrollOffset(x = 0f, y = scrollState.value.toFloat()) })
+            .collect { scroll -> onEvent(nodeId, scroll) }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -60,10 +60,17 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  *
  * 2. **The tap re-checks the live keymap anyway.** The interceptor has early exits that skip matching
  *    entirely — an unregistered focused window returns before it consults the keymap — and this
- *    modifier would happily forward a `Cmd+T` that arrived down one of those paths. Asking
- *    [KeymapMatcher] the same question the interceptor asks makes "the host keymap wins" a property of
- *    the forwarding rule itself rather than an emergent property of dispatch order, and it is what
- *    makes the rule testable without driving AWT.
+ *    modifier would happily forward a `Cmd+T` that arrived down one of those paths. Consulting
+ *    [KeymapMatcher] makes "the host keymap wins" a property of the forwarding rule itself rather than
+ *    an emergent property of dispatch order, and it is what makes the rule testable without driving AWT.
+ *
+ *    **It is not literally the same code path, and that is a known risk.**
+ *    `AWTKeyboardInterceptor.findMatchingBinding` takes a [KeymapMatcher] and then ignores it,
+ *    reimplementing the match over AWT key codes. So there are two answers to "is this bound" and they
+ *    can drift — a chord the interceptor claims but the matcher does not is merely forwarded
+ *    redundantly (guarantee 1 already consumed it), but the reverse would lose a key to both sides,
+ *    which is the `Shift+/` failure below in another guise. Making the interceptor delegate to its own
+ *    parameter is the fix; it is a change to the host keymap path rather than to this one.
  *
  * 3. **This handler always returns `false`.** It is a tap, not a handler: the key continues to
  *    whatever the host has above the surface exactly as if the plugin were not there. A plugin can
@@ -91,6 +98,11 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  * @param hostKeymap the keymap to check against; the live user settings in production, injected in
  *   tests so an assertion about a shortcut does not depend on whoever's `~/.boss/keymap-settings.json`
  *   the suite happens to run beside.
+ * @param context which bindings count as the host's. [ShortcutContext.GLOBAL] is right for every
+ *   surface today and is what the interceptor derives for one, but the interceptor resolves context
+ *   *per window* — so once remote surfaces are placed, a panel inside a browser or terminal window will
+ *   have the interceptor matching in `BROWSER`/`TERMINAL` while this still says `GLOBAL`. A parameter
+ *   now so that change has a seam rather than a silent mismatch to find later.
  */
 @Composable
 internal fun Modifier.forwardUnclaimedKeys(
@@ -118,9 +130,9 @@ internal fun Modifier.forwardUnclaimedKeys(
  *   bare `VK_SHIFT` ahead of the letter, and a plugin listening for keys would see two events for one
  *   keystroke. The modifier is not lost — it arrives as a flag on the key it modifies, which is the
  *   only form the wire type can express. Same set the AWT interceptor skips, for the same reason.
- * - **Anything the host would actually act on.** Matched in [ShortcutContext.GLOBAL] — what
- *   [KeymapMatcher] resolves for a surface that is neither a browser, a terminal nor an editor, the
- *   same context the AWT interceptor derives for one, and which also covers `WORKSPACE` bindings.
+ * - **Anything the host would actually act on**, matched in [context] — [ShortcutContext.GLOBAL] for
+ *   every surface today, which is what the AWT interceptor derives for one and which also covers
+ *   `WORKSPACE` bindings.
  *
  *   "Would act on", not "has a binding for", and the difference is a bug that review caught: the
  *   interceptor returns *before* it consults the keymap unless Meta, Ctrl or Alt is down, so a binding
@@ -138,12 +150,15 @@ internal fun Modifier.forwardUnclaimedKeys(
  * documented meaning is a platform key code, which on this host is the AWT `VK_` constant. The packed
  * Compose value would neither fit nor mean anything to a plugin.
  */
-internal fun ComposeKeyEvent.toForwardedKey(hostKeymap: KeymapMatcher): WidgetEvent.Key? {
+internal fun ComposeKeyEvent.toForwardedKey(
+    hostKeymap: KeymapMatcher,
+    context: ShortcutContext = ShortcutContext.GLOBAL,
+): WidgetEvent.Key? {
     // Cheap tests first so the keymap lookup — the only costly one — is skipped for key-ups and for the
     // modifier presses that bracket every chord.
     if (type != KeyEventType.KeyDown || key.nativeKeyCode in MODIFIER_ONLY_KEYS) return null
     val claimedByHost =
-        hostKeymap.match(this, ShortcutContext.GLOBAL)?.let(hostKeymap::hasSystemModifier) == true
+        hostKeymap.match(this, context)?.let(hostKeymap::hasSystemModifier) == true
     return if (claimedByHost) {
         null
     } else {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.focusable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEventType
@@ -76,19 +78,30 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
  *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
  *   Same convention as lifecycle, per `EmittedEvent`.
+ * ## Cost
+ *
+ * The matcher is built once per keymap, not once per keystroke. A held key auto-repeats at ~25-30/s and
+ * `KeymapMatcher.match` is not free — it allocates a filtered candidate list twice (context, then
+ * `WORKSPACE`) and does string normalization per candidate — so constructing one inside the handler put
+ * a few hundred short-lived allocations per keystroke on the Compose UI thread. Reading the settings
+ * during composition also means a rebind takes effect without the surface having to be re-created.
+ *
  * @param hostKeymap the keymap to check against; the live user settings in production, injected in
  *   tests so an assertion about a shortcut does not depend on whoever's `~/.boss/keymap-settings.json`
  *   the suite happens to run beside.
  */
+@Composable
 internal fun Modifier.forwardUnclaimedKeys(
     onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
-    hostKeymap: () -> KeymapSettings = { KeymapSettingsManager.currentSettings.value },
-): Modifier =
-    onKeyEvent { keyEvent ->
-        keyEvent.toForwardedKey(hostKeymap())?.let { forwarded -> onEvent("", forwarded) }
+    hostKeymap: KeymapSettings = KeymapSettingsManager.currentSettings.collectAsState().value,
+): Modifier {
+    val matcher = remember(hostKeymap) { KeymapMatcher(hostKeymap) }
+    return onKeyEvent { keyEvent ->
+        keyEvent.toForwardedKey(matcher)?.let { forwarded -> onEvent("", forwarded) }
         // Never true. See point 3 above — this is the anti-trap guarantee, and it is one word.
         false
     }.focusable()
+}
 
 /**
  * The `Key` event a plugin should see for this key press, or `null` if it must not be forwarded.
@@ -102,21 +115,21 @@ internal fun Modifier.forwardUnclaimedKeys(
  *   bare `VK_SHIFT` ahead of the letter, and a plugin listening for keys would see two events for one
  *   keystroke. The modifier is not lost — it arrives as a flag on the key it modifies, which is the
  *   only form the wire type can express. Same set the AWT interceptor skips, for the same reason.
- * - **Anything bound in the host keymap.** Checked in [ShortcutContext.GLOBAL], which is what
- *   [KeymapMatcher] resolves for a surface that is neither a browser, a terminal nor an editor — the
- *   same context the AWT interceptor derives for one — and which also covers `WORKSPACE` bindings.
+ * - **Anything [hostKeymap] binds.** Checked in [ShortcutContext.GLOBAL], which is what [KeymapMatcher]
+ *   resolves for a surface that is neither a browser, a terminal nor an editor — the same context the
+ *   AWT interceptor derives for one — and which also covers `WORKSPACE` bindings.
  *
  * `Key.nativeKeyCode` rather than the packed `Key.keyCode`: the proto field is an `int32` and the
  * documented meaning is a platform key code, which on this host is the AWT `VK_` constant. The packed
  * Compose value would neither fit nor mean anything to a plugin.
  */
-internal fun ComposeKeyEvent.toForwardedKey(hostKeymap: KeymapSettings): WidgetEvent.Key? {
+internal fun ComposeKeyEvent.toForwardedKey(hostKeymap: KeymapMatcher): WidgetEvent.Key? {
     // One conjunction rather than three guard clauses: `&&` short-circuits, so the keymap lookup — the
     // only expensive test of the three — still runs at most once per real key press.
     val forwardable =
         type == KeyEventType.KeyDown &&
             key.nativeKeyCode !in MODIFIER_ONLY_KEYS &&
-            KeymapMatcher(hostKeymap).match(this, ShortcutContext.GLOBAL) == null
+            hostKeymap.match(this, ShortcutContext.GLOBAL) == null
     return if (!forwardable) {
         null
     } else {
@@ -133,9 +146,10 @@ internal fun ComposeKeyEvent.toForwardedKey(hostKeymap: KeymapSettings): WidgetE
 /**
  * Keys that only ever qualify another key.
  *
- * Mirrors `AWTKeyboardInterceptor.isModifierOnlyKey`. Kept as its own list rather than shared with the
- * interceptor because the two answer different questions — the interceptor asks "can this be a
- * shortcut", this asks "is this an event a plugin wants" — and they happen to agree.
+ * A superset of `AWTKeyboardInterceptor.isModifierOnlyKey`, which lacks `VK_ALT_GRAPH`. Kept as its own
+ * list rather than shared with the interceptor because the two answer different questions — the
+ * interceptor asks "can this be a shortcut", this asks "is this an event a plugin wants" — and the
+ * answers only mostly coincide.
  */
 private val MODIFIER_ONLY_KEYS =
     setOf(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.focusable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEventType
@@ -96,11 +98,12 @@ internal fun Modifier.forwardUnclaimedKeys(
     hostKeymap: KeymapSettings = KeymapSettingsManager.currentSettings.collectAsState().value,
 ): Modifier {
     val matcher = remember(hostKeymap) { KeymapMatcher(hostKeymap) }
-    return onKeyEvent { keyEvent ->
-        keyEvent.toForwardedKey(matcher)?.let { forwarded -> onEvent("", forwarded) }
-        // Never true. See point 3 above — this is the anti-trap guarantee, and it is one word.
-        false
-    }.focusable()
+    return this
+        .onKeyEvent { keyEvent ->
+            keyEvent.toForwardedKey(matcher)?.let { forwarded -> onEvent("", forwarded) }
+            // Never true. See point 3 above — this is the anti-trap guarantee, and it is one word.
+            false
+        }.focusable()
 }
 
 /**
@@ -115,22 +118,33 @@ internal fun Modifier.forwardUnclaimedKeys(
  *   bare `VK_SHIFT` ahead of the letter, and a plugin listening for keys would see two events for one
  *   keystroke. The modifier is not lost — it arrives as a flag on the key it modifies, which is the
  *   only form the wire type can express. Same set the AWT interceptor skips, for the same reason.
- * - **Anything [hostKeymap] binds.** Checked in [ShortcutContext.GLOBAL], which is what [KeymapMatcher]
- *   resolves for a surface that is neither a browser, a terminal nor an editor — the same context the
- *   AWT interceptor derives for one — and which also covers `WORKSPACE` bindings.
+ * - **Anything the host would actually act on.** Matched in [ShortcutContext.GLOBAL] — what
+ *   [KeymapMatcher] resolves for a surface that is neither a browser, a terminal nor an editor, the
+ *   same context the AWT interceptor derives for one, and which also covers `WORKSPACE` bindings.
+ *
+ *   "Would act on", not "has a binding for", and the difference is a bug that review caught: the
+ *   interceptor returns *before* it consults the keymap unless Meta, Ctrl or Alt is down, so a binding
+ *   with no system modifier is never dispatched. The shipped preset has one — `Shift+/` opens the
+ *   shortcut sheet — and refusing it here made `?` on a focused remote surface do nothing at all,
+ *   claimed by neither side. [KeymapMatcher.hasSystemModifier] is the interceptor's own test for that
+ *   and is now shared rather than reimplemented, so the two cannot drift.
+ *
+ *   Not consulted: `PluginShortcutRegistryImpl`'s defaults, which the interceptor checks after the
+ *   keymap. They sit behind the same system-modifier early exit, so anything they could claim is
+ *   already refused above by having a modifier — with one narrow exception, a plugin default arriving
+ *   down the unregistered-window path, where the interceptor would not have dispatched it either.
  *
  * `Key.nativeKeyCode` rather than the packed `Key.keyCode`: the proto field is an `int32` and the
  * documented meaning is a platform key code, which on this host is the AWT `VK_` constant. The packed
  * Compose value would neither fit nor mean anything to a plugin.
  */
 internal fun ComposeKeyEvent.toForwardedKey(hostKeymap: KeymapMatcher): WidgetEvent.Key? {
-    // One conjunction rather than three guard clauses: `&&` short-circuits, so the keymap lookup — the
-    // only expensive test of the three — still runs at most once per real key press.
-    val forwardable =
-        type == KeyEventType.KeyDown &&
-            key.nativeKeyCode !in MODIFIER_ONLY_KEYS &&
-            hostKeymap.match(this, ShortcutContext.GLOBAL) == null
-    return if (!forwardable) {
+    // Cheap tests first so the keymap lookup — the only costly one — is skipped for key-ups and for the
+    // modifier presses that bracket every chord.
+    if (type != KeyEventType.KeyDown || key.nativeKeyCode in MODIFIER_ONLY_KEYS) return null
+    val claimedByHost =
+        hostKeymap.match(this, ShortcutContext.GLOBAL)?.let(hostKeymap::hasSystemModifier) == true
+    return if (claimedByHost) {
         null
     } else {
         WidgetEvent.Key(
@@ -181,9 +195,13 @@ internal fun ReportScrollPosition(
     scrollState: ScrollState,
     onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
 ) {
+    // rememberUpdatedState so the long-lived effect always calls the current sink. Harmless today —
+    // every caller passes a lambda capturing only its component — but it is the classic stale-capture
+    // shape, and the effect outlives many recompositions.
+    val sink by rememberUpdatedState(onEvent)
     LaunchedEffect(nodeId, scrollState) {
         ScrollCoalescer
             .coalesce(snapshotFlow { ScrollOffset(x = 0f, y = scrollState.value.toFloat()) })
-            .collect { scroll -> onEvent(nodeId, scroll) }
+            .collect { scroll -> sink(nodeId, scroll) }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -64,13 +64,25 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  *    [KeymapMatcher] makes "the host keymap wins" a property of the forwarding rule itself rather than
  *    an emergent property of dispatch order, and it is what makes the rule testable without driving AWT.
  *
- *    **It is not literally the same code path, and that is a known risk.**
+ **It is not the same code path, and the two have already drifted — see #52.**
  *    `AWTKeyboardInterceptor.findMatchingBinding` takes a [KeymapMatcher] and then ignores it,
- *    reimplementing the match over AWT key codes. So there are two answers to "is this bound" and they
- *    can drift — a chord the interceptor claims but the matcher does not is merely forwarded
- *    redundantly (guarantee 1 already consumed it), but the reverse would lose a key to both sides,
- *    which is the `Shift+/` failure below in another guise. Making the interceptor delegate to its own
- *    parameter is the fix; it is a change to the host keymap path rather than to this one.
+ *    reimplementing the match over AWT key codes *without* normalizing the binding's key name, while
+ *    [KeymapMatcher.keyMatches] normalizes both sides. So they disagree today, on shipped bindings:
+ *    `Cmd+DirectionLeft` and friends (`PANEL_NAVIGATE_*`), `Ctrl+Space` (`QUICK_SWITCHER_OPEN`), and
+ *    anything a user binds as `Return`, `Escape`, `-`, `=` or `/`.
+ *
+ *    The asymmetry matters. Interceptor-claims-but-matcher-does-not is harmless: guarantee 1 already
+ *    consumed the key, so the forward never happens. The reverse — matcher claims, interceptor does
+ *    not — declines a key the host then fails to dispatch, and it is dead to both sides. That is the
+ *    `Shift+/` failure below reached by a different route, and those bindings are *already* dead
+ *    app-wide because of the interceptor's own bug; this tap only stops them falling through to a
+ *    plugin. The fix is one change — make `findMatchingBinding` use its `matcher` parameter — and it
+ *    repairs the host-side bug at the same time, which is why it is #52 and not a patch here.
+ *
+ *    A second, narrower case with the same shape: the interceptor consumes only when `dispatchAction`
+ *    returns `true`, so a binding for a `plugin.*` action whose plugin is disabled matches, declines,
+ *    and is not consumed — and is then refused here. "Would actually dispatch" is the best question
+ *    this side of the boundary can ask, not a complete one; only trying it answers it.
  *
  * 3. **This handler always returns `false`.** It is a tap, not a handler: the key continues to
  *    whatever the host has above the surface exactly as if the plugin were not there. A plugin can
@@ -84,6 +96,9 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  * what the field ignores bubbles this far. That is the same "host first, then the specific thing, then
  * the surface" ordering one level down.
  *
+ * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
+ *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
+ *   Same convention as lifecycle, per `EmittedEvent`.
  * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
  *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
  *   Same convention as lifecycle, per `EmittedEvent`.
@@ -103,16 +118,19 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  *   *per window* — so once remote surfaces are placed, a panel inside a browser or terminal window will
  *   have the interceptor matching in `BROWSER`/`TERMINAL` while this still says `GLOBAL`. A parameter
  *   now so that change has a seam rather than a silent mismatch to find later.
+ *
+
  */
 @Composable
 internal fun Modifier.forwardUnclaimedKeys(
     onEvent: (nodeId: String, event: WidgetEvent) -> Unit,
     hostKeymap: KeymapSettings = KeymapSettingsManager.currentSettings.collectAsState().value,
+    context: ShortcutContext = ShortcutContext.GLOBAL,
 ): Modifier {
     val matcher = remember(hostKeymap) { KeymapMatcher(hostKeymap) }
     return this
         .onKeyEvent { keyEvent ->
-            keyEvent.toForwardedKey(matcher)?.let { forwarded -> onEvent("", forwarded) }
+            keyEvent.toForwardedKey(matcher, context)?.let { forwarded -> onEvent("", forwarded) }
             // Never true. See point 3 above — this is the anti-trap guarantee, and it is one word.
             false
         }.focusable()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInput.kt
@@ -8,7 +8,6 @@ import ai.rever.boss.ui.sdk.ScrollCoalescer
 import ai.rever.boss.ui.sdk.ScrollOffset
 import ai.rever.boss.ui.sdk.WidgetEvent
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.focusable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -62,12 +61,13 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  *    entirely — an unregistered focused window returns before it consults the keymap — and this
  *    modifier would happily forward a `Cmd+T` that arrived down one of those paths. Consulting
  *    [KeymapMatcher] makes "the host keymap wins" a property of the forwarding rule itself rather than
- *    an emergent property of dispatch order, and it is what makes the rule testable without driving AWT.
+ *    an emergent property of dispatch order, and it is what makes the rule testable without driving
+ *    AWT.
  *
- **It is not the same code path, and the two have already drifted — see #52.**
+ *    **It is not the same code path, and the two have already drifted — see #52.**
  *    `AWTKeyboardInterceptor.findMatchingBinding` takes a [KeymapMatcher] and then ignores it,
  *    reimplementing the match over AWT key codes *without* normalizing the binding's key name, while
- *    [KeymapMatcher.keyMatches] normalizes both sides. So they disagree today, on shipped bindings:
+ *    `KeymapMatcher.keyMatches` normalizes both sides. So they disagree today, on shipped bindings:
  *    `Cmd+DirectionLeft` and friends (`PANEL_NAVIGATE_*`), `Ctrl+Space` (`QUICK_SWITCHER_OPEN`), and
  *    anything a user binds as `Return`, `Escape`, `-`, `=` or `/`.
  *
@@ -89,27 +89,36 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  *    *observe* what is left over; it can never claim it. Even a plugin process that hangs cannot
  *    delay a host shortcut, because the shortcut never entered this path.
  *
- * ## What gets forwarded
+ * ## What gets forwarded, and what makes the surface eligible at all
  *
  * Keys the *focused widget* did not take, because `onKeyEvent` fires on the way up from the focus
  * target: typing into a remote text field produces `TextChange`, not a `Key` per character, and only
  * what the field ignores bubbles this far. That is the same "host first, then the specific thing, then
  * the surface" ordering one level down.
  *
- * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
- *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
- *   Same convention as lifecycle, per `EmittedEvent`.
- * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
- *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
- *   Same convention as lifecycle, per `EmittedEvent`.
+ * **The surface is deliberately not a focus target of its own.** An earlier revision ended this chain
+ * in `.focusable()`, which made a surface with no interactive content a Tab stop that began streaming
+ * every unclaimed key-down to a separate OS process — with no plugin identity, no capability model and
+ * nothing visible in the UI. Reviewers were unanimous that that is the wrong default to ship, and the
+ * directions are not symmetric: granting it later behind a declared `wants_keys` on `UIRegistration` is
+ * additive, whereas revoking it after a plugin has shipped against it is a negotiation. So a surface
+ * receives keys only once something inside it holds focus — which is every surface built for
+ * interaction, and none of the ones with no business seeing keystrokes.
+ *
  * ## Cost
  *
- * The matcher is built once per keymap, not once per keystroke. A held key auto-repeats at ~25-30/s and
- * `KeymapMatcher.match` is not free — it allocates a filtered candidate list twice (context, then
- * `WORKSPACE`) and does string normalization per candidate — so constructing one inside the handler put
- * a few hundred short-lived allocations per keystroke on the Compose UI thread. Reading the settings
- * during composition also means a rebind takes effect without the surface having to be re-created.
+ * A held key auto-repeats at ~25-30/s and every one of those runs a [KeymapMatcher.match]. The matcher
+ * is at least built once per keymap rather than once per keystroke, and reading the settings during
+ * composition also means a rebind takes effect without the surface being re-created — but to be honest
+ * about what that bought: `KeymapMatcher` has no `init`, so hoisting it saves one wrapper allocation.
+ * The real cost is inside `match()` — a filtered candidate list built once or twice per call, plus
+ * `Key.toString()` and two name normalizations per candidate — and it is still paid per key-down.
+ * Fixing it means precomputing the per-context binding lists in the matcher, which also speeds up the
+ * interceptor's far hotter path; that is part of #52 rather than a change to make from here.
  *
+ * @param onEvent the surface's event sink. Key events are tagged with an **empty node id** — they
+ *   reach the surface precisely *because* no node claimed them, so attributing one would be a guess.
+ *   Same convention as lifecycle, per `EmittedEvent`.
  * @param hostKeymap the keymap to check against; the live user settings in production, injected in
  *   tests so an assertion about a shortcut does not depend on whoever's `~/.boss/keymap-settings.json`
  *   the suite happens to run beside.
@@ -118,8 +127,6 @@ import java.awt.event.KeyEvent as AwtKeyEvent
  *   *per window* — so once remote surfaces are placed, a panel inside a browser or terminal window will
  *   have the interceptor matching in `BROWSER`/`TERMINAL` while this still says `GLOBAL`. A parameter
  *   now so that change has a seam rather than a silent mismatch to find later.
- *
-
  */
 @Composable
 internal fun Modifier.forwardUnclaimedKeys(
@@ -133,7 +140,7 @@ internal fun Modifier.forwardUnclaimedKeys(
             keyEvent.toForwardedKey(matcher, context)?.let { forwarded -> onEvent("", forwarded) }
             // Never true. See point 3 above — this is the anti-trap guarantee, and it is one word.
             false
-        }.focusable()
+        }
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
@@ -39,7 +39,16 @@ fun RemoteWidgetRenderer(
     onEvent: (nodeId: String, event: WidgetEvent) -> Unit = { _, _ -> },
 ) {
     val root = tree.nodes[tree.rootId] ?: return
-    RenderNode(node = root, tree = tree, onEvent = onEvent)
+    // A wrapper only so the surface has one node above the whole tree to tap keys at — see
+    // Modifier.forwardUnclaimedKeys for why that node is the right place and why it never consumes.
+    // propagateMinConstraints so a root that fills its parent still does; the Box is otherwise
+    // transparent to layout.
+    Box(
+        modifier = Modifier.forwardUnclaimedKeys(onEvent),
+        propagateMinConstraints = true,
+    ) {
+        RenderNode(node = root, tree = tree, onEvent = onEvent)
+    }
 }
 
 @Composable
@@ -71,6 +80,10 @@ private fun RenderNode(
 
         WidgetType.SCROLL -> {
             val scrollState = rememberScrollState()
+            // Coalesced, not per-frame: an unthrottled scroll is one IPC message every ~16ms for the
+            // length of a fling. See ScrollCoalescer for the window and for why the resting position
+            // is always delivered.
+            ReportScrollPosition(node.id, scrollState, onEvent)
             Column(modifier = modifier.verticalScroll(scrollState)) {
                 // Everything below is measured with an unbounded max height — see the LIST branch.
                 CompositionLocalProvider(LocalUnboundedHeight provides true) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycle.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycle.kt
@@ -1,0 +1,93 @@
+package ai.rever.boss.kernel.ui
+
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.ui.sdk.LifecycleStates
+import ai.rever.boss.ui.sdk.UIEventMapper
+import ai.rever.boss.ui.sdk.WidgetEvent
+
+/**
+ * `created` / `destroyed` for a remote surface — the half of the lifecycle family that can actually be
+ * delivered, and nothing else.
+ *
+ * ## What the events mean
+ *
+ * **A surface's rendered lifetime**, not a plugin's. `created` says "a host renderer is attached and
+ * your stream is live — your widgets are on screen"; `destroyed` says that stopped being true. That is
+ * the thing a plugin cannot work out for itself and the thing it needs in order to start and stop
+ * doing work; whereas "my process registered a surface" is something it already knows, having done it.
+ *
+ * The pairing is a **rendezvous between two independent lifetimes**, so it is announced by whichever
+ * half completes it — the component attaching to a streaming surface, or a stream binding under an
+ * already-attached component — and the latch below makes that exactly once either way. It re-arms on
+ * teardown, so a plugin that crashes and respawns under a component that never went away is told
+ * `created` again: the new process never heard the first one.
+ *
+ * ## Why `destroyed` is deliverable after all
+ *
+ * #34 deferred this family because "`destroyed` cannot be flushed: the outgoing flow dies with the
+ * surface scope", and a create-without-destroy lifecycle is worse than none. That was true of a flush
+ * *after* teardown. It is not true of an ordinary send *before* one: `RemoteUiSurface.close()` calls
+ * `Channel.close()`, which is graceful — already-buffered elements are handed to the collector and
+ * *then* the flow completes. So enqueueing `destroyed` and immediately closing delivers it, as the
+ * last event the plugin sees, with no drain phase and no new API.
+ *
+ * Every teardown path that still has a transport therefore announces it: a host component detaching,
+ * the plugin's own `UnregisterUI`, and kernel shutdown.
+ *
+ * ## The one path that cannot, and why that is not a hole
+ *
+ * A **dead stream** — `RemoteUiSurfaceRegistry.closeStream` after a plugin crashed or its channel
+ * dropped. There is nothing to deliver over and nobody to receive it. Stream completion is the signal
+ * there, exactly as #34 anticipated: the plugin's own event flow ending *is* the notice, and a process
+ * that has died does not need one. So the guarantee this file offers is precise rather than absolute:
+ * **a plugin that can be told, is told** — and it is never told `destroyed` without having been told
+ * `created`, which is the asymmetry that made the family a footgun.
+ */
+internal object RemoteUiLifecycle {
+    /**
+     * Announce that [surface] is now rendered. No-op if it already was.
+     *
+     * @return whether an event was queued — `false` means it was already announced, or the surface is
+     *   closed. Returned rather than logged so the registry's call sites stay one line and tests can
+     *   assert the latch directly.
+     */
+    fun announceCreated(surface: RemoteUiSurface): Boolean =
+        surface.createdAnnounced.compareAndSet(false, true) &&
+            surface.emitLifecycle(LifecycleStates.CREATED)
+
+    /**
+     * Announce that [surface] is no longer rendered. No-op unless [announceCreated] fired first.
+     *
+     * The CAS is what makes the pair symmetric by construction instead of by discipline: there is no
+     * ordering of attach, detach, register, unregister and shutdown that can produce a `destroyed`
+     * with no `created`, or two of either. Reset rather than set, so a respawn under the same
+     * component announces afresh.
+     */
+    fun announceDestroyed(surface: RemoteUiSurface): Boolean =
+        surface.createdAnnounced.compareAndSet(true, false) &&
+            surface.emitLifecycle(LifecycleStates.DESTROYED)
+
+    /**
+     * Queue one lifecycle event on the surface's outgoing stream.
+     *
+     * Surface-level, so the node id is empty — a lifecycle transition belongs to the surface and not
+     * to any node in its tree (see `EmittedEvent`).
+     */
+    private fun RemoteUiSurface.emitLifecycle(state: String): Boolean {
+        val event = UIEventMapper.toProto(surfaceId, "", WidgetEvent.Lifecycle(state), System.currentTimeMillis())
+        val delivered = emit(event)
+        if (!delivered) {
+            // Reachable and unremarkable: the surface closed between the latch and here. Debug, because
+            // a crash-looping plugin would otherwise write a line per restart.
+            logger.debug(
+                LogCategory.UI,
+                "Surface closed before its lifecycle event could be queued",
+                mapOf("surfaceId" to surfaceId, "state" to state),
+            )
+        }
+        return delivered
+    }
+
+    private val logger = BossLogger.forComponent("RemoteUiLifecycle")
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycle.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycle.kt
@@ -41,8 +41,17 @@ import ai.rever.boss.ui.sdk.WidgetEvent
  * dropped. There is nothing to deliver over and nobody to receive it. Stream completion is the signal
  * there, exactly as #34 anticipated: the plugin's own event flow ending *is* the notice, and a process
  * that has died does not need one. So the guarantee this file offers is precise rather than absolute:
- * **a plugin that can be told, is told** — and it is never told `destroyed` without having been told
- * `created`, which is the asymmetry that made the family a footgun.
+ * **a plugin that can be told, is told**.
+ *
+ * ## The limit of the pairing
+ *
+ * The latch pairs the two events **at enqueue**. Delivery is the outgoing channel's business, and that
+ * channel sheds its **oldest** entry when a plugin stops reading (`RemoteUiSurface.OUTGOING_BUFFER`) —
+ * and `created` is by construction the oldest thing a rendered surface ever queues. A plugin that stops
+ * reading for long enough to shed its own first [RemoteUiSurface.OUTGOING_BUFFER] events can therefore
+ * lose its `created` and later receive a `destroyed` on its own. Narrow, and self-announcing:
+ * [RemoteUiSurface.shedEventCount] is non-zero exactly when it is possible. Documented rather than
+ * engineered around, because the alternative is a second delivery path for two events per surface.
  */
 internal object RemoteUiLifecycle {
     /**
@@ -52,9 +61,16 @@ internal object RemoteUiLifecycle {
      *   closed. Returned rather than logged so the registry's call sites stay one line and tests can
      *   assert the latch directly.
      */
-    fun announceCreated(surface: RemoteUiSurface): Boolean =
-        surface.createdAnnounced.compareAndSet(false, true) &&
-            surface.emitLifecycle(LifecycleStates.CREATED)
+    fun announceCreated(surface: RemoteUiSurface): Boolean {
+        if (!surface.createdAnnounced.compareAndSet(false, true)) return false
+        val queued = surface.emitLifecycle(LifecycleStates.CREATED)
+        // Roll the latch back rather than leave the surface owing a `destroyed` for a `created` no plugin
+        // saw. Unreachable today only by coincidence — `emit` fails solely on a closed surface, and a
+        // closed surface would fail the matching `destroyed` too — but that makes the pairing depend on
+        // the overflow policy of a channel declared in another file, which is not a thing to rely on.
+        if (!queued) surface.createdAnnounced.set(false)
+        return queued
+    }
 
     /**
      * Announce that [surface] is no longer rendered. No-op unless [announceCreated] fired first.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycle.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycle.kt
@@ -61,16 +61,17 @@ internal object RemoteUiLifecycle {
      *   closed. Returned rather than logged so the registry's call sites stay one line and tests can
      *   assert the latch directly.
      */
-    fun announceCreated(surface: RemoteUiSurface): Boolean {
-        if (!surface.createdAnnounced.compareAndSet(false, true)) return false
-        val queued = surface.emitLifecycle(LifecycleStates.CREATED)
-        // Roll the latch back rather than leave the surface owing a `destroyed` for a `created` no plugin
-        // saw. Unreachable today only by coincidence — `emit` fails solely on a closed surface, and a
-        // closed surface would fail the matching `destroyed` too — but that makes the pairing depend on
-        // the overflow policy of a channel declared in another file, which is not a thing to rely on.
-        if (!queued) surface.createdAnnounced.set(false)
-        return queued
-    }
+    fun announceCreated(surface: RemoteUiSurface): Boolean =
+        synchronized(surface.createdAnnounced) {
+            if (!surface.createdAnnounced.compareAndSet(false, true)) return@synchronized false
+            val queued = surface.emitLifecycle(LifecycleStates.CREATED)
+            // Roll the latch back rather than leave the surface owing a `destroyed` for a `created` no
+            // plugin saw. Under the monitor, not just a CAS: an unsynchronized rollback leaves a window
+            // between the failed emit and the reset in which a concurrent announceDestroyed can take the
+            // latch and emit an unmatched teardown — the very asymmetry the latch exists to prevent.
+            if (!queued) surface.createdAnnounced.set(false)
+            queued
+        }
 
     /**
      * Announce that [surface] is no longer rendered. No-op unless [announceCreated] fired first.
@@ -81,8 +82,12 @@ internal object RemoteUiLifecycle {
      * component announces afresh.
      */
     fun announceDestroyed(surface: RemoteUiSurface): Boolean =
-        surface.createdAnnounced.compareAndSet(true, false) &&
-            surface.emitLifecycle(LifecycleStates.DESTROYED)
+        // Same monitor as announceCreated, so the two transitions are ordered against each other rather
+        // than merely each being atomic on their own.
+        synchronized(surface.createdAnnounced) {
+            surface.createdAnnounced.compareAndSet(true, false) &&
+                surface.emitLifecycle(LifecycleStates.DESTROYED)
+        }
 
     /**
      * Queue one lifecycle event on the surface's outgoing stream.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurface.kt
@@ -93,6 +93,16 @@ class RemoteUiSurface internal constructor(
      */
     private val outgoing = Channel<UIEvent>(OUTGOING_BUFFER, BufferOverflow.DROP_OLDEST)
 
+    /**
+     * Whether this surface has told its plugin it is rendered, and therefore owes it a `destroyed`.
+     *
+     * Lives here rather than in [RemoteUiLifecycle] because it is per-surface state with exactly this
+     * object's lifetime — a map keyed by surface id there would need its own eviction, and would get it
+     * wrong across a respawn, where a *new* surface under the same id must start un-announced. Owned by
+     * [RemoteUiLifecycle]; nothing else may touch it.
+     */
+    internal val createdAnnounced = AtomicBoolean(false)
+
     private val streamClaimed = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
     private val eventsTaken = AtomicBoolean(false)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -195,6 +195,9 @@ class RemoteUiSurfaceRegistry {
                     "Reclaimed an abandoned UI surface for its own process — treating it as a respawn",
                     mapOf("surfaceId" to surfaceId, "processId" to created.processId),
                 )
+                // No `announceDestroyed`: `abandoned` requires `!blocker.streaming`, and a surface is
+                // only ever announced *created* while streaming, so the latch cannot be set here. The
+                // one teardown path that opts out on purpose rather than because it cannot deliver.
                 blocker.close()
                 blocker = null
             } else {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/ui/RemoteUiSurfaceRegistry.kt
@@ -219,6 +219,10 @@ class RemoteUiSurfaceRegistry {
      */
     fun unregister(surfaceId: String): Boolean {
         val surface = surfaces.remove(surfaceId) ?: return false
+        // Before close(), and that order is the whole reason `destroyed` is deliverable: Channel.close()
+        // is graceful, so an event queued first is handed to the still-collecting StreamUI call and only
+        // then does the flow complete. See RemoteUiLifecycle.
+        RemoteUiLifecycle.announceDestroyed(surface)
         surface.close()
         // debug, not info: register + unregister + closeStream at info is three lines per restart of a
         // crash-looping plugin. The registration itself is the event worth seeing at info.
@@ -245,6 +249,11 @@ class RemoteUiSurfaceRegistry {
             }
 
             else -> {
+                // Half two of the rendezvous. `claimStream()` above has already set `streaming`, and
+                // `attach` publishes its host into `hosts` before reading `streaming` — so whichever of
+                // the two runs second sees the other's write and announces. Neither ordering can miss it,
+                // and the latch in RemoteUiLifecycle means both racing cannot double-announce.
+                if (hosts.containsKey(surfaceId)) RemoteUiLifecycle.announceCreated(surface)
                 SurfaceStream.Bound(surface)
             }
         }
@@ -257,6 +266,12 @@ class RemoteUiSurfaceRegistry {
      * process is gone — there is no `UnregisterUI` from a process that crashed — so holding the claim
      * would lock the id out and a respawned plugin could never re-register it. Any attached component
      * stays attached and simply sees `connected == false`, ready for the replacement process.
+     *
+     * Pointedly **no** `destroyed` announcement here, unlike every other teardown path: this one is
+     * reached because the transport is gone, so there is nothing to send over and nobody to receive it.
+     * Stream completion is the plugin's notice, which is what #34 meant by inferring destruction from
+     * the stream. A graceful `UnregisterUI` still gets the event — it announces before closing, and
+     * arrives here afterwards with the latch already spent. See [RemoteUiLifecycle].
      */
     fun closeStream(surface: RemoteUiSurface) {
         surfaces.remove(surface.surfaceId, surface)
@@ -298,6 +313,10 @@ class RemoteUiSurfaceRegistry {
             host.onConnectionChanged(false)
         } else {
             surface.replayTo(host)
+            // Half one of the rendezvous — see openStream for why reading `streaming` *after* publishing
+            // into `hosts` is what makes the handshake gapless. Announced after the replay so the plugin
+            // never hears "you are rendered" before the component holds the tree it is rendering.
+            if (surface.streaming) RemoteUiLifecycle.announceCreated(surface)
         }
     }
 
@@ -314,7 +333,12 @@ class RemoteUiSurfaceRegistry {
         surfaceId: String,
         host: RemoteUiSurfaceHost,
     ) {
-        hosts.remove(surfaceId, host)
+        // Only the owner's removal ends the rendered lifetime. A late `dispose()` from a component that
+        // was already displaced must not tell a live plugin its successor's surface went away.
+        if (!hosts.remove(surfaceId, host)) return
+        // The plugin is still streaming here, so this is the `destroyed` most worth sending: its UI was
+        // closed by the user and it should stop doing work for a surface nobody is looking at.
+        surfaces[surfaceId]?.let(RemoteUiLifecycle::announceDestroyed)
     }
 
     /**
@@ -340,7 +364,14 @@ class RemoteUiSurfaceRegistry {
      */
     fun clear() {
         val closing = surfaces.keys.toList()
-        closing.forEach { surfaceId -> surfaces.remove(surfaceId)?.close() }
+        closing.forEach { surfaceId ->
+            surfaces.remove(surfaceId)?.let { surface ->
+                // Same before-close ordering as unregister: a plugin whose stream is still up on the way
+                // down gets a last `destroyed` rather than an abrupt completion.
+                RemoteUiLifecycle.announceDestroyed(surface)
+                surface.close()
+            }
+        }
         if (closing.isNotEmpty()) {
             logger.info(LogCategory.UI, "Closed all remote UI surfaces", mapOf("count" to closing.size))
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -246,7 +246,6 @@ class RemoteSurfaceInputComposeTest {
      * Filtered rather than positional because focusing a widget legitimately queues a `Focus` event
      * first, and a test about keys should not break when an unrelated family starts being emitted.
      */
-
     private fun RemoteUiSurface.firstEventWhere(predicate: (UIEvent) -> Boolean): UIEvent =
         runBlocking {
             withTimeout(WAIT_TIMEOUT_MS) { events().filter(predicate).take(1).toList() }.single()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -101,7 +101,7 @@ class RemoteSurfaceInputComposeTest {
         compose.setContent {
             Box(
                 Modifier
-                    .forwardUnclaimedKeys({ _, event -> forwarded += event }, hostKeymap = { keymapBinding("F7") })
+                    .forwardUnclaimedKeys({ _, event -> forwarded += event }, hostKeymap = keymapBinding("F7"))
                     .focusRequester(focus)
                     .focusable(),
             )

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -90,6 +91,42 @@ class RemoteSurfaceInputComposeTest {
         assertTrue(queued.key.alt, "the alt modifier must survive the crossing")
         assertTrue(queued.key.shift, "the shift modifier must survive the crossing")
         panel.dispose()
+    }
+
+    @Test
+    fun `a key the focused widget consumes never reaches the plugin`() {
+        // "The focused widget gets first refusal" is the property that keeps ordinary typing off the
+        // wire — a text field consumes its character keys, so a plugin sees one TextChange per edit
+        // rather than a Key per keystroke — and it is the whole reason the tap is `onKeyEvent` (which
+        // fires on the way *up* from the focus target) rather than `onPreviewKeyEvent`. Asserted with a
+        // child that consumes explicitly, because Compose's key injection cannot synthesise the codepoint
+        // a real `BasicTextField` needs in order to treat a press as text: driving a field here would
+        // assert nothing, which the mutation check caught before this comment existed.
+        val forwarded = mutableListOf<WidgetEvent>()
+        val focus = FocusRequester()
+        compose.setContent {
+            Box(Modifier.forwardUnclaimedKeys({ _, event -> forwarded += event })) {
+                Box(
+                    Modifier
+                        .onKeyEvent { it.key == Key.H }
+                        .focusRequester(focus)
+                        .focusable(),
+                )
+            }
+        }
+        compose.runOnIdle { focus.requestFocus() }
+
+        compose.onRoot().performKeyInput {
+            pressKey(Key.H)
+            pressKey(Key.J)
+        }
+        compose.waitForIdle()
+
+        assertEquals(
+            listOf(AwtKeyEvent.VK_J),
+            forwarded.filterIsInstance<WidgetEvent.Key>().map { it.keyCode },
+            "the consumed key must not reach the plugin; the unconsumed one must",
+        )
     }
 
     @Test
@@ -209,6 +246,7 @@ class RemoteSurfaceInputComposeTest {
      * Filtered rather than positional because focusing a widget legitimately queues a `Focus` event
      * first, and a test about keys should not break when an unrelated family starts being emitted.
      */
+
     private fun RemoteUiSurface.firstEventWhere(predicate: (UIEvent) -> Boolean): UIEvent =
         runBlocking {
             withTimeout(WAIT_TIMEOUT_MS) { events().filter(predicate).take(1).toList() }.single()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceInputComposeTest.kt
@@ -1,0 +1,247 @@
+package ai.rever.boss.components.plugin.remote
+
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.kernel.ui.RemoteUiSurface
+import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
+import ai.rever.boss.kernel.ui.SurfaceRegistration
+import ai.rever.boss.keymap.KeymapSettingsManager
+import ai.rever.boss.keymap.handler.KeymapMatcher
+import ai.rever.boss.keymap.model.KeyBinding
+import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.ui.sdk.WidgetEvent
+import ai.rever.boss.ui.sdk.WidgetModifier
+import ai.rever.boss.ui.sdk.WidgetNode
+import ai.rever.boss.ui.sdk.WidgetTree
+import ai.rever.boss.ui.sdk.WidgetType
+import ai.rever.boss.utils.SystemUtils
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.withKeyDown
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
+import java.awt.event.KeyEvent as AwtKeyEvent
+
+/**
+ * `key` and `scroll` emission driven through a real composition, to the surface's outgoing queue.
+ *
+ * [RemoteSurfaceKeyRoutingTest] pins the routing *rule* and
+ * [ScrollCoalescerTest][ai.rever.boss.ui.sdk.ScrollCoalescerTest] pins the throttling *policy*; neither
+ * says the renderer is wired to them. These do: a key pressed on a rendered surface, a scroll performed
+ * on a rendered surface, and the `UIEvent` that comes out the other side.
+ *
+ * The third test is the one that matters most for safety. "The plugin cannot trap the user" is not a
+ * property of the routing rule — it is the claim that this modifier *never returns true*, and the only
+ * way to assert it is to put a host handler above the surface and check the key still gets there.
+ */
+@OptIn(InternalComposeUiApi::class)
+class RemoteSurfaceInputComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `a key the host does not claim reaches the plugin with its payload intact`() {
+        val registry = RemoteUiSurfaceRegistry()
+        val surface = registry.accept(PANEL)
+        val panel = RemotePanelComponent(PANEL, "Test Panel", PROCESS, registry)
+        surface.pushTree(textFieldTree())
+        panel.attach()
+        assertUnboundInLiveKeymap()
+
+        compose.setContent { panel.Content() }
+        // Focus a widget inside the surface, then press a chord it does not want: the key has to travel
+        // up out of the focused field to the surface root before anything forwards it, which is the
+        // "the focused widget gets first refusal" half of the policy doing its job.
+        compose.onNode(hasSetTextAction()).requestFocus()
+        compose.onRoot().performKeyInput {
+            withKeyDown(Key.AltLeft) { withKeyDown(Key.ShiftLeft) { pressKey(Key.F7) } }
+        }
+        compose.waitForIdle()
+
+        val queued = surface.firstEventWhere { it.hasKey() }
+        assertEquals(PANEL, queued.surfaceId)
+        // Surface-level: no widget claimed it, so there is no node to attribute it to.
+        assertEquals("", queued.targetNodeId)
+        assertEquals(AwtKeyEvent.VK_F7, queued.key.keyCode)
+        assertTrue(queued.key.alt, "the alt modifier must survive the crossing")
+        assertTrue(queued.key.shift, "the shift modifier must survive the crossing")
+        panel.dispose()
+    }
+
+    @Test
+    fun `a key the host keymap claims is not forwarded`() {
+        // Driven against an injected keymap rather than the renderer's live one, so the assertion does
+        // not depend on whatever ~/.boss/keymap-settings.json the suite runs beside.
+        val forwarded = mutableListOf<WidgetEvent>()
+        val focus = FocusRequester()
+        compose.setContent {
+            Box(
+                Modifier
+                    .forwardUnclaimedKeys({ _, event -> forwarded += event }, hostKeymap = { keymapBinding("F7") })
+                    .focusRequester(focus)
+                    .focusable(),
+            )
+        }
+        compose.runOnIdle { focus.requestFocus() }
+
+        compose.onRoot().performKeyInput { withKeyDown(primaryModifier()) { pressKey(Key.F7) } }
+        compose.onRoot().performKeyInput { withKeyDown(primaryModifier()) { pressKey(Key.F8) } }
+        compose.waitForIdle()
+
+        // F7 is bound and must be swallowed *for the plugin*; F8 is not and must get through. Asserting
+        // both in one composition is what rules out "nothing was forwarded because nothing worked".
+        assertEquals(
+            listOf(AwtKeyEvent.VK_F8),
+            forwarded.filterIsInstance<WidgetEvent.Key>().map { it.keyCode },
+        )
+    }
+
+    @Test
+    fun `the surface never consumes a key — a host handler above it still receives one`() {
+        // The anti-trap guarantee, and the only place it is observable. If the tap ever returned true, a
+        // plugin could hold onto every key that reached its surface and the user would have no way out
+        // of the panel. Flip the `false` in forwardUnclaimedKeys and this is the test that goes red.
+        val forwarded = mutableListOf<WidgetEvent>()
+        var reachedHost = false
+        val focus = FocusRequester()
+        compose.setContent {
+            Box(
+                Modifier.onKeyEvent {
+                    reachedHost = true
+                    false
+                },
+            ) {
+                Box(
+                    Modifier
+                        .forwardUnclaimedKeys({ _, event -> forwarded += event })
+                        .focusRequester(focus)
+                        .focusable(),
+                )
+            }
+        }
+        compose.runOnIdle { focus.requestFocus() }
+
+        compose.onRoot().performKeyInput { pressKey(Key.F7) }
+        compose.waitForIdle()
+
+        assertTrue(forwarded.any { it is WidgetEvent.Key }, "the plugin should have seen the key")
+        assertTrue(reachedHost, "the host handler above the surface must still receive the key")
+    }
+
+    @Test
+    fun `scrolling a rendered scroll node puts a coalesced scroll on the wire`() {
+        val registry = RemoteUiSurfaceRegistry()
+        val surface = registry.accept(PANEL)
+        val panel = RemotePanelComponent(PANEL, "Test Panel", PROCESS, registry)
+        surface.pushTree(scrollTree())
+        panel.attach()
+
+        compose.setContent { panel.Content() }
+        // Scrolls the enclosing scrollable until the row is visible — a real offset change, driven the
+        // way a user drives one, rather than by poking a ScrollState the renderer owns.
+        compose.onNodeWithText("row-19").performScrollTo()
+        compose.waitForIdle()
+
+        val queued = surface.firstEvent()
+        assertEquals(PANEL, queued.surfaceId)
+        assertEquals(SCROLL, queued.targetNodeId, "a scroll belongs to the node that scrolled")
+        assertTrue(queued.hasScroll(), "expected a scroll event, got ${queued.eventCase}")
+        assertTrue(queued.scroll.deltaY > 0f, "scrolling down must report a positive delta")
+        panel.dispose()
+    }
+
+    /**
+     * Fail loudly if the environment's keymap claims the chord the forwarding test relies on.
+     *
+     * `Alt+Shift+F7` is unbound in every shipped preset. A developer who has bound it locally should see
+     * an explicit message here rather than a mystifying "no event arrived".
+     */
+    private fun assertUnboundInLiveKeymap() {
+        val live = KeymapSettingsManager.currentSettings.value
+        val chord = ComposeKeyEvent(Key.F7, KeyEventType.KeyDown, isAltPressed = true, isShiftPressed = true)
+        assertNull(
+            KeymapMatcher(live).match(chord, ShortcutContext.GLOBAL),
+            "this test needs Alt+Shift+F7 to be unbound; the active keymap claims it",
+        )
+    }
+
+    /** The platform's "Cmd": `KeymapMatcher` maps a `Cmd` binding onto Meta on macOS and Ctrl elsewhere. */
+    private fun primaryModifier(): Key = if (SystemUtils.isMacOS) Key.MetaLeft else Key.CtrlLeft
+
+    private fun keymapBinding(key: String): KeymapSettings {
+        val binding = KeyBinding(actionId = "test.action", key = key, modifiers = listOf("Cmd"))
+        return KeymapSettings(shortcuts = mapOf(binding.actionId to binding))
+    }
+
+    private fun RemoteUiSurfaceRegistry.accept(surfaceId: String): RemoteUiSurface =
+        (register(surfaceId, PROCESS) as SurfaceRegistration.Accepted).surface
+
+    /** Bounded, so a regression fails the build instead of hanging it. Mirrors RemoteWidgetRendererComposeTest. */
+    private fun RemoteUiSurface.firstEvent(): UIEvent = firstEventWhere { true }
+
+    /**
+     * The first queued event matching [predicate].
+     *
+     * Filtered rather than positional because focusing a widget legitimately queues a `Focus` event
+     * first, and a test about keys should not break when an unrelated family starts being emitted.
+     */
+    private fun RemoteUiSurface.firstEventWhere(predicate: (UIEvent) -> Boolean): UIEvent =
+        runBlocking {
+            withTimeout(WAIT_TIMEOUT_MS) { events().filter(predicate).take(1).toList() }.single()
+        }
+
+    private fun textFieldTree(): WidgetTree =
+        WidgetTree(
+            rootId = "field",
+            nodes = mapOf("field" to WidgetNode("field", WidgetType.TEXT_FIELD, properties = mapOf("value" to ""))),
+        )
+
+    /** A short scroll viewport over enough rows that scrolling to the last one has to move the offset. */
+    private fun scrollTree(): WidgetTree {
+        val rows =
+            (0 until ROWS).map { index ->
+                WidgetNode("row-$index", WidgetType.TEXT, mapOf("value" to "row-$index"))
+            }
+        val scroll =
+            WidgetNode(
+                id = SCROLL,
+                type = WidgetType.SCROLL,
+                childIds = rows.map { it.id },
+                modifier = WidgetModifier(height = VIEWPORT_DP),
+            )
+        return WidgetTree(rootId = SCROLL, nodes = (rows + scroll).associateBy { it.id })
+    }
+
+    private companion object {
+        const val PANEL = "panel-input"
+        const val PROCESS = "plugin-a"
+        const val SCROLL = "scroll-1"
+        const val ROWS = 20
+        const val VIEWPORT_DP = 40
+        const val WAIT_TIMEOUT_MS = 10_000L
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceKeyRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceKeyRoutingTest.kt
@@ -1,0 +1,218 @@
+package ai.rever.boss.components.plugin.remote
+
+import ai.rever.boss.keymap.handler.KeymapMatcher
+import ai.rever.boss.keymap.model.KeyBinding
+import ai.rever.boss.keymap.model.KeymapActions
+import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.keymap.presets.KeymapPresets
+import ai.rever.boss.ui.sdk.WidgetEvent
+import ai.rever.boss.utils.SystemUtils
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
+import java.awt.event.KeyEvent as AwtKeyEvent
+
+/**
+ * The key-routing policy: **the host keymap wins, and the plugin gets what is left.**
+ *
+ * #34 deferred `key` emission for want of exactly this decision. The risk it was guarding against is
+ * specific — an out-of-process plugin that can swallow `Cmd+W` traps the user in a panel it also
+ * controls — so these tests are about what is *refused* at least as much as what is delivered.
+ *
+ * Three separate things make a host shortcut safe, and this file asserts the two that are decidable
+ * without AWT:
+ *
+ * 1. `AWTKeyboardInterceptor` consumes claimed keys at the `KeyboardFocusManager`, upstream of Compose
+ *    entirely — structural, and not something a unit test can meaningfully re-check.
+ * 2. The forwarding rule refuses anything the live keymap binds, so the guarantee does not rest on
+ *    dispatch order alone. **Here.**
+ * 3. The tap never consumes — asserted in [RemoteSurfaceInputComposeTest], against a real composition,
+ *    since "the key carried on past the surface" is a statement about a modifier chain.
+ *
+ * Events are built with Compose's own `KeyEvent(...)` factory, which is `@InternalComposeUiApi`. The
+ * alternative — driving keys through a composition — is what [RemoteSurfaceInputComposeTest] does; what
+ * is wanted *here* is to sweep the whole shipped preset in one cheap pass, which needs synthetic events.
+ * If a Compose upgrade removes the factory this fails to compile, which is the right failure.
+ */
+@OptIn(InternalComposeUiApi::class)
+class RemoteSurfaceKeyRoutingTest {
+    @Test
+    fun `a real host shortcut from the shipped preset is claimed by the host and never forwarded`() {
+        // Taken from the preset rather than hardcoded, so the test still means "a real shortcut" after
+        // someone rebinds Cmd+T. Both halves are asserted: the host still matches it (the shortcut
+        // fires), and the surface refuses it (it is not *also* handed to the plugin).
+        val preset = KeymapPresets.getBOSSDefault()
+        val newTab = preset.shortcuts[KeymapActions.TAB_NEW]
+        val binding = assertNotNull(newTab, "the shipped preset must bind ${KeymapActions.TAB_NEW}")
+        val event = binding.asKeyDown()
+
+        assertNotNull(
+            KeymapMatcher(preset).match(event, ShortcutContext.GLOBAL),
+            "the host keymap must still claim ${binding.displayString()} — otherwise this asserts nothing",
+        )
+        assertNull(
+            event.toForwardedKey(preset),
+            "a key the host keymap claims must not also reach the plugin",
+        )
+    }
+
+    @Test
+    fun `every single-key global binding in the shipped preset is refused`() {
+        // One binding proves the rule is wired; the whole preset proves there is no shortcut-shaped hole
+        // in it. Cheap, and it is the assertion that catches a matcher regression rather than a wiring
+        // one. Restricted to single-character keys because that is the set [asKeyDown] can synthesise
+        // faithfully — "Tab" and "Left" have no char to derive a VK_ code from.
+        val preset = KeymapPresets.getBOSSDefault()
+        val forwarded =
+            preset.shortcuts.values
+                .filter { it.enabled && it.context == ShortcutContext.GLOBAL && it.key.length == 1 }
+                .filter { it.asKeyDown().toForwardedKey(preset) != null }
+                .map { it.actionId }
+
+        assertEquals(emptyList<String>(), forwarded, "no host shortcut may be forwarded to a plugin")
+    }
+
+    @Test
+    fun `a chord the host does not bind is forwarded with its key code and modifiers intact`() {
+        // The payload is the point: #48 replaced a (type, data) string pair precisely because it could
+        // not carry a key's modifiers, so "it arrived" is not enough — it has to arrive whole.
+        val keymap = onlyBinding(key = "T")
+
+        val forwarded =
+            keyDown(AwtKeyEvent.VK_K, meta = true, shift = true, alt = true, ctrl = true)
+                .toForwardedKey(keymap)
+
+        assertEquals(
+            WidgetEvent.Key(keyCode = AwtKeyEvent.VK_K, ctrl = true, alt = true, shift = true, meta = true),
+            forwarded,
+        )
+    }
+
+    @Test
+    fun `an unmodified key press is forwarded`() {
+        // The AWT interceptor never even looks at these — it returns early unless Meta, Ctrl or Alt is
+        // down — so a plain Escape or F5 can only ever reach a plugin through this path. Worth pinning:
+        // a stricter "modifiers required" rule would silently make the whole family useless for the keys
+        // plugins actually want.
+        val forwarded = keyDown(AwtKeyEvent.VK_ESCAPE).toForwardedKey(onlyBinding(key = "T"))
+
+        assertEquals(WidgetEvent.Key(keyCode = AwtKeyEvent.VK_ESCAPE), forwarded)
+    }
+
+    @Test
+    fun `a key release is not forwarded`() {
+        // ui_protocol's KeyEvent has no up/down discriminator, so forwarding both edges delivers every
+        // press twice with nothing to tell them apart.
+        val release = keyEvent(AwtKeyEvent.VK_ESCAPE, KeyEventType.KeyUp)
+
+        assertNull(release.toForwardedKey(onlyBinding(key = "T")))
+    }
+
+    @Test
+    fun `a modifier pressed on its own is not forwarded`() {
+        // Found by the Compose test, not by reading: holding Shift to type a capital letter delivered a
+        // bare VK_SHIFT ahead of the letter, so a plugin saw two events for one keystroke. The modifier
+        // is not lost — it rides on the key it qualifies, which is the only shape the wire type has.
+        val keymap = onlyBinding(key = "T")
+        val modifiers = listOf(AwtKeyEvent.VK_SHIFT, AwtKeyEvent.VK_CONTROL, AwtKeyEvent.VK_ALT, AwtKeyEvent.VK_META)
+
+        val forwarded = modifiers.filter { keyDown(it).toForwardedKey(keymap) != null }
+
+        assertEquals(emptyList<Int>(), forwarded, "a modifier alone is not a key press a plugin can use")
+    }
+
+    @Test
+    fun `a binding the user disabled is forwarded again`() {
+        // Disabling a shortcut hands the key back to the app. The plugin is part of the app, so it should
+        // get it — and this is the case that fails if the check asks "is this chord in the keymap" rather
+        // than "would the keymap act on it".
+        val enabled = onlyBinding(key = "T")
+        val disabled = enabled.copy(shortcuts = enabled.shortcuts.mapValues { (_, b) -> b.copy(enabled = false) })
+        val event = keyDown(AwtKeyEvent.VK_T, primary = true)
+
+        assertNull(event.toForwardedKey(enabled), "enabled, the host claims it")
+        assertNotNull(event.toForwardedKey(disabled), "disabled, the host does not act on it — the plugin may have it")
+    }
+
+    /**
+     * A keymap with exactly one GLOBAL binding on [key] plus the platform's primary modifier.
+     *
+     * Built rather than loaded so the assertions do not depend on whatever `~/.boss/keymap-settings.json`
+     * the suite happens to run beside — `KeymapSettingsManager` reads the real user file on class init.
+     */
+    private fun onlyBinding(key: String): KeymapSettings {
+        val binding =
+            KeyBinding(
+                actionId = "test.action",
+                key = key,
+                modifiers = listOf("Cmd"),
+                context = ShortcutContext.GLOBAL,
+            )
+        return KeymapSettings(shortcuts = mapOf(binding.actionId to binding))
+    }
+
+    /**
+     * The key-down event a user produces by typing this binding.
+     *
+     * Only the primary keystroke and only the modifiers `KeymapMatcher` distinguishes; a binding whose
+     * key name the AWT table below does not know is skipped by returning an event that matches nothing,
+     * which the preset-wide test tolerates because it asserts a *refusal*.
+     */
+    private fun KeyBinding.asKeyDown(): ComposeKeyEvent {
+        val mods = modifiers.map { it.lowercase() }
+        return keyDown(
+            keyCode = AwtKeyEvent.getExtendedKeyCodeForChar(key.first().code),
+            primary = mods.any { it == "cmd" || it == "meta" },
+            ctrl = mods.any { it == "ctrl" || it == "control" },
+            shift = mods.any { it == "shift" },
+            alt = mods.any { it == "alt" || it == "option" },
+        )
+    }
+
+    /**
+     * A key-down event.
+     *
+     * @param primary the platform's "Cmd" modifier. `KeymapMatcher` is platform-aware — a binding on
+     *   `Cmd` matches Meta on macOS and Ctrl everywhere else — so a test that hardcoded one of them
+     *   would assert the opposite thing on the other two CI runners.
+     */
+    private fun keyDown(
+        keyCode: Int,
+        primary: Boolean = false,
+        meta: Boolean = false,
+        ctrl: Boolean = false,
+        shift: Boolean = false,
+        alt: Boolean = false,
+    ): ComposeKeyEvent =
+        keyEvent(
+            keyCode = keyCode,
+            type = KeyEventType.KeyDown,
+            meta = meta || (primary && SystemUtils.isMacOS),
+            ctrl = ctrl || (primary && !SystemUtils.isMacOS),
+            shift = shift,
+            alt = alt,
+        )
+
+    private fun keyEvent(
+        keyCode: Int,
+        type: KeyEventType,
+        meta: Boolean = false,
+        ctrl: Boolean = false,
+        shift: Boolean = false,
+        alt: Boolean = false,
+    ): ComposeKeyEvent =
+        ComposeKeyEvent(
+            key = Key(nativeKeyCode = keyCode),
+            type = type,
+            isMetaPressed = meta,
+            isCtrlPressed = ctrl,
+            isShiftPressed = shift,
+            isAltPressed = alt,
+        )
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceKeyRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceKeyRoutingTest.kt
@@ -67,11 +67,14 @@ class RemoteSurfaceKeyRoutingTest {
         // One binding proves the rule is wired; the whole preset proves there is no shortcut-shaped hole
         // in it. Cheap, and it is the assertion that catches a matcher regression rather than a wiring
         // one. Restricted to single-character keys because that is the set [asKeyDown] can synthesise
-        // faithfully — "Tab" and "Left" have no char to derive a VK_ code from.
+        // faithfully — "Tab" and "Left" have no char to derive a VK_ code from — and to bindings with a
+        // system modifier, which are the ones the host actually dispatches; the rest are covered by the
+        // Shift+/ test above, which asserts the opposite.
         val preset = KeymapPresets.getBOSSDefault()
         val forwarded =
             preset.shortcuts.values
                 .filter { it.enabled && it.context == ShortcutContext.GLOBAL && it.key.length == 1 }
+                .filter { KeymapMatcher(preset).hasSystemModifier(it) }
                 .filter { it.asKeyDown().toForwardedKey(KeymapMatcher(preset)) != null }
                 .map { it.actionId }
 
@@ -112,6 +115,26 @@ class RemoteSurfaceKeyRoutingTest {
         val release = keyEvent(AwtKeyEvent.VK_ESCAPE, KeyEventType.KeyUp)
 
         assertNull(release.toForwardedKey(onlyBinding(key = "T")))
+    }
+
+    @Test
+    fun `a bound key the host would never dispatch is still forwarded`() {
+        // The bug review caught. AWTKeyboardInterceptor returns before it consults the keymap unless
+        // Meta, Ctrl or Alt is down, so a binding with no system modifier is never dispatched — and
+        // refusing it here too made the key vanish, claimed by neither side. The shipped preset really
+        // has one: Shift+/ opens the shortcut sheet, so `?` on a focused remote surface did nothing.
+        val preset = KeymapPresets.getBOSSDefault()
+        val help = preset.shortcuts[KeymapActions.HELP_SHORTCUTS]
+        val binding = assertNotNull(help, "the preset must bind ${KeymapActions.HELP_SHORTCUTS}")
+        assertEquals(listOf("Shift"), binding.modifiers, "this test is about the modifier-less case")
+        val matcher = KeymapMatcher(preset)
+        val event = keyDown(AwtKeyEvent.VK_SLASH, shift = true)
+
+        assertNotNull(matcher.match(event, ShortcutContext.GLOBAL), "the keymap does match it")
+        assertNotNull(
+            event.toForwardedKey(matcher),
+            "…but the host never dispatches it, so declining to forward it would lose the key entirely",
+        )
     }
 
     @Test
@@ -162,9 +185,10 @@ class RemoteSurfaceKeyRoutingTest {
     /**
      * The key-down event a user produces by typing this binding.
      *
-     * Only the primary keystroke and only the modifiers `KeymapMatcher` distinguishes; a binding whose
-     * key name the AWT table below does not know is skipped by returning an event that matches nothing,
-     * which the preset-wide test tolerates because it asserts a *refusal*.
+     * Only the primary keystroke and only the modifiers `KeymapMatcher` distinguishes. A binding whose
+     * key name has no single char to derive a `VK_` code from would synthesise an event matching nothing
+     * — which would *fail* the preset sweep rather than pass it, hence the `key.length == 1` filter
+     * there rather than a tolerance here.
      */
     private fun KeyBinding.asKeyDown(): ComposeKeyEvent {
         val mods = modifiers.map { it.lowercase() }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceKeyRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteSurfaceKeyRoutingTest.kt
@@ -57,7 +57,7 @@ class RemoteSurfaceKeyRoutingTest {
             "the host keymap must still claim ${binding.displayString()} — otherwise this asserts nothing",
         )
         assertNull(
-            event.toForwardedKey(preset),
+            event.toForwardedKey(KeymapMatcher(preset)),
             "a key the host keymap claims must not also reach the plugin",
         )
     }
@@ -72,7 +72,7 @@ class RemoteSurfaceKeyRoutingTest {
         val forwarded =
             preset.shortcuts.values
                 .filter { it.enabled && it.context == ShortcutContext.GLOBAL && it.key.length == 1 }
-                .filter { it.asKeyDown().toForwardedKey(preset) != null }
+                .filter { it.asKeyDown().toForwardedKey(KeymapMatcher(preset)) != null }
                 .map { it.actionId }
 
         assertEquals(emptyList<String>(), forwarded, "no host shortcut may be forwarded to a plugin")
@@ -132,8 +132,10 @@ class RemoteSurfaceKeyRoutingTest {
         // Disabling a shortcut hands the key back to the app. The plugin is part of the app, so it should
         // get it — and this is the case that fails if the check asks "is this chord in the keymap" rather
         // than "would the keymap act on it".
-        val enabled = onlyBinding(key = "T")
-        val disabled = enabled.copy(shortcuts = enabled.shortcuts.mapValues { (_, b) -> b.copy(enabled = false) })
+        val binding = KeyBinding(actionId = "test.action", key = "T", modifiers = listOf("Cmd"))
+        val enabled = KeymapMatcher(KeymapSettings(shortcuts = mapOf(binding.actionId to binding)))
+        val off = binding.copy(enabled = false)
+        val disabled = KeymapMatcher(KeymapSettings(shortcuts = mapOf(off.actionId to off)))
         val event = keyDown(AwtKeyEvent.VK_T, primary = true)
 
         assertNull(event.toForwardedKey(enabled), "enabled, the host claims it")
@@ -141,12 +143,12 @@ class RemoteSurfaceKeyRoutingTest {
     }
 
     /**
-     * A keymap with exactly one GLOBAL binding on [key] plus the platform's primary modifier.
+     * A matcher over exactly one GLOBAL binding on [key] plus the platform's primary modifier.
      *
      * Built rather than loaded so the assertions do not depend on whatever `~/.boss/keymap-settings.json`
      * the suite happens to run beside — `KeymapSettingsManager` reads the real user file on class init.
      */
-    private fun onlyBinding(key: String): KeymapSettings {
+    private fun onlyBinding(key: String): KeymapMatcher {
         val binding =
             KeyBinding(
                 actionId = "test.action",
@@ -154,7 +156,7 @@ class RemoteSurfaceKeyRoutingTest {
                 modifiers = listOf("Cmd"),
                 context = ShortcutContext.GLOBAL,
             )
-        return KeymapSettings(shortcuts = mapOf(binding.actionId to binding))
+        return KeymapMatcher(KeymapSettings(shortcuts = mapOf(binding.actionId to binding)))
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRendererComposeTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -215,7 +216,18 @@ class RemoteWidgetRendererComposeTest {
             assertTrue(runBlocking { plugin.registerUI(registration).success })
 
             val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
-            val events = pluginScope.async { plugin.streamUI(updates.consumeAsFlow()).take(1).toList() }
+            // Filtered to clicks, not `take(1)`. The rendezvous now announces `created` the moment this
+            // stream binds under the already-attached panel, so the first event on the wire is a
+            // lifecycle one — and `take(1)` cancels the RPC, which would tear the surface down before
+            // the click was made. Any consumer that reads "the first event" has to allow for that.
+            val events =
+                pluginScope.async {
+                    plugin
+                        .streamUI(updates.consumeAsFlow())
+                        .filter { it.hasClick() }
+                        .take(1)
+                        .toList()
+                }
             val fullTree =
                 WidgetUpdate
                     .newBuilder()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycleTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycleTest.kt
@@ -25,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -172,6 +173,35 @@ class RemoteUiLifecycleTest {
         registry.closeStream(surface)
 
         assertEquals(listOf(LifecycleStates.CREATED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `a created that could not be queued does not leave the surface owing a destroyed`() {
+        // The latch is what makes the pair symmetric, so a failed emit must roll it back rather than
+        // leave the surface owing a `destroyed` for a `created` no plugin ever saw. Unreachable through
+        // the registry today — `emit` fails only on a closed surface, which would fail the `destroyed`
+        // too — so the invariant currently rests on the overflow policy of a channel in another file.
+        // Asserted directly instead.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        surface.close()
+
+        assertFalse(RemoteUiLifecycle.announceCreated(surface), "a closed surface cannot be announced")
+        assertFalse(surface.createdAnnounced.get(), "the latch must not stay set for an event nobody got")
+    }
+
+    @Test
+    fun `kernel shutdown announces destroyed to every rendered surface`() {
+        // clear() runs on kernel shutdown while plugin streams may still be up, and it closes surfaces
+        // by the same before-close ordering as unregister. Claimed in three separate comments and, until
+        // this test, asserted nowhere — which for a file whose value is that the pairing is *checked*
+        // rather than intended was the obvious hole.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.attach(SURFACE, RecordingHost())
+
+        registry.clear()
+
+        assertEquals(listOf(LifecycleStates.CREATED, LifecycleStates.DESTROYED), surface.lifecycleStates())
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycleTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycleTest.kt
@@ -22,7 +22,9 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -176,6 +178,59 @@ class RemoteUiLifecycleTest {
     }
 
     @Test
+    fun `unregister announces destroyed directly, not only over the transport`() {
+        // The gRPC test proves it reaches a plugin; this localises a regression to the registry instead
+        // of leaving the transport test as the only witness.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.attach(SURFACE, RecordingHost())
+
+        assertTrue(registry.unregister(SURFACE))
+
+        assertEquals(listOf(LifecycleStates.CREATED, LifecycleStates.DESTROYED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `attach and openStream racing still announce created exactly once`() {
+        // The claim the whole rendezvous rests on, and the one every other test here drives on a single
+        // thread: `attach` writes into `hosts` then reads `streaming`, `openStream` sets `streaming` then
+        // reads `hosts`, so whichever runs second sees the other's write. That is a Dekker-shaped
+        // argument about visibility, correct only because ConcurrentHashMap mutations and AtomicBoolean
+        // accesses are synchronization actions — i.e. exactly the kind of reasoning that deserves to be
+        // executed rather than believed. Released together, repeatedly, asserting exactly one `created`.
+        //
+        // Honest about its reach: this catches a DOUBLE announce reliably, and it exercises the real
+        // concurrent path. It does not reliably catch the reverse — inverting attach() to read
+        // `streaming` before publishing its host leaves it green, because the losing interleaving needs
+        // both reads to precede both writes and a barrier cannot make that window wide enough. The
+        // ordering still has to be read to be trusted; this only stops it regressing loudly.
+        repeat(RACE_ROUNDS) { round ->
+            val id = "$SURFACE-$round"
+            val isolated = RemoteUiSurfaceRegistry()
+            val surface = isolated.register(id, PROCESS).accepted()
+            val barrier = CyclicBarrier(2)
+            val threads =
+                listOf(
+                    thread {
+                        barrier.await()
+                        isolated.attach(id, RecordingHost())
+                    },
+                    thread {
+                        barrier.await()
+                        isolated.openStream(id)
+                    },
+                )
+            threads.forEach { it.join() }
+
+            assertEquals(
+                listOf(LifecycleStates.CREATED),
+                surface.lifecycleStates(),
+                "round $round announced the wrong number of created events",
+            )
+        }
+    }
+
+    @Test
     fun `a created that could not be queued does not leave the surface owing a destroyed`() {
         // The latch is what makes the pair symmetric, so a failed emit must roll it back rather than
         // leave the surface owing a `destroyed` for a `created` no plugin ever saw. Unreachable through
@@ -318,5 +373,8 @@ class RemoteUiLifecycleTest {
         const val AWAIT_TIMEOUT_MS = 10_000L
         const val POLL_INTERVAL_MS = 5L
         const val SHUTDOWN_TIMEOUT_MS = 5_000L
+
+        /** Enough rounds to make a visibility gap show up, cheap enough to keep in the suite. */
+        const val RACE_ROUNDS = 2_000
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycleTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ui/RemoteUiLifecycleTest.kt
@@ -1,0 +1,292 @@
+package ai.rever.boss.kernel.ui
+
+import ai.rever.boss.ipc.proto.PluginUIServiceGrpcKt
+import ai.rever.boss.ipc.proto.UIEvent
+import ai.rever.boss.ipc.proto.UIRegistration
+import ai.rever.boss.ipc.proto.UIUnregistration
+import ai.rever.boss.ipc.proto.WidgetUpdate
+import ai.rever.boss.kernel.services.PluginUIServiceBridge
+import ai.rever.boss.ui.sdk.LifecycleStates
+import ai.rever.boss.ui.sdk.WidgetNode
+import ai.rever.boss.ui.sdk.WidgetProtoConverter.toProto
+import ai.rever.boss.ui.sdk.WidgetTree
+import ai.rever.boss.ui.sdk.WidgetType
+import io.grpc.ManagedChannelBuilder
+import io.grpc.ServerBuilder
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The surface lifecycle family, which #34 deferred entirely rather than ship half of.
+ *
+ * Its objection was precise: `created` is easy, `destroyed` "cannot be flushed" because the outgoing
+ * flow dies with the surface scope, and a create-without-destroy lifecycle is a worse footgun than no
+ * lifecycle at all. The first half of that is answered by ordering rather than by machinery — enqueue
+ * `destroyed` *before* closing the channel and Kotlin's graceful close delivers it — and the second
+ * half is answered by a latch, so the symmetry is a property of the code rather than a convention.
+ *
+ * These tests are therefore mostly about pairing: every ordering of attach, detach, stream and
+ * unregister, checked for exactly one `created` and at most one matching `destroyed`. The last test is
+ * the one #34 asked for by name — a plugin, over real gRPC, receiving `destroyed`.
+ */
+class RemoteUiLifecycleTest {
+    private val registry = RemoteUiSurfaceRegistry()
+
+    @Test
+    fun `a component attaching to a streaming surface announces created`() {
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        registry.attach(SURFACE, RecordingHost())
+
+        assertEquals(listOf(LifecycleStates.CREATED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `a stream binding under an attached component announces created`() {
+        // The other order, which is just as normal: the user opens the panel, and the plugin process
+        // comes up afterwards. Both halves have to be able to complete the rendezvous or the event is
+        // only delivered when the timing happens to suit.
+        registry.attach(SURFACE, RecordingHost())
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        assertEquals(listOf(LifecycleStates.CREATED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `half a surface announces nothing`() {
+        // A registered plugin with nowhere to draw, and a component with no plugin. Neither is "created":
+        // the event means the widgets are on screen, and in both cases they are not.
+        val unattached = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.attach(OTHER, RecordingHost())
+
+        assertEquals(emptyList(), unattached.lifecycleStates(), "a streaming surface nobody renders is not created")
+    }
+
+    @Test
+    fun `a registered surface with no stream is not created when a component attaches`() {
+        // RegisterUI has returned but StreamUI has not bound yet — there is no transport to deliver over,
+        // and the surface is not being rendered from either. Announcing here would emit into a queue that
+        // may never be drained.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+
+        registry.attach(SURFACE, RecordingHost())
+
+        assertEquals(emptyList(), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `created is announced exactly once however many times the halves are re-established`() {
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        val host = RecordingHost()
+
+        registry.attach(SURFACE, host)
+        registry.attach(SURFACE, host)
+        registry.attach(SURFACE, RecordingHost())
+
+        assertEquals(listOf(LifecycleStates.CREATED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `a component detaching announces destroyed to a plugin that is still there`() {
+        // The case worth having: the user closed the panel, the plugin is alive and reading, and it
+        // should stop doing work for a surface nobody is looking at.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+
+        registry.detach(SURFACE, host)
+
+        assertEquals(listOf(LifecycleStates.CREATED, LifecycleStates.DESTROYED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `a component that was already displaced cannot announce destroyed over its successor`() {
+        // detach is scoped to its owner. A component disposed late would otherwise tell a live plugin that
+        // the surface its *replacement* is rendering has gone away.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        val first = RecordingHost()
+        registry.attach(SURFACE, first)
+        registry.attach(SURFACE, RecordingHost())
+
+        registry.detach(SURFACE, first)
+
+        assertEquals(listOf(LifecycleStates.CREATED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `destroyed is never announced without a created`() {
+        // The asymmetry #34 called a footgun, made unreachable rather than merely avoided: the latch is a
+        // compare-and-set from true, so no ordering produces an unmatched teardown.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        val host = RecordingHost()
+        registry.attach(SURFACE, host)
+
+        registry.detach(SURFACE, host)
+        registry.unregister(SURFACE)
+
+        assertEquals(emptyList(), surface.lifecycleStates(), "the surface was never rendered, so nothing was destroyed")
+    }
+
+    @Test
+    fun `a plugin respawning under a live component is told created again`() {
+        // The new process never heard the first one. A latch that stayed set would leave a respawned
+        // plugin waiting for an event that had already been spent on its predecessor.
+        val first = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.attach(SURFACE, RecordingHost())
+        registry.closeStream(first)
+
+        val respawned = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+
+        assertEquals(listOf(LifecycleStates.CREATED), respawned.lifecycleStates())
+    }
+
+    @Test
+    fun `a dying stream announces nothing — destruction is inferred from the stream ending`() {
+        // The one path that genuinely cannot deliver, and the reason this family is documented as
+        // "a plugin that can be told, is told" rather than as a guarantee. There is no transport left.
+        val surface = registry.register(SURFACE, PROCESS).accepted()
+        assertIs<SurfaceStream.Bound>(registry.openStream(SURFACE))
+        registry.attach(SURFACE, RecordingHost())
+
+        registry.closeStream(surface)
+
+        assertEquals(listOf(LifecycleStates.CREATED), surface.lifecycleStates())
+    }
+
+    @Test
+    fun `a plugin over real gRPC receives created and then destroyed as its last event`() {
+        // What #34 asked to see before this family shipped. Nothing here is faked: a real server, the
+        // generated plugin-side stub, and a response flow whose completion is what ends the collection —
+        // so `destroyed` arriving *last* proves it was delivered before the channel closed rather than
+        // dropped by the teardown that closes it.
+        val server =
+            ServerBuilder
+                .forPort(0)
+                .addService(PluginUIServiceBridge(registry))
+                .build()
+                .start()
+        val channel = ManagedChannelBuilder.forAddress("localhost", server.port).usePlaintext().build()
+        val plugin = PluginUIServiceGrpcKt.PluginUIServiceCoroutineStub(channel)
+        try {
+            val received =
+                runBlocking {
+                    coroutineScope {
+                        assertTrue(plugin.registerUI(registration()).success)
+                        val updates = Channel<WidgetUpdate>(Channel.UNLIMITED)
+                        val events = async { plugin.streamUI(updates.consumeAsFlow()).toList() }
+                        updates.send(fullTree())
+
+                        // Bind first, then attach: the component arriving second is the ordering a user
+                        // produces by opening a panel a running plugin already registered.
+                        awaitTrue { registry.surfaceOf(SURFACE)?.streaming == true }
+                        registry.attach(SURFACE, RecordingHost())
+
+                        plugin.unregisterUI(UIUnregistration.newBuilder().setSurfaceId(SURFACE).build())
+                        withTimeout(AWAIT_TIMEOUT_MS) { events.await() }
+                    }
+                }
+
+            assertEquals(
+                listOf(LifecycleStates.CREATED, LifecycleStates.DESTROYED),
+                received.filter { it.hasLifecycle() }.map { it.lifecycle.lifecycleState },
+            )
+            assertTrue(received.last().hasLifecycle(), "destroyed must be the final event on the stream")
+            assertEquals("", received.last().targetNodeId, "a lifecycle event belongs to the surface, not a node")
+        } finally {
+            channel.shutdownNow()
+            channel.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            server.shutdownNow()
+            server.awaitTermination(SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    // ---- Helpers ----
+
+    /**
+     * Every lifecycle state queued for the plugin, in order.
+     *
+     * Closes the surface first, which seals the queue so the flow completes and the collection returns at
+     * once instead of waiting on a timeout. `close()` itself announces nothing — only the registry does,
+     * and always *before* closing — so sealing cannot manufacture the event under test.
+     */
+    private fun RemoteUiSurface.lifecycleStates(): List<String> =
+        runBlocking {
+            close()
+            withTimeout(AWAIT_TIMEOUT_MS) { events().toList() }
+                .filter { it.hasLifecycle() }
+                .map { it.lifecycle.lifecycleState }
+        }
+
+    private suspend fun awaitTrue(condition: () -> Boolean) {
+        withTimeout(AWAIT_TIMEOUT_MS) {
+            while (!condition()) {
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun SurfaceRegistration.accepted(): RemoteUiSurface = assertIs<SurfaceRegistration.Accepted>(this).surface
+
+    private fun registration(): UIRegistration =
+        UIRegistration
+            .newBuilder()
+            .setSurfaceId(SURFACE)
+            .setSurfaceType("panel")
+            .setProcessId(PROCESS)
+            .build()
+
+    private fun fullTree(): WidgetUpdate =
+        WidgetUpdate
+            .newBuilder()
+            .setSurfaceId(SURFACE)
+            .setFullTree(
+                WidgetTree(
+                    rootId = NODE,
+                    nodes = mapOf(NODE to WidgetNode(NODE, WidgetType.TEXT, mapOf("value" to "hello"))),
+                ).toProto(),
+            ).build()
+
+    private class RecordingHost : RemoteUiSurfaceHost {
+        val trees = CopyOnWriteArrayList<WidgetTree>()
+        val connections = CopyOnWriteArrayList<Boolean>()
+
+        override fun onTreeUpdated(tree: WidgetTree) {
+            trees += tree
+        }
+
+        override fun onConnectionChanged(connected: Boolean) {
+            connections += connected
+        }
+    }
+
+    private companion object {
+        const val SURFACE = "panel-1"
+        const val OTHER = "panel-2"
+        const val PROCESS = "plugin-a"
+        const val NODE = "node-1"
+        const val AWAIT_TIMEOUT_MS = 10_000L
+        const val POLL_INTERVAL_MS = 5L
+        const val SHUTDOWN_TIMEOUT_MS = 5_000L
+    }
+}

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -234,8 +234,10 @@ plugin as `UIEvent.key`. Three things bound that, and one thing does not:
   tap re-checks the keymap itself as a backstop, using `KeymapMatcher.hasSystemModifier` so it declines
   only keys the interceptor would actually have acted on. (Declining *everything* bound would lose keys
   the host never dispatches, such as `Shift+/`.)
-- **The focused widget gets first refusal.** `onKeyEvent` fires on the way up from the focus target, so
-  typing into a remote text field produces a text-change event, not a key per character.
+- **The focused widget gets first refusal.** `onKeyEvent` fires on the way *up* from the focus target,
+  so a widget that handles a key keeps it: typing into a remote text field produces a text-change event,
+  not a key per character. The boundary is consumption, though — keys a widget ignores still reach the
+  plugin while that surface has focus.
 - **The tap never consumes.** It always returns `false`, so a plugin cannot swallow a shortcut or trap
   the user in a panel.
 

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -223,3 +223,25 @@ Common issues:
 - **Stale settings file**: Delete `~/.boss/keymap-settings.json` and restart
 - **Conflicts**: Settings UI shows visual warnings for conflicting shortcuts
 - **Focus mode**: Settings window and shortcuts work in focus mode (fixed in Issue #74)
+
+## Remote plugin surfaces are keystroke sinks while focused
+
+A remote (out-of-process) plugin surface taps keys the host did not claim and forwards them to the
+plugin as `UIEvent.key`. Three things bound that, and one thing does not:
+
+- **The host keymap wins.** `AWTKeyboardInterceptor` runs at the `KeyboardFocusManager`, upstream of
+  Compose, and consumes what it dispatches — so a bound shortcut never reaches a plugin surface. The
+  tap re-checks the keymap itself as a backstop, using `KeymapMatcher.hasSystemModifier` so it declines
+  only keys the interceptor would actually have acted on. (Declining *everything* bound would lose keys
+  the host never dispatches, such as `Shift+/`.)
+- **The focused widget gets first refusal.** `onKeyEvent` fires on the way up from the focus target, so
+  typing into a remote text field produces a text-change event, not a key per character.
+- **The tap never consumes.** It always returns `false`, so a plugin cannot swallow a shortcut or trap
+  the user in a panel.
+
+**What is not bounded is which plugin may listen.** `Modifier.forwardUnclaimedKeys` ends in
+`.focusable()`, so a remote surface is a focus target in its own right — a surface made only of labels
+can still take focus and receive every unclaimed key-down, including plain typing when no widget inside
+it holds focus. There is no plugin capability model gating that today. The intended fix is a declared
+opt-in (a `wants_keys` flag on `UIRegistration`), which makes both the focus stop and the tap something
+a plugin asks for; it needs the same per-connection plugin identity as attributing `UnregisterUI`.

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -300,6 +300,12 @@ message KeyEvent {
 // about the middle of a fling in fewer, larger steps. One event per frame would be ~60 IPC messages
 // per second per scrolling node.
 //
+// The sum holds across one surface's continuous scroll reporting. Treat a surface teardown or a tree
+// update that replaces the scrolling node as a RESET of the accumulator: the host re-seeds its baseline
+// from wherever the new node starts, and a delta bridging the two would be meaningless.
+//
+// Units are layout pixels, not density-independent units.
+//
 // The JVM host currently reports these for WIDGET_TYPE_SCROLL nodes only, and vertically only, so
 // delta_x is always 0 there. WIDGET_TYPE_LIST does not yet report its own scrolling.
 message ScrollEvent {

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -278,6 +278,10 @@ message SelectionEvent {
 // Key DOWN only; there is no up/down discriminator here, so both edges would read as two presses. A
 // modifier pressed on its own is not sent — it arrives as a flag on the key it qualifies.
 // target_node_id is empty: no node claimed the press, so there is none to attribute it to.
+//
+// UNTHROTTLED, unlike ScrollEvent: a key held down produces one of these per OS auto-repeat tick
+// (~25-30/s). Plugins should not treat the rate as bounded, and should not do per-event work that
+// assumes it is.
 message KeyEvent {
   int32 key_code = 1;  // Platform key code (the AWT VK_ constant on the JVM host)
   bool ctrl = 2;
@@ -288,11 +292,16 @@ message KeyEvent {
 
 // A scroll movement, coalesced.
 //
-// Deltas, not positions, and the kernel throttles them: at most one event per ~60ms, with the
-// remainder always flushed when the gesture stops. The invariant a plugin may rely on is that the
-// deltas SUM to the total displacement — accumulate them and you are never out of step with the
-// screen, you just learn about the middle of a fling in fewer, larger steps. Sending one event per
-// frame would be ~60 IPC messages per second per scrolling surface.
+// Deltas, not positions. A conforming host coalesces them before they reach the transport — the
+// transport itself enforces nothing — to at most one event per ~60ms per scrolling NODE, with the
+// remainder always flushed when the gesture stops. A surface with several scroll containers therefore
+// produces that rate per container. The invariant a plugin may rely on is that the deltas SUM to the
+// total displacement: accumulate them and you are never out of step with the screen, you just learn
+// about the middle of a fling in fewer, larger steps. One event per frame would be ~60 IPC messages
+// per second per scrolling node.
+//
+// The JVM host currently reports these for WIDGET_TYPE_SCROLL nodes only, and vertically only, so
+// delta_x is always 0 there. WIDGET_TYPE_LIST does not yet report its own scrolling.
 message ScrollEvent {
   float delta_x = 1;
   float delta_y = 2;
@@ -309,9 +318,14 @@ message ToggleEvent {
 // A transition in the surface's RENDERED lifetime.
 //
 // "created" means a host renderer is attached and this stream is live — the widgets are on screen.
-// "destroyed" means that stopped being true. They are a matched pair: the kernel never sends
-// "destroyed" without having sent "created", and never sends either twice in a row. A plugin that
-// crashes and respawns under a component that stayed open is told "created" again.
+// "destroyed" means that stopped being true. They are enqueued as a matched pair: the kernel never
+// queues "destroyed" without having queued "created", and never queues either twice in a row. A
+// plugin that crashes and respawns under a component that stayed open is told "created" again.
+//
+// Pairing is guaranteed at enqueue, not at delivery. A plugin that stops reading its event stream long
+// enough for the kernel to start shedding (see the surface event buffer) can lose its "created", since
+// it is the oldest event on the queue, and then see a "destroyed" on its own. Handle an unmatched
+// "destroyed" as a teardown rather than as a protocol error.
 //
 // "destroyed" is delivered on every teardown that still has a transport (the component detaching,
 // the plugin's own UnregisterUI, kernel shutdown) and is enqueued BEFORE the stream closes, so it

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -272,8 +272,10 @@ message SelectionEvent {
 //
 // The kernel keymap always wins: a key bound to a host shortcut is consumed before the surface sees
 // it and is never forwarded, so a plugin cannot swallow a window/tab/split binding. What arrives here
-// is what the host declined AND the focused widget declined — typing into a text field produces
-// TextChangeEvent, not one KeyEvent per character.
+// is what the host declined AND the focused widget declined: events travel UP from the focus target,
+// so a widget that handles a key keeps it. Typing into a text field therefore produces TextChangeEvent
+// rather than one KeyEvent per character — but note the boundary is "the focused widget consumed it",
+// so keys a widget ignores (function keys, unhandled chords) do reach the plugin while it has focus.
 //
 // Key DOWN only; there is no up/down discriminator here, so both edges would read as two presses. A
 // modifier pressed on its own is not sent — it arrives as a flag on the key it qualifies.

--- a/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
+++ b/modules/boss-ipc/src/main/proto/boss/ipc/v1/ui_protocol.proto
@@ -268,14 +268,31 @@ message SelectionEvent {
   int32 selected_index = 2;
 }
 
+// A key press the surface received and nothing claimed.
+//
+// The kernel keymap always wins: a key bound to a host shortcut is consumed before the surface sees
+// it and is never forwarded, so a plugin cannot swallow a window/tab/split binding. What arrives here
+// is what the host declined AND the focused widget declined — typing into a text field produces
+// TextChangeEvent, not one KeyEvent per character.
+//
+// Key DOWN only; there is no up/down discriminator here, so both edges would read as two presses. A
+// modifier pressed on its own is not sent — it arrives as a flag on the key it qualifies.
+// target_node_id is empty: no node claimed the press, so there is none to attribute it to.
 message KeyEvent {
-  int32 key_code = 1;
+  int32 key_code = 1;  // Platform key code (the AWT VK_ constant on the JVM host)
   bool ctrl = 2;
   bool alt = 3;
   bool shift = 4;
   bool meta = 5;
 }
 
+// A scroll movement, coalesced.
+//
+// Deltas, not positions, and the kernel throttles them: at most one event per ~60ms, with the
+// remainder always flushed when the gesture stops. The invariant a plugin may rely on is that the
+// deltas SUM to the total displacement — accumulate them and you are never out of step with the
+// screen, you just learn about the middle of a fling in fewer, larger steps. Sending one event per
+// frame would be ~60 IPC messages per second per scrolling surface.
 message ScrollEvent {
   float delta_x = 1;
   float delta_y = 2;
@@ -289,6 +306,21 @@ message ToggleEvent {
   bool checked = 1;
 }
 
+// A transition in the surface's RENDERED lifetime.
+//
+// "created" means a host renderer is attached and this stream is live — the widgets are on screen.
+// "destroyed" means that stopped being true. They are a matched pair: the kernel never sends
+// "destroyed" without having sent "created", and never sends either twice in a row. A plugin that
+// crashes and respawns under a component that stayed open is told "created" again.
+//
+// "destroyed" is delivered on every teardown that still has a transport (the component detaching,
+// the plugin's own UnregisterUI, kernel shutdown) and is enqueued BEFORE the stream closes, so it
+// arrives as the last event. The one case it cannot be delivered is a stream that already died — a
+// crashed process — where the response stream simply completing is the notice.
+//
+// "resumed"/"paused" are reserved and not currently emitted. Unknown states must be ignored, not
+// rejected: the field stays a string so a newer kernel can add one without breaking older plugins.
+// target_node_id is empty — a lifecycle transition belongs to the surface, not to a node.
 message LifecycleEvent {
   string lifecycle_state = 1;  // "created", "resumed", "paused", "destroyed"
 }

--- a/modules/boss-ui-sdk/build.gradle.kts
+++ b/modules/boss-ui-sdk/build.gradle.kts
@@ -13,7 +13,9 @@ java {
 
 dependencies {
     implementation(project(":boss-ipc"))
-    implementation(libs.kotlinx.coroutines.core)
+    // api, not implementation: ScrollCoalescer.coalesce is typed on Flow in both directions, so a
+    // consumer of the published jar needs coroutines on its own compile classpath to call it.
+    api(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.kotlin.test.junit)

--- a/modules/boss-ui-sdk/build.gradle.kts
+++ b/modules/boss-ui-sdk/build.gradle.kts
@@ -17,4 +17,8 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.kotlin.test.junit)
+    // ScrollCoalescer's contract is "one event per window, and the resting position always arrives" —
+    // both are statements about time, so they are asserted on runTest's virtual clock rather than by
+    // sleeping and hoping.
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/ScrollCoalescer.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/ScrollCoalescer.kt
@@ -1,0 +1,94 @@
+package ai.rever.boss.ui.sdk
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flow
+
+/**
+ * A scroll container's absolute offset, in logical pixels.
+ *
+ * Absolute rather than a delta on purpose: `ScrollEvent` is a delta on the wire, but *deriving* those
+ * deltas from positions is what makes coalescing lossless. Two positions always yield the one delta
+ * between them however many frames were skipped, whereas dropping a delta destroys information that
+ * cannot be recovered.
+ */
+data class ScrollOffset(
+    val x: Float,
+    val y: Float,
+)
+
+/**
+ * Turns a scroll container's per-frame offset stream into the handful of `ScrollEvent`s worth putting
+ * on an IPC stream.
+ *
+ * `ui_protocol.proto` has carried `ScrollEvent` since the beginning and nothing ever raised one, for a
+ * concrete reason: a fling emits one offset per frame, so wiring a scroll position straight to the wire
+ * is one cross-process message every ~16ms for the duration of the gesture, per scrolling surface. That
+ * is the throttling policy #34 deferred this family for.
+ *
+ * ## The policy
+ *
+ * At most one event per [WINDOW_MS], **and the resting position always arrives**. Those are two
+ * requirements, and the second is the one that is easy to get wrong: the obvious throttle
+ * (`Flow.sample`) samples on a timer and simply does not emit the tail of a burst, so a fling leaves
+ * the plugin holding whatever offset happened to be current at the last tick — permanently wrong, with
+ * no later event to correct it, because a scroll that has stopped produces nothing more.
+ *
+ * ## How it holds
+ *
+ * [conflate] plus a [delay] in the collector, rather than a timer:
+ *
+ * - conflation keeps the **newest** pending offset and discards the ones it superseded, which is
+ *   exactly coalescing — and it cannot drop the last one, because the last one is by definition never
+ *   superseded;
+ * - the collector's `delay` is the window, and it is applied *after* emitting, so the first movement of
+ *   a gesture goes out immediately instead of waiting a frame budget;
+ * - upstream completion cannot outrun the collector: a conflated channel closes gracefully, so the
+ *   buffered value is delivered before the flow ends.
+ *
+ * The result is an invariant a test can hold onto, and a stronger one than "the last event arrives":
+ * **the emitted deltas sum to the total displacement**, always, whatever the burst shape. A plugin that
+ * accumulates them is never out of step with what the user sees — it just learns about the middle of a
+ * fling in fewer, larger steps.
+ *
+ * No timers, no shared mutable state across coroutines, and nothing to leak when the surface goes away:
+ * the flow is cold and dies with its collector.
+ */
+object ScrollCoalescer {
+    /**
+     * The coalescing window.
+     *
+     * ~4 frames at 60Hz. Small enough that a plugin driving a scrollbar or a "scrolled to bottom" check
+     * still feels live, large enough that a one-second fling costs ~16 messages instead of ~60.
+     */
+    const val WINDOW_MS: Long = 60L
+
+    /**
+     * Coalesce [offsets] into scroll deltas.
+     *
+     * The first offset seeds the baseline and produces **no** event: it is where the container already
+     * is, not a movement. An offset equal to the current baseline produces no event either, so a
+     * recomposition that re-reports the same position stays off the wire.
+     *
+     * @param windowMs minimum spacing between emissions. A parameter only so tests can pick a window
+     *   they can reason about; production uses [WINDOW_MS].
+     */
+    fun coalesce(
+        offsets: Flow<ScrollOffset>,
+        windowMs: Long = WINDOW_MS,
+    ): Flow<WidgetEvent.Scroll> =
+        flow {
+            var baseline: ScrollOffset? = null
+            offsets.conflate().collect { offset ->
+                val from = baseline
+                baseline = offset
+                if (from == null || from == offset) return@collect
+                emit(WidgetEvent.Scroll(deltaX = offset.x - from.x, deltaY = offset.y - from.y))
+                // After the emit, not before: the leading edge of a gesture is the part a plugin most
+                // wants promptly, and delaying first would add a window's latency to every scroll that
+                // is only one nudge long. While this suspends, upstream conflates into one pending value.
+                delay(windowMs)
+            }
+        }
+}

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/ScrollCoalescer.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/ScrollCoalescer.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.flow
 
 /**
- * A scroll container's absolute offset, in logical pixels.
+ * A scroll container's absolute offset, in **layout pixels** — Compose's `ScrollState.value`, not
+ * density-independent units. Stated because the Rust renderer mirrors this spec and the two differ on
+ * a HiDPI display.
  *
  * Absolute rather than a delta on purpose: `ScrollEvent` is a delta on the wire, but *deriving* those
  * deltas from positions is what makes coalescing lossless. Two positions always yield the one delta
@@ -48,9 +50,16 @@ data class ScrollOffset(
  *   buffered value is delivered before the flow ends.
  *
  * The result is an invariant a test can hold onto, and a stronger one than "the last event arrives":
- * **the emitted deltas sum to the total displacement**, always, whatever the burst shape. A plugin that
+ * **the emitted deltas sum to the total displacement**, whatever the burst shape. A plugin that
  * accumulates them is never out of step with what the user sees — it just learns about the middle of a
  * fling in fewer, larger steps.
+ *
+ * The invariant is scoped to **one continuous collection**, which is worth being exact about because in
+ * production the upstream never completes and the flow only ever ends by cancellation. A collector
+ * cancelled mid-window discards the pending offset, and a restart (a tree update replacing the node, so
+ * a fresh `ScrollState` at zero) silently re-seeds its baseline. Both are teardowns from the plugin's
+ * point of view, and the proto tells plugins to treat them as a reset rather than to keep accumulating
+ * across one.
  *
  * No timers, no shared mutable state across coroutines, and nothing to leak when the surface goes away:
  * the flow is cold and dies with its collector.

--- a/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetEvent.kt
+++ b/modules/boss-ui-sdk/src/main/kotlin/ai/rever/boss/ui/sdk/WidgetEvent.kt
@@ -31,7 +31,14 @@ sealed interface WidgetEvent {
         val index: Int,
     ) : WidgetEvent
 
-    /** A key press on a focused widget. [keyCode] is the platform key code. */
+    /**
+     * A key press the surface received and nothing claimed.
+     *
+     * Surface-level, so it carries an empty node id: it arrives *because* neither the host keymap nor
+     * the focused widget wanted it, which leaves no node to attribute it to. [keyCode] is the platform
+     * key code (the AWT `VK_` constant on the JVM host). Key **down** only — the wire type has no
+     * up/down discriminator, so both edges would read as two presses.
+     */
     data class Key(
         val keyCode: Int,
         val ctrl: Boolean = false,
@@ -72,8 +79,8 @@ object LifecycleStates {
 /**
  * A [WidgetEvent] tagged with the node that produced it.
  *
- * Surface-level events (lifecycle) carry an empty [nodeId] — they belong to the surface, not to a
- * node in its tree.
+ * Surface-level events ([WidgetEvent.Lifecycle], and [WidgetEvent.Key] once no widget has claimed the
+ * press) carry an empty [nodeId] — they belong to the surface, not to a node in its tree.
  */
 data class EmittedEvent(
     val nodeId: String,

--- a/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/ScrollCoalescerTest.kt
+++ b/modules/boss-ui-sdk/src/test/kotlin/ai/rever/boss/ui/sdk/ScrollCoalescerTest.kt
@@ -1,0 +1,156 @@
+package ai.rever.boss.ui.sdk
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The scroll throttling policy, on a virtual clock.
+ *
+ * `ScrollEvent` was in the proto from the start and emitted by nobody, because an unthrottled scroll is
+ * one IPC message per frame. Throttling is easy; throttling *without losing where the user ended up* is
+ * the part that is easy to get wrong, and it is the part these tests exist for — the standard throttle
+ * (`Flow.sample`) satisfies every "it coalesced" assertion and silently drops the tail of a fling,
+ * leaving the plugin permanently out of step with the screen and nothing later to correct it.
+ *
+ * So the invariant asserted throughout is the strong one: **the emitted deltas sum to the total
+ * displacement**. A plugin accumulating them is never wrong, only coarser.
+ */
+class ScrollCoalescerTest {
+    @Test
+    fun `the first offset seeds the baseline without reporting a scroll`() =
+        runTest {
+            // Where the container already is, not a movement. A surface that renders a scroll node and is
+            // never touched must put nothing on the wire.
+            val events = ScrollCoalescer.coalesce(offsetsOf(120f), WINDOW).toList()
+
+            assertEquals(emptyList(), events, "a single starting position is not a scroll")
+        }
+
+    @Test
+    fun `an offset that has not moved reports nothing`() =
+        runTest {
+            // snapshotFlow re-reports on recomposition; an unchanged position must not become traffic.
+            val events = ScrollCoalescer.coalesce(offsetsOf(0f, 0f, 0f), WINDOW).toList()
+
+            assertEquals(emptyList(), events, "a repeated position is not a scroll")
+        }
+
+    @Test
+    fun `the first movement is reported without waiting for the window`() =
+        runTest {
+            // Leading edge. A single nudge — a wheel click, a keyboard scroll — must not sit for a window
+            // before the plugin hears about it, which is why the window is applied after the emit and not
+            // before it. Sampled at emission, because collecting to a list also runs the trailing window.
+            val emittedAt = mutableListOf<Long>()
+
+            val events =
+                ScrollCoalescer
+                    .coalesce(offsetsOf(0f, 40f), WINDOW)
+                    .onEach { emittedAt += testScheduler.currentTime }
+                    .toList()
+
+            assertEquals(listOf(WidgetEvent.Scroll(0f, 40f)), events)
+            assertEquals(listOf(0L), emittedAt, "the leading edge must not be delayed by a window")
+        }
+
+    @Test
+    fun `a burst arriving faster than the window collapses into a couple of events`() =
+        runTest {
+            // The pathological shape: a hundred offsets with no gaps at all. Wired straight through, that
+            // is a hundred cross-process messages for one gesture.
+            val events = ScrollCoalescer.coalesce(offsetsOf(*ramp(101)), WINDOW).toList()
+
+            assertTrue(events.size <= 3, "a gapless burst must collapse, got ${events.size}: $events")
+            assertEquals(100f, events.totalY(), "no displacement may be lost to coalescing")
+        }
+
+    @Test
+    fun `a fling emits roughly one event per window and lands on the resting position`() =
+        runTest {
+            // 60 frames at ~60Hz: what a real fling looks like. Sixty messages unthrottled; the window is
+            // 60ms, so this should cost about a sixth of that.
+            val offsets =
+                flow {
+                    repeat(FRAMES) { frame ->
+                        emit(ScrollOffset(0f, frame.toFloat()))
+                        delay(FRAME_MS)
+                    }
+                }
+
+            val events = ScrollCoalescer.coalesce(offsets, WINDOW).toList()
+
+            val expectedWindows = FRAMES * FRAME_MS / WINDOW
+            assertTrue(events.size < FRAMES, "a fling must not produce one event per frame")
+            assertTrue(
+                events.size <= expectedWindows + 3,
+                "expected about $expectedWindows events for a $FRAMES-frame fling, got ${events.size}",
+            )
+            // The whole point. `sample()` passes both assertions above and fails this one, because the
+            // tail of the gesture never reaches a tick.
+            assertEquals(
+                (FRAMES - 1).toFloat(),
+                events.totalY(),
+                "the accumulated deltas must land the plugin exactly where the user stopped",
+            )
+        }
+
+    @Test
+    fun `a burst that stops mid-window still delivers its final position`() =
+        runTest {
+            // The specific regression, isolated: movement inside a window and then silence. Anything that
+            // waits for the next tick to publish never publishes, because a scroll that has stopped emits
+            // nothing more to trigger one.
+            val offsets =
+                flow {
+                    emit(ScrollOffset(0f, 0f))
+                    emit(ScrollOffset(0f, 10f))
+                    delay(WINDOW / 4)
+                    emit(ScrollOffset(0f, 11f))
+                    delay(WINDOW / 4)
+                    emit(ScrollOffset(0f, 12f))
+                    // …and the user lifts their fingers here, well inside the window.
+                }
+
+            val events = ScrollCoalescer.coalesce(offsets, WINDOW).toList()
+
+            assertEquals(
+                12f,
+                events.totalY(),
+                "the resting position must arrive even though the gesture ended mid-window",
+            )
+            assertEquals(
+                WidgetEvent.Scroll(0f, 2f),
+                events.last(),
+                "the trailing event carries exactly the movement the earlier ones did not",
+            )
+        }
+
+    @Test
+    fun `horizontal and vertical deltas are reported independently`() =
+        runTest {
+            val offsets = flowOf(ScrollOffset(0f, 0f), ScrollOffset(30f, -12f))
+
+            val events = ScrollCoalescer.coalesce(offsets, WINDOW).toList()
+
+            assertEquals(listOf(WidgetEvent.Scroll(30f, -12f)), events)
+        }
+
+    private fun offsetsOf(vararg y: Float) = flowOf(*y.map { ScrollOffset(0f, it) }.toTypedArray())
+
+    private fun ramp(count: Int): FloatArray = FloatArray(count) { it.toFloat() }
+
+    private fun List<WidgetEvent.Scroll>.totalY(): Float = sumOf { it.deltaY.toDouble() }.toFloat()
+
+    private companion object {
+        const val WINDOW = 60L
+        const val FRAME_MS = 16L
+        const val FRAMES = 60
+    }
+}


### PR DESCRIPTION
#48 mapped all eight `UIEvent` families onto the wire; #50 built the transport that carries them. Three families still had no emitter, each deferred in #34's own comment for a policy decision rather than for want of a few lines. This makes the three decisions, wires them up, and — because the transport now exists — verifies each one end to end rather than at the mapping layer.

## 1. `key` — the host keymap wins, the plugin gets what is left

**Where it hooks in:** a Compose `onKeyEvent` at the remote surface's root (`Modifier.forwardUnclaimedKeys`, wrapping the rendered tree in `RemoteWidgetRenderer`). **Nothing in `AWTKeyboardInterceptor` changed.**

That is the correct insertion point because the host keymap runs strictly upstream of it, at a different layer:

```kotlin
// AWTKeyboardInterceptor.install() — a KeyEventDispatcher on the KeyboardFocusManager
if (binding != null) {
    val handled = dispatchAction(binding.actionId, windowId)
    if (handled) {
        event.consume()
        return@KeyEventDispatcher true   // never delivered onward — Compose never sees it
    }
}
…
false // Let event propagate normally    ← this tap sits immediately after this line
```

A `KeyEventDispatcher` sees every key *before* AWT routes it to the focused component, so by the time a key reaches any Compose modifier the host keymap has already declined it. Three separate things then make a host shortcut safe, and only the second is code in this PR:

1. **Structural.** A claimed shortcut is consumed upstream and never enters this path. A hung plugin cannot even delay one.
2. **Explicit.** The tap re-checks the live keymap through `KeymapMatcher`, because the interceptor has early exits that skip matching entirely — an unregistered focused window returns before it consults the keymap. That makes "the host keymap wins" a property of the forwarding rule rather than an emergent property of dispatch order, and it is what makes the rule testable without driving AWT. It refuses only what the host **would actually dispatch**, via the shared `KeymapMatcher.hasSystemModifier`: the interceptor never gets as far as the keymap unless Meta/Ctrl/Alt is down, so refusing everything *bound* would lose a key like `Shift+/` (the shortcut sheet) to both sides. Review caught that one; there is now a regression test on it.
3. **The tap never consumes.** It always returns `false`. A plugin can *observe* what is left over; it can never claim it, and the key carries on to whatever the host has above the surface exactly as if the plugin were not there.

**Why not hook the interceptor itself**, which would be the other obvious answer: it cannot tell *which* remote surface has focus. It routes by AWT window, and placing a remote surface in a window is a separate open item I did not touch. Compose's own focus system answers that for free — and gets the full key set, where the interceptor only ever sees `KEY_PRESSED` with Meta/Ctrl/Alt down, so a plain Escape or arrow key could never reach a plugin through it.

Also decided, both mirroring the interceptor: **key down only** (the wire type has no up/down discriminator, so both edges read as two presses) and **no bare modifier presses** (holding Shift to type a capital would otherwise deliver `VK_SHIFT` ahead of the letter — this one was found by the Compose test, not by reading). Key events carry an **empty node id**: they reach the surface precisely because nothing claimed them, so attributing one would be a guess.

## 2. `scroll` — coalesced to ~60ms, resting position always delivered

`ScrollCoalescer` lives in `boss-ui-sdk`, following #48's rationale: the policy is testable without a UI toolkit and the Rust renderer has one spec to mirror. The implementation is `conflate()` plus a `delay` in the collector, not a timer:

- conflation keeps the **newest** pending offset and discards what it superseded — that *is* coalescing, and it cannot drop the last one, because the last one is by definition never superseded;
- the delay is applied **after** emitting, so the leading edge of a gesture goes out immediately instead of costing a window of latency;
- a conflated channel closes gracefully, so upstream completing cannot outrun the collector.

No timers, no state shared across coroutines, nothing to leak — the flow is cold and dies with its collector.

The invariant I actually assert is stronger than "the last event arrives": **the emitted deltas sum to the total displacement**, whatever the burst shape. A plugin accumulating them is never out of step with the screen, it just learns about the middle of a fling in fewer, larger steps. That framing matters because it is what rules out the standard throttle — `Flow.sample` passes every "it coalesced" assertion and silently drops the tail of a gesture, leaving the plugin permanently wrong with nothing later to correct it. A 60-frame fling goes from ~60 IPC messages to ~16.

## 3. `lifecycle` — `created`/`destroyed` as a matched pair, and `destroyed` really is delivered

#34's objection was that `destroyed` "cannot be flushed: the outgoing flow dies with the surface scope". True of a flush *after* teardown; not true of an ordinary send *before* one. `RemoteUiSurface.close()` calls `Channel.close()`, which is graceful — buffered elements are handed to the collector and *then* the flow completes. So enqueueing `destroyed` and immediately closing delivers it as the last event the plugin sees, with no drain phase and no new API. I took the better option the brief left open rather than the default.

**What the events mean:** the surface's *rendered* lifetime. `created` = "a host renderer is attached and your stream is live — your widgets are on screen"; `destroyed` = that stopped being true. That is the thing a plugin cannot work out for itself; "my process registered a surface" is something it already knows, having done it.

**Order-independent.** The two halves start independently, so the pair is announced by whichever completes the rendezvous — `attach` publishes into `hosts` *before* reading `streaming`, and `openStream` sets `streaming` *before* reading `hosts`, so neither ordering has a gap and a `compareAndSet` latch means both racing cannot double-announce. The latch re-arms on teardown, so a plugin that crashes and respawns under a component that never went away is told `created` again — the new process never heard the first one.

**Symmetry is enforced, not conventional.** `announceDestroyed` is a CAS *from* `true`, so no ordering of attach / detach / register / unregister / shutdown can produce an unmatched or doubled event. That is the footgun #34 named, made unreachable.

**Delivered on every path that still has a transport:** a component detaching (the plugin is alive and should stop working for a surface nobody is looking at), the plugin's own `UnregisterUI`, and kernel `clear()`. **The one path that cannot is a dead stream** (`closeStream` after a crash) — there is nothing to send over and nobody to receive it, and stream completion is the notice, exactly as #34 anticipated. So the guarantee is precise rather than absolute: *a plugin that can be told, is told*.

**And one limit, stated rather than papered over** (raised in review): the latch pairs the events *at enqueue*. Delivery belongs to the outgoing channel, which sheds its **oldest** entry when a plugin stops reading — and `created` is by construction the oldest thing a rendered surface ever queues. A plugin that falls far enough behind to shed its own first 256 events can lose it and later see an unmatched `destroyed`. Narrow, and self-announcing (`shedEventCount` is non-zero exactly when it is possible), so the proto and KDoc say so instead of claiming an absolute the transport cannot keep.

## Where the code went, and one constraint worth naming

`RemoteUiSurfaceRegistry` and `RemoteUiSurface` sit right at detekt's `TooManyFunctions` threshold, and adding even a private helper to either would have tripped it. Rather than baseline that, the lifecycle policy lives in its own `RemoteUiLifecycle` object called from the registry's existing function bodies (its only footprint on the surface is one `AtomicBoolean` field), and the Compose input glue lives in its own `RemoteSurfaceInput.kt` — which is where it belonged anyway.

`ui_protocol.proto` gains **comments only** — no message, field, number or type changed, so the wire format and the `1.0.0` IPC stamp are untouched and no plugin needs rebuilding. The comments document the emission contract (host-keymap precedence, down-only keys, the delta-sum invariant, the created/destroyed pairing and the one undeliverable case) so the Rust renderer and any runtime client have the same spec.

## Tested

**+35 tests, all executed, full suites green:**

```
:composeApp:desktopTest   1074 tests, 0 failures, 0 skipped   (78 classes; baseline 1046 / 75)
:boss-ui-sdk:test           82 tests, 0 failures              (7 classes;  baseline 75 / 6)
./gradlew detekt ktlintCheck    BUILD SUCCESSFUL — full repo, all modules
./gradlew … --rerun-tasks       BUILD SUCCESSFUL — 380/380 executed, nothing up-to-date
```

Baseline measured by stashing this branch and re-running, so the delta is real and no class silently stopped running.

- **`ScrollCoalescerTest` (7)** — on `runTest`'s virtual clock: the seed offset is not a scroll, an unchanged offset is not traffic, the leading edge is not delayed, a gapless 100-offset burst collapses to ≤3, a 60-frame fling lands on the exact resting position, and a gesture that **stops mid-window** still delivers its remainder.
- **`RemoteSurfaceKeyRoutingTest` (8)** — a real shortcut pulled from the shipped preset is both still claimed by the host *and* refused for forwarding (asserting only the refusal would pass vacuously); every single-key GLOBAL binding in the preset swept in one pass; payload intact with all four modifiers; key-up refused; bare modifiers refused; a *disabled* binding forwarded again; and a bound-but-never-dispatched binding (`Shift+/`) still forwarded, so the refusal cannot silently widen into "modifiers required".
- **`RemoteSurfaceInputComposeTest` (5)** — against a real composition: an unclaimed chord travelling up out of a focused text field to the surface queue with its modifiers; a bound chord swallowed while an unbound one in the same composition gets through (so "nothing arrived" cannot pass as success); **the surface never consuming** — a host handler above it still receives the key; **first refusal** — a key the focused widget consumes never reaches the plugin, which is what keeps ordinary typing off the wire; and a real `performScrollTo` producing a coalesced `ScrollEvent` on the wire.
- **`RemoteUiLifecycleTest` (15)** — both rendezvous orders, half a surface announcing nothing, exactly-once, detach-announces-destroyed, a displaced component unable to announce over its successor, no destroy without a create, respawn re-announcing, a dying stream announcing nothing, kernel shutdown announcing, a failed enqueue rolling the latch back — and **a plugin over real gRPC receiving `created` and then `destroyed` as the final event before its flow completes.**

### Mutation checks

Every new test was shown to fail under a deliberate break, with one documented exception. 25 mutations, each reverted and the suite re-verified green in between:

| # | Mutation | Killed |
|---|---|---|
| S1 | `conflate()`+`delay` → `Flow.sample(window)` | 5 scroll tests, incl. both resting-position ones |
| S2 | drop `conflate()` | 3 scroll tests (one event per frame) |
| S3 | `delay` before the emit instead of after | leading-edge test |
| S4a | drop the unchanged-offset guard | "an offset that has not moved reports nothing" |
| S4b | treat the seed offset as a movement from zero | "the first offset seeds the baseline" |
| M1 | drop the host-keymap refusal | 4 (3 routing + the Compose one) |
| M2 | tap returns `true` (consumes) | the anti-trap test, and only it |
| M3 | forward key-up too | key-release test |
| M4 | forward bare modifier presses | 3 |
| M5 | announce `destroyed` **after** `close()` (the un-flushable order #34 described) | the gRPC delivery test, and only it |
| M6 | drop the created/destroyed latch | 3 pairing tests |
| M7 | announce `created` for half a surface | 6 |
| M8 | renderer stops reporting scroll | the Compose scroll test |
| M9 | renderer stops tapping keys | the Compose key test |
| M10 | `attach` no longer completes the rendezvous | 6 |
| M11 | `openStream` no longer completes it | 2 |
| M12 | `detach` announces nothing | detach test |
| M13 | a dying stream announces `destroyed` | the inference test |
| M14 | drop the shift flag from the payload | 2 |
| M15 | require a modifier before forwarding | 2 |
| M16 | `clear()` announces nothing | the kernel-shutdown test |
| M17 | no latch rollback on a failed emit | the latch-rollback test |
| M18 | refuse every bound key, not just dispatchable ones | the `Shift+/` regression test |
| M19 | tap previews keys instead of bubbling (focused widget loses first refusal) | the first-refusal test |
| M20 | `attach` reads `streaming` before publishing its host | **nothing** — reported, see below |

M5 is the one worth reading: it reproduces exactly the failure mode #34 predicted, and exactly one test catches it.

**M20 is the honest failure.** The rendezvous race test (2000 rounds, `CyclicBarrier`) catches a *double* `created` reliably, but inverting `attach`'s read/write order — the exact gap the ordering exists to close — leaves it green, because the losing interleaving needs both reads to precede both writes and a barrier cannot widen that window. The limit is written into the test. The Dekker argument still has to be read to be trusted; the test stops it regressing loudly rather than proving it.

### One pre-existing test updated

`RemoteWidgetRendererComposeTest`'s gRPC round trip took `.take(1)` off the plugin's stream and asserted it was the click. Plugins now receive `created` first — and `take(1)` **cancels the RPC**, which tore the surface down mid-test. Filtered to clicks. Flagging it because it is a real contract change: any consumer that reads "the first event" has to allow for a lifecycle event preceding it.

### Platform exclusions

None needed. All three new test classes land under `**/plugin/remote/**` or `**/kernel/**`, already excluded from `desktopTest` on Windows ARM64 by #43/#50, and `boss-ui-sdk` is excluded from that build entirely.

## What remains open on #34

`Refs #34`, not `Fixes` — deliberately, though item 8 itself is now complete. All eight items are done (1–7 in #48; item 8's wire mapping in #48, its transport in #50, its `key`/`scroll`/`lifecycle` emission here). What keeps the issue worth leaving open is that **nothing in the host constructs a `RemotePanelComponent` or `RemoteTabComponent` yet**, so no remote surface is placed in a window: every path in this PR is exercisable and tested, but not yet reachable by a user. Two known follow-ups, both flagged as being handled separately:

- **Surface placement** — `RemoteUiSurfaceDescriptor` already carries `surface_type`, `default_slot`, name and icon for it.
- **Plugin-identity `ServerInterceptor`** — `UnregisterUI` still carries no attribution, so any connected plugin can tear down another's surface. Not fixable in the body of the request; it needs per-connection identity. **Review added a second item with the same root cause:** nothing gates *which* plugin may observe keystrokes. The host-keymap refusal protects the host, not the user — while a remote surface has focus, every unclaimed key is streamed to an out-of-process plugin, and no capability model in the tree can currently gate it. The right shape is a `wants_keys` flag on `UIRegistration`/`RemoteUiSurfaceDescriptor` making both the focus stop and the tap opt-in, which is a proto field change and so belongs with the identity work.
- **#52 — `AWTKeyboardInterceptor.findMatchingBinding` ignores its `KeymapMatcher`** and reimplements matching without normalizing binding key names, so `Cmd+DirectionLeft` (`PANEL_NAVIGATE_*`), `Ctrl+Space` (`QUICK_SWITCHER_OPEN`) and anything bound as `Return`/`Escape`/`-`/`=`/`/` never fire. Found by review while checking this PR's claims. Those keys are already dead app-wide; this PR's tap only stops them falling through to a plugin instead. Fixed where the bug is, because delegating would start dispatching `Cmd+←` for the first time — a user-visible host-keyboard change that does not belong in a remote-UI PR.
- **`WIDGET_TYPE_LIST` does not report scroll.** `LazyListState` exposes index + intra-item offset, not a global pixel offset, so the delta-sum invariant that makes the coalescer safe does not survive the translation — and a virtualized list driving pagination is the canonical scroll consumer. Documented in the proto; wants its own change rather than an approximation on a published contract.

Close #34 on merge if you would rather track those two on their own issues — item 8 is finished either way.

One judgement call I did not make unilaterally: `Modifier.forwardUnclaimedKeys` ends in `.focusable()`, so a remote surface is a focus target in its own right and can receive keys even when it holds no focusable widget. Without it the family is vacuous for a surface made of labels; with it, the surface is one extra Tab stop — and, as review pointed out, a surface made entirely of labels becomes a Tab stop that quietly starts streaming keystrokes. It costs nothing to drop if you would rather placement (or the `wants_keys` flag above) decide focus policy.

---

**Round 2** (`edbe32b6`) addresses the first review's six findings: the lifecycle contract reworded to be true rather than absolute, the latch rollback fixed and asserted, the `KeymapMatcher` hoisted out of the per-keystroke path (it was being rebuilt ~25-30×/s on the Compose UI thread for a held key), `clear()`'s announcement tested, and the proto corrected on key throttling, per-node scroll rate, which widgets report scroll, and the throttle being a host obligation rather than a transport guarantee. **Round 3** (`c8dcf76c`) fixes a real defect the second review found — the tap refused every *bound* key rather than every *dispatchable* one, so `Shift+/` was lost to both sides — plus the scroll invariant scoped to one collection, `ScrollOffset` units stated as layout pixels, `rememberUpdatedState` for the scroll sink, and a `docs/KEYBOARD_SHORTCUTS.md` note that a focused remote surface is a keystroke sink. **Round 4** (`654c9abe`) adds the first-refusal assertion the privacy claim was missing — the first attempt at it was vacuous and the mutation check said so — plus a `ShortcutContext` seam for placement, one monitor over both latch transitions, and an honest note that the tap and the interceptor are two implementations of "is this bound" that can drift. **Round 5** (`83ae36cd`) threads the `context` parameter that round 4 documented but did not add, and replaces the KDoc's "the two matchers can drift" with the list of shipped bindings on which they already do — filed as #52. Full replies in the PR comments.

**Resolved:** `.focusable()` is **dropped** (round 6). Two independent reviews argued for it and the asymmetry decides it — granting keystrokes later behind a declared `wants_keys` on `UIRegistration` is additive, revoking them after a plugin ships against the default is a negotiation. A surface now receives keys only once something inside it holds focus, which is every surface built for interaction and none of the label-only ones. Trivially restorable if you disagree.
