### PR TITLE
fix(passkey): revoke create_mobile_registration_session from PUBLIC

### DIFF
--- a/supabase/migrations/20260728000000_revoke_registration_session_rpc_from_public.sql
+++ b/supabase/migrations/20260728000000_revoke_registration_session_rpc_from_public.sql
@@ -1,0 +1,25 @@
+-- Close the anon-reachable path to create_mobile_registration_session that
+-- 20260727000000 missed.
+--
+-- That migration revoked EXECUTE from "anon" and "authenticated", which is not
+-- sufficient: PostgreSQL grants EXECUTE on a function to PUBLIC by default when
+-- the function is created, and both roles inherit it from there. Verified
+-- against production after 20260727000000 was applied — an anon-key POST to
+-- /rest/v1/rpc/create_mobile_registration_session still reached the function
+-- body and returned its own "User not found or email not confirmed" error,
+-- proving execution rather than denial.
+--
+-- The function is SECURITY DEFINER and mints a registration challenge bound to
+-- any account it can find by email, with a caller-supplied challenge value, so
+-- anon reachability is an account-takeover path: /register/complete derives the
+-- enrolling user from the challenge row.
+--
+-- service_role keeps its explicit grant from 20251023000014 and is unaffected
+-- by a PUBLIC revoke. The function has no callers in the repo; the shipped flow
+-- uses the passkey Edge Function's POST /register/challenge, which requires a
+-- verified session.
+
+REVOKE ALL ON FUNCTION "public"."create_mobile_registration_session"("p_user_email" "text", "p_challenge" "text", "p_session_id" "text") FROM PUBLIC;
+
+-- Re-assert the intended grant so the end state is explicit rather than implied.
+GRANT EXECUTE ON FUNCTION "public"."create_mobile_registration_session"("p_user_email" "text", "p_challenge" "text", "p_session_id" "text") TO "service_role";


### PR DESCRIPTION
Follow-up to #46. **The revoke in that PR did not close the path** — found by probing production after deploying it.

## What was wrong

`20260727000000` revoked `EXECUTE` from `anon` and `authenticated`. That is not sufficient: PostgreSQL grants `EXECUTE` on a function to **PUBLIC** by default at creation time, and both roles inherit it from there. Revoking the named roles leaves the PUBLIC grant intact.

## How it was verified

After `20260727000000` was applied to production, an anon-key request still **executed** the function:

```
POST /rest/v1/rpc/create_mobile_registration_session   (apikey: anon)
→ HTTP 400  {"code":"P0001","message":"User not found or email not confirmed: probe@example.com"}
```

That error comes from inside the function body, so the call was permitted. After this migration:

```
→ HTTP 401  {"code":"42501","message":"permission denied for function create_mobile_registration_session"}
```

## Why it matters

The function is `SECURITY DEFINER`, looks a user up by email, and inserts a `registration` challenge bound to them with a caller-supplied challenge value. `/register/complete` derives the enrolling user from the challenge row, so anon reachability was a second route to the same account-takeover #46 set out to close — and it would have made #46's edge-function auth cosmetic.

`service_role` keeps its explicit grant from `20251023000014` and is unaffected by a PUBLIC revoke. The function has no callers in the repo.

## Deployment state

**Already applied to production** (`20260728000000`), because #46 had just been deployed and this left the hole open. This PR brings the repo in line with what is deployed — merging it is a no-op against prod, but `supabase db push` on any other environment needs it.

## Worth generalising

Other `SECURITY DEFINER` functions in this schema may have the same latent PUBLIC grant. `20251023000014_grants.sql` grants explicitly to `anon`/`authenticated`/`service_role` throughout, which reads as if those are the only grants — an audit of `SECURITY DEFINER` functions against their PUBLIC grants is worth doing separately.