### PR TITLE
fix(plugins): stop a closing plugin classloader from resolving plugin classes against the host

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -828,6 +828,34 @@ kotlin {
 }
 
 // ---------------------------------------------------------------------------
+// Drop the accidental ktor SERVER stack.
+//
+// BossConsole declares ktor CLIENT only (see desktopMain above). ktor-server-cio
+// and ktor-server-core arrive transitively through
+// io.github.jan-tennert.supabase:auth-kt, whose only consumer of them is
+// io.github.jan.supabase.auth.server.HttpCallback* — the localhost HTTP callback
+// used by desktop OAuth-provider / SSO sign-in (Utils_desktopKt.startExternalAuth).
+// BOSS never takes that path: it authenticates with OTP, email and passkeys, and
+// no source file outside the standalone `server/` module (not on this graph)
+// imports io.ktor.server.*. Verified with
+// `./gradlew :composeApp:dependencyInsight --configuration desktopRuntimeClasspath
+//  --dependency ktor-server-cio`.
+//
+// Keeping them was not free: 529 io.ktor.server.* classes sat in the host
+// classloader as fallback targets for any plugin that bundles its own ktor
+// server, which is exactly the material a plugin-classloader parent fallback
+// turns into a loader-constraint LinkageError.
+//
+// If BOSS ever adds OAuth-provider or SSO sign-in, delete this block — the
+// symptom would be a NoClassDefFoundError on io/ktor/server/cio/CIO.
+configurations.configureEach {
+    exclude(group = "io.ktor", module = "ktor-server-cio")
+    exclude(group = "io.ktor", module = "ktor-server-cio-jvm")
+    exclude(group = "io.ktor", module = "ktor-server-core")
+    exclude(group = "io.ktor", module = "ktor-server-core-jvm")
+}
+
+// ---------------------------------------------------------------------------
 // macOS code signing resolution
 //
 // Release builds sign with a "Developer ID Application" certificate. CI imports

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -855,7 +855,12 @@ kotlin {
 // declaration here would only remove one of them. Consequence to know about:
 // libs.ktor.server.tests (ktor-server-test-host) needs ktor-server-core, so it
 // cannot be added to a composeApp source set while this block stands.
-// KtorServerAbsentFromHostTest pins both halves of the outcome.
+//
+// Gradle has no module-name wildcard, so this list is an enumeration and cannot
+// anticipate a future ktor-server-sse / -websockets / -netty arriving by some
+// new transitive path. KtorServerAbsentFromHostTest is the drift guard: it
+// scans the classpath for io/ktor/server/ rather than for these four names, so
+// a newcomer fails CI and names itself.
 configurations.configureEach {
     exclude(group = "io.ktor", module = "ktor-server-cio")
     exclude(group = "io.ktor", module = "ktor-server-cio-jvm")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -848,6 +848,14 @@ kotlin {
 //
 // If BOSS ever adds OAuth-provider or SSO sign-in, delete this block — the
 // symptom would be a NoClassDefFoundError on io/ktor/server/cio/CIO.
+//
+// Blanket rather than a per-dependency exclude on purpose: auth-kt reaches this
+// graph twice, once as composeApp's own dependency and once transitively via
+// project(':plugin-platform:plugin-repository'), so an exclude attached to the
+// declaration here would only remove one of them. Consequence to know about:
+// libs.ktor.server.tests (ktor-server-test-host) needs ktor-server-core, so it
+// cannot be added to a composeApp source set while this block stands.
+// KtorServerAbsentFromHostTest pins both halves of the outcome.
 configurations.configureEach {
     exclude(group = "io.ktor", module = "ktor-server-cio")
     exclude(group = "io.ktor", module = "ktor-server-cio-jvm")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/KtorServerAbsentFromHostTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/KtorServerAbsentFromHostTest.kt
@@ -1,8 +1,10 @@
 package ai.rever.boss.plugin
 
+import java.io.File
+import java.util.zip.ZipFile
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * The host must not ship a ktor SERVER stack.
@@ -15,36 +17,72 @@ import kotlin.test.assertNotNull
  * parent fallback turns into a loader-constraint LinkageError — the failure
  * mode a terminal-tab hot-reload hit on io/ktor/util/AttributeKey.
  *
- * This is a classpath assertion, not a behaviour test: a supabase (or other)
- * dependency bump that reaches io.ktor.server.* from a path BOSS does take
- * would otherwise reappear silently and only fail in a packaged build.
+ * Gradle has no wildcard for module names, so the exclusion in the build file
+ * is an enumeration and would not notice a future ktor-server-sse /
+ * -websockets / -netty arriving by a new transitive path. This test is the
+ * drift guard: it scans the whole classpath rather than probing known class
+ * names, so anything carrying io/ktor/server/ fails here and names the artifact
+ * to add.
  */
 class KtorServerAbsentFromHostTest {
-    @Test
-    fun `no ktor server classes on the host classpath`() {
-        for (name in listOf(
-            "io.ktor.server.cio.CIOApplicationEngine",
-            "io.ktor.server.application.Application",
-            "io.ktor.server.http.HttpRequestLifecycleKt",
-            "io.ktor.server.engine.DefaultEnginePipelineKt",
-        )) {
-            assertFailsWith<ClassNotFoundException>("$name must not be on the host classpath") {
-                Class.forName(name)
+    private fun classpathEntries(): List<File> =
+        System
+            .getProperty("java.class.path")
+            .orEmpty()
+            .split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map(::File)
+
+    private fun carriesKtorServer(entry: File): Boolean =
+        when {
+            entry.isDirectory -> {
+                File(entry, "io/ktor/server").isDirectory
+            }
+
+            entry.isFile && entry.name.endsWith(".jar") -> {
+                runCatching {
+                    ZipFile(entry).use { zip ->
+                        zip.entries().asSequence().any {
+                            it.name.startsWith("io/ktor/server/") && it.name.endsWith(".class")
+                        }
+                    }
+                }.getOrDefault(false)
+            }
+
+            else -> {
+                false
             }
         }
+
+    @Test
+    fun `nothing on the host classpath carries io ktor server classes`() {
+        val offenders = classpathEntries().filter(::carriesKtorServer).map { it.name }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "ktor-server is back on the host classpath via ${offenders.joinToString()}. Find the " +
+                "new transitive path with `./gradlew :composeApp:dependencyInsight --configuration " +
+                "desktopRuntimeClasspath --dependency <artifact>` and add it to the exclusion block " +
+                "in composeApp/build.gradle.kts — or, if the host genuinely needs a ktor server " +
+                "now, delete that block and this test together.",
+        )
     }
 
     @Test
     fun `the ktor client stack the app actually uses is still present`() {
-        // The other half of the assertion: the exclusion must not have taken
-        // the client engine (supabase, the plugin store and the updater all
-        // ride on it) with it.
+        // The other half of the assertion: the exclusion must not have taken the
+        // client engine (supabase, the plugin store and the updater all ride on
+        // it) with it. initialize=false — this is a classpath assertion and has
+        // no business running static initializers.
         for (name in listOf(
             "io.ktor.client.HttpClient",
             "io.ktor.client.engine.cio.CIOEngine",
             "io.ktor.util.AttributeKey",
         )) {
-            assertNotNull(Class.forName(name), "$name must stay on the host classpath")
+            assertNotNull(
+                Class.forName(name, false, javaClass.classLoader),
+                "$name must stay on the host classpath",
+            )
         }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/KtorServerAbsentFromHostTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/KtorServerAbsentFromHostTest.kt
@@ -1,0 +1,50 @@
+package ai.rever.boss.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+/**
+ * The host must not ship a ktor SERVER stack.
+ *
+ * BossConsole declares ktor client only; ktor-server-cio and ktor-server-core
+ * used to arrive transitively through supabase auth-kt, whose only consumer of
+ * them is the localhost OAuth/SSO HTTP callback BOSS never takes. They are
+ * excluded in composeApp/build.gradle.kts, because 529 host-owned
+ * io.ktor.server.* classes are exactly the material a plugin classloader's
+ * parent fallback turns into a loader-constraint LinkageError — the failure
+ * mode a terminal-tab hot-reload hit on io/ktor/util/AttributeKey.
+ *
+ * This is a classpath assertion, not a behaviour test: a supabase (or other)
+ * dependency bump that reaches io.ktor.server.* from a path BOSS does take
+ * would otherwise reappear silently and only fail in a packaged build.
+ */
+class KtorServerAbsentFromHostTest {
+    @Test
+    fun `no ktor server classes on the host classpath`() {
+        for (name in listOf(
+            "io.ktor.server.cio.CIOApplicationEngine",
+            "io.ktor.server.application.Application",
+            "io.ktor.server.http.HttpRequestLifecycleKt",
+            "io.ktor.server.engine.DefaultEnginePipelineKt",
+        )) {
+            assertFailsWith<ClassNotFoundException>("$name must not be on the host classpath") {
+                Class.forName(name)
+            }
+        }
+    }
+
+    @Test
+    fun `the ktor client stack the app actually uses is still present`() {
+        // The other half of the assertion: the exclusion must not have taken
+        // the client engine (supabase, the plugin store and the updater all
+        // ride on it) with it.
+        for (name in listOf(
+            "io.ktor.client.HttpClient",
+            "io.ktor.client.engine.cio.CIOEngine",
+            "io.ktor.util.AttributeKey",
+        )) {
+            assertNotNull(Class.forName(name), "$name must stay on the host classpath")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,12 +17,26 @@ kotlin = "2.4.0"
 kotlinx-coroutines = "1.11.0"
 ktlint-gradle = "14.2.0"
 kotlinx-datetime = "0.8.0-0.6.x-compat"
-# Pinned to the stack the MCP Kotlin SDK supports (ktor <= 3.3/3.4 → serialization 1.9.x).
-# The terminal-tab plugin bundles ktor 3.3 + mcp-sdk, but resolves kotlinx-serialization
-# parent-first from the host; ktor 3.5 / serialization 1.11 break the bundled MCP server
-# (encodeToSink / sse signature drift). Revert when the MCP SDK supports ktor 3.5+.
-# (ktor 3.5.0 was an automated bump in #736; 3.4.3 was the prior known-good version.)
+# kotlinx-serialization is a SHARED, parent-first package for plugins
+# (PluginClassLoader.defaultSharedPackages), so this line is the version every
+# plugin gets at runtime no matter what it bundles — terminal-tab, for one,
+# bundles ktor 3.3.2 + the MCP Kotlin SDK and ships zero kotlinx.serialization
+# classes of its own. Treat a bump here as a cross-repo change.
+#
+# This pin was 1.9.0 and was raised to 1.11.0 by an automated bump (#839,
+# 2026-07-16) whose comment block still claimed 1.9.x was required. Re-verified
+# on 1.11.0: ktor 3.4.3 asks for serialization 1.9.0 and is upgraded to 1.11.0
+# by conflict resolution; ktor's sink/source converter path resolves against
+# kotlinx-serialization-json-io 1.11.0, which still exports
+# encodeToSink/decodeFromSource; and terminal-tab's bundled MCP server runs
+# against a 1.11.0 host. The old "serialization 1.11 breaks the MCP server"
+# warning does not hold — but the coupling it described does, hence this note.
+# Note terminal-tab's own build.gradle.kts still documents the host as 1.9.0.
 kotlinx-serialization = "1.11.0"
+# ktor is NOT shared with plugins (no io.ktor prefix in defaultSharedPackages),
+# so a plugin's bundled ktor is unaffected by this pin; it constrains the host's
+# own client stack only. 3.5.0 arrived as an automated bump in #736 and was
+# reverted to the prior known-good 3.4.3.
 ktor = "3.4.3"
 logback = "1.5.38"
 precompose = "1.6.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,13 @@ kotlinx-datetime = "0.8.0-0.6.x-compat"
 kotlinx-serialization = "1.11.0"
 # ktor is NOT shared with plugins (no io.ktor prefix in defaultSharedPackages),
 # so a plugin's bundled ktor is unaffected by this pin; it constrains the host's
-# own client stack only. 3.5.0 arrived as an automated bump in #736 and was
-# reverted to the prior known-good 3.4.3.
+# own client stack only.
+#
+# 3.5.0 arrived as an automated bump (#736) and was reverted. The reason on
+# record was plugin compatibility, which cannot be right — the host's ktor never
+# reaches a plugin. NO host-side diagnosis was ever recorded, so there is no
+# known reason this cannot move: treat the next 3.5.x bump as worth trying, and
+# if it fails, write down what broke here.
 ktor = "3.4.3"
 logback = "1.5.38"
 precompose = "1.6.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,20 +18,12 @@ kotlinx-coroutines = "1.11.0"
 ktlint-gradle = "14.2.0"
 kotlinx-datetime = "0.8.0-0.6.x-compat"
 # kotlinx-serialization is a SHARED, parent-first package for plugins
-# (PluginClassLoader.defaultSharedPackages), so this line is the version every
+# (PluginClassLoader.defaultSharedPackages): this line is the version every
 # plugin gets at runtime no matter what it bundles — terminal-tab, for one,
-# bundles ktor 3.3.2 + the MCP Kotlin SDK and ships zero kotlinx.serialization
-# classes of its own. Treat a bump here as a cross-repo change.
-#
-# This pin was 1.9.0 and was raised to 1.11.0 by an automated bump (#839,
-# 2026-07-16) whose comment block still claimed 1.9.x was required. Re-verified
-# on 1.11.0: ktor 3.4.3 asks for serialization 1.9.0 and is upgraded to 1.11.0
-# by conflict resolution; ktor's sink/source converter path resolves against
-# kotlinx-serialization-json-io 1.11.0, which still exports
-# encodeToSink/decodeFromSource; and terminal-tab's bundled MCP server runs
-# against a 1.11.0 host. The old "serialization 1.11 breaks the MCP server"
-# warning does not hold — but the coupling it described does, hence this note.
-# Note terminal-tab's own build.gradle.kts still documents the host as 1.9.0.
+# bundles ktor + the MCP Kotlin SDK and ships zero kotlinx.serialization classes
+# of its own. A bump here is a cross-repo change; re-check the plugins riding on
+# it rather than trusting a comment. (History of the 1.9.0 -> 1.11.0 move and
+# how it was re-verified: PR #57.)
 kotlinx-serialization = "1.11.0"
 # ktor is NOT shared with plugins (no io.ktor prefix in defaultSharedPackages),
 # so a plugin's bundled ktor is unaffected by this pin; it constrains the host's

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/DynamicPluginLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/DynamicPluginLoader.kt
@@ -403,7 +403,14 @@ class DynamicPluginLoaderImpl(
             // Update state
             loadedPlugins[pluginId] = loadedPlugin.copy(state = PluginState.UNLOADING)
 
-            // Dispose plugin instance
+            // Dispose plugin instance.
+            //
+            // ORDER MATTERS: dispose() must run BEFORE prepareUnload() below.
+            // Once the classloader leaves ACTIVE it refuses to resolve anything
+            // new against the host (PluginClassLoader.loadClassChildFirst), so
+            // moving the mark up would make every plugin's dispose() that
+            // lazily touches a host class start throwing. PluginUnloadOrderingTest
+            // pins this.
             try {
                 loadedPlugin.instance.dispose()
             } catch (e: Exception) {

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -38,6 +38,11 @@ enum class ClassLoaderState {
  * This ensures plugins get their own dependencies while sharing common APIs
  * with the host application.
  *
+ * Once the loader leaves [ClassLoaderState.ACTIVE] the child-first miss stops
+ * delegating to the parent: a plugin class requested after teardown must fail
+ * loudly rather than silently resolve to the host's copy. See
+ * [loadClassChildFirst].
+ *
  * @param pluginId The ID of the plugin this classloader serves
  * @param urls URLs to the plugin JAR and its dependencies
  * @param parent Parent classloader (usually the application classloader)
@@ -200,7 +205,12 @@ class PluginClassLoader(
             return loadedClass
         }
 
-        // Check state
+        // Check state. Loading is still allowed while the loader winds down —
+        // orderly teardown needs it: classes this loader already defined (the
+        // early return above), shared host classes (parent-first, below), and
+        // the plugin's own jar until close() shuts the jar. What is NOT allowed
+        // any more is delegating a class the plugin jar cannot supply to the
+        // host — see [loadClassChildFirst].
         if (isUnloading) {
             logger.warn(
                 LogCategory.SYSTEM,
@@ -211,7 +221,6 @@ class PluginClassLoader(
                     "state" to state.name,
                 ),
             )
-            // Still allow loading during unload process for cleanup
         }
 
         // Check if this is a shared package (parent-first)
@@ -228,6 +237,11 @@ class PluginClassLoader(
 
     /**
      * Load a class with child-first strategy.
+     *
+     * While the loader is ACTIVE a miss in the plugin jar delegates to the
+     * parent — that is the normal path for every host-provided class. Once the
+     * loader is unloading or closed the same delegation becomes destructive, so
+     * it is refused instead; see the comment in the catch block.
      */
     private fun loadClassChildFirst(
         name: String,
@@ -240,7 +254,56 @@ class PluginClassLoader(
                 resolveClass(clazz)
             }
             return clazz
-        } catch (ignored: ClassNotFoundException) {
+        } catch (notInPluginJar: ClassNotFoundException) {
+            if (isUnloading) {
+                // A closed URLClassLoader answers findClass() with
+                // ClassNotFoundException for EVERY name, including the ones its
+                // own jar carries. Delegating here would therefore hand the
+                // plugin the HOST's copy of a class the plugin owns, splicing
+                // two class graphs together. The JVM does not complain at that
+                // moment — it complains later and elsewhere, as a loader
+                // constraint LinkageError naming two unrelated classes (this is
+                // how a terminal-tab hot-reload produced an
+                // io/ktor/util/AttributeKey constraint violation between
+                // CIOApplicationEngine and HttpRequestLifecycleKt, both of which
+                // the plugin jar actually contained).
+                //
+                // Refuse at the request instead, where the caller is still on
+                // the stack. ClassNotFoundException specifically: loadClass
+                // already declares it, every caller — including the JVM's own
+                // resolution machinery, which turns it into a precise
+                // NoClassDefFoundError at the resolution site — already handles
+                // it. An unchecked exception or a raw Error thrown from a
+                // classloader runs on whatever straggler thread made the late
+                // request (a Ktor worker, a coroutine dispatcher, an AWT
+                // handler) and can tear that thread down mid-teardown.
+                val refusal =
+                    ClassNotFoundException(
+                        "Plugin classloader for '$pluginId' is $state; refusing to resolve '$name' " +
+                            "against the host classloader. Something still referenced the plugin " +
+                            "after it was unloaded — that reference is the bug.",
+                        notInPluginJar,
+                    )
+                // WARN, not ERROR: refusing is the correct outcome and teardown
+                // continues. The throwable is attached so the log carries the
+                // straggler's stack. Best effort — logging must never replace
+                // the refusal, which is the thing that has to propagate.
+                try {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Refused to resolve a plugin class against the host after unload",
+                        mapOf(
+                            "pluginId" to pluginId,
+                            "className" to name,
+                            "state" to state.name,
+                        ),
+                        refusal,
+                    )
+                } catch (_: Throwable) {
+                    // Logging can itself fail during shutdown; the refusal stands.
+                }
+                throw refusal
+            }
             // Fall back to parent. Deliberately unlogged: this is the expected
             // delegation path for every host-provided class a plugin touches, so
             // logging here would flood at class-load time on a hot path.

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
 import java.net.URL
 import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -40,7 +41,10 @@ enum class ClassLoaderState {
  *
  * Once the loader leaves [ClassLoaderState.ACTIVE] the child-first miss stops
  * delegating to the parent: a plugin class requested after teardown must fail
- * loudly rather than silently resolve to the host's copy. See
+ * loudly rather than silently resolve to the host's copy. Only FIRST-TIME loads
+ * are refused — the JVM records this loader as the initiating loader for every
+ * name it has already resolved, host classes included, so `findLoadedClass`
+ * keeps answering those after close and orderly teardown is unaffected. See
  * [loadClassChildFirst].
  *
  * @param pluginId The ID of the plugin this classloader serves
@@ -78,6 +82,33 @@ class PluginClassLoader(
         fun findPluginForClass(className: String): String? {
             val snapshot = synchronized(allInstances) { allInstances.toList() }
             return snapshot.firstOrNull { it.definedClassNamed(className) }?.pluginId
+        }
+
+        /**
+         * First sighting of a refused class name gets a WARN carrying the
+         * straggler's stack; repeats drop to DEBUG so a retry loop cannot bury
+         * the shutdown log. Lives on the companion so the instance stays under
+         * detekt's per-class function budget.
+         */
+        private fun logRefusal(
+            firstSighting: Boolean,
+            details: Map<String, Any?>,
+            refusal: ClassNotFoundException,
+        ) {
+            if (firstSighting) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Refused to resolve a plugin class against the host after unload",
+                    details,
+                    refusal,
+                )
+            } else {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Refused a repeat request for an already-refused plugin class",
+                    details,
+                )
+            }
         }
 
         /**
@@ -147,6 +178,15 @@ class PluginClassLoader(
      * Timestamp when the classloader was created.
      */
     val createdAt: Long = System.currentTimeMillis()
+
+    /**
+     * Class names already refused by [loadClassChildFirst] after unload. The
+     * straggler this catches is by construction a thread that did not get the
+     * memo — a Ktor accept loop, a reconnecting coroutine — so it asks for the
+     * same name over and over. Logging is therefore deduped to one WARN with a
+     * stack per name; the refusal itself is never deduped.
+     */
+    private val refusedClassNames: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     /**
      * Whether this classloader has been marked for unloading.
@@ -255,59 +295,63 @@ class PluginClassLoader(
             }
             return clazz
         } catch (notInPluginJar: ClassNotFoundException) {
-            if (isUnloading) {
-                // A closed URLClassLoader answers findClass() with
-                // ClassNotFoundException for EVERY name, including the ones its
-                // own jar carries. Delegating here would therefore hand the
-                // plugin the HOST's copy of a class the plugin owns, splicing
-                // two class graphs together. The JVM does not complain at that
-                // moment — it complains later and elsewhere, as a loader
-                // constraint LinkageError naming two unrelated classes (this is
-                // how a terminal-tab hot-reload produced an
-                // io/ktor/util/AttributeKey constraint violation between
-                // CIOApplicationEngine and HttpRequestLifecycleKt, both of which
-                // the plugin jar actually contained).
-                //
-                // Refuse at the request instead, where the caller is still on
-                // the stack. ClassNotFoundException specifically: loadClass
-                // already declares it, every caller — including the JVM's own
-                // resolution machinery, which turns it into a precise
-                // NoClassDefFoundError at the resolution site — already handles
-                // it. An unchecked exception or a raw Error thrown from a
-                // classloader runs on whatever straggler thread made the late
-                // request (a Ktor worker, a coroutine dispatcher, an AWT
-                // handler) and can tear that thread down mid-teardown.
-                val refusal =
-                    ClassNotFoundException(
-                        "Plugin classloader for '$pluginId' is $state; refusing to resolve '$name' " +
-                            "against the host classloader. Something still referenced the plugin " +
-                            "after it was unloaded — that reference is the bug.",
-                        notInPluginJar,
-                    )
-                // WARN, not ERROR: refusing is the correct outcome and teardown
-                // continues. The throwable is attached so the log carries the
-                // straggler's stack. Best effort — logging must never replace
-                // the refusal, which is the thing that has to propagate.
-                try {
-                    logger.warn(
-                        LogCategory.SYSTEM,
-                        "Refused to resolve a plugin class against the host after unload",
-                        mapOf(
-                            "pluginId" to pluginId,
-                            "className" to name,
-                            "state" to state.name,
-                        ),
-                        refusal,
-                    )
-                } catch (_: Throwable) {
-                    // Logging can itself fail during shutdown; the refusal stands.
-                }
-                throw refusal
+            // One read: _state can move UNLOAD_IN_PROGRESS -> UNLOADED under us,
+            // and the message must not disagree with the structured field.
+            val stateAtRefusal = state
+            if (stateAtRefusal == ClassLoaderState.ACTIVE) {
+                // Fall back to parent. Deliberately unlogged: this is the
+                // expected delegation path for every host-provided class a
+                // plugin touches, so logging here would flood at class-load
+                // time on a hot path.
+                return parent.loadClass(name)
             }
-            // Fall back to parent. Deliberately unlogged: this is the expected
-            // delegation path for every host-provided class a plugin touches, so
-            // logging here would flood at class-load time on a hot path.
-            return parent.loadClass(name)
+
+            // A closed URLClassLoader answers findClass() with
+            // ClassNotFoundException for EVERY name, including the ones its own
+            // jar carries. Delegating here would therefore hand the plugin the
+            // HOST's copy of a class the plugin owns, splicing two class graphs
+            // together. The JVM does not complain at that moment — it complains
+            // later and elsewhere, as a loader constraint LinkageError naming
+            // two unrelated classes (this is how a terminal-tab hot-reload
+            // produced an io/ktor/util/AttributeKey constraint violation between
+            // CIOApplicationEngine and HttpRequestLifecycleKt, both of which the
+            // plugin jar actually contained).
+            //
+            // Refuse at the request instead, where the caller is still on the
+            // stack. ClassNotFoundException specifically: loadClass already
+            // declares it, every caller — including the JVM's own resolution
+            // machinery, which turns it into a precise NoClassDefFoundError at
+            // the resolution site — already handles it. An unchecked exception
+            // or a raw Error thrown from a classloader runs on whatever
+            // straggler thread made the late request (a Ktor worker, a
+            // coroutine dispatcher, an AWT handler) and can tear that thread
+            // down mid-teardown.
+            val refusal =
+                ClassNotFoundException(
+                    "Plugin classloader for '$pluginId' is $stateAtRefusal; refusing to resolve " +
+                        "'$name' against the host classloader. Something still referenced the " +
+                        "plugin after it was unloaded — that reference is the bug.",
+                    notInPluginJar,
+                )
+            // WARN, not ERROR: refusing is the correct outcome and teardown
+            // continues. The throwable is attached so the first entry for a name
+            // carries the straggler's stack; repeats drop to DEBUG so a retry
+            // loop cannot bury the shutdown log. Best effort — logging must
+            // never replace the refusal, which is the thing that has to
+            // propagate.
+            val details =
+                mapOf(
+                    "pluginId" to pluginId,
+                    "className" to name,
+                    "state" to stateAtRefusal.name,
+                )
+            val firstSighting = refusedClassNames.add(name)
+            try {
+                logRefusal(firstSighting, details, refusal)
+            } catch (_: Throwable) {
+                // Logging can itself fail during shutdown; the refusal stands.
+            }
+            throw refusal
         }
     }
 

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt
@@ -92,21 +92,25 @@ class PluginClassLoader(
          */
         private fun logRefusal(
             firstSighting: Boolean,
-            details: Map<String, Any?>,
+            pluginId: String,
+            className: String,
+            state: ClassLoaderState,
             refusal: ClassNotFoundException,
         ) {
+            // Built per branch, not up front: the repeat path is the hot one and
+            // its DEBUG call is usually disabled.
             if (firstSighting) {
                 logger.warn(
                     LogCategory.SYSTEM,
                     "Refused to resolve a plugin class against the host after unload",
-                    details,
+                    mapOf("pluginId" to pluginId, "className" to className, "state" to state.name),
                     refusal,
                 )
             } else {
                 logger.debug(
                     LogCategory.SYSTEM,
                     "Refused a repeat request for an already-refused plugin class",
-                    details,
+                    mapOf("pluginId" to pluginId, "className" to className, "state" to state.name),
                 )
             }
         }
@@ -251,8 +255,13 @@ class PluginClassLoader(
         // the plugin's own jar until close() shuts the jar. What is NOT allowed
         // any more is delegating a class the plugin jar cannot supply to the
         // host — see [loadClassChildFirst].
+        //
+        // DEBUG, not WARN: this fires on every post-ACTIVE attempt including the
+        // legitimate ones above, and it is not deduped, so at WARN a retry loop
+        // would bury the shutdown log with the benign message and hide the one
+        // that matters. The refusal in loadClassChildFirst is the WARN.
         if (isUnloading) {
-            logger.warn(
+            logger.debug(
                 LogCategory.SYSTEM,
                 "Attempt to load class from unloading classloader",
                 mapOf(
@@ -282,6 +291,19 @@ class PluginClassLoader(
      * parent — that is the normal path for every host-provided class. Once the
      * loader is unloading or closed the same delegation becomes destructive, so
      * it is refused instead; see the comment in the catch block.
+     *
+     * The two post-ACTIVE states are refused for different reasons, and only one
+     * of them is load-bearing for the LinkageError this exists to prevent:
+     * - [ClassLoaderState.UNLOADED] — CORRECTNESS. The jar is shut, `findClass`
+     *   misses on every name including ones the plugin owns, so delegating
+     *   splices the host's class graph into the plugin's.
+     * - [ClassLoaderState.UNLOAD_IN_PROGRESS] — POLICY. The jar is still open
+     *   here, so a miss is a genuine miss and delegating could not corrupt
+     *   anything. It is refused anyway as fail-fast on a lifecycle bug: the
+     *   plugin's own `dispose()` has already returned by the time this state is
+     *   set (see `DynamicPluginLoader.unloadPlugin`), so a first-time load in
+     *   this window is a straggler that would be refused a moment later anyway
+     *   once `close()` lands. One rule beats two.
      */
     private fun loadClassChildFirst(
         name: String,
@@ -339,15 +361,8 @@ class PluginClassLoader(
             // loop cannot bury the shutdown log. Best effort — logging must
             // never replace the refusal, which is the thing that has to
             // propagate.
-            val details =
-                mapOf(
-                    "pluginId" to pluginId,
-                    "className" to name,
-                    "state" to stateAtRefusal.name,
-                )
-            val firstSighting = refusedClassNames.add(name)
             try {
-                logRefusal(firstSighting, details, refusal)
+                logRefusal(refusedClassNames.add(name), pluginId, name, stateAtRefusal, refusal)
             } catch (_: Throwable) {
                 // Logging can itself fail during shutdown; the refusal stands.
             }

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadFallbackTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadFallbackTest.kt
@@ -50,8 +50,11 @@ class PluginClassLoaderUnloadFallbackTest {
     }
 
     /** Copy the given classes out of the test classpath into a fresh jar. */
-    private fun jarContaining(vararg classes: Class<*>): String {
+    private fun jarContaining(vararg classes: Class<*>): File {
         val jar = File.createTempFile("plugin-cl-unload-test", ".jar")
+        // Backstop for the cleanup(): a test that throws before its close()
+        // leaves the jar locked on Windows, where delete() then silently fails.
+        jar.deleteOnExit()
         tempJars.add(jar)
         JarOutputStream(jar.outputStream()).use { out ->
             for (cls in classes) {
@@ -65,13 +68,13 @@ class PluginClassLoaderUnloadFallbackTest {
                 out.closeEntry()
             }
         }
-        return jar.absolutePath
+        return jar
     }
 
     private fun loaderOver(vararg classes: Class<*>): PluginClassLoader =
         PluginClassLoader(
-            pluginId = "com.example.unload",
-            urls = arrayOf(File(jarContaining(*classes)).toURI().toURL()),
+            pluginId = PLUGIN_ID,
+            urls = arrayOf(jarContaining(*classes).toURI().toURL()),
             parent = hostLoader,
         )
 
@@ -122,7 +125,7 @@ class PluginClassLoaderUnloadFallbackTest {
             "refusal must name the class that was requested: ${failure.message}",
         )
         assertTrue(
-            failure.message.orEmpty().contains("com.example.unload"),
+            failure.message.orEmpty().contains(PLUGIN_ID),
             "refusal must name the plugin: ${failure.message}",
         )
         assertTrue(
@@ -130,6 +133,12 @@ class PluginClassLoaderUnloadFallbackTest {
             "refusal must name the loader state: ${failure.message}",
         )
         assertNotNull(failure.cause, "the underlying findClass miss is kept as the cause")
+
+        // Logging of a refusal is deduped per class name; the refusal is not.
+        // A retry loop must keep failing, not start succeeding on the 2nd call.
+        assertFailsWith<ClassNotFoundException> {
+            loader.loadClass(OwnedByPluginB::class.java.name)
+        }
     }
 
     @Test
@@ -163,11 +172,21 @@ class PluginClassLoaderUnloadFallbackTest {
     fun `an unloading loader keeps resolving shared host classes`() {
         val loader = loaderOver(OwnedByPluginA::class.java)
 
-        loader.close()
+        loader.markUnloading()
 
         // kotlin.* is parent-first by [PluginClassLoader.defaultSharedPackages]:
         // teardown code runs on these, so the refusal must not touch them.
         assertSame(Unit::class.java, loader.loadClass("kotlin.Unit"))
+        loader.close()
+    }
+
+    @Test
+    fun `a closed loader keeps resolving shared host classes`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+
+        loader.close()
+
+        assertSame(Enum::class.java, loader.loadClass("java.lang.Enum"))
     }
 
     @Test
@@ -178,11 +197,19 @@ class PluginClassLoaderUnloadFallbackTest {
 
         loader.close()
 
-        // ...and NOT resolvable once closed, even though the parent still has
-        // it. Whether the plugin jar carried it is unknowable after close, so
-        // the state is the only safe discriminator.
+        // ...and refused once closed. Note this direct loadClass() call does not
+        // register this loader as an initiating loader for B, so the
+        // findLoadedClass early return does not cover it. In production a
+        // JVM-resolved host class WOULD be registered and would keep resolving
+        // after close — only first-time names reach the refusal. What this pins
+        // is the discriminator: after close, "not in the plugin jar" and "the
+        // jar is shut" are indistinguishable, so state is the only safe signal.
         assertFailsWith<ClassNotFoundException> {
             loader.loadClass(OwnedByPluginB::class.java.name)
         }
+    }
+
+    private companion object {
+        const val PLUGIN_ID = "com.example.unload"
     }
 }

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadFallbackTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadFallbackTest.kt
@@ -159,6 +159,21 @@ class PluginClassLoaderUnloadFallbackTest {
     // --- teardown must not be wedged by the refusal --------------------------
 
     @Test
+    fun `an unloading loader still loads from its own jar`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+
+        loader.markUnloading()
+
+        // The jar is open until close(), so the plugin's own classes must still
+        // resolve — what is refused is the parent FALLBACK, not loading itself.
+        // Without this, a mutation that refuses everything post-ACTIVE before
+        // even trying findClass would survive the suite.
+        val resolved = loader.loadClass(OwnedByPluginA::class.java.name)
+        assertSame(loader, resolved.classLoader, "the plugin's own jar must still answer")
+        loader.close()
+    }
+
+    @Test
     fun `classes the loader already defined still resolve after close`() {
         val loader = loaderOver(OwnedByPluginA::class.java)
         val before = loader.loadClass(OwnedByPluginA::class.java.name)

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadFallbackTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginClassLoaderUnloadFallbackTest.kt
@@ -1,0 +1,188 @@
+package ai.rever.boss.plugin.loader
+
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Two classes that exist BOTH in the test's own classpath (so the host/parent
+ * loader can supply them) and in the synthetic plugin jar these tests build (so
+ * the plugin loader can define its own copy). That duplication is the whole
+ * point: it is what makes the silent parent fallback observable — without the
+ * fix, asking a closed plugin loader for [OwnedByPluginB] hands back the
+ * PARENT's copy instead of failing, and the plugin ends up with two class
+ * graphs spliced together.
+ *
+ * They are deliberately dependency-free and live in a package that is NOT in
+ * [PluginClassLoader.defaultSharedPackages], so they take the child-first path.
+ */
+class OwnedByPluginA
+
+class OwnedByPluginB
+
+/**
+ * Regression cover for the silent parent fallback in
+ * [PluginClassLoader.loadClassChildFirst].
+ *
+ * A closed [java.net.URLClassLoader] answers `findClass` with
+ * ClassNotFoundException for every name — including classes its own jar
+ * carries. The old catch block treated that as "the plugin doesn't have it" and
+ * delegated to the host, which is how a terminal-tab hot-reload produced a
+ * loader constraint LinkageError on `io/ktor/util/AttributeKey` between
+ * `CIOApplicationEngine` (plugin loader) and `HttpRequestLifecycleKt` (loader
+ * 'app') even though the plugin jar contained both.
+ */
+class PluginClassLoaderUnloadFallbackTest {
+    private val tempJars = mutableListOf<File>()
+
+    private val hostLoader: ClassLoader = PluginClassLoaderUnloadFallbackTest::class.java.classLoader
+
+    @AfterTest
+    fun cleanup() {
+        tempJars.forEach { it.delete() }
+    }
+
+    /** Copy the given classes out of the test classpath into a fresh jar. */
+    private fun jarContaining(vararg classes: Class<*>): String {
+        val jar = File.createTempFile("plugin-cl-unload-test", ".jar")
+        tempJars.add(jar)
+        JarOutputStream(jar.outputStream()).use { out ->
+            for (cls in classes) {
+                val path = cls.name.replace('.', '/') + ".class"
+                val bytes =
+                    requireNotNull(hostLoader.getResourceAsStream(path)) {
+                        "test class $path missing from the test classpath"
+                    }.use { it.readBytes() }
+                out.putNextEntry(JarEntry(path))
+                out.write(bytes)
+                out.closeEntry()
+            }
+        }
+        return jar.absolutePath
+    }
+
+    private fun loaderOver(vararg classes: Class<*>): PluginClassLoader =
+        PluginClassLoader(
+            pluginId = "com.example.unload",
+            urls = arrayOf(File(jarContaining(*classes)).toURI().toURL()),
+            parent = hostLoader,
+        )
+
+    // --- the legitimate case, which must keep working exactly as before ------
+
+    @Test
+    fun `an open loader still falls back to the parent for a class it does not carry`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+
+        val resolved = loader.loadClass(OwnedByPluginB::class.java.name)
+
+        assertSame(
+            OwnedByPluginB::class.java,
+            resolved,
+            "an ACTIVE loader must keep delegating a genuine miss to the parent",
+        )
+        loader.close()
+    }
+
+    @Test
+    fun `an open loader defines its own copy of a class the jar carries`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+
+        val resolved = loader.loadClass(OwnedByPluginA::class.java.name)
+
+        assertSame(loader, resolved.classLoader, "child-first must win over the parent's copy")
+        loader.close()
+    }
+
+    // --- the bug: delegation after teardown ----------------------------------
+
+    @Test
+    fun `a closed loader refuses to resolve a plugin class against the host`() {
+        val loader = loaderOver(OwnedByPluginA::class.java, OwnedByPluginB::class.java)
+        // Touch one class so the loader is genuinely live before it is closed.
+        assertSame(loader, loader.loadClass(OwnedByPluginA::class.java.name).classLoader)
+
+        loader.close()
+
+        // OwnedByPluginB IS in the plugin jar, but the jar is shut. Falling back
+        // would silently hand over the host's copy — the LinkageError machine.
+        val failure =
+            assertFailsWith<ClassNotFoundException> {
+                loader.loadClass(OwnedByPluginB::class.java.name)
+            }
+        assertTrue(
+            failure.message.orEmpty().contains(OwnedByPluginB::class.java.name),
+            "refusal must name the class that was requested: ${failure.message}",
+        )
+        assertTrue(
+            failure.message.orEmpty().contains("com.example.unload"),
+            "refusal must name the plugin: ${failure.message}",
+        )
+        assertTrue(
+            failure.message.orEmpty().contains(ClassLoaderState.UNLOADED.name),
+            "refusal must name the loader state: ${failure.message}",
+        )
+        assertNotNull(failure.cause, "the underlying findClass miss is kept as the cause")
+    }
+
+    @Test
+    fun `an unloading loader refuses to resolve a missing class against the host`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+
+        // markUnloading only — the jar is still open, so this exercises the
+        // UNLOAD_IN_PROGRESS state rather than the closed-jar one.
+        loader.markUnloading()
+        assertEquals(ClassLoaderState.UNLOAD_IN_PROGRESS, loader.state)
+
+        assertFailsWith<ClassNotFoundException> {
+            loader.loadClass(OwnedByPluginB::class.java.name)
+        }
+        loader.close()
+    }
+
+    // --- teardown must not be wedged by the refusal --------------------------
+
+    @Test
+    fun `classes the loader already defined still resolve after close`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+        val before = loader.loadClass(OwnedByPluginA::class.java.name)
+
+        loader.close()
+
+        assertSame(before, loader.loadClass(OwnedByPluginA::class.java.name))
+    }
+
+    @Test
+    fun `an unloading loader keeps resolving shared host classes`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+
+        loader.close()
+
+        // kotlin.* is parent-first by [PluginClassLoader.defaultSharedPackages]:
+        // teardown code runs on these, so the refusal must not touch them.
+        assertSame(Unit::class.java, loader.loadClass("kotlin.Unit"))
+    }
+
+    @Test
+    fun `a class the plugin never carried is refused too once the loader is closed`() {
+        val loader = loaderOver(OwnedByPluginA::class.java)
+        // Resolvable from the parent while open...
+        assertSame(OwnedByPluginB::class.java, loader.loadClass(OwnedByPluginB::class.java.name))
+
+        loader.close()
+
+        // ...and NOT resolvable once closed, even though the parent still has
+        // it. Whether the plugin jar carried it is unknowable after close, so
+        // the state is the only safe discriminator.
+        assertFailsWith<ClassNotFoundException> {
+            loader.loadClass(OwnedByPluginB::class.java.name)
+        }
+    }
+}

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginUnloadOrderingTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/PluginUnloadOrderingTest.kt
@@ -1,0 +1,134 @@
+package ai.rever.boss.plugin.loader
+
+import ai.rever.boss.plugin.api.Plugin
+import ai.rever.boss.plugin.api.PluginContext
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Pins the ordering invariant that [PluginClassLoader]'s refusal policy rests
+ * on: a plugin's own `dispose()` runs while its classloader is still
+ * [ClassLoaderState.ACTIVE].
+ *
+ * Since the loader refuses to resolve anything new against the host once the
+ * state leaves ACTIVE, a "mark it dead before we touch it" refactor of
+ * `unloadPlugin` would make every plugin's dispose() that lazily touches a host
+ * class start throwing — surfacing as scattered NoClassDefFoundErrors rather
+ * than a red test. This is that red test. The prose lives in
+ * DynamicPluginLoader.unloadPlugin; the enforcement lives here.
+ */
+class PluginUnloadOrderingTest {
+    private val tempJars = mutableListOf<File>()
+
+    @BeforeTest
+    fun resetSharedState() {
+        PluginClassLoaderManager.resetSharedApiLayerForTests()
+        UnloadOrderProbe.reset()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        PluginClassLoaderManager.resetSharedApiLayerForTests()
+        UnloadOrderProbe.reset()
+        tempJars.forEach { it.delete() }
+    }
+
+    /**
+     * A manifest-only jar. The plugin classloader misses on the mainClass and
+     * (while ACTIVE) delegates to the test classpath, which is where
+     * [OrderProbePlugin] lives — the same trick [ForceUnloadTest] uses.
+     */
+    private fun probePluginJar(): String {
+        val jar = File.createTempFile("unload-ordering", ".jar")
+        jar.deleteOnExit()
+        tempJars.add(jar)
+        JarOutputStream(jar.outputStream()).use { out ->
+            out.putNextEntry(JarEntry("META-INF/boss-plugin/plugin.json"))
+            out.write(
+                """
+                {
+                  "manifestVersion": 1,
+                  "pluginId": "$FIXTURE_ID",
+                  "displayName": "Unload Order Probe",
+                  "version": "1.0.0",
+                  "apiVersion": "1.0.0",
+                  "mainClass": "${OrderProbePlugin::class.java.name}"
+                }
+                """.trimIndent().toByteArray(),
+            )
+            out.closeEntry()
+        }
+        return jar.absolutePath
+    }
+
+    @Test
+    fun `plugin dispose runs while its classloader is still ACTIVE`() =
+        runBlocking<Unit> {
+            val loader = DynamicPluginLoaderImpl()
+            loader.loadPlugin(probePluginJar()).getOrThrow()
+
+            UnloadOrderProbe.classLoader =
+                assertNotNull(
+                    loader.getClassLoaderManager().getClassLoader(FIXTURE_ID),
+                    "fixture must have a classloader while loaded",
+                )
+
+            loader.unloadPlugin(FIXTURE_ID).getOrThrow()
+
+            assertEquals(
+                ClassLoaderState.ACTIVE,
+                UnloadOrderProbe.stateAtDispose,
+                "dispose() must run before the classloader is marked for unload — the refusal " +
+                    "in PluginClassLoader.loadClassChildFirst assumes it",
+            )
+        }
+
+    @Test
+    fun `the classloader is unloaded by the time unloadPlugin returns`() =
+        runBlocking<Unit> {
+            val loader = DynamicPluginLoaderImpl()
+            loader.loadPlugin(probePluginJar()).getOrThrow()
+            val classLoader =
+                assertNotNull(loader.getClassLoaderManager().getClassLoader(FIXTURE_ID))
+
+            loader.unloadPlugin(FIXTURE_ID).getOrThrow()
+
+            // The other end of the window: ACTIVE during dispose, UNLOADED after.
+            assertEquals(ClassLoaderState.UNLOADED, classLoader.state)
+        }
+
+    private companion object {
+        const val FIXTURE_ID = "com.example.unload.ordering"
+    }
+}
+
+/** Cross-classloader handoff between the test and its fixture plugin. */
+object UnloadOrderProbe {
+    @Volatile var classLoader: PluginClassLoader? = null
+
+    @Volatile var stateAtDispose: ClassLoaderState? = null
+
+    fun reset() {
+        classLoader = null
+        stateAtDispose = null
+    }
+}
+
+/** Records the classloader state observed from inside `dispose()`. */
+class OrderProbePlugin : Plugin {
+    override val pluginId = "com.example.unload.ordering"
+    override val displayName = "Unload Order Probe"
+
+    override fun register(context: PluginContext) = Unit
+
+    override fun dispose() {
+        UnloadOrderProbe.stateAtDispose = UnloadOrderProbe.classLoader?.state
+    }
+}


### PR DESCRIPTION
## The crash

A `terminal-tab` hot-reload killed the running app with:

```
LinkageError: loader constraint violation ... io/ktor/util/AttributeKey
  io.ktor.server.cio.CIOApplicationEngine      -> PluginClassLoader   (plugin jar)
  io.ktor.server.http.HttpRequestLifecycleKt   -> loader 'app'        (host)
```

## The evidence chain

**1. The plugin was not under-bundling.** `HttpRequestLifecycleKt`, `DefaultEnginePipelineKt`, `ServerSSESessionKt`, `CIOApplicationEngine` and `AttributeKey` are *all* in `boss-plugin-terminal-tab-2.5.30.jar` (2,312 `io/ktor/**` entries). Child-first loading should have kept every one of them inside the plugin loader.

**2. `io.ktor` is not parent-first.** `PluginClassLoader.defaultSharedPackages` has no ktor prefix and no wildcard, and no manifest declares one. So nothing *should* have sent those names to the host.

**3. The silent fallback is the only way in.** A closed `URLClassLoader` answers `findClass()` with `ClassNotFoundException` for **every** name — including the ones its own jar carries. `loadClassChildFirst` caught that and delegated to `parent.loadClass(name)`, with a comment saying the fallback is deliberately unlogged. Once the loader starts closing, that turns "the plugin doesn't have this class" into "give the plugin the host's copy of a class it owns".

**4. The LinkageError is the delayed symptom.** Splicing two class graphs is legal at define time; the JVM only complains later, at some unrelated call site, naming two classes that look like they have nothing to do with the unload. That is why this was hard to attribute.

So the mixed-classloader `LinkageError` is not a second bug — it is what the silent fallback *produces* once a loader begins closing.

## What changed

### 1. Fail loudly once the loader leaves `ACTIVE` (the fix)

`plugin-platform/plugin-loader/.../PluginClassLoader.kt`

| loader state | class in plugin jar | before | now |
|---|---|---|---|
| `ACTIVE` | yes | plugin's copy | **unchanged** |
| `ACTIVE` | no | host's copy, unlogged | **unchanged** |
| unloading / closed | already defined by this loader | plugin's copy | **unchanged** (`findLoadedClass` early return) |
| unloading / closed | shared package (`kotlin.`, `androidx.compose.`, …) | host's copy | **unchanged** (parent-first) |
| unloading / closed | anything else | **host's copy, silently** | **refused** |

**The choice: throw `ClassNotFoundException`, log once at `WARN`.**

- *Why `ClassNotFoundException` and not an unchecked exception or an `Error`.* `loadClass` already declares `ClassNotFoundException`; every caller handles it, including the JVM's own resolution machinery, which converts it into a `NoClassDefFoundError` **at the resolution site** — precise and attributable, the opposite of the LinkageError this replaces. This runs on arbitrary threads during teardown (a Ktor worker, a coroutine dispatcher, an AWT handler); an unchecked throw from inside a classloader can slip past a `catch (e: Exception)` net and tear that thread down mid-teardown. A checked exception the call site already expects cannot.
- *Why `WARN`, not `ERROR`.* Refusing is the correct outcome and teardown continues normally; nothing is broken by the refusal itself. The throwable is attached to the log call so the entry carries the straggler's stack — that stack is the actual bug, and it is the thing this change exists to surface.
- *Why the log cannot wedge shutdown.* The refusal object is constructed first, the log call is wrapped, and a logging failure is swallowed. What propagates is always the refusal.
- *Why `UNLOAD_IN_PROGRESS` counts, not just closed.* `DynamicPluginLoader.unloadPlugin` calls `instance.dispose()` **before** `prepareUnload()` (which sets `UNLOAD_IN_PROGRESS`) and before `close()`. By the time the state leaves `ACTIVE`, the plugin's own orderly teardown has already finished, so there is no legitimate first-time class load left to serve.

The pre-existing `state=UNLOADED` warning stays as the breadcrumb that a late load happened at all; the new line records that one was refused.

### 2. Drop the accidental `io.ktor.server.*` from the host

`composeApp/build.gradle.kts`

Nothing in BossConsole declares it. Established with `dependencyInsight`:

```
io.ktor:ktor-server-cio:3.4.3
\--- io.github.jan-tennert.supabase:auth-kt-jvm:3.6.0
```

`ktor-server-core` arrives the same way. Checked before excluding:

- Inside `auth-kt`, the **only** classes referencing `io/ktor/server` are `io.github.jan.supabase.auth.server.HttpCallback*` — the localhost HTTP callback for **desktop OAuth-provider / SSO sign-in**, reached solely through `Utils_desktopKt.startExternalAuth`. `AuthConfig`/`HttpCallbackConfig` carry no ktor-server references, so `install(Auth)` does not touch them.
- BOSS authenticates with **OTP, email and passkeys** (`EmailAuthService`, `PasskeySessionHandler`, `SupabaseAuthClient`). It never calls `signInWith(<OAuthProvider>)` or SSO.
- No source file outside the standalone `server/` module — which is not on composeApp's graph — imports `io.ktor.server.*`.

Verdict: **exclude**. Supabase auth is untouched; 529 host classes disappear — exactly the ones the LinkageError was drawn from. The comment at the exclusion says what to delete if OAuth-provider or SSO sign-in is ever added, and names the symptom (`NoClassDefFoundError` on `io/ktor/server/cio/CIO`).

Verified after the change: `desktopRuntimeClasspath` has **zero** `ktor-server` entries and all the `ktor-client` / `ktor-utils` / `ktor-io` / … artifacts are still present; `:composeApp:compileKotlinDesktop` green; the full 1,074-test `composeApp:desktopTest` suite green.

### 3. The `libs.versions.toml` contradiction

`gradle/libs.versions.toml:20-25` — the comment said serialization is pinned to 1.9.x, line 25 said `1.11.0`.

**The pin drifted, and the requirement the comment protects no longer holds.** From the archive repo: commit `32819b10`, 2026-07-16, *"deps: Bump kotlinx-serialization from 1.9.0 to 1.11.0 (#839)"* — a one-line Dependabot change that left the "1.9.x required" rationale sitting directly above it.

So the pin's *value* was the original one; the question is whether the requirement still binds. It does not:

- `ktor 3.4.3` requests serialization `1.9.0` and is upgraded to `1.11.0` by conflict resolution (also 1.6.3 from essenty, 1.10.0 from cryptography) — a normal, satisfied upgrade.
- The cited break is `encodeToSink` / `decodeFromSource`. In the terminal-tab jar exactly one class references them — `io/ktor/serialization/kotlinx/json/ExperimentalJsonConverter`, against the `kotlinx/serialization/json/io/` package — and `kotlinx-serialization-json-io-jvm:1.11.0` is on the host classpath and still exports both (`javap` shows four overloads).
- Empirically: `terminal-tab` bundles **zero** `kotlinx.serialization` classes, so it runs entirely on the host's copy — and its MCP server answers requests today against a 1.11.0 host.

The comment is rewritten rather than deleted, because the *coupling* it described is real and load-bearing: `kotlinx.serialization.` is parent-first, so this line is the version every plugin gets regardless of what it bundles. Also corrected: the ktor note implied the pin exists because the MCP SDK caps at ktor ≤ 3.3.x — the host does not depend on the MCP SDK, and `io.ktor` is not shared with plugins, so the host's ktor version cannot reach a plugin's bundled one.

**Follow-up for another repo (not fixed here):** `boss_plugins/terminal-tab/build.gradle.kts:131-137` still documents the host as `kotlinx-serialization 1.9.0` and reasons from it. That statement has been wrong since #839.

## Why this is a loader fix, not a plugin fix

The same trap is armed for any plugin that under-bundles something the host happens to carry. Measuring the exposure — host `io.ktor` classes the plugin does **not** bundle, i.e. what the host could silently supply:

| plugin | host `io.ktor` classes it does not bundle | of which `ktor-server-*` |
|---|---|---|
| fluck-browser 1.2.8 | 687 | 0 |
| flow-tab 1.0.5 | 177 | 76 |
| terminal-tab 2.5.30 | 2 | 0 |

Two refinements worth recording, since the 687 / 177 figures have circulated as "missing names":

1. That column is *exposure*, not unresolved references. Counting only names each plugin **actually references and does not bundle**: fluck-browser 28, flow-tab 36, terminal-tab 38 — and **zero** of those resolve from the host in any of the three (they are Kotlin typealiases such as `io/ktor/events/EventHandler`, `io/ktor/server/routing/RoutingHandler`, `ProxyConfig`, which are not real classes). No plugin currently depends on the host's `io.ktor` while its loader is open.
2. terminal-tab bundles all but 2 of the host's `io.ktor` classes. Its LinkageError therefore *cannot* be explained by under-bundling — which is what pins the diagnosis on the closed loader.

## Tested vs reasoned

**Tested** — `PluginClassLoaderUnloadFallbackTest`, 7 cases. It builds a synthetic plugin jar by copying two dependency-free test classes out of the test classpath, so each class exists in both the jar and the parent: that duplication is what makes a silent fallback observable rather than indistinguishable from a correct load.

- open loader still delegates a genuine miss to the parent
- open loader defines its own copy of a class the jar carries
- **closed** loader refuses a class the jar *does* carry (the exact bug), with the plugin id, class name and state in the message and the `findClass` miss as the cause
- **unloading** loader refuses a missing class
- classes already defined survive `close()` (same `Class` object)
- shared parent-first packages still resolve after `close()`
- a class the plugin never carried is refused too once closed

**Mutation-checked** — every claim above was verified by breaking the production path and confirming the suite goes red:

| mutation | expected to die | result |
|---|---|---|
| remove the refusal block entirely (restore silent fallback) | the 3 refusal tests | **3 failed** |
| refuse unconditionally, including while `ACTIVE` | the open-loader fallback tests | **2 failed** |
| refuse only when `UNLOADED`, not `UNLOAD_IN_PROGRESS` | the unloading-state test | **1 failed** |
| also refuse shared parent-first classes during unload | the shared-package teardown test | **1 failed** |

**Reasoned, not tested:** that the real-world Ktor teardown sequence in terminal-tab is what made the late request (the log gives the effect, not the caller); and the thread-safety argument for `ClassNotFoundException` over an unchecked throw.

**Not in scope:** `getResource` / `getResources` take the same silent parent-fallback shape (`findResource(name) ?: parent.getResource(name)`), so a closed loader can hand back the host's copy of a plugin resource. Left alone deliberately — returning `null` there risks NPEs in teardown paths that assume a resource exists, and it needs its own reasoning about `META-INF/services` and `plugin.json`.

**Platform note:** the tests use only JDK zip/classloader APIs, so they need none of the Windows-ARM64 `desktopTest` exclusions in `composeApp/build.gradle.kts` (those exist for `boss-ipc` / protoc, and the loader module has no such dependency).

## Gates

| gate | result |
|---|---|
| `./gradlew detekt ktlintCheck` (full aggregate, all modules) | **BUILD SUCCESSFUL** — 265 actionable tasks; `plugin-loader:detekt`, both `plugin-loader` ktlint source-set tasks, `composeApp:detekt` and `composeApp:ktlintKotlinScriptCheck` all executed, not cached |
| `:plugin-platform:plugin-loader:desktopTest` | **87 tests, 0 failures** (11 classes; 7 new) |
| `:composeApp:desktopTest` | **1,074 tests, 0 failures** (78 classes) |
| `:composeApp:compileKotlinDesktop` | **BUILD SUCCESSFUL** |
| `desktopRuntimeClasspath` after the exclusion | 0 `ktor-server` entries, all ktor-client artifacts intact |

## Related

Companion plugin-side fix: risa-labs-inc/boss-plugin-terminal-tab#52 removes the *trigger* for one plugin. This removes the *mechanism* for all of them.

---

## Follow-up commit (review response)

`5ea5d0d8` addresses the review on `ee5161ed`:

- **Refusal logging is deduped; the refusal is not.** The straggler is by construction a retry loop, so one `WARN` with a stack per class name, `DEBUG` after. A new assertion in the closed-loader test proves the *second* request still throws — dedup must never turn into "succeeds on retry". Mutation `m5` (dedupe the refusal itself, not just the log) kills 3 tests.
- **State is snapshotted once** in the refusal path, so the message and the structured `state` field cannot disagree across an `UNLOAD_IN_PROGRESS → UNLOADED` transition mid-refusal.
- **The ordering invariant is now enforced, not just documented.** `PluginUnloadOrderingTest` loads a real fixture plugin through `DynamicPluginLoaderImpl` and asserts its `dispose()` observes `ACTIVE`, plus that the loader is `UNLOADED` once `unloadPlugin` returns. Mutation `m6` — move `markUnloading()` ahead of `dispose()` in `unloadPlugin`, the exact refactor that would silently break every plugin's dispose — makes it fail.
- **The ktor-server exclusion is asserted in CI.** `KtorServerAbsentFromHostTest` checks both halves: no `io.ktor.server.*` on the host classpath, and the ktor client stack (`HttpClient`, `CIOEngine`, `AttributeKey`) still present. Mutation `m7` — delete the exclusion block — makes it fail. This converts a hand-run `dependencyInsight` into a standing guarantee against a future supabase bump.
- **Why the exclusion is blanket** rather than a declaration-site `exclude`: `auth-kt` reaches this graph twice, directly and via `project(':plugin-platform:plugin-repository')`, so a per-dependency exclude would only remove one of them. Documented at the block, including the consequence that `libs.ktor.server.tests` cannot be added to a composeApp source set while it stands.
- **The version-catalog comment is trimmed to the durable invariant.** The old comment was wrong precisely because it recorded a point-in-time verification as a standing requirement; the archaeology stays in this PR description where it cannot rot into a false constraint.
- **KDoc records the margin** that makes a blanket refusal tolerable: only *first-time* loads are refused, because the JVM registers this loader as the initiating loader for every name it already resolved — host classes included — so `findLoadedClass` keeps answering them after `close()`.

Declined, with reasoning: snapshotting the plugin jar's class-name index at `close()` to refuse *precisely* the classes the plugin owns. It would narrow the collateral (a late thread touching a non-shared host class it never touched before), but it adds a per-loader index and a second source of truth to a teardown path, for a case that is a lifecycle bug either way. The blanket rule is the one that is easy to reason about.

Deferred to its own issue rather than this PR: #58, the same silent parent fallback in `getResource`/`getResources`. `getResources` is the sharper edge — `META-INF/services` falling through means a closed loader can hand `ServiceLoader` the *host's* implementations.

### Updated gates

| gate | result |
|---|---|
| `./gradlew detekt ktlintCheck` (full aggregate) | **BUILD SUCCESSFUL**, 262 actionable tasks. Caught two real violations first: `NestedBlockDepth` on the refusal path (fixed by making the ACTIVE fallback an early return and moving the log helper to the companion, which also keeps the class under detekt's 11-function budget) and `EmptyFunctionBlock` in the new fixture. |
| `:plugin-platform:plugin-loader:desktopTest` | **90 tests, 0 failures** (12 classes) |
| `:composeApp:desktopTest` | **1,076 tests, 0 failures** (79 classes) |

### Full mutation matrix

| # | mutation | expected to die | result |
|---|---|---|---|
| m1 | remove the refusal block (restore silent fallback) | the 3 refusal tests | **3 failed** |
| m2 | refuse unconditionally, including while `ACTIVE` | open-loader fallback + both fixture-plugin suites | **6 failed** |
| m3 | refuse only when `UNLOADED`, not `UNLOAD_IN_PROGRESS` | the unloading-state test | **1 failed** |
| m4 | also refuse shared parent-first classes during unload | both shared-package teardown tests | **2 failed** |
| m5 | dedupe the refusal itself, not just the log | the 3 refusal tests | **3 failed** |
| m6 | `markUnloading()` before `dispose()` in `unloadPlugin` | the ordering test | **1 failed** |
| m7 | delete the ktor-server exclusion | the classpath-absence test | **1 failed** |

---

## Second review round (`f11748ff`)

**#1 — the un-deduped WARN defeated the dedup. Fixed.** Correct and the most important finding: the pre-existing `"Attempt to load class from unloading classloader"` fired at WARN on *every* post-`ACTIVE` attempt with no dedup, so a retry loop still flooded shutdown, just with the benign message. Dropped to DEBUG. The refusal is now the single WARN, and it is deduped per class name.

**#2 — `UNLOAD_IN_PROGRESS` buys nothing against LinkageError. Kept, and the reasoning is now explicit in the KDoc.** You are right on the mechanism, and the KDoc no longer pretends one argument covers both states:

- `UNLOADED` — **correctness**. The jar is shut, `findClass` misses on every name including ones the plugin owns, delegation splices two class graphs.
- `UNLOAD_IN_PROGRESS` — **policy**. The jar is still open, so a miss is a genuine miss and delegation cannot corrupt anything. Refused anyway as fail-fast on a lifecycle bug.

Why keep it: `dispose()` has already returned by the time this state is set, and `prepareUnload()` → `closeClassLoader()` run back to back with nothing between them (`DynamicPluginLoader.kt:424-426`), so the window is microseconds. A straggler that gets delegation in that window gets refused a moment later once `close()` lands — the collateral you describe applies to the `UNLOADED` state too, which we refuse regardless. So the choice is between one rule and two rules for the same outcome. On `disposeAll()`: it calls `close()` directly without `markUnloading()`, so it goes `ACTIVE → UNLOADED` and never enters the policy half at all.

**#3 — the exclusion and its test covered `core`/`cio` only. Fixed, as you suggested.** `KtorServerAbsentFromHostTest` now scans every classpath entry for `io/ktor/server/` rather than probing four names, so `ktor-server-sse` / `-websockets` / `-netty` arriving by a new path fails CI. Under mutation `m7` it reports: *"ktor-server is back on the host classpath via ktor-server-cio-jvm-3.4.3.jar, ktor-server-core-jvm-3.4.3.jar"* — the artifact names, plus the `dependencyInsight` command to find the path. `Class.forName(name, false, loader)` on the positive half.

**#4 — untested claim that the still-open jar keeps serving. Fixed.** New test: `markUnloading()`, then `loadClass(OwnedByPluginA)` must succeed *and* report the plugin loader as its `classLoader`. New mutation `m8` (refuse post-`ACTIVE` before even trying `findClass`) kills it — confirming the gap was real, since `m8` would otherwise have survived.

**#5 — dangling prose reference. Fixed.** The "dispose() must precede prepareUnload()" rule now sits next to the `dispose()` call in `unloadPlugin`, pointing at the test, so the invariant is visible to whoever would break it.

**#6 — the ktor pin lost its rationale. Fixed, and the honest answer is that there never was one.** The reverted reason on record was plugin compatibility, which cannot apply: the host's ktor never reaches a plugin. No host-side diagnosis of 3.5.0 was ever recorded. The comment now says exactly that and says to retry the next 3.5.x bump rather than implying a known-bad.

**#7 — not parallel-capable.** Real, pre-existing, and on-topic: no `registerAsParallelCapable()`, and the child-first path bypasses `getClassLoadingLock`. Filed as **#59** so a duplicate-definition `LinkageError` in the wild is not mistaken for a regression from this PR.

**#8 nits.** `details` is now built per branch (the repeat path no longer allocates for a usually-disabled DEBUG). Declined: swapping `parent.loadClass(name)` for `super.loadClass(name, resolve)` — it would also register this loader as an initiating loader for host classes, which changes the `findLoadedClass` margin this PR documents; worth doing, but not as an unmeasured rider. `refusedClassNames` unboundedness and the `UnloadOrderProbe` global are acknowledged as noted.

**Declined:** snapshotting the jar's class-name index at `close()` to refuse precisely the plugin's own classes. It narrows collateral but adds a second source of truth to a teardown path, for a case that is a lifecycle bug either way.

### Gates after this round

Two real detekt violations were caught by the full aggregate and fixed before pushing (`NestedBlockDepth` on the refusal path — resolved by making the `ACTIVE` fallback an early return and moving the log helper to the companion, which also keeps the class under the 11-function budget; `EmptyFunctionBlock` in the new fixture).

| gate | result |
|---|---|
| `./gradlew detekt ktlintCheck` (full aggregate) | **BUILD SUCCESSFUL** |
| `:plugin-platform:plugin-loader:desktopTest` | **91 tests, 0 failures** (12 classes) |
| `:composeApp:desktopTest` | **1,076 tests, 0 failures** (79 classes) |

### Final mutation matrix — 8 mutations, 8 killed

| # | mutation | killed by | result |
|---|---|---|---|
| m1 | never refuse (original silent fallback) | the 3 refusal tests | **3 failed** |
| m2 | refuse even while `ACTIVE` | open-loader fallback + both fixture-plugin suites | **6 failed** |
| m3 | refuse only when `UNLOADED` | the `UNLOAD_IN_PROGRESS` test | **1 failed** |
| m4 | also refuse shared parent-first classes | both shared-package tests + the open-jar test | **3 failed** |
| m5 | dedupe the refusal itself, not just the log | the second-request assertion | **1 failed** |
| m6 | `markUnloading()` before `dispose()` | the ordering test | **1 failed** |
| m7 | delete the ktor-server exclusion | the classpath scan (named both jars) | **1 failed** |
| m8 | refuse before trying the plugin's own jar | the open-jar test | **2 failed** |

An earlier m5 formulation (`refusedClassNames.size <= 1`) survived because it still threw on both calls — it did not actually model refusal-dedup. Reported here because a mutation that cannot distinguish the behaviours is not evidence; the corrected m5 gates on `firstSighting` and dies.

### Related issues

- #58 — `getResource`/`getResources` take the same silent parent fallback (deferred from this PR)
- #59 — `PluginClassLoader` is not parallel-capable and bypasses `getClassLoadingLock` (pre-existing)
