### PR TITLE
Only record browser history for pages that actually loaded

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/Fluck.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/Fluck.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.plugin.tab_types.fluck
 import ai.rever.boss.components.registery.*
 import ai.rever.boss.dashboard.DashboardStatsManager
 import ai.rever.boss.dashboard.RecentBrowserPagesManager
+import ai.rever.boss.plugin.browser.NavigationOutcomeTracker
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.tabfullscreen.TabFullscreenStateManager
@@ -167,9 +168,13 @@ class FluckTabInfo(
             newIndex = newHistory.size - 1
         }
 
-        // Track page visit
-        RecentBrowserPagesManager.recordPageVisit(url, title, faviconCacheKey)
-        DashboardStatsManager.recordPageVisit()
+        // Track page visit. The back/forward list above still gets the entry — the tab is
+        // sitting on that URL either way — but a navigation that ended on an error page
+        // isn't a page the user visited, so it stays out of the dashboard and its counter.
+        if (!NavigationOutcomeTracker.didFail(url)) {
+            RecentBrowserPagesManager.recordPageVisit(url, title, faviconCacheKey)
+            DashboardStatsManager.recordPageVisit()
+        }
 
         // Return NEW instance with updated values (no mutation!)
         // Note: We DON'T update _title here because onTitleUpdate handles that separately
@@ -213,9 +218,11 @@ class FluckTabInfo(
             historyIndex = navigationHistory.size - 1
         }
 
-        // Track page visit in dashboard
-        RecentBrowserPagesManager.recordPageVisit(url, title, faviconCacheKey)
-        DashboardStatsManager.recordPageVisit()
+        // Track page visit in dashboard (skipping navigations that never loaded a page)
+        if (!NavigationOutcomeTracker.didFail(url)) {
+            RecentBrowserPagesManager.recordPageVisit(url, title, faviconCacheKey)
+            DashboardStatsManager.recordPageVisit()
+        }
     }
 
     @Synchronized

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.dashboard
 
+import ai.rever.boss.plugin.browser.NavigationOutcomeTracker
+import ai.rever.boss.plugin.browser.canonicalUrlKey
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -61,6 +63,9 @@ object RecentBrowserPagesManager {
     private val logger = BossLogger.forComponent("RecentBrowserPagesManager")
     private const val MAX_PAGES = 30
     private const val SAVE_DEBOUNCE_MS = 5000L // Debounce saves to max once per 5 seconds
+
+    /** Schemes that address the browser itself rather than a page someone visited. */
+    private val INTERNAL_URL_PREFIXES = listOf("about:", "chrome:", "data:")
     private val settingsFile = BossDirectories.resolve("recent-browser-pages.json")
     private val json =
         Json {
@@ -313,9 +318,13 @@ object RecentBrowserPagesManager {
         title: String,
         faviconCacheKey: String? = null,
     ) {
-        // Skip internal URLs and empty titles
-        if (url.isBlank() || title.isBlank()) return
-        if (url.startsWith("about:") || url.startsWith("chrome:") || url.startsWith("data:")) return
+        // Internal URLs have no page behind them, and a navigation that ended on an error
+        // page never showed the user anything — it still reports a title and a finished
+        // load, so without the outcome check a mistyped host would sit in the recent pages
+        // (and come back as a suggestion) as if it had loaded.
+        val isInternal = INTERNAL_URL_PREFIXES.any { url.startsWith(it) }
+        val describesAPage = url.isNotBlank() && title.isNotBlank() && !isInternal
+        if (!describesAPage || NavigationOutcomeTracker.didFail(url)) return
 
         scope.launch {
             val currentPages = _recentPages.value.toMutableList()
@@ -358,6 +367,27 @@ object RecentBrowserPagesManager {
         scope.launch {
             _recentPages.value = _recentPages.value.filter { it.url != url }
             scheduleSave()
+        }
+    }
+
+    /**
+     * Remove every page that points at the same place as [url].
+     *
+     * Matching is by [canonicalUrlKey] rather than string equality, so a page recorded
+     * under the URL the user typed is still found when the browser reports the URL it
+     * actually tried to load. Used to retire entries for addresses that turn out not to
+     * exist.
+     */
+    fun removeMatchingPages(url: String) {
+        val key = canonicalUrlKey(url)
+        if (key.isEmpty()) return
+
+        scope.launch {
+            val remaining = _recentPages.value.filter { canonicalUrlKey(it.url) != key }
+            if (remaining.size != _recentPages.value.size) {
+                _recentPages.value = remaining
+                scheduleSave()
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.atomicWriteText
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.logging.LogSanitizer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -419,9 +420,16 @@ object RecentBrowserPagesManager {
                 logger.info(
                     LogCategory.BROWSER,
                     "Removed recent pages for an address that failed to load",
-                    mapOf("removed" to removed.toString()),
+                    mapOf(
+                        "url" to LogSanitizer.maskUriParams(url),
+                        "removed" to removed.toString(),
+                    ),
                 )
-                scheduleSave()
+                // Immediately, not on the 5s debounce the additive path uses: the whole
+                // scenario here is mistype, see the error page, close the app — which
+                // lands inside that window and would leave the typo in the file to come
+                // back as a dashboard recent on the next launch.
+                saveImmediately()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -2,7 +2,9 @@ package ai.rever.boss.dashboard
 
 import ai.rever.boss.plugin.browser.NavigationOutcomeTracker
 import ai.rever.boss.plugin.browser.canonicalUrlKey
+import ai.rever.boss.plugin.browser.suggestableHost
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.atomicWriteText
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
@@ -63,9 +65,6 @@ object RecentBrowserPagesManager {
     private val logger = BossLogger.forComponent("RecentBrowserPagesManager")
     private const val MAX_PAGES = 30
     private const val SAVE_DEBOUNCE_MS = 5000L // Debounce saves to max once per 5 seconds
-
-    /** Schemes that address the browser itself rather than a page someone visited. */
-    private val INTERNAL_URL_PREFIXES = listOf("about:", "chrome:", "data:")
     private val settingsFile = BossDirectories.resolve("recent-browser-pages.json")
     private val json =
         Json {
@@ -298,7 +297,9 @@ object RecentBrowserPagesManager {
                 settingsFile.parentFile?.mkdirs()
                 val data = RecentBrowserPagesData(pages = _recentPages.value)
                 val content = json.encodeToString(RecentBrowserPagesData.serializer(), data)
-                settingsFile.writeText(content)
+                // Atomic: the debounced save and an eviction can land together, and a
+                // half-written file reads back as "no recent pages".
+                settingsFile.atomicWriteText(content)
             } catch (e: Exception) {
                 logger.warn(LogCategory.SYSTEM, "Error saving recent pages", error = e)
             }
@@ -318,12 +319,13 @@ object RecentBrowserPagesManager {
         title: String,
         faviconCacheKey: String? = null,
     ) {
-        // Internal URLs have no page behind them, and a navigation that ended on an error
-        // page never showed the user anything — it still reports a title and a finished
-        // load, so without the outcome check a mistyped host would sit in the recent pages
-        // (and come back as a suggestion) as if it had loaded.
-        val isInternal = INTERNAL_URL_PREFIXES.any { url.startsWith(it) }
-        val describesAPage = url.isNotBlank() && title.isNotBlank() && !isInternal
+        // A navigation that ended on an error page never showed the user anything — it
+        // still reports a title and a finished load, so without the outcome check a
+        // mistyped host would sit in the recent pages (and come back as a suggestion) as
+        // if it had loaded. The host check is shared with the URL history so the two
+        // stores can't drift on what counts as a page: `about:`, `data:`, `blob:`,
+        // `chrome://` and `file://` have no domain to match or display.
+        val describesAPage = title.isNotBlank() && suggestableHost(url) != null
         if (!describesAPage || NavigationOutcomeTracker.didFail(url)) return
 
         scope.launch {
@@ -377,14 +379,31 @@ object RecentBrowserPagesManager {
      * under the URL the user typed is still found when the browser reports the URL it
      * actually tried to load. Used to retire entries for addresses that turn out not to
      * exist.
+     *
+     * @param recordedWithinMs when set, only removes pages visited that recently — the
+     *   race where a title callback recorded a visit just before the browser reported the
+     *   navigation as failed. Older entries are real history and are left alone. Null
+     *   removes regardless of age.
      */
-    fun removeMatchingPages(url: String) {
+    fun removeMatchingPages(
+        url: String,
+        recordedWithinMs: Long? = null,
+    ) {
         val key = canonicalUrlKey(url)
         if (key.isEmpty()) return
 
         scope.launch {
-            val remaining = _recentPages.value.filter { canonicalUrlKey(it.url) != key }
+            val cutoff = recordedWithinMs?.let { System.currentTimeMillis() - it }
+            val remaining =
+                _recentPages.value.filterNot { page ->
+                    canonicalUrlKey(page.url) == key && (cutoff == null || page.lastVisited >= cutoff)
+                }
             if (remaining.size != _recentPages.value.size) {
+                logger.info(
+                    LogCategory.BROWSER,
+                    "Removed recent pages for an address that failed to load",
+                    mapOf("removed" to (_recentPages.value.size - remaining.size).toString()),
+                )
                 _recentPages.value = remaining
                 scheduleSave()
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -75,6 +76,7 @@ object RecentBrowserPagesManager {
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var saveJob: Job? = null
+    private val saveJobLock = Any()
 
     private val _recentPages = MutableStateFlow<List<RecentBrowserPage>>(emptyList())
     val recentPages: StateFlow<List<RecentBrowserPage>> = _recentPages.asStateFlow()
@@ -280,12 +282,17 @@ object RecentBrowserPagesManager {
      * Cancels any pending save and schedules a new one after SAVE_DEBOUNCE_MS.
      */
     private fun scheduleSave() {
-        saveJob?.cancel()
-        saveJob =
-            scope.launch {
-                delay(SAVE_DEBOUNCE_MS)
-                saveImmediately()
-            }
+        // Swap the debounce job under a lock: callers now arrive from concurrent
+        // coroutines (a visit and an eviction racing), and an unsynchronized
+        // cancel-then-assign can drop the reference to a job that is still pending.
+        synchronized(saveJobLock) {
+            saveJob?.cancel()
+            saveJob =
+                scope.launch {
+                    delay(SAVE_DEBOUNCE_MS)
+                    saveImmediately()
+                }
+        }
     }
 
     /**
@@ -329,35 +336,39 @@ object RecentBrowserPagesManager {
         if (!describesAPage || NavigationOutcomeTracker.didFail(url)) return
 
         scope.launch {
-            val currentPages = _recentPages.value.toMutableList()
-            val existingIndex = currentPages.indexOfFirst { it.url == url }
+            // update{} rather than read-then-write: this runs on a multi-threaded
+            // dispatcher and is *expected* to race an eviction — that is the whole
+            // TitleChanged-arrived-first case — so a lost update here would put back the
+            // entry that was just retracted.
+            _recentPages.update { pages ->
+                val currentPages = pages.toMutableList()
+                val existingIndex = currentPages.indexOfFirst { it.url == url }
 
-            val newPage =
-                if (existingIndex >= 0) {
-                    // Update existing entry
-                    val existing = currentPages.removeAt(existingIndex)
-                    existing.copy(
-                        title = title,
-                        lastVisited = System.currentTimeMillis(),
-                        faviconCacheKey = faviconCacheKey ?: existing.faviconCacheKey,
-                        visitCount = existing.visitCount + 1,
-                    )
-                } else {
-                    // Create new entry
-                    RecentBrowserPage(
-                        url = url,
-                        title = title,
-                        lastVisited = System.currentTimeMillis(),
-                        faviconCacheKey = faviconCacheKey,
-                        visitCount = 1,
-                    )
-                }
+                val newPage =
+                    if (existingIndex >= 0) {
+                        // Update existing entry
+                        val existing = currentPages.removeAt(existingIndex)
+                        existing.copy(
+                            title = title,
+                            lastVisited = System.currentTimeMillis(),
+                            faviconCacheKey = faviconCacheKey ?: existing.faviconCacheKey,
+                            visitCount = existing.visitCount + 1,
+                        )
+                    } else {
+                        // Create new entry
+                        RecentBrowserPage(
+                            url = url,
+                            title = title,
+                            lastVisited = System.currentTimeMillis(),
+                            faviconCacheKey = faviconCacheKey,
+                            visitCount = 1,
+                        )
+                    }
 
-            // Add to front (most recent)
-            currentPages.add(0, newPage)
-
-            // Trim to max size
-            _recentPages.value = currentPages.take(MAX_PAGES)
+                // Add to front (most recent), trimmed to max size
+                currentPages.add(0, newPage)
+                currentPages.take(MAX_PAGES)
+            }
             scheduleSave()
         }
     }
@@ -367,7 +378,7 @@ object RecentBrowserPagesManager {
      */
     fun removePage(url: String) {
         scope.launch {
-            _recentPages.value = _recentPages.value.filter { it.url != url }
+            _recentPages.update { pages -> pages.filter { it.url != url } }
             scheduleSave()
         }
     }
@@ -394,17 +405,22 @@ object RecentBrowserPagesManager {
 
         scope.launch {
             val cutoff = recordedWithinMs?.let { System.currentTimeMillis() - it }
-            val remaining =
-                _recentPages.value.filterNot { page ->
-                    canonicalUrlKey(page.url) == key && (cutoff == null || page.lastVisited >= cutoff)
-                }
-            if (remaining.size != _recentPages.value.size) {
+            var removed = 0
+            _recentPages.update { pages ->
+                val remaining =
+                    pages.filterNot { page ->
+                        canonicalUrlKey(page.url) == key &&
+                            (cutoff == null || page.lastVisited >= cutoff)
+                    }
+                removed = pages.size - remaining.size
+                remaining
+            }
+            if (removed > 0) {
                 logger.info(
                     LogCategory.BROWSER,
                     "Removed recent pages for an address that failed to load",
-                    mapOf("removed" to (_recentPages.value.size - remaining.size).toString()),
+                    mapOf("removed" to removed.toString()),
                 )
-                _recentPages.value = remaining
                 scheduleSave()
             }
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.dashboard
 
 import ai.rever.boss.plugin.browser.NavigationOutcomeTracker
 import ai.rever.boss.plugin.browser.canonicalUrlKey
+import ai.rever.boss.plugin.browser.shouldRetireVisit
 import ai.rever.boss.plugin.browser.suggestableHost
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.atomicWriteText
@@ -409,8 +410,7 @@ object RecentBrowserPagesManager {
             _recentPages.update { pages ->
                 val remaining =
                     pages.filterNot { page ->
-                        canonicalUrlKey(page.url) == key &&
-                            (cutoff == null || page.lastVisited >= cutoff)
+                        shouldRetireVisit(page.url, page.lastVisited, page.visitCount, key, cutoff)
                     }
                 removed = pages.size - remaining.size
                 remaining

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -82,7 +82,12 @@ object NavigationOutcomeTracker {
     ) {
         val key = canonicalUrlKey(url)
         if (key.isEmpty()) return
-        lastLoadedAt = now
+        // Only a page fetched over the network is evidence that name resolution works.
+        // `about:blank` commits as a normal main-frame navigation in this app — it is the
+        // new-tab/dashboard page — and so do file:// pages, so counting them would let
+        // opening a tab during a DNS outage vouch for the resolver and re-arm the
+        // eviction this flag exists to hold back.
+        if (suggestableHost(url) != null) lastLoadedAt = now
         synchronized(failedUrls) {
             failedUrls.remove(key)
         }
@@ -174,6 +179,28 @@ fun suggestableHost(url: String): String? =
         // that want a breadcrumb log the masked URL themselves.
         null
     }
+
+/**
+ * Whether a stored visit should be retired because a navigation to [targetKey] failed.
+ *
+ * Shared by both stores so the *destructive* decision can't drift between them — the same
+ * reason [suggestableHost] is shared for the additive one.
+ *
+ * @param cutoff the earliest `lastVisited` a retraction may touch, or null for eviction of
+ *   an address that no longer exists. A retraction also requires a single visit: it exists
+ *   to undo one racing record, and `lastVisited` alone can't tell that apart from a
+ *   long-standing entry that happens to have been open a moment ago.
+ */
+fun shouldRetireVisit(
+    entryUrl: String,
+    entryLastVisited: Long,
+    entryVisitCount: Int,
+    targetKey: String,
+    cutoff: Long?,
+): Boolean {
+    if (targetKey.isEmpty() || canonicalUrlKey(entryUrl) != targetKey) return false
+    return cutoff == null || (entryLastVisited >= cutoff && entryVisitCount <= 1)
+}
 
 /**
  * Like [canonicalUrlKey], but two URLs are only the same page if their fragments agree.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -61,18 +61,47 @@ object NavigationOutcomeTracker {
      */
     const val FAILURE_TTL_MS = 30_000L
 
+    /**
+     * How recently something must have loaded for name-resolution failures to be read as
+     * "this address does not exist" rather than "DNS is broken right now".
+     */
+    const val RESOLVER_HEALTH_WINDOW_MS = 60_000L
+
     /** Bounds memory if a page redirect-loops through failures; oldest keys go first. */
     private const val MAX_TRACKED_FAILURES = 256
 
     private val failedUrls = LinkedHashMap<String, Long>()
 
+    @Volatile
+    private var lastLoadedAt: Long? = null
+
     /** Record that a main-frame navigation to [url] committed a real page. */
-    fun recordSuccess(url: String) {
+    fun recordSuccess(
+        url: String,
+        now: Long = System.currentTimeMillis(),
+    ) {
         val key = canonicalUrlKey(url)
         if (key.isEmpty()) return
+        lastLoadedAt = now
         synchronized(failedUrls) {
             failedUrls.remove(key)
         }
+    }
+
+    /**
+     * Whether some page has loaded recently enough to trust that name resolution works.
+     *
+     * `ERR_NAME_NOT_RESOLVED` is not a typo signal on its own — it is also the everyday
+     * symptom of a resolver that has stopped answering: captive-portal Wi-Fi, a VPN that
+     * dropped its DNS, a flaky router. (`ERR_INTERNET_DISCONNECTED` only fires when the OS
+     * itself reports no route, so it doesn't cover this.) Treating an outage as proof that
+     * an address doesn't exist would delete a real, heavily-visited entry for every site
+     * tried while DNS was down. A page that loaded moments ago is the evidence that
+     * resolution is working and this one address really is the odd one out.
+     */
+    fun hasLoadedRecently(now: Long = System.currentTimeMillis()): Boolean {
+        val loadedAt = lastLoadedAt ?: return false
+        return now - loadedAt <= RESOLVER_HEALTH_WINDOW_MS
     }
 
     /** Record that a main-frame navigation to [url] ended on an error page (or never committed). */
@@ -120,6 +149,7 @@ object NavigationOutcomeTracker {
 
     /** Drop all tracked outcomes. */
     internal fun clear() {
+        lastLoadedAt = null
         synchronized(failedUrls) { failedUrls.clear() }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -34,6 +34,41 @@ fun classifyNavigation(
         else -> NavigationVerdict.LOADED
     }
 
+/** How much stored history a failed navigation is allowed to take with it. */
+enum class RetractionScope {
+    /** The address does not exist: every entry for it goes, whatever its age or count. */
+    EVICT_ALL,
+
+    /** Undo only a visit a racing callback recorded moments ago. */
+    RETRACT_RECENT,
+
+    /** Touch nothing. */
+    LEAVE_ALONE,
+}
+
+/**
+ * How far a failed navigation may reach into stored history.
+ *
+ * Only an error page can have raced a visit into the stores: Chromium titles the error
+ * document, and that title is what reaches the history before the navigation verdict
+ * does. A navigation that never committed — stop pressed, a link clicked while a reload
+ * was in flight, a load that turned into a download — produces no title and therefore no
+ * visit to undo, so treating it as a failure worth retracting would delete the entry for a
+ * page the user is happily looking at.
+ *
+ * @param addressIsGone the caller's judgement that this address does not exist, which
+ *   needs more than a name-resolution error: see [NavigationOutcomeTracker.hasLoadedRecently].
+ */
+fun retractionScopeFor(
+    isErrorPage: Boolean,
+    addressIsGone: Boolean,
+): RetractionScope =
+    when {
+        addressIsGone -> RetractionScope.EVICT_ALL
+        isErrorPage -> RetractionScope.RETRACT_RECENT
+        else -> RetractionScope.LEAVE_ALONE
+    }
+
 /**
  * Remembers which addresses just failed to load, so the stores that record visits can
  * skip them.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -59,6 +59,21 @@ object NavigationOutcomeTracker {
 }
 
 /**
+ * Like [canonicalUrlKey], but two URLs are only the same page if their fragments agree.
+ *
+ * Use this to decide whether two history entries describe one page. [canonicalUrlKey]
+ * ignores the fragment, which is right for navigation outcomes — an address that doesn't
+ * resolve doesn't resolve for any `#section` of it — but wrong for identity: a
+ * hash-routed app serves genuinely different pages from one path, so treating them as
+ * one would fold every Gmail view (`#inbox`, `#sent`, `#search/…`) into a single entry.
+ */
+fun distinctPageKey(url: String): String {
+    val base = canonicalUrlKey(url)
+    val fragment = url.trim().substringAfter('#', "")
+    return if (base.isEmpty() || fragment.isEmpty()) base else "$base#$fragment"
+}
+
+/**
  * Normalize [url] into a key that survives the cosmetic differences between the URL a
  * user typed, the URL a plugin reports, and the URL the engine committed: scheme and
  * host casing, a `http(s)://` prefix, a `www.` prefix, a trailing slash, and a fragment.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -1,25 +1,70 @@
 package ai.rever.boss.plugin.browser
 
+/** What a finished navigation means for the stores that record visits. */
+enum class NavigationVerdict {
+    /** Not about the page the user is on (a sub-frame, or no URL to key on). */
+    IGNORED,
+
+    /** A real page loaded — record the visit. */
+    LOADED,
+
+    /** An error page, an aborted load, or a network error — record nothing. */
+    FAILED,
+}
+
 /**
- * Remembers whether the last main-frame navigation to a URL actually produced a page.
+ * Classify a finished navigation from the facts the browser engine reports.
+ *
+ * Kept free of engine types so the rule itself is testable: everything about which
+ * [com.teamdev.jxbrowser.net.NetError] values mean what stays at the call site.
+ *
+ * "Never committed" counts as failure because nothing was shown — a load that turned into
+ * a download, or was replaced before it painted, is not a page anyone visited.
+ */
+fun classifyNavigation(
+    isMainFrame: Boolean,
+    hasUrl: Boolean,
+    isErrorPage: Boolean,
+    hasCommitted: Boolean,
+    hasNetworkError: Boolean,
+): NavigationVerdict =
+    when {
+        !isMainFrame || !hasUrl -> NavigationVerdict.IGNORED
+        isErrorPage || !hasCommitted || hasNetworkError -> NavigationVerdict.FAILED
+        else -> NavigationVerdict.LOADED
+    }
+
+/**
+ * Remembers which addresses just failed to load, so the stores that record visits can
+ * skip them.
  *
  * A browser reports a title and a "load finished" for a URL that never loaded — typing
  * `youtube.como` still commits an error page, still fires TitleChanged, and used to land
- * in the URL history and the dashboard's recent pages, where it came back as a
- * suggestion forever. The browser engine is the only layer that knows a navigation
- * ended on an error page, so it records the outcome here and the two history stores
- * consult it before recording a visit.
+ * in the URL history and the dashboard's recent pages, where it came back as a suggestion
+ * forever. The engine is the only layer that knows a navigation ended on an error page,
+ * so it records the outcome here and the stores consult it before recording a visit.
  *
  * Entries are keyed by [canonicalUrlKey] so the URL the engine committed
- * (`https://youtube.como/`) matches the one a caller reports (`youtube.como`), and the
- * failure set is bounded — it only needs to survive the moment between a navigation
- * finishing and the title/load callbacks that follow it.
+ * (`https://youtube.como/`) matches the one a caller reports (`youtube.como`).
+ *
+ * **Failures expire.** A verdict is only meant to cover the moment between a navigation
+ * finishing and the callbacks that follow it, and [FAILURE_TTL_MS] enforces that rather
+ * than trusting a later success on the same key to clear it — a redirect commits a
+ * *different* URL, so the address the user actually asked for would otherwise stay
+ * "failed" for the rest of the session and quietly drop every later visit to it.
  */
 object NavigationOutcomeTracker {
-    /** Plenty for the in-flight window; oldest keys are dropped first. */
+    /**
+     * How long a failure verdict stays authoritative. Comfortably longer than the gap
+     * between a navigation finishing and its title/load callbacks (milliseconds), short
+     * enough that a stale verdict can't shadow a page the user goes back to.
+     */
+    const val FAILURE_TTL_MS = 30_000L
+
+    /** Bounds memory if a page redirect-loops through failures; oldest keys go first. */
     private const val MAX_TRACKED_FAILURES = 256
 
-    private val failedUrls = LinkedHashSet<String>()
+    private val failedUrls = LinkedHashMap<String, Long>()
 
     /** Record that a main-frame navigation to [url] committed a real page. */
     fun recordSuccess(url: String) {
@@ -31,32 +76,74 @@ object NavigationOutcomeTracker {
     }
 
     /** Record that a main-frame navigation to [url] ended on an error page (or never committed). */
-    fun recordFailure(url: String) {
+    fun recordFailure(
+        url: String,
+        now: Long = System.currentTimeMillis(),
+    ) {
         val key = canonicalUrlKey(url)
         if (key.isEmpty()) return
         synchronized(failedUrls) {
             // Re-insert so a repeated failure counts as the most recent entry.
             failedUrls.remove(key)
-            failedUrls.add(key)
+            failedUrls[key] = now
             while (failedUrls.size > MAX_TRACKED_FAILURES) {
-                val oldest = failedUrls.first()
-                failedUrls.remove(oldest)
+                failedUrls.remove(failedUrls.keys.first())
             }
         }
     }
 
-    /** Whether the last main-frame navigation to [url] failed to load a page. */
-    fun didFail(url: String): Boolean {
+    /** Whether a main-frame navigation to [url] failed within the last [FAILURE_TTL_MS]. */
+    fun didFail(
+        url: String,
+        now: Long = System.currentTimeMillis(),
+    ): Boolean {
         val key = canonicalUrlKey(url)
         if (key.isEmpty()) return false
-        return synchronized(failedUrls) { failedUrls.contains(key) }
+        return synchronized(failedUrls) {
+            val failedAt = failedUrls[key]
+            when {
+                failedAt == null -> {
+                    false
+                }
+
+                now - failedAt <= FAILURE_TTL_MS -> {
+                    true
+                }
+
+                else -> {
+                    failedUrls.remove(key)
+                    false
+                }
+            }
+        }
     }
 
-    /** Drop all tracked outcomes. Used by tests. */
-    fun clear() {
+    /** Drop all tracked outcomes. */
+    internal fun clear() {
         synchronized(failedUrls) { failedUrls.clear() }
     }
 }
+
+/**
+ * The host of [url] when it is an address worth remembering, else null.
+ *
+ * Both stores match and display by domain, so anything without one — `about:blank`,
+ * `data:`, `blob:`, `chrome://`, `file://` — has nothing to contribute to a suggestion
+ * list, and an unparsable URL has no business in one either. Shared so the URL history
+ * and the dashboard's recent pages can't drift apart on what counts as a page.
+ */
+fun suggestableHost(url: String): String? =
+    try {
+        val parsed = java.net.URL(url)
+        val scheme = parsed.protocol?.lowercase()
+        val host = parsed.host?.lowercase().orEmpty()
+        if ((scheme == "http" || scheme == "https") && host.isNotBlank()) host else null
+    } catch (e: java.net.MalformedURLException) {
+        // Not a URL we can key on, which is the answer the caller wants. The message
+        // would echo the whole URL including its query, so it isn't logged here — callers
+        // that want a breadcrumb log the masked URL themselves.
+        null
+    }
 
 /**
  * Like [canonicalUrlKey], but two URLs are only the same page if their fragments agree.
@@ -75,8 +162,12 @@ fun distinctPageKey(url: String): String {
 
 /**
  * Normalize [url] into a key that survives the cosmetic differences between the URL a
- * user typed, the URL a plugin reports, and the URL the engine committed: scheme and
- * host casing, a `http(s)://` prefix, a `www.` prefix, a trailing slash, and a fragment.
+ * user typed, the URL a plugin reports, and the URL the engine committed: scheme and host
+ * casing, a `http(s)://` prefix, a `www.` prefix, a trailing slash, and a fragment.
+ *
+ * Only the parts that are genuinely case-insensitive get lowercased. Paths, queries and
+ * opaque bodies are left alone — servers and filesystems distinguish `/Doc` from `/doc`,
+ * and the payload of a `data:` URL is case-sensitive outright.
  *
  * Returns an empty string for a URL with nothing to key on.
  */
@@ -88,29 +179,37 @@ fun canonicalUrlKey(url: String): String {
     val scheme = if (schemeEnd >= 0) trimmed.substring(0, schemeEnd).lowercase() else ""
     val remainder = if (schemeEnd >= 0) trimmed.substring(schemeEnd + 3) else trimmed
 
-    // "about:blank", "data:…", "localhost:3000/app" — a colon with no slash before it and
-    // no "://" means there is no authority to normalize, so key the whole thing. (The
-    // host:port form lands here too and still matches its "http://host:port" spelling,
-    // which is the point.)
-    val leadingSegment = remainder.substringBefore(':', "")
-    val hasOpaqueBody = schemeEnd < 0 && leadingSegment.isNotEmpty() && !leadingSegment.contains('/')
-    val isWebScheme = scheme.isEmpty() || scheme == "http" || scheme == "https"
-
     return when {
-        !isWebScheme -> {
-            "$scheme://${remainder.trimEnd('/')}".lowercase()
+        // about:blank, data:…, mailto:… — a scheme with no authority behind it. Told
+        // apart from a bare "host:port/path" by what follows the colon.
+        schemeEnd < 0 && hasOpaqueBody(remainder) -> {
+            val opaqueScheme = remainder.substringBefore(':').lowercase()
+            "$opaqueScheme:${remainder.substringAfter(':').trimEnd('/')}"
         }
 
-        hasOpaqueBody -> {
-            remainder.trimEnd('/').lowercase()
+        // file://, chrome://, devtools://: normalize the authority, keep the path as-is.
+        scheme.isNotEmpty() && scheme != "http" && scheme != "https" -> {
+            "$scheme://${normalizeAuthorityAndPath(remainder)}"
         }
 
         else -> {
-            val authorityEnd = remainder.indexOfFirst { it == '/' || it == '?' }
-            val authority = if (authorityEnd < 0) remainder else remainder.substring(0, authorityEnd)
-            val path = if (authorityEnd < 0) "" else remainder.substring(authorityEnd)
-            val host = authority.lowercase().removePrefix("www.")
-            (host + path.trimEnd('/')).ifEmpty { trimmed.lowercase() }
+            normalizeAuthorityAndPath(remainder).ifEmpty { trimmed.lowercase() }
         }
     }
+}
+
+/** True when [value] is `scheme:body` (about:blank) rather than `host:port/path`. */
+private fun hasOpaqueBody(value: String): Boolean {
+    val beforeColon = value.substringBefore(':', "")
+    if (beforeColon.isEmpty() || beforeColon.contains('/')) return false
+    // A port is digits; anything else after the colon means it was a scheme.
+    return value.substringAfter(':').firstOrNull()?.isDigit() != true
+}
+
+/** Lowercase the authority and strip a `www.` prefix; leave path and query untouched. */
+private fun normalizeAuthorityAndPath(value: String): String {
+    val authorityEnd = value.indexOfFirst { it == '/' || it == '?' }
+    val authority = if (authorityEnd < 0) value else value.substring(0, authorityEnd)
+    val path = if (authorityEnd < 0) "" else value.substring(authorityEnd)
+    return authority.lowercase().removePrefix("www.") + path.trimEnd('/')
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -1,0 +1,101 @@
+package ai.rever.boss.plugin.browser
+
+/**
+ * Remembers whether the last main-frame navigation to a URL actually produced a page.
+ *
+ * A browser reports a title and a "load finished" for a URL that never loaded — typing
+ * `youtube.como` still commits an error page, still fires TitleChanged, and used to land
+ * in the URL history and the dashboard's recent pages, where it came back as a
+ * suggestion forever. The browser engine is the only layer that knows a navigation
+ * ended on an error page, so it records the outcome here and the two history stores
+ * consult it before recording a visit.
+ *
+ * Entries are keyed by [canonicalUrlKey] so the URL the engine committed
+ * (`https://youtube.como/`) matches the one a caller reports (`youtube.como`), and the
+ * failure set is bounded — it only needs to survive the moment between a navigation
+ * finishing and the title/load callbacks that follow it.
+ */
+object NavigationOutcomeTracker {
+    /** Plenty for the in-flight window; oldest keys are dropped first. */
+    private const val MAX_TRACKED_FAILURES = 256
+
+    private val failedUrls = LinkedHashSet<String>()
+
+    /** Record that a main-frame navigation to [url] committed a real page. */
+    fun recordSuccess(url: String) {
+        val key = canonicalUrlKey(url)
+        if (key.isEmpty()) return
+        synchronized(failedUrls) {
+            failedUrls.remove(key)
+        }
+    }
+
+    /** Record that a main-frame navigation to [url] ended on an error page (or never committed). */
+    fun recordFailure(url: String) {
+        val key = canonicalUrlKey(url)
+        if (key.isEmpty()) return
+        synchronized(failedUrls) {
+            // Re-insert so a repeated failure counts as the most recent entry.
+            failedUrls.remove(key)
+            failedUrls.add(key)
+            while (failedUrls.size > MAX_TRACKED_FAILURES) {
+                val oldest = failedUrls.first()
+                failedUrls.remove(oldest)
+            }
+        }
+    }
+
+    /** Whether the last main-frame navigation to [url] failed to load a page. */
+    fun didFail(url: String): Boolean {
+        val key = canonicalUrlKey(url)
+        if (key.isEmpty()) return false
+        return synchronized(failedUrls) { failedUrls.contains(key) }
+    }
+
+    /** Drop all tracked outcomes. Used by tests. */
+    fun clear() {
+        synchronized(failedUrls) { failedUrls.clear() }
+    }
+}
+
+/**
+ * Normalize [url] into a key that survives the cosmetic differences between the URL a
+ * user typed, the URL a plugin reports, and the URL the engine committed: scheme and
+ * host casing, a `http(s)://` prefix, a `www.` prefix, a trailing slash, and a fragment.
+ *
+ * Returns an empty string for a URL with nothing to key on.
+ */
+fun canonicalUrlKey(url: String): String {
+    val trimmed = url.trim().substringBefore('#')
+    if (trimmed.isEmpty()) return ""
+
+    val schemeEnd = trimmed.indexOf("://")
+    val scheme = if (schemeEnd >= 0) trimmed.substring(0, schemeEnd).lowercase() else ""
+    val remainder = if (schemeEnd >= 0) trimmed.substring(schemeEnd + 3) else trimmed
+
+    // "about:blank", "data:…", "localhost:3000/app" — a colon with no slash before it and
+    // no "://" means there is no authority to normalize, so key the whole thing. (The
+    // host:port form lands here too and still matches its "http://host:port" spelling,
+    // which is the point.)
+    val leadingSegment = remainder.substringBefore(':', "")
+    val hasOpaqueBody = schemeEnd < 0 && leadingSegment.isNotEmpty() && !leadingSegment.contains('/')
+    val isWebScheme = scheme.isEmpty() || scheme == "http" || scheme == "https"
+
+    return when {
+        !isWebScheme -> {
+            "$scheme://${remainder.trimEnd('/')}".lowercase()
+        }
+
+        hasOpaqueBody -> {
+            remainder.trimEnd('/').lowercase()
+        }
+
+        else -> {
+            val authorityEnd = remainder.indexOfFirst { it == '/' || it == '?' }
+            val authority = if (authorityEnd < 0) remainder else remainder.substring(0, authorityEnd)
+            val path = if (authorityEnd < 0) "" else remainder.substring(authorityEnd)
+            val host = authority.lowercase().removePrefix("www.")
+            (host + path.trimEnd('/')).ifEmpty { trimmed.lowercase() }
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -414,32 +414,31 @@ internal class BrowserHandleImpl(
 
                 NavigationVerdict.LOADED -> {
                     NavigationOutcomeTracker.recordSuccess(url)
+                    // This host can serve pages, so it is never a candidate for the
+                    // "address does not exist" eviction below, however it fails later.
+                    suggestableHost(url)?.let(ResolvedHostsStore::recordLoaded)
                 }
 
                 NavigationVerdict.FAILED -> {
                     NavigationOutcomeTracker.recordFailure(url)
 
-                    // Only treat "the address does not exist" as permanent while name
-                    // resolution is demonstrably working — otherwise a DNS outage would
-                    // read as every site the user tried having ceased to exist, and take
-                    // their history with it.
+                    // "The address does not exist" needs more than a name error. Two
+                    // things have to hold: something else resolved recently, so this isn't
+                    // a total DNS outage; and this host has never served a page, so it
+                    // isn't an address the user relies on that happens to be unreachable
+                    // from where they are — the split-horizon case, where a developer off
+                    // the VPN watches `jira.internal.corp` fail while public DNS is fine.
+                    val host = suggestableHost(url)
                     val addressIsGone =
                         error in ADDRESS_DOES_NOT_EXIST_ERRORS &&
-                            NavigationOutcomeTracker.hasLoadedRecently()
+                            NavigationOutcomeTracker.hasLoadedRecently() &&
+                            (host == null || !ResolvedHostsStore.hasEverLoaded(host))
 
-                    // Retraction is only for the callback that raced this verdict, and
-                    // only an error page races it: Chromium titles the error document,
-                    // which is what can reach the history before this handler runs. A
-                    // navigation that never committed (stop pressed, a link clicked while
-                    // a reload was in flight, a load that became a download) produces no
-                    // title and no visit, so there is nothing to undo — and treating it as
-                    // failure here would delete the entry for a page the user is happily
-                    // looking at.
                     val window =
-                        when {
-                            addressIsGone -> null
-                            event.isErrorPage -> RACE_RETRACTION_MS
-                            else -> return
+                        when (retractionScopeFor(event.isErrorPage, addressIsGone)) {
+                            RetractionScope.EVICT_ALL -> null
+                            RetractionScope.RETRACT_RECENT -> RACE_RETRACTION_MS
+                            RetractionScope.LEAVE_ALONE -> return
                         }
                     // Off the engine's event thread: this walks the whole history.
                     retractionScope.launch {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.cache.FaviconCache
+import ai.rever.boss.dashboard.RecentBrowserPagesManager
 import ai.rever.boss.plugin.window.LocalWindowId
 import ai.rever.boss.tabfullscreen.FullscreenBrowserWindow
 import ai.rever.boss.utils.MacOSGestureHandler
@@ -38,6 +39,7 @@ import com.teamdev.jxbrowser.navigation.event.NavigationFinished
 import com.teamdev.jxbrowser.navigation.event.NavigationStarted
 import com.teamdev.jxbrowser.net.ByteData
 import com.teamdev.jxbrowser.net.HttpHeader
+import com.teamdev.jxbrowser.net.NetError
 import com.teamdev.jxbrowser.net.callback.BeforeSendUploadDataCallback
 import com.teamdev.jxbrowser.ui.KeyCode
 import com.teamdev.jxbrowser.ui.KeyModifiers
@@ -240,6 +242,13 @@ internal class BrowserHandleImpl(
         // Navigation finished - track loading state, notify URL change, and inject trackers
         subscriptions +=
             browser.navigation().on(NavigationFinished::class.java) { event ->
+                // Record the outcome BEFORE notifying anyone: the loading, navigation and
+                // title callbacks below are what feed the URL history and the dashboard's
+                // recent pages, and they must see whether this navigation actually landed
+                // on a page. A mistyped host (youtube.como) commits an error page and still
+                // fires all three, so without this it gets recorded as a visited page.
+                recordNavigationOutcome(event)
+
                 _isLoading = false
                 loadingListeners.forEach { listener ->
                     try {
@@ -349,6 +358,52 @@ internal class BrowserHandleImpl(
                 coBrowseSink = null
                 coBrowseBridge.onEvent = null
             }
+    }
+
+    /**
+     * Publish whether a finished main-frame navigation actually loaded a page, so the URL
+     * history and the dashboard's recent pages can skip the ones that didn't.
+     *
+     * A navigation counts as failed when Chromium swapped in its error page, when nothing
+     * committed at all (a download or a cancelled load), or when the engine reported a
+     * network error. Sub-frames are ignored: an iframe that fails says nothing about the
+     * page the user is on.
+     *
+     * Failures that mean "this address does not exist" also evict any entry a previous
+     * visit left behind, so a host that was recorded before this gating existed stops
+     * coming back as a suggestion the next time it's tried. Failures that are about the
+     * connection rather than the address (offline, timeout, aborted) leave history alone —
+     * a site you can't reach right now is still a site you visited.
+     */
+    private fun recordNavigationOutcome(event: NavigationFinished) {
+        try {
+            val url = if (event.isInMainFrame) event.url() else ""
+            if (url.isBlank()) return
+
+            val error =
+                try {
+                    event.error()
+                } catch (e: Exception) {
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Navigation error state unavailable",
+                        mapOf("error" to e.toString()),
+                    )
+                    NetError.OK
+                }
+
+            if (!event.isErrorPage && event.hasCommitted() && error == NetError.OK) {
+                NavigationOutcomeTracker.recordSuccess(url)
+            } else {
+                NavigationOutcomeTracker.recordFailure(url)
+                if (error in ADDRESS_DOES_NOT_EXIST_ERRORS) {
+                    UrlHistoryManager.removeMatchingUrls(url)
+                    RecentBrowserPagesManager.removeMatchingPages(url)
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.BROWSER, "Failed to record navigation outcome", error = e)
+        }
     }
 
     private fun setupBrowserHandlers() {
@@ -1662,6 +1717,22 @@ internal class BrowserHandleImpl(
 
         /** Best-effort cap on [loadUrlAndWait]; returns (no throw) if a load runs long. */
         private const val LOAD_TIMEOUT_MS = 30_000L
+
+        /**
+         * Network errors that mean the address itself is wrong rather than temporarily
+         * unreachable — a typo like `youtube.como` resolves to nothing, and no retry will
+         * change that. Only these evict existing history entries; see
+         * [recordNavigationOutcome].
+         */
+        private val ADDRESS_DOES_NOT_EXIST_ERRORS =
+            setOf(
+                NetError.NAME_NOT_RESOLVED,
+                NetError.NAME_RESOLUTION_FAILED,
+                NetError.ADDRESS_INVALID,
+                NetError.INVALID_URL,
+                NetError.UNKNOWN_URL_SCHEME,
+                NetError.DISALLOWED_URL_SCHEME,
+            )
 
         /**
          * Install an engine-wide [BeforeSendUploadDataCallback] that captures

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -411,8 +411,14 @@ internal class BrowserHandleImpl(
 
                 NavigationVerdict.FAILED -> {
                     NavigationOutcomeTracker.recordFailure(url)
-                    val window =
-                        if (error in ADDRESS_DOES_NOT_EXIST_ERRORS) null else RACE_RETRACTION_MS
+                    // Only treat "the address does not exist" as permanent while name
+                    // resolution is demonstrably working — otherwise a DNS outage would
+                    // read as every site the user tried having ceased to exist, and take
+                    // their history with it.
+                    val addressIsGone =
+                        error in ADDRESS_DOES_NOT_EXIST_ERRORS &&
+                            NavigationOutcomeTracker.hasLoadedRecently()
+                    val window = if (addressIsGone) null else RACE_RETRACTION_MS
                     UrlHistoryManager.removeMatchingUrls(url, window)
                     RecentBrowserPagesManager.removeMatchingPages(url, window)
                 }
@@ -1735,13 +1741,6 @@ internal class BrowserHandleImpl(
         private const val LOAD_TIMEOUT_MS = 30_000L
 
         /**
-         * Network errors that mean the address itself is wrong rather than temporarily
-         * unreachable — a typo like `youtube.como` resolves to nothing, and no retry will
-         * change that. Only these evict existing history entries; see
-         * [recordNavigationOutcome].
-         */
-
-        /**
          * How far back a failure retracts visits recorded by a callback that raced ahead
          * of it. Long enough to cover the title/load callbacks for the navigation that
          * just failed, short enough that a genuine earlier visit to the same address is
@@ -1749,6 +1748,12 @@ internal class BrowserHandleImpl(
          */
         private const val RACE_RETRACTION_MS = 5_000L
 
+        /**
+         * Network errors that mean the address itself is wrong rather than temporarily
+         * unreachable — a typo like `youtube.como` resolves to nothing, and no retry will
+         * change that. Only these can evict history entries regardless of age, and only
+         * while name resolution is otherwise working; see [recordNavigationOutcome].
+         */
         private val ADDRESS_DOES_NOT_EXIST_ERRORS =
             setOf(
                 NetError.NAME_NOT_RESOLVED,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -364,22 +364,21 @@ internal class BrowserHandleImpl(
      * Publish whether a finished main-frame navigation actually loaded a page, so the URL
      * history and the dashboard's recent pages can skip the ones that didn't.
      *
-     * A navigation counts as failed when Chromium swapped in its error page, when nothing
-     * committed at all (a download or a cancelled load), or when the engine reported a
-     * network error. Sub-frames are ignored: an iframe that fails says nothing about the
-     * page the user is on.
+     * Two kinds of eviction follow a failure, because publishing a verdict is not enough
+     * on its own. The loading and navigation callbacks below run inside this handler and
+     * are guaranteed to see it, but **title callbacks are a separate event stream**
+     * (`TitleChanged`, wired in [setupEventListeners]) and Chromium sets an error page's
+     * title around commit time — so a visit can already have been recorded by the time
+     * this runs. Retracting anything recorded in the last few seconds closes that race
+     * for every failure class, not just the ones that evict unconditionally.
      *
-     * Failures that mean "this address does not exist" also evict any entry a previous
-     * visit left behind, so a host that was recorded before this gating existed stops
-     * coming back as a suggestion the next time it's tried. Failures that are about the
-     * connection rather than the address (offline, timeout, aborted) leave history alone —
-     * a site you can't reach right now is still a site you visited.
+     * Failures that mean "this address does not exist" evict regardless of age, which is
+     * what retires a typo recorded before this gating existed. Failures about the
+     * connection rather than the address (offline, timeout, aborted) only ever retract the
+     * racing entry — a site you can't reach right now is still a site you visited.
      */
     private fun recordNavigationOutcome(event: NavigationFinished) {
         try {
-            val url = if (event.isInMainFrame) event.url() else ""
-            if (url.isBlank()) return
-
             val error =
                 try {
                     event.error()
@@ -391,14 +390,31 @@ internal class BrowserHandleImpl(
                     )
                     NetError.OK
                 }
+            val url = event.url()
+            val verdict =
+                classifyNavigation(
+                    isMainFrame = event.isInMainFrame,
+                    hasUrl = url.isNotBlank(),
+                    isErrorPage = event.isErrorPage,
+                    hasCommitted = event.hasCommitted(),
+                    hasNetworkError = error != NetError.OK,
+                )
 
-            if (!event.isErrorPage && event.hasCommitted() && error == NetError.OK) {
-                NavigationOutcomeTracker.recordSuccess(url)
-            } else {
-                NavigationOutcomeTracker.recordFailure(url)
-                if (error in ADDRESS_DOES_NOT_EXIST_ERRORS) {
-                    UrlHistoryManager.removeMatchingUrls(url)
-                    RecentBrowserPagesManager.removeMatchingPages(url)
+            when (verdict) {
+                NavigationVerdict.IGNORED -> {
+                    return
+                }
+
+                NavigationVerdict.LOADED -> {
+                    NavigationOutcomeTracker.recordSuccess(url)
+                }
+
+                NavigationVerdict.FAILED -> {
+                    NavigationOutcomeTracker.recordFailure(url)
+                    val window =
+                        if (error in ADDRESS_DOES_NOT_EXIST_ERRORS) null else RACE_RETRACTION_MS
+                    UrlHistoryManager.removeMatchingUrls(url, window)
+                    RecentBrowserPagesManager.removeMatchingPages(url, window)
                 }
             }
         } catch (e: Exception) {
@@ -1724,6 +1740,15 @@ internal class BrowserHandleImpl(
          * change that. Only these evict existing history entries; see
          * [recordNavigationOutcome].
          */
+
+        /**
+         * How far back a failure retracts visits recorded by a callback that raced ahead
+         * of it. Long enough to cover the title/load callbacks for the navigation that
+         * just failed, short enough that a genuine earlier visit to the same address is
+         * never mistaken for one.
+         */
+        private const val RACE_RETRACTION_MS = 5_000L
+
         private val ADDRESS_DOES_NOT_EXIST_ERRORS =
             setOf(
                 NetError.NAME_NOT_RESOLVED,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -180,6 +180,13 @@ internal class BrowserHandleImpl(
     // Main-thread scope for injection/teardown (rrweb inject + executeJavaScript run on Main).
     private val coBrowseScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
+    /**
+     * Runs history retraction off the engine's event thread. Not tied to this handle's
+     * lifetime on purpose — a retraction triggered by the navigation that closed a tab
+     * still has to complete.
+     */
+    private val retractionScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     // Lock for thread-safe browser operations
     private val browserLock = ReentrantReadWriteLock()
 
@@ -411,6 +418,7 @@ internal class BrowserHandleImpl(
 
                 NavigationVerdict.FAILED -> {
                     NavigationOutcomeTracker.recordFailure(url)
+
                     // Only treat "the address does not exist" as permanent while name
                     // resolution is demonstrably working — otherwise a DNS outage would
                     // read as every site the user tried having ceased to exist, and take
@@ -418,8 +426,25 @@ internal class BrowserHandleImpl(
                     val addressIsGone =
                         error in ADDRESS_DOES_NOT_EXIST_ERRORS &&
                             NavigationOutcomeTracker.hasLoadedRecently()
-                    val window = if (addressIsGone) null else RACE_RETRACTION_MS
-                    UrlHistoryManager.removeMatchingUrls(url, window)
+
+                    // Retraction is only for the callback that raced this verdict, and
+                    // only an error page races it: Chromium titles the error document,
+                    // which is what can reach the history before this handler runs. A
+                    // navigation that never committed (stop pressed, a link clicked while
+                    // a reload was in flight, a load that became a download) produces no
+                    // title and no visit, so there is nothing to undo — and treating it as
+                    // failure here would delete the entry for a page the user is happily
+                    // looking at.
+                    val window =
+                        when {
+                            addressIsGone -> null
+                            event.isErrorPage -> RACE_RETRACTION_MS
+                            else -> return
+                        }
+                    // Off the engine's event thread: this walks the whole history.
+                    retractionScope.launch {
+                        UrlHistoryManager.removeMatchingUrls(url, window)
+                    }
                     RecentBrowserPagesManager.removeMatchingPages(url, window)
                 }
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ResolvedHostsStore.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ResolvedHostsStore.kt
@@ -1,0 +1,104 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.atomicWriteText
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The hosts that have served this user a page at least once, remembered across restarts.
+ *
+ * This is what separates "you mistyped an address that has never existed" from "an address
+ * you use every day isn't resolving from where you're sitting". A resolver-health check
+ * can't tell those apart: it only sees that *some* name resolved, which stays true when a
+ * developer is off the VPN and `jira.internal.corp` stops resolving while `github.com`
+ * keeps working — a split-horizon outage looks identical to a typo from the outside.
+ *
+ * So a host that has ever loaded is never retired on a name-resolution failure, however
+ * long it has been failing. `youtube.como` has never appeared here for anyone, because it
+ * cannot load; that is exactly the set of addresses safe to forget.
+ *
+ * A title-based heuristic cannot stand in for this: Chromium titles its error document
+ * with the failed host, so an entry created by a typo carries a title too.
+ */
+object ResolvedHostsStore {
+    private val logger = BossLogger.forComponent("ResolvedHostsStore")
+
+    /** Overridable so tests exercise the real read/write path without touching `~/.boss`. */
+    internal var storeFile: File = BossDirectories.resolve("browser-resolved-hosts.json")
+
+    private val hosts = ConcurrentHashMap.newKeySet<String>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val saveLock = Mutex()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        try {
+            if (!storeFile.exists()) return
+            val content = storeFile.readText()
+            if (content.isEmpty()) return
+            hosts.addAll(json.decodeFromString<List<String>>(content))
+        } catch (e: IOException) {
+            logger.warn(LogCategory.BROWSER, "Failed to read resolved hosts", error = e)
+        } catch (e: SerializationException) {
+            // A corrupt file just means starting over: the set is a cache of successes,
+            // and the only cost of losing it is being cautious about eviction again.
+            logger.warn(LogCategory.BROWSER, "Discarding unreadable resolved hosts", error = e)
+        }
+    }
+
+    /** Whether [host] has ever served a page, in this session or a previous one. */
+    fun hasEverLoaded(host: String): Boolean = hosts.contains(host.lowercase())
+
+    /**
+     * Remember that [host] served a page. Persists only when the host is new, so the
+     * common case — navigating around somewhere already known — costs a set lookup.
+     */
+    fun recordLoaded(host: String) {
+        if (host.isBlank()) return
+        if (hosts.add(host.lowercase())) {
+            // Bind the destination and the contents now rather than inside the coroutine:
+            // the write is what must land, and reading either one later would let an
+            // unrelated change in between decide where it goes or what it says.
+            save(storeFile, hosts.toList().sorted())
+        }
+    }
+
+    private fun save(
+        target: File,
+        snapshot: List<String>,
+    ) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                saveLock.withLock {
+                    try {
+                        target.atomicWriteText(json.encodeToString(snapshot))
+                    } catch (e: IOException) {
+                        logger.warn(LogCategory.BROWSER, "Failed to save resolved hosts", error = e)
+                    }
+                }
+            }
+        }
+    }
+
+    /** Drop everything. Used by tests. */
+    internal fun clear() {
+        hosts.clear()
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -1,12 +1,16 @@
 package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.atomicWriteText
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.logging.LogSanitizer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -22,11 +26,58 @@ data class UrlHistoryEntry(
     val lastVisited: Long = System.currentTimeMillis(),
 )
 
+/**
+ * Collapse entries that are the same page under different spellings.
+ *
+ * History recorded before the browser plugin reported committed URLs holds both what the
+ * user typed (`https://youtube.com`, no title) and what the browser loaded
+ * (`https://www.youtube.com/`, "YouTube") — two suggestions for one site, one of them
+ * titleless. Merging keeps the entry that knows the page's title, sums the visit counts so
+ * ranking isn't split between the two, and takes the later visit. An `https` spelling wins
+ * over its plaintext twin regardless of counts: the merged URL is one we will navigate to.
+ *
+ * Grouping is by [distinctPageKey], NOT the fragment-insensitive [canonicalUrlKey]:
+ * hash-routed apps put genuinely different pages behind one path, so merging on the looser
+ * key would fold every Gmail view (`#inbox`, `#sent`, `#search/…`) into one.
+ *
+ * Top-level rather than a member so it can be tested without [UrlHistoryManager]'s `init`
+ * reading the developer's real history file.
+ */
+internal fun mergeDuplicateHistoryEntries(entries: List<UrlHistoryEntry>): List<UrlHistoryEntry> =
+    entries
+        .groupBy { distinctPageKey(it.url) }
+        .map { (_, group) ->
+            if (group.size == 1) {
+                group.first()
+            } else {
+                val primary =
+                    group
+                        .sortedWith(
+                            compareByDescending<UrlHistoryEntry> { it.title.isNotBlank() }
+                                .thenByDescending { it.url.startsWith("https", ignoreCase = true) }
+                                .thenByDescending { it.visitCount }
+                                .thenByDescending { it.lastVisited },
+                        ).first()
+                primary.copy(
+                    visitCount = group.sumOf { it.visitCount },
+                    lastVisited = group.maxOf { it.lastVisited },
+                )
+            }
+        }
+
 object UrlHistoryManager {
     private val logger = BossLogger.forComponent("UrlHistoryManager")
     private val historyFile = BossDirectories.resolve("browser-history.json")
     private val history = ConcurrentHashMap<String, UrlHistoryEntry>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * One writer at a time. [saveHistory] is public and fires from several directions —
+     * the browser plugin on every page load, a deletion, an eviction — and two overlapping
+     * writes would interleave into a file that no longer parses, which [loadHistory]
+     * reports as "no history" and silently starts empty.
+     */
+    private val saveLock = Mutex()
     private val json =
         Json {
             prettyPrint = true
@@ -43,7 +94,7 @@ object UrlHistoryManager {
                 val content = historyFile.readText()
                 if (content.isNotEmpty()) {
                     val entries = json.decodeFromString<List<UrlHistoryEntry>>(content)
-                    mergeDuplicates(entries).forEach { entry ->
+                    mergeDuplicateHistoryEntries(entries).forEach { entry ->
                         history[entry.url] = entry
                     }
                 }
@@ -53,52 +104,21 @@ object UrlHistoryManager {
         }
     }
 
-    /**
-     * Collapse entries that are the same page under different spellings.
-     *
-     * History recorded before the browser plugin reported committed URLs holds both what
-     * the user typed (`https://youtube.com`, no title) and what the browser loaded
-     * (`https://www.youtube.com/`, "YouTube") — two suggestions for one site, one of them
-     * titleless. Merging keeps the entry that knows the page's title, sums the visit
-     * counts so ranking isn't split between the two, and takes the later visit.
-     *
-     * Grouping is by [distinctPageKey], NOT the fragment-insensitive [canonicalUrlKey]:
-     * hash-routed apps put genuinely different pages behind one path, so merging on the
-     * looser key would fold every Gmail view (`#inbox`, `#sent`, `#search/…`) into one.
-     */
-    internal fun mergeDuplicates(entries: List<UrlHistoryEntry>): List<UrlHistoryEntry> =
-        entries
-            .groupBy { distinctPageKey(it.url) }
-            .map { (_, group) ->
-                if (group.size == 1) {
-                    group.first()
-                } else {
-                    val primary =
-                        group
-                            .sortedWith(
-                                compareByDescending<UrlHistoryEntry> { it.title.isNotBlank() }
-                                    .thenByDescending { it.visitCount }
-                                    .thenByDescending { it.lastVisited },
-                            ).first()
-                    primary.copy(
-                        visitCount = group.sumOf { it.visitCount },
-                        lastVisited = group.maxOf { it.lastVisited },
-                    )
-                }
-            }
-
     suspend fun saveHistory() =
         withContext(Dispatchers.IO) {
-            try {
-                historyFile.parentFile?.mkdirs()
-                val entries =
-                    history.values
-                        .toList()
-                        .sortedByDescending { it.visitCount * 1000 + (it.lastVisited / 1000000) }
-                        .take(1000) // Keep only top 1000 entries
-                historyFile.writeText(json.encodeToString(entries))
-            } catch (e: Exception) {
-                logger.warn(LogCategory.BROWSER, "Failed to save browser history", error = e)
+            saveLock.withLock {
+                try {
+                    val entries =
+                        history.values
+                            .toList()
+                            .sortedByDescending { it.visitCount * 1000 + (it.lastVisited / 1000000) }
+                            .take(1000) // Keep only top 1000 entries
+                    // Atomic: a crash or a concurrent writer leaves the previous file
+                    // intact rather than a half-written one.
+                    historyFile.atomicWriteText(json.encodeToString(entries))
+                } catch (e: Exception) {
+                    logger.warn(LogCategory.BROWSER, "Failed to save browser history", error = e)
+                }
             }
         }
 
@@ -106,7 +126,14 @@ object UrlHistoryManager {
         url: String,
         title: String,
     ) {
-        val domain = suggestableHostOrNull(url)
+        val domain = suggestableHost(url)
+        if (domain == null) {
+            logger.debug(
+                LogCategory.BROWSER,
+                "Ignoring history entry without a suggestable host",
+                mapOf("url" to LogSanitizer.maskUriParams(url)),
+            )
+        }
 
         // A page the browser never managed to load is not somewhere the user has been —
         // suggesting it back to them is how a typo like `youtube.como` became permanent.
@@ -131,29 +158,6 @@ object UrlHistoryManager {
                 )
             }
     }
-
-    /**
-     * The host of [url] when it is an address worth offering back as a suggestion, else
-     * null.
-     *
-     * Suggestions are matched and displayed by domain, so anything without one —
-     * `about:blank`, `data:`, `blob:`, `chrome://`, `file://` — has nothing to contribute
-     * to the list, and an unparsable URL has no business in it either.
-     */
-    private fun suggestableHostOrNull(url: String): String? =
-        try {
-            val parsed = java.net.URL(url)
-            val scheme = parsed.protocol?.lowercase()
-            val host = parsed.host?.lowercase().orEmpty()
-            if ((scheme == "http" || scheme == "https") && host.isNotBlank()) host else null
-        } catch (e: Exception) {
-            logger.debug(
-                LogCategory.BROWSER,
-                "Ignoring history entry with unparsable URL",
-                mapOf("error" to e.toString()),
-            )
-            null
-        }
 
     fun getSuggestions(
         query: String,
@@ -205,15 +209,38 @@ object UrlHistoryManager {
      * (`youtube.como`), while the engine reports the URL it tried to load
      * (`https://youtube.como/`).
      *
+     * @param recordedWithinMs when set, only removes entries last visited that recently.
+     *   This is the narrow case: a title callback that raced ahead of the navigation
+     *   verdict and recorded a visit the browser was about to report as failed. Entries
+     *   older than the window are real history — a site that is down today was still
+     *   visited last week — and are left alone. Pass null to evict regardless of age,
+     *   for failures that mean the address does not exist at all.
      * @return the number of entries removed
      */
-    fun removeMatchingUrls(url: String): Int {
+    fun removeMatchingUrls(
+        url: String,
+        recordedWithinMs: Long? = null,
+    ): Int {
         val key = canonicalUrlKey(url)
+        if (key.isEmpty()) return 0
+
+        val cutoff = recordedWithinMs?.let { System.currentTimeMillis() - it }
         val matches =
-            if (key.isEmpty()) emptyList() else history.keys.filter { canonicalUrlKey(it) == key }
+            history.values.filter { entry ->
+                canonicalUrlKey(entry.url) == key && (cutoff == null || entry.lastVisited >= cutoff)
+            }
 
         if (matches.isNotEmpty()) {
-            matches.forEach { history.remove(it) }
+            matches.forEach { history.remove(it.url) }
+            logger.info(
+                LogCategory.BROWSER,
+                "Removed history entries for an address that failed to load",
+                mapOf(
+                    "url" to LogSanitizer.maskUriParams(url),
+                    "removed" to matches.size.toString(),
+                    "scope" to if (cutoff == null) "all" else "recent",
+                ),
+            )
             // Persist here rather than waiting for the next saveHistory() — an evicted
             // entry that survives in the file is exactly the stale suggestion we just
             // removed.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -50,20 +50,56 @@ internal fun mergeDuplicateHistoryEntries(entries: List<UrlHistoryEntry>): List<
             if (group.size == 1) {
                 group.first()
             } else {
+                // The URL and the title are chosen independently: the surviving URL is one
+                // we will navigate to, so https wins outright, but the title comes from
+                // whichever spelling actually rendered the page. Picking one entry whole
+                // would force a choice between a safe URL and a known title.
                 val primary =
                     group
                         .sortedWith(
-                            compareByDescending<UrlHistoryEntry> { it.title.isNotBlank() }
-                                .thenByDescending { it.url.startsWith("https", ignoreCase = true) }
+                            compareByDescending<UrlHistoryEntry> {
+                                it.url.startsWith("https", ignoreCase = true)
+                            }.thenByDescending { it.title.isNotBlank() }
                                 .thenByDescending { it.visitCount }
                                 .thenByDescending { it.lastVisited },
                         ).first()
+                val bestTitle =
+                    group
+                        .filter { it.title.isNotBlank() }
+                        .maxByOrNull { it.lastVisited }
+                        ?.title
                 primary.copy(
+                    title = bestTitle ?: primary.title,
                     visitCount = group.sumOf { it.visitCount },
                     lastVisited = group.maxOf { it.lastVisited },
                 )
             }
         }
+
+/**
+ * The entries that a failed navigation to [url] should retire.
+ *
+ * Pure so the destructive decision is testable without touching a real history file.
+ *
+ * @param recordedWithinMs when set, only entries visited that recently are candidates —
+ *   the narrow case of a title callback that recorded a visit just before the browser
+ *   reported the navigation as failed. Null means the address itself is gone, and every
+ *   spelling of it goes regardless of age.
+ */
+internal fun entriesToEvict(
+    entries: Collection<UrlHistoryEntry>,
+    url: String,
+    recordedWithinMs: Long?,
+    now: Long = System.currentTimeMillis(),
+): List<UrlHistoryEntry> {
+    val key = canonicalUrlKey(url)
+    if (key.isEmpty()) return emptyList()
+
+    val cutoff = recordedWithinMs?.let { now - it }
+    return entries.filter { entry ->
+        canonicalUrlKey(entry.url) == key && (cutoff == null || entry.lastVisited >= cutoff)
+    }
+}
 
 object UrlHistoryManager {
     private val logger = BossLogger.forComponent("UrlHistoryManager")
@@ -126,18 +162,10 @@ object UrlHistoryManager {
         url: String,
         title: String,
     ) {
-        val domain = suggestableHost(url)
-        if (domain == null) {
-            logger.debug(
-                LogCategory.BROWSER,
-                "Ignoring history entry without a suggestable host",
-                mapOf("url" to LogSanitizer.maskUriParams(url)),
-            )
-        }
-
         // A page the browser never managed to load is not somewhere the user has been —
         // suggesting it back to them is how a typo like `youtube.como` became permanent.
-        if (domain == null || NavigationOutcomeTracker.didFail(url)) return
+        val domain = suggestableHost(url) ?: return
+        if (NavigationOutcomeTracker.didFail(url)) return
 
         val existing = history[url]
 
@@ -221,14 +249,7 @@ object UrlHistoryManager {
         url: String,
         recordedWithinMs: Long? = null,
     ): Int {
-        val key = canonicalUrlKey(url)
-        if (key.isEmpty()) return 0
-
-        val cutoff = recordedWithinMs?.let { System.currentTimeMillis() - it }
-        val matches =
-            history.values.filter { entry ->
-                canonicalUrlKey(entry.url) == key && (cutoff == null || entry.lastVisited >= cutoff)
-            }
+        val matches = entriesToEvict(history.values, url, recordedWithinMs)
 
         if (matches.isNotEmpty()) {
             matches.forEach { history.remove(it.url) }
@@ -238,7 +259,7 @@ object UrlHistoryManager {
                 mapOf(
                     "url" to LogSanitizer.maskUriParams(url),
                     "removed" to matches.size.toString(),
-                    "scope" to if (cutoff == null) "all" else "recent",
+                    "scope" to if (recordedWithinMs == null) "all" else "recent",
                 ),
             )
             // Persist here rather than waiting for the next saveHistory() — an evicted

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -3,7 +3,10 @@ package ai.rever.boss.plugin.browser
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -23,6 +26,7 @@ object UrlHistoryManager {
     private val logger = BossLogger.forComponent("UrlHistoryManager")
     private val historyFile = BossDirectories.resolve("browser-history.json")
     private val history = ConcurrentHashMap<String, UrlHistoryEntry>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val json =
         Json {
             prettyPrint = true
@@ -68,41 +72,54 @@ object UrlHistoryManager {
         url: String,
         title: String,
     ) {
-        if (url.isBlank() || url == "about:blank" || url.startsWith("data:")) return
+        val domain = suggestableHostOrNull(url)
 
+        // A page the browser never managed to load is not somewhere the user has been —
+        // suggesting it back to them is how a typo like `youtube.como` became permanent.
+        if (domain == null || NavigationOutcomeTracker.didFail(url)) return
+
+        val existing = history[url]
+
+        history[url] =
+            if (existing != null) {
+                existing.copy(
+                    title = title.ifBlank { existing.title },
+                    visitCount = existing.visitCount + 1,
+                    lastVisited = System.currentTimeMillis(),
+                )
+            } else {
+                UrlHistoryEntry(
+                    url = url,
+                    title = title,
+                    domain = domain,
+                    visitCount = 1,
+                    lastVisited = System.currentTimeMillis(),
+                )
+            }
+    }
+
+    /**
+     * The host of [url] when it is an address worth offering back as a suggestion, else
+     * null.
+     *
+     * Suggestions are matched and displayed by domain, so anything without one —
+     * `about:blank`, `data:`, `blob:`, `chrome://`, `file://` — has nothing to contribute
+     * to the list, and an unparsable URL has no business in it either.
+     */
+    private fun suggestableHostOrNull(url: String): String? =
         try {
-            val domain =
-                java.net
-                    .URL(url)
-                    .host
-                    .lowercase()
-            val existing = history[url]
-
-            history[url] =
-                if (existing != null) {
-                    existing.copy(
-                        title = title.ifBlank { existing.title },
-                        visitCount = existing.visitCount + 1,
-                        lastVisited = System.currentTimeMillis(),
-                    )
-                } else {
-                    UrlHistoryEntry(
-                        url = url,
-                        title = title,
-                        domain = domain,
-                        visitCount = 1,
-                        lastVisited = System.currentTimeMillis(),
-                    )
-                }
+            val parsed = java.net.URL(url)
+            val scheme = parsed.protocol?.lowercase()
+            val host = parsed.host?.lowercase().orEmpty()
+            if ((scheme == "http" || scheme == "https") && host.isNotBlank()) host else null
         } catch (e: Exception) {
-            // Invalid URL - not worth recording in history
             logger.debug(
                 LogCategory.BROWSER,
                 "Ignoring history entry with unparsable URL",
                 mapOf("error" to e.toString()),
             )
+            null
         }
-    }
 
     fun getSuggestions(
         query: String,
@@ -136,5 +153,30 @@ object UrlHistoryManager {
 
     fun deleteUrl(url: String) {
         history.remove(url)
+    }
+
+    /**
+     * Remove every entry that points at the same place as [url].
+     *
+     * Matching is by [canonicalUrlKey] rather than string equality: an entry recorded
+     * before this gating existed may be stored as whatever the user typed
+     * (`youtube.como`), while the engine reports the URL it tried to load
+     * (`https://youtube.como/`).
+     *
+     * @return the number of entries removed
+     */
+    fun removeMatchingUrls(url: String): Int {
+        val key = canonicalUrlKey(url)
+        val matches =
+            if (key.isEmpty()) emptyList() else history.keys.filter { canonicalUrlKey(it) == key }
+
+        if (matches.isNotEmpty()) {
+            matches.forEach { history.remove(it) }
+            // Persist here rather than waiting for the next saveHistory() — an evicted
+            // entry that survives in the file is exactly the stale suggestion we just
+            // removed.
+            scope.launch { saveHistory() }
+        }
+        return matches.size
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -43,7 +43,7 @@ object UrlHistoryManager {
                 val content = historyFile.readText()
                 if (content.isNotEmpty()) {
                     val entries = json.decodeFromString<List<UrlHistoryEntry>>(content)
-                    entries.forEach { entry ->
+                    mergeDuplicates(entries).forEach { entry ->
                         history[entry.url] = entry
                     }
                 }
@@ -52,6 +52,40 @@ object UrlHistoryManager {
             logger.warn(LogCategory.BROWSER, "Failed to load browser history", error = e)
         }
     }
+
+    /**
+     * Collapse entries that are the same page under different spellings.
+     *
+     * History recorded before the browser plugin reported committed URLs holds both what
+     * the user typed (`https://youtube.com`, no title) and what the browser loaded
+     * (`https://www.youtube.com/`, "YouTube") — two suggestions for one site, one of them
+     * titleless. Merging keeps the entry that knows the page's title, sums the visit
+     * counts so ranking isn't split between the two, and takes the later visit.
+     *
+     * Grouping is by [distinctPageKey], NOT the fragment-insensitive [canonicalUrlKey]:
+     * hash-routed apps put genuinely different pages behind one path, so merging on the
+     * looser key would fold every Gmail view (`#inbox`, `#sent`, `#search/…`) into one.
+     */
+    internal fun mergeDuplicates(entries: List<UrlHistoryEntry>): List<UrlHistoryEntry> =
+        entries
+            .groupBy { distinctPageKey(it.url) }
+            .map { (_, group) ->
+                if (group.size == 1) {
+                    group.first()
+                } else {
+                    val primary =
+                        group
+                            .sortedWith(
+                                compareByDescending<UrlHistoryEntry> { it.title.isNotBlank() }
+                                    .thenByDescending { it.visitCount }
+                                    .thenByDescending { it.lastVisited },
+                            ).first()
+                    primary.copy(
+                        visitCount = group.sumOf { it.visitCount },
+                        lastVisited = group.maxOf { it.lastVisited },
+                    )
+                }
+            }
 
     suspend fun saveHistory() =
         withContext(Dispatchers.IO) {
@@ -151,8 +185,16 @@ object UrlHistoryManager {
             ).take(limit)
     }
 
+    /**
+     * Forget a single entry — the URL bar's "don't suggest this again".
+     *
+     * Persists immediately: a deletion the user has to repeat after a restart isn't a
+     * deletion.
+     */
     fun deleteUrl(url: String) {
-        history.remove(url)
+        if (history.remove(url) != null) {
+            scope.launch { saveHistory() }
+        }
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -81,10 +81,13 @@ internal fun mergeDuplicateHistoryEntries(entries: List<UrlHistoryEntry>): List<
  *
  * Pure so the destructive decision is testable without touching a real history file.
  *
- * @param recordedWithinMs when set, only entries visited that recently are candidates —
- *   the narrow case of a title callback that recorded a visit just before the browser
- *   reported the navigation as failed. Null means the address itself is gone, and every
- *   spelling of it goes regardless of age.
+ * @param recordedWithinMs when set, this is the **retraction** case: undoing a visit a
+ *   title callback recorded moments before the browser reported the navigation as failed.
+ *   It only takes entries that the racing callback could itself have created — a single
+ *   visit — because `lastVisited` is refreshed on every visit, so "touched in the last 5s"
+ *   would otherwise also describe a site with three hundred visits that was simply open a
+ *   moment ago. Null is the **eviction** case: the address itself is gone, and every
+ *   spelling of it goes regardless of age or visit count.
  */
 internal fun entriesToEvict(
     entries: Collection<UrlHistoryEntry>,
@@ -97,7 +100,7 @@ internal fun entriesToEvict(
 
     val cutoff = recordedWithinMs?.let { now - it }
     return entries.filter { entry ->
-        canonicalUrlKey(entry.url) == key && (cutoff == null || entry.lastVisited >= cutoff)
+        shouldRetireVisit(entry.url, entry.lastVisited, entry.visitCount, key, cutoff)
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryEvictionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryEvictionTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.browser
 
+import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -116,6 +117,57 @@ class HistoryEvictionTest {
 
         NavigationOutcomeTracker.recordSuccess("https://github.com/", now = now)
         assertTrue(NavigationOutcomeTracker.hasLoadedRecently(now))
+    }
+
+    @Test
+    fun `only an error page reaches into stored history`() {
+        // An uncommitted navigation — stop pressed, a link clicked mid-reload, a load that
+        // became a download — produced no title and so no visit to undo. Retracting for it
+        // would delete the entry for the page the user is still looking at.
+        assertEquals(
+            RetractionScope.LEAVE_ALONE,
+            retractionScopeFor(isErrorPage = false, addressIsGone = false),
+        )
+        assertEquals(
+            RetractionScope.RETRACT_RECENT,
+            retractionScopeFor(isErrorPage = true, addressIsGone = false),
+        )
+        assertEquals(
+            RetractionScope.EVICT_ALL,
+            retractionScopeFor(isErrorPage = true, addressIsGone = true),
+        )
+    }
+
+    @Test
+    fun `an address known to exist is never evicted wholesale`() {
+        // Split horizon: off the VPN, jira.internal.corp stops resolving while public DNS
+        // is healthy, so the resolver-health check alone would approve deleting it.
+        withTemporaryResolvedHostsStore {
+            ResolvedHostsStore.recordLoaded("jira.internal.corp")
+
+            assertTrue(ResolvedHostsStore.hasEverLoaded("jira.internal.corp"))
+            assertTrue(ResolvedHostsStore.hasEverLoaded("JIRA.Internal.Corp"))
+            // A typo has never served a page to anyone — that is what makes it safe to
+            // forget, and what a title heuristic can't tell you, since Chromium titles its
+            // error document with the failed host.
+            assertFalse(ResolvedHostsStore.hasEverLoaded("youtube.como"))
+        }
+    }
+
+    /** Points the store at a scratch file so the developer's own profile is untouched. */
+    private fun withTemporaryResolvedHostsStore(block: () -> Unit) {
+        val original = ResolvedHostsStore.storeFile
+        val temp = File.createTempFile("resolved-hosts", ".json")
+        temp.delete()
+        try {
+            ResolvedHostsStore.storeFile = temp
+            ResolvedHostsStore.clear()
+            block()
+        } finally {
+            temp.delete()
+            ResolvedHostsStore.storeFile = original
+            ResolvedHostsStore.clear()
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryEvictionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryEvictionTest.kt
@@ -75,6 +75,50 @@ class HistoryEvictionTest {
     }
 
     @Test
+    fun `a retraction spares an entry with visits behind it`() {
+        // lastVisited is refreshed on every visit, so "touched in the last 5s" also
+        // describes a site with hundreds of visits that was simply open a moment ago.
+        // Only an entry the racing callback could have created is a candidate.
+        val established =
+            UrlHistoryEntry(
+                url = "https://github.com/",
+                title = "GitHub",
+                domain = "github.com",
+                visitCount = 300,
+                lastVisited = now - 1_000,
+            )
+        val racing = entry("https://github.com/", lastVisited = now - 1_000).copy(visitCount = 1)
+
+        assertEquals(0, entriesToEvict(listOf(established), "https://github.com/", 5_000, now).size)
+        assertEquals(1, entriesToEvict(listOf(racing), "https://github.com/", 5_000, now).size)
+    }
+
+    @Test
+    fun `an address that is gone takes even a well-visited entry`() {
+        // The other half of the rule: once resolution is known to work and the address
+        // still doesn't exist, visit count says nothing — those visits went to an error
+        // page, which is how the typo accumulated them in the first place.
+        val entries =
+            listOf(entry("https://youtube.como/", lastVisited = now).copy(visitCount = 6))
+
+        assertEquals(1, entriesToEvict(entries, "https://youtube.como/", null, now).size)
+    }
+
+    @Test
+    fun `opening a new tab is not evidence that dns works`() {
+        // about:blank commits as a normal main-frame navigation in this app, so counting
+        // it would let opening a tab during an outage re-arm unconditional eviction.
+        NavigationOutcomeTracker.recordSuccess("about:blank", now = now)
+        assertFalse(NavigationOutcomeTracker.hasLoadedRecently(now))
+
+        NavigationOutcomeTracker.recordSuccess("file:///Users/me/notes.html", now = now)
+        assertFalse(NavigationOutcomeTracker.hasLoadedRecently(now))
+
+        NavigationOutcomeTracker.recordSuccess("https://github.com/", now = now)
+        assertTrue(NavigationOutcomeTracker.hasLoadedRecently(now))
+    }
+
+    @Test
     fun `an unrelated address is never touched`() {
         val entries = listOf(entry("https://github.com/", lastVisited = now))
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryEvictionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/HistoryEvictionTest.kt
@@ -1,0 +1,104 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the destructive half of the history gating: which entries a failed navigation
+ * retires, and — the part with real blast radius — when a name-resolution failure is
+ * allowed to mean "this address does not exist" rather than "DNS is down right now".
+ */
+class HistoryEvictionTest {
+    private val now = 1_000_000L
+
+    private fun entry(
+        url: String,
+        lastVisited: Long,
+        title: String = "A page",
+    ) = UrlHistoryEntry(
+        url = url,
+        title = title,
+        domain = url.substringAfter("://").substringBefore('/'),
+        visitCount = 1,
+        lastVisited = lastVisited,
+    )
+
+    @BeforeTest
+    @AfterTest
+    fun resetTracker() {
+        NavigationOutcomeTracker.clear()
+    }
+
+    @Test
+    fun `an address that is gone takes every spelling of itself with it`() {
+        val entries =
+            listOf(
+                entry("https://youtube.como/", lastVisited = now - 500_000),
+                entry("youtube.como", lastVisited = now - 900_000),
+                entry("http://www.youtube.como", lastVisited = now - 100),
+                entry("https://youtube.com/", lastVisited = now - 500_000),
+            )
+
+        val evicted = entriesToEvict(entries, "https://youtube.como/", recordedWithinMs = null, now = now)
+
+        assertEquals(
+            listOf("https://youtube.como/", "youtube.como", "http://www.youtube.como"),
+            evicted.map { it.url },
+        )
+    }
+
+    @Test
+    fun `a windowed retraction only reaches what was just recorded`() {
+        val entries =
+            listOf(
+                // The racing entry: recorded a moment ago by a title callback.
+                entry("https://example.com/", lastVisited = now - 1_000),
+                // Real history for the same address, from last week.
+                entry("https://www.example.com/", lastVisited = now - 604_800_000),
+            )
+
+        val evicted = entriesToEvict(entries, "https://example.com/", recordedWithinMs = 5_000, now = now)
+
+        assertEquals(listOf("https://example.com/"), evicted.map { it.url })
+    }
+
+    @Test
+    fun `the retraction window includes its own boundary`() {
+        val entries = listOf(entry("https://example.com/", lastVisited = now - 5_000))
+
+        assertEquals(1, entriesToEvict(entries, "https://example.com/", 5_000, now).size)
+        assertEquals(0, entriesToEvict(entries, "https://example.com/", 4_999, now).size)
+    }
+
+    @Test
+    fun `an unrelated address is never touched`() {
+        val entries = listOf(entry("https://github.com/", lastVisited = now))
+
+        assertEquals(0, entriesToEvict(entries, "https://gitlab.com/", null, now).size)
+        assertEquals(0, entriesToEvict(entries, "", null, now).size)
+    }
+
+    @Test
+    fun `a resolution failure is only trusted while something else is loading`() {
+        // The scenario that must not delete history: the resolver stops answering, so
+        // every address the user tries reports NAME_NOT_RESOLVED. Nothing has loaded, so
+        // nothing about those failures says the addresses stopped existing.
+        assertFalse(NavigationOutcomeTracker.hasLoadedRecently(now))
+
+        NavigationOutcomeTracker.recordSuccess("https://github.com/", now = now - 1_000)
+        assertTrue(NavigationOutcomeTracker.hasLoadedRecently(now))
+    }
+
+    @Test
+    fun `evidence that resolution works goes stale`() {
+        val window = NavigationOutcomeTracker.RESOLVER_HEALTH_WINDOW_MS
+        NavigationOutcomeTracker.recordSuccess("https://github.com/", now = now - window)
+
+        assertTrue(NavigationOutcomeTracker.hasLoadedRecently(now))
+        assertFalse(NavigationOutcomeTracker.hasLoadedRecently(now + 1))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
@@ -1,0 +1,103 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins down the gate that keeps addresses that never loaded out of the URL history and
+ * the dashboard's recent pages.
+ *
+ * The two sides of the gate see different spellings of the same address — the browser
+ * engine reports the URL it committed (`https://youtube.como/`), the callers report what
+ * the tab is showing, which for a typo is close to what the user typed — so the matching
+ * has to survive scheme, `www.`, casing and trailing-slash differences without merging
+ * genuinely different pages.
+ */
+class NavigationOutcomeTrackerTest {
+    @BeforeTest
+    @AfterTest
+    fun resetTracker() {
+        NavigationOutcomeTracker.clear()
+    }
+
+    @Test
+    fun `a failed navigation is recognised from the url the user typed`() {
+        NavigationOutcomeTracker.recordFailure("https://youtube.como/")
+
+        assertTrue(NavigationOutcomeTracker.didFail("https://youtube.como/"))
+        assertTrue(NavigationOutcomeTracker.didFail("youtube.como"))
+        assertTrue(NavigationOutcomeTracker.didFail("http://www.youtube.como"))
+    }
+
+    @Test
+    fun `a failure on one address says nothing about another`() {
+        NavigationOutcomeTracker.recordFailure("https://youtube.como/")
+
+        assertFalse(NavigationOutcomeTracker.didFail("https://youtube.com/"))
+        assertFalse(NavigationOutcomeTracker.didFail("https://youtube.como.example.com/"))
+    }
+
+    @Test
+    fun `a later success clears the failure`() {
+        NavigationOutcomeTracker.recordFailure("https://flaky.example/")
+        NavigationOutcomeTracker.recordSuccess("https://flaky.example/")
+
+        assertFalse(NavigationOutcomeTracker.didFail("https://flaky.example/"))
+    }
+
+    @Test
+    fun `paths distinguish pages on the same host`() {
+        NavigationOutcomeTracker.recordFailure("https://example.com/gone")
+
+        assertTrue(NavigationOutcomeTracker.didFail("https://example.com/gone"))
+        assertFalse(NavigationOutcomeTracker.didFail("https://example.com/"))
+        assertFalse(NavigationOutcomeTracker.didFail("https://example.com/other"))
+    }
+
+    @Test
+    fun `the failure set stays bounded`() {
+        repeat(400) { i -> NavigationOutcomeTracker.recordFailure("https://host$i.example/") }
+
+        // The oldest entries are dropped; the recent ones — the only ones a title or load
+        // callback can still arrive for — are kept.
+        assertFalse(NavigationOutcomeTracker.didFail("https://host0.example/"))
+        assertTrue(NavigationOutcomeTracker.didFail("https://host399.example/"))
+    }
+
+    @Test
+    fun `an empty url is never treated as failed`() {
+        NavigationOutcomeTracker.recordFailure("")
+        NavigationOutcomeTracker.recordFailure("   ")
+
+        assertFalse(NavigationOutcomeTracker.didFail(""))
+    }
+
+    @Test
+    fun `canonical keys ignore cosmetic differences`() {
+        val expected = "example.com/path"
+
+        assertEquals(expected, canonicalUrlKey("https://example.com/path"))
+        assertEquals(expected, canonicalUrlKey("http://EXAMPLE.com/path"))
+        assertEquals(expected, canonicalUrlKey("https://www.example.com/path/"))
+        assertEquals(expected, canonicalUrlKey("example.com/path#section"))
+        assertEquals(expected, canonicalUrlKey("  https://example.com/path  "))
+    }
+
+    @Test
+    fun `canonical keys keep what actually distinguishes a page`() {
+        assertEquals("example.com/a?q=1", canonicalUrlKey("https://example.com/a?q=1"))
+        assertEquals("example.com/Path", canonicalUrlKey("https://example.com/Path"))
+        assertEquals("localhost:3000/app", canonicalUrlKey("http://localhost:3000/app"))
+        assertEquals("about:blank", canonicalUrlKey("about:blank"))
+        assertEquals("", canonicalUrlKey("   "))
+    }
+
+    @Test
+    fun `a host reached over both schemes is the same place`() {
+        assertEquals(canonicalUrlKey("http://example.com"), canonicalUrlKey("https://example.com"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
@@ -99,5 +100,32 @@ class NavigationOutcomeTrackerTest {
     @Test
     fun `a host reached over both schemes is the same place`() {
         assertEquals(canonicalUrlKey("http://example.com"), canonicalUrlKey("https://example.com"))
+    }
+
+    @Test
+    fun `page identity normalizes the same spellings as the outcome key`() {
+        assertEquals(
+            distinctPageKey("https://www.youtube.com/"),
+            distinctPageKey("https://youtube.com"),
+        )
+    }
+
+    @Test
+    fun `page identity keeps hash-routed views apart`() {
+        // Gmail serves #inbox and #sent from one path. Merging history entries on the
+        // outcome key would collapse every view of it into a single suggestion.
+        val inbox = "https://mail.google.com/mail/u/0/#inbox"
+        val sent = "https://mail.google.com/mail/u/0/#sent"
+
+        assertEquals(canonicalUrlKey(inbox), canonicalUrlKey(sent))
+        assertNotEquals(distinctPageKey(inbox), distinctPageKey(sent))
+    }
+
+    @Test
+    fun `a fragment does not change whether a navigation failed`() {
+        NavigationOutcomeTracker.recordFailure("https://youtube.como/")
+
+        // The address doesn't resolve, so no #section of it resolves either.
+        assertTrue(NavigationOutcomeTracker.didFail("https://youtube.como/#watch"))
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -127,5 +128,132 @@ class NavigationOutcomeTrackerTest {
 
         // The address doesn't resolve, so no #section of it resolves either.
         assertTrue(NavigationOutcomeTracker.didFail("https://youtube.como/#watch"))
+    }
+
+    @Test
+    fun `a failure stops counting once it is stale`() {
+        val failedAt = 1_000_000L
+        NavigationOutcomeTracker.recordFailure("https://example.com/", now = failedAt)
+
+        val ttl = NavigationOutcomeTracker.FAILURE_TTL_MS
+        assertTrue(NavigationOutcomeTracker.didFail("https://example.com/", now = failedAt + ttl))
+        // Past the window the verdict is dropped: a redirect commits a different URL, so
+        // nothing would ever clear the address the user actually asked for.
+        assertFalse(
+            NavigationOutcomeTracker.didFail("https://example.com/", now = failedAt + ttl + 1),
+        )
+    }
+
+    @Test
+    fun `a host with a port normalizes like any other host`() {
+        // The typed form and the committed form differ in scheme, www and path casing;
+        // all three have to land on one key or the gate silently misses.
+        assertEquals(
+            canonicalUrlKey("https://www.Example.com:8443/App"),
+            canonicalUrlKey("example.com:8443/App"),
+        )
+    }
+
+    @Test
+    fun `paths keep their case`() {
+        // Servers distinguish /Doc from /doc, and a file:// path may sit on a
+        // case-sensitive filesystem — these keys drive deletion, so they must not merge.
+        assertNotEquals(canonicalUrlKey("https://example.com/Doc"), canonicalUrlKey("https://example.com/doc"))
+        assertNotEquals(
+            canonicalUrlKey("file:///Users/me/Doc.html"),
+            canonicalUrlKey("file:///users/me/doc.html"),
+        )
+    }
+
+    @Test
+    fun `an opaque body is preserved exactly`() {
+        // data: payloads are base64 — lowercasing one changes what it decodes to.
+        assertEquals("data:text/plain;base64,SGVsbG8", canonicalUrlKey("data:text/plain;base64,SGVsbG8"))
+        assertEquals("about:blank", canonicalUrlKey("ABOUT:blank"))
+    }
+
+    @Test
+    fun `a scheme is normalized but its authority still is too`() {
+        assertEquals(canonicalUrlKey("CHROME://Settings"), canonicalUrlKey("chrome://settings"))
+    }
+
+    @Test
+    fun `only http and https addresses are worth suggesting`() {
+        assertEquals("example.com", suggestableHost("https://example.com/path"))
+        assertEquals("example.com", suggestableHost("HTTP://Example.com"))
+        assertNull(suggestableHost("file:///Users/me/notes.html"))
+        assertNull(suggestableHost("about:blank"))
+        assertNull(suggestableHost("data:text/plain,hi"))
+        assertNull(suggestableHost("not a url at all"))
+    }
+
+    @Test
+    fun `a navigation that loaded a page is the only kind worth recording`() {
+        assertEquals(
+            NavigationVerdict.LOADED,
+            classifyNavigation(
+                isMainFrame = true,
+                hasUrl = true,
+                isErrorPage = false,
+                hasCommitted = true,
+                hasNetworkError = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `error pages, uncommitted loads and network errors all count as failure`() {
+        val errorPage =
+            classifyNavigation(
+                isMainFrame = true,
+                hasUrl = true,
+                isErrorPage = true,
+                hasCommitted = true,
+                hasNetworkError = false,
+            )
+        val neverCommitted =
+            classifyNavigation(
+                isMainFrame = true,
+                hasUrl = true,
+                isErrorPage = false,
+                hasCommitted = false,
+                hasNetworkError = false,
+            )
+        val netError =
+            classifyNavigation(
+                isMainFrame = true,
+                hasUrl = true,
+                isErrorPage = false,
+                hasCommitted = true,
+                hasNetworkError = true,
+            )
+
+        assertEquals(NavigationVerdict.FAILED, errorPage)
+        assertEquals(NavigationVerdict.FAILED, neverCommitted)
+        assertEquals(NavigationVerdict.FAILED, netError)
+    }
+
+    @Test
+    fun `sub-frames and blank urls say nothing about the page`() {
+        // An iframe that fails to load is not the page the user is on.
+        val subFrame =
+            classifyNavigation(
+                isMainFrame = false,
+                hasUrl = true,
+                isErrorPage = true,
+                hasCommitted = false,
+                hasNetworkError = true,
+            )
+        val noUrl =
+            classifyNavigation(
+                isMainFrame = true,
+                hasUrl = false,
+                isErrorPage = false,
+                hasCommitted = true,
+                hasNetworkError = false,
+            )
+
+        assertEquals(NavigationVerdict.IGNORED, subFrame)
+        assertEquals(NavigationVerdict.IGNORED, noUrl)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryMergeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryMergeTest.kt
@@ -1,0 +1,90 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins down the one-time cleanup that collapses the duplicate entries left by the browser
+ * plugin recording URL bar text: history holds both what the user typed
+ * (`https://youtube.com`, no title) and what the browser committed
+ * (`https://www.youtube.com/`, "YouTube"), which showed up as two suggestions for one
+ * site with their visit counts split between them.
+ */
+class UrlHistoryMergeTest {
+    private fun entry(
+        url: String,
+        title: String = "",
+        visits: Int = 1,
+        lastVisited: Long = 0,
+    ) = UrlHistoryEntry(
+        url = url,
+        title = title,
+        domain = url.substringAfter("://").substringBefore('/'),
+        visitCount = visits,
+        lastVisited = lastVisited,
+    )
+
+    @Test
+    fun `the entry that knows the title wins and the counts add up`() {
+        val merged =
+            UrlHistoryManager.mergeDuplicates(
+                listOf(
+                    entry("https://youtube.com", visits = 7, lastVisited = 200),
+                    entry("https://www.youtube.com/", title = "YouTube", visits = 48, lastVisited = 100),
+                ),
+            )
+
+        assertEquals(1, merged.size)
+        val only = merged.single()
+        assertEquals("https://www.youtube.com/", only.url)
+        assertEquals("YouTube", only.title)
+        assertEquals(55, only.visitCount)
+        // The later visit survives even though it came from the entry that lost.
+        assertEquals(200, only.lastVisited)
+    }
+
+    @Test
+    fun `hash-routed views of one path stay separate`() {
+        val entries =
+            listOf(
+                entry("https://mail.google.com/mail/u/0/#inbox", title = "Inbox"),
+                entry("https://mail.google.com/mail/u/0/#sent", title = "Sent"),
+                entry("https://mail.google.com/mail/u/0/#drafts", title = "Drafts"),
+            )
+
+        assertEquals(3, UrlHistoryManager.mergeDuplicates(entries).size)
+    }
+
+    @Test
+    fun `different pages on a host are untouched`() {
+        val entries =
+            listOf(
+                entry("https://example.com/a", title = "A"),
+                entry("https://example.com/b", title = "B"),
+                entry("https://example.com/a?q=1", title = "A search"),
+            )
+
+        assertEquals(3, UrlHistoryManager.mergeDuplicates(entries).size)
+    }
+
+    @Test
+    fun `a history with nothing to merge comes back unchanged`() {
+        val entries = listOf(entry("https://example.com/", title = "Example", visits = 3))
+
+        assertEquals(entries, UrlHistoryManager.mergeDuplicates(entries))
+    }
+
+    @Test
+    fun `when no entry has a title the most visited one represents the group`() {
+        val merged =
+            UrlHistoryManager.mergeDuplicates(
+                listOf(
+                    entry("https://example.com", visits = 2),
+                    entry("https://www.example.com/", visits = 9),
+                ),
+            )
+
+        assertEquals("https://www.example.com/", merged.single().url)
+        assertEquals(11, merged.single().visitCount)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryMergeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryMergeTest.kt
@@ -75,6 +75,37 @@ class UrlHistoryMergeTest {
     }
 
     @Test
+    fun `the https spelling wins even when only the plaintext twin has a title`() {
+        // The case the earlier test missed: both spellings sharing a title let the
+        // comparator's title check decide first, so an http URL could survive as the one
+        // we navigate to. The title still comes across from whichever entry rendered.
+        val merged =
+            mergeDuplicateHistoryEntries(
+                listOf(
+                    entry("http://example.com/app", title = "App", visits = 40, lastVisited = 5),
+                    entry("https://example.com/app", visits = 1, lastVisited = 1),
+                ),
+            )
+
+        assertEquals("https://example.com/app", merged.single().url)
+        assertEquals("App", merged.single().title)
+        assertEquals(41, merged.single().visitCount)
+    }
+
+    @Test
+    fun `the most recent title wins when spellings disagree`() {
+        val merged =
+            mergeDuplicateHistoryEntries(
+                listOf(
+                    entry("https://example.com/", title = "Old name", lastVisited = 100),
+                    entry("https://www.example.com/", title = "New name", lastVisited = 200),
+                ),
+            )
+
+        assertEquals("New name", merged.single().title)
+    }
+
+    @Test
     fun `the https spelling wins even when the plaintext twin has the visits`() {
         // The merged URL is one we will navigate to, so it must not downgrade the user
         // to http just because the old entry was visited more often.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryMergeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryMergeTest.kt
@@ -27,7 +27,7 @@ class UrlHistoryMergeTest {
     @Test
     fun `the entry that knows the title wins and the counts add up`() {
         val merged =
-            UrlHistoryManager.mergeDuplicates(
+            mergeDuplicateHistoryEntries(
                 listOf(
                     entry("https://youtube.com", visits = 7, lastVisited = 200),
                     entry("https://www.youtube.com/", title = "YouTube", visits = 48, lastVisited = 100),
@@ -52,7 +52,7 @@ class UrlHistoryMergeTest {
                 entry("https://mail.google.com/mail/u/0/#drafts", title = "Drafts"),
             )
 
-        assertEquals(3, UrlHistoryManager.mergeDuplicates(entries).size)
+        assertEquals(3, mergeDuplicateHistoryEntries(entries).size)
     }
 
     @Test
@@ -64,20 +64,36 @@ class UrlHistoryMergeTest {
                 entry("https://example.com/a?q=1", title = "A search"),
             )
 
-        assertEquals(3, UrlHistoryManager.mergeDuplicates(entries).size)
+        assertEquals(3, mergeDuplicateHistoryEntries(entries).size)
     }
 
     @Test
     fun `a history with nothing to merge comes back unchanged`() {
         val entries = listOf(entry("https://example.com/", title = "Example", visits = 3))
 
-        assertEquals(entries, UrlHistoryManager.mergeDuplicates(entries))
+        assertEquals(entries, mergeDuplicateHistoryEntries(entries))
+    }
+
+    @Test
+    fun `the https spelling wins even when the plaintext twin has the visits`() {
+        // The merged URL is one we will navigate to, so it must not downgrade the user
+        // to http just because the old entry was visited more often.
+        val merged =
+            mergeDuplicateHistoryEntries(
+                listOf(
+                    entry("http://example.com/app", title = "App", visits = 40),
+                    entry("https://example.com/app", title = "App", visits = 2),
+                ),
+            )
+
+        assertEquals("https://example.com/app", merged.single().url)
+        assertEquals(42, merged.single().visitCount)
     }
 
     @Test
     fun `when no entry has a title the most visited one represents the group`() {
         val merged =
-            UrlHistoryManager.mergeDuplicates(
+            mergeDuplicateHistoryEntries(
                 listOf(
                     entry("https://example.com", visits = 2),
                     entry("https://www.example.com/", visits = 9),


### PR DESCRIPTION
Typing an address that doesn't resolve — `youtube.como` — still commits a Chromium error page, and an error page fires `TitleChanged` and "load finished" exactly like a real one. Every store that records a visit took that at face value, so the typo was saved as a visited page and came back as a URL bar suggestion (and a dashboard recent) from then on.

## What changed

- **`NavigationOutcomeTracker`** (new, commonMain) — bounded set of addresses whose last main-frame navigation failed. Keyed by a canonicalized URL (`canonicalUrlKey`) so the address the engine committed (`https://youtube.como/`) matches the spelling a caller reports (`youtube.como`): scheme, `www.`, casing, trailing slash and fragment differences all collapse, while path and query still distinguish pages.
- **`BrowserHandleImpl`** — publishes the outcome of every finished main-frame navigation *before* notifying its loading/navigation/title listeners, so the callbacks that record a visit can tell an error page from a real one. A navigation counts as failed when Chromium swapped in its error page, when nothing committed (download, cancelled load), or when the engine reported a `NetError`.
- **`UrlHistoryManager`** and **`RecentBrowserPagesManager`** consult the tracker before recording; `FluckTabInfo` gates the dashboard's page counter the same way. The tab's own back/forward list still gets the entry — the tab is sitting on that URL either way.
- **Self-heal for entries already in history** — a failure that means *the address does not exist* (`NAME_NOT_RESOLVED`, `ADDRESS_INVALID`, …) evicts matching entries from both stores, so a typo recorded before this gating existed retires the next time it's tried. Failures about the connection rather than the address (offline, timeout, aborted) leave history alone: a site you can't reach right now is still a site you visited.
- **`addUrl` now requires an http(s) URL with a host** — suggestions are matched and displayed by domain, so `file://`, `blob:` and `chrome://` entries had nothing to contribute to that list.

An HTTP error status is deliberately *not* a failure here: a 404 served by a real host is still a page someone visited, which is how Chrome treats it too.

## Companion change

The browser plugin recorded the URL bar text rather than the committed URL, so entries were filed under half-typed input — that side is [risa-labs-inc/boss-plugin-fluck-browser#16](https://github.com/risa-labs-inc/boss-plugin-fluck-browser/pull/16). Each change stands on its own, but the `youtube.como` case needs both: the gate here matches on the committed URL the plugin now reports.

## Testing

- 9 new unit tests for the tracker and its URL canonicalization (`NavigationOutcomeTrackerTest`).
- Full `:composeApp:desktopTest` suite green (1123 tests), plus `ktlintCheck` and `detekt`.
