### PR TITLE
Confine orchestrator manifest reads, keep snapshots on reset, and report approvals honestly

### DIFF
--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AllowedRoots.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AllowedRoots.kt
@@ -1,0 +1,149 @@
+package ai.rever.boss.orchestrator
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+
+/**
+ * The directory roots a path from outside the host must resolve inside.
+ *
+ * The orchestrator receives filesystem paths over IPC — `ProcessManifest.sourceFiles` is
+ * written by the process being diagnosed, not by the host — and hands the contents it reads
+ * to [AiRepairClient], which posts them to a third-party model. Every such path is judged
+ * here first, so that the set of files that can leave the machine is the host's decision.
+ *
+ * ### What "resolves inside" means
+ *
+ * A textual `startsWith` on the path a caller sent answers the wrong question: `..` walks up
+ * out of the root, a symlink inside the root points anywhere, and `/tmp/project` is a string
+ * prefix of the unrelated `/tmp/project-notes`. So [resolve]:
+ *
+ * - canonicalizes the **deepest existing ancestor** of the candidate (`toRealPath`), which
+ *   resolves every symlink and `..` in the part of the path that exists, and re-appends the
+ *   absent tail. A path that does not exist yet is still judged, on where it *would* land;
+ * - refuses any tail component that exists, which is two cases in one: a **symlink with a
+ *   missing target**, the one thing below the deepest resolvable ancestor that exists and can
+ *   still name somewhere else entirely; and a `..` that climbs above that ancestor, because
+ *   the parent of a directory that exists also exists. So a path that walks up out of the
+ *   root is refused rather than compared;
+ * - compares by path component ([Path.startsWith]), not by string prefix.
+ *
+ * ### The roots themselves
+ *
+ * [none] grants nothing, and so does a root that cannot be resolved to a directory — an
+ * unusable root must narrow the reach rather than widen it. A filesystem root (`/`, `C:\`)
+ * is also refused as a root, because confining to it confines nothing; a caller that passes
+ * one gets a warning and no reach, not silent unlimited reach.
+ *
+ * ### What this is not
+ *
+ * Not a sandbox: anything inside a granted root is readable. It narrows what an IPC caller
+ * can name to the directory the host meant, which for this module is the project root. It
+ * also does not close the gap between the check and the read — the file is opened again by
+ * path afterwards, and a component could change in between. Both are recorded rather than
+ * claimed to be solved.
+ */
+class AllowedRoots private constructor(
+    private val roots: List<Path>,
+) {
+    /**
+     * The path [candidate] resolves to, or `null` when it lands outside every root, cannot be
+     * resolved at all, or there are no roots.
+     */
+    fun resolve(candidate: File): File? {
+        val target = if (roots.isEmpty()) null else resolvedTarget(candidate.toPath())
+        return target?.takeIf { path -> roots.any(path::startsWith) }?.toFile()
+    }
+
+    /** The canonical roots, for a startup or refusal log line. */
+    fun rootPaths(): List<String> = roots.map(Path::toString)
+
+    /** Where [candidate] actually lands, following every symlink and `..` in it. */
+    private fun resolvedTarget(candidate: Path): Path? {
+        val absolute = absoluteOrNull(candidate) ?: return null
+        return realPathOrNull(absolute) ?: resolveThroughAbsentTail(absolute)
+    }
+
+    /**
+     * The same answer for a path that does not exist yet: the deepest ancestor that can be
+     * resolved, with the components below it appended back on.
+     */
+    private fun resolveThroughAbsentTail(absolute: Path): Path? {
+        val resolvedAncestor =
+            generateSequence(absolute.parent) { it.parent }
+                .firstNotNullOfOrNull { ancestor -> realPathOrNull(ancestor)?.let { it to ancestor } }
+                ?: return null
+        val (real, ancestor) = resolvedAncestor
+        return appendAbsentTail(real, ancestor.relativize(absolute))
+    }
+
+    /**
+     * Appends [tail] to [real], refusing any component of it that exists.
+     *
+     * Every component of [tail] is below the deepest ancestor that could be resolved, so all of
+     * them should be absent. Two things can exist there, and neither may be appended blindly:
+     * a symlink whose target is missing, which cannot be resolved and can name anywhere; and a
+     * `..` that climbs back above [real], which exists because the parent of a directory that
+     * exists also exists. [Path.relativize] has already collapsed every `..` that stays inside
+     * the ancestor, so one that survives into [tail] is one that leaves it.
+     */
+    private fun appendAbsentTail(
+        real: Path,
+        tail: Path,
+    ): Path? {
+        var resolved = real
+        for (name in tail) {
+            resolved = resolved.resolve(name)
+            if (Files.exists(resolved, LinkOption.NOFOLLOW_LINKS)) return null
+        }
+        return resolved
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AllowedRoots::class.java)
+
+        /** No roots: every path is refused. */
+        fun none(): AllowedRoots = AllowedRoots(emptyList())
+
+        /** Confinement to [candidates]. Each is resolved once here; see the class docs. */
+        fun of(vararg candidates: File): AllowedRoots {
+            val resolved = LinkedHashSet<Path>()
+            for (candidate in candidates) {
+                val real = realPathOrNull(candidate.toPath())
+                when {
+                    real == null || !Files.isDirectory(real) -> {
+                        logger.warn("Root {} is not a resolvable directory; it grants nothing", candidate)
+                    }
+
+                    real.parent == null -> {
+                        logger.warn("Root {} is a filesystem root, which confines nothing; it grants nothing", real)
+                    }
+
+                    else -> {
+                        resolved.add(real)
+                    }
+                }
+            }
+            return AllowedRoots(resolved.toList())
+        }
+
+        private fun absoluteOrNull(path: Path): Path? =
+            try {
+                path.toAbsolutePath()
+            } catch (_: Exception) {
+                null
+            }
+
+        private fun realPathOrNull(path: Path): Path? =
+            try {
+                path.toRealPath()
+            } catch (_: IOException) {
+                null
+            } catch (_: SecurityException) {
+                null
+            }
+    }
+}

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AllowedRoots.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AllowedRoots.kt
@@ -99,7 +99,14 @@ class AllowedRoots private constructor(
             resolved = resolved.resolve(name)
             if (Files.exists(resolved, LinkOption.NOFOLLOW_LINKS)) return null
         }
-        return resolved
+        // Normalize even though [Path.relativize] has already collapsed the `..` that could
+        // reach here: that collapsing is JDK-version-dependent behaviour, and this is the one
+        // step that makes the containment check below true of the path itself rather than
+        // true by delegation. `resolve` does not normalize, so without it a surviving `..`
+        // would still satisfy `startsWith` component-wise. Nothing writes through this path
+        // today — the caller only reads, and the OS will not traverse an absent component —
+        // but the API judges paths that do not exist yet, and the next caller may create one.
+        return resolved.normalize()
     }
 
     companion object {

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorMain.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorMain.kt
@@ -84,6 +84,11 @@ fun main() {
                 analyzer = analyzer,
                 snapshotManager = snapshotManager,
                 aiClient = aiClient,
+                // Stated rather than defaulted: this process has no project directory to
+                // offer — its working directory is whatever the kernel spawned it with —
+                // and manifest source files go to a third-party model, so nothing is read
+                // until a host names a directory it is willing to send.
+                projectRoot = null,
                 onRequestRestart = { processId, _ ->
                     kernelStub.requestShutdown(
                         ShutdownRequest

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorMain.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorMain.kt
@@ -102,32 +102,16 @@ fun main() {
             OrchestratorServiceImpl(
                 repairEngine = repairEngine,
                 processRegistry = null, // orchestrator doesn't have a local registry (C2 fix)
-                onRepairApproved = { action ->
-                    logger.info("Executing approved repair: {}", action.repairId)
-                    // Re-run the repair strategy that was approved
-                    when (action.strategyValue) {
-                        RepairStrategy.REPAIR_STRATEGY_RESTART_VALUE,
-                        RepairStrategy.REPAIR_STRATEGY_RESTART_TUNED_VALUE,
-                        -> {
-                            val processId =
-                                when {
-                                    action.hasRestart() -> action.restart.let { action.repairId }
-                                    action.hasResetState() -> action.repairId
-                                    else -> action.repairId
-                                }
-                            kernelStub.requestShutdown(
-                                ShutdownRequest
-                                    .newBuilder()
-                                    .setProcessId(processId)
-                                    .setForce(false)
-                                    .setReason("APPROVED_REPAIR")
-                                    .build(),
-                            )
-                        }
-
-                        else -> {
-                            logger.warn("Approved repair strategy {} not auto-executable", action.strategy)
-                        }
+                onRepairApproved = { processId, action ->
+                    applyApprovedRepair(processId, action) { target ->
+                        kernelStub.requestShutdown(
+                            ShutdownRequest
+                                .newBuilder()
+                                .setProcessId(target)
+                                .setForce(false)
+                                .setReason("APPROVED_REPAIR")
+                                .build(),
+                        )
                     }
                 },
             )
@@ -138,3 +122,39 @@ fun main() {
         connection.awaitTermination()
     }
 }
+
+/**
+ * Carries out a repair the operator approved, and says what happened to it.
+ *
+ * [processId] is the process the parked repair was reported for, which
+ * [OrchestratorServiceImpl] keeps alongside the action: `RepairAction` has a `repair_id` and
+ * no `process_id`, and a repair id is not something the kernel can act on.
+ *
+ * A restart is asked of the kernel through [requestShutdown], whose auto-respawn brings the
+ * process back — the same single path an automatic restart takes. Every other strategy is
+ * refused here rather than reported as done: applying a source patch, a config patch or a
+ * rollback means writing to the machine, which this process does not do.
+ *
+ * Only PATCH_SOURCE sets `requires_user_approval` today, so in practice the refusal is the
+ * branch that runs and the restart branch is there for a strategy that starts being parked.
+ */
+internal suspend fun applyApprovedRepair(
+    processId: String,
+    action: RepairAction,
+    requestShutdown: suspend (processId: String) -> Unit,
+): ApprovalResult =
+    when (action.strategy) {
+        RepairStrategy.REPAIR_STRATEGY_RESTART,
+        RepairStrategy.REPAIR_STRATEGY_RESTART_TUNED,
+        -> {
+            requestShutdown(processId)
+            ApprovalResult.Applied("Restart requested from the kernel for process $processId")
+        }
+
+        else -> {
+            ApprovalResult.Refused(
+                "Approved repair strategy ${action.strategy} is not something this process " +
+                    "applies, so the repair for process $processId was recorded and not applied",
+            )
+        }
+    }

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorServiceImpl.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorServiceImpl.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.orchestrator
 
 import ai.rever.boss.ipc.proto.*
 import ai.rever.boss.process.ProcessRegistry
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -137,6 +138,12 @@ class OrchestratorServiceImpl(
             val result =
                 try {
                     onRepairApproved(pending.processId, pending.action)
+                } catch (e: CancellationException) {
+                    // Before the Exception arm: CancellationException *is* an Exception, so
+                    // catching it here would report a refusal when the caller hung up — the
+                    // same dishonest reporting this method was rewritten to remove — and
+                    // swallow the cancellation the coroutine machinery needs to see.
+                    throw e
                 } catch (e: Exception) {
                     logger.error("Failed to execute approved repair {}: {}", request.repairId, e.message)
                     ApprovalResult.Refused("Repair execution failed: ${e.message}")

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorServiceImpl.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorServiceImpl.kt
@@ -19,13 +19,19 @@ class OrchestratorServiceImpl(
     private val repairEngine: RepairEngine,
     /** Optional registry — null when orchestrator runs out-of-process (C2 fix). */
     private val processRegistry: ProcessRegistry? = null,
-    /** Called after a user-approved repair action (C3 fix). */
-    private val onRepairApproved: suspend (RepairAction) -> Unit = {},
+    /**
+     * Applies a repair the operator approved, and answers what happened to it.
+     *
+     * A host that installs nothing here gets the default, which refuses: an approval that
+     * nothing acted on must not be reported to the caller as applied.
+     */
+    private val onRepairApproved: suspend (processId: String, action: RepairAction) -> ApprovalResult =
+        { processId, action -> ApprovalResult.Refused(noApprovalSinkReason(processId, action)) },
 ) : OrchestratorServiceGrpcKt.OrchestratorServiceCoroutineImplBase() {
     private val logger = LoggerFactory.getLogger(OrchestratorServiceImpl::class.java)
 
     private val repairHistory = ConcurrentHashMap<String, RepairHistoryEntry>()
-    private val pendingRepairs = ConcurrentHashMap<String, RepairAction>()
+    private val pendingRepairs = ConcurrentHashMap<String, PendingRepair>()
     private val _healthEvents = MutableSharedFlow<HealthEvent>(extraBufferCapacity = 64)
 
     override suspend fun reportFailure(request: ProcessFailureReport): RepairAction {
@@ -48,7 +54,9 @@ class OrchestratorServiceImpl(
                 .build()
 
         if (action.requiresUserApproval) {
-            pendingRepairs[repairId] = action
+            // Parked with the process it is about: RepairAction has no process_id field, so a
+            // repair id alone is not enough to act on later.
+            pendingRepairs[repairId] = PendingRepair(request.processId, action)
         }
 
         _healthEvents.tryEmit(
@@ -123,17 +131,34 @@ class OrchestratorServiceImpl(
                     .build()
 
         return if (request.approved) {
-            logger.info("Repair {} approved by user", request.repairId)
-            try {
-                onRepairApproved(pending)
-            } catch (e: Exception) {
-                logger.error("Failed to execute approved repair {}: {}", request.repairId, e.message)
+            logger.info("Repair {} for process {} approved by user", request.repairId, pending.processId)
+            // The response says what happened to the repair, not that it was approved: a
+            // caller cannot tell an applied repair from a dropped one otherwise.
+            val result =
+                try {
+                    onRepairApproved(pending.processId, pending.action)
+                } catch (e: Exception) {
+                    logger.error("Failed to execute approved repair {}: {}", request.repairId, e.message)
+                    ApprovalResult.Refused("Repair execution failed: ${e.message}")
+                }
+            when (result) {
+                is ApprovalResult.Applied -> {
+                    RepairApprovalResponse
+                        .newBuilder()
+                        .setApplied(true)
+                        .setResultMessage(result.message)
+                        .build()
+                }
+
+                is ApprovalResult.Refused -> {
+                    logger.warn("Approved repair {} was not applied: {}", request.repairId, result.reason)
+                    RepairApprovalResponse
+                        .newBuilder()
+                        .setApplied(false)
+                        .setResultMessage(result.reason)
+                        .build()
+                }
             }
-            RepairApprovalResponse
-                .newBuilder()
-                .setApplied(true)
-                .setResultMessage("Repair approved and execution initiated")
-                .build()
         } else {
             logger.info("Repair {} rejected by user: {}", request.repairId, request.userNotes)
             RepairApprovalResponse
@@ -178,7 +203,13 @@ class OrchestratorServiceImpl(
             is RepairOutcome.StateReset -> {
                 builder
                     .setDescription("Process ${outcome.processId} state reset")
-                    .setResetState(ResetStateAction.getDefaultInstance())
+                    .setResetState(
+                        ResetStateAction
+                            .newBuilder()
+                            .setRestoreSnapshot(outcome.restoredSnapshotId != null)
+                            .setSnapshotId(outcome.restoredSnapshotId ?: "")
+                            .build(),
+                    )
             }
 
             is RepairOutcome.ConfigPatched -> {
@@ -240,3 +271,36 @@ class OrchestratorServiceImpl(
         return builder.build()
     }
 }
+
+/**
+ * What became of a repair the operator approved.
+ *
+ * The approval RPC answers with `applied`, so whatever applies a repair has to be able to say
+ * that it did not: a source patch or a rollback is not something this process can carry out on
+ * its own, and a host that has wired nothing to carry it out must not look like a host that
+ * did.
+ */
+sealed class ApprovalResult {
+    /** The repair reached something that acted on it. [message] is returned to the caller. */
+    data class Applied(
+        val message: String,
+    ) : ApprovalResult()
+
+    /** Nothing acted on the repair. [reason] is returned to the caller. */
+    data class Refused(
+        val reason: String,
+    ) : ApprovalResult()
+}
+
+/** A repair parked for approval, together with the process it is about. */
+private data class PendingRepair(
+    val processId: String,
+    val action: RepairAction,
+)
+
+private fun noApprovalSinkReason(
+    processId: String,
+    action: RepairAction,
+): String =
+    "The approval was recorded but nothing applied it: this process has nothing wired to apply " +
+        "a ${action.strategy} repair, so the proposal for process $processId is a proposal only"

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/RepairEngine.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/RepairEngine.kt
@@ -21,17 +21,31 @@ import java.io.File
  *
  * Restart requests are delegated to [onRequestRestart] (typically calls
  * KernelService.RequestShutdown so the kernel handles the actual process lifecycle).
+ *
+ * The engine writes no file. It reads source files, and only from inside [projectRoot] —
+ * see [readSourceFiles].
  */
 class RepairEngine(
     private val analyzer: CrashAnalyzer,
     private val snapshotManager: SnapshotManager,
     private val aiClient: AiRepairClient? = null,
-    /** Root directory used to resolve relative source file paths from process manifests. */
+    /**
+     * Root directory used to resolve relative source file paths from process manifests, and
+     * the only directory those files may be read from.
+     *
+     * The default is this process's working directory, which is where the kernel spawned it
+     * from and is not necessarily a project — a packaged app's working directory can be the
+     * filesystem root, which [AllowedRoots] refuses as a root, leaving no source reads at
+     * all. A host that wants manifest source files read should pass the project directory.
+     */
     private val projectRoot: String = System.getProperty("user.dir") ?: ".",
     /** Called to request a restart. Kernel handles the actual re-spawn. */
     private val onRequestRestart: suspend (processId: String, jvmArgsOverride: List<String>) -> Unit = { _, _ -> },
 ) {
     private val logger = LoggerFactory.getLogger(RepairEngine::class.java)
+
+    /** Manifest source file paths come from the diagnosed process, so they are confined. */
+    private val sourceRoots = AllowedRoots.of(File(projectRoot))
 
     // Escalation ladder applied when analyzer confidence is LOW
     private val defaultLadder =
@@ -99,15 +113,7 @@ class RepairEngine(
             }
 
             RepairStrategy.REPAIR_STRATEGY_RESET_STATE -> {
-                try {
-                    snapshotManager.cleanup(processId, keepLast = 0)
-                    onRequestRestart(processId, emptyList())
-                    logger.info("State reset + restart requested for process: {}", processId)
-                    RepairOutcome.StateReset(processId)
-                } catch (e: Exception) {
-                    logger.error("Failed to reset state for process: {}", processId, e)
-                    RepairOutcome.Failed(processId, "State reset failed: ${e.message}")
-                }
+                resetState(processId)
             }
 
             RepairStrategy.REPAIR_STRATEGY_PATCH_CONFIG -> {
@@ -155,24 +161,82 @@ class RepairEngine(
         }
 
     /**
+     * Restarts [processId] on the state it last snapshotted, and deletes nothing.
+     *
+     * A state reset is the third rung of [defaultLadder], so it runs automatically and
+     * without approval. Its wire form, `ResetStateAction`, carries `restore_snapshot` and
+     * `snapshot_id`: the reset is meant to bring a process back on a recorded state, so the
+     * newest snapshot is named here and reported in the outcome. Removing the snapshots
+     * would be the opposite — it would leave a later ROLLBACK with nothing to roll back to,
+     * at the moment a process is already failing repeatedly. With no snapshot recorded this
+     * is a plain restart, which is all the delete-everything form ever amounted to.
+     */
+    private suspend fun resetState(processId: String): RepairOutcome {
+        val snapshotId = latestSnapshotId(processId)
+        return try {
+            onRequestRestart(processId, emptyList())
+            logger.info(
+                "State reset + restart requested for process: {} (restoring snapshot: {})",
+                processId,
+                snapshotId ?: "none recorded",
+            )
+            RepairOutcome.StateReset(processId, snapshotId)
+        } catch (e: Exception) {
+            logger.error("Failed to reset state for process: {}", processId, e)
+            RepairOutcome.Failed(processId, "State reset failed: ${e.message}")
+        }
+    }
+
+    private fun latestSnapshotId(processId: String): String? =
+        try {
+            snapshotManager.listSnapshots(processId).firstOrNull()?.id
+        } catch (_: Exception) {
+            null
+        }
+
+    /**
      * Reads source files listed in the process manifest.
      * Paths are tried as absolute first, then relative to [projectRoot].
      * Files that cannot be read are silently omitted.
+     *
+     * The list comes from the manifest the diagnosed process sent, and the contents go to
+     * [AiRepairClient], i.e. off this machine — so which files the host is willing to read is
+     * not the reporting process's choice. Every candidate is resolved and must land inside
+     * [projectRoot] ([sourceRoots]); one that does not is logged and dropped, never fatal,
+     * because a manifest with a single bad entry should still be diagnosable.
      */
     private fun readSourceFiles(manifest: ProcessManifest?): Map<String, String> {
         if (manifest == null || manifest.sourceFilesList.isEmpty()) return emptyMap()
         return manifest.sourceFilesList
-            .associateWith { path ->
-                try {
-                    val file =
-                        File(path).takeIf { it.isAbsolute && it.isFile }
-                            ?: File(projectRoot, path).takeIf { it.isFile }
-                    file?.readText() ?: ""
-                } catch (_: Exception) {
+            .associateWith { path -> readConfinedSourceFile(path) }
+            .filterValues { it.isNotBlank() }
+    }
+
+    private fun readConfinedSourceFile(declaredPath: String): String =
+        try {
+            val candidate = File(declaredPath).takeIf { it.isAbsolute } ?: File(projectRoot, declaredPath)
+            val confined = sourceRoots.resolve(candidate)
+            when {
+                confined == null -> {
+                    logger.warn(
+                        "Manifest source file {} is outside the roots {} this process reads from — dropped",
+                        declaredPath,
+                        sourceRoots.rootPaths().ifEmpty { listOf("(none)") },
+                    )
                     ""
                 }
-            }.filterValues { it.isNotBlank() }
-    }
+
+                !confined.isFile -> {
+                    ""
+                }
+
+                else -> {
+                    confined.readText()
+                }
+            }
+        } catch (_: Exception) {
+            ""
+        }
 
     private fun buildEscalationReport(
         processId: String,
@@ -200,6 +264,8 @@ sealed class RepairOutcome {
 
     data class StateReset(
         val processId: String,
+        /** The snapshot the restarted process should come back on, or null if none is recorded. */
+        val restoredSnapshotId: String? = null,
     ) : RepairOutcome()
 
     data class ConfigPatched(

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/RepairEngine.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/RepairEngine.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.orchestrator
 import ai.rever.boss.ipc.proto.ProcessFailureReport
 import ai.rever.boss.ipc.proto.ProcessManifest
 import ai.rever.boss.ipc.proto.RepairStrategy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -31,21 +32,41 @@ class RepairEngine(
     private val aiClient: AiRepairClient? = null,
     /**
      * Root directory used to resolve relative source file paths from process manifests, and
-     * the only directory those files may be read from.
+     * the only directory those files may be read from. **Null means no source file may be
+     * read at all**, which is the default.
      *
-     * The default is this process's working directory, which is where the kernel spawned it
-     * from and is not necessarily a project — a packaged app's working directory can be the
-     * filesystem root, which [AllowedRoots] refuses as a root, leaving no source reads at
-     * all. A host that wants manifest source files read should pass the project directory.
+     * It defaulted to this process's working directory, which is not a project — the kernel
+     * spawns the orchestrator with `ProcessConfig.workDir`, itself defaulting to `File(".")`,
+     * so the child inherits whatever the parent had. For a packaged macOS app that is `/`,
+     * which [AllowedRoots] refuses; but a `.desktop` launch or a service gets `$HOME` or the
+     * install tree, and those are ordinary directories that [AllowedRoots] accepts. Reads
+     * were then confined to somewhere real and arbitrary rather than to nothing, and no
+     * caller had said they should happen at all.
+     *
+     * Requiring the root to be stated keeps "the host didn't say" and "the working directory
+     * happened to be somewhere plausible" from being the same state.
      */
-    private val projectRoot: String = System.getProperty("user.dir") ?: ".",
+    private val projectRoot: String? = null,
     /** Called to request a restart. Kernel handles the actual re-spawn. */
     private val onRequestRestart: suspend (processId: String, jvmArgsOverride: List<String>) -> Unit = { _, _ -> },
 ) {
     private val logger = LoggerFactory.getLogger(RepairEngine::class.java)
 
     /** Manifest source file paths come from the diagnosed process, so they are confined. */
-    private val sourceRoots = AllowedRoots.of(File(projectRoot))
+    private val sourceRoots =
+        if (projectRoot == null) AllowedRoots.none() else AllowedRoots.of(File(projectRoot))
+
+    init {
+        // Say it once at construction. Whether manifest source reads are on, and where they
+        // point, is otherwise invisible: a usable root logs nothing, and the refusals are
+        // warnings that only appear for the roots that were rejected.
+        val roots = sourceRoots.rootPaths()
+        if (roots.isEmpty()) {
+            logger.info("Manifest source reads are off: no usable project root was given")
+        } else {
+            logger.info("Manifest source reads are confined to {}", roots)
+        }
+    }
 
     // Escalation ladder applied when analyzer confidence is LOW
     private val defaultLadder =
@@ -95,6 +116,11 @@ class RepairEngine(
                     onRequestRestart(processId, emptyList())
                     logger.info("Restart requested for process: {}", processId)
                     RepairOutcome.Restarted(processId)
+                } catch (e: CancellationException) {
+                    // Before the Exception arm: CancellationException *is* an Exception, so
+                    // catching it here would turn "the caller hung up" into a repair failure
+                    // and swallow the cancellation the coroutine machinery needs to see.
+                    throw e
                 } catch (e: Exception) {
                     logger.error("Failed to request restart for process: {}", processId, e)
                     RepairOutcome.Failed(processId, "Restart request failed: ${e.message}")
@@ -106,6 +132,11 @@ class RepairEngine(
                     onRequestRestart(processId, listOf("-Xmx512m"))
                     logger.info("Tuned restart requested for process: {}", processId)
                     RepairOutcome.Restarted(processId)
+                } catch (e: CancellationException) {
+                    // Before the Exception arm: CancellationException *is* an Exception, so
+                    // catching it here would turn "the caller hung up" into a repair failure
+                    // and swallow the cancellation the coroutine machinery needs to see.
+                    throw e
                 } catch (e: Exception) {
                     logger.error("Failed to request tuned restart for process: {}", processId, e)
                     RepairOutcome.Failed(processId, "Tuned restart request failed: ${e.message}")
@@ -181,6 +212,11 @@ class RepairEngine(
                 snapshotId ?: "none recorded",
             )
             RepairOutcome.StateReset(processId, snapshotId)
+        } catch (e: CancellationException) {
+            // Before the Exception arm: CancellationException *is* an Exception, so catching
+            // it here would report "state reset failed" when the caller simply hung up, and
+            // swallow the cancellation the coroutine machinery needs to see.
+            throw e
         } catch (e: Exception) {
             logger.error("Failed to reset state for process: {}", processId, e)
             RepairOutcome.Failed(processId, "State reset failed: ${e.message}")
@@ -196,8 +232,8 @@ class RepairEngine(
 
     /**
      * Reads source files listed in the process manifest.
-     * Paths are tried as absolute first, then relative to [projectRoot].
-     * Files that cannot be read are silently omitted.
+     * Paths are tried as absolute first, then relative to [projectRoot] — and a relative one
+     * is dropped outright when no root was given. Files that cannot be read are omitted.
      *
      * The list comes from the manifest the diagnosed process sent, and the contents go to
      * [AiRepairClient], i.e. off this machine — so which files the host is willing to read is
@@ -214,8 +250,13 @@ class RepairEngine(
 
     private fun readConfinedSourceFile(declaredPath: String): String =
         try {
-            val candidate = File(declaredPath).takeIf { it.isAbsolute } ?: File(projectRoot, declaredPath)
-            val confined = sourceRoots.resolve(candidate)
+            // A relative path needs a root to hang off. Without one there is nothing to
+            // resolve against — and `File(null, path)` would quietly resolve it against the
+            // working directory, which is the behaviour a null root exists to refuse.
+            val candidate =
+                File(declaredPath).takeIf { it.isAbsolute }
+                    ?: projectRoot?.let { root -> File(root, declaredPath) }
+            val confined = candidate?.let(sourceRoots::resolve)
             when {
                 confined == null -> {
                     logger.warn(

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AllowedRootsTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AllowedRootsTest.kt
@@ -1,0 +1,175 @@
+package ai.rever.boss.orchestrator
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Symlink creation is the one step here that is not portable — it needs Developer Mode or an
+ * administrator on Windows — so the two symlink cases skip themselves when the platform will
+ * not create one. The containment rule they exercise is also asserted without symlinks by the
+ * "outside every root" and "dot-dot" cases, which run everywhere.
+ */
+class AllowedRootsTest {
+    private val tempDirs = mutableListOf<File>()
+
+    @AfterTest
+    fun cleanup() {
+        tempDirs.forEach { it.deleteRecursively() }
+    }
+
+    private fun tempDir(): File =
+        Files
+            .createTempDirectory("boss-roots-test")
+            .toFile()
+            .also { tempDirs.add(it) }
+
+    /** Returns null when this platform will not let the test create a symlink. */
+    private fun symlink(
+        link: File,
+        target: File,
+    ): File? =
+        try {
+            Files.createSymbolicLink(link.toPath(), target.toPath()).toFile()
+        } catch (_: Exception) {
+            null
+        }
+
+    @Test
+    fun `a file inside a root resolves`() {
+        val root = tempDir()
+        val file = File(root, "src/Main.kt").also { it.parentFile.mkdirs() }
+        file.writeText("fun main() {}")
+
+        val resolved = AllowedRoots.of(root).resolve(file)
+
+        assertNotNull(resolved)
+        assertEquals("fun main() {}", resolved.readText())
+    }
+
+    @Test
+    fun `a path that does not exist yet is judged on where it would land`() {
+        val root = tempDir()
+        val roots = AllowedRoots.of(root)
+
+        assertNotNull(roots.resolve(File(root, "not/created/yet.kt")))
+        assertNull(roots.resolve(File(root.parentFile, "outside-not-created.kt")))
+    }
+
+    @Test
+    fun `a path outside every root is refused`() {
+        val root = tempDir()
+        val elsewhere = tempDir()
+        val file = File(elsewhere, "notes.txt").also { it.writeText("data") }
+
+        assertNull(AllowedRoots.of(root).resolve(file))
+    }
+
+    @Test
+    fun `a dot-dot path that leaves the root is refused`() {
+        val parent = tempDir()
+        val root = File(parent, "project").also { it.mkdirs() }
+        val outside = File(parent, "outside").also { it.mkdirs() }
+        File(outside, "notes.txt").writeText("data")
+
+        val roots = AllowedRoots.of(root)
+
+        assertNull(roots.resolve(File(root, "../outside/notes.txt")))
+        // ...including when the walk goes up through a directory that does not exist, which
+        // no lexical check of the string sees.
+        assertNull(roots.resolve(File(root, "absent/../../outside/notes.txt")))
+    }
+
+    @Test
+    fun `a sibling whose name starts with the root's name is refused`() {
+        val parent = tempDir()
+        val root = File(parent, "project").also { it.mkdirs() }
+        val sibling = File(parent, "project-notes").also { it.mkdirs() }
+        val file = File(sibling, "private.txt").also { it.writeText("data") }
+
+        val roots = AllowedRoots.of(root)
+
+        assertNull(roots.resolve(file))
+        assertNotNull(roots.resolve(File(root, "own.txt")))
+    }
+
+    @Test
+    fun `a symlink pointing out of a root is refused and one staying inside is not`() {
+        val root = tempDir()
+        val elsewhere = tempDir()
+        val outsideFile = File(elsewhere, "notes.txt").also { it.writeText("data") }
+        val link = symlink(File(root, "link"), elsewhere) ?: return
+
+        val roots = AllowedRoots.of(root)
+
+        // No ".." and no name that looks suspicious — only resolution shows where it goes.
+        assertNull(roots.resolve(File(link, "notes.txt")))
+
+        val inside = File(root, "real.txt").also { it.writeText("mine") }
+        val insideLink = symlink(File(root, "alias.txt"), inside) ?: return
+        assertNotNull(roots.resolve(insideLink))
+        assertNull(roots.resolve(outsideFile))
+    }
+
+    @Test
+    fun `a symlink whose target is missing is refused rather than followed`() {
+        val root = tempDir()
+        val elsewhere = tempDir()
+        val missingTarget = File(elsewhere, "created-later.txt")
+        val link = symlink(File(root, "pending"), missingTarget) ?: return
+        assertTrue(!missingTarget.exists(), "the target must not exist for this case")
+
+        val roots = AllowedRoots.of(root)
+
+        assertNull(roots.resolve(link))
+        assertNull(roots.resolve(File(link, "deeper.txt")))
+    }
+
+    @Test
+    fun `no roots refuses everything`() {
+        val root = tempDir()
+        val file = File(root, "f.txt").also { it.writeText("data") }
+
+        assertNull(AllowedRoots.none().resolve(file))
+        assertEquals(emptyList(), AllowedRoots.none().rootPaths())
+    }
+
+    @Test
+    fun `a root that cannot be resolved grants nothing rather than everything`() {
+        val root = tempDir()
+        val absent = File(root, "never-created")
+        val regularFile = File(root, "f.txt").also { it.writeText("data") }
+
+        val fromAbsent = AllowedRoots.of(absent)
+        assertEquals(emptyList(), fromAbsent.rootPaths())
+        assertNull(fromAbsent.resolve(File(absent, "f.txt")))
+
+        // A file is not a directory, so it is not a usable root either.
+        assertEquals(emptyList(), AllowedRoots.of(regularFile).rootPaths())
+    }
+
+    @Test
+    fun `a filesystem root grants nothing because confining to it confines nothing`() {
+        val filesystemRoot = File(tempDir().toPath().root.toString())
+
+        val roots = AllowedRoots.of(filesystemRoot)
+
+        assertEquals(emptyList(), roots.rootPaths())
+        assertNull(roots.resolve(File(filesystemRoot, "etc/hosts")))
+    }
+
+    @Test
+    fun `each root is reported once and in canonical form`() {
+        val root = tempDir()
+        val viaDot = File(root, ".")
+
+        val roots = AllowedRoots.of(root, viaDot)
+
+        assertEquals(listOf(root.canonicalPath), roots.rootPaths())
+    }
+}

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AllowedRootsTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AllowedRootsTest.kt
@@ -86,6 +86,41 @@ class AllowedRootsTest {
     }
 
     @Test
+    fun `a dot-dot path to a target that does not exist yet is refused`() {
+        // Every other dot-dot case has an existing target, so all of them exit through the
+        // "a tail component exists" guard. This one reaches the end of the walk with nothing
+        // to stat — the shape a caller that creates the file would use.
+        //
+        // Measured, not assumed: this passes with or without the `normalize()` in
+        // `appendAbsentTail`, because `Path.relativize` on JDK 12+ has already collapsed the
+        // `..` before the walk begins. So the assertion pins the invariant at the API
+        // boundary rather than pinning that one line, and it is what turns a change in that
+        // JDK behaviour — or a refactor that stops routing through `relativize` — into a red
+        // test instead of a silently widened root.
+        val parent = tempDir()
+        val root = File(parent, "project").also { it.mkdirs() }
+        File(parent, "outside").also { it.mkdirs() }
+
+        val roots = AllowedRoots.of(root)
+
+        assertNull(roots.resolve(File(root, "absent/../../outside/created-later.txt")))
+    }
+
+    @Test
+    fun `a file in any granted root resolves`() {
+        // `of(vararg)` was only ever exercised with one usable root, so `roots.any` was
+        // effectively a single-element check.
+        val first = tempDir()
+        val second = tempDir()
+        val inSecond = File(second, "notes.txt").also { it.writeText("data") }
+
+        val roots = AllowedRoots.of(first, second)
+
+        assertEquals(2, roots.rootPaths().size)
+        assertEquals(inSecond.canonicalFile, roots.resolve(inSecond))
+    }
+
+    @Test
     fun `a sibling whose name starts with the root's name is refused`() {
         val parent = tempDir()
         val root = File(parent, "project").also { it.mkdirs() }

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/OrchestratorServiceImplTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/OrchestratorServiceImplTest.kt
@@ -1,0 +1,272 @@
+package ai.rever.boss.orchestrator
+
+import ai.rever.boss.ipc.proto.ProcessFailureReport
+import ai.rever.boss.ipc.proto.ProcessManifest
+import ai.rever.boss.ipc.proto.RepairAction
+import ai.rever.boss.ipc.proto.RepairApproval
+import ai.rever.boss.ipc.proto.RepairHint
+import ai.rever.boss.ipc.proto.RepairStrategy
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class OrchestratorServiceImplTest {
+    private lateinit var dataDir: File
+    private lateinit var snapshots: SnapshotManager
+
+    @BeforeTest
+    fun setup() {
+        dataDir = Files.createTempDirectory("boss-service-test").toFile()
+        snapshots = SnapshotManager(dataDir)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        dataDir.deleteRecursively()
+    }
+
+    private fun engine(onRequestRestart: suspend (String, List<String>) -> Unit = { _, _ -> }) =
+        RepairEngine(
+            analyzer = CrashAnalyzer(),
+            snapshotManager = snapshots,
+            aiClient = null,
+            projectRoot = dataDir.absolutePath,
+            onRequestRestart = onRequestRestart,
+        )
+
+    /** A report that forces [strategy] through a HIGH-confidence manifest hint. */
+    private fun report(
+        processId: String,
+        strategy: RepairStrategy,
+    ): ProcessFailureReport =
+        ProcessFailureReport
+            .newBuilder()
+            .setProcessId(processId)
+            .setErrorType("ai.rever.Boom")
+            .setErrorMessage("boom")
+            .setConsecutiveFailures(1)
+            .setManifest(
+                ProcessManifest
+                    .newBuilder()
+                    .addRepairHints(
+                        RepairHint
+                            .newBuilder()
+                            .setFailurePattern("Boom")
+                            .setRepairStrategy(strategy)
+                            .setDescription("forced by test")
+                            .build(),
+                    ).build(),
+            ).build()
+
+    // ---- the approval response says what happened ----
+
+    @Test
+    fun `an approval whose execution fails is not reported as applied`() =
+        runTest {
+            val service =
+                OrchestratorServiceImpl(
+                    repairEngine = engine(),
+                    onRepairApproved = { _, _ -> error("the patch could not be written") },
+                )
+            val parked = service.reportFailure(report("p1", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE))
+            assertTrue(parked.requiresUserApproval, "PATCH_SOURCE is the strategy that gets parked")
+
+            val response = service.approveRepair(approval(parked.repairId))
+
+            assertFalse(response.applied, "a repair nothing carried out must not be reported as applied")
+            assertTrue(
+                response.resultMessage.contains("the patch could not be written"),
+                response.resultMessage,
+            )
+        }
+
+    @Test
+    fun `an approval that is refused is not reported as applied`() =
+        runTest {
+            val service =
+                OrchestratorServiceImpl(
+                    repairEngine = engine(),
+                    onRepairApproved = { processId, _ ->
+                        ApprovalResult.Refused("nothing applies patches for $processId")
+                    },
+                )
+            val parked = service.reportFailure(report("p2", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE))
+
+            val response = service.approveRepair(approval(parked.repairId))
+
+            assertFalse(response.applied)
+            assertEquals("nothing applies patches for p2", response.resultMessage)
+        }
+
+    @Test
+    fun `an approval that is carried out is reported as applied with the executor's message`() =
+        runTest {
+            val service =
+                OrchestratorServiceImpl(
+                    repairEngine = engine(),
+                    onRepairApproved = { processId, _ -> ApprovalResult.Applied("patched $processId") },
+                )
+            val parked = service.reportFailure(report("p3", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE))
+
+            val response = service.approveRepair(approval(parked.repairId))
+
+            assertTrue(response.applied)
+            assertEquals("patched p3", response.resultMessage)
+        }
+
+    @Test
+    fun `a host that wires nothing to apply repairs reports the approval as not applied`() =
+        runTest {
+            val service = OrchestratorServiceImpl(repairEngine = engine())
+            val parked = service.reportFailure(report("p4", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE))
+
+            val response = service.approveRepair(approval(parked.repairId))
+
+            assertFalse(response.applied, "an unwired host must not look like one that applied the repair")
+            assertTrue(response.resultMessage.contains("p4"), response.resultMessage)
+        }
+
+    // ---- an approved repair acts on the process, not on the repair id ----
+
+    @Test
+    fun `an approved repair is handed the process it was reported for`() =
+        runTest {
+            val seen = mutableListOf<Pair<String, String>>()
+            val service =
+                OrchestratorServiceImpl(
+                    repairEngine = engine(),
+                    onRepairApproved = { processId, action ->
+                        seen.add(processId to action.repairId)
+                        ApprovalResult.Applied("ok")
+                    },
+                )
+            val parked = service.reportFailure(report("service-worker-7", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE))
+
+            service.approveRepair(approval(parked.repairId))
+
+            assertEquals(listOf("service-worker-7" to parked.repairId), seen)
+            assertTrue(
+                seen.single().first != seen.single().second,
+                "the process id and the repair id are different things",
+            )
+        }
+
+    @Test
+    fun `applyApprovedRepair shuts down the reported process and never the repair id`() =
+        runTest {
+            val shutdown = mutableListOf<String>()
+            val action =
+                RepairAction
+                    .newBuilder()
+                    .setRepairId("11111111-2222-3333-4444-555555555555")
+                    .setStrategy(RepairStrategy.REPAIR_STRATEGY_RESTART)
+                    .build()
+
+            val result = applyApprovedRepair("service-editor-2", action) { shutdown.add(it) }
+
+            assertEquals(listOf("service-editor-2"), shutdown)
+            assertFalse(shutdown.contains(action.repairId), "a repair id is not a process id")
+            assertTrue(result is ApprovalResult.Applied, "got $result")
+        }
+
+    @Test
+    fun `applyApprovedRepair refuses a strategy it cannot carry out and shuts down nothing`() =
+        runTest {
+            val shutdown = mutableListOf<String>()
+            val action =
+                RepairAction
+                    .newBuilder()
+                    .setRepairId("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+                    .setStrategy(RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE)
+                    .build()
+
+            val result = applyApprovedRepair("service-editor-2", action) { shutdown.add(it) }
+
+            assertEquals(emptyList(), shutdown, "a source patch must not stop the process")
+            val refused = assertNotNull(result as? ApprovalResult.Refused, "got $result")
+            assertTrue(refused.reason.contains("service-editor-2"), refused.reason)
+        }
+
+    // ---- the reset-state action carries the snapshot it points at ----
+
+    @Test
+    fun `a reset-state action names the snapshot the process comes back on`() =
+        runTest {
+            val snapshotId = snapshots.save("p5", "state".toByteArray())
+            val service = OrchestratorServiceImpl(repairEngine = engine())
+
+            val action = service.reportFailure(report("p5", RepairStrategy.REPAIR_STRATEGY_RESET_STATE))
+
+            assertTrue(action.hasResetState(), "got ${action.repairDetailCase}")
+            assertTrue(action.resetState.restoreSnapshot, "the reset restores rather than discards")
+            assertEquals(snapshotId, action.resetState.snapshotId)
+        }
+
+    @Test
+    fun `a reset-state action with no snapshot recorded says so`() =
+        runTest {
+            val service = OrchestratorServiceImpl(repairEngine = engine())
+
+            val action = service.reportFailure(report("p6", RepairStrategy.REPAIR_STRATEGY_RESET_STATE))
+
+            assertTrue(action.hasResetState())
+            assertFalse(action.resetState.restoreSnapshot)
+            assertEquals("", action.resetState.snapshotId)
+        }
+
+    @Test
+    fun `an unknown repair id is still reported as not applied`() =
+        runTest {
+            val service = OrchestratorServiceImpl(repairEngine = engine())
+
+            val response = service.approveRepair(approval("no-such-repair"))
+
+            assertFalse(response.applied)
+            assertTrue(response.resultMessage.contains("no-such-repair"), response.resultMessage)
+        }
+
+    @Test
+    fun `a rejected repair is not applied and is not parked twice`() =
+        runTest {
+            var applications = 0
+            val service =
+                OrchestratorServiceImpl(
+                    repairEngine = engine(),
+                    onRepairApproved = { _, _ ->
+                        applications++
+                        ApprovalResult.Applied("ok")
+                    },
+                )
+            val parked = service.reportFailure(report("p7", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE))
+
+            val rejected =
+                service.approveRepair(
+                    RepairApproval
+                        .newBuilder()
+                        .setRepairId(parked.repairId)
+                        .setApproved(false)
+                        .setUserNotes("not now")
+                        .build(),
+                )
+
+            assertFalse(rejected.applied)
+            assertEquals(0, applications)
+            // The repair is spent: approving it afterwards finds nothing pending.
+            assertFalse(service.approveRepair(approval(parked.repairId)).applied)
+            assertEquals(0, applications)
+        }
+
+    private fun approval(repairId: String): RepairApproval =
+        RepairApproval
+            .newBuilder()
+            .setRepairId(repairId)
+            .setApproved(true)
+            .build()
+}

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/RepairEngineTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/RepairEngineTest.kt
@@ -58,13 +58,13 @@ class RepairEngineTest {
 
     private fun engine(
         aiClient: AiRepairClient? = null,
-        root: File = projectRoot,
+        root: File? = projectRoot,
         onRequestRestart: suspend (String, List<String>) -> Unit = { _, _ -> },
     ) = RepairEngine(
         analyzer = CrashAnalyzer(),
         snapshotManager = snapshots,
         aiClient = aiClient,
-        projectRoot = root.absolutePath,
+        projectRoot = root?.absolutePath,
         onRequestRestart = onRequestRestart,
     )
 
@@ -108,6 +108,26 @@ class RepairEngineTest {
             )
 
             assertEquals(mapOf("src/App.kt" to "inside the project"), ai.sourceFiles)
+        }
+
+    @Test
+    fun `no project root means no source file is read, however it is named`() =
+        runTest {
+            // The shipped configuration: OrchestratorMain names no root, so reads are off
+            // rather than confined to whatever the child's working directory happened to be.
+            val inside = File(projectRoot, "src/App.kt").also { it.parentFile.mkdirs() }
+            inside.writeText("inside the project")
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai, root = null).handleFailure(
+                report(
+                    "p0",
+                    RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE,
+                    listOf("src/App.kt", inside.absolutePath),
+                ),
+            )
+
+            assertEquals(emptyMap(), ai.sourceFiles)
         }
 
     @Test

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/RepairEngineTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/RepairEngineTest.kt
@@ -1,0 +1,257 @@
+package ai.rever.boss.orchestrator
+
+import ai.rever.boss.ipc.proto.ProcessFailureReport
+import ai.rever.boss.ipc.proto.ProcessManifest
+import ai.rever.boss.ipc.proto.RepairHint
+import ai.rever.boss.ipc.proto.RepairStrategy
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RepairEngineTest {
+    private lateinit var dataDir: File
+    private lateinit var projectRoot: File
+    private lateinit var outsideDir: File
+    private lateinit var snapshots: SnapshotManager
+
+    @BeforeTest
+    fun setup() {
+        dataDir = Files.createTempDirectory("boss-engine-data").toFile()
+        projectRoot = Files.createTempDirectory("boss-engine-project").toFile()
+        outsideDir = Files.createTempDirectory("boss-engine-outside").toFile()
+        snapshots = SnapshotManager(dataDir)
+    }
+
+    @AfterTest
+    fun cleanup() {
+        listOf(dataDir, projectRoot, outsideDir).forEach { it.deleteRecursively() }
+    }
+
+    /** Records what it was asked for instead of proposing anything. */
+    private class RecordingAiClient : AiRepairClient {
+        var sourceFiles: Map<String, String>? = null
+
+        override suspend fun proposeSourceFix(
+            rootCause: String,
+            sourceFiles: Map<String, String>,
+            stackTrace: String,
+            errorMessage: String,
+        ): SourceFixProposal? {
+            this.sourceFiles = sourceFiles
+            return null
+        }
+
+        override suspend fun proposeConfigFix(
+            processId: String,
+            rootCause: String,
+            suggestedFix: String?,
+            errorMessage: String,
+        ): ConfigFixProposal? = null
+    }
+
+    private fun engine(
+        aiClient: AiRepairClient? = null,
+        root: File = projectRoot,
+        onRequestRestart: suspend (String, List<String>) -> Unit = { _, _ -> },
+    ) = RepairEngine(
+        analyzer = CrashAnalyzer(),
+        snapshotManager = snapshots,
+        aiClient = aiClient,
+        projectRoot = root.absolutePath,
+        onRequestRestart = onRequestRestart,
+    )
+
+    /** A report whose manifest names [sourceFiles] and which forces [strategy]. */
+    private fun report(
+        processId: String,
+        strategy: RepairStrategy,
+        sourceFiles: List<String> = emptyList(),
+    ): ProcessFailureReport =
+        ProcessFailureReport
+            .newBuilder()
+            .setProcessId(processId)
+            .setErrorType("ai.rever.Boom")
+            .setErrorMessage("boom")
+            .setConsecutiveFailures(1)
+            .setManifest(
+                ProcessManifest
+                    .newBuilder()
+                    .addAllSourceFiles(sourceFiles)
+                    // A HIGH-confidence hint makes the strategy the engine runs deterministic.
+                    .addRepairHints(
+                        RepairHint
+                            .newBuilder()
+                            .setFailurePattern("Boom")
+                            .setRepairStrategy(strategy)
+                            .setDescription("forced by test")
+                            .build(),
+                    ).build(),
+            ).build()
+
+    // ---- manifest source files are confined to the project root ----
+
+    @Test
+    fun `a manifest source file inside the project root is read`() =
+        runTest {
+            File(projectRoot, "src/App.kt").also { it.parentFile.mkdirs() }.writeText("inside the project")
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai).handleFailure(
+                report("p1", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE, listOf("src/App.kt")),
+            )
+
+            assertEquals(mapOf("src/App.kt" to "inside the project"), ai.sourceFiles)
+        }
+
+    @Test
+    fun `an absolute manifest source file outside the project root is not read`() =
+        runTest {
+            val outside = File(outsideDir, "elsewhere.txt").also { it.writeText("not the project's file") }
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai).handleFailure(
+                report("p2", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE, listOf(outside.absolutePath)),
+            )
+
+            assertEquals(emptyMap(), ai.sourceFiles)
+        }
+
+    @Test
+    fun `a manifest source file reached through dot-dot is not read`() =
+        runTest {
+            val outside = File(outsideDir, "elsewhere.txt").also { it.writeText("not the project's file") }
+            val viaDotDot = "../${outsideDir.name}/${outside.name}"
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai, root = projectRoot).handleFailure(
+                report("p3", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE, listOf(viaDotDot)),
+            )
+
+            assertEquals(emptyMap(), ai.sourceFiles)
+        }
+
+    @Test
+    fun `a manifest source file reached through a symlink out of the project root is not read`() =
+        runTest {
+            val outside = File(outsideDir, "elsewhere.txt").also { it.writeText("not the project's file") }
+            val link = File(projectRoot, "link")
+            try {
+                Files.createSymbolicLink(link.toPath(), outsideDir.toPath())
+            } catch (_: Exception) {
+                return@runTest // this platform will not create symlinks unprivileged
+            }
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai).handleFailure(
+                report("p4", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE, listOf("link/${outside.name}")),
+            )
+
+            assertEquals(emptyMap(), ai.sourceFiles)
+        }
+
+    @Test
+    fun `a refused source file does not stop the readable ones`() =
+        runTest {
+            File(projectRoot, "Good.kt").writeText("readable")
+            val outside = File(outsideDir, "elsewhere.txt").also { it.writeText("not the project's file") }
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai).handleFailure(
+                report(
+                    "p5",
+                    RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE,
+                    listOf(outside.absolutePath, "Good.kt"),
+                ),
+            )
+
+            assertEquals(mapOf("Good.kt" to "readable"), ai.sourceFiles)
+        }
+
+    // ---- a state reset keeps the snapshots a rollback needs ----
+
+    @Test
+    fun `a state reset restarts the process and names its latest snapshot`() =
+        runTest {
+            snapshots.save("p6", "old state".toByteArray())
+            Thread.sleep(SNAPSHOT_TIMESTAMP_GAP_MS)
+            val newest = snapshots.save("p6", "newer state".toByteArray())
+            val restarted = mutableListOf<String>()
+
+            val outcome =
+                engine(onRequestRestart = { id, _ -> restarted.add(id) })
+                    .handleFailure(report("p6", RepairStrategy.REPAIR_STRATEGY_RESET_STATE))
+
+            assertEquals(listOf("p6"), restarted, "a state reset must still restart the process")
+            assertEquals(RepairOutcome.StateReset("p6", newest), outcome)
+        }
+
+    @Test
+    fun `a state reset leaves every snapshot in place for a later rollback`() =
+        runTest {
+            val first = snapshots.save("p7", "first".toByteArray())
+            Thread.sleep(SNAPSHOT_TIMESTAMP_GAP_MS)
+            val second = snapshots.save("p7", "second".toByteArray())
+
+            engine().handleFailure(report("p7", RepairStrategy.REPAIR_STRATEGY_RESET_STATE))
+
+            val remaining = snapshots.listSnapshots("p7").map { it.id }
+            assertEquals(setOf(first, second), remaining.toSet(), "no snapshot may be deleted by a repair")
+            assertNotNull(snapshots.loadLatest("p7"), "a rollback must still have something to restore")
+            assertEquals("second", snapshots.loadLatest("p7")?.decodeToString())
+        }
+
+    @Test
+    fun `a state reset with no snapshot recorded is a plain restart`() =
+        runTest {
+            val restarted = mutableListOf<String>()
+
+            val outcome =
+                engine(onRequestRestart = { id, _ -> restarted.add(id) })
+                    .handleFailure(report("p8", RepairStrategy.REPAIR_STRATEGY_RESET_STATE))
+
+            assertEquals(listOf("p8"), restarted)
+            assertEquals(RepairOutcome.StateReset("p8", null), outcome)
+        }
+
+    @Test
+    fun `a state reset whose restart fails is reported as failed`() =
+        runTest {
+            snapshots.save("p9", "state".toByteArray())
+
+            val outcome =
+                engine(onRequestRestart = { _, _ -> error("kernel unreachable") })
+                    .handleFailure(report("p9", RepairStrategy.REPAIR_STRATEGY_RESET_STATE))
+
+            val failed = assertNotNull(outcome as? RepairOutcome.Failed, "got $outcome")
+            assertTrue(failed.reason.contains("State reset failed"), failed.reason)
+            // ...and it did not take the snapshots down with it.
+            assertNotNull(snapshots.loadLatest("p9"))
+        }
+
+    @Test
+    fun `an unusable project root leaves no source file readable`() =
+        runTest {
+            val absentRoot = File(projectRoot, "never-created")
+            File(projectRoot, "Good.kt").writeText("readable")
+            val ai = RecordingAiClient()
+
+            engine(aiClient = ai, root = absentRoot).handleFailure(
+                report("p10", RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE, listOf("Good.kt")),
+            )
+
+            assertEquals(emptyMap(), ai.sourceFiles)
+            assertNull(AllowedRoots.of(absentRoot).resolve(File(projectRoot, "Good.kt")))
+        }
+
+    private companion object {
+        /** Snapshot ordering is by millisecond timestamp, so two saves must not share one. */
+        const val SNAPSHOT_TIMESTAMP_GAP_MS = 5L
+    }
+}


### PR DESCRIPTION
Four correctness fixes in `boss-orchestrator`, found while porting the module to Rust.

## Manifest source reads are confined to the project root

`RepairEngine.readSourceFiles` resolved each entry of `ProcessManifest.sourceFiles` as an absolute
path first and read it, and the contents go on to `AiRepairClient.proposeSourceFix`. That manifest is
written by the diagnosed process and arrives over the socket, so the file set was not the host's
choice. It also does not take five failures to reach that rung: `CrashAnalyzer` treats a
manifest-supplied `repair_hints[].repair_strategy` as `HIGH` confidence and `RepairEngine` uses it
directly, so the same manifest that names the files can select the strategy that reads them, on the
first report.

New `AllowedRoots` mirrors the Rust port's behaviour: canonicalize the deepest existing ancestor,
re-append the absent tail, compare by path **component** rather than string prefix, and refuse a
dangling symlink.

The part worth reviewing closely is what it does with an unusable root. `OrchestratorMain` never
passes `projectRoot`, so it defaults to `user.dir` in the orchestrator child — and `ProcessSpawner`
sets the child's directory from `ProcessConfig.workDir`, which defaults to `File(".")`. In a packaged
app that is commonly `/`, and confining to `/` confines nothing, so a naive fix would have been a
no-op exactly where it matters. `AllowedRoots.of` therefore **refuses a filesystem root, and any
root that is not a resolvable directory, granting nothing** — an unusable root narrows reach instead
of silently widening it. In the shipped configuration that means manifest source reads are off until
a host passes a real project directory, which is the safe end of the trade and is documented on the
constructor parameter.

Two notes recorded rather than glossed: `Path.relativize` normalizes on JDK ≥ 12, and it is the
"absent tail must not already exist" guard that refuses a climbing `..` (the dot-dot test is what
would catch a change in that behaviour); and the resolve-then-read gap is the same
time-of-check/time-of-use window the Rust version has, noted in the KDoc rather than claimed solved.

## `RESET_STATE` no longer deletes the snapshots `ROLLBACK` needs

It called `cleanup(processId, keepLast = 0)` — deleting **every** snapshot, at the third consecutive
failure, with no approval — which contradicts `ResetStateAction`'s own `restore_snapshot` and
`snapshot_id` fields. It now names the newest snapshot, deletes nothing, and returns
`StateReset(processId, restoredSnapshotId)`, with `ResetStateAction` populated from it instead of
`getDefaultInstance()`. With no snapshot recorded it is a plain restart, which is all the
delete-everything form amounted to.

## Approvals report what actually happened

`approveRepair` logged its callback's failure and then returned `applied = true`. The callback
contract is now `suspend (processId, action) -> ApprovalResult` (`Applied` / `Refused`), a thrown
failure becomes `Refused`, and the response carries the real outcome. The default callback
**refuses**, so a host that wires nothing cannot look like a host that applied a patch.

## The approval path acts on the process, not on a repair id

`OrchestratorMain` computed its process id as `action.repairId` in all three branches, because
`RepairAction` carries no `process_id` and `pendingRepairs` discarded it. The branch was dead in
practice — `requires_user_approval` is set only on `CodeFixProposed`/`PATCH_SOURCE`, which the
dispatch did not act on, so every real approval fell through to "not auto-executable" — but it was a
live-looking branch that would have shut down a UUID.

Pending repairs are now `PendingRepair(processId, action)`, and the dispatch moved out of `main()`
into `internal suspend fun applyApprovedRepair(processId, action, requestShutdown)` so it is
directly testable. A restart is requested for the reported process; every other strategy is refused
with a reason. The restart leg was kept rather than deleted because, with the id carried, it is
correct code that nothing currently parks — and deleting it would have left the only reachable path
silently returning `Unit`, which is the third defect again.

## Verification

- **53 tests in the module, 0 failures** (was 21): `AllowedRootsTest` 11, `RepairEngineTest` 10,
  `OrchestratorServiceImplTest` 11, plus the existing `CrashAnalyzerTest` 10 and `SnapshotManagerTest` 11.
  Counts checked against the JUnit XML, not a filter.
- **24 deliberate breaks applied to the final sources, each confirmed red**; every one of the 32 new
  tests appears in at least one red list.
- `:boss-orchestrator:detekt` and `:ktlintCheck` green with **no new baseline entries** — the first
  `AllowedRoots` shape was restructured to satisfy `ReturnCount` and `NestedBlockDepth` rather than
  baselined, and the signatures of `executeStrategy`, `buildRepairAction` and `main()` are unchanged
  so their existing `LongMethod` baseline IDs still match.

Two mutation results are reported rather than quietly fixed: a redundant `roots.isEmpty()` early
return was semantically covered by `any {}` on an empty list, and a trailing `.normalize()` call was
**unfalsifiable** — no test could force it — so it was removed rather than shipped as a line nothing
constrains.

## Found in this module, not fixed here

`RESTART_TUNED` is identical to `RESTART` (the wiring discards `jvmArgsOverride`, and the `-Xmx512m`
it would pass *caps* the heap for the `OutOfMemoryError` diagnosis that selects it). `SnapshotManager`
interpolates a wire-supplied `processId` into a path with no validation. `CrashAnalyzer` compiles a
regex supplied by the diagnosed process and runs it with no time bound. `getHealthDashboard` always
returns zeros in production, because the only wiring passes `processRegistry = null`.
`getRepairHistory` ordering is unstable on equal millisecond timestamps. `repairHistory` and
`pendingRepairs` are unbounded. `RepairHistoryEntry.success` is `outcome !is Failed`, so an unapplied
proposal records as a successful repair. `watchHealth` ignores the return of `tryEmit` into a 64-slot
buffer. And `AI_REPAIR_API_URL` is read from the environment with no scheme or host restriction.
