### PR TITLE
Fix suggestion ranking, in-session duplicates, and store testability

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -68,7 +68,9 @@ object RecentBrowserPagesManager {
     private val logger = BossLogger.forComponent("RecentBrowserPagesManager")
     private const val MAX_PAGES = 30
     private const val SAVE_DEBOUNCE_MS = 5000L // Debounce saves to max once per 5 seconds
-    private val settingsFile = BossDirectories.resolve("recent-browser-pages.json")
+
+    /** Overridable so tests exercise the real read/write path without touching `~/.boss`. */
+    internal var settingsFile: File = BossDirectories.resolve("recent-browser-pages.json")
     private val json =
         Json {
             prettyPrint = false
@@ -287,12 +289,13 @@ object RecentBrowserPagesManager {
         // Swap the debounce job under a lock: callers now arrive from concurrent
         // coroutines (a visit and an eviction racing), and an unsynchronized
         // cancel-then-assign can drop the reference to a job that is still pending.
+        val target = settingsFile
         synchronized(saveJobLock) {
             saveJob?.cancel()
             saveJob =
                 scope.launch {
                     delay(SAVE_DEBOUNCE_MS)
-                    saveImmediately()
+                    saveImmediately(target)
                 }
         }
     }
@@ -300,15 +303,21 @@ object RecentBrowserPagesManager {
     /**
      * Immediately save recent pages to disk (bypasses debounce).
      */
-    private suspend fun saveImmediately() =
+
+    /**
+     * @param target resolved by the caller, never read here: a debounced save that picked
+     *   its destination at execution time would follow [settingsFile] if it changed in
+     *   between, and write one profile's pages into another's file.
+     */
+    private suspend fun saveImmediately(target: File = settingsFile) =
         withContext(Dispatchers.IO) {
             try {
-                settingsFile.parentFile?.mkdirs()
+                target.parentFile?.mkdirs()
                 val data = RecentBrowserPagesData(pages = _recentPages.value)
                 val content = json.encodeToString(RecentBrowserPagesData.serializer(), data)
                 // Atomic: the debounced save and an eviction can land together, and a
                 // half-written file reads back as "no recent pages".
-                settingsFile.atomicWriteText(content)
+                target.atomicWriteText(content)
             } catch (e: Exception) {
                 logger.warn(LogCategory.SYSTEM, "Error saving recent pages", error = e)
             }
@@ -413,6 +422,9 @@ object RecentBrowserPagesManager {
                     pages.filterNot { page ->
                         shouldRetireVisit(page.url, page.lastVisited, page.visitCount, key, cutoff)
                     }
+                // Assigned inside the lambda: MutableStateFlow.update retries on
+                // contention, so only the winning invocation's value survives — which is
+                // exactly the count that matches the list we committed.
                 removed = pages.size - remaining.size
                 remaining
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTracker.kt
@@ -207,7 +207,16 @@ fun suggestableHost(url: String): String? =
         val parsed = java.net.URL(url)
         val scheme = parsed.protocol?.lowercase()
         val host = parsed.host?.lowercase().orEmpty()
-        if ((scheme == "http" || scheme == "https") && host.isNotBlank()) host else null
+        if ((scheme == "http" || scheme == "https") && host.isNotBlank()) {
+            // Normalized the same way [canonicalUrlKey] normalizes an authority, because
+            // this value is stored as the entry's domain and then matched against what
+            // the user types. Keeping the `www.` meant typing "you" never ranked
+            // www.youtube.com in the domain-prefix bucket; dropping the port meant
+            // localhost:3000 and localhost:8080 were indistinguishable in the list.
+            normalizeAuthority(host + (parsed.port.takeIf { it != -1 }?.let { ":$it" } ?: ""))
+        } else {
+            null
+        }
     } catch (e: java.net.MalformedURLException) {
         // Not a URL we can key on, which is the answer the caller wants. The message
         // would echo the whole URL including its query, so it isn't logged here — callers
@@ -298,10 +307,31 @@ private fun hasOpaqueBody(value: String): Boolean {
     return value.substringAfter(':').firstOrNull()?.isDigit() != true
 }
 
-/** Lowercase the authority and strip a `www.` prefix; leave path and query untouched. */
+/**
+ * Lowercase an authority and strip a `www.` prefix, keeping any port.
+ *
+ * The one place host normalization is defined, so a key and a stored domain can't
+ * disagree about what host a URL is on.
+ */
+internal fun normalizeAuthority(authority: String): String = authority.lowercase().removePrefix("www.")
+
+/**
+ * Normalize an authority and append its path and query.
+ *
+ * The path keeps its case and its internal shape; only a trailing slash goes, and only
+ * from the path — trimming the whole remainder would make `?q=a/` and `?q=a` the same
+ * key, and these keys drive deletion. A path of exactly `/` is dropped so
+ * `example.com/?q=1` and `example.com?q=1` agree, since Chromium always commits the
+ * former and a caller may well report the latter.
+ */
 private fun normalizeAuthorityAndPath(value: String): String {
     val authorityEnd = value.indexOfFirst { it == '/' || it == '?' }
     val authority = if (authorityEnd < 0) value else value.substring(0, authorityEnd)
-    val path = if (authorityEnd < 0) "" else value.substring(authorityEnd)
-    return authority.lowercase().removePrefix("www.") + path.trimEnd('/')
+    val remainder = if (authorityEnd < 0) "" else value.substring(authorityEnd)
+
+    val queryStart = remainder.indexOf('?')
+    val path = if (queryStart < 0) remainder else remainder.substring(0, queryStart)
+    val query = if (queryStart < 0) "" else remainder.substring(queryStart)
+
+    return normalizeAuthority(authority) + path.trimEnd('/') + query
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -180,13 +180,6 @@ internal class BrowserHandleImpl(
     // Main-thread scope for injection/teardown (rrweb inject + executeJavaScript run on Main).
     private val coBrowseScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
-    /**
-     * Runs history retraction off the engine's event thread. Not tied to this handle's
-     * lifetime on purpose — a retraction triggered by the navigation that closed a tab
-     * still has to complete.
-     */
-    private val retractionScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
     // Lock for thread-safe browser operations
     private val browserLock = ReentrantReadWriteLock()
 
@@ -1760,6 +1753,13 @@ internal class BrowserHandleImpl(
 
         private val uploadCallbackInstalled = AtomicBoolean(false)
         private val staticLogger = BossLogger.forComponent("BrowserHandleImpl")
+
+        /**
+         * Runs history retraction off the engine's event thread. Deliberately not tied to
+         * any handle's lifetime — a retraction triggered by the navigation that closed a
+         * tab still has to complete — and one per process rather than one per browser.
+         */
+        private val retractionScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
         /** Best-effort cap on [loadUrlAndWait]; returns (no throw) if a load runs long. */
         private const val LOAD_TIMEOUT_MS = 30_000L

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManager.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -104,9 +105,40 @@ internal fun entriesToEvict(
     }
 }
 
+/**
+ * How strongly an entry should be suggested: visits dominate, recency breaks ties.
+ *
+ * The previous expression — `visitCount * 1000 + lastVisited / 1_000_000` — was effectively
+ * pure recency, because the recency term is around 1.75e6 at current epoch milliseconds, so
+ * a site needed roughly 1750 visits before its count moved it at all. Bounding recency to a
+ * 0..100 decay over a few days restores what the comment always claimed. Matches
+ * `RecentBrowserPagesManager.getSuggestions`, so the dashboard and the URL bar order the
+ * same history the same way.
+ */
+internal fun rankOf(
+    entry: UrlHistoryEntry,
+    now: Long,
+): Double {
+    val hoursAgo = (now - entry.lastVisited) / (1000.0 * 60 * 60)
+    val recencyScore = maxOf(0.0, 100 - hoursAgo)
+    return (entry.visitCount * 1000.0) + recencyScore
+}
+
 object UrlHistoryManager {
     private val logger = BossLogger.forComponent("UrlHistoryManager")
-    private val historyFile = BossDirectories.resolve("browser-history.json")
+
+    /** Overridable so tests exercise the real read/write path without touching `~/.boss`. */
+    internal var historyFile: File = BossDirectories.resolve("browser-history.json")
+
+    /**
+     * Keyed by [distinctPageKey], not by the raw URL.
+     *
+     * Two spellings of one page — `https://x.com` as typed, `https://www.x.com/` as
+     * committed — used to occupy two slots and show up as two suggestions until a restart
+     * merged them. Keying by page identity means the second recording finds the first, so
+     * [mergeDuplicateHistoryEntries] is a one-time migration for old files rather than a
+     * repair that has to run on every load.
+     */
     private val history = ConcurrentHashMap<String, UrlHistoryEntry>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -117,6 +149,14 @@ object UrlHistoryManager {
      * reports as "no history" and silently starts empty.
      */
     private val saveLock = Mutex()
+
+    /**
+     * The most recent background write, so a caller that needs the file to be current can
+     * wait for it. Deletions and evictions persist without blocking the caller, which
+     * leaves no other way to know when the bytes have landed.
+     */
+    @Volatile
+    private var pendingWrite: Job? = null
     private val json =
         Json {
             prettyPrint = true
@@ -127,39 +167,63 @@ object UrlHistoryManager {
         loadHistory()
     }
 
-    private fun loadHistory() {
+    internal fun loadHistory() {
         try {
-            if (historyFile.exists()) {
-                val content = historyFile.readText()
-                if (content.isNotEmpty()) {
-                    val entries = json.decodeFromString<List<UrlHistoryEntry>>(content)
-                    mergeDuplicateHistoryEntries(entries).forEach { entry ->
-                        history[entry.url] = entry
-                    }
-                }
+            history.clear()
+            val content = if (historyFile.exists()) historyFile.readText() else ""
+            if (content.isEmpty()) return
+
+            val entries = json.decodeFromString<List<UrlHistoryEntry>>(content)
+            mergeDuplicateHistoryEntries(entries).forEach { entry ->
+                // Recompute the domain rather than trusting the stored one: files written
+                // before host normalization was shared carry a `www.` that keeps the entry
+                // out of the domain-prefix bucket when ranking.
+                val domain = suggestableHost(entry.url) ?: entry.domain
+                history[distinctPageKey(entry.url)] = entry.copy(domain = domain)
             }
         } catch (e: Exception) {
             logger.warn(LogCategory.BROWSER, "Failed to load browser history", error = e)
         }
     }
 
-    suspend fun saveHistory() =
-        withContext(Dispatchers.IO) {
-            saveLock.withLock {
-                try {
-                    val entries =
-                        history.values
-                            .toList()
-                            .sortedByDescending { it.visitCount * 1000 + (it.lastVisited / 1000000) }
-                            .take(1000) // Keep only top 1000 entries
-                    // Atomic: a crash or a concurrent writer leaves the previous file
-                    // intact rather than a half-written one.
-                    historyFile.atomicWriteText(json.encodeToString(entries))
-                } catch (e: Exception) {
-                    logger.warn(LogCategory.BROWSER, "Failed to save browser history", error = e)
-                }
+    suspend fun saveHistory() = writeTo(historyFile, entriesToPersist())
+
+    /**
+     * The entries a save would write: best first, capped.
+     *
+     * Snapshotted by the caller rather than read inside the write, so what lands on disk
+     * is the history as it stood when the save was asked for.
+     */
+    private fun entriesToPersist(): List<UrlHistoryEntry> {
+        val now = System.currentTimeMillis()
+        return history.values
+            .toList()
+            .sortedByDescending { rankOf(it, now) }
+            .take(1000) // Keep only top 1000 entries
+    }
+
+    /**
+     * Write [entries] to [target].
+     *
+     * Both are parameters, never fields read here: a background save that resolved its
+     * destination at execution time would follow [historyFile] if it changed in between,
+     * which is how a test pointing the store at a scratch file wrote an empty history over
+     * the real one.
+     */
+    private suspend fun writeTo(
+        target: File,
+        entries: List<UrlHistoryEntry>,
+    ) = withContext(Dispatchers.IO) {
+        saveLock.withLock {
+            try {
+                // Atomic: a crash or a concurrent writer leaves the previous file intact
+                // rather than a half-written one.
+                target.atomicWriteText(json.encodeToString(entries))
+            } catch (e: Exception) {
+                logger.warn(LogCategory.BROWSER, "Failed to save browser history", error = e)
             }
         }
+    }
 
     fun addUrl(
         url: String,
@@ -170,12 +234,17 @@ object UrlHistoryManager {
         val domain = suggestableHost(url) ?: return
         if (NavigationOutcomeTracker.didFail(url)) return
 
-        val existing = history[url]
+        val key = distinctPageKey(url)
+        val existing = history[key]
 
-        history[url] =
+        history[key] =
             if (existing != null) {
                 existing.copy(
+                    // Keep the URL the browser committed over one a caller typed: it is
+                    // the spelling we will navigate back to.
+                    url = if (url.startsWith("https", ignoreCase = true)) url else existing.url,
                     title = title.ifBlank { existing.title },
+                    domain = domain,
                     visitCount = existing.visitCount + 1,
                     lastVisited = System.currentTimeMillis(),
                 )
@@ -197,6 +266,7 @@ object UrlHistoryManager {
         if (query.isBlank()) return emptyList()
 
         val lowerQuery = query.lowercase()
+        val now = System.currentTimeMillis()
 
         return history.values
             .filter { entry ->
@@ -207,15 +277,12 @@ object UrlHistoryManager {
                 compareBy(
                     // Prioritize domain starts with query
                     { !it.domain.startsWith(lowerQuery) },
-                    // Then URL starts with query
-                    {
-                        !it.url
-                            .removePrefix("https://")
-                            .removePrefix("http://")
-                            .startsWith(lowerQuery)
-                    },
-                    // Then by visit count and recency
-                    { -(it.visitCount * 1000 + (it.lastVisited / 1000000)) },
+                    // Then URL starts with query. Matched against the canonical form —
+                    // no scheme, no `www.` — so a stored `www.` doesn't sink an entry the
+                    // user is plainly typing towards.
+                    { !canonicalUrlKey(it.url).startsWith(lowerQuery) },
+                    // Then by visit count, with recency breaking ties
+                    { -rankOf(it, now) },
                 ),
             ).take(limit)
     }
@@ -227,9 +294,22 @@ object UrlHistoryManager {
      * deletion.
      */
     fun deleteUrl(url: String) {
-        if (history.remove(url) != null) {
-            scope.launch { saveHistory() }
+        // By page identity, so a caller holding a different spelling of the same entry
+        // than the one stored still removes it.
+        if (history.remove(distinctPageKey(url)) != null) {
+            persistInBackground()
         }
+    }
+
+    private fun persistInBackground() {
+        val target = historyFile
+        val entries = entriesToPersist()
+        pendingWrite = scope.launch { writeTo(target, entries) }
+    }
+
+    /** Wait for any background write to reach disk. */
+    internal suspend fun awaitPendingWrites() {
+        pendingWrite?.join()
     }
 
     /**
@@ -255,7 +335,7 @@ object UrlHistoryManager {
         val matches = entriesToEvict(history.values, url, recordedWithinMs)
 
         if (matches.isNotEmpty()) {
-            matches.forEach { history.remove(it.url) }
+            matches.forEach { history.remove(distinctPageKey(it.url)) }
             logger.info(
                 LogCategory.BROWSER,
                 "Removed history entries for an address that failed to load",
@@ -268,7 +348,7 @@ object UrlHistoryManager {
             // Persist here rather than waiting for the next saveHistory() — an evicted
             // entry that survives in the file is exactly the stale suggestion we just
             // removed.
-            scope.launch { saveHistory() }
+            persistInBackground()
         }
         return matches.size
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NavigationOutcomeTrackerTest.kt
@@ -99,6 +99,35 @@ class NavigationOutcomeTrackerTest {
     }
 
     @Test
+    fun `a root path and a bare host with a query are one key`() {
+        // Chromium always commits the slashed form; a caller may report either.
+        assertEquals(
+            canonicalUrlKey("https://example.com/?q=1"),
+            canonicalUrlKey("https://example.com?q=1"),
+        )
+    }
+
+    @Test
+    fun `a trailing slash inside a query is part of the query`() {
+        // These keys drive deletion, so trimming the whole remainder would let a search
+        // for "a/" retire the entry for a search for "a".
+        assertNotEquals(
+            canonicalUrlKey("https://example.com/s?q=a/"),
+            canonicalUrlKey("https://example.com/s?q=a"),
+        )
+    }
+
+    @Test
+    fun `the host a suggestion is filed under matches the key it is found by`() {
+        // One normalization: the stored domain and the lookup key agree on `www.` and
+        // on the port, which is what makes prefix ranking work.
+        assertEquals("youtube.com", suggestableHost("https://www.YouTube.com/watch"))
+        assertEquals("localhost:3000", suggestableHost("http://localhost:3000/app"))
+        assertTrue(canonicalUrlKey("https://www.youtube.com/watch").startsWith("youtube.com"))
+        assertTrue(canonicalUrlKey("http://localhost:3000/app").startsWith("localhost:3000"))
+    }
+
+    @Test
     fun `a host reached over both schemes is the same place`() {
         assertEquals(canonicalUrlKey("http://example.com"), canonicalUrlKey("https://example.com"))
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/UrlHistoryManagerTest.kt
@@ -1,0 +1,181 @@
+package ai.rever.boss.plugin.browser
+
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the store itself rather than the pure helpers around it: the gate on what gets
+ * recorded, how one page recorded under two spellings collapses, and the ordering the URL
+ * bar actually sees.
+ *
+ * [UrlHistoryManager.historyFile] is pointed at a scratch file so this exercises the real
+ * read/write path without reading or writing the developer's own history.
+ */
+class UrlHistoryManagerTest {
+    private lateinit var tempFile: File
+    private lateinit var originalFile: File
+
+    @BeforeTest
+    fun useScratchFile() {
+        originalFile = UrlHistoryManager.historyFile
+        tempFile = File.createTempFile("browser-history", ".json").also { it.delete() }
+        UrlHistoryManager.historyFile = tempFile
+        UrlHistoryManager.loadHistory()
+        NavigationOutcomeTracker.clear()
+    }
+
+    @AfterTest
+    fun restore() {
+        // Drain first. A background write still in flight when the pointer moves back is
+        // how an earlier version of this test wrote an empty history over a real one —
+        // the store now binds its target when the write is requested, and waiting here
+        // means the test can't depend on that being true.
+        runBlocking { UrlHistoryManager.awaitPendingWrites() }
+        tempFile.delete()
+        UrlHistoryManager.historyFile = originalFile
+        UrlHistoryManager.loadHistory()
+        NavigationOutcomeTracker.clear()
+    }
+
+    @Test
+    fun `two spellings of one page are a single suggestion straight away`() {
+        // Previously these occupied two slots until a restart merged them.
+        UrlHistoryManager.addUrl("https://x.com", "X")
+        UrlHistoryManager.addUrl("https://www.x.com/", "X")
+
+        val suggestions = UrlHistoryManager.getSuggestions("x.com")
+
+        assertEquals(1, suggestions.size)
+        assertEquals(2, suggestions.single().visitCount)
+    }
+
+    @Test
+    fun `the https spelling is the one we keep`() {
+        UrlHistoryManager.addUrl("http://x.com/app", "App")
+        UrlHistoryManager.addUrl("https://x.com/app", "App")
+
+        assertEquals("https://x.com/app", UrlHistoryManager.getSuggestions("x.com").single().url)
+    }
+
+    @Test
+    fun `a prefix of the host ranks above a match buried in a title`() {
+        // The `www.` in a stored domain used to keep the obvious answer out of the
+        // domain-prefix bucket, so typing "you" ranked an unrelated page first.
+        UrlHistoryManager.addUrl("https://example.com/watch", "Youtube tips and tricks")
+        UrlHistoryManager.addUrl("https://www.youtube.com/", "YouTube")
+
+        assertEquals("https://www.youtube.com/", UrlHistoryManager.getSuggestions("you").first().url)
+    }
+
+    @Test
+    fun `a host and port are kept apart`() {
+        UrlHistoryManager.addUrl("http://localhost:3000/", "Dev")
+        UrlHistoryManager.addUrl("http://localhost:8080/", "Docs")
+
+        val domains = UrlHistoryManager.getSuggestions("localhost").map { it.domain }.toSet()
+
+        assertEquals(setOf("localhost:3000", "localhost:8080"), domains)
+    }
+
+    @Test
+    fun `visits outrank recency`() {
+        // The old score was recency in all but name: a count needed to pass ~1750 before
+        // it moved anything.
+        UrlHistoryManager.addUrl("https://daily.example/", "Daily")
+        repeat(4) { UrlHistoryManager.addUrl("https://daily.example/", "Daily") }
+        UrlHistoryManager.addUrl("https://once.example/", "Once")
+
+        val ranked = UrlHistoryManager.getSuggestions("example")
+
+        assertEquals("https://daily.example/", ranked.first().url)
+    }
+
+    @Test
+    fun `an address that failed to load is never recorded`() {
+        NavigationOutcomeTracker.recordFailure("https://youtube.como/")
+
+        UrlHistoryManager.addUrl("https://youtube.como/", "youtube.como")
+
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("youtube.como"))
+    }
+
+    @Test
+    fun `addresses with no host to suggest are turned away`() {
+        UrlHistoryManager.addUrl("about:blank", "New tab")
+        UrlHistoryManager.addUrl("file:///Users/me/notes.html", "Notes")
+        UrlHistoryManager.addUrl("data:text/plain,hi", "hi")
+
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("notes"))
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("blank"))
+    }
+
+    @Test
+    fun `a deletion survives a reload`() {
+        UrlHistoryManager.addUrl("https://gone.example/", "Gone")
+        runBlocking { UrlHistoryManager.saveHistory() }
+
+        UrlHistoryManager.deleteUrl("https://gone.example/")
+        runBlocking { UrlHistoryManager.awaitPendingWrites() }
+        UrlHistoryManager.loadHistory()
+
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("gone.example"))
+    }
+
+    @Test
+    fun `a deletion finds the entry under any spelling of it`() {
+        UrlHistoryManager.addUrl("https://www.spelling.example/", "Spelling")
+
+        UrlHistoryManager.deleteUrl("spelling.example")
+
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("spelling"))
+    }
+
+    @Test
+    fun `history written before shared host normalization is repaired on load`() {
+        tempFile.writeText(
+            """
+            [
+              {
+                "url": "https://www.legacy.example/",
+                "title": "Legacy",
+                "domain": "www.legacy.example",
+                "visitCount": 3,
+                "lastVisited": 1
+              }
+            ]
+            """.trimIndent(),
+        )
+
+        UrlHistoryManager.loadHistory()
+
+        assertEquals("legacy.example", UrlHistoryManager.getSuggestions("legacy").single().domain)
+    }
+
+    @Test
+    fun `an empty store answers nothing rather than everything`() {
+        UrlHistoryManager.addUrl("https://example.com/", "Example")
+
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions(""))
+        assertEquals(emptyList(), UrlHistoryManager.getSuggestions("   "))
+    }
+
+    @Test
+    fun `saving keeps the file parseable and the entries intact`() {
+        UrlHistoryManager.addUrl("https://persisted.example/page", "Persisted")
+        runBlocking { UrlHistoryManager.saveHistory() }
+
+        assertTrue(tempFile.exists())
+        UrlHistoryManager.loadHistory()
+
+        val reloaded = UrlHistoryManager.getSuggestions("persisted").single()
+        assertEquals("https://persisted.example/page", reloaded.url)
+        assertEquals("Persisted", reloaded.title)
+        assertNull(UrlHistoryManager.getSuggestions("nothing-here").firstOrNull())
+    }
+}


### PR DESCRIPTION
Works through [#69](https://github.com/risa-labs-inc/BossConsole/issues/69), the follow-ups from #66.

## Suggestions land where you'd expect

**One host normalization.** `suggestableHost` kept `www.` and dropped the port; `canonicalUrlKey` did the opposite. Since `suggestableHost`'s result is stored as an entry's `domain` and `getSuggestions` ranks on `domain.startsWith(query)`, typing `you` never put `www.youtube.com` in the domain-prefix bucket — an unrelated page whose *title* mentioned YouTube outranked it. And `localhost:3000` / `localhost:8080` were both filed under `localhost`. Both paths now go through `normalizeAuthority`, and `loadHistory` recomputes the stored domain so existing files are repaired rather than left mis-ranked.

**Ranking was recency wearing a visit-count label.** `visitCount * 1000 + lastVisited / 1_000_000`: the recency term is ~1.75e6 at current epoch milliseconds, so a site needed roughly 1750 visits before its count changed anything — despite the comment claiming visits were "weighted heavily". Replaced with a bounded 0..100 recency decay over a few days, so visits decide and recency breaks ties. This is the shape `RecentBrowserPagesManager.getSuggestions` already used, so the dashboard and the URL bar now order the same history the same way.

**Duplicates collapse as they're recorded.** History is keyed by `distinctPageKey` rather than the raw URL string, so `https://x.com` typed and `https://www.x.com/` committed find each other immediately instead of showing as two suggestions until a restart merged them. That demotes `mergeDuplicateHistoryEntries` to a one-time migration for old files, and lets `deleteUrl` find an entry stored under a different spelling than the caller happens to hold.

**Two `canonicalUrlKey` edges.** `example.com?q=1` and `example.com/?q=1` now agree — Chromium always commits the latter, so a caller reporting the former silently missed the gate. And the trailing-slash trim applies to the path only: trimming the whole remainder made `?q=a/` and `?q=a` the same key, and these keys drive deletion.

## Testability, and a bug it caught

Both stores now take an injectable file, so the `addUrl` gate, the ranking, and the persistence round-trip are covered directly (12 new cases) instead of only through extracted pure helpers.

Writing that test cost me my own history file, which is worth recording: a background save resolved `historyFile` *inside* the coroutine, so when the test moved the pointer back to the real path while a write was still in flight, an empty history landed on top of 703 real entries. (Recovered — the running app still had them in memory and rewrote the file on the next page load.) Saves now bind their destination *and* their contents when the write is requested, which is the discipline `ResolvedHostsStore` already used and the reason it was never affected. `RecentBrowserPagesManager`'s debounced save got the same treatment, and `UrlHistoryManager` exposes `awaitPendingWrites()` so a deletion's persistence is observable rather than fire-and-forget.

## Deliberately left in #69

- **Per-tab keying of the outcome tracker.** Needs browser identity plumbed through the plugin API's `addUrl`, so it wants its own change across api → host → plugin rather than riding along here.
- **Host-scoped rather than path-scoped eviction.** Widens the blast radius of a delete; better to leave until the `ResolvedHostsStore` guard has some real use behind it.

The redirect question from #69 resolves by reading the flow rather than changing anything: `classifyNavigation` only returns `FAILED` for an error page, an uncommitted navigation, or a `NetError`, and a redirect commits normally with a single `NavigationFinished` for the final URL — so no failure is ever published for the pre-redirect spelling.

## Testing

1169 tests green, `ktlintCheck` and `detekt` clean. Verified against a real profile that the test run leaves `~/.boss/browser-history.json` untouched.
