### PR TITLE
feat(self-healing): run the repair engine, and let settings choose its model

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/AdvancedSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/AdvancedSettings.kt
@@ -73,6 +73,11 @@ fun AdvancedSettings() {
             }
         }
 
+        // Always shown, including with Microkernel Mode off: this is where source egress is turned
+        // on, and an operator should be able to read and set it before enabling the mode that runs
+        // it. The readiness card says when the mode is what's holding it back.
+        SelfHealingSettings(kernelMode = kernelMode)
+
         // Plugin JVM Settings (only visible in KERNEL mode)
         if (kernelMode) {
             val perfSettings by PerformanceSettingsManager.currentSettings.collectAsState()
@@ -171,8 +176,9 @@ fun AdvancedSettings() {
                     Text(
                         text =
                             "When enabled, plugins and services run in isolated child processes " +
-                                "with gRPC-based IPC. The RepairEngine provides AI-powered self-healing " +
-                                "using the OpenAI API key from LLM Providers settings. " +
+                                "with gRPC-based IPC, and a crashed process is diagnosed and recovered " +
+                                "by the orchestrator rather than simply restarted. Asking a model to " +
+                                "propose a source patch is a separate opt-in, configured above. " +
                                 "When disabled, everything runs in a single JVM process (default).",
                         fontSize = 11.sp,
                         color = TextSecondary,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SelfHealingSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SelfHealingSettings.kt
@@ -23,12 +23,15 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * The instruction the orchestrator uses when this field is left empty.
@@ -55,9 +58,14 @@ fun SelfHealingSettings(kernelMode: Boolean) {
     val settings by SelfHealingSettingsManager.currentSettings.collectAsState()
     val provider = remember(settings.provider) { SelfHealingProvider.of(settings.provider) }
 
-    // Recomputed whenever the provider changes: the key may come from the environment or from LLM
-    // Providers settings, and either can differ per provider.
-    val hasKey = remember(settings.provider) { SelfHealingSettingsManager.hasApiKey(provider) }
+    // Off the composition thread: resolving a key reads llm_settings.json (see docs/THREADING.md).
+    // Re-run on every settings change as well as on provider change, so the card stops saying "no
+    // API key" as soon as the operator comes back from LLM Providers having entered one — that is
+    // the one thing this card exists to get right, and keying it on the provider alone left it
+    // stale until the screen was recreated.
+    val hasKey by produceState(initialValue = true, settings) {
+        value = withContext(Dispatchers.IO) { SelfHealingSettingsManager.hasApiKey(provider) }
+    }
 
     fun update(change: (SelfHealingSettingsData) -> SelfHealingSettingsData) {
         scope.launch { SelfHealingSettingsManager.updateSettings(change(settings)) }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SelfHealingSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SelfHealingSettings.kt
@@ -1,0 +1,212 @@
+package ai.rever.boss.components.settings.sections
+
+import ai.rever.boss.components.settings.shared.SettingsButtonRow
+import ai.rever.boss.components.settings.shared.SettingsDropdown
+import ai.rever.boss.components.settings.shared.SettingsSection
+import ai.rever.boss.components.settings.shared.SettingsTextArea
+import ai.rever.boss.components.settings.shared.SettingsTextField
+import ai.rever.boss.components.settings.shared.SettingsTheme.AccentColor
+import ai.rever.boss.components.settings.shared.SettingsTheme.TextSecondary
+import ai.rever.boss.components.settings.shared.SettingsToggle
+import ai.rever.boss.kernel.SelfHealingProvider
+import ai.rever.boss.kernel.SelfHealingSettingsData
+import ai.rever.boss.kernel.SelfHealingSettingsManager
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+
+/**
+ * The instruction the orchestrator uses when this field is left empty.
+ *
+ * Duplicated from `DEFAULT_REPAIR_SYSTEM_PROMPT` in boss-orchestrator, which the host cannot depend
+ * on — it is a separate process. Shown as placeholder text only; the value actually used still
+ * comes from the orchestrator when the field is blank.
+ */
+private const val DEFAULT_SYSTEM_PROMPT_HINT =
+    "You are a precise code repair assistant. Always respond with valid JSON only. " +
+        "Do not include markdown code fences."
+
+/**
+ * Settings for the self-healing orchestrator's use of a model.
+ *
+ * Self-healing itself needs no model — restart, tuned restart, state reset and escalation all work
+ * without one. What is configured here is the optional step beyond that: asking a model to read the
+ * crashing process's source and propose a patch. That sends source off the machine, so it is off by
+ * default and every field that decides where it goes is stated rather than inferred.
+ */
+@Composable
+fun SelfHealingSettings(kernelMode: Boolean) {
+    val scope = rememberCoroutineScope()
+    val settings by SelfHealingSettingsManager.currentSettings.collectAsState()
+    val provider = remember(settings.provider) { SelfHealingProvider.of(settings.provider) }
+
+    // Recomputed whenever the provider changes: the key may come from the environment or from LLM
+    // Providers settings, and either can differ per provider.
+    val hasKey = remember(settings.provider) { SelfHealingSettingsManager.hasApiKey(provider) }
+
+    fun update(change: (SelfHealingSettingsData) -> SelfHealingSettingsData) {
+        scope.launch { SelfHealingSettingsManager.updateSettings(change(settings)) }
+    }
+
+    SettingsSection(title = "Self-Healing") {
+        SettingsToggle(
+            label = "AI-Assisted Repair",
+            checked = settings.aiRepairEnabled,
+            onCheckedChange = { enabled -> update { it.copy(aiRepairEnabled = enabled) } },
+            description =
+                "Let the orchestrator send the crashing process's source files to the model below " +
+                    "and propose a patch. Restart, state reset and escalation work without this.",
+        )
+
+        if (settings.aiRepairEnabled) {
+            RepairModelFields(settings = settings, provider = provider, onChange = ::update)
+
+            Spacer(modifier = Modifier.height(8.dp))
+            RepairReadinessCard(settings = settings, provider = provider, hasKey = hasKey, kernelMode = kernelMode)
+        }
+    }
+}
+
+/**
+ * Where proposals come from and what the model is told.
+ *
+ * Model and endpoint are shown with the chosen provider's default as placeholder text rather than
+ * pre-filled, so a blank field keeps tracking the default instead of pinning today's value.
+ */
+@Composable
+private fun RepairModelFields(
+    settings: SelfHealingSettingsData,
+    provider: SelfHealingProvider,
+    onChange: ((SelfHealingSettingsData) -> SelfHealingSettingsData) -> Unit,
+) {
+    Spacer(modifier = Modifier.height(8.dp))
+    SettingsDropdown(
+        label = "Provider",
+        options = SelfHealingProvider.entries.map { it.displayName },
+        selectedOption = provider.displayName,
+        onOptionSelected = { chosen ->
+            val picked = SelfHealingProvider.entries.first { it.displayName == chosen }
+            // Model and endpoint are provider-specific; carrying them across would point a new
+            // provider at another one's URL. Clearing restores that provider's defaults.
+            onChange { it.copy(provider = picked.name, model = "", endpoint = "") }
+        },
+        description = "Where repair proposals are generated. The API key comes from LLM Providers settings.",
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+    SettingsTextField(
+        label = "Model",
+        value = settings.model,
+        onValueChange = { value -> onChange { it.copy(model = value) } },
+        placeholder = provider.defaultModel.ifBlank { "Required for a custom provider" },
+        description = "Leave empty to use the provider's default.",
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+    SettingsTextField(
+        label = "Endpoint",
+        value = settings.endpoint,
+        onValueChange = { value -> onChange { it.copy(endpoint = value) } },
+        placeholder = provider.defaultEndpoint.ifBlank { "https://your-gateway/v1/chat/completions" },
+        description = "Leave empty to use the provider's default.",
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+    SettingsTextField(
+        label = "Source root",
+        value = settings.projectRoot,
+        onValueChange = { value -> onChange { it.copy(projectRoot = value) } },
+        placeholder = "/path/to/your/checkout",
+        description =
+            "The only directory source may be read from and sent to the model. " +
+                "Without one, AI repair stays off.",
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+    SettingsTextArea(
+        label = "System prompt",
+        value = settings.systemPrompt,
+        onValueChange = { value -> onChange { it.copy(systemPrompt = value) } },
+        placeholder = DEFAULT_SYSTEM_PROMPT_HINT,
+        description =
+            "Leave empty for the default. Proposals are parsed as JSON, so a replacement " +
+                "should still ask for JSON only.",
+    )
+
+    if (settings.systemPrompt.isNotBlank()) {
+        Spacer(modifier = Modifier.height(8.dp))
+        SettingsButtonRow(
+            label = "Custom system prompt in use",
+            buttonText = "Reset to default",
+            onClick = { onChange { it.copy(systemPrompt = "") } },
+        )
+    }
+}
+
+/**
+ * Says whether AI repair will actually run, and what is missing if not.
+ *
+ * Three separate things have to line up — a key, a source root, and microkernel mode — and each is
+ * withheld silently at spawn time. Naming the missing one here is the difference between a setting
+ * that appears on and a setting that works.
+ */
+@Composable
+private fun RepairReadinessCard(
+    settings: SelfHealingSettingsData,
+    provider: SelfHealingProvider,
+    hasKey: Boolean,
+    kernelMode: Boolean,
+) {
+    val blockers =
+        buildList {
+            if (!hasKey) {
+                add("no API key for ${provider.displayName} (set one in LLM Providers, or ${provider.apiKeyEnvVar})")
+            }
+            if (settings.projectRoot.isBlank()) add("no source root named")
+            if (settings.endpoint.isBlank() && provider.defaultEndpoint.isBlank()) add("no endpoint")
+            if (settings.model.isBlank() && provider.defaultModel.isBlank()) add("no model")
+            if (!kernelMode) add("Microkernel Mode is off, so the orchestrator does not run")
+        }
+
+    val ready = blockers.isEmpty()
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        backgroundColor = if (ready) AccentColor.copy(alpha = 0.12f) else BossTheme.colors.alert.copy(alpha = 0.12f),
+        shape = RoundedCornerShape(6.dp),
+        elevation = 0.dp,
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = if (ready) "AI repair is configured" else "AI repair will not run",
+                fontSize = 12.sp,
+                color = if (ready) AccentColor else BossTheme.colors.alert,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text =
+                    if (ready) {
+                        "Applies the next time the orchestrator starts. Restart BOSS to pick up changes."
+                    } else {
+                        "Missing: ${blockers.joinToString("; ")}."
+                    },
+                fontSize = 11.sp,
+                color = TextSecondary,
+            )
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/shared/SettingsComponents.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/shared/SettingsComponents.kt
@@ -421,6 +421,70 @@ fun SettingsTextField(
 }
 
 /**
+ * A multi-line text field, for free text that wraps — a prompt, a note, a template.
+ *
+ * Separate from [SettingsTextField] rather than a flag on it: the two differ in how they are sized
+ * and scrolled, and a one-line field is the right default for a setting.
+ */
+@Composable
+fun SettingsTextArea(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    description: String? = null,
+    enabled: Boolean = true,
+    minLines: Int = 4,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .background(SurfaceColor)
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Text(text = label, color = if (enabled) TextPrimary else TextMuted, fontSize = 13.sp)
+        if (description != null) {
+            Text(
+                text = description,
+                color = TextMuted,
+                fontSize = 11.sp,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+        }
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            enabled = enabled,
+            minLines = minLines,
+            textStyle = TextStyle(color = TextPrimary, fontSize = 13.sp),
+            cursorBrush = SolidColor(AccentColor),
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(BackgroundColor, RoundedCornerShape(4.dp))
+                            .border(1.dp, BorderColor, RoundedCornerShape(4.dp))
+                            .padding(horizontal = 8.dp, vertical = 8.dp),
+                ) {
+                    if (value.isEmpty()) {
+                        Text(text = placeholder, color = TextMuted, fontSize = 13.sp)
+                    }
+                    innerTextField()
+                }
+            },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+        )
+    }
+}
+
+/**
  * A dropdown selector.
  */
 @Composable

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -1,8 +1,13 @@
 package ai.rever.boss.kernel
 
+import ai.rever.boss.ipc.BossIpcClient
 import ai.rever.boss.ipc.BossIpcServer
 import ai.rever.boss.ipc.IpcAddressResolver
+import ai.rever.boss.ipc.proto.OrchestratorServiceGrpcKt
+import ai.rever.boss.ipc.proto.ProcessFailureReport
 import ai.rever.boss.ipc.proto.ProcessState
+import ai.rever.boss.ipc.proto.RepairAction
+import ai.rever.boss.ipc.proto.RepairStrategy
 import ai.rever.boss.ipc.services.EventBusServiceImpl
 import ai.rever.boss.ipc.services.KernelServiceImpl
 import ai.rever.boss.ipc.services.StateServiceImpl
@@ -11,6 +16,7 @@ import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.plugin.api.*
 import ai.rever.boss.process.ManagedProcess
 import ai.rever.boss.process.ProcessConfig
+import ai.rever.boss.process.ProcessFailure
 import ai.rever.boss.process.ProcessMode
 import ai.rever.boss.process.ProcessMonitor
 import ai.rever.boss.process.ProcessRegistry
@@ -23,8 +29,142 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+
+/**
+ * Find [jarName] in [dir], tolerating the version every `fatJar` task actually puts in the name.
+ *
+ * The kernel has always looked for `boss-orchestrator-all.jar`, and no service module strips its
+ * version — `fatJar` produces `boss-orchestrator-1.0.0-all.jar`. Nothing ever matched, which is
+ * part of why no service has ever spawned. Rather than renaming nine artifacts, accept both: the
+ * exact name first, then the newest versioned sibling.
+ */
+internal fun serviceJarIn(
+    dir: File,
+    jarName: String,
+): File? {
+    if (!dir.isDirectory) return null
+
+    val prefix = jarName.removeSuffix("-all.jar")
+    return File(dir, jarName).takeIf { it.isFile }
+        ?: dir
+            .listFiles { f -> f.isFile && f.name.startsWith("$prefix-") && f.name.endsWith("-all.jar") }
+            ?.maxByOrNull { it.lastModified() }
+}
+
+/**
+ * Where a service's fat JAR actually is, preferring an operator-supplied copy.
+ *
+ * Three places, in order: `$BOSS_DATA_DIR/services` so an operator can drop in a build of
+ * their own; the app's bundled resources, which is where packaged builds ship them; and the
+ * module build directory, so `./gradlew run` works straight after `:<service>:fatJar` without
+ * anyone copying files around. Nothing is copied — a staged duplicate is one more thing to go
+ * stale.
+ *
+ * Falls back to the `$BOSS_DATA_DIR` path when none exists, so [spawnIfJarExists] reports the
+ * location an operator would populate.
+ */
+private fun resolveServiceJar(
+    bossDataDir: String,
+    jarName: String,
+): String {
+    // "boss-orchestrator-all.jar" is built by module "boss-orchestrator" under modules/.
+    val moduleName = jarName.removeSuffix("-all.jar")
+    val installedDir = File("$bossDataDir/services")
+    val searchDirs =
+        listOfNotNull(
+            installedDir,
+            System.getProperty("compose.application.resources.dir")?.let { File(it, "services") },
+            File("modules/$moduleName/build/libs"),
+            File("../modules/$moduleName/build/libs"),
+        )
+
+    return searchDirs
+        .firstNotNullOfOrNull { serviceJarIn(it, jarName) }
+        ?.absolutePath
+        ?: File(installedDir, jarName).path
+}
+
+private val notifyLogger = LoggerFactory.getLogger("KernelRepairNotice")
+
+/**
+ * Surface a repair the operator has to decide on, using the same toast plugin crashes use.
+ *
+ * Logged as well as shown: a service can die before the window exists, and `showMessage` posts to a
+ * flow that nobody is collecting yet — the notice would otherwise be lost with no trace.
+ */
+private fun notifyOperator(
+    processId: String,
+    summary: String,
+) {
+    notifyLogger.warn("Repair for {} needs operator attention: {}", processId, summary)
+    ai.rever.boss.components.bars.horizontal.StatusMessageManager
+        .showMessage("$processId needs attention: $summary", durationMs = 10_000)
+}
+
+/** What the kernel does about a crashed child once the orchestrator has had its say. */
+internal sealed interface Recovery {
+    /** Bring it back as configured. Also the answer when there is no advice to act on. */
+    data object Respawn : Recovery
+
+    /** Bring it back with different JVM args — the analyzer's answer to an OOM. */
+    data class RespawnTuned(
+        val jvmArgs: List<String>,
+    ) : Recovery
+
+    /** Tell the operator, then bring it back anyway. */
+    data class NotifyAndRespawn(
+        val reason: String,
+    ) : Recovery
+}
+
+/**
+ * Turn repair advice into what the kernel will actually do.
+ *
+ * Pure, because this is the part with judgement in it and the rest is process plumbing. A null
+ * [action] means the orchestrator could not be asked — it is the fallback path, and it must come
+ * out as the plain respawn the kernel did before any of this existed.
+ *
+ * Every branch ends in the process coming back. A repair that needs a human still restarts it
+ * first: withholding recovery until someone clicks would leave an operator with a dead service and
+ * a notification, which is worse than what they had.
+ */
+internal fun recoveryFor(action: RepairAction?): Recovery {
+    if (action == null) return Recovery.Respawn
+
+    val needsOperator =
+        action.requiresUserApproval || action.strategy == RepairStrategy.REPAIR_STRATEGY_ESCALATE
+
+    return when {
+        needsOperator -> {
+            Recovery.NotifyAndRespawn(action.description.ifBlank { action.strategy.name })
+        }
+
+        // RESET_STATE is a restart on this side too: the orchestrator has already named the
+        // snapshot to restore, and the kernel's job is to bring the process back up.
+        action.strategy == RepairStrategy.REPAIR_STRATEGY_RESTART ||
+            action.strategy == RepairStrategy.REPAIR_STRATEGY_RESET_STATE -> {
+            Recovery.Respawn
+        }
+
+        action.strategy == RepairStrategy.REPAIR_STRATEGY_RESTART_TUNED -> {
+            action.restart.jvmArgsOverrideList
+                .takeIf { it.isNotEmpty() }
+                ?.let { Recovery.RespawnTuned(it) }
+                ?: Recovery.Respawn
+        }
+
+        // PATCH_CONFIG / PATCH_SOURCE reach here only if they ever stop requiring approval.
+        // Nothing on this side applies a patch, so restore service and let the operator know.
+        else -> {
+            Recovery.NotifyAndRespawn(action.description.ifBlank { action.strategy.name })
+        }
+    }
+}
 
 /**
  * Bootstraps the microkernel infrastructure when running in KERNEL mode.
@@ -45,6 +185,18 @@ class KernelBootstrap(
         @Volatile
         var instance: KernelBootstrap? = null
             private set
+
+        /** Process id of the self-healing orchestrator, as spawned by [spawnServices]. */
+        const val ORCHESTRATOR_PROCESS_ID = "boss-orchestrator"
+
+        /**
+         * How long the kernel waits for repair advice before recovering on its own.
+         *
+         * Every crash pays this at worst, and the fallback restores exactly the behaviour that
+         * existed before the orchestrator was consulted — so it is set to lose no meaningful time
+         * when the orchestrator is wedged.
+         */
+        const val REPAIR_ADVICE_TIMEOUT_MS = 2_000L
     }
 
     private val logger = LoggerFactory.getLogger(KernelBootstrap::class.java)
@@ -67,6 +219,17 @@ class KernelBootstrap(
         private set
     var kernelAddress: String? = null
         private set
+
+    /**
+     * IPC address of each registered child, so the kernel can call *them*.
+     *
+     * [KernelServiceImpl] has always known these — it just handed them to a callback that dropped
+     * them on the floor, which is why nothing on this side could ever reach the orchestrator.
+     */
+    private val serviceAddresses = ConcurrentHashMap<String, String>()
+
+    /** Cached orchestrator channel, keyed by the address it was opened against. */
+    private var orchestratorClient: Pair<String, BossIpcClient>? = null
 
     /**
      * Initialize the kernel infrastructure. No-op in MONOLITH mode.
@@ -110,10 +273,11 @@ class KernelBootstrap(
         // Create gRPC services
         kernelService =
             KernelServiceImpl(
-                onProcessRegistered = { id, manifest, _ ->
-                    logger.info("Process registered via IPC: {}", id)
+                onProcessRegistered = { id, manifest, ipcAddress ->
+                    logger.info("Process registered via IPC: {} at {}", id, ipcAddress)
                     registry.updateManifest(id, manifest)
                     registry.getProcess(id)?.updateState(ProcessState.PROCESS_STATE_RUNNING)
+                    if (ipcAddress.isNotBlank()) serviceAddresses[id] = ipcAddress
                 },
                 onShutdownRequested = { id, force ->
                     val process = registry.getProcess(id)
@@ -159,41 +323,10 @@ class KernelBootstrap(
         // Start process monitor
         processMonitor!!.startGlobalMonitor()
 
-        // Listen for failures: auto-respawn ON_FAILURE processes (C2+M7 fix)
+        // Listen for failures: ask the orchestrator what to do, else auto-respawn (C2+M7 fix)
         scope.launch {
             processMonitor!!.failures.collect { failure ->
-                val process = registry.getProcess(failure.processId)
-                if (process != null && process.config.restartPolicy == RestartPolicy.ON_FAILURE) {
-                    val restartCount = registry.getRestartCount(failure.processId)
-                    if (restartCount < process.config.maxRestarts) {
-                        logger.info(
-                            "Auto-respawning process {} (attempt {}/{})",
-                            failure.processId,
-                            restartCount + 1,
-                            process.config.maxRestarts,
-                        )
-                        try {
-                            val newProcess = spawner.spawn(process.config)
-                            registry.register(failure.processId, newProcess, registry.getManifest(failure.processId))
-                            registry.incrementRestartCount(failure.processId)
-                        } catch (e: Exception) {
-                            logger.error("Auto-respawn failed for {}: {}", failure.processId, e.message)
-                        }
-                    } else {
-                        logger.error(
-                            "Process {} exceeded max restarts ({}), not respawning",
-                            failure.processId,
-                            process.config.maxRestarts,
-                        )
-                    }
-                } else {
-                    logger.error(
-                        "Process failure detected: {} - {} (no auto-respawn: policy={})",
-                        failure.processId,
-                        failure.errorMessage,
-                        process?.config?.restartPolicy,
-                    )
-                }
+                handleFailure(registry, spawner, failure)
             }
         }
 
@@ -207,12 +340,166 @@ class KernelBootstrap(
     }
 
     /**
+     * Decide what to do about a crashed child, and do it.
+     *
+     * The orchestrator gets first say — it runs the analyzer, the escalation ladder and the
+     * snapshot bookkeeping that this loop knows nothing about. What it returns is *advice*: the
+     * kernel is still the only thing that spawns processes, so a wrong or missing answer costs a
+     * strategy, never a recovery.
+     *
+     * Recovery therefore falls back to the plain respawn this loop has always done whenever the
+     * advice can't be trusted: the orchestrator is the process that just died, it has never
+     * registered, or the call fails or outruns [REPAIR_ADVICE_TIMEOUT_MS]. Trading a mechanism
+     * that works for one that is merely cleverer is how self-healing turns into self-harm.
+     */
+    private suspend fun handleFailure(
+        registry: ProcessRegistry,
+        spawner: ProcessSpawner,
+        failure: ProcessFailure,
+    ) {
+        val process = registry.getProcess(failure.processId)
+        if (process == null || process.config.restartPolicy != RestartPolicy.ON_FAILURE) {
+            logger.error(
+                "Process failure detected: {} - {} (no auto-respawn: policy={})",
+                failure.processId,
+                failure.errorMessage,
+                process?.config?.restartPolicy,
+            )
+            return
+        }
+
+        val action = requestRepairAdvice(registry, failure)
+        if (action == null) {
+            respawn(registry, spawner, failure.processId)
+            return
+        }
+
+        logger.info(
+            "Repair advice for {}: strategy={} approval={} — {}",
+            failure.processId,
+            action.strategy,
+            action.requiresUserApproval,
+            action.description,
+        )
+
+        when (val recovery = recoveryFor(action)) {
+            is Recovery.Respawn -> {
+                respawn(registry, spawner, failure.processId)
+            }
+
+            is Recovery.RespawnTuned -> {
+                respawn(registry, spawner, failure.processId, jvmArgsOverride = recovery.jvmArgs)
+            }
+
+            is Recovery.NotifyAndRespawn -> {
+                notifyOperator(failure.processId, recovery.reason)
+                respawn(registry, spawner, failure.processId)
+            }
+        }
+    }
+
+    /**
+     * Ask the orchestrator how to repair [failure], or null when it cannot be asked in time.
+     */
+    private suspend fun requestRepairAdvice(
+        registry: ProcessRegistry,
+        failure: ProcessFailure,
+    ): RepairAction? {
+        // Never ask the orchestrator to diagnose its own death, and never wait on one that has
+        // not registered an address yet.
+        val stub = if (failure.processId == ORCHESTRATOR_PROCESS_ID) null else orchestratorStub()
+        if (stub == null) return null
+
+        val report =
+            ProcessFailureReport
+                .newBuilder()
+                .setProcessId(failure.processId)
+                .setErrorType(failure.reason.name)
+                .setErrorMessage(failure.errorMessage)
+                .setStackTrace(failure.stackTrace)
+                .setExitCode(failure.exitCode)
+                .setTimestamp(failure.timestamp)
+                .setConsecutiveFailures(registry.getRestartCount(failure.processId) + 1)
+                .apply { registry.getManifest(failure.processId)?.let { setManifest(it) } }
+                .build()
+
+        return try {
+            withTimeoutOrNull(REPAIR_ADVICE_TIMEOUT_MS) { stub.reportFailure(report) }
+                ?: run {
+                    logger.warn(
+                        "Orchestrator did not answer within {}ms for {} — recovering without advice",
+                        REPAIR_ADVICE_TIMEOUT_MS,
+                        failure.processId,
+                    )
+                    null
+                }
+        } catch (e: Exception) {
+            logger.warn(
+                "Could not reach the orchestrator for {} ({}) — recovering without advice",
+                failure.processId,
+                e.message,
+            )
+            null
+        }
+    }
+
+    /** A stub for the running orchestrator, or null while it has no registered address. */
+    private fun orchestratorStub(): OrchestratorServiceGrpcKt.OrchestratorServiceCoroutineStub? {
+        val address = serviceAddresses[ORCHESTRATOR_PROCESS_ID] ?: return null
+        val cached = orchestratorClient
+        // Re-dial when the orchestrator comes back at a new address; the old channel is dead.
+        val client =
+            if (cached != null && cached.first == address) {
+                cached.second
+            } else {
+                cached?.second?.runCatching { shutdown() }
+                BossIpcClient(address).also { orchestratorClient = address to it }
+            }
+        return OrchestratorServiceGrpcKt.OrchestratorServiceCoroutineStub(client.channel)
+    }
+
+    /** Bring a crashed process back, honouring its restart cap. */
+    private fun respawn(
+        registry: ProcessRegistry,
+        spawner: ProcessSpawner,
+        processId: String,
+        jvmArgsOverride: List<String>? = null,
+    ) {
+        val process = registry.getProcess(processId) ?: return
+        val restartCount = registry.getRestartCount(processId)
+        if (restartCount >= process.config.maxRestarts) {
+            logger.error(
+                "Process {} exceeded max restarts ({}), not respawning",
+                processId,
+                process.config.maxRestarts,
+            )
+            return
+        }
+
+        val config =
+            if (jvmArgsOverride != null) process.config.copy(jvmArgs = jvmArgsOverride) else process.config
+        logger.info(
+            "Respawning process {} (attempt {}/{}{})",
+            processId,
+            restartCount + 1,
+            process.config.maxRestarts,
+            if (jvmArgsOverride != null) ", tuned: $jvmArgsOverride" else "",
+        )
+        try {
+            val newProcess = spawner.spawn(config)
+            registry.register(processId, newProcess, registry.getManifest(processId))
+            registry.incrementRestartCount(processId)
+        } catch (e: Exception) {
+            logger.error("Respawn failed for {}: {}", processId, e.message)
+        }
+    }
+
+    /**
      * Spawn the standard set of microkernel service processes.
      *
-     * NOTE: Classpath must point to fat JARs produced by each service module's
-     * shadowJar/fatJar task. In development, run:
-     *   ./gradlew :boss-orchestrator:shadowJar :boss-service-auth:shadowJar
-     * to build them first.
+     * Each service runs from a fat JAR built by its module's `fatJar` task. Packaged builds ship
+     * them under the app's resources; in development, build them with:
+     *   ./gradlew :boss-orchestrator:fatJar :boss-service-auth:fatJar
      */
     private fun spawnServices(
         registry: ProcessRegistry,
@@ -226,20 +513,34 @@ class KernelBootstrap(
                     "${System.getProperty("user.home")}/.boss"
                 }
 
-        val orchestratorJar = "$bossDataDir/services/boss-orchestrator-all.jar"
-        val authJar = "$bossDataDir/services/boss-service-auth-all.jar"
+        val orchestratorJar = resolveServiceJar(bossDataDir, "boss-orchestrator-all.jar")
+        val authJar = resolveServiceJar(bossDataDir, "boss-service-auth-all.jar")
+
+        // Children inherit nothing useful about where BOSS keeps its data, and the orchestrator
+        // writes snapshots there — say it explicitly rather than letting the child re-derive a
+        // default that may not match this process's.
+        val serviceEnvironment = mapOf("BOSS_DATA_DIR" to bossDataDir)
+
+        // The model choice — and the API key that goes with it — is the orchestrator's alone. The
+        // other eight services have no use for a credential, so they are not given one.
+        val repairEnvironment = SelfHealingSettingsManager.orchestratorEnvironment()
+        logger.info(
+            "AI repair for the orchestrator is {}",
+            if (repairEnvironment.isEmpty()) "off" else "on (${repairEnvironment["AI_REPAIR_MODEL"]})",
+        )
 
         spawnIfJarExists(
             spawner,
             registry,
             ProcessConfig(
-                processId = "boss-orchestrator",
+                processId = ORCHESTRATOR_PROCESS_ID,
                 processType = ProcessType.ORCHESTRATOR,
                 displayName = "BOSS Orchestrator",
                 mainClass = "ai.rever.boss.orchestrator.OrchestratorMainKt",
                 classpath = orchestratorJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 5,
+                environment = serviceEnvironment + repairEnvironment,
             ),
             orchestratorJar,
         )
@@ -255,11 +556,12 @@ class KernelBootstrap(
                 classpath = authJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 3,
+                environment = serviceEnvironment,
             ),
             authJar,
         )
 
-        val masteryOrchestratorJar = "$bossDataDir/services/boss-mastery-orchestrator-all.jar"
+        val masteryOrchestratorJar = resolveServiceJar(bossDataDir, "boss-mastery-orchestrator-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -271,11 +573,12 @@ class KernelBootstrap(
                 classpath = masteryOrchestratorJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 3,
+                environment = serviceEnvironment,
             ),
             masteryOrchestratorJar,
         )
 
-        val workspaceJar = "$bossDataDir/services/boss-service-workspace-all.jar"
+        val workspaceJar = resolveServiceJar(bossDataDir, "boss-service-workspace-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -287,11 +590,12 @@ class KernelBootstrap(
                 classpath = workspaceJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 3,
+                environment = serviceEnvironment,
             ),
             workspaceJar,
         )
 
-        val settingsJar = "$bossDataDir/services/boss-service-settings-all.jar"
+        val settingsJar = resolveServiceJar(bossDataDir, "boss-service-settings-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -303,11 +607,12 @@ class KernelBootstrap(
                 classpath = settingsJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 3,
+                environment = serviceEnvironment,
             ),
             settingsJar,
         )
 
-        val filesystemJar = "$bossDataDir/services/boss-service-filesystem-all.jar"
+        val filesystemJar = resolveServiceJar(bossDataDir, "boss-service-filesystem-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -319,11 +624,12 @@ class KernelBootstrap(
                 classpath = filesystemJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 3,
+                environment = serviceEnvironment,
             ),
             filesystemJar,
         )
 
-        val terminalJar = "$bossDataDir/services/boss-app-terminal-all.jar"
+        val terminalJar = resolveServiceJar(bossDataDir, "boss-app-terminal-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -335,11 +641,12 @@ class KernelBootstrap(
                 classpath = terminalJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 5,
+                environment = serviceEnvironment,
             ),
             terminalJar,
         )
 
-        val editorJar = "$bossDataDir/services/boss-app-editor-all.jar"
+        val editorJar = resolveServiceJar(bossDataDir, "boss-app-editor-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -351,11 +658,12 @@ class KernelBootstrap(
                 classpath = editorJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 5,
+                environment = serviceEnvironment,
             ),
             editorJar,
         )
 
-        val browserJar = "$bossDataDir/services/boss-app-browser-all.jar"
+        val browserJar = resolveServiceJar(bossDataDir, "boss-app-browser-all.jar")
         spawnIfJarExists(
             spawner,
             registry,
@@ -367,6 +675,7 @@ class KernelBootstrap(
                 classpath = browserJar,
                 restartPolicy = RestartPolicy.ON_FAILURE,
                 maxRestarts = 5,
+                environment = serviceEnvironment,
             ),
             browserJar,
         )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -323,10 +323,15 @@ class KernelBootstrap(
         // Start process monitor
         processMonitor!!.startGlobalMonitor()
 
-        // Listen for failures: ask the orchestrator what to do, else auto-respawn (C2+M7 fix)
+        // Listen for failures: ask the orchestrator what to do, else auto-respawn (C2+M7 fix).
+        //
+        // Each failure is handled in its own coroutine. Handling them inline would serialize the
+        // advice deadline: a bad build taking several services down at once would make the last of
+        // N crashes wait N×2s, with the monitor's suspending emit blocked behind it. Per-process
+        // recovery is independent, and the monitor emits once per detection.
         scope.launch {
             processMonitor!!.failures.collect { failure ->
-                handleFailure(registry, spawner, failure)
+                launch { handleFailure(registry, spawner, failure) }
             }
         }
 
@@ -521,8 +526,10 @@ class KernelBootstrap(
         // default that may not match this process's.
         val serviceEnvironment = mapOf("BOSS_DATA_DIR" to bossDataDir)
 
-        // The model choice — and the API key that goes with it — is the orchestrator's alone. The
-        // other eight services have no use for a credential, so they are not given one.
+        // The model choice — and the key the operator entered for it — goes to the orchestrator
+        // alone; the other eight have no use for a credential. (A key exported into BOSS's own
+        // environment is still inherited by every child via ProcessSpawner — see
+        // SelfHealingSettingsManager.orchestratorEnvironment.)
         val repairEnvironment = SelfHealingSettingsManager.orchestratorEnvironment()
         logger.info(
             "AI repair for the orchestrator is {}",
@@ -769,6 +776,12 @@ class KernelBootstrap(
         // 6b. Close remote UI surfaces. The registry is process-wide and outlives this bootstrap, so a
         // restart would otherwise come up still holding claims from processes that are now dead.
         RemoteUiSurfaceRegistry.shared.clear()
+
+        // 6c. Close the orchestrator channel. Nothing else owns it, so a mode switch or in-process
+        // restart would otherwise leak the channel and its threads.
+        orchestratorClient?.second?.shutdown()
+        orchestratorClient = null
+        serviceAddresses.clear()
 
         // 7. Cancel scope
         scope.cancel()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/SelfHealingSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/SelfHealingSettings.kt
@@ -62,8 +62,11 @@ enum class SelfHealingProvider(
     ;
 
     companion object {
-        /** The stored provider, or [ANTHROPIC] if the file names one this build doesn't have. */
-        fun of(name: String): SelfHealingProvider = entries.firstOrNull { it.name == name } ?: ANTHROPIC
+        /** The stored provider, or null if the file names one this build doesn't have. */
+        fun parse(name: String): SelfHealingProvider? = entries.firstOrNull { it.name == name }
+
+        /** The stored provider, or [ANTHROPIC] as a display default. For the UI, not for routing. */
+        fun of(name: String): SelfHealingProvider = parse(name) ?: ANTHROPIC
     }
 }
 
@@ -127,6 +130,12 @@ object SelfHealingSettingsManager {
      * usable key. A half-configured environment is worse than none: it would start the client and
      * fail per crash, and emitting the key while the feature is off would put a secret in a child
      * process for no reason.
+     *
+     * Note what this does *not* do. `ProcessSpawner` starts each child from a copy of BOSS's own
+     * environment, so an `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` exported into the app's process is
+     * inherited by all nine children whatever this returns. What is withheld here is the key the
+     * operator entered in settings, and — the part that actually gates anything — `BOSS_AI_REPAIR`
+     * and the source root, without which the orchestrator constructs no client at all.
      */
     fun orchestratorEnvironment(): Map<String, String> =
         repairEnvironment(
@@ -235,23 +244,31 @@ internal fun repairEnvironment(
     settings: SelfHealingSettingsData,
     apiKey: String?,
 ): Map<String, String> {
-    val provider = SelfHealingProvider.of(settings.provider)
+    // A name this build doesn't know means the file was written by a newer version, so the endpoint
+    // beside it belongs to a provider this build cannot speak to. Defaulting the *wire* while
+    // keeping that *endpoint* would post the key — resolved under the defaulted provider's name — to
+    // a host the operator never chose for it. Unknown provider is unconfigured.
+    val provider = SelfHealingProvider.parse(settings.provider)
 
     // Each of these has to be present for AI repair to do anything, so they are gathered first and
     // checked as a set — a configuration missing any one of them yields no environment at all.
     val required =
         mapOf(
             "BOSS_REPAIR_PROJECT_ROOT" to settings.projectRoot.trim(),
-            "AI_REPAIR_API_URL" to settings.endpoint.trim().ifBlank { provider.defaultEndpoint },
-            "AI_REPAIR_MODEL" to settings.model.trim().ifBlank { provider.defaultModel },
+            "AI_REPAIR_API_URL" to settings.endpoint.trim().ifBlank { provider?.defaultEndpoint.orEmpty() },
+            "AI_REPAIR_MODEL" to settings.model.trim().ifBlank { provider?.defaultModel.orEmpty() },
             "AI_REPAIR_API_KEY" to apiKey.orEmpty().trim(),
         )
-    if (!settings.aiRepairEnabled || required.values.any { it.isBlank() }) return emptyMap()
+    val configured = settings.aiRepairEnabled && required.values.none { it.isBlank() }
 
-    return required +
-        buildMap {
-            put("BOSS_AI_REPAIR", "true")
-            put("AI_REPAIR_PROVIDER", provider.wireProtocol)
-            settings.systemPrompt.ifBlank { null }?.let { put("AI_REPAIR_SYSTEM_PROMPT", it) }
-        }
+    return if (provider == null || !configured) {
+        emptyMap()
+    } else {
+        required +
+            buildMap {
+                put("BOSS_AI_REPAIR", "true")
+                put("AI_REPAIR_PROVIDER", provider.wireProtocol)
+                settings.systemPrompt.ifBlank { null }?.let { put("AI_REPAIR_SYSTEM_PROMPT", it) }
+            }
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/SelfHealingSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/SelfHealingSettings.kt
@@ -1,0 +1,257 @@
+package ai.rever.boss.kernel
+
+import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.atomicWriteText
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.IOException
+
+/**
+ * A model provider the self-healing orchestrator can be pointed at.
+ *
+ * Names deliberately match [ai.rever.boss.components.plugin.panels.right_top.LLMProvider], because
+ * the API key is looked up under the provider's name in the same `llm_settings.json` the LLM
+ * Providers screen writes — self-healing chooses a model, it does not ask for a second copy of a
+ * key the operator has already entered.
+ */
+enum class SelfHealingProvider(
+    val displayName: String,
+    /** Which HTTP shape the orchestrator should speak; see `AiRepairWire` in boss-orchestrator. */
+    val wireProtocol: String,
+    val defaultEndpoint: String,
+    val defaultModel: String,
+    val apiKeyEnvVar: String,
+) {
+    ANTHROPIC(
+        displayName = "Anthropic Claude",
+        wireProtocol = "anthropic",
+        defaultEndpoint = "https://api.anthropic.com/v1/messages",
+        defaultModel = "claude-opus-5",
+        apiKeyEnvVar = "ANTHROPIC_API_KEY",
+    ),
+    OPENAI(
+        displayName = "OpenAI",
+        wireProtocol = "openai",
+        defaultEndpoint = "https://api.openai.com/v1/chat/completions",
+        defaultModel = "gpt-5.4",
+        apiKeyEnvVar = "OPENAI_API_KEY",
+    ),
+    TOGETHER(
+        displayName = "Together AI",
+        wireProtocol = "openai",
+        defaultEndpoint = "https://api.together.xyz/v1/chat/completions",
+        defaultModel = "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+        apiKeyEnvVar = "TOGETHER_API_KEY",
+    ),
+    CUSTOM(
+        displayName = "Custom (OpenAI-compatible)",
+        wireProtocol = "openai",
+        defaultEndpoint = "",
+        defaultModel = "",
+        apiKeyEnvVar = "CUSTOM_LLM_API_KEY",
+    ),
+    ;
+
+    companion object {
+        /** The stored provider, or [ANTHROPIC] if the file names one this build doesn't have. */
+        fun of(name: String): SelfHealingProvider = entries.firstOrNull { it.name == name } ?: ANTHROPIC
+    }
+}
+
+/**
+ * How the orchestrator's AI repair should be configured, as the operator left it.
+ *
+ * Blank means "use the provider's default" for [model] and [endpoint], and "use the built-in
+ * instruction" for [systemPrompt] — a cleared field in the UI should restore the default rather
+ * than send an empty model name.
+ */
+@Serializable
+data class SelfHealingSettingsData(
+    /**
+     * Whether the orchestrator may send crash source to a third-party model.
+     *
+     * Off by default and stays off until someone turns it on: this is the data-egress switch, not a
+     * convenience toggle, and it is deliberately separate from whether self-healing runs at all
+     * (restart, state reset and escalation need no model and are always available).
+     */
+    val aiRepairEnabled: Boolean = false,
+    val provider: String = SelfHealingProvider.ANTHROPIC.name,
+    val model: String = "",
+    val endpoint: String = "",
+    val systemPrompt: String = "",
+    /** The only directory the model may be shown source from. No root, no AI repair. */
+    val projectRoot: String = "",
+)
+
+/**
+ * Reads and writes `~/.boss/self-healing-settings.json`, and turns it into the environment the
+ * kernel hands the orchestrator process.
+ *
+ * Follows the BOSS settings convention: synchronous load on first touch, async save on write.
+ */
+object SelfHealingSettingsManager {
+    private val logger = BossLogger.forComponent("SelfHealingSettings")
+    private val settingsFile: File = BossDirectories.resolve("self-healing-settings.json")
+    private val json =
+        Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        }
+
+    private val _currentSettings = MutableStateFlow(SelfHealingSettingsData())
+    val currentSettings: StateFlow<SelfHealingSettingsData> = _currentSettings.asStateFlow()
+
+    init {
+        settingsFile.parentFile?.mkdirs()
+        loadSettingsSync()
+    }
+
+    suspend fun updateSettings(settings: SelfHealingSettingsData) {
+        _currentSettings.value = settings
+        saveSettings()
+    }
+
+    /**
+     * The environment variables the orchestrator needs to run AI repair.
+     *
+     * Empty unless every part of the decision is present — switched on, a named source root, and a
+     * usable key. A half-configured environment is worse than none: it would start the client and
+     * fail per crash, and emitting the key while the feature is off would put a secret in a child
+     * process for no reason.
+     */
+    fun orchestratorEnvironment(): Map<String, String> =
+        repairEnvironment(
+            settings = _currentSettings.value,
+            apiKey = resolveApiKey(SelfHealingProvider.of(_currentSettings.value.provider)),
+        )
+
+    /**
+     * Whether a key for [provider] can be found, without handing the key out.
+     *
+     * The settings screen needs this: a missing key silently withholds the whole environment, and
+     * an operator who has flipped the switch deserves to be told that nothing will happen.
+     */
+    fun hasApiKey(provider: SelfHealingProvider): Boolean = !resolveApiKey(provider).isNullOrBlank()
+
+    /**
+     * The key for [provider], from the same places the LLM Providers screen looks.
+     *
+     * `AI_REPAIR_API_KEY` wins so an operator can point self-healing at a separate, narrower key
+     * than the one their assistant chat uses. Then the provider's own environment variable, then
+     * `llm_settings.json`.
+     *
+     * The file is read directly rather than through `LLMSettings`: that singleton is populated by a
+     * startup effect that runs after the window opens, and the kernel spawns services before then.
+     */
+    private fun resolveApiKey(provider: SelfHealingProvider): String? =
+        System.getenv("AI_REPAIR_API_KEY")?.ifBlank { null }
+            ?: System.getenv(provider.apiKeyEnvVar)?.ifBlank { null }
+            ?: storedLlmApiKey(provider)
+
+    private fun storedLlmApiKey(provider: SelfHealingProvider): String? {
+        val file = BossDirectories.resolve("llm_settings.json")
+        if (!file.exists()) return null
+        return try {
+            json
+                .decodeFromString(StoredLlmKeys.serializer(), file.readText())
+                .apiKeys[provider.name]
+                ?.ifBlank { null }
+        } catch (e: SerializationException) {
+            reportUnreadableKeys(e)
+            null
+        } catch (e: IOException) {
+            reportUnreadableKeys(e)
+            null
+        }
+    }
+
+    /**
+     * Says the key file could not be read, without saying what was in it.
+     *
+     * Deliberately logs only the exception type: kotlinx.serialization embeds a snippet of the
+     * offending JSON near the failure offset, and that file holds API keys.
+     */
+    private fun reportUnreadableKeys(e: Exception) {
+        logger.warn(
+            LogCategory.SYSTEM,
+            "Could not read stored LLM API keys",
+            mapOf("exception" to (e::class.simpleName ?: "Exception")),
+        )
+    }
+
+    private suspend fun saveSettings() =
+        withContext(Dispatchers.IO) {
+            try {
+                settingsFile.parentFile?.mkdirs()
+                settingsFile.atomicWriteText(
+                    json.encodeToString(SelfHealingSettingsData.serializer(), _currentSettings.value),
+                )
+            } catch (e: IOException) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Failed to save self-healing settings",
+                    mapOf("file" to settingsFile.absolutePath),
+                    error = e,
+                )
+            }
+        }
+
+    private fun loadSettingsSync() {
+        if (!settingsFile.exists()) return
+        try {
+            _currentSettings.value =
+                json.decodeFromString(SelfHealingSettingsData.serializer(), settingsFile.readText())
+        } catch (e: SerializationException) {
+            logger.warn(LogCategory.SYSTEM, "Unreadable self-healing settings — using defaults", error = e)
+        } catch (e: IOException) {
+            logger.warn(LogCategory.SYSTEM, "Could not load self-healing settings — using defaults", error = e)
+        }
+    }
+
+    /** Just the key map out of `llm_settings.json`; the rest of that file is not ours to interpret. */
+    @Serializable
+    private data class StoredLlmKeys(
+        val apiKeys: Map<String, String> = emptyMap(),
+    )
+}
+
+/**
+ * Turn a settings snapshot plus a resolved key into the orchestrator's environment.
+ *
+ * Pure and separate from the manager because it is the egress decision in one place: which of these
+ * three conditions is missing decides whether any source ever leaves the machine, and that should be
+ * assertable without a filesystem or an environment.
+ */
+internal fun repairEnvironment(
+    settings: SelfHealingSettingsData,
+    apiKey: String?,
+): Map<String, String> {
+    val provider = SelfHealingProvider.of(settings.provider)
+
+    // Each of these has to be present for AI repair to do anything, so they are gathered first and
+    // checked as a set — a configuration missing any one of them yields no environment at all.
+    val required =
+        mapOf(
+            "BOSS_REPAIR_PROJECT_ROOT" to settings.projectRoot.trim(),
+            "AI_REPAIR_API_URL" to settings.endpoint.trim().ifBlank { provider.defaultEndpoint },
+            "AI_REPAIR_MODEL" to settings.model.trim().ifBlank { provider.defaultModel },
+            "AI_REPAIR_API_KEY" to apiKey.orEmpty().trim(),
+        )
+    if (!settings.aiRepairEnabled || required.values.any { it.isBlank() }) return emptyMap()
+
+    return required +
+        buildMap {
+            put("BOSS_AI_REPAIR", "true")
+            put("AI_REPAIR_PROVIDER", provider.wireProtocol)
+            settings.systemPrompt.ifBlank { null }?.let { put("AI_REPAIR_SYSTEM_PROMPT", it) }
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/RecoveryDecisionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/RecoveryDecisionTest.kt
@@ -1,0 +1,110 @@
+package ai.rever.boss.kernel
+
+import ai.rever.boss.ipc.proto.RepairAction
+import ai.rever.boss.ipc.proto.RepairStrategy
+import ai.rever.boss.ipc.proto.RestartAction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins what the kernel does with the orchestrator's repair advice.
+ *
+ * The case that matters most is the one with no advice at all: routing crash recovery through
+ * another process is only safe while an unreachable, wedged or crashed orchestrator still leaves
+ * the kernel doing exactly what it did before — respawning. Everything else here is about not
+ * silently swallowing a repair that a human was supposed to see.
+ */
+class RecoveryDecisionTest {
+    private fun action(
+        strategy: RepairStrategy,
+        approval: Boolean = false,
+        description: String = "",
+        tunedArgs: List<String> = emptyList(),
+    ): RepairAction =
+        RepairAction
+            .newBuilder()
+            .setRepairId("r1")
+            .setStrategy(strategy)
+            .setRequiresUserApproval(approval)
+            .setDescription(description)
+            .apply {
+                if (tunedArgs.isNotEmpty()) {
+                    restart = RestartAction.newBuilder().addAllJvmArgsOverride(tunedArgs).build()
+                }
+            }.build()
+
+    @Test
+    fun `no advice still recovers the process`() {
+        // The orchestrator is down, unreachable, or timed out. This is the whole safety argument
+        // for consulting it at all.
+        assertEquals(Recovery.Respawn, recoveryFor(null))
+    }
+
+    @Test
+    fun `a plain restart is a plain respawn`() {
+        assertEquals(Recovery.Respawn, recoveryFor(action(RepairStrategy.REPAIR_STRATEGY_RESTART)))
+    }
+
+    @Test
+    fun `a state reset is a respawn on this side`() {
+        // The orchestrator has already picked the snapshot; the kernel only brings it back up.
+        assertEquals(Recovery.Respawn, recoveryFor(action(RepairStrategy.REPAIR_STRATEGY_RESET_STATE)))
+    }
+
+    @Test
+    fun `a tuned restart carries the new jvm args`() {
+        val recovery =
+            recoveryFor(
+                action(RepairStrategy.REPAIR_STRATEGY_RESTART_TUNED, tunedArgs = listOf("-Xmx512m")),
+            )
+
+        assertEquals(Recovery.RespawnTuned(listOf("-Xmx512m")), recovery)
+    }
+
+    @Test
+    fun `a tuned restart with no args is just a restart`() {
+        // Nothing to apply — don't hand an empty jvmArgs list to the spawner and lose the
+        // process's configured defaults.
+        assertEquals(
+            Recovery.Respawn,
+            recoveryFor(action(RepairStrategy.REPAIR_STRATEGY_RESTART_TUNED)),
+        )
+    }
+
+    @Test
+    fun `anything needing approval reaches the operator and still restarts`() {
+        val recovery =
+            recoveryFor(
+                action(
+                    RepairStrategy.REPAIR_STRATEGY_PATCH_SOURCE,
+                    approval = true,
+                    description = "Proposed fix for NullPointerException",
+                ),
+            )
+
+        assertEquals(Recovery.NotifyAndRespawn("Proposed fix for NullPointerException"), recovery)
+    }
+
+    @Test
+    fun `an escalation reaches the operator and still restarts`() {
+        val recovery = recoveryFor(action(RepairStrategy.REPAIR_STRATEGY_ESCALATE, description = "Needs a human"))
+
+        assertEquals(Recovery.NotifyAndRespawn("Needs a human"), recovery)
+    }
+
+    @Test
+    fun `a strategy the kernel cannot apply is never silently dropped`() {
+        // PATCH_CONFIG without an approval flag: the kernel patches nothing, so the operator hears
+        // about it rather than the advice evaporating into a restart.
+        val recovery = recoveryFor(action(RepairStrategy.REPAIR_STRATEGY_PATCH_CONFIG))
+
+        assertEquals(Recovery.NotifyAndRespawn("REPAIR_STRATEGY_PATCH_CONFIG"), recovery)
+    }
+
+    @Test
+    fun `a repair with no description falls back to naming its strategy`() {
+        val recovery = recoveryFor(action(RepairStrategy.REPAIR_STRATEGY_ESCALATE, approval = true))
+
+        assertEquals(Recovery.NotifyAndRespawn("REPAIR_STRATEGY_ESCALATE"), recovery)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/SelfHealingEnvironmentTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/SelfHealingEnvironmentTest.kt
@@ -1,0 +1,152 @@
+package ai.rever.boss.kernel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins what the settings screen actually hands the orchestrator.
+ *
+ * This map is the egress decision made concrete: an empty one means no source can leave the
+ * machine, because the orchestrator's own gate needs all of `BOSS_AI_REPAIR`,
+ * `BOSS_REPAIR_PROJECT_ROOT` and a key before it will construct a client. Most of what is asserted
+ * here is therefore the *absence* of variables when the operator's configuration is incomplete.
+ */
+class SelfHealingEnvironmentTest {
+    private fun settings(
+        enabled: Boolean = true,
+        provider: SelfHealingProvider = SelfHealingProvider.ANTHROPIC,
+        model: String = "",
+        endpoint: String = "",
+        systemPrompt: String = "",
+        projectRoot: String = "/work/boss",
+    ) = SelfHealingSettingsData(
+        aiRepairEnabled = enabled,
+        provider = provider.name,
+        model = model,
+        endpoint = endpoint,
+        systemPrompt = systemPrompt,
+        projectRoot = projectRoot,
+    )
+
+    @Test
+    fun `switched off sends nothing at all`() {
+        assertEquals(emptyMap(), repairEnvironment(settings(enabled = false), apiKey = "sk-live"))
+    }
+
+    @Test
+    fun `switched off does not leak the key into the child process`() {
+        // The orchestrator would ignore a key without the opt-in, but a credential handed to a
+        // process that has no use for it is still a credential in one more place.
+        val env = repairEnvironment(settings(enabled = false), apiKey = "sk-live")
+
+        assertFalse(env.values.any { it.contains("sk-live") })
+    }
+
+    @Test
+    fun `no source root means no AI repair`() {
+        assertEquals(emptyMap(), repairEnvironment(settings(projectRoot = ""), apiKey = "sk-live"))
+    }
+
+    @Test
+    fun `a whitespace root is not a root`() {
+        assertEquals(emptyMap(), repairEnvironment(settings(projectRoot = "   "), apiKey = "sk-live"))
+    }
+
+    @Test
+    fun `no key means nothing is sent`() {
+        assertEquals(emptyMap(), repairEnvironment(settings(), apiKey = null))
+        assertEquals(emptyMap(), repairEnvironment(settings(), apiKey = "  "))
+    }
+
+    @Test
+    fun `a custom provider with no endpoint of its own is incomplete`() {
+        // CUSTOM has no default URL to fall back on, so an unset endpoint is not a configuration.
+        val env = repairEnvironment(settings(provider = SelfHealingProvider.CUSTOM, model = "m"), apiKey = "sk-live")
+
+        assertEquals(emptyMap(), env)
+    }
+
+    @Test
+    fun `a custom provider with no model of its own is incomplete`() {
+        val env =
+            repairEnvironment(
+                settings(provider = SelfHealingProvider.CUSTOM, endpoint = "https://gw/v1/chat/completions"),
+                apiKey = "sk-live",
+            )
+
+        assertEquals(emptyMap(), env)
+    }
+
+    @Test
+    fun `a complete configuration names provider, endpoint, model, root and key`() {
+        val env = repairEnvironment(settings(), apiKey = "sk-live")
+
+        assertEquals("true", env["BOSS_AI_REPAIR"])
+        assertEquals("/work/boss", env["BOSS_REPAIR_PROJECT_ROOT"])
+        assertEquals("anthropic", env["AI_REPAIR_PROVIDER"])
+        assertEquals("https://api.anthropic.com/v1/messages", env["AI_REPAIR_API_URL"])
+        assertEquals("claude-opus-5", env["AI_REPAIR_MODEL"])
+        assertEquals("sk-live", env["AI_REPAIR_API_KEY"])
+    }
+
+    @Test
+    fun `an unset system prompt is omitted so the orchestrator's default applies`() {
+        assertFalse(repairEnvironment(settings(), apiKey = "sk-live").containsKey("AI_REPAIR_SYSTEM_PROMPT"))
+    }
+
+    @Test
+    fun `a written system prompt is passed through verbatim, newlines and all`() {
+        val prompt = "Respond with JSON only.\n\nPrefer the smallest possible diff."
+
+        val env = repairEnvironment(settings(systemPrompt = prompt), apiKey = "sk-live")
+
+        assertEquals(prompt, env["AI_REPAIR_SYSTEM_PROMPT"])
+    }
+
+    @Test
+    fun `blank model and endpoint resolve to the chosen provider's defaults`() {
+        val env = repairEnvironment(settings(provider = SelfHealingProvider.TOGETHER), apiKey = "sk-live")
+
+        assertEquals("openai", env["AI_REPAIR_PROVIDER"])
+        assertEquals("https://api.together.xyz/v1/chat/completions", env["AI_REPAIR_API_URL"])
+        assertEquals("meta-llama/Llama-3.3-70B-Instruct-Turbo", env["AI_REPAIR_MODEL"])
+    }
+
+    @Test
+    fun `the operator's model and endpoint win over the defaults`() {
+        val env =
+            repairEnvironment(
+                settings(
+                    provider = SelfHealingProvider.CUSTOM,
+                    model = "internal-repair-v2",
+                    endpoint = "https://gateway.internal/v1/chat/completions",
+                ),
+                apiKey = "sk-live",
+            )
+
+        assertEquals("internal-repair-v2", env["AI_REPAIR_MODEL"])
+        assertEquals("https://gateway.internal/v1/chat/completions", env["AI_REPAIR_API_URL"])
+    }
+
+    @Test
+    fun `a provider name this build does not know falls back to Anthropic rather than misrouting`() {
+        // Downgrade, or a settings file written by a newer version. Sending a key to whatever URL
+        // happened to be stored would be worse than using the house default.
+        val stored = SelfHealingSettingsData(aiRepairEnabled = true, provider = "GEMINI", projectRoot = "/work/boss")
+
+        val env = repairEnvironment(stored, apiKey = "sk-live")
+
+        assertEquals("anthropic", env["AI_REPAIR_PROVIDER"])
+        assertEquals("https://api.anthropic.com/v1/messages", env["AI_REPAIR_API_URL"])
+    }
+
+    @Test
+    fun `AI repair is off in a fresh install`() {
+        val fresh = SelfHealingSettingsData()
+
+        assertFalse(fresh.aiRepairEnabled)
+        assertTrue(repairEnvironment(fresh, apiKey = "sk-live").isEmpty())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/SelfHealingEnvironmentTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/SelfHealingEnvironmentTest.kt
@@ -131,15 +131,29 @@ class SelfHealingEnvironmentTest {
     }
 
     @Test
-    fun `a provider name this build does not know falls back to Anthropic rather than misrouting`() {
-        // Downgrade, or a settings file written by a newer version. Sending a key to whatever URL
-        // happened to be stored would be worse than using the house default.
+    fun `a provider name this build does not know is treated as unconfigured`() {
+        // Downgrade, or a settings file written by a newer version.
         val stored = SelfHealingSettingsData(aiRepairEnabled = true, provider = "GEMINI", projectRoot = "/work/boss")
+
+        assertEquals(emptyMap(), repairEnvironment(stored, apiKey = "sk-live"))
+    }
+
+    @Test
+    fun `an unknown provider does not send the key to the endpoint stored beside it`() {
+        // The dangerous half: defaulting the wire while keeping the stored URL would post a key
+        // resolved under the defaulted provider's name to a host the operator never chose for it.
+        val stored =
+            SelfHealingSettingsData(
+                aiRepairEnabled = true,
+                provider = "GEMINI",
+                model = "gemini-3-pro",
+                endpoint = "https://generativelanguage.googleapis.com/v1/models:generateContent",
+                projectRoot = "/work/boss",
+            )
 
         val env = repairEnvironment(stored, apiKey = "sk-live")
 
-        assertEquals("anthropic", env["AI_REPAIR_PROVIDER"])
-        assertEquals("https://api.anthropic.com/v1/messages", env["AI_REPAIR_API_URL"])
+        assertTrue(env.isEmpty(), "nothing should be sent for a provider this build cannot speak to")
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ServiceJarLookupTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ServiceJarLookupTest.kt
@@ -1,0 +1,82 @@
+package ai.rever.boss.kernel
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the jar lookup that decides whether a microkernel service can be spawned at all.
+ *
+ * The kernel asks for `boss-orchestrator-all.jar`; every module's `fatJar` task actually produces
+ * `boss-orchestrator-<version>-all.jar`, because none of them strip the version. Those two have
+ * never agreed, so the spawn path silently found nothing and logged "build fat JARs first" even
+ * right after someone had.
+ */
+class ServiceJarLookupTest {
+    private val dirs = mutableListOf<File>()
+
+    private fun tempDir(): File =
+        File.createTempFile("services", "").let {
+            it.delete()
+            it.mkdirs()
+            dirs += it
+            it
+        }
+
+    @AfterTest
+    fun cleanUp() {
+        dirs.forEach { it.deleteRecursively() }
+    }
+
+    @Test
+    fun `the exact name is used when it is there`() {
+        val dir = tempDir()
+        val exact = File(dir, "boss-orchestrator-all.jar").also { it.writeText("jar") }
+
+        assertEquals(exact, serviceJarIn(dir, "boss-orchestrator-all.jar"))
+    }
+
+    @Test
+    fun `a versioned jar is found under the unversioned name`() {
+        // This is what `./gradlew :boss-orchestrator:fatJar` leaves behind.
+        val dir = tempDir()
+        val versioned = File(dir, "boss-orchestrator-1.0.0-all.jar").also { it.writeText("jar") }
+
+        assertEquals(versioned, serviceJarIn(dir, "boss-orchestrator-all.jar"))
+    }
+
+    @Test
+    fun `the newest build wins when several versions are lying around`() {
+        val dir = tempDir()
+        val old = File(dir, "boss-orchestrator-1.0.0-all.jar").also { it.writeText("old") }
+        val new = File(dir, "boss-orchestrator-1.1.0-all.jar").also { it.writeText("new") }
+        old.setLastModified(1_000_000)
+        new.setLastModified(2_000_000)
+
+        assertEquals(new, serviceJarIn(dir, "boss-orchestrator-all.jar"))
+    }
+
+    @Test
+    fun `another service's jar is never mistaken for this one`() {
+        val dir = tempDir()
+        File(dir, "boss-service-auth-1.0.0-all.jar").writeText("jar")
+
+        assertNull(serviceJarIn(dir, "boss-orchestrator-all.jar"))
+    }
+
+    @Test
+    fun `a thin jar is not a fat jar`() {
+        // `fatJar` and `jar` land in the same directory; only the -all one can be spawned.
+        val dir = tempDir()
+        File(dir, "boss-orchestrator-1.0.0.jar").writeText("thin")
+
+        assertNull(serviceJarIn(dir, "boss-orchestrator-all.jar"))
+    }
+
+    @Test
+    fun `a missing directory is simply no match`() {
+        assertNull(serviceJarIn(File("/nonexistent/services"), "boss-orchestrator-all.jar"))
+    }
+}

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AiRepairConfig.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AiRepairConfig.kt
@@ -95,11 +95,17 @@ fun aiRepairConfig(
  * `AI_REPAIR_API_KEY` falls back to `OPENAI_API_KEY` for operators who configured this before there
  * was a settings screen.
  */
-fun aiRepairConfigFromEnvironment(getenv: (String) -> String? = { System.getenv(it) }): AiRepairConfig =
-    aiRepairConfig(
-        provider = getenv("AI_REPAIR_PROVIDER"),
+fun aiRepairConfigFromEnvironment(getenv: (String) -> String? = { System.getenv(it) }): AiRepairConfig {
+    val provider = getenv("AI_REPAIR_PROVIDER")
+    // The legacy fallback only makes sense for the wire it was written for: sending an OpenAI key
+    // as `x-api-key` to Anthropic is a credential going somewhere it cannot work and should not go.
+    val speaksOpenAi = provider?.trim()?.equals("anthropic", ignoreCase = true) != true
+    val legacyKey = getenv("OPENAI_API_KEY").takeIf { speaksOpenAi }
+    return aiRepairConfig(
+        provider = provider,
         endpoint = getenv("AI_REPAIR_API_URL"),
-        apiKey = getenv("AI_REPAIR_API_KEY") ?: getenv("OPENAI_API_KEY"),
+        apiKey = getenv("AI_REPAIR_API_KEY") ?: legacyKey,
         model = getenv("AI_REPAIR_MODEL"),
         systemPrompt = getenv("AI_REPAIR_SYSTEM_PROMPT"),
     )
+}

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AiRepairConfig.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AiRepairConfig.kt
@@ -1,0 +1,105 @@
+package ai.rever.boss.orchestrator
+
+/**
+ * The HTTP shape a configured endpoint speaks.
+ *
+ * Two are enough to cover the providers BOSS offers: Anthropic's Messages API, and the
+ * OpenAI chat-completions shape that OpenAI, Together and most self-hosted gateways implement.
+ */
+enum class AiRepairWire(
+    val defaultEndpoint: String,
+    val defaultModel: String,
+    /**
+     * Output ceiling for one repair proposal.
+     *
+     * Higher on Anthropic because `max_tokens` there bounds thinking *and* answer text, and
+     * thinking is on by default on current models — sizing it around the JSON alone truncates
+     * the proposal mid-object.
+     */
+    val maxTokens: Int,
+) {
+    ANTHROPIC(
+        defaultEndpoint = "https://api.anthropic.com/v1/messages",
+        defaultModel = "claude-opus-5",
+        maxTokens = 8192,
+    ),
+    OPENAI(
+        defaultEndpoint = "https://api.openai.com/v1/chat/completions",
+        defaultModel = "gpt-5.4",
+        maxTokens = 2048,
+    ),
+}
+
+/**
+ * What the repair client sends, and where.
+ *
+ * Everything here is operator-chosen (Settings → Advanced → Self-Healing, forwarded as environment
+ * variables when the kernel spawns this process). It is a plain value so the choice can be read and
+ * asserted without standing up an HTTP client.
+ */
+data class AiRepairConfig(
+    val wire: AiRepairWire,
+    val endpoint: String,
+    val apiKey: String,
+    val model: String,
+    val systemPrompt: String,
+)
+
+/**
+ * The instruction the model gets when nobody has written one.
+ *
+ * Both prompts the client builds ask for a bare JSON object, so the default reinforces that and
+ * nothing else — an operator replacing it is free to add house rules, but a replacement that drops
+ * the JSON requirement will produce proposals the parser rejects.
+ */
+const val DEFAULT_REPAIR_SYSTEM_PROMPT: String =
+    "You are a precise code repair assistant. Always respond with valid JSON only. " +
+        "Do not include markdown code fences."
+
+/**
+ * Resolve a repair configuration from whatever the operator supplied.
+ *
+ * Blank is treated as unset throughout: an empty environment variable is what a settings field the
+ * operator cleared actually looks like by the time it reaches this process, and it should mean "use
+ * the default", not "send an empty model name".
+ *
+ * [provider] is matched leniently — only "anthropic" selects the Messages API shape, because every
+ * other provider BOSS offers (OpenAI, Together, custom gateways) speaks chat-completions.
+ */
+fun aiRepairConfig(
+    provider: String?,
+    endpoint: String?,
+    apiKey: String?,
+    model: String?,
+    systemPrompt: String?,
+): AiRepairConfig {
+    val wire =
+        if (provider?.trim()?.equals("anthropic", ignoreCase = true) == true) {
+            AiRepairWire.ANTHROPIC
+        } else {
+            AiRepairWire.OPENAI
+        }
+    return AiRepairConfig(
+        wire = wire,
+        endpoint = endpoint?.trim()?.ifBlank { null } ?: wire.defaultEndpoint,
+        apiKey = apiKey?.trim().orEmpty(),
+        model = model?.trim()?.ifBlank { null } ?: wire.defaultModel,
+        systemPrompt = systemPrompt?.ifBlank { null } ?: DEFAULT_REPAIR_SYSTEM_PROMPT,
+    )
+}
+
+/**
+ * The same resolution, reading the variables the kernel sets when it spawns this process.
+ *
+ * [getenv] is injectable so the mapping can be tested without mutating the real environment.
+ * `AI_REPAIR_API_KEY` falls back to `OPENAI_API_KEY` for operators who configured this before there
+ * was a settings screen.
+ */
+fun aiRepairConfigFromEnvironment(getenv: (String) -> String? = { System.getenv(it) }): AiRepairConfig =
+    aiRepairConfig(
+        provider = getenv("AI_REPAIR_PROVIDER"),
+        endpoint = getenv("AI_REPAIR_API_URL"),
+        apiKey = getenv("AI_REPAIR_API_KEY") ?: getenv("OPENAI_API_KEY"),
+        model = getenv("AI_REPAIR_MODEL"),
+        systemPrompt = getenv("AI_REPAIR_SYSTEM_PROMPT"),
+    )

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AiRepairSettings.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/AiRepairSettings.kt
@@ -1,0 +1,33 @@
+package ai.rever.boss.orchestrator
+
+/**
+ * Whether AI repair may run, and the only directory it may read source from.
+ *
+ * [enabled] requires all three of: an explicit opt-in, a named root, and a key. Each covers a
+ * different way this could switch itself on by accident — an operator who set a key for something
+ * else, a deployment that meant to enable the feature but never said where to read from, or a
+ * config that asks for AI repair on a machine with no credentials.
+ */
+internal data class AiRepairSettings(
+    val enabled: Boolean,
+    val projectRoot: String?,
+)
+
+/**
+ * Decide whether source may be sent to a third-party model.
+ *
+ * Pure and separate from [main] because it is a data-egress decision: it should be readable and
+ * testable on its own, not inferred from the shape of an environment.
+ */
+internal fun aiRepairSettings(
+    optIn: String?,
+    projectRoot: String?,
+    apiKey: String?,
+): AiRepairSettings {
+    val root = projectRoot?.takeIf { it.isNotBlank() }
+    val enabled =
+        optIn?.equals("true", ignoreCase = true) == true &&
+            root != null &&
+            !apiKey.isNullOrBlank()
+    return AiRepairSettings(enabled = enabled, projectRoot = root.takeIf { enabled })
+}

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/HttpAiRepairClient.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/HttpAiRepairClient.kt
@@ -38,6 +38,97 @@ private fun stripCodeFences(text: String): String {
 }
 
 /**
+ * Why the model declined, or null if it didn't.
+ *
+ * A refusal is a successful HTTP 200 carrying no answer, so it has to be recognised before the
+ * response is read as a proposal.
+ */
+private fun refusalReason(
+    json: Json,
+    rawResponse: String,
+): String? {
+    val root = json.parseToJsonElement(rawResponse).jsonObject
+    if (root["stop_reason"]?.jsonPrimitive?.contentOrNull != "refusal") return null
+    val details = root["stop_details"]?.jsonObject
+    val category = details?.get("category")?.jsonPrimitive?.contentOrNull ?: "unspecified"
+    val explanation = details?.get("explanation")?.jsonPrimitive?.contentOrNull ?: "no explanation given"
+    return "category=$category, $explanation"
+}
+
+/**
+ * The first `text` block of an Anthropic response.
+ *
+ * Indexing `content[0]` is wrong here: thinking is on by default on current models, so the answer is
+ * preceded by one or more thinking blocks. Refusals are handled before this is reached.
+ */
+private fun extractAnthropicText(
+    json: Json,
+    rawResponse: String,
+): String? =
+    json
+        .parseToJsonElement(rawResponse)
+        .jsonObject["content"]
+        ?.jsonArray
+        ?.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "text" }
+        ?.jsonObject
+        ?.get("text")
+        ?.jsonPrimitive
+        ?.contentOrNull
+
+/** The assistant message out of an OpenAI-compatible chat-completions response. */
+private fun extractOpenAiText(
+    json: Json,
+    rawResponse: String,
+): String? =
+    json
+        .parseToJsonElement(rawResponse)
+        .jsonObject["choices"]
+        ?.jsonArray
+        ?.firstOrNull()
+        ?.jsonObject
+        ?.get("message")
+        ?.jsonObject
+        ?.get("content")
+        ?.jsonPrimitive
+        ?.contentOrNull
+
+/**
+ * One proposed patch, resolved against the file it applies to.
+ *
+ * The model is asked for a snippet swap; falling back to the whole patched body, and then to the
+ * original, keeps a partial answer from being reported as a rewrite of the file to nothing.
+ */
+private fun filePatch(
+    obj: JsonObject,
+    sourceFiles: Map<String, String>,
+): FilePatch? {
+    val filePath = obj["filePath"]?.jsonPrimitive?.contentOrNull ?: return null
+    val originalSnippet = obj["originalSnippet"]?.jsonPrimitive?.contentOrNull ?: ""
+    val patchedSnippet = obj["patchedSnippet"]?.jsonPrimitive?.contentOrNull ?: ""
+    val originalContent = sourceFiles[filePath] ?: ""
+    val patchedContent =
+        when {
+            originalSnippet.isNotBlank() && originalContent.contains(originalSnippet) -> {
+                originalContent.replace(originalSnippet, patchedSnippet)
+            }
+
+            patchedSnippet.isNotBlank() -> {
+                patchedSnippet
+            }
+
+            else -> {
+                originalContent
+            }
+        }
+    return FilePatch(
+        filePath = filePath,
+        originalContent = originalContent,
+        patchedContent = patchedContent,
+        description = obj["description"]?.jsonPrimitive?.contentOrNull ?: "",
+    )
+}
+
+/**
  * Calls the operator's chosen model to generate repair proposals.
  *
  * Two wire shapes are supported — Anthropic's Messages API and the OpenAI chat-completions shape
@@ -237,123 +328,96 @@ class HttpAiRepairClient(
 
     // ---- Response parsers ----
 
+    /**
+     * The proposal object out of a response, or null when there isn't one.
+     *
+     * "Parsed some JSON" is not "got a proposal": a refusal, an error body or a bare envelope all
+     * parse fine and carry none of [keys], and reporting one as a repair hands the operator an
+     * empty diff described as a successful fix.
+     */
+    private fun proposalRoot(
+        rawResponse: String,
+        vararg keys: String,
+    ): JsonObject? {
+        val root = extractContent(rawResponse)?.let(::parseObject)
+        return when {
+            root == null -> {
+                null
+            }
+
+            keys.any { root[it] != null } -> {
+                root
+            }
+
+            else -> {
+                logger.warn("AI response carried no proposal (looked for {})", keys.joinToString())
+                null
+            }
+        }
+    }
+
+    private fun parseObject(content: String): JsonObject? =
+        try {
+            json.parseToJsonElement(content).jsonObject
+        } catch (e: Exception) {
+            logger.error("Failed to parse AI response: {}", e.message)
+            null
+        }
+
     private fun parseSourceFixResponse(
         rawResponse: String,
         sourceFiles: Map<String, String>,
     ): SourceFixProposal? {
-        return try {
-            val root = json.parseToJsonElement(extractContent(rawResponse)).jsonObject
-            val explanation = root["explanation"]?.jsonPrimitive?.contentOrNull ?: ""
-            val patches =
-                root["patches"]?.jsonArray?.mapNotNull { el ->
-                    val obj = el.jsonObject
-                    val filePath = obj["filePath"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-                    val description = obj["description"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val originalSnippet = obj["originalSnippet"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val patchedSnippet = obj["patchedSnippet"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val originalContent = sourceFiles[filePath] ?: ""
-                    val patchedContent =
-                        when {
-                            originalSnippet.isNotBlank() && originalContent.contains(originalSnippet) -> {
-                                originalContent.replace(originalSnippet, patchedSnippet)
-                            }
-
-                            patchedSnippet.isNotBlank() -> {
-                                patchedSnippet
-                            }
-
-                            else -> {
-                                originalContent
-                            }
-                        }
-                    FilePatch(
-                        filePath = filePath,
-                        originalContent = originalContent,
-                        patchedContent = patchedContent,
-                        description = description,
-                    )
-                } ?: emptyList()
-            SourceFixProposal(explanation = explanation, patches = patches)
-        } catch (e: Exception) {
-            logger.error("Failed to parse AI source-fix response: {}", e.message)
-            null
-        }
+        val root = proposalRoot(rawResponse, "explanation", "patches") ?: return null
+        return SourceFixProposal(
+            explanation = root["explanation"]?.jsonPrimitive?.contentOrNull ?: "",
+            patches =
+                root["patches"]
+                    ?.jsonArray
+                    ?.mapNotNull { filePatch(it.jsonObject, sourceFiles) }
+                    ?: emptyList(),
+        )
     }
 
-    private fun parseConfigFixResponse(rawResponse: String): ConfigFixProposal? =
-        try {
-            val root = json.parseToJsonElement(extractContent(rawResponse)).jsonObject
-            val explanation = root["explanation"]?.jsonPrimitive?.contentOrNull ?: ""
-            val configChanges =
-                root["configChanges"]
-                    ?.let { it as? JsonObject }
+    private fun parseConfigFixResponse(rawResponse: String): ConfigFixProposal? {
+        val root = proposalRoot(rawResponse, "explanation", "configChanges") ?: return null
+        return ConfigFixProposal(
+            explanation = root["explanation"]?.jsonPrimitive?.contentOrNull ?: "",
+            configChanges =
+                (root["configChanges"] as? JsonObject)
                     ?.entries
                     ?.associate { (k, v) -> k to (v.jsonPrimitive.contentOrNull ?: "") }
-                    ?: emptyMap()
-            ConfigFixProposal(explanation = explanation, configChanges = configChanges)
-        } catch (e: Exception) {
-            logger.error("Failed to parse AI config-fix response: {}", e.message)
-            null
-        }
+                    ?: emptyMap(),
+        )
+    }
 
     /**
-     * Extracts the assistant's text from a response in the configured wire's shape.
+     * The assistant's text out of a response in the configured wire's shape, or null when the model
+     * did not give one.
      *
-     * Falls back to returning the raw string if parsing fails (e.g. some gateways return the JSON
-     * payload directly), which the callers then try to parse as a proposal.
+     * Null is load-bearing. A refusal must NOT fall through to the raw envelope the way an
+     * unrecognised shape does: that envelope is itself valid JSON, so the parsers would read it as
+     * a proposal with no explanation and no patches — and an empty proposal reaches the operator as
+     * a *successful* repair carrying an empty diff, which is worse than no answer.
      */
-    private fun extractContent(rawResponse: String): String =
+    private fun extractContent(rawResponse: String): String? =
         try {
-            val text =
-                when (config.wire) {
-                    AiRepairWire.ANTHROPIC -> extractAnthropicText(rawResponse)
-                    AiRepairWire.OPENAI -> extractOpenAiText(rawResponse)
-                }
-            stripCodeFences(text ?: rawResponse)
+            val refusal = if (config.wire == AiRepairWire.ANTHROPIC) refusalReason(json, rawResponse) else null
+            if (refusal != null) {
+                logger.warn("Model declined the repair request: {}", refusal)
+                null
+            } else {
+                val text =
+                    when (config.wire) {
+                        AiRepairWire.ANTHROPIC -> extractAnthropicText(json, rawResponse)
+                        AiRepairWire.OPENAI -> extractOpenAiText(json, rawResponse)
+                    }
+                // Falling back to the raw string covers gateways that return the payload directly.
+                stripCodeFences(text ?: rawResponse)
+            }
         } catch (_: Exception) {
             rawResponse
         }
-
-    private fun extractOpenAiText(rawResponse: String): String? =
-        json
-            .parseToJsonElement(rawResponse)
-            .jsonObject["choices"]
-            ?.jsonArray
-            ?.firstOrNull()
-            ?.jsonObject
-            ?.get("message")
-            ?.jsonObject
-            ?.get("content")
-            ?.jsonPrimitive
-            ?.contentOrNull
-
-    /**
-     * The first `text` block of an Anthropic response.
-     *
-     * Indexing `content[0]` is wrong here: thinking is on by default on current models, so the
-     * answer is preceded by one or more thinking blocks. A refusal carries no text block at all,
-     * which is reported rather than left to surface as an unhelpful JSON parse failure.
-     */
-    private fun extractAnthropicText(rawResponse: String): String? {
-        val root = json.parseToJsonElement(rawResponse).jsonObject
-        if (root["stop_reason"]?.jsonPrimitive?.contentOrNull == "refusal") {
-            val category =
-                root["stop_details"]
-                    ?.jsonObject
-                    ?.get("category")
-                    ?.jsonPrimitive
-                    ?.contentOrNull
-            logger.warn("Model declined the repair request (category={})", category ?: "unspecified")
-            return null
-        }
-        return root["content"]
-            ?.jsonArray
-            ?.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "text" }
-            ?.jsonObject
-            ?.get("text")
-            ?.jsonPrimitive
-            ?.contentOrNull
-    }
 
     private companion object {
         /** Pinned per Anthropic's API contract; unrelated to the model in [AiRepairConfig]. */

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/HttpAiRepairClient.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/HttpAiRepairClient.kt
@@ -19,26 +19,41 @@ import java.net.URL
 import java.nio.charset.StandardCharsets
 
 /**
- * Calls any OpenAI-compatible chat-completions API to generate repair proposals.
+ * Drop a ```` ``` ````-fenced wrapper if the model added one.
  *
- * Configuration via environment variables:
- *   AI_REPAIR_API_URL  — defaults to https://api.openai.com/v1/chat/completions
- *   AI_REPAIR_API_KEY  — required; falls back to OPENAI_API_KEY if not set
- *   AI_REPAIR_MODEL    — defaults to gpt-5.4
- *
- * Uses [java.net.HttpURLConnection] — no additional runtime dependencies required.
+ * The default system prompt forbids fences, but that prompt is operator-editable now, and a
+ * replacement that omits the rule shouldn't turn every proposal into a parse failure.
  */
-class HttpAiRepairClient : AiRepairClient {
+private fun stripCodeFences(text: String): String {
+    val trimmed = text.trim()
+    return if (!trimmed.startsWith("```")) {
+        trimmed
+    } else {
+        trimmed
+            .removePrefix("```")
+            .substringAfter('\n', "")
+            .substringBeforeLast("```")
+            .trim()
+    }
+}
+
+/**
+ * Calls the operator's chosen model to generate repair proposals.
+ *
+ * Two wire shapes are supported — Anthropic's Messages API and the OpenAI chat-completions shape
+ * that OpenAI, Together and most gateways implement — because provider, model and system prompt are
+ * an operator choice (Settings → Advanced → Self-Healing), forwarded here as the environment
+ * variables [aiRepairConfigFromEnvironment] reads.
+ *
+ * Uses [java.net.HttpURLConnection] — no additional runtime dependencies required, which matters for
+ * a service that ships as a fat JAR spawned by the kernel.
+ */
+class HttpAiRepairClient(
+    private val config: AiRepairConfig = aiRepairConfigFromEnvironment(),
+) : AiRepairClient {
     private val logger = LoggerFactory.getLogger(HttpAiRepairClient::class.java)
 
-    private val apiUrl =
-        System.getenv("AI_REPAIR_API_URL")
-            ?: "https://api.openai.com/v1/chat/completions"
-    private val apiKey =
-        System.getenv("AI_REPAIR_API_KEY")
-            ?: System.getenv("OPENAI_API_KEY")
-            ?: ""
-    private val model = System.getenv("AI_REPAIR_MODEL") ?: "gpt-5.4"
+    private val apiKey = config.apiKey
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -131,33 +146,15 @@ class HttpAiRepairClient : AiRepairClient {
 
     private suspend fun callApi(userPrompt: String): String =
         withContext(Dispatchers.IO) {
-            val requestBody =
-                buildJsonObject {
-                    put("model", model)
-                    put("max_tokens", 2048)
-                    put("temperature", 0.2)
-                    putJsonArray("messages") {
-                        addJsonObject {
-                            put("role", "system")
-                            put(
-                                "content",
-                                "You are a precise code repair assistant. Always respond with valid JSON only. Do not include markdown code fences.",
-                            )
-                        }
-                        addJsonObject {
-                            put("role", "user")
-                            put("content", userPrompt)
-                        }
-                    }
-                }.toString()
+            val requestBody = buildRequestBody(userPrompt)
 
-            val url = URL(apiUrl)
+            val url = URL(config.endpoint)
             val connection =
                 (url.openConnection() as HttpURLConnection).apply {
                     requestMethod = "POST"
                     setRequestProperty("Content-Type", "application/json")
-                    setRequestProperty("Authorization", "Bearer $apiKey")
                     setRequestProperty("Accept", "application/json")
+                    applyAuth(this)
                     connectTimeout = 30_000
                     readTimeout = 60_000
                     doOutput = true
@@ -181,6 +178,62 @@ class HttpAiRepairClient : AiRepairClient {
                 connection.disconnect()
             }
         }
+
+    /**
+     * The request body for the configured wire.
+     *
+     * Anthropic takes the system prompt as a top-level field rather than a message, and rejects
+     * `temperature` outright on current models — so the two shapes differ by more than field names
+     * and are built separately instead of patched from a common object.
+     */
+    private fun buildRequestBody(userPrompt: String): String =
+        when (config.wire) {
+            AiRepairWire.ANTHROPIC -> {
+                buildJsonObject {
+                    put("model", config.model)
+                    put("max_tokens", config.wire.maxTokens)
+                    put("system", config.systemPrompt)
+                    putJsonArray("messages") {
+                        addJsonObject {
+                            put("role", "user")
+                            put("content", userPrompt)
+                        }
+                    }
+                }.toString()
+            }
+
+            AiRepairWire.OPENAI -> {
+                buildJsonObject {
+                    put("model", config.model)
+                    put("max_tokens", config.wire.maxTokens)
+                    put("temperature", 0.2)
+                    putJsonArray("messages") {
+                        addJsonObject {
+                            put("role", "system")
+                            put("content", config.systemPrompt)
+                        }
+                        addJsonObject {
+                            put("role", "user")
+                            put("content", userPrompt)
+                        }
+                    }
+                }.toString()
+            }
+        }
+
+    /** Anthropic authenticates with `x-api-key` plus a version header; everyone else with a bearer token. */
+    private fun applyAuth(connection: HttpURLConnection) {
+        when (config.wire) {
+            AiRepairWire.ANTHROPIC -> {
+                connection.setRequestProperty("x-api-key", apiKey)
+                connection.setRequestProperty("anthropic-version", ANTHROPIC_VERSION)
+            }
+
+            AiRepairWire.OPENAI -> {
+                connection.setRequestProperty("Authorization", "Bearer $apiKey")
+            }
+        }
+    }
 
     // ---- Response parsers ----
 
@@ -244,25 +297,66 @@ class HttpAiRepairClient : AiRepairClient {
         }
 
     /**
-     * Extracts the assistant message content from an OpenAI-compatible response JSON.
-     * Falls back to returning the raw string if parsing fails (e.g. some providers
-     * return the JSON payload directly).
+     * Extracts the assistant's text from a response in the configured wire's shape.
+     *
+     * Falls back to returning the raw string if parsing fails (e.g. some gateways return the JSON
+     * payload directly), which the callers then try to parse as a proposal.
      */
     private fun extractContent(rawResponse: String): String =
         try {
-            json
-                .parseToJsonElement(rawResponse)
-                .jsonObject["choices"]
-                ?.jsonArray
-                ?.firstOrNull()
-                ?.jsonObject
-                ?.get("message")
-                ?.jsonObject
-                ?.get("content")
-                ?.jsonPrimitive
-                ?.contentOrNull
-                ?: rawResponse
+            val text =
+                when (config.wire) {
+                    AiRepairWire.ANTHROPIC -> extractAnthropicText(rawResponse)
+                    AiRepairWire.OPENAI -> extractOpenAiText(rawResponse)
+                }
+            stripCodeFences(text ?: rawResponse)
         } catch (_: Exception) {
             rawResponse
         }
+
+    private fun extractOpenAiText(rawResponse: String): String? =
+        json
+            .parseToJsonElement(rawResponse)
+            .jsonObject["choices"]
+            ?.jsonArray
+            ?.firstOrNull()
+            ?.jsonObject
+            ?.get("message")
+            ?.jsonObject
+            ?.get("content")
+            ?.jsonPrimitive
+            ?.contentOrNull
+
+    /**
+     * The first `text` block of an Anthropic response.
+     *
+     * Indexing `content[0]` is wrong here: thinking is on by default on current models, so the
+     * answer is preceded by one or more thinking blocks. A refusal carries no text block at all,
+     * which is reported rather than left to surface as an unhelpful JSON parse failure.
+     */
+    private fun extractAnthropicText(rawResponse: String): String? {
+        val root = json.parseToJsonElement(rawResponse).jsonObject
+        if (root["stop_reason"]?.jsonPrimitive?.contentOrNull == "refusal") {
+            val category =
+                root["stop_details"]
+                    ?.jsonObject
+                    ?.get("category")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+            logger.warn("Model declined the repair request (category={})", category ?: "unspecified")
+            return null
+        }
+        return root["content"]
+            ?.jsonArray
+            ?.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "text" }
+            ?.jsonObject
+            ?.get("text")
+            ?.jsonPrimitive
+            ?.contentOrNull
+    }
+
+    private companion object {
+        /** Pinned per Anthropic's API contract; unrelated to the model in [AiRepairConfig]. */
+        const val ANTHROPIC_VERSION = "2023-06-01"
+    }
 }

--- a/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorMain.kt
+++ b/modules/boss-orchestrator/src/main/kotlin/ai/rever/boss/orchestrator/OrchestratorMain.kt
@@ -18,6 +18,7 @@ import java.io.File
  * to restart processes via KernelService.RequestShutdown, and the kernel's auto-respawn
  * handles the actual re-spawn.
  */
+
 fun main() {
     val logger = LoggerFactory.getLogger("OrchestratorMain")
     logger.info("Orchestrator starting...")
@@ -64,16 +65,38 @@ fun main() {
         val snapshotManager = SnapshotManager(dataDir)
         val analyzer = CrashAnalyzer()
 
-        // Use AI-powered repairs when AI_REPAIR_API_KEY or OPENAI_API_KEY is configured
+        // AI repair sends the crashing process's source to a third-party model. That is a
+        // data-egress decision, so it takes an explicit opt-in AND a named root to read from —
+        // an API key sitting in the environment for some other purpose must never be enough to
+        // start uploading source, which is exactly what keying off the key alone did.
         val repairApiKey =
             System.getenv("AI_REPAIR_API_KEY")
                 ?: System.getenv("OPENAI_API_KEY")
+        val aiRepair =
+            aiRepairSettings(
+                optIn = System.getenv("BOSS_AI_REPAIR"),
+                projectRoot = System.getenv("BOSS_REPAIR_PROJECT_ROOT"),
+                apiKey = repairApiKey,
+            )
+
         val aiClient: AiRepairClient? =
-            if (!repairApiKey.isNullOrBlank()) {
-                logger.info("AI repair client enabled (model={})", System.getenv("AI_REPAIR_MODEL") ?: "gpt-5.4")
-                HttpAiRepairClient()
+            if (aiRepair.enabled) {
+                val repairConfig = aiRepairConfigFromEnvironment()
+                logger.warn(
+                    "AI repair ENABLED (endpoint={}, model={}, source root={}) — " +
+                        "crash source files will be sent off this machine",
+                    repairConfig.endpoint,
+                    repairConfig.model,
+                    aiRepair.projectRoot,
+                )
+                HttpAiRepairClient(repairConfig)
             } else {
-                logger.info("AI_REPAIR_API_KEY / OPENAI_API_KEY not set — AI repair proposals disabled")
+                logger.info(
+                    "AI repair disabled (opt-in={}, root named={}, key present={}) — no source leaves this machine",
+                    System.getenv("BOSS_AI_REPAIR") ?: "unset",
+                    System.getenv("BOSS_REPAIR_PROJECT_ROOT") != null,
+                    !repairApiKey.isNullOrBlank(),
+                )
                 null
             }
 
@@ -87,8 +110,9 @@ fun main() {
                 // Stated rather than defaulted: this process has no project directory to
                 // offer — its working directory is whatever the kernel spawned it with —
                 // and manifest source files go to a third-party model, so nothing is read
-                // until a host names a directory it is willing to send.
-                projectRoot = null,
+                // until a host names a directory it is willing to send. Only honoured when
+                // AI repair is switched on; a root without a client reads files nothing uses.
+                projectRoot = aiRepair.projectRoot,
                 onRequestRestart = { processId, _ ->
                     kernelStub.requestShutdown(
                         ShutdownRequest

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AiRepairConfigTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AiRepairConfigTest.kt
@@ -118,6 +118,15 @@ class AiRepairConfigTest {
     }
 
     @Test
+    fun `the legacy OpenAI key is not offered to Anthropic`() {
+        // It would be sent as x-api-key: a credential going somewhere it cannot work and should not
+        // go. AI_REPAIR_API_KEY is the way to configure the Anthropic wire.
+        val env = mapOf("AI_REPAIR_PROVIDER" to "anthropic", "OPENAI_API_KEY" to "sk-openai")
+
+        assertEquals("", aiRepairConfigFromEnvironment { env[it] }.apiKey)
+    }
+
+    @Test
     fun `a dedicated repair key wins over the general one`() {
         val env = mapOf("AI_REPAIR_API_KEY" to "sk-narrow", "OPENAI_API_KEY" to "sk-broad")
 

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AiRepairConfigTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AiRepairConfigTest.kt
@@ -1,0 +1,133 @@
+package ai.rever.boss.orchestrator
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins how an operator's provider/model/prompt choice reaches the HTTP client.
+ *
+ * The settings screen forwards these as environment variables, and a field the operator cleared
+ * arrives here as an empty string rather than as absent — so "blank means default" is the property
+ * that keeps a cleared field from being sent as an empty model name.
+ */
+class AiRepairConfigTest {
+    @Test
+    fun `nothing configured is OpenAI, as it always was`() {
+        // Prior behaviour: the client only ever spoke chat-completions to api.openai.com.
+        val config = aiRepairConfig(provider = null, endpoint = null, apiKey = null, model = null, systemPrompt = null)
+
+        assertEquals(AiRepairWire.OPENAI, config.wire)
+        assertEquals("https://api.openai.com/v1/chat/completions", config.endpoint)
+        assertEquals("gpt-5.4", config.model)
+        assertEquals(DEFAULT_REPAIR_SYSTEM_PROMPT, config.systemPrompt)
+    }
+
+    @Test
+    fun `anthropic selects the messages API and a Claude model`() {
+        val config =
+            aiRepairConfig(provider = "anthropic", endpoint = null, apiKey = "k", model = null, systemPrompt = null)
+
+        assertEquals(AiRepairWire.ANTHROPIC, config.wire)
+        assertEquals("https://api.anthropic.com/v1/messages", config.endpoint)
+        assertEquals("claude-opus-5", config.model)
+    }
+
+    @Test
+    fun `the provider name is matched leniently`() {
+        listOf("Anthropic", "ANTHROPIC", " anthropic ").forEach { name ->
+            assertEquals(
+                AiRepairWire.ANTHROPIC,
+                aiRepairConfig(name, null, null, null, null).wire,
+                "provider \"$name\" should select the Anthropic wire",
+            )
+        }
+    }
+
+    @Test
+    fun `every other provider speaks chat-completions`() {
+        // Together and self-hosted gateways are OpenAI-compatible; only Anthropic differs.
+        listOf("openai", "together", "custom", "", "something-new").forEach { name ->
+            assertEquals(
+                AiRepairWire.OPENAI,
+                aiRepairConfig(name, null, null, null, null).wire,
+                "provider \"$name\" should speak chat-completions",
+            )
+        }
+    }
+
+    @Test
+    fun `a cleared field falls back to the default rather than being sent empty`() {
+        val config = aiRepairConfig(provider = "openai", endpoint = "  ", apiKey = "k", model = "", systemPrompt = "")
+
+        assertEquals("https://api.openai.com/v1/chat/completions", config.endpoint)
+        assertEquals("gpt-5.4", config.model)
+        assertEquals(DEFAULT_REPAIR_SYSTEM_PROMPT, config.systemPrompt)
+    }
+
+    @Test
+    fun `an operator's choices are used as given`() {
+        val config =
+            aiRepairConfig(
+                provider = "custom",
+                endpoint = "https://gateway.internal/v1/chat/completions",
+                apiKey = "sk-live",
+                model = "internal-repair-v2",
+                systemPrompt = "Reply with JSON. House style applies.",
+            )
+
+        assertEquals("https://gateway.internal/v1/chat/completions", config.endpoint)
+        assertEquals("internal-repair-v2", config.model)
+        assertEquals("Reply with JSON. House style applies.", config.systemPrompt)
+        assertEquals("sk-live", config.apiKey)
+    }
+
+    @Test
+    fun `a multi-line system prompt survives intact`() {
+        // It travels as an environment variable; newlines are the whole point of the field.
+        val prompt = "Line one.\nLine two.\n\nRespond with JSON only."
+
+        assertEquals(prompt, aiRepairConfig(null, null, null, null, prompt).systemPrompt)
+    }
+
+    @Test
+    fun `the environment mapping reads the variables the kernel sets`() {
+        val env =
+            mapOf(
+                "AI_REPAIR_PROVIDER" to "anthropic",
+                "AI_REPAIR_API_URL" to "https://proxy.internal/v1/messages",
+                "AI_REPAIR_API_KEY" to "sk-repair",
+                "AI_REPAIR_MODEL" to "claude-opus-5",
+                "AI_REPAIR_SYSTEM_PROMPT" to "Be terse.",
+            )
+
+        val config = aiRepairConfigFromEnvironment { env[it] }
+
+        assertEquals(AiRepairWire.ANTHROPIC, config.wire)
+        assertEquals("https://proxy.internal/v1/messages", config.endpoint)
+        assertEquals("sk-repair", config.apiKey)
+        assertEquals("claude-opus-5", config.model)
+        assertEquals("Be terse.", config.systemPrompt)
+    }
+
+    @Test
+    fun `OPENAI_API_KEY still works for operators who configured this before the settings screen`() {
+        val config = aiRepairConfigFromEnvironment { name -> "sk-legacy".takeIf { name == "OPENAI_API_KEY" } }
+
+        assertEquals("sk-legacy", config.apiKey)
+    }
+
+    @Test
+    fun `a dedicated repair key wins over the general one`() {
+        val env = mapOf("AI_REPAIR_API_KEY" to "sk-narrow", "OPENAI_API_KEY" to "sk-broad")
+
+        assertEquals("sk-narrow", aiRepairConfigFromEnvironment { env[it] }.apiKey)
+    }
+
+    @Test
+    fun `Anthropic gets room for thinking as well as an answer`() {
+        // max_tokens bounds thinking plus text there, and thinking is on by default on current
+        // models — sizing it around the JSON alone truncates the proposal.
+        assertTrue(AiRepairWire.ANTHROPIC.maxTokens > AiRepairWire.OPENAI.maxTokens)
+    }
+}

--- a/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AiRepairSettingsTest.kt
+++ b/modules/boss-orchestrator/src/test/kotlin/ai/rever/boss/orchestrator/AiRepairSettingsTest.kt
@@ -1,0 +1,81 @@
+package ai.rever.boss.orchestrator
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the switch that decides whether crash source files leave the machine.
+ *
+ * This used to turn itself on because `OPENAI_API_KEY` happened to be set — a key that is present
+ * on developer machines for entirely unrelated reasons. Enabling source upload is a decision
+ * someone has to make on purpose, so it now takes an explicit opt-in *and* a named root, and each
+ * of those is asserted separately here.
+ */
+class AiRepairSettingsTest {
+    @Test
+    fun `a key on its own does not enable source upload`() {
+        val settings = aiRepairSettings(optIn = null, projectRoot = "/work/project", apiKey = "sk-live")
+
+        assertFalse(settings.enabled)
+        assertNull(settings.projectRoot)
+    }
+
+    @Test
+    fun `an opt-in without a named root does not enable it`() {
+        // "Yes, use AI repair" without saying what it may read is not an answer.
+        val settings = aiRepairSettings(optIn = "true", projectRoot = null, apiKey = "sk-live")
+
+        assertFalse(settings.enabled)
+        assertNull(settings.projectRoot)
+    }
+
+    @Test
+    fun `a blank root counts as no root`() {
+        val settings = aiRepairSettings(optIn = "true", projectRoot = "   ", apiKey = "sk-live")
+
+        assertFalse(settings.enabled)
+    }
+
+    @Test
+    fun `an opt-in without a key does not enable it`() {
+        val settings = aiRepairSettings(optIn = "true", projectRoot = "/work/project", apiKey = null)
+
+        assertFalse(settings.enabled)
+        assertNull(settings.projectRoot)
+    }
+
+    @Test
+    fun `all three together enable it, and name the root`() {
+        val settings = aiRepairSettings(optIn = "true", projectRoot = "/work/project", apiKey = "sk-live")
+
+        assertTrue(settings.enabled)
+        assertEquals("/work/project", settings.projectRoot)
+    }
+
+    @Test
+    fun `the opt-in is not case sensitive`() {
+        assertTrue(aiRepairSettings("TRUE", "/work/project", "sk-live").enabled)
+    }
+
+    @Test
+    fun `anything other than true is off`() {
+        // Including the shapes a config file might plausibly produce.
+        listOf("false", "1", "yes", "", "  ").forEach { value ->
+            assertFalse(
+                aiRepairSettings(value, "/work/project", "sk-live").enabled,
+                "opt-in \"$value\" must not enable source upload",
+            )
+        }
+    }
+
+    @Test
+    fun `the root is withheld when the feature is off`() {
+        // RepairEngine reads nothing without a root, so an off switch must not leak one through.
+        val settings = aiRepairSettings(optIn = "false", projectRoot = "/work/project", apiKey = "sk-live")
+
+        assertNull(settings.projectRoot)
+    }
+}


### PR DESCRIPTION
## What

Makes the self-healing orchestrator actually run, and puts its model choice in Settings.

The repair engine — `CrashAnalyzer`, `RepairEngine`'s strategy ladder, `SnapshotManager`, `AiRepairClient` — has been built and tested since it landed, and has **never executed**. Four independent gates kept it unreachable:

1. **No jar was ever found.** The kernel looked for `boss-orchestrator-all.jar`; every module's `fatJar` task emits `boss-orchestrator-<version>-all.jar`. Nothing matched, and the log said "build the fat JARs first" even right after someone had.
2. **Nothing asked it anything.** The failure collector respawned directly and never called `reportFailure`; `onProcessRegistered` discarded the child's `ipcAddress`, so there was nothing to dial regardless.
3. **The AI gate keyed off the wrong thing** — it enabled itself merely because `OPENAI_API_KEY` was set.
4. **Nothing was configurable** — model, endpoint and system prompt were hardcoded or env-only.

## Recovery does not get worse

This is the part that mattered most. Routing crash recovery through another process is only safe if an unreachable, wedged, or crashed orchestrator leaves the kernel doing exactly what it did before.

`recoveryFor(null)` is the plain respawn, and that is the answer whenever the orchestrator **is** the process that died, is not registered yet, times out (2s), or errors. `maxRestarts` still caps everything. Every branch ends with the process coming back — including repairs that need a human, because withholding recovery until someone clicks would leave an operator with a dead service and a notification.

`RecoveryDecisionTest` pins that, starting with the no-advice case.

## Settings → Advanced → Self-Healing

Provider (Anthropic / OpenAI / Together / custom OpenAI-compatible), model, endpoint, source root, and an editable system prompt with reset-to-default. A readiness card names what is missing, since each blocker otherwise withholds the whole thing silently at spawn time.

**On the egress decision.** `PATCH_SOURCE` sends the crashing process's source to a third-party model, so it stays off by default and now takes an explicit opt-in **and** a named root **and** a key — the old behaviour switched itself on from a key that sits on developer machines for unrelated reasons and is already in `local.properties`. `repairEnvironment()` returns an empty map unless all three are present, so a half-configured screen sends nothing and the key never reaches the other eight services.

The key is not asked for twice: it resolves from the same places the LLM Providers screen uses (`AI_REPAIR_API_KEY` → provider env var → `llm_settings.json`). That file is read directly rather than through `LLMSettings`, whose startup effect runs after the window opens — later than the kernel spawns services.

## Anthropic wire support

`HttpAiRepairClient` speaks both shapes now, because "provider" should mean more than swapping a URL:

- `x-api-key` + `anthropic-version`, top-level `system`, and **no `temperature`** (rejected on current models)
- a higher output ceiling — `max_tokens` bounds thinking as well as the answer there, and thinking is on by default
- the first `text` block rather than `content[0]`, since thinking blocks precede it
- a refusal is reported explicitly instead of surfacing as an unhelpful JSON parse failure

Kept on `HttpURLConnection` rather than pulling an SDK into a service that ships as a fat jar.

## Testing

- 1256 composeApp desktop tests, 75 boss-orchestrator tests — all green
- 25 new: `RecoveryDecisionTest` (9), `SelfHealingEnvironmentTest` (14 — mostly asserting *absence* of variables when config is incomplete), `ServiceJarLookupTest` (6), `AiRepairConfigTest` (11), `AiRepairSettingsTest` (8)
- ktlint + detekt clean on both modules

## Not in this PR

- Packaged builds still run MONOLITH (`BOSS_MODE` is not part of embedded-config generation)
- The approval sink still refuses source patches — an operator cannot approve a diff they cannot see
- `readSourceFiles` byte/entry caps
