### PR TITLE
Identify Dockerfiles and Makefiles in editor language detection

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt
@@ -1,0 +1,169 @@
+package ai.rever.boss.components.plugin.language
+
+/**
+ * The host's single answer to "what language is this file?".
+ *
+ * There were three copies of this map in the host with different membership, and
+ * they disagreed: one knew 27 extensions, one knew 12 and never lowercased, and a
+ * third carried `pyw`/`mjs` the others lacked. None could identify `Dockerfile` or
+ * `Makefile`, because every one of them keyed on an extension and those files have
+ * none.
+ *
+ * Everything host-side routes here now, so a fix lands once instead of three times
+ * — and `editor_detect_language` cannot report one language while the editor tab
+ * highlights another.
+ *
+ * The editor-tab plugin keeps its own `LanguageDetection` (separate artifact, cannot
+ * depend on this) and the ids must stay byte-identical to it: `properties` not
+ * `ini`, `batch` not `bat`.
+ *
+ * The tables are data rather than a `when` chain — a 40-branch `when` is both harder
+ * to scan and, at complexity 44, something detekt rightly objects to.
+ */
+object EditorLanguages {
+    /**
+     * Language id for [filePath], or `"text"` when nothing matches.
+     *
+     * File *name* patterns are tried before the extension, because the files that
+     * most need identifying have no extension: `substringAfterLast('.')` yields `""`
+     * for both `Dockerfile` and `Makefile`.
+     *
+     * The extension is read from the file name, not the whole path. Reading it from
+     * the path let a dot in a parent directory leak into the answer —
+     * `/srv/v1.2/Makefile` produced the "extension" `2/Makefile`.
+     */
+    fun detect(filePath: String): String {
+        val fileName = filePath.substringAfterLast('/').substringAfterLast('\\')
+        forFileName(fileName)?.let { return it }
+        return EXTENSIONS[fileName.substringAfterLast('.', "").lowercase()] ?: TEXT
+    }
+
+    /**
+     * Languages identified by file name rather than extension.
+     *
+     * Checked before extensions so that `Dockerfile.dev` is a Dockerfile rather than
+     * whatever `.dev` might otherwise suggest.
+     *
+     * Deliberately omits `CMakeLists.txt`: CMake is not Make, and a Make lexer would
+     * hunt for tab-indented recipes that do not exist while missing `if()/endif()`
+     * and `${VAR}`. No highlighting beats confidently wrong highlighting.
+     */
+    private fun forFileName(fileName: String): String? {
+        val lower = fileName.lowercase()
+        EXACT_NAMES[lower]?.let { return it }
+        return PREFIXED_NAMES.firstNotNullOfOrNull { (prefix, language) ->
+            language.takeIf { lower.startsWith(prefix) }
+        }
+    }
+
+    private const val TEXT = "text"
+
+    /** Whole file names. Bare only — `Gemfile.lock` is generated data, not Ruby. */
+    private val EXACT_NAMES =
+        mapOf(
+            "dockerfile" to "dockerfile",
+            "containerfile" to "dockerfile",
+            "makefile" to "makefile",
+            "gnumakefile" to "makefile",
+            ".env" to "properties",
+            "gemfile" to "ruby",
+            "rakefile" to "ruby",
+        )
+
+    /** Name prefixes, for the `Dockerfile.dev` / `.env.local` family. */
+    private val PREFIXED_NAMES =
+        listOf(
+            "dockerfile." to "dockerfile",
+            "containerfile." to "dockerfile",
+            "makefile." to "makefile",
+            ".env." to "properties",
+        )
+
+    private val EXTENSIONS =
+        mapOf(
+            "kt" to "kotlin",
+            "kts" to "kotlin",
+            "java" to "java",
+            "js" to "javascript",
+            "jsx" to "javascript",
+            "mjs" to "javascript",
+            "cjs" to "javascript",
+            "ts" to "typescript",
+            "tsx" to "typescript",
+            "py" to "python",
+            "pyw" to "python",
+            "json" to "json",
+            "xml" to "xml",
+            "html" to "html",
+            "htm" to "html",
+            "css" to "css",
+            "scss" to "css",
+            "sass" to "css",
+            "md" to "markdown",
+            "markdown" to "markdown",
+            "toml" to "toml",
+            "gradle" to "groovy",
+            "swift" to "swift",
+            "c" to "c",
+            "h" to "c",
+            "cpp" to "cpp",
+            "cc" to "cpp",
+            "cxx" to "cpp",
+            "hpp" to "cpp",
+            "cs" to "csharp",
+            "rs" to "rust",
+            "go" to "go",
+            "rb" to "ruby",
+            "php" to "php",
+            "pl" to "perl",
+            "pm" to "perl",
+            "lua" to "lua",
+            "sh" to "bash",
+            "bash" to "bash",
+            "zsh" to "bash",
+            "yml" to "yaml",
+            "yaml" to "yaml",
+            "sql" to "sql",
+            "r" to "r",
+            "scala" to "scala",
+            // Languages the editor has lexers for that no host map ever named.
+            "dockerfile" to "dockerfile",
+            "mk" to "makefile",
+            "mak" to "makefile",
+            "properties" to "properties",
+            "ini" to "properties",
+            "cfg" to "properties",
+            "env" to "properties",
+            "diff" to "diff",
+            "patch" to "diff",
+            "bat" to "batch",
+            "cmd" to "batch",
+            "clj" to "clojure",
+            "cljs" to "clojure",
+            "cljc" to "clojure",
+            "edn" to "clojure",
+            "tex" to "latex",
+            "sty" to "latex",
+            "cls" to "latex",
+            "bib" to "latex",
+            "lisp" to "lisp",
+            "lsp" to "lisp",
+            "el" to "lisp",
+            "scm" to "lisp",
+            "tcl" to "tcl",
+            "f" to "fortran",
+            "f90" to "fortran",
+            "f95" to "fortran",
+            "f03" to "fortran",
+            "for" to "fortran",
+            "d" to "d",
+            "pas" to "delphi",
+            "dpr" to "delphi",
+            "dfm" to "delphi",
+            "vb" to "visualbasic",
+            "vbs" to "visualbasic",
+            "as" to "actionscript",
+            "jsp" to "jsp",
+            "jspx" to "jsp",
+        )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt
@@ -9,13 +9,24 @@ package ai.rever.boss.components.plugin.language
  * `Makefile`, because every one of them keyed on an extension and those files have
  * none.
  *
- * Everything host-side routes here now, so a fix lands once instead of three times
- * — and `editor_detect_language` cannot report one language while the editor tab
- * highlights another.
+ * Both host-side consumers of the plugin-facing language id route here — this
+ * provider and the built-in editor tab — so `editor_detect_language` cannot report
+ * one language while that tab highlights another.
+ *
+ * It is **not** yet every map in the tree. `EditorServiceImpl` in
+ * `modules/boss-app-editor` keeps its own (`plaintext` for unknown, `shell` rather
+ * than `bash`, and a `proto` this table lacks), and `FileIcons.forSpecialFileName`
+ * in `plugin-platform/plugin-icons` is a third. Neither can depend on
+ * `composeApp/commonMain`, so absorbing them means moving this table into a
+ * `plugin-platform` module — which both of those, and plugins, *can* consume.
+ * Until then those remain hand-maintained.
  *
  * The editor-tab plugin keeps its own `LanguageDetection` (separate artifact, cannot
- * depend on this) and the ids must stay byte-identical to it: `properties` not
- * `ini`, `batch` not `bat`.
+ * depend on this). Measured against it: the 15 ids added here are identical
+ * (`properties` not `ini`, `batch` not `bat`); `sh`/`bash`/`zsh` differ — `bash`
+ * here, `shell` there — but its lexer factory accepts both, so they resolve to the
+ * same lexer; and `r` has no lexer on either side, so `.r` files are named but not
+ * highlighted. Nothing enforces this at build time.
  *
  * The tables are data rather than a `when` chain — a 40-branch `when` is both harder
  * to scan and, at complexity 44, something detekt rightly objects to.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/tab_types/CodeEditor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/tab_types/CodeEditor.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin.tab_types
 
 import ai.rever.boss.components.events.RunEventBus
 import ai.rever.boss.components.plugin.DefaultPlugin
+import ai.rever.boss.components.plugin.language.EditorLanguages
 import ai.rever.boss.components.plugin.providers.publishSystemEvent
 import ai.rever.boss.plugin.api.FileChangeEvent
 import ai.rever.boss.plugin.api.FileChangeType
@@ -593,23 +594,10 @@ class CodeEditorTabComponent(
     }
 
     private fun updateLanguageFromPath(path: String) {
-        val extension = path.substringAfterLast('.', "")
-        _language.value =
-            when (extension) {
-                "kt", "kts" -> "kotlin"
-                "java" -> "java"
-                "js", "jsx" -> "javascript"
-                "ts", "tsx" -> "typescript"
-                "py" -> "python"
-                "json" -> "json"
-                "xml" -> "xml"
-                "html", "htm" -> "html"
-                "css" -> "css"
-                "md" -> "markdown"
-                "toml" -> "toml"
-                "gradle" -> "groovy"
-                else -> "text"
-            }
+        // Was a third, smaller copy of the language map here: 12 extensions, no
+        // lowercase(), and the extension read from the whole path. It is the copy a
+        // user actually sees, so it now shares one implementation with the rest.
+        _language.value = EditorLanguages.detect(path)
     }
 
     @Composable

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/EditorContentProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/EditorContentProviderImpl.kt
@@ -83,8 +83,26 @@ class EditorContentProviderImpl : EditorContentProvider {
         content: String,
     ): Boolean = writeFileContent(filePath, content)
 
+    /**
+     * Language id for [filePath], as reported to plugins and to the
+     * `editor_detect_language` MCP tool.
+     *
+     * File *name* patterns are checked before the extension: the files that most
+     * need identifying have no extension at all, and an extension-only lookup can
+     * never match `Dockerfile` or `Makefile` (`substringAfterLast('.')` yields `""`).
+     *
+     * The extension is read from the file name rather than the whole path, because
+     * reading it from the path let a dot in a parent directory leak into the answer —
+     * `/srv/v1.2/Makefile` produced the "extension" `2/Makefile`.
+     *
+     * Kept in step with `LanguageDetection` in the editor-tab plugin, which is what
+     * actually selects the lexer; a disagreement between the two shows up as the
+     * tool reporting one language while the editor highlights another.
+     */
     override fun detectLanguage(filePath: String): String {
-        val extension = filePath.substringAfterLast('.', "").lowercase()
+        val fileName = filePath.substringAfterLast('/').substringAfterLast('\\')
+        languageForFileName(fileName)?.let { return it }
+        val extension = fileName.substringAfterLast('.', "").lowercase()
         return when (extension) {
             "kt", "kts" -> "kotlin"
             "java" -> "java"
@@ -110,7 +128,40 @@ class EditorContentProviderImpl : EditorContentProvider {
             "sql" -> "sql"
             "r" -> "r"
             "scala" -> "scala"
+            // Languages the editor has lexers for but this map never named.
+            "dockerfile" -> "dockerfile"
+            "mk", "mak" -> "makefile"
+            "properties", "ini", "cfg", "env" -> "properties"
+            "diff", "patch" -> "diff"
+            "bat", "cmd" -> "batch"
+            "clj", "cljs", "cljc", "edn" -> "clojure"
+            "tex", "sty", "cls", "bib" -> "latex"
+            "lisp", "lsp", "el", "scm" -> "lisp"
+            "tcl" -> "tcl"
+            "f", "f90", "f95", "f03", "for" -> "fortran"
+            "d" -> "d"
+            "pas", "dpr", "dfm" -> "delphi"
+            "vb", "vbs" -> "visualbasic"
+            "as" -> "actionscript"
+            "jsp", "jspx" -> "jsp"
             else -> "text"
+        }
+    }
+
+    /**
+     * Languages identified by file name rather than extension, so that
+     * `Dockerfile.dev` is a Dockerfile rather than whatever `.dev` might suggest.
+     */
+    private fun languageForFileName(fileName: String): String? {
+        val lower = fileName.lowercase()
+        return when {
+            lower == "dockerfile" || lower.startsWith("dockerfile.") -> "dockerfile"
+            lower == "containerfile" || lower.startsWith("containerfile.") -> "dockerfile"
+            lower == "makefile" || lower == "gnumakefile" || lower.startsWith("makefile.") -> "makefile"
+            lower == "cmakelists.txt" -> "makefile"
+            lower == ".env" || lower.startsWith(".env.") -> "properties"
+            lower == "gemfile" || lower == "rakefile" -> "ruby"
+            else -> null
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/EditorContentProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/EditorContentProviderImpl.kt
@@ -105,63 +105,85 @@ class EditorContentProviderImpl : EditorContentProvider {
         val extension = fileName.substringAfterLast('.', "").lowercase()
         return when (extension) {
             "kt", "kts" -> "kotlin"
+
             "java" -> "java"
+
             "js", "jsx" -> "javascript"
+
             "ts", "tsx" -> "typescript"
+
             "py" -> "python"
+
             "json" -> "json"
+
             "xml" -> "xml"
+
             "html", "htm" -> "html"
+
             "css" -> "css"
+
             "md" -> "markdown"
+
             "toml" -> "toml"
+
             "gradle" -> "groovy"
+
             "swift" -> "swift"
+
             "c", "h" -> "c"
+
             "cpp", "cc", "cxx", "hpp" -> "cpp"
+
             "rs" -> "rust"
+
             "go" -> "go"
+
             "rb" -> "ruby"
+
             "php" -> "php"
+
             "sh", "bash" -> "bash"
+
             "yml", "yaml" -> "yaml"
+
             "sql" -> "sql"
+
             "r" -> "r"
+
             "scala" -> "scala"
+
             // Languages the editor has lexers for but this map never named.
             "dockerfile" -> "dockerfile"
-            "mk", "mak" -> "makefile"
-            "properties", "ini", "cfg", "env" -> "properties"
-            "diff", "patch" -> "diff"
-            "bat", "cmd" -> "batch"
-            "clj", "cljs", "cljc", "edn" -> "clojure"
-            "tex", "sty", "cls", "bib" -> "latex"
-            "lisp", "lsp", "el", "scm" -> "lisp"
-            "tcl" -> "tcl"
-            "f", "f90", "f95", "f03", "for" -> "fortran"
-            "d" -> "d"
-            "pas", "dpr", "dfm" -> "delphi"
-            "vb", "vbs" -> "visualbasic"
-            "as" -> "actionscript"
-            "jsp", "jspx" -> "jsp"
-            else -> "text"
-        }
-    }
 
-    /**
-     * Languages identified by file name rather than extension, so that
-     * `Dockerfile.dev` is a Dockerfile rather than whatever `.dev` might suggest.
-     */
-    private fun languageForFileName(fileName: String): String? {
-        val lower = fileName.lowercase()
-        return when {
-            lower == "dockerfile" || lower.startsWith("dockerfile.") -> "dockerfile"
-            lower == "containerfile" || lower.startsWith("containerfile.") -> "dockerfile"
-            lower == "makefile" || lower == "gnumakefile" || lower.startsWith("makefile.") -> "makefile"
-            lower == "cmakelists.txt" -> "makefile"
-            lower == ".env" || lower.startsWith(".env.") -> "properties"
-            lower == "gemfile" || lower == "rakefile" -> "ruby"
-            else -> null
+            "mk", "mak" -> "makefile"
+
+            "properties", "ini", "cfg", "env" -> "properties"
+
+            "diff", "patch" -> "diff"
+
+            "bat", "cmd" -> "batch"
+
+            "clj", "cljs", "cljc", "edn" -> "clojure"
+
+            "tex", "sty", "cls", "bib" -> "latex"
+
+            "lisp", "lsp", "el", "scm" -> "lisp"
+
+            "tcl" -> "tcl"
+
+            "f", "f90", "f95", "f03", "for" -> "fortran"
+
+            "d" -> "d"
+
+            "pas", "dpr", "dfm" -> "delphi"
+
+            "vb", "vbs" -> "visualbasic"
+
+            "as" -> "actionscript"
+
+            "jsp", "jspx" -> "jsp"
+
+            else -> "text"
         }
     }
 
@@ -292,3 +314,23 @@ private fun DetectedMainFunction.toMainFunctionInfo(): MainFunctionInfo =
                 "packageName" to (this.packageName ?: ""),
             ),
     )
+
+/**
+ * Languages identified by file name rather than extension, so that `Dockerfile.dev`
+ * is a Dockerfile rather than whatever `.dev` might otherwise suggest.
+ *
+ * A top-level function rather than a member: it needs nothing from the provider, and
+ * as a method it pushed the class past detekt's TooManyFunctions threshold.
+ */
+private fun languageForFileName(fileName: String): String? {
+    val lower = fileName.lowercase()
+    return when {
+        lower == "dockerfile" || lower.startsWith("dockerfile.") -> "dockerfile"
+        lower == "containerfile" || lower.startsWith("containerfile.") -> "dockerfile"
+        lower == "makefile" || lower == "gnumakefile" || lower.startsWith("makefile.") -> "makefile"
+        lower == "cmakelists.txt" -> "makefile"
+        lower == ".env" || lower.startsWith(".env.") -> "properties"
+        lower == "gemfile" || lower == "rakefile" -> "ruby"
+        else -> null
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/EditorContentProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/EditorContentProviderImpl.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin.providers
 
 import ai.rever.boss.components.events.FileEventBus
 import ai.rever.boss.components.events.RunEventBus
+import ai.rever.boss.components.plugin.language.EditorLanguages
 import ai.rever.boss.components.plugin.tab_types.CodeEditorUI
 import ai.rever.boss.components.plugin.tab_types.readFileContentSafe
 import ai.rever.boss.components.plugin.tab_types.writeFileContent
@@ -87,105 +88,10 @@ class EditorContentProviderImpl : EditorContentProvider {
      * Language id for [filePath], as reported to plugins and to the
      * `editor_detect_language` MCP tool.
      *
-     * File *name* patterns are checked before the extension: the files that most
-     * need identifying have no extension at all, and an extension-only lookup can
-     * never match `Dockerfile` or `Makefile` (`substringAfterLast('.')` yields `""`).
-     *
-     * The extension is read from the file name rather than the whole path, because
-     * reading it from the path let a dot in a parent directory leak into the answer —
-     * `/srv/v1.2/Makefile` produced the "extension" `2/Makefile`.
-     *
-     * Kept in step with `LanguageDetection` in the editor-tab plugin, which is what
-     * actually selects the lexer; a disagreement between the two shows up as the
-     * tool reporting one language while the editor highlights another.
+     * Delegates to [EditorLanguages] so this and the built-in editor tab cannot
+     * give different answers for the same file.
      */
-    override fun detectLanguage(filePath: String): String {
-        val fileName = filePath.substringAfterLast('/').substringAfterLast('\\')
-        languageForFileName(fileName)?.let { return it }
-        val extension = fileName.substringAfterLast('.', "").lowercase()
-        return when (extension) {
-            "kt", "kts" -> "kotlin"
-
-            "java" -> "java"
-
-            "js", "jsx" -> "javascript"
-
-            "ts", "tsx" -> "typescript"
-
-            "py" -> "python"
-
-            "json" -> "json"
-
-            "xml" -> "xml"
-
-            "html", "htm" -> "html"
-
-            "css" -> "css"
-
-            "md" -> "markdown"
-
-            "toml" -> "toml"
-
-            "gradle" -> "groovy"
-
-            "swift" -> "swift"
-
-            "c", "h" -> "c"
-
-            "cpp", "cc", "cxx", "hpp" -> "cpp"
-
-            "rs" -> "rust"
-
-            "go" -> "go"
-
-            "rb" -> "ruby"
-
-            "php" -> "php"
-
-            "sh", "bash" -> "bash"
-
-            "yml", "yaml" -> "yaml"
-
-            "sql" -> "sql"
-
-            "r" -> "r"
-
-            "scala" -> "scala"
-
-            // Languages the editor has lexers for but this map never named.
-            "dockerfile" -> "dockerfile"
-
-            "mk", "mak" -> "makefile"
-
-            "properties", "ini", "cfg", "env" -> "properties"
-
-            "diff", "patch" -> "diff"
-
-            "bat", "cmd" -> "batch"
-
-            "clj", "cljs", "cljc", "edn" -> "clojure"
-
-            "tex", "sty", "cls", "bib" -> "latex"
-
-            "lisp", "lsp", "el", "scm" -> "lisp"
-
-            "tcl" -> "tcl"
-
-            "f", "f90", "f95", "f03", "for" -> "fortran"
-
-            "d" -> "d"
-
-            "pas", "dpr", "dfm" -> "delphi"
-
-            "vb", "vbs" -> "visualbasic"
-
-            "as" -> "actionscript"
-
-            "jsp", "jspx" -> "jsp"
-
-            else -> "text"
-        }
-    }
+    override fun detectLanguage(filePath: String): String = EditorLanguages.detect(filePath)
 
     // ============ PSI Navigation APIs ============
 
@@ -314,23 +220,3 @@ private fun DetectedMainFunction.toMainFunctionInfo(): MainFunctionInfo =
                 "packageName" to (this.packageName ?: ""),
             ),
     )
-
-/**
- * Languages identified by file name rather than extension, so that `Dockerfile.dev`
- * is a Dockerfile rather than whatever `.dev` might otherwise suggest.
- *
- * A top-level function rather than a member: it needs nothing from the provider, and
- * as a method it pushed the class past detekt's TooManyFunctions threshold.
- */
-private fun languageForFileName(fileName: String): String? {
-    val lower = fileName.lowercase()
-    return when {
-        lower == "dockerfile" || lower.startsWith("dockerfile.") -> "dockerfile"
-        lower == "containerfile" || lower.startsWith("containerfile.") -> "dockerfile"
-        lower == "makefile" || lower == "gnumakefile" || lower.startsWith("makefile.") -> "makefile"
-        lower == "cmakelists.txt" -> "makefile"
-        lower == ".env" || lower.startsWith(".env.") -> "properties"
-        lower == "gemfile" || lower == "rakefile" -> "ruby"
-        else -> null
-    }
-}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/EditorLanguageDetectionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/EditorLanguageDetectionTest.kt
@@ -63,4 +63,75 @@ class EditorLanguageDetectionTest {
         assertEquals("text", provider.detectLanguage("/a/notes.unknownext"))
         assertEquals("text", provider.detectLanguage("/a/plain"))
     }
+
+    @Test
+    fun `newly named languages are identified`() {
+        listOf(
+            "/a/build.mk" to "makefile",
+            "/a/app.properties" to "properties",
+            "/a/settings.ini" to "properties",
+            "/a/change.diff" to "diff",
+            "/a/change.patch" to "diff",
+            "/a/run.bat" to "batch",
+            "/a/core.clj" to "clojure",
+            "/a/paper.tex" to "latex",
+            "/a/init.el" to "lisp",
+            "/a/script.tcl" to "tcl",
+            "/a/solver.f90" to "fortran",
+            "/a/mod.d" to "d",
+            "/a/unit.pas" to "delphi",
+            "/a/Form.vb" to "visualbasic",
+            "/a/Main.as" to "actionscript",
+            "/a/index.jsp" to "jsp",
+        ).forEach { (path, expected) ->
+            assertEquals(expected, provider.detectLanguage(path), path)
+        }
+    }
+
+    @Test
+    fun `name patterns are case-insensitive`() {
+        assertEquals("dockerfile", provider.detectLanguage("/a/DOCKERFILE"))
+        assertEquals("makefile", provider.detectLanguage("/a/MAKEFILE"))
+        assertEquals("dockerfile", provider.detectLanguage("/a/Containerfile.dev"))
+    }
+
+    @Test
+    fun `bare Gemfile is ruby but its lockfile is not`() {
+        assertEquals("ruby", provider.detectLanguage("/a/Gemfile"))
+        assertEquals("ruby", provider.detectLanguage("/a/Rakefile"))
+        // A lockfile is generated data, not Ruby source.
+        assertEquals("text", provider.detectLanguage("/a/Gemfile.lock"))
+    }
+
+    /**
+     * CMake is not Make. Mapping it to the Make lexer would hunt for tab-indented
+     * recipes that do not exist, so it stays unhighlighted on purpose.
+     */
+    @Test
+    fun `CMakeLists is deliberately not claimed as makefile`() {
+        assertEquals("text", provider.detectLanguage("/a/CMakeLists.txt"))
+    }
+
+    /**
+     * The built-in editor tab used to carry its own smaller copy of this map. Both
+     * now call [ai.rever.boss.components.plugin.language.EditorLanguages], so a
+     * file cannot be reported as one language and highlighted as another.
+     */
+    @Test
+    fun `the provider agrees with the shared implementation`() {
+        listOf(
+            "/a/Dockerfile",
+            "/a/Makefile",
+            "/a/Main.kt",
+            "/a/Chart.yaml",
+            "/a/plain",
+        ).forEach { path ->
+            assertEquals(
+                ai.rever.boss.components.plugin.language.EditorLanguages
+                    .detect(path),
+                provider.detectLanguage(path),
+                path,
+            )
+        }
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/EditorLanguageDetectionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/EditorLanguageDetectionTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertEquals
  * language while the editor highlights another.
  */
 class EditorLanguageDetectionTest {
-
     private val provider = EditorContentProviderImpl()
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/EditorLanguageDetectionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/EditorLanguageDetectionTest.kt
@@ -1,0 +1,67 @@
+package ai.rever.boss.components.plugin.providers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guards the language mapping this provider reports to plugins and to the
+ * `editor_detect_language` MCP tool.
+ *
+ * Two things were wrong and both were silent. Extension-less files could never be
+ * identified — `Dockerfile` and `Makefile` have no extension for
+ * `substringAfterLast('.')` to find — and the extension was read from the whole
+ * path, so a dot in a parent directory leaked into the result.
+ *
+ * The mapping is duplicated in the editor-tab plugin's `LanguageDetection`, which
+ * is what actually picks the lexer. These assertions are the cheap way to notice
+ * the two drifting apart, since a mismatch surfaces only as the tool naming one
+ * language while the editor highlights another.
+ */
+class EditorLanguageDetectionTest {
+
+    private val provider = EditorContentProviderImpl()
+
+    @Test
+    fun `extension-less container and make files are identified`() {
+        assertEquals("dockerfile", provider.detectLanguage("/srv/app/Dockerfile"))
+        assertEquals("dockerfile", provider.detectLanguage("/srv/app/Containerfile"))
+        assertEquals("makefile", provider.detectLanguage("/srv/app/Makefile"))
+        assertEquals("makefile", provider.detectLanguage("/srv/app/GNUmakefile"))
+    }
+
+    @Test
+    fun `a filename pattern beats the extension`() {
+        // `.dev` must not win over the Dockerfile name.
+        assertEquals("dockerfile", provider.detectLanguage("/srv/app/Dockerfile.dev"))
+        assertEquals("dockerfile", provider.detectLanguage("/srv/app/Dockerfile.prod"))
+        assertEquals("properties", provider.detectLanguage("/srv/app/.env.local"))
+    }
+
+    @Test
+    fun `the dockerfile extension form is identified`() {
+        assertEquals("dockerfile", provider.detectLanguage("/srv/app/build.dockerfile"))
+    }
+
+    @Test
+    fun `a dot in a parent directory does not leak into the extension`() {
+        assertEquals("makefile", provider.detectLanguage("/srv/v1.2/Makefile"))
+        assertEquals("yaml", provider.detectLanguage("/srv/v1.2/values.yaml"))
+        assertEquals("text", provider.detectLanguage("/srv/v1.2/README"))
+    }
+
+    @Test
+    fun `windows separators are handled`() {
+        assertEquals("dockerfile", provider.detectLanguage("C:\\src\\app\\Dockerfile"))
+    }
+
+    @Test
+    fun `previously working mappings are unchanged`() {
+        assertEquals("kotlin", provider.detectLanguage("/a/Main.kt"))
+        assertEquals("yaml", provider.detectLanguage("/a/Chart.yaml"))
+        assertEquals("json", provider.detectLanguage("/a/package.json"))
+        assertEquals("markdown", provider.detectLanguage("/a/README.md"))
+        assertEquals("bash", provider.detectLanguage("/a/run.sh"))
+        assertEquals("text", provider.detectLanguage("/a/notes.unknownext"))
+        assertEquals("text", provider.detectLanguage("/a/plain"))
+    }
+}


### PR DESCRIPTION
Identify Dockerfiles and Makefiles in editor language detection

`detectLanguage` is what this provider reports to plugins and what the
`editor_detect_language` MCP tool answers with. It was a `when` over the
file extension only, so two classes of file could never be identified.

Extension-less files, first. `Dockerfile` and `Makefile` are the
canonical spellings and have no extension for `substringAfterLast('.')`
to find, so both returned "text". `Dockerfile.dev` failed too -- the
`.dev` extension matched nothing -- and so did `build.dockerfile`, since
"dockerfile" was absent from the map even as an extension. File name
patterns are now checked before the extension.

Second, the extension was read from the whole path rather than the file
name, so a dot in a parent directory leaked into it:
`/srv/v1.2/Makefile` produced the "extension" `2/Makefile`. It happened
to still answer "text", which is why nobody noticed.

Also names the other languages the editor has lexers for -- makefile,
properties, diff, batch, clojure, latex, lisp, tcl, fortran, d, delphi,
visualbasic, actionscript, jsp.

This mapping is duplicated in the editor-tab plugin's LanguageDetection,
which is what actually selects the lexer (see its PR #10). The two must
agree; a mismatch is invisible except as the tool naming one language
while the editor highlights another, so six tests pin the behaviour on
this side.
