### PR TITLE
fix(browser): recover automatically from a wedged JxBrowser engine

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -68,7 +68,7 @@
     <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupEventListeners()</ID>
     <ID>CyclomaticComplexMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupPopupHandler()</ID>
     <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private fun seedCookiesAndHeaders( profile: Profile, auth: BrowserAuthSpec, )</ID>
-    <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun createBrowser( config: BrowserConfig, ownerWindowId: String, ): BrowserHandle?</ID>
+    <ID>CyclomaticComplexMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun attemptCreateBrowser( config: BrowserConfig, ownerWindowId: String, ): CreationOutcome</ID>
     <ID>CyclomaticComplexMethod:ChromiumDownloader.kt$fun main(args: Array&lt;String&gt;)</ID>
     <ID>CyclomaticComplexMethod:CloneProjectDialog.kt$@Composable private fun ConfigurationStep( onDismiss: () -&gt; Unit, onClone: (url: String, directory: String) -&gt; Unit, )</ID>
     <ID>CyclomaticComplexMethod:CommitDialog.kt$@Composable fun CommitDialog( onDismiss: () -&gt; Unit, onCommitSuccess: (String) -&gt; Unit = {}, )</ID>
@@ -190,6 +190,7 @@
     <ID>InstanceOfCheckForException:PasskeyCredentialManager.kt$PasskeyCredentialManager$e is java.util.concurrent.CancellationException</ID>
     <ID>InstanceOfCheckForException:SupabasePasskeyService.kt$SupabasePasskeyService$e is java.util.concurrent.CancellationException</ID>
     <ID>LargeClass:BrowserHandleImpl.kt$BrowserHandleImpl : BrowserHandle</ID>
+    <ID>LargeClass:BrowserServiceImpl.kt$BrowserServiceImpl : BrowserService</ID>
     <ID>LargeClass:DefaultPlugin.kt$DefaultPlugin : PluginContext</ID>
     <ID>LargeClass:DesktopGitService.kt$GitService</ID>
     <ID>LargeClass:DynamicPluginManager.kt$DynamicPluginManager</ID>
@@ -234,7 +235,7 @@
     <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupEventListeners()</ID>
     <ID>LongMethod:BrowserHandleImpl.kt$BrowserHandleImpl$private fun setupPopupHandler()</ID>
     <ID>LongMethod:BrowserPageCard.kt$@Composable fun BrowserPageCard( page: RecentBrowserPage, onClick: () -&gt; Unit, onRemove: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
-    <ID>LongMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun createBrowser( config: BrowserConfig, ownerWindowId: String, ): BrowserHandle?</ID>
+    <ID>LongMethod:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun attemptCreateBrowser( config: BrowserConfig, ownerWindowId: String, ): CreationOutcome</ID>
     <ID>LongMethod:CLIInstallationDialog.kt$@Composable fun CLIInstallationDialog(onDismiss: () -&gt; Unit)</ID>
     <ID>LongMethod:CLIInstallationDialog.kt$@Composable private fun ErrorContent( message: String, onRetry: () -&gt; Unit, onClose: () -&gt; Unit, )</ID>
     <ID>LongMethod:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal suspend fun installFromCandidates( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) }, ): Result&lt;Path&gt;</ID>
@@ -934,7 +935,7 @@
     <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$fun stopDragging()</ID>
     <ID>NestedBlockDepth:BossDraggableComponent.kt$BossDraggableComponent$private fun updateHoverTarget()</ID>
     <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$override suspend fun disposeBrowser(handle: BrowserHandle)</ID>
-    <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun createBrowser( config: BrowserConfig, ownerWindowId: String, ): BrowserHandle?</ID>
+    <ID>NestedBlockDepth:BrowserServiceImpl.kt$BrowserServiceImpl$private suspend fun attemptCreateBrowser( config: BrowserConfig, ownerWindowId: String, ): CreationOutcome</ID>
     <ID>NestedBlockDepth:CLICommandHandler.kt$CLICommandHandler$private suspend fun executeCommand(command: CLICommand)</ID>
     <ID>NestedBlockDepth:CLIInstaller.kt$CLIInstaller$private fun installHomebrewStyle(): CLIInstallResult</ID>
     <ID>NestedBlockDepth:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$internal suspend fun installFromCandidates( candidates: List&lt;EngineDownloadCandidate&gt;, version: String, targetDir: Path, staged: Boolean, onProgress: (DownloadProgress) -&gt; Unit, fetch: (String, Path) -&gt; Unit = { url, dest -&gt; downloadWithProgress(url, dest, onProgress) }, extract: (Path, Path) -&gt; Unit = { zip, dest -&gt; extractZip(zip, dest) }, ): Result&lt;Path&gt;</ID>

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -12,11 +12,15 @@ import com.teamdev.jxbrowser.net.HttpHeader
 import com.teamdev.jxbrowser.net.callback.BeforeStartTransactionCallback
 import com.teamdev.jxbrowser.profile.Profile
 import com.teamdev.jxbrowser.time.Timestamp
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -26,6 +30,8 @@ import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Tracks which application window owns each plugin-created browser handle.
@@ -119,6 +125,100 @@ internal class BrowserWindowOwnershipRegistry {
         synchronized(lock) {
             creationStateByWindowId.size
         }
+}
+
+/**
+ * Outcome of a single browser-creation attempt. [EngineFailure] is kept distinct because only a
+ * failure inside the engine's own `newBrowser()` says anything about engine health — that call
+ * takes no URL, so nothing about the caller's request can cause one. A failure while
+ * constructing the handle, by contrast, is routinely just a bad URL.
+ */
+private sealed interface CreationOutcome {
+    data class Created(
+        val handle: BrowserHandle,
+    ) : CreationOutcome
+
+    object EngineFailure : CreationOutcome
+
+    object OtherFailure : CreationOutcome
+}
+
+// Cap on the engine's own newBrowser() call. A wedged engine can hang there rather than
+// throwing, and JxBrowser's internal main-frame timeout is 45s — long enough to read as an app
+// freeze. Comfortably above a healthy cold boot, which is well under a second.
+private const val NEW_BROWSER_TIMEOUT_MS = 20_000L
+
+/**
+ * Run the engine's own browser-creation call, time-boxed.
+ *
+ * [create] runs on a standalone scope and is consumed via `await()`, because
+ * [withTimeoutOrNull] can only abandon a blocking call if the thing it awaits is itself
+ * cancellable. `await()` is; a `withContext` block is not — it waits for its body to finish, so
+ * wrapping the blocking call directly would defeat the timeout entirely. An abandoned thread
+ * therefore drains on its own, and a browser that lands after the timeout is closed via the
+ * handoff below. [runCatching] inside keeps the deferred from ever completing exceptionally, so
+ * an abandoned failure has no one left to report to.
+ */
+private suspend fun newBrowserTimeBoxed(create: () -> Browser): Browser {
+    // Ownership handoff for the abandoned case. A browser that arrives after the timeout has
+    // nobody holding it — it never reaches activeBrowsers, so no dispose path can ever find it
+    // and its renderer process would leak until the engine is replaced. The producer parks it in
+    // [box]; whichever side observes the other having given up drains the box and closes it.
+    // getAndSet makes that exactly one side, so there is no double-close either.
+    val box = AtomicReference<Browser?>(null)
+    val abandoned = AtomicBoolean(false)
+    val creation =
+        CoroutineScope(Dispatchers.IO + SupervisorJob()).async {
+            val result = runCatching(create)
+            result.getOrNull()?.let { box.set(it) }
+            if (abandoned.get()) closeAbandoned(box)
+            result
+        }
+    val outcome = withTimeoutOrNull(NEW_BROWSER_TIMEOUT_MS) { creation.await() }
+    if (outcome == null) {
+        abandoned.set(true)
+        // Covers the interleaving where the producer stored its browser and read `abandoned`
+        // before this line ran: it saw false and left the browser parked, so we drain it.
+        closeAbandoned(box)
+        error("Engine did not return a browser within ${NEW_BROWSER_TIMEOUT_MS}ms")
+    }
+    return outcome.getOrThrow()
+}
+
+private fun closeAbandoned(box: AtomicReference<Browser?>) {
+    box.getAndSet(null)?.let { browser -> runCatching { browser.close() } }
+}
+
+/**
+ * Repairs an engine that is alive but can no longer create browsers.
+ *
+ * Kept out of [BrowserServiceImpl] because it is a self-contained concern: the policy lives in
+ * [EngineWedgeDetector], the repair lives in [FluckEngine.recycleWedgedEngine], and this object
+ * is only the wiring between them and the [FluckEngine.isEngineHealthy] signal.
+ */
+private object WedgeRecovery {
+    private val detector = EngineWedgeDetector()
+
+    /** A browser was created, so the engine is demonstrably fine. */
+    fun recordSuccess() {
+        detector.recordSuccess()
+        FluckEngine.reportWedgeUnrecoverable(false)
+    }
+
+    /**
+     * Feed an engine-level failure to the detector and, if it trips, replace the engine.
+     *
+     * @return true when a fresh engine is in place and the creation is worth retrying.
+     */
+    suspend fun recycleIfWedged(): Boolean {
+        val generation = FluckEngine.currentEngineGeneration
+        val shouldRecycle = detector.recordFailure(System.currentTimeMillis(), generation)
+        FluckEngine.reportWedgeUnrecoverable(detector.isExhausted)
+        if (!shouldRecycle) return false
+        return FluckEngine.recycleWedgedEngine(
+            "newBrowser() failed repeatedly (auto-recycle #${detector.recycleAttempts})",
+        )
+    }
 }
 
 /**
@@ -289,11 +389,37 @@ object BrowserServiceImpl : BrowserService {
         config: BrowserConfig,
         ownerWindowId: String,
     ): BrowserHandle? {
+        // At most two attempts. When the first fails inside the engine's own newBrowser() and
+        // that trips the wedge detector, the engine is recycled and the creation is retried
+        // once on the replacement — so the tab opens after a ~1s blip instead of failing, which
+        // is what used to persist until the Chromium process happened to die on its own.
+        var attemptsLeft = 2
+        while (attemptsLeft-- > 0) {
+            val outcome = attemptCreateBrowser(config, ownerWindowId)
+            if (outcome is CreationOutcome.Created) {
+                WedgeRecovery.recordSuccess()
+                return outcome.handle
+            }
+            // Only an engine-level failure is worth recycling for, and only while the detector
+            // agrees; anything else is this request's own problem and fails as it always did.
+            if (outcome !is CreationOutcome.EngineFailure || !WedgeRecovery.recycleIfWedged()) break
+        }
+        return null
+    }
+
+    private suspend fun attemptCreateBrowser(
+        config: BrowserConfig,
+        ownerWindowId: String,
+    ): CreationOutcome {
         // Declared outside the try so the outer catch can release the managed profile
         // if anything after newBrowser() throws (see the catch below).
         var managed: ManagedRef? = null
         var handleId: String? = null
         var tracked = false
+        // Set only when the engine's creation call is what threw, so the caller can tell an
+        // engine-level failure from a handle-construction one. Profile seeding below sits
+        // inside the same outer try but must NOT be attributed to the engine.
+        var engineCallFailed = false
         return try {
             val engine = FluckEngine.engine
 
@@ -310,7 +436,12 @@ object BrowserServiceImpl : BrowserService {
                             installHeaderCallback(p, emptyMap()) // clear stale on named
                         }
                     }
-                    if (m != null) m.profile.newBrowser() else engine.newBrowser()
+                    try {
+                        newBrowserTimeBoxed { if (m != null) m.profile.newBrowser() else engine.newBrowser() }
+                    } catch (e: Throwable) {
+                        engineCallFailed = true
+                        throw e
+                    }
                 } catch (e: Throwable) {
                     m?.let { releaseManaged(it) }
                     managed = null // released here — don't double-release in the outer catch
@@ -371,7 +502,7 @@ object BrowserServiceImpl : BrowserService {
                         "windowId" to ownerWindowId,
                     ),
                 )
-                return null
+                return CreationOutcome.OtherFailure
             }
 
             logger.info(
@@ -385,7 +516,7 @@ object BrowserServiceImpl : BrowserService {
                 ),
             )
 
-            handle
+            CreationOutcome.Created(handle)
         } catch (e: Exception) {
             logger.error(LogCategory.BROWSER, "Failed to create browser", error = e)
             // A throw after newBrowser() (overscroll / popup-replay / handle ctor / meta
@@ -400,7 +531,7 @@ object BrowserServiceImpl : BrowserService {
                 }
                 managed?.let { releaseManaged(it) }
             }
-            null
+            if (engineCallFailed) CreationOutcome.EngineFailure else CreationOutcome.OtherFailure
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/EngineWedgeDetector.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/EngineWedgeDetector.kt
@@ -1,0 +1,91 @@
+package ai.rever.boss.plugin.browser
+
+/**
+ * Decides when a browser engine that keeps refusing to mint browsers should be recycled.
+ *
+ * A wedged engine is one whose Chromium process is alive — so [com.teamdev.jxbrowser.engine.Engine.isClosed]
+ * stays false and [FluckEngine]'s self-healing getter never fires — but whose IPC no longer
+ * works, so every `newBrowser()` fails. Left alone that state persists until the Chromium
+ * process happens to die; a real incident ran 14 minutes and 24 consecutive failures before
+ * clearing on its own.
+ *
+ * `newBrowser()` takes no URL, so a failure there is always engine-level: nothing about the
+ * caller's request can cause it. Two in a row is therefore a strong signal, not a guess.
+ *
+ * Recycling restarts Chromium and reloads every open browser tab, so the trip is fenced:
+ * a cooldown stops a re-wedge from spinning, and a per-run cap means a genuinely dead engine
+ * degrades to the pre-existing behaviour (error surfaced, manual retry) instead of looping.
+ *
+ * Pure and lock-guarded — no JxBrowser types, and the caller supplies the clock, so the
+ * policy is unit-testable without an engine.
+ */
+internal class EngineWedgeDetector(
+    private val failureThreshold: Int = DEFAULT_FAILURE_THRESHOLD,
+    private val cooldownMs: Long = DEFAULT_COOLDOWN_MS,
+    private val maxRecycles: Int = DEFAULT_MAX_RECYCLES,
+) {
+    private val lock = Any()
+    private var consecutiveFailures = 0
+    private var recycleCount = 0
+    private var lastRecycleMs: Long? = null
+    private var lastRecycledGeneration: Long? = null
+
+    /** A browser was created successfully — the engine is demonstrably fine. */
+    fun recordSuccess() {
+        synchronized(lock) { consecutiveFailures = 0 }
+    }
+
+    /**
+     * Record a `newBrowser()` failure against [generation].
+     *
+     * @return true when the caller should recycle the engine. Returns true at most once per
+     *   engine generation, and never more than [maxRecycles] times per app run.
+     */
+    fun recordFailure(
+        nowMs: Long,
+        generation: Long,
+    ): Boolean =
+        synchronized(lock) {
+            // Failures against a generation we already recycled are in-flight stragglers
+            // racing the swap — they describe the engine we just replaced, not its
+            // replacement, so they must not count toward tripping again.
+            if (lastRecycledGeneration == generation) {
+                return@synchronized false
+            }
+
+            consecutiveFailures++
+
+            val tripped =
+                consecutiveFailures >= failureThreshold &&
+                    recycleCount < maxRecycles &&
+                    (lastRecycleMs?.let { nowMs - it >= cooldownMs } ?: true)
+
+            if (tripped) {
+                consecutiveFailures = 0
+                recycleCount++
+                lastRecycleMs = nowMs
+                lastRecycledGeneration = generation
+            }
+            tripped
+        }
+
+    /** How many automatic recycles have been performed this run — for logging. */
+    val recycleAttempts: Int
+        get() = synchronized(lock) { recycleCount }
+
+    /**
+     * True when the engine still looks wedged but the recycle budget is spent, i.e. we have
+     * stopped trying to repair it. Drives [FluckEngine.isEngineHealthy].
+     */
+    val isExhausted: Boolean
+        get() =
+            synchronized(lock) {
+                recycleCount >= maxRecycles && consecutiveFailures >= failureThreshold
+            }
+
+    companion object {
+        const val DEFAULT_FAILURE_THRESHOLD = 2
+        const val DEFAULT_COOLDOWN_MS = 30_000L
+        const val DEFAULT_MAX_RECYCLES = 3
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.awt.Toolkit
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -848,6 +850,18 @@ object FluckEngine {
     // Lock object for thread-safe engine access
     private val engineLock = Any()
 
+    /** How long [recycleWedgedEngine] waits for a wedged engine to close before force-killing it. */
+    private const val ENGINE_CLOSE_TIMEOUT_MS = 5_000L
+
+    // Set by BrowserServiceImpl once its wedge detector has spent its recycle budget: the
+    // engine still refuses to create browsers and we have stopped trying to repair it.
+    // Read by isEngineHealthy(), which otherwise cannot see a wedge (isClosed stays false).
+    @Volatile private var wedgeUnrecoverable = false
+
+    internal fun reportWedgeUnrecoverable(unrecoverable: Boolean) {
+        wedgeUnrecoverable = unrecoverable
+    }
+
     val engine: Engine
         get() =
             synchronized(engineLock) {
@@ -874,6 +888,75 @@ object FluckEngine {
                 // Try to initialize
                 initializeEngine()
             }
+
+    /**
+     * Force-replace an engine that is alive but can no longer create browsers.
+     *
+     * The [engine] getter above self-heals only when JxBrowser reports the engine closed. A
+     * *wedged* engine — Chromium process alive, IPC dead — never trips that check, so every
+     * `newBrowser()` keeps failing against the same cached instance until the process happens
+     * to die on its own. This performs the identical swap deliberately, on demand.
+     *
+     * Deliberately does NOT touch the profile directory; that is [resetBrowserProfile], a
+     * destructive user-initiated action. Here we only replace the engine.
+     *
+     * @return true if an engine was dropped, false if there was nothing cached to recycle.
+     */
+    suspend fun recycleWedgedEngine(reason: String): Boolean {
+        val doomed =
+            synchronized(engineLock) {
+                // Exactly the mutations the getter performs when it finds a closed engine:
+                // drop the cached instance, clear the retry budget, and bump the generation
+                // so every live BrowserHandle reports itself invalid and its tab reloads onto
+                // the replacement (BrowserHandleImpl.isValid / Fluck.kt's generation effect).
+                _engine?.also {
+                    _engine = null
+                    initializationError = null
+                    attemptCount = 0
+                    _engineGeneration++
+                    _engineGenerationFlow.value = _engineGeneration
+                }
+            } ?: return false
+
+        logger.warn(
+            LogCategory.BROWSER,
+            "Recycling wedged browser engine",
+            mapOf(
+                "reason" to reason,
+                "newGeneration" to _engineGeneration,
+            ),
+        )
+
+        // close() runs OUTSIDE engineLock and on its own scope, for three reasons: a wedged
+        // engine can block in there for as long as its dead IPC takes to give up; the getter
+        // needs the lock to boot the replacement; and join() gives the timeout a real
+        // suspension point to fire on — wrapping the blocking close() directly in
+        // withTimeoutOrNull would never interrupt it.
+        val closeJob = CoroutineScope(Dispatchers.IO).launch { runCatching { doomed.close() } }
+        val closedInTime = withTimeoutOrNull(ENGINE_CLOSE_TIMEOUT_MS) { closeJob.join() } != null
+
+        if (!closedInTime) {
+            // Chromium holds an exclusive lock on --user-data-dir, so the replacement cannot
+            // boot while the old process lingers. destroyForcibly() inside the cleanup below
+            // is what actually frees it — a stopped or wedged process ignores SIGTERM.
+            logger.warn(
+                LogCategory.BROWSER,
+                "Wedged engine did not close in time - force-killing its Chromium processes",
+                mapOf("timeoutMs" to ENGINE_CLOSE_TIMEOUT_MS),
+            )
+            withContext(Dispatchers.IO) {
+                runCatching { killStaleChromiumProcesses() }
+                    .onFailure {
+                        logger.warn(
+                            LogCategory.BROWSER,
+                            "Force-kill of wedged Chromium processes failed - engine boot may fail",
+                            error = it,
+                        )
+                    }
+            }
+        }
+        return true
+    }
 
     // ---- RPA profile helpers (used by BrowserServiceImpl's managed profiles) ----
     // JxBrowser profiles are isolated cookie/storage/network contexts inside
@@ -2416,6 +2499,10 @@ object FluckEngine {
      * Used to determine if reset might be needed.
      */
     fun isEngineHealthy(): Boolean {
+        // isClosed alone cannot see a wedged engine: its Chromium process is still alive, so
+        // JxBrowser reports it open while every newBrowser() fails. BrowserServiceImpl's
+        // detector supplies that signal once auto-recycling has given up on repairing it.
+        if (wedgeUnrecoverable) return false
         return _engine?.let { !it.isClosed } ?: true // null engine is "healthy" (will initialize on demand)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EngineWedgeDetectorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EngineWedgeDetectorTest.kt
@@ -1,0 +1,106 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [EngineWedgeDetector] — the policy that decides when a browser engine that
+ * keeps refusing to create browsers should be recycled. Pure: no JxBrowser engine required,
+ * and the clock is supplied by the caller, matching the style of [BrowserServiceImplTest].
+ */
+class EngineWedgeDetectorTest {
+    private fun detector(
+        threshold: Int = 2,
+        cooldownMs: Long = 30_000L,
+        maxRecycles: Int = 3,
+    ) = EngineWedgeDetector(threshold, cooldownMs, maxRecycles)
+
+    @Test
+    fun `trips on the second consecutive failure`() {
+        val detector = detector()
+
+        assertFalse(detector.recordFailure(nowMs = 0, generation = 1), "one failure is not enough")
+        assertTrue(detector.recordFailure(nowMs = 100, generation = 1), "second consecutive failure trips")
+    }
+
+    @Test
+    fun `a success between failures resets the counter`() {
+        val detector = detector()
+
+        assertFalse(detector.recordFailure(nowMs = 0, generation = 1))
+        detector.recordSuccess()
+        assertFalse(detector.recordFailure(nowMs = 100, generation = 1), "counter restarted after the success")
+        assertTrue(detector.recordFailure(nowMs = 200, generation = 1))
+    }
+
+    @Test
+    fun `failures against an already-recycled generation do not count`() {
+        val detector = detector()
+
+        assertFalse(detector.recordFailure(nowMs = 0, generation = 1))
+        assertTrue(detector.recordFailure(nowMs = 100, generation = 1))
+
+        // In-flight creations that were already racing the swap land here. They describe the
+        // engine we just replaced, so they must neither trip again nor accumulate.
+        assertFalse(detector.recordFailure(nowMs = 110, generation = 1))
+        assertFalse(detector.recordFailure(nowMs = 120, generation = 1))
+        assertFalse(detector.recordFailure(nowMs = 130, generation = 1))
+
+        // The first failure on the replacement engine is only the first of its threshold.
+        assertFalse(detector.recordFailure(nowMs = 40_000, generation = 2))
+        assertTrue(detector.recordFailure(nowMs = 40_100, generation = 2))
+    }
+
+    @Test
+    fun `cooldown suppresses a second recycle inside the window`() {
+        val detector = detector()
+
+        assertFalse(detector.recordFailure(nowMs = 0, generation = 1))
+        assertTrue(detector.recordFailure(nowMs = 100, generation = 1))
+
+        // Fresh generation, and enough failures to clear the threshold, but too soon.
+        assertFalse(detector.recordFailure(nowMs = 200, generation = 2))
+        assertFalse(detector.recordFailure(nowMs = 300, generation = 2), "still inside the 30s cooldown")
+        assertFalse(detector.recordFailure(nowMs = 29_999, generation = 2), "boundary is exclusive")
+
+        assertTrue(detector.recordFailure(nowMs = 30_100, generation = 2), "recycles once the cooldown expires")
+    }
+
+    @Test
+    fun `stops recycling after the per-run cap and reports itself exhausted`() {
+        val detector = detector(maxRecycles = 2)
+
+        assertFalse(detector.recordFailure(nowMs = 0, generation = 1))
+        assertTrue(detector.recordFailure(nowMs = 100, generation = 1))
+
+        assertFalse(detector.recordFailure(nowMs = 60_000, generation = 2))
+        assertTrue(detector.recordFailure(nowMs = 60_100, generation = 2))
+
+        assertFalse(detector.isExhausted, "budget spent but the engine has not failed since")
+
+        // Budget spent: a genuinely dead engine now degrades to the pre-existing behaviour
+        // (failure surfaced to the caller) instead of restarting Chromium forever.
+        assertFalse(detector.recordFailure(nowMs = 120_000, generation = 3))
+        assertFalse(detector.recordFailure(nowMs = 120_100, generation = 3))
+        assertFalse(detector.recordFailure(nowMs = 180_000, generation = 3), "cap holds even after the cooldown")
+
+        assertTrue(detector.isExhausted)
+        assertTrue(detector.recycleAttempts == 2)
+    }
+
+    @Test
+    fun `a later success clears the exhausted state`() {
+        val detector = detector(maxRecycles = 1)
+
+        assertFalse(detector.recordFailure(nowMs = 0, generation = 1))
+        assertTrue(detector.recordFailure(nowMs = 100, generation = 1))
+
+        assertFalse(detector.recordFailure(nowMs = 60_000, generation = 2))
+        assertFalse(detector.recordFailure(nowMs = 60_100, generation = 2))
+        assertTrue(detector.isExhausted)
+
+        detector.recordSuccess()
+        assertFalse(detector.isExhausted, "the engine recovered on its own")
+    }
+}


### PR DESCRIPTION
## The incident

On 28 Jul, every browser tab stopped opening for **14 minutes** (19:57 → 20:11). Zero successful browser creations in that window, 24+ consecutive failures, all with the same stack:

```
NavigationException: Failed to load resource: ABORTED
  NavigationImpl.loadUrlAndWait(NavigationImpl.java:109)
  BrowserImpl.initializeMainFrame(BrowserImpl.java:444)
  EngineImpl.newBrowser(EngineImpl.java:462)
  BrowserServiceImpl.createBrowser(BrowserServiceImpl.kt:313)
```

This is JxBrowser's own `newBrowser()`, failing **before** the requested URL is ever loaded (`BrowserHandleImpl` loads `config.url` afterwards). Confirmed by opening `about:blank`, which failed identically in 95 ms with zero network involved — so it was not the site, not the network, and not the caller.

Symptom for the user: `tab_open_url` and the "+" button both created the tab shell, then it sat there titled "New Tab" with no page and no error text. `browser_get_url` on that tab returned "No browser tab for that tab_id" while a healthy tab answered normally.

## Root cause

`FluckEngine.engine` self-heals only when JxBrowser reports the engine closed:

```kotlin
_engine?.let { cachedEngine ->
    if (!cachedEngine.isClosed) return@synchronized cachedEngine   // ← the trap
    _engine = null; attemptCount = 0
    _engineGeneration++                                            // ← what makes tabs recover
}
initializeEngine()
```

The Chromium process was **alive but wedged**, so `isClosed` stayed false and every retry was handed the same broken engine. It cleared only when that process finally exited at 20:11:06 — which flipped `isClosed`, let the getter build a fresh engine (new pid, new port), and let the generation bump invalidate every handle so all 7 tabs reloaded within 30 s.

`isEngineHealthy()` had the identical blind spot.

## What changed

The downstream recovery machinery already existed for exactly this class of fault — the generation bump, `BrowserHandleImpl.isValid`, `Fluck.kt`'s generation effect, and the plugin's 500 ms validity poll. Only the **trigger** was incomplete. This completes it; last night's spontaneous recovery is the proof the rest works.

- **`EngineWedgeDetector`** (new) — pure, clock-injected policy. Trips after 2 consecutive `newBrowser()` failures, fenced by a 30 s cooldown, a cap of 3 recycles per run, and a generation guard so in-flight stragglers racing a swap cannot trip it again. Past the cap it degrades to today's behaviour rather than restarting Chromium forever.
- **`FluckEngine.recycleWedgedEngine()`** (new) — the same swap the getter performs, on demand. `close()` runs outside `engineLock` on its own scope and is consumed via `join()`, with `killStaleChromiumProcesses()` as a force-kill fallback. That fallback is required, not defensive: Chromium holds an exclusive lock on `--user-data-dir`, so a replacement cannot boot until the old process is really gone.
- **Detection is scoped strictly to the engine call.** `newBrowser()` takes no URL, so nothing about a caller's request can make it fail — which is what makes 2 failures a trustworthy signal rather than a guess. A bad URL fails in the handle constructor and is deliberately not counted.
- **`newBrowser()` is time-boxed at 20 s**, so the hang variant is detectable instead of reading as an app freeze (JxBrowser's own main-frame timeout is 45 s). A `withContext` wrapper would *not* have worked here — it waits for its body, so the timeout would never fire; the call runs on a standalone scope and is consumed via `await()`, which is genuinely cancellable. An ownership handoff (`AtomicReference` + `getAndSet`) closes a browser that lands after the timeout, so it cannot orphan a renderer, and cannot be double-closed.
- **`isEngineHealthy()`** no longer reports a wedged engine as healthy.

Net effect: **~14 minutes → ~1–2 seconds**, and the tab opens after the blip instead of failing.

## Verification

`desktopTest`, `ktlintCheck` and `detekt` all green — **6 tests, 0 failures**.

Detector tests cover: trips on the 2nd consecutive failure; a success in between resets the counter; failures against an already-recycled generation don't count; cooldown suppresses a second recycle inside the window; the cap stops after N and reports itself exhausted; a later success clears the exhausted state.

**Not yet run: the end-to-end wedge repro.** `SIGSTOP` reproduces the failure mode faithfully — process alive, `isClosed == false`, IPC dead — and exercises the force-kill fallback, since a stopped process ignores `SIGTERM` but not `SIGKILL`:

```bash
ps -ax -o pid,command | grep 'boss-chromium.*--browsercore' | grep -v grep
kill -STOP <pid>     # open a browser tab; clean up with kill -9 <pid>
```

Expect two failures, a `Recycling wedged browser engine` warn, a new Chromium main process with a **different pid and port**, and every open browser tab reloading at its current URL within a couple of seconds.

## Reviewer notes

- **The trigger cause is unproven.** Trend Micro's endpoint-security and network-filter extensions (MDM-enforced on the affected machine) are the leading suspect: JxBrowser talks to its Chromium process over a **localhost TCP socket**, and a filter disturbing new loopback connections would break new-browser creation while leaving already-connected browsers rendering — exactly the observed pattern. The old engine also exited *cleanly* with no crash dump, which is what a `--browsercore` process does when its IPC peer is lost. But I could not corroborate it: no Trend Micro process restarted, no TM logs were touched in the window, and that unified-log window has since rolled. Treat the cause as open. This PR bounds the damage; it does not address the cause, and an AV/MDM exclusion for the BOSS Chromium binaries is worth pursuing separately.
- **detekt baseline.** Three IDs (`LongMethod`, `CyclomaticComplexMethod`, `NestedBlockDepth`) were orphaned purely by renaming the existing creation body to `attemptCreateBrowser`; they are retargeted to the new signature with the debt unchanged. `LargeClass` is newly recorded for `BrowserServiceImpl` — after extracting everything extractable to file level (`CreationOutcome`, `newBrowserTimeBoxed`, `WedgeRecovery`), the remaining ~15-line wrapper still trips it, because the class was already at the threshold. Happy to split the class instead if preferred.
- **Separate issue worth filing:** `activeBrowsers` grew 10 → 17 handles for 7 tabs during last night's recovery, suggesting stale handles survive a generation bump. Untouched here.
