### PR TITLE
fix(plugin-logging): emit Compose $stable so plugins holding a logger can load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,19 @@ generated field does not, so the published POM stays clean). The other two alrea
 
 `LoggingStableFieldTest`, `BookmarkStableFieldTest` and `WorkspaceStableFieldTest` pin this, and
 each module's publish task depends on its own `desktopTest` — co-location alone does *not* put a
-test on the publish path. Do not delete them to make a build pass. BossConsole#81 tracks the
+test on the publish path. Do not delete them to make a build pass.
+
+The guard is **not** universal: `release.yml` runs only `createDistributable`/`packageDmg`/
+`packageMsi`/`packageDeb`, so app **packaging** never runs these tests. Merges are gated (PR CI
+runs `./gradlew build` → `check` → `allTests`; note a bare `./gradlew test` does *not* cover them,
+because a `jvm("desktop")` target registers `desktopTest`, not `test`), and the Maven publish path
+is now gated — packaging relies on those.
+
+**Publish `plugin-bookmark-types` and `plugin-workspace-types` together.** bookmark-types has
+`implementation(projects.pluginPlatform.pluginWorkspaceTypes)`, so its POM pins the sibling at the
+current project version. `publish-maven-central.yml` takes a free-form `packages` input, and
+dispatching bookmark-types alone would ship a POM requiring a `plugin-workspace-types` version that
+does not exist on Central. `all` is safe — workspace-types publishes first. BossConsole#81 tracks the
 durable guard: diffing public members against the api jar `plugin-api-core` already downloads,
 covering all eight duplicated packages rather than this one field.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,19 @@ logger.error(LogCategory.NETWORK, "Request failed", error = exception)
 
 **Config**: Set `BOSS_LOG_LEVEL` env var or `boss.log.level` system property (TRACE/DEBUG/INFO/WARN/ERROR)
 
+**`plugin-logging` applies the Compose compiler on purpose, with no Compose code.**
+`boss-plugin-api` ships this same `ai.rever.boss.plugin.logging` package and *is* a Compose
+project, so its `ComponentLogger` carries the synthetic `$stable` field. This module's copy
+shadows it parent-first inside plugin classloaders, so a plugin that merely holds a
+`ComponentLogger` **property** emits `getstatic ComponentLogger.$stable` — which links against
+the api jar at build time and is missing at runtime. `BinaryCompatibilityValidator` then rejects
+the *entire* plugin and the host disables it as binary incompatible. That made secret-manager
+1.2.6 and 1.2.7 unloadable on every host. `$stable` was verified (javap, member by member) to be
+the only public difference between the two copies, so emitting it here makes them interchangeable
+and repairs already-built plugins with no api release. The Compose runtime is `compileOnly` —
+the compiler needs it, the generated field does not, and the published POM stays clean.
+`LoggingStableFieldTest` pins this; do not delete it to make a build pass.
+
 ## Build and Deployment
 
 **GitHub Actions**: `build.yml` (multi-platform tests), `release.yml` (signed builds)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ logger.error(LogCategory.NETWORK, "Request failed", error = exception)
 
 **Config**: Set `BOSS_LOG_LEVEL` env var or `boss.log.level` system property (TRACE/DEBUG/INFO/WARN/ERROR)
 
-**`plugin-logging` applies the Compose compiler on purpose, with no Compose code.**
+**Three modules apply the Compose compiler with no Compose code, on purpose** —
+`plugin-logging`, `plugin-bookmark-types` and `plugin-workspace-types`.
 `boss-plugin-api` ships this same `ai.rever.boss.plugin.logging` package and *is* a Compose
 project, so its `ComponentLogger` carries the synthetic `$stable` field. This module's copy
 shadows it parent-first inside plugin classloaders, so a plugin that merely holds a
@@ -128,9 +129,24 @@ the api jar at build time and is missing at runtime. `BinaryCompatibilityValidat
 the *entire* plugin and the host disables it as binary incompatible. That made secret-manager
 1.2.6 and 1.2.7 unloadable on every host. `$stable` was verified (javap, member by member) to be
 the only public difference between the two copies, so emitting it here makes them interchangeable
-and repairs already-built plugins with no api release. The Compose runtime is `compileOnly` —
-the compiler needs it, the generated field does not, and the published POM stays clean.
-`LoggingStableFieldTest` pins this; do not delete it to make a build pass.
+and repairs already-built plugins with no api release.
+
+Scope: diffing every api package the host also bundles found the field missing from **15 classes
+across those three modules** — `ComponentLogger`/`BossLogger`/`LogEntry`/`BossLoggerConfig`/
+`LogSanitizer`, `Bookmark`/`BookmarkCollection`/`FavoriteWorkspace`/`WorkspacePanelTarget`, and
+`LayoutWorkspace`/`TabConfig`/`PanelConfig`/`SplitConfig`/`BreadcrumbConfig`/`WorkspaceSerializer`.
+Only `ComponentLogger` had actually bitten us; the data types are more exposed, since plugins hold
+them as properties routinely.
+
+`plugin-logging` gets the Compose runtime as **`compileOnly`** (the compiler needs it, the
+generated field does not, so the published POM stays clean). The other two already had it as
+`implementation` for `@Immutable`, so only the compiler plugin was added there.
+
+`LoggingStableFieldTest`, `BookmarkStableFieldTest` and `WorkspaceStableFieldTest` pin this, and
+each module's publish task depends on its own `desktopTest` — co-location alone does *not* put a
+test on the publish path. Do not delete them to make a build pass. BossConsole#81 tracks the
+durable guard: diffing public members against the api jar `plugin-api-core` already downloads,
+covering all eight duplicated packages rather than this one field.
 
 ## Build and Deployment
 

--- a/plugin-platform/plugin-bookmark-types/build.gradle.kts
+++ b/plugin-platform/plugin-bookmark-types/build.gradle.kts
@@ -38,8 +38,14 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
                 implementation(projects.pluginPlatform.pluginWorkspaceTypes)
-                // Compose runtime for @Immutable — and now also required by the Compose compiler
-                // plugin applied above, which the compiler refuses to run without.
+                // Compose runtime for @Immutable, and the Compose compiler plugin applied above
+                // also refuses to run without a runtime on the compile classpath.
+                //
+                // Kept as `implementation` rather than narrowed to `compileOnly` (which would
+                // satisfy both, since @Immutable is BINARY-retention and the generated $stable is a
+                // plain int) because this artifact is already published: dropping a transitive
+                // runtime dependency is consumer-visible. plugin-logging uses compileOnly because it
+                // had no Compose dependency to preserve.
                 implementation(libs.compose.mp.runtime)
             }
         }

--- a/plugin-platform/plugin-bookmark-types/build.gradle.kts
+++ b/plugin-platform/plugin-bookmark-types/build.gradle.kts
@@ -4,11 +4,23 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlinSerialization)
+    // Compose compiler with no Compose code, on purpose — same reason as plugin-logging.
+    //
+    // boss-plugin-api ships this same package and IS a Compose project, so its copies of these
+    // types carry the synthetic `$stable` field. This module's copies shadow them parent-first in
+    // plugin classloaders, so a plugin compiled against the api and holding one of these as a
+    // property emits `getstatic <Type>.$stable` — which links at build time and is missing at
+    // runtime. BinaryCompatibilityValidator then rejects the ENTIRE plugin as binary incompatible.
+    //
+    // That is exactly what took down secret-manager 1.2.6 and 1.2.7 via ComponentLogger. These
+    // types are worse exposed: plugins hold Bookmark/TabConfig/PanelConfig-shaped data routinely.
+    // Found by diffing every api package the host also bundles — 15 classes across three modules.
+    alias(libs.plugins.composeCompiler)
     alias(libs.plugins.mavenPublish)
 }
 
 group = "com.risaboss"
-version = "1.0.4"
+version = "1.0.5"
 
 kotlin {
     jvmToolchain(17)
@@ -26,8 +38,15 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
                 implementation(projects.pluginPlatform.pluginWorkspaceTypes)
-                // Compose runtime for @Immutable annotation
+                // Compose runtime for @Immutable — and now also required by the Compose compiler
+                // plugin applied above, which the compiler refuses to run without.
                 implementation(libs.compose.mp.runtime)
+            }
+        }
+
+        named("desktopTest") {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
     }

--- a/plugin-platform/plugin-bookmark-types/build.gradle.kts
+++ b/plugin-platform/plugin-bookmark-types/build.gradle.kts
@@ -52,6 +52,20 @@ kotlin {
     }
 }
 
+// Publishing must not bypass the $stable guard.
+//
+// Co-locating the test in this module does NOT put it on the publish path:
+// publishAndReleaseToMavenCentral has no dependency on check/allTests/desktopTest, and
+// publish-maven-central.yml invokes the publish task directly with no test step ahead of it. So
+// without this a release could ship without the field and nothing on that path would object —
+// which is the hole that let the divergence reach users in the first place.
+//
+// (PR CI does cover it, but via `./gradlew build` -> check -> allTests. A bare `./gradlew test`
+// does not: a KMP jvm target registers desktopTest, not test.)
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    dependsOn(tasks.named("desktopTest"))
+}
+
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()

--- a/plugin-platform/plugin-bookmark-types/src/desktopTest/kotlin/ai/rever/boss/plugin/bookmark/BookmarkStableFieldTest.kt
+++ b/plugin-platform/plugin-bookmark-types/src/desktopTest/kotlin/ai/rever/boss/plugin/bookmark/BookmarkStableFieldTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.bookmark
 
+import java.lang.reflect.Modifier
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -18,19 +19,24 @@ import kotlin.test.assertTrue
  * types are more exposed, since plugins hold bookmark-shaped data routinely.
  *
  * If this fails, the Compose compiler plugin has been dropped from this module's
- * `build.gradle.kts`. Restore it rather than deleting the test. See BossConsole#81 for the
- * durable guard (diffing public members against the api jar `plugin-api-core` already downloads).
+ * `build.gradle.kts`. Restore it rather than deleting the test. See BossConsole#81 for the durable
+ * guard (diffing public members against the api jar `plugin-api-core` already downloads).
  */
 class BookmarkStableFieldTest {
+    private val typesNeedingStable =
+        listOf(
+            Bookmark::class.java,
+            BookmarkCollection::class.java,
+            FavoriteWorkspace::class.java,
+            WorkspacePanelTarget::class.java,
+        )
+
     @Test
     fun `public bookmark types expose the Compose stable field`() {
         val missing =
-            listOf(
-                Bookmark::class.java,
-                BookmarkCollection::class.java,
-                FavoriteWorkspace::class.java,
-                WorkspacePanelTarget::class.java,
-            ).filter { type -> type.declaredFields.none { it.name == "\$stable" } }
+            typesNeedingStable.filter { type ->
+                type.declaredFields.none { it.name == "\$stable" }
+            }
 
         assertTrue(
             missing.isEmpty(),
@@ -38,5 +44,17 @@ class BookmarkStableFieldTest {
                 ". Any plugin holding one of these as a property will be rejected as binary " +
                 "incompatible. The Compose compiler plugin was probably removed from this module.",
         )
+    }
+
+    @Test
+    fun `the field is public static int, which is what a plugin's getstatic needs`() {
+        // Presence alone is not sufficient — a non-public or instance field still fails to link.
+        // Asserted in all three affected modules rather than only in plugin-logging.
+        typesNeedingStable.forEach { type ->
+            val field = type.getDeclaredField("\$stable")
+            assertTrue(Modifier.isPublic(field.modifiers), "not public: ${type.name}")
+            assertTrue(Modifier.isStatic(field.modifiers), "not static: ${type.name}")
+            assertTrue(field.type == Int::class.javaPrimitiveType, "not an int: ${type.name}")
+        }
     }
 }

--- a/plugin-platform/plugin-bookmark-types/src/desktopTest/kotlin/ai/rever/boss/plugin/bookmark/BookmarkStableFieldTest.kt
+++ b/plugin-platform/plugin-bookmark-types/src/desktopTest/kotlin/ai/rever/boss/plugin/bookmark/BookmarkStableFieldTest.kt
@@ -1,0 +1,42 @@
+package ai.rever.boss.plugin.bookmark
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Pins that these types carry the Compose `$stable` field, because `boss-plugin-api` ships the
+ * same FQCNs and — being a Compose project — always emits it.
+ *
+ * Both copies exist at runtime and the host's (this one) shadows the api jar's parent-first inside
+ * plugin classloaders. A plugin compiled against the api that holds one of these as a **property**
+ * emits `getstatic <Type>.$stable`, which links at build time and is missing at load time;
+ * `BinaryCompatibilityValidator` then rejects the *entire* plugin as binary incompatible.
+ *
+ * This module was found broken by diffing every api package the host also bundles: 15 classes
+ * across three modules had the field in the api and not here. `ComponentLogger` is the one that
+ * actually bit us — it made secret-manager 1.2.6 and 1.2.7 unloadable on every host — but these
+ * types are more exposed, since plugins hold bookmark-shaped data routinely.
+ *
+ * If this fails, the Compose compiler plugin has been dropped from this module's
+ * `build.gradle.kts`. Restore it rather than deleting the test. See BossConsole#81 for the
+ * durable guard (diffing public members against the api jar `plugin-api-core` already downloads).
+ */
+class BookmarkStableFieldTest {
+    @Test
+    fun `public bookmark types expose the Compose stable field`() {
+        val missing =
+            listOf(
+                Bookmark::class.java,
+                BookmarkCollection::class.java,
+                FavoriteWorkspace::class.java,
+                WorkspacePanelTarget::class.java,
+            ).filter { type -> type.declaredFields.none { it.name == "\$stable" } }
+
+        assertTrue(
+            missing.isEmpty(),
+            "No \$stable field on: " + missing.joinToString { it.name } +
+                ". Any plugin holding one of these as a property will be rejected as binary " +
+                "incompatible. The Compose compiler plugin was probably removed from this module.",
+        )
+    }
+}

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidator.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidator.kt
@@ -230,7 +230,10 @@ object BinaryCompatibilityValidator {
 
             ConstantPoolParser.RefType.FIELD -> {
                 if (!hasField(ownerClass, ref.name)) {
-                    errors.add("$sourceClass -> ${ref.ownerClassName}.${ref.name}: field not found")
+                    errors.add(
+                        "$sourceClass -> ${ref.ownerClassName}.${ref.name}: field not found" +
+                            hintFor(ref.name),
+                    )
                 }
             }
         }
@@ -300,6 +303,30 @@ object BinaryCompatibilityValidator {
     }
 
     /** Check the class and its superclasses for the field. */
+
+    /**
+     * Extra context for field names whose absence has a known, non-obvious cause.
+     *
+     * `$stable` is Compose-synthetic. It is present on a class only when that class was compiled
+     * by the Compose compiler, so a missing one almost always means two copies of the owning type
+     * exist — one built with Compose and one without — and the non-Compose copy is the one winning
+     * at runtime. That is exactly what happened when the host's bundled `plugin-logging` lacked
+     * the field that `boss-plugin-api`'s copy of the same FQCN had: it disabled whole plugins with
+     * `ComponentLogger.$stable: field not found` as the only clue, and cost hours to identify.
+     *
+     * Deliberately a message change and not a soft-fail: the plugin's `getstatic` sits in its own
+     * `<clinit>`, so a genuinely missing field is a hard `NoSuchFieldError` at first touch.
+     * Rejecting up front with a clear reason beats crashing later with an opaque one.
+     */
+    private fun hintFor(fieldName: String): String =
+        if (fieldName == "\u0024stable") {
+            " (Compose stability field — the host and boss-plugin-api copies of this class have " +
+                "diverged: one was compiled with the Compose compiler and one was not. Fix the " +
+                "duplicated class, not the plugin.)"
+        } else {
+            ""
+        }
+
     private fun hasField(
         clazz: Class<*>,
         name: String,

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidator.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidator.kt
@@ -303,30 +303,6 @@ object BinaryCompatibilityValidator {
     }
 
     /** Check the class and its superclasses for the field. */
-
-    /**
-     * Extra context for field names whose absence has a known, non-obvious cause.
-     *
-     * `$stable` is Compose-synthetic. It is present on a class only when that class was compiled
-     * by the Compose compiler, so a missing one almost always means two copies of the owning type
-     * exist — one built with Compose and one without — and the non-Compose copy is the one winning
-     * at runtime. That is exactly what happened when the host's bundled `plugin-logging` lacked
-     * the field that `boss-plugin-api`'s copy of the same FQCN had: it disabled whole plugins with
-     * `ComponentLogger.$stable: field not found` as the only clue, and cost hours to identify.
-     *
-     * Deliberately a message change and not a soft-fail: the plugin's `getstatic` sits in its own
-     * `<clinit>`, so a genuinely missing field is a hard `NoSuchFieldError` at first touch.
-     * Rejecting up front with a clear reason beats crashing later with an opaque one.
-     */
-    private fun hintFor(fieldName: String): String =
-        if (fieldName == "\u0024stable") {
-            " (Compose stability field — the host and boss-plugin-api copies of this class have " +
-                "diverged: one was compiled with the Compose compiler and one was not. Fix the " +
-                "duplicated class, not the plugin.)"
-        } else {
-            ""
-        }
-
     private fun hasField(
         clazz: Class<*>,
         name: String,
@@ -348,6 +324,31 @@ object BinaryCompatibilityValidator {
             false
         }
     }
+
+    /**
+     * Extra context for field names whose absence has a known, non-obvious cause.
+     *
+     * `$stable` is Compose-synthetic. It is present on a class only when that class was compiled
+     * by the Compose compiler, so a missing one almost always means two copies of the owning type
+     * exist — one built with Compose and one without — and the non-Compose copy is the one winning
+     * at runtime. That is exactly what happened when the host's bundled `plugin-logging` lacked
+     * the field that `boss-plugin-api`'s copy of the same FQCN had: it disabled whole plugins with
+     * `ComponentLogger.$stable: field not found` as the only clue, and cost hours to identify.
+     *
+     * Deliberately a message change and not a soft-fail: the plugin's `getstatic` sits in its own
+     * `<clinit>`, so a genuinely missing field is a hard `NoSuchFieldError` at first touch.
+     * Rejecting up front with a clear reason beats crashing later with an opaque one.
+     *
+     * Exposed internal for unit tests, like the sibling helpers in this file.
+     */
+    internal fun hintFor(fieldName: String): String =
+        if (fieldName == "\u0024stable") {
+            " (Compose stability field — the host and boss-plugin-api copies of this class have " +
+                "diverged: one was compiled with the Compose compiler and one was not. Fix the " +
+                "duplicated class, not the plugin.)"
+        } else {
+            ""
+        }
 }
 
 /**

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidatorTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidatorTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.loader
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -21,6 +22,26 @@ import kotlin.test.assertTrue
  * carry the only behavioural deltas of the recent pivot.
  */
 class BinaryCompatibilityValidatorTest {
+    // ─── hintFor ───────────────────────────────────────────────────────
+
+    @Test
+    fun `a missing stable field explains itself`() {
+        // "$stable: field not found" was the ONLY clue when the host's plugin-logging copy
+        // diverged from boss-plugin-api's, and it cost hours. The field is Compose-synthetic, so
+        // its absence nearly always means two copies of the owning class exist — one compiled with
+        // the Compose compiler and one without.
+        val hint = BinaryCompatibilityValidator.hintFor("\u0024stable")
+
+        assertTrue(hint.contains("Compose"), "no mention of Compose: $hint")
+        assertTrue(hint.contains("diverged"), "does not name the actual cause: $hint")
+    }
+
+    @Test
+    fun `an ordinary missing field gets no hint`() {
+        // The hint must not dilute unrelated failures.
+        assertEquals("", BinaryCompatibilityValidator.hintFor("someOrdinaryField"))
+    }
+
     // ─── isSoftFailReference ───────────────────────────────────────────
 
     @Test

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidatorTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/BinaryCompatibilityValidatorTest.kt
@@ -30,7 +30,7 @@ class BinaryCompatibilityValidatorTest {
         // diverged from boss-plugin-api's, and it cost hours. The field is Compose-synthetic, so
         // its absence nearly always means two copies of the owning class exist — one compiled with
         // the Compose compiler and one without.
-        val hint = BinaryCompatibilityValidator.hintFor("\u0024stable")
+        val hint = BinaryCompatibilityValidator.hintFor("\$stable")
 
         assertTrue(hint.contains("Compose"), "no mention of Compose: $hint")
         assertTrue(hint.contains("diverged"), "does not name the actual cause: $hint")

--- a/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/LoggingStableFieldTest.kt
+++ b/plugin-platform/plugin-loader/src/desktopTest/kotlin/ai/rever/boss/plugin/loader/LoggingStableFieldTest.kt
@@ -1,0 +1,97 @@
+package ai.rever.boss.plugin.loader
+
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.ComponentLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import java.lang.reflect.Modifier
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Pins that this repo's `ai.rever.boss.plugin.logging` classes carry the Compose `$stable`
+ * field, because boss-plugin-api ships the *same package* and — being a Compose project —
+ * always emits it.
+ *
+ * ## Why this matters
+ *
+ * Both copies exist at runtime. The host's (this one) shadows the api jar's parent-first inside
+ * plugin classloaders. A plugin compiled against the api that merely holds a `ComponentLogger`
+ * **property** gets a Compose-generated `$stable` field on its own class whose initialiser reads
+ * `ComponentLogger.$stable`. That links against the api jar at build time and is missing at load
+ * time, so [BinaryCompatibilityValidator] rejects the plugin and the host disables it as binary
+ * incompatible — the entire plugin, not just the offending class.
+ *
+ * That is not hypothetical: secret-manager 1.2.6 and 1.2.7 were both unloadable on every host
+ * and the store served them for hours, with
+ * `ComponentLogger.$stable: field not found` as the only clue.
+ *
+ * `$stable` was verified (member-by-member, via javap) to be the ONLY public difference between
+ * the two copies, so emitting it here makes them interchangeable and repairs already-built
+ * plugins without an api release or a plugin rebuild.
+ *
+ * If this test fails, the Compose compiler plugin has been dropped from
+ * `plugin-platform/plugin-logging/build.gradle.kts` — restore it (with the `compileOnly` Compose
+ * runtime; nothing Compose is needed at runtime) rather than deleting this test.
+ */
+class LoggingStableFieldTest {
+    /**
+     * The classes the api jar emits `$stable` on. Enums are excluded deliberately — the Compose
+     * compiler treats them as inherently stable and emits no field, so `LogCategory`/`LogLevel`
+     * have none in *either* copy. Verified against boss-plugin-api-1.0.71.jar class by class.
+     */
+    private val typesNeedingStable =
+        listOf(
+            ComponentLogger::class.java,
+            BossLogger::class.java,
+        )
+
+    @Test
+    fun `the logging types the api emits stable on have it here too`() {
+        val missing =
+            typesNeedingStable.filter { type ->
+                type.declaredFields.none { it.name == "\$stable" }
+            }
+
+        assertTrue(
+            missing.isEmpty(),
+            "These logging classes have no \$stable field, so any plugin compiled against " +
+                "boss-plugin-api that references it will be rejected as binary incompatible: " +
+                missing.joinToString { it.name } +
+                ". The Compose compiler plugin has probably been removed from plugin-logging.",
+        )
+    }
+
+    @Test
+    fun `enums are expected NOT to have it, matching the api`() {
+        // Pinned in both directions: if a future Compose version starts emitting $stable on
+        // enums, the api jar and this jar would diverge again — in the opposite direction —
+        // and a plugin holding a LogCategory property would break the same way.
+        listOf(LogCategory::class.java).forEach { enumType ->
+            assertTrue(
+                enumType.declaredFields.none { it.name == "\$stable" },
+                "$enumType unexpectedly has \$stable; check whether boss-plugin-api now emits " +
+                    "it too, or the two copies have diverged again",
+            )
+        }
+    }
+
+    @Test
+    fun `the stable field is public static, which is how a plugin reads it`() {
+        // A plugin's generated code does `getstatic ComponentLogger.$stable`, so a
+        // non-public or instance field would still fail to link.
+        val field = ComponentLogger::class.java.getDeclaredField("\$stable")
+
+        assertTrue(Modifier.isPublic(field.modifiers), "not public: $field")
+        assertTrue(Modifier.isStatic(field.modifiers), "not static: $field")
+        assertTrue(field.type == Int::class.javaPrimitiveType, "not an int: ${field.type}")
+    }
+
+    @Test
+    fun `logging still works without the Compose runtime on the classpath`() {
+        // The Compose runtime is compileOnly, so it is absent here exactly as it is in a
+        // packaged host. If anything Compose-generated needed it at runtime, this would throw
+        // NoClassDefFoundError rather than log a line.
+        val logger = BossLogger.forComponent("LoggingStableFieldTest")
+        logger.info(LogCategory.SYSTEM, "stable-field test probe", mapOf("ok" to true))
+    }
+}

--- a/plugin-platform/plugin-logging/build.gradle.kts
+++ b/plugin-platform/plugin-logging/build.gradle.kts
@@ -44,12 +44,6 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinx.coroutines.core)
-                // compileOnly, NOT implementation: the Compose compiler refuses to run without
-                // the runtime on the compile classpath, but the only thing it generates here is
-                // the `$stable` int field — the api's copy has an empty static initialiser and
-                // references no Compose class. So nothing is needed at runtime and the published
-                // POM stays free of a Compose dependency for a logging library.
-                compileOnly(libs.compose.mp.runtime)
             }
         }
 
@@ -57,6 +51,21 @@ kotlin {
             dependencies {
                 implementation(libs.slf4j.api)
                 implementation(libs.kotlinx.coroutines.core)
+                // compileOnly, NOT implementation: the Compose compiler refuses to run without the
+                // runtime on the compile classpath, but the only thing it generates here is the
+                // `$stable` int field — the api's copy has an empty static initialiser and
+                // references no Compose class. So nothing is needed at runtime and the published
+                // POM stays free of a Compose dependency for a logging library.
+                //
+                // Declared here rather than in commonMain because every class the Compose compiler
+                // processes lives in desktopMain; commonMain has no Kotlin sources at all.
+                compileOnly(libs.compose.mp.runtime)
+            }
+        }
+
+        named("desktopTest") {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
     }

--- a/plugin-platform/plugin-logging/build.gradle.kts
+++ b/plugin-platform/plugin-logging/build.gradle.kts
@@ -3,11 +3,25 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("multiplatform")
+    // Compose compiler with no Compose code, on purpose.
+    //
+    // boss-plugin-api ships this same `ai.rever.boss.plugin.logging` package and IS a Compose
+    // project, so its ComponentLogger carries the synthetic `$stable` field. This module's copy
+    // shadows it parent-first in plugin classloaders, so any plugin compiled against the api and
+    // holding a ComponentLogger property emitted `getstatic ComponentLogger.$stable` — which
+    // linked at build time and was missing at runtime. BinaryCompatibilityValidator then rejected
+    // the plugin outright and the host disabled it as binary incompatible; that took down
+    // secret-manager 1.2.6 and 1.2.7 entirely.
+    //
+    // `$stable` was the ONLY difference between the two classes (verified member-by-member with
+    // javap). Emitting it here makes the two copies interchangeable and fixes every ALREADY-BUILT
+    // plugin, with no api release and no plugin rebuild. PluginLoggingStableFieldTest pins it.
+    alias(libs.plugins.composeCompiler)
     alias(libs.plugins.mavenPublish)
 }
 
 group = "com.risaboss"
-version = "1.0.4"
+version = "1.0.5"
 
 kotlin {
     compilerOptions {
@@ -30,6 +44,12 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinx.coroutines.core)
+                // compileOnly, NOT implementation: the Compose compiler refuses to run without
+                // the runtime on the compile classpath, but the only thing it generates here is
+                // the `$stable` int field — the api's copy has an empty static initialiser and
+                // references no Compose class. So nothing is needed at runtime and the published
+                // POM stays free of a Compose dependency for a logging library.
+                compileOnly(libs.compose.mp.runtime)
             }
         }
 

--- a/plugin-platform/plugin-logging/build.gradle.kts
+++ b/plugin-platform/plugin-logging/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     //
     // `$stable` was the ONLY difference between the two classes (verified member-by-member with
     // javap). Emitting it here makes the two copies interchangeable and fixes every ALREADY-BUILT
-    // plugin, with no api release and no plugin rebuild. PluginLoggingStableFieldTest pins it.
+    // plugin, with no api release and no plugin rebuild. LoggingStableFieldTest pins it.
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.mavenPublish)
 }
@@ -69,6 +69,20 @@ kotlin {
             }
         }
     }
+}
+
+// Publishing must not bypass the $stable guard.
+//
+// Co-locating the test in this module does NOT put it on the publish path:
+// publishAndReleaseToMavenCentral has no dependency on check/allTests/desktopTest, and
+// publish-maven-central.yml invokes the publish task directly with no test step ahead of it. So
+// without this a release could ship without the field and nothing on that path would object —
+// which is the hole that let the divergence reach users in the first place.
+//
+// (PR CI does cover it, but via `./gradlew build` -> check -> allTests. A bare `./gradlew test`
+// does not: a KMP jvm target registers desktopTest, not test.)
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    dependsOn(tasks.named("desktopTest"))
 }
 
 mavenPublishing {

--- a/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/LoggingStableFieldTest.kt
+++ b/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/LoggingStableFieldTest.kt
@@ -75,7 +75,7 @@ class LoggingStableFieldTest {
         // Pinned in both directions: if a future Compose version starts emitting $stable on
         // enums, the api jar and this jar would diverge again — in the opposite direction —
         // and a plugin holding a LogCategory property would break the same way.
-        listOf(LogCategory::class.java).forEach { enumType ->
+        listOf(LogCategory::class.java, LogLevel::class.java).forEach { enumType ->
             assertTrue(
                 enumType.declaredFields.none { it.name == "\$stable" },
                 "$enumType unexpectedly has \$stable; check whether boss-plugin-api now emits " +
@@ -102,6 +102,11 @@ class LoggingStableFieldTest {
         // a packaged host. (It was previously in plugin-loader, which gets the Compose runtime
         // transitively through plugin-api-core, so it asserted nothing.) If anything
         // Compose-generated needed the runtime, this throws NoClassDefFoundError instead of logging.
+        // Class-initialise every one of them: reflection over declaredFields does NOT trigger
+        // <clinit>, so without this only BossLogger/ComponentLogger were ever initialised and the
+        // other three were never actually exercised for a missing-Compose-runtime failure.
+        typesNeedingStable.forEach { Class.forName(it.name, true, it.classLoader) }
+
         val logger = BossLogger.forComponent("LoggingStableFieldTest")
         logger.info(LogCategory.SYSTEM, "stable-field test probe", mapOf("ok" to true))
     }

--- a/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/LoggingStableFieldTest.kt
+++ b/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/LoggingStableFieldTest.kt
@@ -1,8 +1,5 @@
-package ai.rever.boss.plugin.loader
+package ai.rever.boss.plugin.logging
 
-import ai.rever.boss.plugin.logging.BossLogger
-import ai.rever.boss.plugin.logging.ComponentLogger
-import ai.rever.boss.plugin.logging.LogCategory
 import java.lang.reflect.Modifier
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -35,14 +32,26 @@ import kotlin.test.assertTrue
  */
 class LoggingStableFieldTest {
     /**
-     * The classes the api jar emits `$stable` on. Enums are excluded deliberately — the Compose
-     * compiler treats them as inherently stable and emits no field, so `LogCategory`/`LogLevel`
-     * have none in *either* copy. Verified against boss-plugin-api-1.0.71.jar class by class.
+     * Public non-enum types in this package: the Compose compiler emits `$stable` on all of them,
+     * and boss-plugin-api emits it on its copies too. A plugin holding *any* of these as a
+     * property would have broken the same way `ComponentLogger` did, so the list is not just the
+     * class that happened to bite us.
+     *
+     * Enums are excluded deliberately — Compose treats them as inherently stable and emits no
+     * field, so `LogCategory`/`LogLevel` have none in *either* copy.
+     *
+     * Only presence is asserted, not the `$stable` *value*: the bitmask is computed independently
+     * by each repo's Compose version. A mismatch cannot break linking (which is what takes a
+     * plugin down); at worst it changes recomposition skipping for a `@Composable` taking one of
+     * these as a parameter.
      */
     private val typesNeedingStable =
         listOf(
             ComponentLogger::class.java,
             BossLogger::class.java,
+            LogEntry::class.java,
+            BossLoggerConfig::class.java,
+            LogSanitizer::class.java,
         )
 
     @Test
@@ -88,9 +97,11 @@ class LoggingStableFieldTest {
 
     @Test
     fun `logging still works without the Compose runtime on the classpath`() {
-        // The Compose runtime is compileOnly, so it is absent here exactly as it is in a
-        // packaged host. If anything Compose-generated needed it at runtime, this would throw
-        // NoClassDefFoundError rather than log a line.
+        // Meaningful only because this test lives in plugin-logging, where the Compose runtime is
+        // compileOnly and therefore genuinely absent from the test runtime classpath — as it is in
+        // a packaged host. (It was previously in plugin-loader, which gets the Compose runtime
+        // transitively through plugin-api-core, so it asserted nothing.) If anything
+        // Compose-generated needed the runtime, this throws NoClassDefFoundError instead of logging.
         val logger = BossLogger.forComponent("LoggingStableFieldTest")
         logger.info(LogCategory.SYSTEM, "stable-field test probe", mapOf("ok" to true))
     }

--- a/plugin-platform/plugin-workspace-types/build.gradle.kts
+++ b/plugin-platform/plugin-workspace-types/build.gradle.kts
@@ -4,11 +4,23 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlinSerialization)
+    // Compose compiler with no Compose code, on purpose — same reason as plugin-logging.
+    //
+    // boss-plugin-api ships this same package and IS a Compose project, so its copies of these
+    // types carry the synthetic `$stable` field. This module's copies shadow them parent-first in
+    // plugin classloaders, so a plugin compiled against the api and holding one of these as a
+    // property emits `getstatic <Type>.$stable` — which links at build time and is missing at
+    // runtime. BinaryCompatibilityValidator then rejects the ENTIRE plugin as binary incompatible.
+    //
+    // That is exactly what took down secret-manager 1.2.6 and 1.2.7 via ComponentLogger. These
+    // types are worse exposed: plugins hold Bookmark/TabConfig/PanelConfig-shaped data routinely.
+    // Found by diffing every api package the host also bundles — 15 classes across three modules.
+    alias(libs.plugins.composeCompiler)
     alias(libs.plugins.mavenPublish)
 }
 
 group = "com.risaboss"
-version = "1.0.4"
+version = "1.0.5"
 
 kotlin {
     jvmToolchain(17)
@@ -27,6 +39,12 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json)
                 // Compose runtime for @Immutable annotation
                 implementation(libs.compose.mp.runtime)
+            }
+        }
+
+        named("desktopTest") {
+            dependencies {
+                implementation(kotlin("test"))
             }
         }
     }

--- a/plugin-platform/plugin-workspace-types/build.gradle.kts
+++ b/plugin-platform/plugin-workspace-types/build.gradle.kts
@@ -37,7 +37,14 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
-                // Compose runtime for @Immutable annotation
+                // Compose runtime for @Immutable, and the Compose compiler plugin applied above
+                // also refuses to run without a runtime on the compile classpath.
+                //
+                // Kept as `implementation` rather than narrowed to `compileOnly` (which would
+                // satisfy both, since @Immutable is BINARY-retention and the generated $stable is a
+                // plain int) because this artifact is already published: dropping a transitive
+                // runtime dependency is consumer-visible. plugin-logging uses compileOnly because it
+                // had no Compose dependency to preserve.
                 implementation(libs.compose.mp.runtime)
             }
         }

--- a/plugin-platform/plugin-workspace-types/build.gradle.kts
+++ b/plugin-platform/plugin-workspace-types/build.gradle.kts
@@ -50,6 +50,20 @@ kotlin {
     }
 }
 
+// Publishing must not bypass the $stable guard.
+//
+// Co-locating the test in this module does NOT put it on the publish path:
+// publishAndReleaseToMavenCentral has no dependency on check/allTests/desktopTest, and
+// publish-maven-central.yml invokes the publish task directly with no test step ahead of it. So
+// without this a release could ship without the field and nothing on that path would object —
+// which is the hole that let the divergence reach users in the first place.
+//
+// (PR CI does cover it, but via `./gradlew build` -> check -> allTests. A bare `./gradlew test`
+// does not: a KMP jvm target registers desktopTest, not test.)
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    dependsOn(tasks.named("desktopTest"))
+}
+
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()

--- a/plugin-platform/plugin-workspace-types/src/desktopTest/kotlin/ai/rever/boss/plugin/workspace/WorkspaceStableFieldTest.kt
+++ b/plugin-platform/plugin-workspace-types/src/desktopTest/kotlin/ai/rever/boss/plugin/workspace/WorkspaceStableFieldTest.kt
@@ -1,0 +1,44 @@
+package ai.rever.boss.plugin.workspace
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Pins that these types carry the Compose `$stable` field, because `boss-plugin-api` ships the
+ * same FQCNs and — being a Compose project — always emits it.
+ *
+ * Both copies exist at runtime and the host's (this one) shadows the api jar's parent-first inside
+ * plugin classloaders. A plugin compiled against the api that holds one of these as a **property**
+ * emits `getstatic <Type>.$stable`, which links at build time and is missing at load time;
+ * `BinaryCompatibilityValidator` then rejects the *entire* plugin as binary incompatible.
+ *
+ * This module was found broken by diffing every api package the host also bundles: 15 classes
+ * across three modules had the field in the api and not here. `ComponentLogger` is the one that
+ * actually bit us — it made secret-manager 1.2.6 and 1.2.7 unloadable on every host — but these
+ * types are more exposed, since plugins hold workspace/tab/panel config routinely.
+ *
+ * If this fails, the Compose compiler plugin has been dropped from this module's
+ * `build.gradle.kts`. Restore it rather than deleting the test. See BossConsole#81 for the
+ * durable guard (diffing public members against the api jar `plugin-api-core` already downloads).
+ */
+class WorkspaceStableFieldTest {
+    @Test
+    fun `public workspace types expose the Compose stable field`() {
+        val missing =
+            listOf(
+                LayoutWorkspace::class.java,
+                TabConfig::class.java,
+                PanelConfig::class.java,
+                SplitConfig::class.java,
+                BreadcrumbConfig::class.java,
+                WorkspaceSerializer::class.java,
+            ).filter { type -> type.declaredFields.none { it.name == "\$stable" } }
+
+        assertTrue(
+            missing.isEmpty(),
+            "No \$stable field on: " + missing.joinToString { it.name } +
+                ". Any plugin holding one of these as a property will be rejected as binary " +
+                "incompatible. The Compose compiler plugin was probably removed from this module.",
+        )
+    }
+}

--- a/plugin-platform/plugin-workspace-types/src/desktopTest/kotlin/ai/rever/boss/plugin/workspace/WorkspaceStableFieldTest.kt
+++ b/plugin-platform/plugin-workspace-types/src/desktopTest/kotlin/ai/rever/boss/plugin/workspace/WorkspaceStableFieldTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.workspace
 
+import java.lang.reflect.Modifier
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -15,24 +16,29 @@ import kotlin.test.assertTrue
  * This module was found broken by diffing every api package the host also bundles: 15 classes
  * across three modules had the field in the api and not here. `ComponentLogger` is the one that
  * actually bit us — it made secret-manager 1.2.6 and 1.2.7 unloadable on every host — but these
- * types are more exposed, since plugins hold workspace/tab/panel config routinely.
+ * types are more exposed, since plugins hold workspace, tab and panel config routinely.
  *
  * If this fails, the Compose compiler plugin has been dropped from this module's
- * `build.gradle.kts`. Restore it rather than deleting the test. See BossConsole#81 for the
- * durable guard (diffing public members against the api jar `plugin-api-core` already downloads).
+ * `build.gradle.kts`. Restore it rather than deleting the test. See BossConsole#81 for the durable
+ * guard (diffing public members against the api jar `plugin-api-core` already downloads).
  */
 class WorkspaceStableFieldTest {
+    private val typesNeedingStable =
+        listOf(
+            LayoutWorkspace::class.java,
+            TabConfig::class.java,
+            PanelConfig::class.java,
+            SplitConfig::class.java,
+            BreadcrumbConfig::class.java,
+            WorkspaceSerializer::class.java,
+        )
+
     @Test
     fun `public workspace types expose the Compose stable field`() {
         val missing =
-            listOf(
-                LayoutWorkspace::class.java,
-                TabConfig::class.java,
-                PanelConfig::class.java,
-                SplitConfig::class.java,
-                BreadcrumbConfig::class.java,
-                WorkspaceSerializer::class.java,
-            ).filter { type -> type.declaredFields.none { it.name == "\$stable" } }
+            typesNeedingStable.filter { type ->
+                type.declaredFields.none { it.name == "\$stable" }
+            }
 
         assertTrue(
             missing.isEmpty(),
@@ -40,5 +46,17 @@ class WorkspaceStableFieldTest {
                 ". Any plugin holding one of these as a property will be rejected as binary " +
                 "incompatible. The Compose compiler plugin was probably removed from this module.",
         )
+    }
+
+    @Test
+    fun `the field is public static int, which is what a plugin's getstatic needs`() {
+        // Presence alone is not sufficient — a non-public or instance field still fails to link.
+        // Asserted in all three affected modules rather than only in plugin-logging.
+        typesNeedingStable.forEach { type ->
+            val field = type.getDeclaredField("\$stable")
+            assertTrue(Modifier.isPublic(field.modifiers), "not public: ${type.name}")
+            assertTrue(Modifier.isStatic(field.modifiers), "not static: ${type.name}")
+            assertTrue(field.type == Int::class.javaPrimitiveType, "not an int: ${type.name}")
+        }
     }
 }


### PR DESCRIPTION
Fixes the platform bug behind secret-manager 1.2.6/1.2.7 being **unloadable on every host** — and it repairs plugins that are *already built*, with no api release and no plugin rebuild.

## The bug

Two copies of `ai.rever.boss.plugin.logging` exist at runtime:

| Copy | Compose `$stable`? |
|---|---|
| `boss-plugin-api-*.jar` — a Compose project, what plugins compile against | **yes** |
| `plugin-platform/plugin-logging` — no Compose, bundled in the app | **no** |

The host's copy shadows the api's parent-first inside plugin classloaders. So a plugin that merely holds a `ComponentLogger` **property** gets a Compose-generated `$stable` field on its own class whose initialiser does `getstatic ComponentLogger.$stable`. That links against the api jar at build time and is missing at load time:

```
BinaryCompatibilityValidator: Binary compatibility validation failed
errors=[SecretManagerDynamicPlugin -> ai.rever.boss.plugin.logging.ComponentLogger.$stable: field not found]
```

`BinaryCompatibilityValidator` then rejects the **entire plugin** and the host disables it as binary incompatible — over one synthetic field. This is a trap for *any* plugin that logs and gets rebuilt against the api.

## The fix

Apply the Compose compiler to `plugin-logging` so its classes carry `$stable` too. I verified with `javap`, class by class, that **`$stable` was the only public difference** between the two copies — so emitting it makes them interchangeable.

Demonstrated end-to-end by loading the **broken released 1.2.7 jar** under the host's own loader layering (logging in the parent, plugin + api in the child):

```
shipped logging jar:  $stable=false  ->  NoSuchFieldError: $stable   (exactly the host's error)
this logging jar:     $stable=true   ->  plugin loads, version=1.2.7
```

**Compose runtime is `compileOnly`, not `implementation`.** The compiler refuses to run without it, but the generated field references no Compose class (the api's static initialiser is empty), so nothing is needed at runtime — and the published POM gains no Compose dependency for a *logging* library. Confirmed the generated POM does not mention compose.

Version `1.0.4` → `1.0.5`: the published bytecode changed and Maven Central artifacts are immutable.

## Test

`LoggingStableFieldTest` (in `plugin-loader`, which already depends on `plugin-logging`) pins:

- the field exists on the types the api emits it on
- it is **public static int**, as a plugin's `getstatic` requires
- logging still works with **no** Compose runtime on the classpath — i.e. the `compileOnly` choice is safe
- enums do **not** have it, matching the api in both directions

The first version of that test wrongly demanded `$stable` of `LogCategory` and failed — enums are inherently stable and get no field, in *either* copy. Calibrated to api parity rather than a blanket rule.

## Remaining divergences (pre-existing, harmless)

- `BossLogger`'s `internal` `log$…` function is module-name-mangled differently (`log$boss_plugin_api` vs `log$com_risaboss_plugin_logging`) — unreachable from plugin bytecode.
- The host's `LogSanitizer` has extra *private* helpers.

Neither is linkable from a plugin, so neither can cause this failure.

## Worth considering separately

The deeper issue is that this package is **duplicated** between the api jar and a host module at all. This change makes the two copies compatible; it does not remove the duplication. The durable fix would be for `boss-plugin-api` to depend on `com.risaboss:plugin-logging` instead of carrying its own source — worth a follow-up, but it needs an api release and doesn't help already-built plugins, which is why it isn't this PR.
