### PR TITLE
fix: contain plugin render-phase crashes instead of killing the app

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -110,27 +110,13 @@ object CrashHandler {
     }
 
     /**
-     * Report [throwable] through the normal crash path — log, crash report,
-     * dialog — without treating it as fatal.
-     *
-     * For exceptions the app has already contained and recovered from, where the
-     * user should still get a report but the window must stay alive. The render
-     * handler in main.kt uses this instead of Compose's default handler, which
-     * disposes the window (and so ends a Compose `application {}`).
-     *
-     * Note [handleCrash] does not terminate on its own — termination is the
-     * dialog's job via [terminateAfterCrash] — so this shares that path rather
-     * than duplicating it.
-     */
-    fun reportNonFatal(
-        throwable: Throwable,
-        thread: Thread = Thread.currentThread(),
-    ) {
-        handleCrash(thread, throwable)
-    }
-
-    /**
      * Handle an uncaught exception.
+     *
+     * Terminal by design, even though this function does not call
+     * [terminateAfterCrash] itself: every exit from the dialog it shows does —
+     * dismiss, submit, and Escape all end the process, and clean-and-restart
+     * deletes the data directory first. Anything that has already been contained
+     * and recovered from must therefore *not* be routed here.
      */
     private fun handleCrash(
         thread: Thread,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -110,13 +110,45 @@ object CrashHandler {
     }
 
     /**
+     * Record a crash report for something already contained and recovered from,
+     * without the dialog.
+     *
+     * The window exception handler cannot use [handleCrash]: that shows a dialog
+     * whose every exit terminates — dismiss, submit and Escape all reach
+     * [terminateAfterCrash], and clean-and-restart deletes the data directory
+     * first — so a recovered fault would end the session on Escape.
+     *
+     * It cannot skip reporting either. That handler sees *all* unattributed
+     * Compose exceptions, not just plugin ones, so a host-side layout or
+     * composition bug used to produce a full crash report and now would produce
+     * one log line and a toast. That is telemetry quietly disappearing: the bugs
+     * stop being reported, which reads as the bugs stopping.
+     *
+     * So: build and publish the report, skip the dialog, do not terminate.
+     */
+    fun recordContained(throwable: Throwable) {
+        if (isIgnorable(throwable)) return
+        try {
+            _pendingCrashReport.value = createCrashReport(throwable)
+        } catch (e: Exception) {
+            // Reporting a contained fault must never itself become a fault.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Failed to record a contained crash report",
+                mapOf("errorType" to throwable.javaClass.simpleName),
+                e,
+            )
+        }
+    }
+
+    /**
      * Handle an uncaught exception.
      *
      * Terminal by design, even though this function does not call
      * [terminateAfterCrash] itself: every exit from the dialog it shows does —
      * dismiss, submit, and Escape all end the process, and clean-and-restart
      * deletes the data directory first. Anything that has already been contained
-     * and recovered from must therefore *not* be routed here.
+     * and recovered from must go to [recordContained] instead.
      */
     private fun handleCrash(
         thread: Thread,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -110,6 +110,26 @@ object CrashHandler {
     }
 
     /**
+     * Report [throwable] through the normal crash path — log, crash report,
+     * dialog — without treating it as fatal.
+     *
+     * For exceptions the app has already contained and recovered from, where the
+     * user should still get a report but the window must stay alive. The render
+     * handler in main.kt uses this instead of Compose's default handler, which
+     * disposes the window (and so ends a Compose `application {}`).
+     *
+     * Note [handleCrash] does not terminate on its own — termination is the
+     * dialog's job via [terminateAfterCrash] — so this shares that path rather
+     * than duplicating it.
+     */
+    fun reportNonFatal(
+        throwable: Throwable,
+        thread: Thread = Thread.currentThread(),
+    ) {
+        handleCrash(thread, throwable)
+    }
+
+    /**
      * Handle an uncaught exception.
      */
     private fun handleCrash(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
@@ -25,7 +25,7 @@ package ai.rever.boss.crash
 class RenderCrashPolicy(
     private val maxFailures: Int = DEFAULT_MAX_FAILURES,
     private val windowMillis: Long = DEFAULT_WINDOW_MILLIS,
-    private val now: () -> Long = System::currentTimeMillis,
+    private val now: () -> Long = { System.nanoTime() / 1_000_000 },
 ) {
     companion object {
         /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
@@ -44,7 +44,7 @@ class RenderCrashPolicy(
      * @return true to swallow and keep the window alive, false to escalate.
      */
     @Synchronized
-    fun shouldContain(): Boolean {
+    fun recordFailureAndShouldContain(): Boolean {
         val timestamp = now()
         // Only failures inside the window count, so a healthy app that hits one
         // bad frame an hour never escalates.
@@ -58,8 +58,4 @@ class RenderCrashPolicy(
     /** Failures currently inside the window. Exposed for logging and tests. */
     @Synchronized
     fun recentFailureCount(): Int = recentFailures.size
-
-    /** Forget recorded failures, e.g. after the user recovers the session. */
-    @Synchronized
-    fun reset() = recentFailures.clear()
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
@@ -1,0 +1,65 @@
+package ai.rever.boss.crash
+
+/**
+ * Decides whether an exception escaping the Compose render loop should be
+ * contained or allowed to take the window down.
+ *
+ * Compose's default `WindowExceptionHandler` shows a dialog and **disposes the
+ * window**, which in a Compose `application {}` ends the app. That is the right
+ * answer for a genuinely unrecoverable host fault and the wrong one for a single
+ * bad frame — and until [ai.rever.boss.plugin.sandbox.ui.PluginRenderBoundary]
+ * covers every path, a plugin's layout bug can still arrive here unattributed
+ * (BossConsole-Releases#16 killed the app exactly this way).
+ *
+ * Containing unconditionally is not the answer either: if the scene is genuinely
+ * corrupt, every subsequent frame throws and the user gets an app that repaints
+ * forever without working. So: tolerate a burst, then stop pretending.
+ *
+ * [shouldContain] returns true while failures stay under [maxFailures] within
+ * [windowMillis], and false once they don't — at which point the caller should
+ * fall back to the default handler and let the app go down honestly.
+ *
+ * Thread-safe: render exceptions arrive on the AWT event thread, but nothing
+ * guarantees a single window or a single thread.
+ */
+class RenderCrashPolicy(
+    private val maxFailures: Int = DEFAULT_MAX_FAILURES,
+    private val windowMillis: Long = DEFAULT_WINDOW_MILLIS,
+    private val now: () -> Long = System::currentTimeMillis,
+) {
+    companion object {
+        /**
+         * Three is enough to ride out a transient bad frame and the retry that
+         * usually follows it, without masking a scene that throws every frame.
+         */
+        const val DEFAULT_MAX_FAILURES = 3
+        const val DEFAULT_WINDOW_MILLIS = 10_000L
+    }
+
+    private val recentFailures = ArrayDeque<Long>()
+
+    /**
+     * Record a render failure and report whether to contain it.
+     *
+     * @return true to swallow and keep the window alive, false to escalate.
+     */
+    @Synchronized
+    fun shouldContain(): Boolean {
+        val timestamp = now()
+        // Only failures inside the window count, so a healthy app that hits one
+        // bad frame an hour never escalates.
+        while (recentFailures.isNotEmpty() && timestamp - recentFailures.first() > windowMillis) {
+            recentFailures.removeFirst()
+        }
+        recentFailures.addLast(timestamp)
+        return recentFailures.size <= maxFailures
+    }
+
+    /** Failures currently inside the window. Exposed for logging and tests. */
+    @Synchronized
+    fun recentFailureCount(): Int = recentFailures.size
+
+    /** Forget recorded failures, e.g. after the user recovers the session. */
+    @Synchronized
+    fun reset() = recentFailures.clear()
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
@@ -1,0 +1,52 @@
+package ai.rever.boss.crash
+
+import ai.rever.boss.plugin.sandbox.ui.isUncontainable
+
+/**
+ * What the window exception handler should do with a throwable that escaped the
+ * Compose render loop.
+ *
+ * Split out of `main.kt` so the decision can be tested. It used to live inline in
+ * an anonymous `WindowExceptionHandler` inside `application {}`, where the one
+ * thing worth asserting — that a dead JVM is never "contained" — could only be
+ * argued for.
+ */
+enum class WindowExceptionRoute {
+    /** Attributable to a plugin; the crash interceptor owns it. */
+    PluginHandled,
+
+    /** Contain: keep the window, recover the plugin panels, tell the user. */
+    Contain,
+
+    /** Hand to Compose's default handler, which disposes the window and ends the app. */
+    Escalate,
+}
+
+/**
+ * Decide how to route [throwable].
+ *
+ * Order matters and is the point of this function:
+ *
+ * 1. **Attributed** to a plugin — the interceptor already knows what to do.
+ * 2. **Uncontainable** ([isUncontainable]) — escalate before anything else. The
+ *    render boundary rethrows [OutOfMemoryError] rather than blaming a plugin for
+ *    it, and that carve-out is worthless unless this agrees: containing here
+ *    would log, toast, and repaint every window, which under heap exhaustion is
+ *    more allocation, three times, before the circuit breaker gives up.
+ * 3. **Too many failures too fast** — the scene is not recovering, so stop
+ *    pretending. Note this consumes a slot in [policy], so it must be reached
+ *    only for faults actually eligible for containment; that is why the
+ *    uncontainable check sits above it rather than below.
+ * 4. Otherwise contain.
+ */
+fun decideWindowExceptionRoute(
+    throwable: Throwable,
+    attributedPluginId: String?,
+    policy: RenderCrashPolicy,
+): WindowExceptionRoute =
+    when {
+        attributedPluginId != null -> WindowExceptionRoute.PluginHandled
+        isUncontainable(throwable) -> WindowExceptionRoute.Escalate
+        !policy.recordFailureAndShouldContain() -> WindowExceptionRoute.Escalate
+        else -> WindowExceptionRoute.Contain
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -9,6 +9,7 @@ import ai.rever.boss.logging.GlobalLogCapture
 import ai.rever.boss.performance.PerformanceDataProviderImpl
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.plugin.sandbox.ui.PluginRenderRecovery
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.services.passkey.PasskeyPlatformInit
 import ai.rever.boss.utils.DeepLinkHandler
@@ -50,6 +51,33 @@ import javax.swing.JPopupMenu
 import kotlin.system.exitProcess
 
 private val logger = BossLogger.forComponent("Main")
+
+/**
+ * What to tell the user after an unattributed render exception.
+ *
+ * Named rather than inlined so the wording is reviewable in one place: the whole
+ * point of recovery is that the user finds out something happened, since the
+ * failure it handles previously left a silently broken window.
+ */
+private fun renderRecoveryMessage(outcome: PluginRenderRecovery.Outcome): String =
+    when (outcome) {
+        is PluginRenderRecovery.Outcome.Quarantined -> {
+            "Paused ${outcome.plugins.joinToString()} — it kept failing to render. " +
+                "Restart it from the panel menu."
+        }
+
+        is PluginRenderRecovery.Outcome.Rebuilt -> {
+            "A plugin panel failed to render and was reloaded."
+        }
+
+        PluginRenderRecovery.Outcome.Unexplained -> {
+            "A UI component keeps failing to render. No plugin accounts for it; the window is still usable."
+        }
+
+        PluginRenderRecovery.Outcome.NotPluginRelated -> {
+            "A UI component failed to render and was recovered."
+        }
+    }
 
 /**
  * Scope for fire-and-forget startup work (PSI warm-up, update-Realtime start).
@@ -502,12 +530,17 @@ fun main(args: Array<String>) {
                                     // would offer to wipe their data over a recovered hiccup.
                                     // It would also stack one crash window per failure.
                                     //
-                                    // The stack trace is already in the log above. The user
-                                    // gets a status message, which is how contained plugin
-                                    // crashes already report themselves.
+                                    // Keeping the window alive is not enough on its own: a
+                                    // repaint over a subtree that still reproduces the fault
+                                    // just leaves the user a broken window and no explanation,
+                                    // which is what containment alone actually delivered.
+                                    // Recovery rebuilds the plugin panels, and quarantines
+                                    // them if the rebuild does not take.
+                                    val outcome =
+                                        PluginRenderRecovery.onUnattributedRenderException(throwable)
                                     ai.rever.boss.components.bars.horizontal.StatusMessageManager
                                         .showMessage(
-                                            "A UI component failed to render and was recovered.",
+                                            renderRecoveryMessage(outcome),
                                             durationMs = 8000,
                                         )
                                     java.awt.Window

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -440,6 +440,11 @@ fun main(args: Array<String>) {
         @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
         val defaultExceptionHandlerFactory = LocalWindowExceptionHandlerFactory.current
 
+        // Shared across windows on purpose: a corrupted scene tends to throw from
+        // whichever window repaints next, and the question being asked is "is this
+        // app still rendering?", not "is this window still rendering?".
+        val renderCrashPolicy = remember { ai.rever.boss.crash.RenderCrashPolicy() }
+
         @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
         val pluginAwareExceptionHandlerFactory =
             remember(defaultExceptionHandlerFactory) {
@@ -464,8 +469,42 @@ fun main(args: Array<String>) {
                                 ai.rever.boss.plugin.sandbox.ui.PluginCrashInterceptor
                                     .tryHandle(pluginId, throwable)
                             } else {
-                                // Not a plugin crash — delegate to default (shows error dialog)
-                                defaultHandler.onException(throwable)
+                                // Unattributed. Compose's default handler shows a dialog and
+                                // disposes the window, which ends a Compose application {} —
+                                // too harsh for one bad frame, and reachable by a plugin whose
+                                // layout throws after its composables have returned, leaving
+                                // nothing of the plugin on the stack to attribute. That is what
+                                // took the app down in BossConsole-Releases#16.
+                                //
+                                // Contain a burst; escalate if the scene keeps throwing, since
+                                // an app that repaints forever without working is worse than
+                                // one that stops.
+                                if (renderCrashPolicy.shouldContain()) {
+                                    logger.error(
+                                        LogCategory.UI,
+                                        "Unattributed render exception — contained, window kept alive",
+                                        mapOf(
+                                            "errorType" to throwable.javaClass.simpleName,
+                                            "recentFailures" to renderCrashPolicy.recentFailureCount().toString(),
+                                        ),
+                                        throwable,
+                                    )
+                                    // Reported, but not fatal: the user gets the crash dialog
+                                    // and keeps their session.
+                                    ai.rever.boss.crash.CrashHandler.reportNonFatal(throwable)
+                                    java.awt.Window.getWindows().forEach { it.repaint() }
+                                } else {
+                                    logger.error(
+                                        LogCategory.UI,
+                                        "Render exceptions are not stopping — escalating to the default handler",
+                                        mapOf(
+                                            "errorType" to throwable.javaClass.simpleName,
+                                            "recentFailures" to renderCrashPolicy.recentFailureCount().toString(),
+                                        ),
+                                        throwable,
+                                    )
+                                    defaultHandler.onException(throwable)
+                                }
                             }
                         }
                     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -443,7 +443,11 @@ fun main(args: Array<String>) {
         // Shared across windows on purpose: a corrupted scene tends to throw from
         // whichever window repaints next, and the question being asked is "is this
         // app still rendering?", not "is this window still rendering?".
-        val renderCrashPolicy = remember { ai.rever.boss.crash.RenderCrashPolicy() }
+        val renderCrashPolicy =
+            remember {
+                ai.rever.boss.crash
+                    .RenderCrashPolicy()
+            }
 
         @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
         val pluginAwareExceptionHandlerFactory =
@@ -491,8 +495,11 @@ fun main(args: Array<String>) {
                                     )
                                     // Reported, but not fatal: the user gets the crash dialog
                                     // and keeps their session.
-                                    ai.rever.boss.crash.CrashHandler.reportNonFatal(throwable)
-                                    java.awt.Window.getWindows().forEach { it.repaint() }
+                                    ai.rever.boss.crash.CrashHandler
+                                        .reportNonFatal(throwable)
+                                    java.awt.Window
+                                        .getWindows()
+                                        .forEach { it.repaint() }
                                 } else {
                                     logger.error(
                                         LogCategory.UI,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -5,10 +5,13 @@ import ai.rever.boss.cli.CLICommandHandler
 import ai.rever.boss.cli.createBossCLI
 import ai.rever.boss.components.dialogs.ChromiumDownloadContent
 import ai.rever.boss.config.ChromiumAutoDownloader
+import ai.rever.boss.crash.WindowExceptionRoute
+import ai.rever.boss.crash.decideWindowExceptionRoute
 import ai.rever.boss.logging.GlobalLogCapture
 import ai.rever.boss.performance.PerformanceDataProviderImpl
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashInterceptor
 import ai.rever.boss.plugin.sandbox.ui.PluginRenderRecovery
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.services.passkey.PasskeyPlatformInit
@@ -485,33 +488,21 @@ fun main(args: Array<String>) {
                         val defaultHandler = defaultExceptionHandlerFactory.exceptionHandler(window)
                         return WindowExceptionHandler { throwable ->
                             val pluginId =
-                                ai.rever.boss.plugin.sandbox.ui.PluginCrashInterceptor
-                                    .attributeToPlugin(throwable)
-                            if (pluginId != null) {
-                                // Plugin crash — let the interceptor handle it (closes tab,
-                                // shows status message)
-                                logger.warn(
-                                    LogCategory.SYSTEM,
-                                    "Compose exception intercepted for plugin",
-                                    mapOf(
-                                        "pluginId" to pluginId,
-                                        "errorType" to throwable.javaClass.simpleName,
-                                    ),
-                                )
-                                ai.rever.boss.plugin.sandbox.ui.PluginCrashInterceptor
-                                    .tryHandle(pluginId, throwable)
-                            } else {
-                                // Unattributed. Compose's default handler shows a dialog and
-                                // disposes the window, which ends a Compose application {} —
-                                // too harsh for one bad frame, and reachable by a plugin whose
-                                // layout throws after its composables have returned, leaving
-                                // nothing of the plugin on the stack to attribute. That is what
-                                // took the app down in BossConsole-Releases#16.
-                                //
-                                // Contain a burst; escalate if the scene keeps throwing, since
-                                // an app that repaints forever without working is worse than
-                                // one that stops.
-                                if (renderCrashPolicy.recordFailureAndShouldContain()) {
+                                PluginCrashInterceptor.attributeToPlugin(throwable)
+                            when (decideWindowExceptionRoute(throwable, pluginId, renderCrashPolicy)) {
+                                WindowExceptionRoute.PluginHandled -> {
+                                    logger.warn(
+                                        LogCategory.SYSTEM,
+                                        "Compose exception intercepted for plugin",
+                                        mapOf(
+                                            "pluginId" to pluginId.orEmpty(),
+                                            "errorType" to throwable.javaClass.simpleName,
+                                        ),
+                                    )
+                                    PluginCrashInterceptor.tryHandle(pluginId.orEmpty(), throwable)
+                                }
+
+                                WindowExceptionRoute.Contain -> {
                                     logger.error(
                                         LogCategory.UI,
                                         "Unattributed render exception — contained, window kept alive",
@@ -521,21 +512,20 @@ fun main(args: Array<String>) {
                                         ),
                                         throwable,
                                     )
-                                    // Deliberately NOT routed through CrashHandler. Its dialog
-                                    // is terminal on every exit — dismiss, submit and Escape
-                                    // all reach terminateAfterCrash(), and clean-and-restart
-                                    // deletes ~/.boss first. Sending a contained fault there
-                                    // would end the session the moment the user pressed
-                                    // Escape, restoring exactly what this branch prevents, and
-                                    // would offer to wipe their data over a recovered hiccup.
-                                    // It would also stack one crash window per failure.
-                                    //
+                                    // Reported, but not through CrashHandler.handleCrash: that
+                                    // dialog is terminal on every exit — dismiss, submit and
+                                    // Escape all reach terminateAfterCrash(), and
+                                    // clean-and-restart deletes ~/.boss first. A recovered
+                                    // fault must not end the session on Escape. recordContained
+                                    // keeps the report and drops the dialog, so a host-side
+                                    // render bug is still visible instead of costing one log
+                                    // line and a toast.
+                                    ai.rever.boss.crash.CrashHandler
+                                        .recordContained(throwable)
                                     // Keeping the window alive is not enough on its own: a
                                     // repaint over a subtree that still reproduces the fault
-                                    // just leaves the user a broken window and no explanation,
-                                    // which is what containment alone actually delivered.
-                                    // Recovery rebuilds the plugin panels, and quarantines
-                                    // them if the rebuild does not take.
+                                    // leaves a broken window and no explanation. Recovery
+                                    // rebuilds the plugin panels, then narrows to one suspect.
                                     val outcome =
                                         PluginRenderRecovery.onUnattributedRenderException(throwable)
                                     ai.rever.boss.components.bars.horizontal.StatusMessageManager
@@ -546,10 +536,12 @@ fun main(args: Array<String>) {
                                     java.awt.Window
                                         .getWindows()
                                         .forEach { it.repaint() }
-                                } else {
+                                }
+
+                                WindowExceptionRoute.Escalate -> {
                                     logger.error(
                                         LogCategory.UI,
-                                        "Render exceptions are not stopping — escalating to the default handler",
+                                        "Render exception is not containable — escalating to the default handler",
                                         mapOf(
                                             "errorType" to throwable.javaClass.simpleName,
                                             "recentFailures" to renderCrashPolicy.recentFailureCount().toString(),

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -483,7 +483,7 @@ fun main(args: Array<String>) {
                                 // Contain a burst; escalate if the scene keeps throwing, since
                                 // an app that repaints forever without working is worse than
                                 // one that stops.
-                                if (renderCrashPolicy.shouldContain()) {
+                                if (renderCrashPolicy.recordFailureAndShouldContain()) {
                                     logger.error(
                                         LogCategory.UI,
                                         "Unattributed render exception — contained, window kept alive",
@@ -493,10 +493,23 @@ fun main(args: Array<String>) {
                                         ),
                                         throwable,
                                     )
-                                    // Reported, but not fatal: the user gets the crash dialog
-                                    // and keeps their session.
-                                    ai.rever.boss.crash.CrashHandler
-                                        .reportNonFatal(throwable)
+                                    // Deliberately NOT routed through CrashHandler. Its dialog
+                                    // is terminal on every exit — dismiss, submit and Escape
+                                    // all reach terminateAfterCrash(), and clean-and-restart
+                                    // deletes ~/.boss first. Sending a contained fault there
+                                    // would end the session the moment the user pressed
+                                    // Escape, restoring exactly what this branch prevents, and
+                                    // would offer to wipe their data over a recovered hiccup.
+                                    // It would also stack one crash window per failure.
+                                    //
+                                    // The stack trace is already in the log above. The user
+                                    // gets a status message, which is how contained plugin
+                                    // crashes already report themselves.
+                                    ai.rever.boss.components.bars.horizontal.StatusMessageManager
+                                        .showMessage(
+                                            "A UI component failed to render and was recovered.",
+                                            durationMs = 8000,
+                                        )
                                     java.awt.Window
                                         .getWindows()
                                         .forEach { it.repaint() }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
@@ -1,0 +1,100 @@
+package ai.rever.boss.crash
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the containment decision for exceptions escaping the Compose render
+ * loop.
+ *
+ * Both directions matter and they pull against each other. Containing too
+ * eagerly leaves the user an app that repaints forever without working;
+ * escalating too eagerly restores the behaviour this exists to fix, where one
+ * bad frame disposes the window and ends the session
+ * (BossConsole-Releases#16).
+ */
+class RenderCrashPolicyTest {
+    /** Controllable clock — a real one would make the window assertions timing-dependent. */
+    private class FakeClock(var now: Long = 0L) {
+        fun advance(millis: Long) {
+            now += millis
+        }
+    }
+
+    private fun policy(
+        clock: FakeClock,
+        maxFailures: Int = 3,
+        windowMillis: Long = 10_000,
+    ) = RenderCrashPolicy(maxFailures = maxFailures, windowMillis = windowMillis, now = { clock.now })
+
+    @Test
+    fun `a burst up to the limit is contained`() {
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(3) { attempt ->
+            assertTrue(policy.shouldContain(), "failure ${attempt + 1} should have been contained")
+        }
+    }
+
+    @Test
+    fun `the failure past the limit escalates`() {
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(3) { policy.shouldContain() }
+
+        assertFalse(policy.shouldContain(), "a scene that keeps throwing must not be contained forever")
+    }
+
+    @Test
+    fun `failures older than the window do not count`() {
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(3) { policy.shouldContain() }
+        clock.advance(10_001)
+
+        assertTrue(
+            policy.shouldContain(),
+            "an app that hits one bad frame long after the last one is healthy, not looping",
+        )
+        assertTrue(policy.recentFailureCount() == 1, "stale failures should have been discarded")
+    }
+
+    @Test
+    fun `failures just inside the window still count`() {
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(3) { policy.shouldContain() }
+        // Inside the window by a millisecond: this is still the same burst.
+        clock.advance(9_999)
+
+        assertFalse(policy.shouldContain(), "a failure inside the window must not reset the count")
+    }
+
+    @Test
+    fun `a slow trickle never escalates`() {
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        // One failure per minute, far apart: annoying, but the app is rendering.
+        repeat(20) {
+            assertTrue(policy.shouldContain(), "a widely spaced failure should always be contained")
+            clock.advance(60_000)
+        }
+    }
+
+    @Test
+    fun `reset forgets the burst`() {
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(3) { policy.shouldContain() }
+        policy.reset()
+
+        assertTrue(policy.shouldContain(), "reset should return the policy to a clean state")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
@@ -26,8 +26,8 @@ class RenderCrashPolicyTest {
 
     private fun policy(
         clock: FakeClock,
-        maxFailures: Int = 3,
-        windowMillis: Long = 10_000,
+        maxFailures: Int = RenderCrashPolicy.DEFAULT_MAX_FAILURES,
+        windowMillis: Long = RenderCrashPolicy.DEFAULT_WINDOW_MILLIS,
     ) = RenderCrashPolicy(maxFailures = maxFailures, windowMillis = windowMillis, now = { clock.now })
 
     @Test
@@ -36,7 +36,7 @@ class RenderCrashPolicyTest {
         val policy = policy(clock)
 
         repeat(3) { attempt ->
-            assertTrue(policy.shouldContain(), "failure ${attempt + 1} should have been contained")
+            assertTrue(policy.recordFailureAndShouldContain(), "failure ${attempt + 1} should have been contained")
         }
     }
 
@@ -45,9 +45,9 @@ class RenderCrashPolicyTest {
         val clock = FakeClock()
         val policy = policy(clock)
 
-        repeat(3) { policy.shouldContain() }
+        repeat(3) { policy.recordFailureAndShouldContain() }
 
-        assertFalse(policy.shouldContain(), "a scene that keeps throwing must not be contained forever")
+        assertFalse(policy.recordFailureAndShouldContain(), "a scene that keeps throwing must not be contained forever")
     }
 
     @Test
@@ -55,11 +55,11 @@ class RenderCrashPolicyTest {
         val clock = FakeClock()
         val policy = policy(clock)
 
-        repeat(3) { policy.shouldContain() }
+        repeat(3) { policy.recordFailureAndShouldContain() }
         clock.advance(10_001)
 
         assertTrue(
-            policy.shouldContain(),
+            policy.recordFailureAndShouldContain(),
             "an app that hits one bad frame long after the last one is healthy, not looping",
         )
         assertTrue(policy.recentFailureCount() == 1, "stale failures should have been discarded")
@@ -70,11 +70,11 @@ class RenderCrashPolicyTest {
         val clock = FakeClock()
         val policy = policy(clock)
 
-        repeat(3) { policy.shouldContain() }
+        repeat(3) { policy.recordFailureAndShouldContain() }
         // Inside the window by a millisecond: this is still the same burst.
         clock.advance(9_999)
 
-        assertFalse(policy.shouldContain(), "a failure inside the window must not reset the count")
+        assertFalse(policy.recordFailureAndShouldContain(), "a failure inside the window must not reset the count")
     }
 
     @Test
@@ -84,19 +84,20 @@ class RenderCrashPolicyTest {
 
         // One failure per minute, far apart: annoying, but the app is rendering.
         repeat(20) {
-            assertTrue(policy.shouldContain(), "a widely spaced failure should always be contained")
+            assertTrue(policy.recordFailureAndShouldContain(), "a widely spaced failure should always be contained")
             clock.advance(60_000)
         }
     }
 
     @Test
-    fun `reset forgets the burst`() {
-        val clock = FakeClock()
-        val policy = policy(clock)
+    fun `the no-arg constructor uses the documented defaults`() {
+        // main.kt constructs it with no arguments, so the defaults are the values
+        // that actually ship.
+        val policy = RenderCrashPolicy()
 
-        repeat(3) { policy.shouldContain() }
-        policy.reset()
-
-        assertTrue(policy.shouldContain(), "reset should return the policy to a clean state")
+        repeat(RenderCrashPolicy.DEFAULT_MAX_FAILURES) {
+            assertTrue(policy.recordFailureAndShouldContain(), "a failure within the default budget")
+        }
+        assertFalse(policy.recordFailureAndShouldContain(), "the failure past the default budget must escalate")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
@@ -16,7 +16,9 @@ import kotlin.test.assertTrue
  */
 class RenderCrashPolicyTest {
     /** Controllable clock — a real one would make the window assertions timing-dependent. */
-    private class FakeClock(var now: Long = 0L) {
+    private class FakeClock(
+        var now: Long = 0L,
+    ) {
         fun advance(millis: Long) {
             now += millis
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/WindowExceptionRouteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/WindowExceptionRouteTest.kt
@@ -1,0 +1,96 @@
+package ai.rever.boss.crash
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers how an exception escaping the Compose render loop is routed.
+ *
+ * The case that matters most is the one that used to be only an argument in a
+ * comment: [PluginRenderBoundary][ai.rever.boss.plugin.sandbox.ui.PluginRenderBoundary]
+ * deliberately rethrows [OutOfMemoryError] rather than blaming a plugin for a
+ * dead JVM — and that carve-out was worthless, because the rethrown error landed
+ * here and got contained anyway, which logs, toasts and repaints every window.
+ * Under heap exhaustion that is more allocation, three times over, before the
+ * circuit breaker gives up.
+ */
+class WindowExceptionRouteTest {
+    private fun policy() = RenderCrashPolicy(now = { 0L })
+
+    @Test
+    fun `an attributed plugin crash is left to the interceptor`() {
+        val route =
+            decideWindowExceptionRoute(
+                IllegalStateException("boom"),
+                attributedPluginId = "ai.rever.boss.plugin.dynamic.bookmarks",
+                policy = policy(),
+            )
+
+        assertEquals(WindowExceptionRoute.PluginHandled, route)
+    }
+
+    @Test
+    fun `an ordinary unattributed fault is contained`() {
+        val route = decideWindowExceptionRoute(IllegalStateException("boom"), null, policy())
+
+        assertEquals(WindowExceptionRoute.Contain, route)
+    }
+
+    @Test
+    fun `an OutOfMemoryError escalates instead of being contained`() {
+        val route = decideWindowExceptionRoute(OutOfMemoryError("Java heap space"), null, policy())
+
+        assertEquals(
+            WindowExceptionRoute.Escalate,
+            route,
+            "containing an OOM means repainting every window under heap exhaustion",
+        )
+    }
+
+    @Test
+    fun `a StackOverflowError escalates`() {
+        val route = decideWindowExceptionRoute(StackOverflowError(), null, policy())
+
+        assertEquals(WindowExceptionRoute.Escalate, route)
+    }
+
+    @Test
+    fun `an uncontainable error does not consume a containment slot`() {
+        // Order matters: if the uncontainable check sat below the policy call, an
+        // OOM would burn budget meant for faults that can actually be contained.
+        val policy = policy()
+        repeat(5) { decideWindowExceptionRoute(OutOfMemoryError(), null, policy) }
+
+        assertEquals(0, policy.recentFailureCount(), "escalated faults must not be recorded as containable ones")
+        assertEquals(
+            WindowExceptionRoute.Contain,
+            decideWindowExceptionRoute(IllegalStateException("boom"), null, policy),
+            "a real containable fault should still have its full budget",
+        )
+    }
+
+    @Test
+    fun `a sustained burst eventually escalates`() {
+        val policy = policy()
+        repeat(RenderCrashPolicy.DEFAULT_MAX_FAILURES) {
+            assertEquals(
+                WindowExceptionRoute.Contain,
+                decideWindowExceptionRoute(IllegalStateException("boom"), null, policy),
+            )
+        }
+
+        assertEquals(
+            WindowExceptionRoute.Escalate,
+            decideWindowExceptionRoute(IllegalStateException("boom"), null, policy),
+        )
+    }
+
+    @Test
+    fun `an attributed crash is never escalated, even when fatal`() {
+        // The interceptor owns anything it can attribute; this branch should not
+        // second-guess it.
+        val route = decideWindowExceptionRoute(OutOfMemoryError(), "some.plugin", policy())
+
+        assertEquals(WindowExceptionRoute.PluginHandled, route)
+    }
+}

--- a/plugin-platform/plugin-sandbox/build.gradle.kts
+++ b/plugin-platform/plugin-sandbox/build.gradle.kts
@@ -64,6 +64,11 @@ kotlin {
                 implementation(kotlin("test-junit5"))
                 implementation(libs.junit.jupiter)
                 implementation(libs.kotlinx.coroutines.test)
+                // PluginRenderBoundary can only be exercised by actually laying out
+                // and drawing something — the phases it guards are not reachable
+                // without a Compose runtime. Used through runComposeUiTest, which
+                // needs no JUnit4 runner and so coexists with JUnit Platform.
+                implementation(compose.desktop.uiTestJUnit4)
             }
         }
     }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -425,6 +425,13 @@ fun PluginErrorBoundary(
                 PluginRenderBoundary(
                     pluginId = pluginId,
                     onRenderCrash = { e ->
+                        // FIRST, deliberately. report() wraps this callback in a
+                        // try/catch that only logs, and `reported` is already
+                        // latched — so if anything below threw, `error` would never
+                        // be set and the panel would stay blank forever with nothing
+                        // further logged. That is the exact failure this line exists
+                        // to prevent, so it cannot run last.
+                        error = e
                         sandbox.recordError(e)
                         // The same recovery a composition crash gets: close the tab,
                         // notify, flip the observable crash state.

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -163,6 +164,34 @@ object PluginCrashRegistry {
                     .getWindows()
                     .forEach { it.repaint() }
             }
+        }
+    }
+
+    /**
+     * Record a crash *without* closing anything.
+     *
+     * [recordCrash] closes the plugin's tab when one is registered, which is right
+     * for a crash known to belong to that plugin. It is badly wrong for a render
+     * fault attributed only by "this panel happened to be on screen": quarantining
+     * suspects that way closed the user's terminal and browser tabs — destroying
+     * live sessions — because an unrelated plugin had a duplicate LazyColumn key.
+     *
+     * This flips the observable crash state only, so the panel swaps to its error
+     * fallback and stops rendering plugin content, which is what actually stops
+     * the exception recurring, while the tab and its contents stay put.
+     */
+    fun recordRenderFault(
+        pluginId: String,
+        error: Throwable,
+    ) {
+        _crashedPluginsMap[pluginId] =
+            CrashInfo(
+                error = error,
+                isBinaryIncompatibility = PluginErrorClassifier.isBinaryIncompatibility(error),
+            )
+        javax.swing.SwingUtilities.invokeLater {
+            _crashedPluginsState.value = _crashedPluginsMap.toMap()
+            onCrashNotify?.invoke(pluginId, error)
         }
     }
 
@@ -372,33 +401,49 @@ fun PluginErrorBoundary(
             },
             LocalPluginSandbox provides sandbox,
         ) {
-            // Composition crashes are caught by PluginCrashInterceptor, which can
-            // find the plugin on the stack. Measure, placement and draw run after
-            // the plugin's composables have returned, so nothing of the plugin is
-            // on the stack there and attribution fails — the window handler then
-            // treats it as a host crash and disposes the window, taking the app
-            // with it. PluginRenderBoundary makes those phases attributable by
-            // position instead.
-            PluginRenderBoundary(
-                pluginId = pluginId,
-                onRenderCrash = { e ->
-                    sandbox.recordError(e)
-                    // The same recovery a composition crash gets: close the tab,
-                    // notify, flip the observable crash state.
-                    PluginCrashRegistry.recordCrash(pluginId, e)
-                    // Set locally as well, and not redundantly. recordCrash has two
-                    // branches: with a tab registered it closes the tab and *removes*
-                    // the registry entry again, so registryCrash reads back null and
-                    // this boundary would never render its fallback. If closeAction
-                    // fails, the panel is then left blank with nothing shown and
-                    // nothing logged — the boundary reports only once. Local state is
-                    // what guarantees the user sees an error rather than an empty
-                    // panel. Safe to write here because PluginRenderBoundary hands
-                    // this callback to the EDT rather than calling it mid-render.
-                    error = e
-                },
-            ) {
-                content()
+            // Tells PluginRenderRecovery this plugin is on screen. When a render
+            // exception arrives that nobody can attribute from the stack — a
+            // direct remeasure of a node inside this subtree, which bypasses the
+            // boundary below — "which plugin panels are mounted" is the only
+            // attribution left.
+            DisposableEffect(pluginId) {
+                val unregister = PluginRenderRecovery.registerMounted(pluginId)
+                onDispose { unregister() }
+            }
+
+            // Rebuilt when recovery bumps the generation: a subcomposition left
+            // inconsistent by a half-finished measure has to be discarded, not
+            // recomposed in place — the same reason SidePanel keys on crash state.
+            key(PluginRenderRecovery.generation) {
+                // Composition crashes are caught by PluginCrashInterceptor, which
+                // can find the plugin on the stack. Measure, placement and draw run
+                // after the plugin's composables have returned, so nothing of the
+                // plugin is on the stack there and attribution fails — the window
+                // handler then treats it as a host crash and disposes the window,
+                // taking the app with it. PluginRenderBoundary makes those phases
+                // attributable by position, for the passes that flow through it.
+                PluginRenderBoundary(
+                    pluginId = pluginId,
+                    onRenderCrash = { e ->
+                        sandbox.recordError(e)
+                        // The same recovery a composition crash gets: close the tab,
+                        // notify, flip the observable crash state.
+                        PluginCrashRegistry.recordCrash(pluginId, e)
+                        // Set locally as well, and not redundantly. recordCrash has
+                        // two branches: with a tab registered it closes the tab and
+                        // *removes* the registry entry again, so registryCrash reads
+                        // back null and this boundary would never render its
+                        // fallback. If closeAction then fails, the panel is left
+                        // blank with nothing shown and nothing logged — the boundary
+                        // reports only once. Local state guarantees the user sees an
+                        // error rather than an empty panel. Safe to write here
+                        // because PluginRenderBoundary hands this callback to the
+                        // EDT rather than calling it mid-render.
+                        error = e
+                    },
+                ) {
+                    content()
+                }
             }
         }
     }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -383,12 +383,19 @@ fun PluginErrorBoundary(
                 pluginId = pluginId,
                 onRenderCrash = { e ->
                     sandbox.recordError(e)
-                    // The same recovery a composition crash gets. Note this does
-                    // not set `error` directly: recordCrash defers its state
-                    // writes to the EDT, and this runs mid-render-pass. The
-                    // registry read above (registryCrash) is what flips this
-                    // boundary to its fallback on the next frame.
+                    // The same recovery a composition crash gets: close the tab,
+                    // notify, flip the observable crash state.
                     PluginCrashRegistry.recordCrash(pluginId, e)
+                    // Set locally as well, and not redundantly. recordCrash has two
+                    // branches: with a tab registered it closes the tab and *removes*
+                    // the registry entry again, so registryCrash reads back null and
+                    // this boundary would never render its fallback. If closeAction
+                    // fails, the panel is then left blank with nothing shown and
+                    // nothing logged — the boundary reports only once. Local state is
+                    // what guarantees the user sees an error rather than an empty
+                    // panel. Safe to write here because PluginRenderBoundary hands
+                    // this callback to the EDT rather than calling it mid-render.
+                    error = e
                 },
             ) {
                 content()

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -372,7 +372,27 @@ fun PluginErrorBoundary(
             },
             LocalPluginSandbox provides sandbox,
         ) {
-            content()
+            // Composition crashes are caught by PluginCrashInterceptor, which can
+            // find the plugin on the stack. Measure, placement and draw run after
+            // the plugin's composables have returned, so nothing of the plugin is
+            // on the stack there and attribution fails — the window handler then
+            // treats it as a host crash and disposes the window, taking the app
+            // with it. PluginRenderBoundary makes those phases attributable by
+            // position instead.
+            PluginRenderBoundary(
+                pluginId = pluginId,
+                onRenderCrash = { e ->
+                    sandbox.recordError(e)
+                    // The same recovery a composition crash gets. Note this does
+                    // not set `error` directly: recordCrash defers its state
+                    // writes to the EDT, and this runs mid-render-pass. The
+                    // registry read above (registryCrash) is what flips this
+                    // boundary to its fallback on the next frame.
+                    PluginCrashRegistry.recordCrash(pluginId, e)
+                },
+            ) {
+                content()
+            }
         }
     }
 }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorFallback.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorFallback.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.plugin.sandbox.ui
 
+import ai.rever.boss.plugin.ui.BossThemeColors
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -58,7 +60,7 @@ fun PluginErrorFallback(
         modifier =
             Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.1f))
+                .background(BossThemeColors.BackgroundColor)
                 .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -76,7 +78,7 @@ fun PluginErrorFallback(
                     Icon(
                         imageVector = Icons.Outlined.Close,
                         contentDescription = "Dismiss",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        tint = BossThemeColors.TextSecondary,
                     )
                 }
             }
@@ -89,7 +91,7 @@ fun PluginErrorFallback(
             imageVector = if (isIncompatible) Icons.Outlined.SystemUpdate else Icons.Outlined.Warning,
             contentDescription = if (isIncompatible) "Update Required" else "Error",
             modifier = Modifier.size(48.dp),
-            tint = if (isIncompatible) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+            tint = if (isIncompatible) BossThemeColors.AccentColor else BossThemeColors.ErrorColor,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -98,7 +100,7 @@ fun PluginErrorFallback(
         Text(
             text = if (isIncompatible) "Plugin Update Required" else "Plugin Error",
             style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = BossThemeColors.TextPrimary,
         )
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -107,7 +109,7 @@ fun PluginErrorFallback(
         Text(
             text = pluginId,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = BossThemeColors.TextSecondary,
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -118,13 +120,14 @@ fun PluginErrorFallback(
                 Modifier
                     .fillMaxWidth(0.9f)
                     .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .background(BossThemeColors.SurfaceColor)
+                    .border(1.dp, BossThemeColors.BorderColor, RoundedCornerShape(8.dp))
                     .padding(12.dp),
         ) {
             Text(
                 text = error.javaClass.simpleName,
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.error,
+                color = BossThemeColors.ErrorColor,
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
@@ -135,7 +138,7 @@ fun PluginErrorFallback(
                         error.message ?: "Unknown error"
                     },
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = BossThemeColors.TextSecondary,
                 maxLines = 3,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -154,7 +157,8 @@ fun PluginErrorFallback(
                 onClick = onRestart,
                 colors =
                     ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
+                        containerColor = BossThemeColors.AccentColor,
+                        contentColor = BossThemeColors.BackgroundColor,
                     ),
             ) {
                 Icon(
@@ -178,7 +182,7 @@ fun PluginErrorFallback(
                     "If this problem persists, try restarting the application."
                 },
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            color = BossThemeColors.TextMuted,
             textAlign = TextAlign.Center,
         )
     }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginExtensionBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginExtensionBoundary.kt
@@ -99,6 +99,10 @@ fun PluginExtensionBoundary(
             // see PluginRenderBoundary.
             PluginRenderBoundary(
                 pluginId = pluginId,
+                // Writing snapshot state straight from a render pass would
+                // invalidate the composition currently being laid out;
+                // PluginRenderBoundary hands this callback to the EDT for exactly
+                // that reason, so these two writes are safe here.
                 onRenderCrash = { t ->
                     error = t
                     crashCount++

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginExtensionBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginExtensionBoundary.kt
@@ -92,7 +92,20 @@ fun PluginExtensionBoundary(
         if (e != null) {
             fallback(e)
         } else {
-            content()
+            // The interceptor above only reaches composition crashes, where the
+            // plugin is on the stack. A status-bar item or settings page that
+            // throws while being measured or drawn leaves no plugin frame behind
+            // and would otherwise escape to the window handler and kill the app —
+            // see PluginRenderBoundary.
+            PluginRenderBoundary(
+                pluginId = pluginId,
+                onRenderCrash = { t ->
+                    error = t
+                    crashCount++
+                },
+            ) {
+                content()
+            }
         }
     }
 }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
@@ -1,0 +1,154 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.layout.Layout
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Contains exceptions thrown while *rendering* a plugin's subtree — during
+ * measure, placement or draw — and attributes them to [pluginId] by position in
+ * the tree rather than by inspecting stack frames.
+ *
+ * ### Why this exists
+ *
+ * [PluginCrashInterceptor] attributes a crash by looking for the plugin in the
+ * stack: a sandbox thread name, a class whose name starts with the plugin id, or
+ * a class loadable from the plugin's classloader. That works for exceptions
+ * thrown *during composition*, which is what it was built for — a
+ * `NoSuchMethodError` from a binary incompatibility has the plugin's own frames
+ * on the stack.
+ *
+ * It cannot work for the layout phases. By the time Compose measures a subtree,
+ * the plugin's composable functions have already run and returned; all they did
+ * was emit `LayoutNode`s. Compose walks those nodes later from its own loop, so
+ * the stack holds nothing but `androidx.compose.*` frames and nothing anywhere
+ * records which plugin owns a node. Attribution returns null, and the window
+ * handler in main.kt then treats it as a host crash — which disposes the window
+ * and takes the whole app down.
+ *
+ * That is not hypothetical: BossConsole-Releases#16 was a bookmarks-plugin bug
+ * (two LazyColumn items under one key, so one `LayoutNode` was measured twice in
+ * a pass) that killed BossConsole with
+ * `IllegalStateException: layout state is not idle before measure starts`, and
+ * the reported stack trace contains not one plugin frame.
+ *
+ * This boundary sidesteps attribution entirely: whatever is thrown underneath it
+ * belongs to the plugin it wraps, because of where it sits.
+ *
+ * ### What happens on a crash
+ *
+ * The throw is swallowed for the current frame, the subtree collapses to the
+ * minimum size the parent allows, and [onRenderCrash] is invoked. That records
+ * the crash, which tears the subtree down and rebuilds it so
+ * [PluginErrorBoundary] can render its fallback — the same recovery path a
+ * composition crash already takes.
+ *
+ * Reported once per boundary instance. A failing measure is usually retried
+ * several times before the rebuild lands, and one broken panel should not
+ * produce a burst of identical crash records.
+ *
+ * ### What it does not cover
+ *
+ * Compose can re-measure a dirty node *directly*, using its last constraints,
+ * without walking down from its ancestors. When that node is inside the plugin
+ * subtree this boundary is not on the stack and cannot intercept. The reported
+ * crash did enter through the ancestors, and a size change from such a remeasure
+ * propagates upward and re-enters here on the next pass — but the gap is real,
+ * which is why the window handler must also stop treating an unattributed render
+ * exception as fatal.
+ *
+ * @param pluginId Plugin that owns [content]; used only for logging here.
+ * @param onRenderCrash Invoked at most once, on the render thread, with the
+ *   throwable. Must be cheap and must not itself throw — see
+ *   [PluginCrashRegistry.recordCrash], which defers its state writes to the EDT
+ *   precisely so it is safe to call from inside a render pass.
+ */
+@Composable
+internal fun PluginRenderBoundary(
+    pluginId: String,
+    onRenderCrash: (Throwable) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val logger = remember { BossLogger.forComponent("PluginRenderBoundary") }
+    val reported = remember(pluginId) { AtomicBoolean(false) }
+
+    // Not a composable: called from measure, placement and draw.
+    fun report(
+        phase: String,
+        error: Throwable,
+    ) {
+        // A cancelled composition and a dead JVM are not the plugin's to own, and
+        // swallowing either would do more harm than the crash.
+        if (error is CancellationException || error is OutOfMemoryError) throw error
+
+        if (!reported.compareAndSet(false, true)) return
+
+        logger.error(
+            LogCategory.UI,
+            "Plugin crashed during $phase — containing it and rebuilding the panel",
+            mapOf(
+                "pluginId" to pluginId,
+                "phase" to phase,
+                "errorType" to error::class.simpleName.orEmpty(),
+            ),
+            error,
+        )
+        try {
+            onRenderCrash(error)
+        } catch (secondary: Throwable) {
+            if (secondary is CancellationException || secondary is OutOfMemoryError) throw secondary
+            // The handler failing must not turn a contained crash into a fatal one.
+            logger.warn(
+                LogCategory.UI,
+                "Crash handler threw while containing a render crash",
+                mapOf("pluginId" to pluginId),
+                secondary,
+            )
+        }
+    }
+
+    Layout(
+        content = content,
+        modifier =
+            Modifier.drawWithContent {
+                try {
+                    drawContent()
+                } catch (t: Throwable) {
+                    report("draw", t)
+                }
+            },
+    ) { measurables, constraints ->
+        // Box semantics: children see relaxed minimums so a wrap-content host
+        // (a status bar item, say) is not forced to expand, while a child that
+        // asks to fill still fills.
+        val childConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+
+        val placeables =
+            try {
+                measurables.map { it.measure(childConstraints) }
+            } catch (t: Throwable) {
+                report("measure", t)
+                // Deliberately no children: measuring again this frame would just
+                // hit the same throw. The rebuild triggered by onRenderCrash
+                // replaces this subtree on a later frame.
+                emptyList()
+            }
+
+        val width = (placeables.maxOfOrNull { it.width } ?: 0).coerceIn(constraints.minWidth, constraints.maxWidth)
+        val height = (placeables.maxOfOrNull { it.height } ?: 0).coerceIn(constraints.minHeight, constraints.maxHeight)
+
+        layout(width, height) {
+            try {
+                placeables.forEach { it.place(0, 0) }
+            } catch (t: Throwable) {
+                report("placement", t)
+            }
+        }
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
@@ -69,6 +69,12 @@ import kotlin.coroutines.cancellation.CancellationException
  *   [PluginCrashRegistry.recordCrash], which defers its state writes to the EDT
  *   precisely so it is safe to call from inside a render pass.
  */
+
+// Catching Throwable is this function's entire contract: a boundary that only
+// caught the exception types it could predict would not be a boundary. The
+// narrowing that does matter is [rethrowIfUncontainable], applied first at every
+// catch site.
+@Suppress("TooGenericExceptionCaught")
 @Composable
 internal fun PluginRenderBoundary(
     pluginId: String,
@@ -78,15 +84,12 @@ internal fun PluginRenderBoundary(
     val logger = remember { BossLogger.forComponent("PluginRenderBoundary") }
     val reported = remember(pluginId) { AtomicBoolean(false) }
 
-    // Not a composable: called from measure, placement and draw.
+    // Not a composable: called from measure, placement and draw, each of which has
+    // already run rethrowIfUncontainable on the throwable.
     fun report(
         phase: String,
         error: Throwable,
     ) {
-        // A cancelled composition and a dead JVM are not the plugin's to own, and
-        // swallowing either would do more harm than the crash.
-        if (error is CancellationException || error is OutOfMemoryError) throw error
-
         if (!reported.compareAndSet(false, true)) return
 
         logger.error(
@@ -102,7 +105,7 @@ internal fun PluginRenderBoundary(
         try {
             onRenderCrash(error)
         } catch (secondary: Throwable) {
-            if (secondary is CancellationException || secondary is OutOfMemoryError) throw secondary
+            secondary.rethrowIfUncontainable()
             // The handler failing must not turn a contained crash into a fatal one.
             logger.warn(
                 LogCategory.UI,
@@ -120,6 +123,7 @@ internal fun PluginRenderBoundary(
                 try {
                     drawContent()
                 } catch (t: Throwable) {
+                    t.rethrowIfUncontainable()
                     report("draw", t)
                 }
             },
@@ -133,6 +137,7 @@ internal fun PluginRenderBoundary(
             try {
                 measurables.map { it.measure(childConstraints) }
             } catch (t: Throwable) {
+                t.rethrowIfUncontainable()
                 report("measure", t)
                 // Deliberately no children: measuring again this frame would just
                 // hit the same throw. The rebuild triggered by onRenderCrash
@@ -147,8 +152,26 @@ internal fun PluginRenderBoundary(
             try {
                 placeables.forEach { it.place(0, 0) }
             } catch (t: Throwable) {
+                t.rethrowIfUncontainable()
                 report("placement", t)
             }
         }
     }
+}
+
+/**
+ * Rethrow what a plugin boundary has no business containing.
+ *
+ * A cancelled composition is control flow, not a fault, and swallowing it would
+ * strand whoever is awaiting the cancellation. An [OutOfMemoryError] says the JVM
+ * is done; reporting it as "this plugin crashed" would be both wrong and a
+ * distraction from the real problem.
+ *
+ * Deliberately not a `when` inside each catch block: pulled out here it stays one
+ * decision in one place, applied identically by measure, placement, draw and the
+ * crash handler itself.
+ */
+private fun Throwable.rethrowIfUncontainable() {
+    if (this is CancellationException) throw this
+    if (this is OutOfMemoryError) throw this
 }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.Layout
@@ -81,6 +82,10 @@ import kotlin.coroutines.cancellation.CancellationException
  * - **Multiple roots stack.** If [content] emits several siblings they are
  *   placed at the same origin with `Box` semantics, where previously the real
  *   parent would have laid them out.
+ * - **Intrinsics go through the default policy.** Intrinsic measurements now
+ *   resolve against `Layout`'s defaults rather than the child's own, which for a
+ *   child with a cheap custom intrinsic — or an expensive real measure, such as a
+ *   lazy list — is neither free nor guaranteed to give the same answer.
  *
  * @param pluginId Plugin that owns [content]; used only for logging here.
  * @param onRenderCrash Invoked at most once per boundary, on the UI thread rather
@@ -108,6 +113,16 @@ internal fun PluginRenderBoundary(
     val logger = remember { BossLogger.forComponent("PluginRenderBoundary") }
     val reported = remember(pluginId) { AtomicBoolean(false) }
 
+    // The callback is read through a remembered holder rather than captured
+    // directly. Capturing it would make the measure lambda and draw modifier
+    // below unstable, so Compose would hand Layout a fresh MeasurePolicy on every
+    // recomposition — and LayoutNode.measurePolicy's setter compares by equality
+    // and calls requestRemeasure() on change, forcing a full remeasure of the
+    // plugin subtree each time. This is on the render path of every plugin panel
+    // and status-bar widget, so that is worth avoiding.
+    val currentOnRenderCrash = rememberUpdatedState(onRenderCrash)
+    val currentDispatch = rememberUpdatedState(dispatchToUiThread)
+
     // Not a composable: called from measure, placement and draw, each of which has
     // already run rethrowIfUncontainable on the throwable.
     fun report(
@@ -133,9 +148,9 @@ internal fun PluginRenderBoundary(
         // to know that: PluginErrorBoundary and PluginExtensionBoundary can both
         // just write state, instead of one deferring through
         // PluginCrashRegistry.recordCrash and the other not.
-        dispatchToUiThread {
+        currentDispatch.value {
             try {
-                onRenderCrash(error)
+                currentOnRenderCrash.value(error)
             } catch (secondary: Throwable) {
                 secondary.rethrowIfUncontainable()
                 // The handler failing must not turn a contained crash into a fatal one.
@@ -215,9 +230,26 @@ internal fun PluginRenderBoundary(
  * hangs rather than fails. The decision itself is pure, so it is tested as such.
  */
 internal fun Throwable.rethrowIfUncontainable() {
-    if (this is CancellationException) throw this
-    if (this is OutOfMemoryError) throw this
+    if (isUncontainable(this)) throw this
 }
+
+/**
+ * Whether [error] is something no layer may contain.
+ *
+ * Public and shared so the boundary and the window handler cannot drift. They
+ * did: the boundary rethrew [OutOfMemoryError] so a dead JVM was never blamed on
+ * a plugin, but the window handler then caught it as an unattributed render
+ * fault, contained it, and repainted every window — allocating more under heap
+ * exhaustion, three times over, before anything escalated. The carve-out existed
+ * only in the boundary's tests.
+ *
+ * [StackOverflowError] is included for the same reason: the stack is gone, and
+ * repainting to recover would immediately blow it again.
+ */
+fun isUncontainable(error: Throwable): Boolean =
+    error is CancellationException ||
+        error is OutOfMemoryError ||
+        error is StackOverflowError
 
 /**
  * Default hand-off for [PluginRenderBoundary]: the AWT event dispatch thread.

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundary.kt
@@ -63,13 +63,36 @@ import kotlin.coroutines.cancellation.CancellationException
  * which is why the window handler must also stop treating an unattributed render
  * exception as fatal.
  *
+ * Same family, equally unattributable, and equally not covered here:
+ * `Modifier.onGloballyPositioned` / `onSizeChanged` callbacks, which run after
+ * the `layout {}` block has returned and so outside its `try`, and pointer-input
+ * and gesture handlers, which run on their own dispatch.
+ *
+ * ### Layout transparency, and where it stops
+ *
+ * Constraints are forwarded untouched and a healthy subtree measures exactly as
+ * it would without this in the way. Two things an inserted `Layout` cannot make
+ * transparent, invisible at the call site:
+ *
+ * - **Parent data does not cross it.** A `Modifier.weight()` or
+ *   `Modifier.align()` applied inside [content] from a captured outer
+ *   `RowScope`/`ColumnScope` now sits on a grandchild of the real parent and is
+ *   ignored. No current caller does this; the next one might.
+ * - **Multiple roots stack.** If [content] emits several siblings they are
+ *   placed at the same origin with `Box` semantics, where previously the real
+ *   parent would have laid them out.
+ *
  * @param pluginId Plugin that owns [content]; used only for logging here.
- * @param onRenderCrash Invoked at most once, on the render thread, with the
- *   throwable. Must be cheap and must not itself throw — see
- *   [PluginCrashRegistry.recordCrash], which defers its state writes to the EDT
- *   precisely so it is safe to call from inside a render pass.
+ * @param onRenderCrash Invoked at most once per boundary, on the UI thread rather
+ *   than inline, so it is free to write snapshot state. It should not throw; if
+ *   it does, the throw is logged and swallowed rather than allowed to escalate a
+ *   contained crash.
+ * @param dispatchToUiThread How that hand-off happens. Defaults to the EDT. A
+ *   parameter rather than a hardcoded `SwingUtilities.invokeLater` because
+ *   `runComposeUiTest` does not pump a real event queue, so a test that waited on
+ *   the EDT would simply hang — and a boundary whose recovery path cannot be
+ *   tested is not worth much.
  */
-
 // Catching Throwable is this function's entire contract: a boundary that only
 // caught the exception types it could predict would not be a boundary. The
 // narrowing that does matter is [rethrowIfUncontainable], applied first at every
@@ -79,6 +102,7 @@ import kotlin.coroutines.cancellation.CancellationException
 internal fun PluginRenderBoundary(
     pluginId: String,
     onRenderCrash: (Throwable) -> Unit,
+    dispatchToUiThread: (() -> Unit) -> Unit = ::defaultUiThreadDispatch,
     content: @Composable () -> Unit,
 ) {
     val logger = remember { BossLogger.forComponent("PluginRenderBoundary") }
@@ -102,17 +126,26 @@ internal fun PluginRenderBoundary(
             ),
             error,
         )
-        try {
-            onRenderCrash(error)
-        } catch (secondary: Throwable) {
-            secondary.rethrowIfUncontainable()
-            // The handler failing must not turn a contained crash into a fatal one.
-            logger.warn(
-                LogCategory.UI,
-                "Crash handler threw while containing a render crash",
-                mapOf("pluginId" to pluginId),
-                secondary,
-            )
+        // Handed off to the EDT rather than called inline. This runs mid render
+        // pass, and every useful thing a handler wants to do — set error state,
+        // bump a key, record a crash — is a snapshot write that invalidates the
+        // composition currently being laid out. Deferring here means no caller has
+        // to know that: PluginErrorBoundary and PluginExtensionBoundary can both
+        // just write state, instead of one deferring through
+        // PluginCrashRegistry.recordCrash and the other not.
+        dispatchToUiThread {
+            try {
+                onRenderCrash(error)
+            } catch (secondary: Throwable) {
+                secondary.rethrowIfUncontainable()
+                // The handler failing must not turn a contained crash into a fatal one.
+                logger.warn(
+                    LogCategory.UI,
+                    "Crash handler threw while containing a render crash",
+                    mapOf("pluginId" to pluginId),
+                    secondary,
+                )
+            }
         }
     }
 
@@ -128,14 +161,16 @@ internal fun PluginRenderBoundary(
                 }
             },
     ) { measurables, constraints ->
-        // Box semantics: children see relaxed minimums so a wrap-content host
-        // (a status bar item, say) is not forced to expand, while a child that
-        // asks to fill still fills.
-        val childConstraints = constraints.copy(minWidth = 0, minHeight = 0)
-
+        // Constraints are forwarded untouched, so a subtree that is not crashing
+        // lays out exactly as it would without this boundary in the way. Relaxing
+        // the minimums here — the obvious way to make the error path collapse —
+        // would silently change healthy plugins too: under a parent that passes a
+        // non-zero minimum down (a Column(Modifier.fillMaxWidth()), say), a
+        // wrap-content plugin root would stop stretching and start hugging its
+        // content. The collapse belongs on the error path only, below.
         val placeables =
             try {
-                measurables.map { it.measure(childConstraints) }
+                measurables.map { it.measure(constraints) }
             } catch (t: Throwable) {
                 t.rethrowIfUncontainable()
                 report("measure", t)
@@ -145,6 +180,8 @@ internal fun PluginRenderBoundary(
                 emptyList()
             }
 
+        // No children — the error path — leaves this at the parent's minimum,
+        // which is the smallest the boundary is allowed to be.
         val width = (placeables.maxOfOrNull { it.width } ?: 0).coerceIn(constraints.minWidth, constraints.maxWidth)
         val height = (placeables.maxOfOrNull { it.height } ?: 0).coerceIn(constraints.minHeight, constraints.maxHeight)
 
@@ -170,8 +207,22 @@ internal fun PluginRenderBoundary(
  * Deliberately not a `when` inside each catch block: pulled out here it stays one
  * decision in one place, applied identically by measure, placement, draw and the
  * crash handler itself.
+ *
+ * `internal` rather than private so it can be tested directly. Driving
+ * cancellation through a real Compose runtime is not an option: throwing a
+ * [CancellationException] out of measure tears down the composition's scope and
+ * `runComposeUiTest` then waits for an idle state that never arrives, so the test
+ * hangs rather than fails. The decision itself is pure, so it is tested as such.
  */
-private fun Throwable.rethrowIfUncontainable() {
+internal fun Throwable.rethrowIfUncontainable() {
     if (this is CancellationException) throw this
     if (this is OutOfMemoryError) throw this
 }
+
+/**
+ * Default hand-off for [PluginRenderBoundary]: the AWT event dispatch thread.
+ *
+ * Matches how [PluginCrashRegistry.recordCrash] already defers its own state
+ * writes, so a crash recorded through either route lands on the same thread.
+ */
+private fun defaultUiThreadDispatch(block: () -> Unit) = javax.swing.SwingUtilities.invokeLater(block)

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -1,0 +1,266 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Recovers the UI after a render exception that could not be attributed to a
+ * plugin from its stack.
+ *
+ * ### Why stack attribution is not enough
+ *
+ * [PluginRenderBoundary] catches what is thrown while measuring, placing or
+ * drawing *through* it. That covers a first layout and any pass that walks down
+ * from the boundary's ancestors. It does not cover the path a real crash
+ * actually took:
+ *
+ * ```
+ * IllegalArgumentException: Key "coll-…" was already used.
+ *   at LayoutNodeSubcompositionsState.subcompose
+ *   at LazyListKt$rememberLazyListMeasurePolicy$1$1.measure
+ *   at LayoutNode.remeasure
+ *   at MeasureAndLayoutDelegate.doRemeasure
+ *   at MeasureAndLayoutDelegate.remeasureIfNeeded          <- straight from the dirty list
+ * ```
+ *
+ * Compose re-measured the plugin's `LazyColumn` node directly, using its cached
+ * constraints, without descending from any ancestor. Nothing of the boundary —
+ * and nothing of the plugin — is on that stack, so neither the boundary nor
+ * [PluginCrashInterceptor] can see whose fault it is. The exception escapes to
+ * the window handler, which can keep the window alive but has no idea what to
+ * fix.
+ *
+ * ### What this does instead
+ *
+ * Attribution comes from *what is mounted* rather than from the stack: every
+ * [PluginErrorBoundary] registers the plugin it is currently rendering. On an
+ * unattributed render exception:
+ *
+ * 1. **First failure — rebuild.** Bump [generation], which every plugin panel
+ *    includes in a `key(...)`, tearing its subtree down and composing it fresh.
+ *    A subcomposition left inconsistent by a half-finished measure is discarded
+ *    rather than retried, and a transient fault ends here.
+ * 2. **Failure again within [REBUILD_GRACE_MILLIS] — quarantine.** The rebuild
+ *    did not help, which means the content reproduces the fault every time (bad
+ *    data, a genuine plugin bug). Rebuilding again would loop forever, so every
+ *    mounted plugin is recorded as crashed instead: their panels swap to the
+ *    error fallback and stop rendering plugin content, which is what finally
+ *    stops the exception recurring.
+ *
+ * Step 2 suspects **one** plugin at a time, not all of them, and corrects itself.
+ * If the fault recurs while a suspect is quarantined, that suspect was innocent:
+ * it is released and the next one is tried. The cycle ends when the exceptions
+ * stop, which leaves exactly the culprit quarantined.
+ *
+ * Quarantining everything at once was the first attempt and it was wrong in
+ * practice, not just in theory. Against the real crash it disabled four plugins
+ * for one plugin's bug, put an error in every open panel, and — because
+ * [PluginCrashRegistry.recordCrash] closes a registered tab — **closed the user's
+ * terminal and browser tabs**, destroying live sessions over a duplicate
+ * LazyColumn key somewhere else. Quarantine now goes through
+ * [PluginCrashRegistry.recordRenderFault], which shows the fallback without
+ * closing anything.
+ */
+object PluginRenderRecovery {
+    private val logger = BossLogger.forComponent("PluginRenderRecovery")
+
+    /**
+     * How long after a rebuild a further failure counts as "the rebuild did not
+     * help". Long enough to cover the frames a rebuild takes to land, short
+     * enough that two unrelated faults minutes apart each get their own retry.
+     */
+    const val REBUILD_GRACE_MILLIS = 4_000L
+
+    /**
+     * Plugins whose panels are currently rendering content, most recently mounted
+     * last. Insertion-ordered because the panel a user just opened or interacted
+     * with is the better first suspect, and a wrong guess only costs one cycle.
+     */
+    private val mounted = java.util.Collections.synchronizedSet(LinkedHashSet<String>())
+
+    /** The single plugin currently held responsible, if any. */
+    @Volatile
+    private var suspect: String? = null
+
+    /** Suspects already tried and released this incident, so we do not retry them. */
+    private val cleared = ConcurrentHashMap.newKeySet<String>()
+
+    private val _generation = mutableStateOf(0)
+
+    /** Read from composition so a bump rebuilds the plugin subtree. */
+    val generation: Int
+        @Composable get() = _generation.value
+
+    @Volatile
+    private var lastRebuildAt = 0L
+
+    /**
+     * Note that [pluginId]'s panel is rendering plugin content, and return the
+     * function that clears it when the panel goes away.
+     */
+    fun registerMounted(pluginId: String): () -> Unit {
+        mounted.add(pluginId)
+        return { mounted.remove(pluginId) }
+    }
+
+    /** Candidates, most recently mounted first, skipping any already ruled out. */
+    private fun nextSuspect(): String? =
+        synchronized(mounted) { mounted.toList() }
+            .asReversed()
+            .firstOrNull { it !in cleared && it != suspect }
+
+    /** Plugins currently rendering content. Exposed for logging and tests. */
+    fun mountedPlugins(): Set<String> = mounted.toSet()
+
+    /**
+     * Handle a render exception nobody could attribute.
+     *
+     * @param now injectable clock — the retry-versus-quarantine decision is
+     *   time-based, and a test should not have to sleep to reach the second half.
+     * @return what was done, for the caller to log and for tests to assert on.
+     */
+    fun onUnattributedRenderException(
+        error: Throwable,
+        now: Long = System.currentTimeMillis(),
+    ): Outcome {
+        val affected = mounted.toSet()
+        val recentlyRebuilt = lastRebuildAt != 0L && now - lastRebuildAt <= REBUILD_GRACE_MILLIS
+        return when {
+            affected.isEmpty() -> {
+                notPluginRelated(error)
+            }
+
+            // A fault well clear of the last one is its own incident.
+            !recentlyRebuilt -> {
+                startFreshCycle(affected, error, now)
+            }
+
+            else -> {
+                // The fault survived a rebuild. Anyone we were already holding is
+                // thereby proven innocent.
+                releaseSuspectAsInnocent()
+                quarantineNextSuspect(error, now)
+            }
+        }
+    }
+
+    private fun notPluginRelated(error: Throwable): Outcome {
+        // Nothing plugin-shaped is on screen, so this is the host's own fault and
+        // not ours to quarantine. The window handler still contains it.
+        logger.warn(
+            LogCategory.UI,
+            "Unattributed render exception with no plugin panel mounted — not a plugin fault",
+            mapOf("errorType" to error::class.simpleName.orEmpty()),
+        )
+        return Outcome.NotPluginRelated
+    }
+
+    private fun startFreshCycle(
+        affected: Set<String>,
+        error: Throwable,
+        now: Long,
+    ): Outcome {
+        releaseSuspect()
+        cleared.clear()
+        logger.warn(
+            LogCategory.UI,
+            "Unattributed render exception — rebuilding plugin panels",
+            mapOf(
+                "plugins" to affected.joinToString(),
+                "errorType" to error::class.simpleName.orEmpty(),
+            ),
+        )
+        lastRebuildAt = now
+        _generation.value += 1
+        return Outcome.Rebuilt(affected)
+    }
+
+    private fun releaseSuspectAsInnocent() {
+        suspect?.let { wronglyHeld ->
+            logger.info(
+                LogCategory.UI,
+                "Fault persisted while suspected — releasing and trying the next plugin",
+                mapOf("released" to wronglyHeld),
+            )
+            cleared.add(wronglyHeld)
+            releaseSuspect()
+        }
+    }
+
+    private fun quarantineNextSuspect(
+        error: Throwable,
+        now: Long,
+    ): Outcome {
+        val next = nextSuspect()
+        if (next == null) {
+            // Everyone mounted has been tried and released, so nothing on screen
+            // explains it. Stop churning: the window handler keeps containing it.
+            logger.error(
+                LogCategory.UI,
+                "Render fault persists with every mounted plugin ruled out — leaving it contained",
+                mapOf("tried" to cleared.joinToString(), "errorType" to error::class.simpleName.orEmpty()),
+                error,
+            )
+            lastRebuildAt = 0L
+            cleared.clear()
+            return Outcome.Unexplained
+        }
+
+        logger.error(
+            LogCategory.UI,
+            "Rebuild did not clear the render fault — quarantining one suspect",
+            mapOf(
+                "suspect" to next,
+                "alreadyRuledOut" to cleared.joinToString(),
+                "errorType" to error::class.simpleName.orEmpty(),
+            ),
+            error,
+        )
+        suspect = next
+        // recordRenderFault, not recordCrash: this is a guess, and a guess must
+        // never close somebody's terminal tab.
+        PluginCrashRegistry.recordRenderFault(next, error)
+        lastRebuildAt = now
+        _generation.value += 1
+        return Outcome.Quarantined(setOf(next))
+    }
+
+    /** Let the current suspect render again. */
+    private fun releaseSuspect() {
+        suspect?.let {
+            PluginCrashRegistry.clearCrash(it)
+            suspect = null
+        }
+    }
+
+    /** Forget the retry window. For tests, and for a clean slate after recovery. */
+    fun resetForTest() {
+        lastRebuildAt = 0L
+        mounted.clear()
+        cleared.clear()
+        suspect = null
+        _generation.value = 0
+    }
+
+    /** What [onUnattributedRenderException] decided. */
+    sealed interface Outcome {
+        /** No plugin panel was mounted; the fault is the host's. */
+        data object NotPluginRelated : Outcome
+
+        /** Plugin subtrees were torn down and rebuilt. */
+        data class Rebuilt(
+            val plugins: Set<String>,
+        ) : Outcome
+
+        /** The rebuild did not help; this plugin is being held responsible for now. */
+        data class Quarantined(
+            val plugins: Set<String>,
+        ) : Outcome
+
+        /** Every mounted plugin was tried and released; none of them explains it. */
+        data object Unexplained : Outcome
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
@@ -33,6 +33,9 @@ import kotlin.test.assertTrue
  * These tests assert the boundary catches each phase, hands the throwable to the
  * owner, and leaves the host composition standing.
  */
+// The boundary under test exists to catch anything, so the tests must be able to
+// throw and observe anything — including Errors.
+@Suppress("TooGenericExceptionCaught")
 @OptIn(ExperimentalTestApi::class)
 class PluginRenderBoundaryTest {
     /** Throws while being measured — the phase from the real crash report. */

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.sandbox.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -12,11 +13,15 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -29,15 +34,26 @@ import kotlin.test.assertTrue
  * window handler then treats it as a host fault and disposes the window, ending
  * the app — which is how a duplicate LazyColumn key in the bookmarks plugin took
  * BossConsole down (BossConsole-Releases#16).
- *
- * These tests assert the boundary catches each phase, hands the throwable to the
- * owner, and leaves the host composition standing.
  */
 // The boundary under test exists to catch anything, so the tests must be able to
 // throw and observe anything — including Errors.
 @Suppress("TooGenericExceptionCaught")
 @OptIn(ExperimentalTestApi::class)
 class PluginRenderBoundaryTest {
+    private companion object {
+        const val PLUGIN_ID = "ai.rever.boss.plugin.dynamic.test"
+
+        /**
+         * Run the boundary's crash hand-off inline instead of on the EDT.
+         *
+         * `runComposeUiTest` does not pump a real event queue, so anything posted
+         * with `invokeLater` never runs and a test that waited for it would hang.
+         * Production still defers — that is what makes the callback safe to write
+         * snapshot state from — and this only changes *when*, not *what*.
+         */
+        val runInline: (() -> Unit) -> Unit = { it() }
+    }
+
     /** Throws while being measured — the phase from the real crash report. */
     @Composable
     private fun ThrowsDuringMeasure(error: Throwable) {
@@ -68,8 +84,9 @@ class PluginRenderBoundaryTest {
             setContent {
                 Box(Modifier.fillMaxSize()) {
                     PluginRenderBoundary(
-                        pluginId = "ai.rever.boss.plugin.dynamic.test",
+                        pluginId = PLUGIN_ID,
                         onRenderCrash = { captured.set(it) },
+                        dispatchToUiThread = runInline,
                         content = content,
                     )
                 }
@@ -85,7 +102,7 @@ class PluginRenderBoundaryTest {
         val captured = captureCrashFrom { ThrowsDuringMeasure(boom) }
 
         assertNotNull(captured, "the measure crash escaped the boundary")
-        assertEquals(boom, captured, "the owner was handed the wrong throwable")
+        assertSame(boom, captured, "the owner was handed the wrong throwable")
     }
 
     @Test
@@ -95,7 +112,7 @@ class PluginRenderBoundaryTest {
         val captured = captureCrashFrom { ThrowsDuringPlacement(boom) }
 
         assertNotNull(captured, "the placement crash escaped the boundary")
-        assertEquals(boom, captured)
+        assertSame(boom, captured)
     }
 
     @Test
@@ -105,68 +122,132 @@ class PluginRenderBoundaryTest {
         val captured = captureCrashFrom { ThrowsDuringDraw(boom) }
 
         assertNotNull(captured, "the draw crash escaped the boundary")
-        assertEquals(boom, captured)
+        assertSame(boom, captured)
     }
 
     @Test
-    fun `the reported duplicate-LazyColumn-key crash is contained`() {
+    fun `the reported duplicate-LazyColumn-key crash is contained and a sibling still renders`() {
         // The actual shape from BossConsole-Releases#16: two items under one key
         // share a subcomposition slot and therefore one LayoutNode, so the list
-        // measures that node twice in a pass. Reproduced here rather than
-        // described, so the boundary is proven against the real failure and not
-        // just a synthetic throw.
+        // measures that node twice in a pass. Reproduced rather than described, so
+        // the boundary is proven against the real failure and not a synthetic one.
         val captured = AtomicReference<Throwable?>(null)
-        var hostStillComposed = false
+        // Set from a draw modifier, not from composition: composition always
+        // completes before measure, so a flag set there would be true whether or
+        // not the crash took the render pass down. Drawing is downstream of the
+        // crash and is the thing that actually has to survive.
+        val siblingDrew = AtomicBoolean(false)
 
         runComposeUiTest {
             setContent {
-                Box(Modifier.fillMaxSize()) {
+                Column(Modifier.fillMaxSize()) {
                     PluginRenderBoundary(
                         pluginId = "ai.rever.boss.plugin.dynamic.bookmarks",
                         onRenderCrash = { captured.set(it) },
+                        dispatchToUiThread = runInline,
                     ) {
-                        LazyColumn(Modifier.fillMaxSize()) {
+                        LazyColumn(Modifier.size(40.dp)) {
                             items(listOf("dup", "dup"), key = { it }) {
                                 Box(Modifier.size(20.dp))
                             }
                         }
                     }
+                    Box(
+                        Modifier
+                            .size(10.dp)
+                            .drawWithContent {
+                                siblingDrew.set(true)
+                                drawContent()
+                            },
+                    )
                 }
-                // Composed as a sibling of the boundary: if the crash had escaped,
-                // the whole composition would have gone down with it.
-                hostStillComposed = true
             }
         }
 
         assertNotNull(
             captured.get(),
-            "duplicate keys did not throw here — if Compose stopped treating this as an error, " +
+            "duplicate keys did not throw here — if Compose stopped treating this as an error " +
                 "this test needs rewriting, but the boundary is still what contains it",
         )
-        assertTrue(hostStillComposed, "the host composition did not survive the plugin's crash")
+        assertTrue(siblingDrew.get(), "the rest of the window stopped rendering when the plugin crashed")
     }
 
     @Test
     fun `content that renders cleanly is untouched`() {
         val captured = AtomicReference<Throwable?>(null)
-        var childComposed = false
+        val childDrew = AtomicBoolean(false)
 
         runComposeUiTest {
             setContent {
                 Box(Modifier.fillMaxSize()) {
                     PluginRenderBoundary(
-                        pluginId = "ai.rever.boss.plugin.dynamic.test",
+                        pluginId = PLUGIN_ID,
                         onRenderCrash = { captured.set(it) },
+                        dispatchToUiThread = runInline,
                     ) {
-                        Box(Modifier.size(24.dp))
-                        childComposed = true
+                        Box(
+                            Modifier
+                                .size(24.dp)
+                                .drawWithContent {
+                                    childDrew.set(true)
+                                    drawContent()
+                                },
+                        )
                     }
                 }
             }
         }
 
         assertNull(captured.get(), "a healthy subtree must not report a crash")
-        assertTrue(childComposed, "the boundary must not stop its content composing")
+        assertTrue(childDrew.get(), "the boundary must not stop its content rendering")
+    }
+
+    @Test
+    fun `a repeatedly failing subtree is reported once`() {
+        // A failing measure is retried before the rebuild lands. One broken panel
+        // must not produce a burst of identical crash records.
+        val reports = AtomicInteger(0)
+
+        runComposeUiTest {
+            setContent {
+                Box(Modifier.fillMaxSize()) {
+                    PluginRenderBoundary(
+                        pluginId = PLUGIN_ID,
+                        onRenderCrash = { reports.incrementAndGet() },
+                        dispatchToUiThread = runInline,
+                    ) {
+                        ThrowsDuringMeasure(IllegalStateException("still broken"))
+                    }
+                }
+            }
+        }
+
+        assertEquals(1, reports.get(), "the boundary reported the same crash more than once")
+    }
+
+    @Test
+    fun `a throwing crash handler does not escalate the contained crash`() {
+        // Documented guarantee: the handler failing must not turn a crash the
+        // boundary already contained into a fatal one.
+        var escaped: Throwable? = null
+
+        try {
+            runComposeUiTest {
+                setContent {
+                    PluginRenderBoundary(
+                        pluginId = PLUGIN_ID,
+                        onRenderCrash = { throw IllegalStateException("the handler itself is broken") },
+                        dispatchToUiThread = runInline,
+                    ) {
+                        ThrowsDuringMeasure(IllegalStateException("measure blew up"))
+                    }
+                }
+            }
+        } catch (t: Throwable) {
+            escaped = t
+        }
+
+        assertNull(escaped, "a throwing crash handler escalated a contained crash")
     }
 
     @Test
@@ -181,8 +262,9 @@ class PluginRenderBoundaryTest {
             runComposeUiTest {
                 setContent {
                     PluginRenderBoundary(
-                        pluginId = "ai.rever.boss.plugin.dynamic.test",
+                        pluginId = PLUGIN_ID,
                         onRenderCrash = { captured.set(it) },
+                        dispatchToUiThread = runInline,
                     ) {
                         ThrowsDuringMeasure(fatal)
                     }
@@ -194,5 +276,42 @@ class PluginRenderBoundaryTest {
 
         assertNull(captured.get(), "a fatal JVM error must not be reported as a plugin crash")
         assertNotNull(escaped, "an OutOfMemoryError must propagate, not be contained")
+        assertTrue(
+            generateSequence(escaped) { it.cause }.any { it === fatal },
+            "something else failed — the OutOfMemoryError itself did not propagate",
+        )
+    }
+
+    @Test
+    fun `rethrowIfUncontainable lets a plugin fault through and stops the rest`() {
+        // Tested directly rather than through the Compose harness: throwing a
+        // CancellationException out of measure tears down the composition scope,
+        // and runComposeUiTest then waits for an idle state that never comes, so
+        // such a test hangs instead of failing. The decision is pure logic, and
+        // the end-to-end propagation half is covered by the OutOfMemoryError test
+        // above.
+        val ordinary = IllegalStateException("a plugin laid itself out wrong")
+        // Must not throw — an ordinary fault is exactly what the boundary contains.
+        ordinary.rethrowIfUncontainable()
+
+        val cancelled = CancellationException("composition cancelled")
+        val cancellationEscaped =
+            try {
+                cancelled.rethrowIfUncontainable()
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        assertSame(cancelled, cancellationEscaped, "cancellation is control flow and must propagate")
+
+        val fatal = OutOfMemoryError("Java heap space")
+        val fatalEscaped =
+            try {
+                fatal.rethrowIfUncontainable()
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        assertSame(fatal, fatalEscaped, "a dead JVM must not be reported as a plugin crash")
     }
 }

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
@@ -3,6 +3,8 @@ package ai.rever.boss.plugin.sandbox.ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,8 +12,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -279,6 +283,73 @@ class PluginRenderBoundaryTest {
         assertTrue(
             generateSequence(escaped) { it.cause }.any { it === fatal },
             "something else failed — the OutOfMemoryError itself did not propagate",
+        )
+    }
+
+    @Test
+    fun `a healthy subtree measures the same with the boundary as without it`() {
+        // The riskiest claim in this change: the boundary is layout-transparent
+        // for content that is not crashing. Relaxing the child's minimum
+        // constraints — the obvious way to make the error path collapse — would
+        // silently reshape every plugin panel, so it is asserted rather than
+        // commented. Both cases run under a parent that passes a non-zero minimum
+        // width down, which is exactly where the difference would show.
+        val withBoundary = AtomicReference<IntSize?>(null)
+        val without = AtomicReference<IntSize?>(null)
+
+        runComposeUiTest {
+            setContent {
+                Column(Modifier.fillMaxSize()) {
+                    Column(Modifier.fillMaxWidth()) {
+                        PluginRenderBoundary(
+                            pluginId = PLUGIN_ID,
+                            onRenderCrash = { },
+                            dispatchToUiThread = runInline,
+                        ) {
+                            Box(Modifier.size(24.dp).onSizeChanged { withBoundary.set(it) })
+                        }
+                    }
+                    Column(Modifier.fillMaxWidth()) {
+                        Box(Modifier.size(24.dp).onSizeChanged { without.set(it) })
+                    }
+                }
+            }
+        }
+
+        assertNotNull(withBoundary.get(), "the wrapped child never measured")
+        assertEquals(
+            without.get(),
+            withBoundary.get(),
+            "the boundary changed the size of healthy content",
+        )
+    }
+
+    @Test
+    fun `a wrap-content child is not stretched by the boundary`() {
+        // The specific regression the constraint forwarding prevents: under a
+        // parent with a non-zero minimum, a relaxed child would hug its content
+        // where it used to stretch, or vice versa.
+        val measured = AtomicReference<IntSize?>(null)
+
+        runComposeUiTest {
+            setContent {
+                Column(Modifier.fillMaxWidth()) {
+                    PluginRenderBoundary(
+                        pluginId = PLUGIN_ID,
+                        onRenderCrash = { },
+                        dispatchToUiThread = runInline,
+                    ) {
+                        Box(Modifier.fillMaxWidth().height(10.dp).onSizeChanged { measured.set(it) })
+                    }
+                }
+            }
+        }
+
+        val size = measured.get()
+        assertNotNull(size, "the child never measured")
+        assertTrue(
+            size.width > 0,
+            "a fillMaxWidth child under the boundary collapsed instead of filling",
         )
     }
 

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderBoundaryTest.kt
@@ -1,0 +1,195 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers containment of plugin crashes in the render phases.
+ *
+ * The failure being guarded against: a plugin's composables have already
+ * returned by the time Compose measures, places or draws their nodes, so an
+ * exception there carries no plugin frame and
+ * [PluginCrashInterceptor.attributeToPlugin] cannot identify an owner. The
+ * window handler then treats it as a host fault and disposes the window, ending
+ * the app — which is how a duplicate LazyColumn key in the bookmarks plugin took
+ * BossConsole down (BossConsole-Releases#16).
+ *
+ * These tests assert the boundary catches each phase, hands the throwable to the
+ * owner, and leaves the host composition standing.
+ */
+@OptIn(ExperimentalTestApi::class)
+class PluginRenderBoundaryTest {
+    /** Throws while being measured — the phase from the real crash report. */
+    @Composable
+    private fun ThrowsDuringMeasure(error: Throwable) {
+        Layout(content = {}) { _, _ -> throw error }
+    }
+
+    /** Throws while placing its children. */
+    @Composable
+    private fun ThrowsDuringPlacement(error: Throwable) {
+        Layout(content = {}) { _, _ ->
+            layout(10, 10) { throw error }
+        }
+    }
+
+    /** Throws while drawing. */
+    @Composable
+    private fun ThrowsDuringDraw(error: Throwable) {
+        Box(
+            Modifier
+                .size(10.dp)
+                .drawWithContent { throw error },
+        )
+    }
+
+    private fun captureCrashFrom(content: @Composable () -> Unit): Throwable? {
+        val captured = AtomicReference<Throwable?>(null)
+        runComposeUiTest {
+            setContent {
+                Box(Modifier.fillMaxSize()) {
+                    PluginRenderBoundary(
+                        pluginId = "ai.rever.boss.plugin.dynamic.test",
+                        onRenderCrash = { captured.set(it) },
+                        content = content,
+                    )
+                }
+            }
+        }
+        return captured.get()
+    }
+
+    @Test
+    fun `a crash during measure is contained and handed to the owner`() {
+        val boom = IllegalStateException("layout state is not idle before measure starts")
+
+        val captured = captureCrashFrom { ThrowsDuringMeasure(boom) }
+
+        assertNotNull(captured, "the measure crash escaped the boundary")
+        assertEquals(boom, captured, "the owner was handed the wrong throwable")
+    }
+
+    @Test
+    fun `a crash during placement is contained`() {
+        val boom = IllegalStateException("placement blew up")
+
+        val captured = captureCrashFrom { ThrowsDuringPlacement(boom) }
+
+        assertNotNull(captured, "the placement crash escaped the boundary")
+        assertEquals(boom, captured)
+    }
+
+    @Test
+    fun `a crash during draw is contained`() {
+        val boom = IllegalStateException("draw blew up")
+
+        val captured = captureCrashFrom { ThrowsDuringDraw(boom) }
+
+        assertNotNull(captured, "the draw crash escaped the boundary")
+        assertEquals(boom, captured)
+    }
+
+    @Test
+    fun `the reported duplicate-LazyColumn-key crash is contained`() {
+        // The actual shape from BossConsole-Releases#16: two items under one key
+        // share a subcomposition slot and therefore one LayoutNode, so the list
+        // measures that node twice in a pass. Reproduced here rather than
+        // described, so the boundary is proven against the real failure and not
+        // just a synthetic throw.
+        val captured = AtomicReference<Throwable?>(null)
+        var hostStillComposed = false
+
+        runComposeUiTest {
+            setContent {
+                Box(Modifier.fillMaxSize()) {
+                    PluginRenderBoundary(
+                        pluginId = "ai.rever.boss.plugin.dynamic.bookmarks",
+                        onRenderCrash = { captured.set(it) },
+                    ) {
+                        LazyColumn(Modifier.fillMaxSize()) {
+                            items(listOf("dup", "dup"), key = { it }) {
+                                Box(Modifier.size(20.dp))
+                            }
+                        }
+                    }
+                }
+                // Composed as a sibling of the boundary: if the crash had escaped,
+                // the whole composition would have gone down with it.
+                hostStillComposed = true
+            }
+        }
+
+        assertNotNull(
+            captured.get(),
+            "duplicate keys did not throw here — if Compose stopped treating this as an error, " +
+                "this test needs rewriting, but the boundary is still what contains it",
+        )
+        assertTrue(hostStillComposed, "the host composition did not survive the plugin's crash")
+    }
+
+    @Test
+    fun `content that renders cleanly is untouched`() {
+        val captured = AtomicReference<Throwable?>(null)
+        var childComposed = false
+
+        runComposeUiTest {
+            setContent {
+                Box(Modifier.fillMaxSize()) {
+                    PluginRenderBoundary(
+                        pluginId = "ai.rever.boss.plugin.dynamic.test",
+                        onRenderCrash = { captured.set(it) },
+                    ) {
+                        Box(Modifier.size(24.dp))
+                        childComposed = true
+                    }
+                }
+            }
+        }
+
+        assertNull(captured.get(), "a healthy subtree must not report a crash")
+        assertTrue(childComposed, "the boundary must not stop its content composing")
+    }
+
+    @Test
+    fun `an OutOfMemoryError is not swallowed`() {
+        // A dead JVM is not the plugin's to own, and pretending otherwise would
+        // turn an unrecoverable condition into a silent one.
+        val fatal = OutOfMemoryError("Java heap space")
+        val captured = AtomicReference<Throwable?>(null)
+        var escaped: Throwable? = null
+
+        try {
+            runComposeUiTest {
+                setContent {
+                    PluginRenderBoundary(
+                        pluginId = "ai.rever.boss.plugin.dynamic.test",
+                        onRenderCrash = { captured.set(it) },
+                    ) {
+                        ThrowsDuringMeasure(fatal)
+                    }
+                }
+            }
+        } catch (t: Throwable) {
+            escaped = t
+        }
+
+        assertNull(captured.get(), "a fatal JVM error must not be reported as a plugin crash")
+        assertNotNull(escaped, "an OutOfMemoryError must propagate, not be contained")
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
@@ -1,0 +1,188 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Covers recovery from a render exception nobody could attribute from the stack.
+ *
+ * This is the half [PluginRenderBoundary] cannot reach. A real crash arrived via
+ * `MeasureAndLayoutDelegate.remeasureIfNeeded` — Compose re-measuring the
+ * plugin's node straight from its dirty list, with neither the boundary nor the
+ * plugin anywhere on the stack. Containing that kept the window alive but left
+ * it broken and silent, because a repaint over a subtree that still reproduces
+ * the fault changes nothing.
+ *
+ * The two properties that fix it pull against each other: rebuild, so a
+ * recoverable fault recovers; but stop rebuilding once it is clear the content
+ * reproduces the fault every time, or the window loops forever.
+ */
+class PluginRenderRecoveryTest {
+    private val error = IllegalArgumentException("""Key "coll-dup" was already used.""")
+
+    @BeforeTest
+    fun setUp() = PluginRenderRecovery.resetForTest()
+
+    @AfterTest
+    fun tearDown() {
+        PluginRenderRecovery.resetForTest()
+        PluginCrashRegistry.clearCrash("plugin.a")
+        PluginCrashRegistry.clearCrash("plugin.b")
+    }
+
+    @Test
+    fun `with no plugin mounted the fault is not blamed on a plugin`() {
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+
+        assertEquals(
+            PluginRenderRecovery.Outcome.NotPluginRelated,
+            outcome,
+            "a host render fault must not quarantine plugins that are not even on screen",
+        )
+    }
+
+    @Test
+    fun `the first failure rebuilds rather than disabling anything`() {
+        PluginRenderRecovery.registerMounted("plugin.a")
+
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Rebuilt>(outcome, "the first failure deserves a retry")
+        assertEquals(setOf("plugin.a"), outcome.plugins)
+        assertTrue(
+            !PluginCrashRegistry.hasCrashed("plugin.a"),
+            "a plugin must not be disabled before a rebuild has been tried",
+        )
+    }
+
+    @Test
+    fun `failing again inside the grace window quarantines instead of looping`() {
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+
+        val outcome =
+            PluginRenderRecovery.onUnattributedRenderException(
+                error,
+                now = 1_000 + PluginRenderRecovery.REBUILD_GRACE_MILLIS,
+            )
+
+        assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome, "the rebuild did not take; stop retrying")
+        assertEquals(setOf("plugin.a"), outcome.plugins)
+        assertTrue(
+            PluginCrashRegistry.hasCrashed("plugin.a"),
+            "quarantine has to record the crash — that is what swaps the panel to its fallback " +
+                "and stops the plugin rendering, which is what actually ends the loop",
+        )
+    }
+
+    @Test
+    fun `a failure long after the rebuild gets its own retry`() {
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+
+        // Well outside the grace window: an unrelated fault later on is not
+        // evidence that the earlier rebuild failed.
+        val outcome =
+            PluginRenderRecovery.onUnattributedRenderException(
+                error,
+                now = 1_000 + PluginRenderRecovery.REBUILD_GRACE_MILLIS + 1,
+            )
+
+        assertIs<PluginRenderRecovery.Outcome.Rebuilt>(outcome, "an unrelated later fault deserves its own retry")
+        assertTrue(!PluginCrashRegistry.hasCrashed("plugin.a"))
+    }
+
+    @Test
+    fun `only one plugin is suspected, not every mounted panel`() {
+        // The first implementation quarantined all of them. Against the real crash
+        // that disabled four plugins for one plugin's bug and closed the user's
+        // terminal and browser tabs.
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.registerMounted("plugin.b")
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+        assertEquals(1, outcome.plugins.size, "exactly one suspect at a time")
+        // Most recently mounted first: the panel just opened is the better guess.
+        assertEquals(setOf("plugin.b"), outcome.plugins)
+        assertTrue(!PluginCrashRegistry.hasCrashed("plugin.a"), "an unsuspected plugin must keep rendering")
+    }
+
+    @Test
+    fun `a suspect that does not stop the fault is released and the next is tried`() {
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.registerMounted("plugin.b")
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000) // suspects b
+
+        // Still failing while b is held, so b was innocent.
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 3_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+        assertEquals(setOf("plugin.a"), outcome.plugins, "should move on to the next candidate")
+        assertTrue(
+            !PluginCrashRegistry.hasCrashed("plugin.b"),
+            "a suspect proven innocent must be released, not left disabled",
+        )
+        assertTrue(PluginCrashRegistry.hasCrashed("plugin.a"))
+    }
+
+    @Test
+    fun `when every mounted plugin has been ruled out it stops churning`() {
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000) // suspects a
+
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 3_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Unexplained>(
+            outcome,
+            "with nobody left to blame it must stop rebuilding rather than loop",
+        )
+        assertTrue(
+            !PluginCrashRegistry.hasCrashed("plugin.a"),
+            "the last innocent suspect is released too",
+        )
+    }
+
+    @Test
+    fun `an unmounted panel is no longer a candidate`() {
+        val unregister = PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.registerMounted("plugin.b")
+        unregister()
+
+        assertEquals(setOf("plugin.b"), PluginRenderRecovery.mountedPlugins())
+
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+        assertEquals(setOf("plugin.b"), outcome.plugins, "a closed panel must not be quarantined")
+    }
+
+    @Test
+    fun `once an incident is resolved the next fault starts a fresh cycle`() {
+        // Guards against a restarted plugin being instantly re-suspected: the
+        // bookkeeping from a finished incident must not carry into the next one.
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000) // suspects a
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 3_000) // rules a out
+        PluginCrashRegistry.clearCrash("plugin.a")
+
+        // Much later, something fails again. That is a new incident.
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 60_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Rebuilt>(
+            outcome,
+            "a later fault must get its own rebuild, not inherit the last incident's verdict",
+        )
+        assertTrue(!PluginCrashRegistry.hasCrashed("plugin.a"))
+    }
+}


### PR DESCRIPTION
A bookmarks-plugin layout bug took the whole app down ([BossConsole-Releases#16](https://github.com/risa-labs-inc/BossConsole-Releases/issues/16)). The plugin bug is fixed and shipped; this PR is about the fact that **nothing in the host caught it**.

## Why the existing gates missed it

`PluginCrashInterceptor.attributeToPlugin()` identifies the culprit three ways — sandbox thread name, a class named after the plugin id, a class loadable from its classloader. All three need the plugin to be **on the stack**.

That holds for a composition crash (`NoSuchMethodError` from binary incompatibility — the case it was built for). It cannot hold for the layout phases: by then the plugin's composables have returned, having only *emitted* `LayoutNode`s. **The reported stack trace contains not one plugin frame.**

So attribution returned null → `main.kt` took the "not a plugin crash" branch → Compose's default handler → **window disposed**, which ends a Compose `application {}`. The plugin was never recorded as crashed either, so it was never badged or disabled.

### Out-of-process isolation would not have helped

`BridgedPanelComponent` is a **split-brain** design: the child process runs the state holder, the UI still composes and lays out **in the kernel process**. Isolation covers logic faults, not layout ones. Confirmed live — with `BOSS_MODE=KERNEL` the plugin ran genuinely out-of-process and the crash still landed in the host's render loop.

## What this changes

**1. `PluginRenderBoundary`** — wraps plugin content in a `Layout` guarding measure, placement and draw. Whatever throws underneath belongs to the plugin it wraps, *by position*, so no stack inspection is involved. Applied to `PluginErrorBoundary` (panels) and `PluginExtensionBoundary` (status bar, settings).

**2. `PluginRenderRecovery`** — and this is the part that actually fixes the reported crash.

Testing against the real bug showed the boundary **does not catch it**. The exception arrives by a path the boundary cannot be on:

```
IllegalArgumentException: Key "coll-collection-1785194024699" was already used.
  at LayoutNodeSubcompositionsState.subcompose
  at LazyListKt$rememberLazyListMeasurePolicy$1$1.measure
  at LayoutNode.remeasure
  at MeasureAndLayoutDelegate.doRemeasure
  at MeasureAndLayoutDelegate.remeasureIfNeeded     ← straight from the dirty list
```

Compose re-measures the plugin's node directly, with neither the boundary nor the plugin on the stack. The unit test passed because it exercises a *first layout*, which does flow through the boundary — false confidence from a test that reproduced the crash but not its route.

Containment alone wasn't a fix either: the window survived, but a repaint over a subtree that still reproduces the fault leaves a broken window and no message.

So recovery attributes by **what is mounted** rather than by the stack:

1. First failure → **rebuild** (bump a generation the panels key on). Transient faults end here.
2. Failure again inside the grace window → **suspect one plugin**, most recently mounted first.
3. Still failing while a suspect is held → it was innocent → **release it, try the next**.
4. Everyone ruled out → stop churning, leave it contained.

Quarantining everything at once was the first attempt and was actively harmful: four plugins disabled for one plugin's bug, an error in every open panel, and — because `recordCrash` closes a registered tab — **the user's terminal and browser tabs closed**, destroying live sessions. Hence `recordRenderFault`, which shows the fallback without closing anything. An attribution guess must never take somebody's terminal.

**3. Unattributed exceptions are no longer fatal.** `decideWindowExceptionRoute` (extracted from `main.kt` so it's testable) routes: attributed → interceptor; uncontainable (`OutOfMemoryError`/`StackOverflowError`/cancellation) → escalate; too many failures too fast → escalate; otherwise contain. The uncontainable check sits **above** the policy deliberately — otherwise an OOM burns containment budget, and containing it means repainting every window under heap exhaustion.

`CrashHandler.recordContained` keeps the crash report without the terminal dialog, so a *host-side* render bug is still reported rather than reduced to a log line.

**4. `PluginErrorFallback` is now themed.** It was written against Material 3 while BOSS themes via `BossTheme` (Material 2), so with no M3 scheme provided every colour fell through to M3 defaults — the restart button was M3's default purple. Repointed at `BossThemeColors`, already reachable through `plugin-api-core`. This mattered more once render faults started routing users to that screen.

## Verification

**77 tests in `plugin-sandbox`, 1321 in `composeApp`**, ktlint and detekt clean.

`PluginRenderBoundaryTest` runs a real Compose runtime and **reproduces the reported crash rather than describing it**, and asserts layout transparency — that a healthy subtree measures identically with and without the boundary under a parent passing a non-zero minimum, which is the riskiest claim here.

**Verified live** against the pre-fix plugin (v2.1.5) and the original duplicate-id `collections.json`, in `BOSS_MODE=KERNEL` with four plugins mounted:

```
rebuilding plugin panels   | runconfigurations, terminaltab, fluckbrowser, bookmarks
quarantining one suspect   | suspect=…bookmarks, alreadyRuledOut=
```

One rebuild, bookmarks quarantined on the first guess, **zero innocent suspects, zero tabs closed, zero further exceptions, app alive** — versus the previous iteration which disabled four plugins and closed two tabs.

## Known limits

- A direct remeasure inside a plugin subtree bypasses the boundary; recovery is the backstop, not the boundary.
- Quarantine is a positional guess. With one panel mounted it is exact; with several it may hold an innocent one briefly before releasing it.
- Parent data does not cross the inserted `Layout`, multiple content roots stack, and intrinsics resolve against the default policy. All documented in the KDoc.
