### PR TITLE
🐛 fix(browser): stop popup windows crashing the EDT on right-click

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -4,7 +4,7 @@ import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.EngineInitError
 import ai.rever.boss.plugin.browser.FluckEngine
 import ai.rever.boss.plugin.browser.LocalAwtWindow
-import ai.rever.boss.plugin.browser.installPopupWindowContextMenu
+import ai.rever.boss.plugin.browser.installPopupWindowChrome
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
@@ -272,9 +272,8 @@ private fun configureBrowserPopupHandler(
                         // Same crash as the BrowserHandleImpl popup path: JxBrowser's built-in
                         // Swing menu resolves its position from a component that the popup may
                         // already have disposed (BossConsole-Releases#17). The dismiss handler is
-                        // paired with the menu - see installPopupWindowContextMenu.
-                        installPopupWindowContextMenu(popupBrowser, browserView)
-                        FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
+                        // paired with the menu inside installPopupWindowChrome.
+                        installPopupWindowChrome(popupBrowser, browserView)
 
                         subscriptions +=
                             popupBrowser.on(com.teamdev.jxbrowser.browser.event.TitleChanged::class.java) { event ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.EngineInitError
 import ai.rever.boss.plugin.browser.FluckEngine
 import ai.rever.boss.plugin.browser.LocalAwtWindow
+import ai.rever.boss.plugin.browser.installPopupWindowContextMenu
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
@@ -270,9 +271,10 @@ private fun configureBrowserPopupHandler(
 
                         // Same crash as the BrowserHandleImpl popup path: JxBrowser's built-in
                         // Swing menu resolves its position from a component that the popup may
-                        // already have disposed (BossConsole-Releases#17).
-                        ai.rever.boss.plugin.browser
-                            .installPopupWindowContextMenu(popupBrowser, browserView)
+                        // already have disposed (BossConsole-Releases#17). The dismiss handler is
+                        // paired with the menu - see installPopupWindowContextMenu.
+                        installPopupWindowContextMenu(popupBrowser, browserView)
+                        FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
 
                         subscriptions +=
                             popupBrowser.on(com.teamdev.jxbrowser.browser.event.TitleChanged::class.java) { event ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -268,6 +268,12 @@ private fun configureBrowserPopupHandler(
                         val browserView = BrowserView.newInstance(popupBrowser)
                         frame.contentPane.add(browserView)
 
+                        // Same crash as the BrowserHandleImpl popup path: JxBrowser's built-in
+                        // Swing menu resolves its position from a component that the popup may
+                        // already have disposed (BossConsole-Releases#17).
+                        ai.rever.boss.plugin.browser
+                            .installPopupWindowContextMenu(popupBrowser, browserView)
+
                         subscriptions +=
                             popupBrowser.on(com.teamdev.jxbrowser.browser.event.TitleChanged::class.java) { event ->
                                 SwingUtilities.invokeLater {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -620,6 +620,22 @@ internal class BrowserHandleImpl(
         }
     }
 
+    /**
+     * Answers Chromium, and never throws while doing it.
+     *
+     * `close()` can fail — already answered, or the browser torn down mid-callback — and both call
+     * sites reach it from a JxBrowser thread, one of them from a `finally`. An escaping exception
+     * there is uncaught and off the EDT, which is the failure class this handler is built around.
+     */
+    @Suppress("TooGenericExceptionCaught") // Error must propagate; see deliverContextMenu.
+    private fun closeQuietly(tell: ShowContextMenuCallback.Action) {
+        try {
+            tell.close()
+        } catch (e: Exception) {
+            logger.warn(LogCategory.BROWSER, "Could not answer the context-menu callback", error = e)
+        }
+    }
+
     private fun setupContextMenuHandler() {
         browser.set(
             ShowContextMenuCallback::class.java,
@@ -629,7 +645,7 @@ internal class BrowserHandleImpl(
                     // Nobody is going to draw a menu, so hand the request back rather than
                     // leaving it unanswered — an un-responded async callback shows nothing
                     // at all, and Chromium keeps waiting on it.
-                    tell.close()
+                    closeQuietly(tell)
                     return@ShowContextMenuCallback
                 }
 
@@ -671,7 +687,7 @@ internal class BrowserHandleImpl(
                         null
                     } finally {
                         // Suppresses JxBrowser's native menu and releases the request.
-                        tell.close()
+                        closeQuietly(tell)
                     }
 
                 if (read == null) return@ShowContextMenuCallback

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1510,6 +1510,12 @@ internal class BrowserHandleImpl(
                             // completes, so a right-click landing on that boundary asks a disposed
                             // component where it is (BossConsole-Releases#17).
                             installPopupWindowContextMenu(popupBrowser, browserView)
+                            // Must be paired with the menu: a Swing popup over a heavyweight
+                            // browser surface does not close when the user clicks back into the
+                            // page, because Chromium consumes that press before AWT sees it. The
+                            // popup browser comes from params.popupBrowser() and gets none of the
+                            // setup a BOSS-created browser does, so this has to be explicit.
+                            FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
 
                             // Update frame title when page title changes
                             subscriptions +=

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1504,6 +1504,13 @@ internal class BrowserHandleImpl(
                                     .newInstance(popupBrowser)
                             frame.contentPane.add(browserView)
 
+                            // Replace JxBrowser's built-in Swing context menu, which crashes the
+                            // EDT here: it positions itself from getLocationOnScreen() inside an
+                            // invokeLater, and an OAuth popup closes itself the moment the flow
+                            // completes, so a right-click landing on that boundary asks a disposed
+                            // component where it is (BossConsole-Releases#17).
+                            installPopupWindowContextMenu(popupBrowser, browserView)
+
                             // Update frame title when page title changes
                             subscriptions +=
                                 popupBrowser.on(TitleChanged::class.java) { event ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1504,18 +1504,12 @@ internal class BrowserHandleImpl(
                                     .newInstance(popupBrowser)
                             frame.contentPane.add(browserView)
 
-                            // Replace JxBrowser's built-in Swing context menu, which crashes the
+                            // Replaces JxBrowser's built-in Swing context menu, which crashes the
                             // EDT here: it positions itself from getLocationOnScreen() inside an
                             // invokeLater, and an OAuth popup closes itself the moment the flow
                             // completes, so a right-click landing on that boundary asks a disposed
                             // component where it is (BossConsole-Releases#17).
-                            installPopupWindowContextMenu(popupBrowser, browserView)
-                            // Must be paired with the menu: a Swing popup over a heavyweight
-                            // browser surface does not close when the user clicks back into the
-                            // page, because Chromium consumes that press before AWT sees it. The
-                            // popup browser comes from params.popupBrowser() and gets none of the
-                            // setup a BOSS-created browser does, so this has to be explicit.
-                            FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
+                            installPopupWindowChrome(popupBrowser, browserView)
 
                             // Update frame title when page title changes
                             subscriptions +=

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -1,0 +1,127 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
+import com.teamdev.jxbrowser.frame.EditorCommand
+import java.awt.Component
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
+import javax.swing.SwingUtilities
+
+private val logger = BossLogger.forComponent("PopupWindowContextMenu")
+
+/**
+ * Context menu for the Swing popup windows BOSS opens for `window.open` popups (OAuth, payment).
+ *
+ * These browsers live in their own [javax.swing.JFrame] rather than in a tab, so BOSS's own
+ * context menu — which is Compose, drawn by the browser plugin — cannot reach them. Until now they
+ * fell through to **JxBrowser's built-in Swing menu**, which crashes:
+ *
+ * ```
+ * java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location
+ *     at ...view.swing.internal.menu.SuggestionsPopup.lambda$show$2(SuggestionsPopup.java:104)
+ * ```
+ *
+ * That menu positions itself from `getLocationOnScreen()` inside an `invokeLater`, so anything that
+ * stops the view showing between the right-click and that lambda throws on the EDT. A popup window
+ * is exactly where that races: an OAuth popup closes *itself* when the flow completes
+ * (`BrowserClosed` → `frame.dispose()`), so a right-click landing as the flow finishes disposes the
+ * frame out from under the pending menu. Reported as BossConsole-Releases#17, on Windows, after a
+ * session full of auth activity.
+ *
+ * Installing any [ShowContextMenuCallback] suppresses the built-in menu, which is what removes the
+ * crash. Rather than leave popup windows with no menu at all, this substitutes a small Swing menu
+ * with the editing actions that matter in a login form. Two differences from the built-in one are
+ * deliberate:
+ *
+ *  - It is shown only when the view [Component.isShowing], and positioned from coordinates
+ *    relative to that component rather than from screen coordinates — so the failure mode above is
+ *    unreachable rather than merely less likely.
+ *  - It offers no spell-check suggestions. Those are what `SuggestionsPopup` exists for, and they
+ *    are not worth re-implementing for a transient OAuth window.
+ */
+internal fun installPopupWindowContextMenu(
+    popupBrowser: Browser,
+    view: Component,
+) {
+    popupBrowser.set(
+        ShowContextMenuCallback::class.java,
+        ShowContextMenuCallback { params, tell ->
+            // Read the location before hopping threads: params is only valid for this call.
+            val location =
+                runCatching { params.location() }
+                    .onFailure {
+                        logger.debug(
+                            LogCategory.BROWSER,
+                            "Could not read popup context-menu location",
+                            mapOf("error" to it.toString()),
+                        )
+                    }.getOrNull()
+
+            // Answer unconditionally, including on the failure path above: an un-responded
+            // callback leaves Chromium waiting and shows nothing at all. This close() is also
+            // what suppresses JxBrowser's built-in menu.
+            tell.close()
+            if (location == null) return@ShowContextMenuCallback
+
+            val x = location.x()
+            val y = location.y()
+            SwingUtilities.invokeLater {
+                // The whole point of this class: by the time this runs the popup may have closed
+                // itself. A disposed or hidden view has no location on screen, and asking for one
+                // is what threw.
+                if (!view.isShowing || popupBrowser.isClosed) {
+                    logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
+                    return@invokeLater
+                }
+                runCatching { buildMenu(popupBrowser).show(view, x, y) }
+                    .onFailure {
+                        logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = it)
+                    }
+            }
+        },
+    )
+}
+
+/**
+ * Cut / Copy / Paste / Select All, enabled according to what the focused frame actually supports.
+ *
+ * Built fresh per open so the enabled states reflect the current selection instead of the one from
+ * whenever a cached menu was created.
+ */
+private fun buildMenu(browser: Browser): JPopupMenu {
+    val menu = JPopupMenu()
+    val frame = browser.focusedFrame().orElse(null) ?: browser.mainFrame().orElse(null)
+
+    fun add(
+        label: String,
+        command: EditorCommand,
+    ) {
+        val item = JMenuItem(label)
+        // isCommandEnabled reflects the live selection - greying out Copy with nothing selected is
+        // the difference between a menu that looks native and one that looks broken.
+        item.isEnabled =
+            frame != null &&
+            runCatching { frame.isCommandEnabled(command.name()) }.getOrDefault(false)
+        item.addActionListener {
+            runCatching { frame?.execute(command) }
+                .onFailure {
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Popup editor command failed",
+                        mapOf("command" to label, "error" to it.toString()),
+                    )
+                }
+        }
+        menu.add(item)
+    }
+
+    add("Cut", EditorCommand.cut())
+    add("Copy", EditorCommand.copy())
+    add("Paste", EditorCommand.paste())
+    menu.addSeparator()
+    add("Select All", EditorCommand.selectAll())
+    return menu
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.utils.logging.LogCategory
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
 import com.teamdev.jxbrowser.frame.EditorCommand
+import com.teamdev.jxbrowser.frame.Frame
+import com.teamdev.jxbrowser.menu.ContextMenuContentType
 import java.awt.Component
 import javax.swing.JMenuItem
 import javax.swing.JPopupMenu
@@ -12,35 +14,77 @@ import javax.swing.SwingUtilities
 
 private val logger = BossLogger.forComponent("PopupWindowContextMenu")
 
+/** One entry in the popup window's context menu. */
+internal data class PopupMenuEntry(
+    val label: String,
+    val command: EditorCommand?,
+    val enabled: Boolean,
+) {
+    /** Separators carry no command and are never enabled. */
+    val isSeparator: Boolean get() = command == null
+}
+
+/**
+ * The menu for a right-click, decided entirely from the click target.
+ *
+ * Pure and derived from [ShowContextMenuCallback.Params] values rather than from the browser,
+ * for two reasons:
+ *
+ *  - **It runs on the EDT.** Asking the browser `isCommandEnabled` per item would be four blocking
+ *    IPC round-trips into the Chromium process while the UI thread waits, and Compose Desktop
+ *    shares that thread — a busy renderer would freeze the whole app on right-click. This repo
+ *    already learned that here: `BrowserHandleImpl` replaced `browser.title()` with a cached value
+ *    on this exact path because "being slow hurts as much as throwing".
+ *  - **It is testable** without an engine.
+ *
+ * Enablement mirrors what the commands would actually do: Cut and Paste need an editable target,
+ * Cut and Copy need a selection, and Select All is always available.
+ */
+internal fun popupMenuEntriesFor(
+    contentTypes: List<ContextMenuContentType>,
+    selectedText: String,
+): List<PopupMenuEntry> {
+    val editable = contentTypes.contains(ContextMenuContentType.EDITABLE)
+    val hasSelection = selectedText.isNotEmpty()
+    return listOf(
+        PopupMenuEntry("Cut", EditorCommand.cut(), editable && hasSelection),
+        PopupMenuEntry("Copy", EditorCommand.copy(), hasSelection),
+        PopupMenuEntry("Paste", EditorCommand.paste(), editable),
+        PopupMenuEntry("", null, false),
+        PopupMenuEntry("Select All", EditorCommand.selectAll(), true),
+    )
+}
+
+/** True when the menu would be nothing but greyed-out items, which is worse than no menu. */
+internal fun hasAnyEnabledEntry(entries: List<PopupMenuEntry>): Boolean = entries.any { it.enabled }
+
 /**
  * Context menu for the Swing popup windows BOSS opens for `window.open` popups (OAuth, payment).
  *
- * These browsers live in their own [javax.swing.JFrame] rather than in a tab, so BOSS's own
- * context menu — which is Compose, drawn by the browser plugin — cannot reach them. Until now they
- * fell through to **JxBrowser's built-in Swing menu**, which crashes:
+ * These browsers live in their own [javax.swing.JFrame] rather than in a tab, so BOSS's own context
+ * menu — Compose, drawn by the browser plugin — cannot reach them. Until now they fell through to
+ * **JxBrowser's built-in Swing menu**, which crashes:
  *
  * ```
  * java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location
  *     at ...view.swing.internal.menu.SuggestionsPopup.lambda$show$2(SuggestionsPopup.java:104)
  * ```
  *
- * That menu positions itself from `getLocationOnScreen()` inside an `invokeLater`, so anything that
- * stops the view showing between the right-click and that lambda throws on the EDT. A popup window
- * is exactly where that races: an OAuth popup closes *itself* when the flow completes
- * (`BrowserClosed` → `frame.dispose()`), so a right-click landing as the flow finishes disposes the
- * frame out from under the pending menu. Reported as BossConsole-Releases#17, on Windows, after a
- * session full of auth activity.
+ * That menu resolves its position from `getLocationOnScreen()` inside an `invokeLater`, so anything
+ * that stops the view showing between the right-click and that lambda throws on the EDT. A popup
+ * window is where that races: an OAuth popup closes *itself* when the flow completes
+ * (`BrowserClosed` → `frame.dispose()`), so a right-click landing on that boundary asks a disposed
+ * component where it is. Reported as BossConsole-Releases#17.
  *
  * Installing any [ShowContextMenuCallback] suppresses the built-in menu, which is what removes the
- * crash. Rather than leave popup windows with no menu at all, this substitutes a small Swing menu
- * with the editing actions that matter in a login form. Two differences from the built-in one are
- * deliberate:
+ * crash. This substitutes a small editing menu rather than leaving popup windows with nothing —
+ * right-click paste into a login form is a reasonable thing to want. It differs from the built-in
+ * menu deliberately: it renders only while the view is showing, positions relative to the component
+ * instead of from screen coordinates, and offers no spell-check suggestions.
  *
- *  - It is shown only when the view [Component.isShowing], and positioned from coordinates
- *    relative to that component rather than from screen coordinates — so the failure mode above is
- *    unreachable rather than merely less likely.
- *  - It offers no spell-check suggestions. Those are what `SuggestionsPopup` exists for, and they
- *    are not worth re-implementing for a transient OAuth window.
+ * Pairs with [FluckEngine.setupSwingPopupDismissOnPageClick], which the caller must also install on
+ * the popup browser — without it a Swing menu over a heavyweight browser surface does not close
+ * when the user clicks back into the page, because Chromium consumes that press before AWT sees it.
  */
 internal fun installPopupWindowContextMenu(
     popupBrowser: Browser,
@@ -49,34 +93,49 @@ internal fun installPopupWindowContextMenu(
     popupBrowser.set(
         ShowContextMenuCallback::class.java,
         ShowContextMenuCallback { params, tell ->
-            // Read the location before hopping threads: params is only valid for this call.
-            val location =
-                runCatching { params.location() }
-                    .onFailure {
-                        logger.debug(
-                            LogCategory.BROWSER,
-                            "Could not read popup context-menu location",
-                            mapOf("error" to it.toString()),
-                        )
-                    }.getOrNull()
+            // Everything needed is read here, while params is still valid, and NOT re-read later:
+            // params belongs to this call only.
+            //
+            // params.frame() is the frame Chromium resolved for the actual click. Using
+            // browser.focusedFrame() instead would answer for the wrong frame inside an iframe -
+            // a lesson already recorded in BrowserHandleImpl - and OAuth and payment pages are
+            // frequently iframed, which is exactly what this menu serves.
+            val target =
+                runCatching {
+                    Triple(
+                        params.location(),
+                        params.frame().orElse(null),
+                        popupMenuEntriesFor(params.contentTypes(), params.selectedText()),
+                    )
+                }.onFailure {
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Could not read the popup context-menu target",
+                        mapOf("error" to it.toString()),
+                    )
+                }.getOrNull()
 
-            // Answer unconditionally, including on the failure path above: an un-responded
-            // callback leaves Chromium waiting and shows nothing at all. This close() is also
-            // what suppresses JxBrowser's built-in menu.
+            // Answer unconditionally, including on the failure path: an un-responded callback
+            // leaves Chromium waiting and shows nothing at all. This close() is also what
+            // suppresses JxBrowser's built-in menu.
             tell.close()
-            if (location == null) return@ShowContextMenuCallback
+            if (target == null) return@ShowContextMenuCallback
+            val (location, frame, entries) = target
+            if (frame == null || !hasAnyEnabledEntry(entries)) return@ShowContextMenuCallback
 
             val x = location.x()
             val y = location.y()
             SwingUtilities.invokeLater {
-                // The whole point of this class: by the time this runs the popup may have closed
-                // itself. A disposed or hidden view has no location on screen, and asking for one
-                // is what threw.
+                // Check-then-act, and safe today only because both frame.dispose() call sites go
+                // through invokeLater, so a disposal cannot land between this check and show().
+                // The runCatching below is what keeps that robust rather than merely lucky: a
+                // disposal added off the EDT later would otherwise reduce this to the very race
+                // being fixed.
                 if (!view.isShowing || popupBrowser.isClosed) {
                     logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
                     return@invokeLater
                 }
-                runCatching { buildMenu(popupBrowser).show(view, x, y) }
+                runCatching { buildMenu(frame, entries).show(view, x, y) }
                     .onFailure {
                         logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = it)
                     }
@@ -85,43 +144,33 @@ internal fun installPopupWindowContextMenu(
     )
 }
 
-/**
- * Cut / Copy / Paste / Select All, enabled according to what the focused frame actually supports.
- *
- * Built fresh per open so the enabled states reflect the current selection instead of the one from
- * whenever a cached menu was created.
- */
-private fun buildMenu(browser: Browser): JPopupMenu {
+/** Renders [entries] against the frame the click resolved to. */
+private fun buildMenu(
+    frame: Frame,
+    entries: List<PopupMenuEntry>,
+): JPopupMenu {
     val menu = JPopupMenu()
-    val frame = browser.focusedFrame().orElse(null) ?: browser.mainFrame().orElse(null)
-
-    fun add(
-        label: String,
-        command: EditorCommand,
-    ) {
-        val item = JMenuItem(label)
-        // isCommandEnabled reflects the live selection - greying out Copy with nothing selected is
-        // the difference between a menu that looks native and one that looks broken.
-        item.isEnabled =
-            frame != null &&
-            runCatching { frame.isCommandEnabled(command.name()) }.getOrDefault(false)
-        item.addActionListener {
-            runCatching { frame?.execute(command) }
-                .onFailure {
-                    logger.debug(
-                        LogCategory.BROWSER,
-                        "Popup editor command failed",
-                        mapOf("command" to label, "error" to it.toString()),
-                    )
-                }
+    entries.forEach { entry ->
+        val command = entry.command
+        if (command == null) {
+            menu.addSeparator()
+            return@forEach
         }
-        menu.add(item)
+        menu.add(
+            JMenuItem(entry.label).apply {
+                isEnabled = entry.enabled
+                addActionListener {
+                    runCatching { frame.execute(command) }
+                        .onFailure {
+                            logger.debug(
+                                LogCategory.BROWSER,
+                                "Popup editor command failed",
+                                mapOf("command" to entry.label, "error" to it.toString()),
+                            )
+                        }
+                }
+            },
+        )
     }
-
-    add("Cut", EditorCommand.cut())
-    add("Copy", EditorCommand.copy())
-    add("Paste", EditorCommand.paste())
-    menu.addSeparator()
-    add("Select All", EditorCommand.selectAll())
     return menu
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -29,23 +29,39 @@ internal data class PopupMenuEntry(
 /**
  * Whether the system clipboard currently holds text that Paste could insert.
  *
- * A local AWT call, not Chromium IPC, so it does not reopen the EDT-blocking concern that moved
- * enablement off `isCommandEnabled`. Defaults to **enabled** when the clipboard cannot be read: it
- * is briefly lockable by another process on Windows, and a Paste that turns out to be a no-op is a
- * far smaller annoyance than Paste greyed out on a login form when the user does have something to
- * paste.
+ * A local AWT call, not Chromium IPC, so it adds no round-trip to the right-click path.
+ *
+ * **Must not throw.** Callers use it while assembling the menu, and an escaping exception there is
+ * caught by an outer handler that leaves the entry list empty — which suppresses the whole menu,
+ * silently, instead of just mis-enabling one item. All three documented ways this call fails are
+ * therefore handled, and every one of them defaults to *enabled*: a Paste that turns out to be a
+ * no-op is a far smaller annoyance than Paste greyed out on a login form when the user does have
+ * something to paste.
+ *
+ *  - [IllegalStateException] — the clipboard is momentarily locked by another process (Windows).
+ *  - [java.awt.HeadlessException] — no display; an `UnsupportedOperationException`, *not* an
+ *    `IllegalStateException`, so it needs its own branch.
+ *  - [SecurityException] — `AWTPermission("accessClipboard")` denied.
  */
 internal fun clipboardHasText(): Boolean =
     try {
         Toolkit.getDefaultToolkit().systemClipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)
     } catch (e: IllegalStateException) {
-        logger.debug(
-            LogCategory.BROWSER,
-            "Clipboard unavailable - assuming paste is possible",
-            mapOf("error" to e.toString()),
-        )
-        true
+        clipboardUnavailable(e)
+    } catch (e: UnsupportedOperationException) {
+        clipboardUnavailable(e)
+    } catch (e: SecurityException) {
+        clipboardUnavailable(e)
     }
+
+private fun clipboardUnavailable(e: Exception): Boolean {
+    logger.debug(
+        LogCategory.BROWSER,
+        "Clipboard unavailable - assuming paste is possible",
+        mapOf("error" to e.toString()),
+    )
+    return true
+}
 
 /**
  * The menu for a right-click, decided entirely from the click target.
@@ -53,11 +69,13 @@ internal fun clipboardHasText(): Boolean =
  * Pure and derived from [ShowContextMenuCallback.Params] values rather than from the browser,
  * for two reasons:
  *
- *  - **It runs on the EDT.** Asking the browser `isCommandEnabled` per item would be four blocking
- *    IPC round-trips into the Chromium process while the UI thread waits, and Compose Desktop
- *    shares that thread — a busy renderer would freeze the whole app on right-click. This repo
- *    already learned that here: `BrowserHandleImpl` replaced `browser.title()` with a cached value
- *    on this exact path because "being slow hurts as much as throwing".
+ *  - **No blocking IPC on the right-click path.** Asking the browser `isCommandEnabled` per item
+ *    would be four synchronous round-trips into the Chromium process before the menu could be
+ *    built, delaying it on every right-click and stalling on a busy renderer. This callback runs
+ *    on a **JxBrowser thread**, not the EDT — which is why showing the menu needs
+ *    `SwingUtilities.invokeLater` — so the cost lands on menu latency rather than on the UI
+ *    thread. `BrowserHandleImpl` reached the same conclusion for the same callback, replacing
+ *    `browser.title()` with a cached value because "being slow hurts as much as throwing".
  *  - **It is testable** without an engine.
  *
  * Enablement mirrors what each command would actually do: Cut and Paste need an editable target,
@@ -164,6 +182,12 @@ internal fun installPopupWindowContextMenu(
             // Exception rather than Throwable: a genuinely fatal Error is not this boundary's to
             // swallow, matching the policy BrowserHandleImpl.deliverContextMenu states for the
             // same callback path.
+            // Read outside the try on purpose. clipboardHasText() is documented not to throw, but
+            // if it ever did from in there, the catch below would leave `entries` empty while
+            // `frame` was already set - and an empty list means shouldShowPopupMenu suppresses the
+            // menu entirely. Keeping it out here makes "no menu at all" unreachable from this call.
+            val clipboardText = clipboardHasText()
+
             var frame: Frame? = null
             var entries: List<PopupMenuEntry> = emptyList()
             var x = 0
@@ -173,7 +197,7 @@ internal fun installPopupWindowContextMenu(
                 x = location.x()
                 y = location.y()
                 frame = params.frame().orElse(null)
-                entries = popupMenuEntriesFor(params.contentTypes(), params.selectedText(), clipboardHasText())
+                entries = popupMenuEntriesFor(params.contentTypes(), params.selectedText(), clipboardText)
             } catch (e: Exception) {
                 logger.debug(
                     LogCategory.BROWSER,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -8,6 +8,7 @@ import com.teamdev.jxbrowser.frame.EditorCommand
 import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.menu.ContextMenuContentType
 import java.awt.Component
+import java.awt.Point
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import javax.swing.JMenuItem
@@ -58,12 +59,29 @@ internal fun clipboardHasText(): Boolean =
     }
 
 private fun clipboardUnavailable(e: Exception): Boolean {
+    // `data` rather than `error = e`, unlike the rest of this file: debug() takes no throwable.
     logger.debug(
         LogCategory.BROWSER,
         "Clipboard unavailable - assuming paste is possible",
         mapOf("error" to e.toString()),
     )
     return true
+}
+
+/**
+ * Answers Chromium, and never throws while doing it.
+ *
+ * `close()` can fail — the request already answered, or the browser torn down mid-callback — and it
+ * is called from a `finally` on a JxBrowser thread, so an escaping exception there would be exactly
+ * the kind of uncaught, off-EDT throw this file exists to remove.
+ */
+@Suppress("TooGenericExceptionCaught") // See installPopupWindowContextMenu - Error must propagate.
+private fun closeQuietly(tell: ShowContextMenuCallback.Action) {
+    try {
+        tell.close()
+    } catch (e: Exception) {
+        logger.warn(LogCategory.BROWSER, "Could not answer the context-menu callback", error = e)
+    }
 }
 
 /**
@@ -108,10 +126,8 @@ internal fun popupMenuEntriesFor(
 /**
  * True when the menu would be nothing but greyed-out items, which is worse than no menu.
  *
- * Note this buys nothing today: `Select All` is unconditionally enabled, so [popupMenuEntriesFor]
- * cannot currently produce a list this rejects. It is a guard against a future entry set, not live
- * behaviour — what a right-click on a plain page actually shows is a one-usable-item menu
- * (`Select All`, under three greyed entries).
+ * Guards a future entry set rather than live behaviour: `Select All` is unconditionally enabled, so
+ * [popupMenuEntriesFor] cannot currently produce a list this rejects.
  */
 internal fun hasAnyEnabledEntry(entries: List<PopupMenuEntry>): Boolean = entries.any { it.enabled }
 
@@ -126,6 +142,46 @@ internal fun shouldShowPopupMenu(
     browserClosed: Boolean,
     entries: List<PopupMenuEntry>,
 ): Boolean = viewShowing && !browserClosed && hasAnyEnabledEntry(entries)
+
+/**
+ * Shows the menu if the view is still able to host one. Returns whether it was shown.
+ *
+ * **Must run on the EDT.** Both the guard and `show()` touch Swing state.
+ *
+ * The guard and the `catch` are a pair, and **neither is dead code**:
+ *
+ *  - `JPopupMenu.show(invoker, x, y)` resolves its position via `invoker.getLocationOnScreen()`
+ *    internally — the very call that threw in `SuggestionsPopup`, reached through a friendlier API.
+ *    Passing component-relative coordinates is therefore not itself protection. Refusing to render
+ *    against a view that has stopped showing is.
+ *  - That check-then-act is safe today only because both `frame.dispose()` call sites go through
+ *    `invokeLater`, so a disposal cannot land between the check and `show()`. The `catch` keeps it
+ *    robust rather than merely lucky — a disposal added off the EDT later would otherwise reduce
+ *    this to the exact race being fixed.
+ *
+ * [browserClosed] is a lambda because reading it is a call into JxBrowser during teardown, and a
+ * throw from the *check* would land uncaught on the EDT — the failure class this file removes.
+ */
+@Suppress("TooGenericExceptionCaught") // See installPopupWindowContextMenu - Error must propagate.
+internal fun showPopupMenuIfPossible(
+    view: Component,
+    browserClosed: () -> Boolean,
+    target: Frame,
+    entries: List<PopupMenuEntry>,
+    at: Point,
+): Boolean =
+    try {
+        if (shouldShowPopupMenu(view.isShowing, browserClosed(), entries)) {
+            buildPopupWindowMenu(target, entries).show(view, at.x, at.y)
+            true
+        } else {
+            logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
+            false
+        }
+    } catch (e: Exception) {
+        logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = e)
+        false
+    }
 
 /**
  * Context menu for the Swing popup windows BOSS opens for `window.open` popups (OAuth, payment).
@@ -203,34 +259,29 @@ internal fun installPopupWindowContextMenu(
                 logger.warn(LogCategory.BROWSER, "Could not fully read the popup context-menu target", error = e)
             } finally {
                 // Answer on every path: an un-responded callback leaves Chromium waiting and shows
-                // nothing at all. This close() is also what suppresses the built-in menu.
-                tell.close()
+                // nothing at all. This close() is also what suppresses the built-in menu. Guarded
+                // in turn because close() can itself throw - already answered, or the browser torn
+                // down mid-callback - and this runs on a JxBrowser thread, where an escaping
+                // exception is the same failure class the whole file exists to remove.
+                closeQuietly(tell)
             }
 
-            val target = frame ?: return@ShowContextMenuCallback
+            val target = frame
+            if (target == null) {
+                // Distinct from the WARN above: this is a params read that SUCCEEDED and reported
+                // no frame. Without a line here that case is a right-click that does nothing, with
+                // no trace at all - indistinguishable in a user's log from the fix not shipping.
+                logger.debug(LogCategory.BROWSER, "No frame resolved for the popup right-click")
+                return@ShowContextMenuCallback
+            }
 
-            // Built AFTER tell.close(), so Chromium is already released before the clipboard read.
-            // Being outside the try also keeps a throw here from emptying the list, which would
-            // suppress the menu entirely.
+            // Built AFTER tell.close(), so Chromium is already released before the clipboard read,
+            // and on this JxBrowser thread rather than the EDT - a slow Windows clipboard read can
+            // then stall neither. Do not hoist this into the invokeLater. Being outside the try
+            // also keeps a throw here from emptying the list, which would suppress the menu.
             val entries = popupMenuEntriesFor(contentTypes, selectedText, ::clipboardHasText)
             SwingUtilities.invokeLater {
-                // The try wraps the guard as well as the show. `popupBrowser.isClosed` is a call
-                // into JxBrowser on the EDT during teardown - the exact window in which things are
-                // being disposed - so an exception from the check itself would land uncaught on the
-                // EDT, which is the failure class this whole file exists to remove.
-                try {
-                    // Check-then-act, and safe today only because both frame.dispose() call sites
-                    // go through invokeLater, so a disposal cannot land between this check and
-                    // show(). The catch keeps that robust rather than merely lucky: a disposal
-                    // added off the EDT later would otherwise reduce this to the race being fixed.
-                    if (!shouldShowPopupMenu(view.isShowing, popupBrowser.isClosed, entries)) {
-                        logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
-                        return@invokeLater
-                    }
-                    buildPopupWindowMenu(target, entries).show(view, x, y)
-                } catch (e: Exception) {
-                    logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = e)
-                }
+                showPopupMenuIfPossible(view, { popupBrowser.isClosed }, target, entries, Point(x, y))
             }
         },
     )
@@ -302,10 +353,11 @@ internal fun buildPopupWindowMenu(
                     try {
                         frame.execute(command)
                     } catch (e: Exception) {
-                        logger.debug(
+                        // WARN: the user picked this item and nothing happened.
+                        logger.warn(
                             LogCategory.BROWSER,
-                            "Popup editor command failed",
-                            mapOf("command" to entry.label, "error" to e.toString()),
+                            "Popup editor command failed: ${entry.label}",
+                            error = e,
                         )
                     }
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -29,7 +29,10 @@ internal data class PopupMenuEntry(
 /**
  * Whether the system clipboard currently holds text that Paste could insert.
  *
- * A local AWT call, not Chromium IPC, so it adds no round-trip to the right-click path.
+ * A local AWT call, not Chromium IPC, but not free either: the JDK's Windows clipboard open is a
+ * retry-with-sleep loop, so on the one platform this crash was reported on it can take tens of
+ * milliseconds while another process holds the clipboard. Hence it runs after `tell.close()`, and
+ * only when the target is editable.
  *
  * **Must not throw.** Callers use it while assembling the menu, and an escaping exception there is
  * caught by an outer handler that leaves the entry list empty — which suppresses the whole menu,
@@ -81,18 +84,22 @@ private fun clipboardUnavailable(e: Exception): Boolean {
  * Enablement mirrors what each command would actually do: Cut and Paste need an editable target,
  * Cut and Copy need a selection, Paste needs something on the clipboard, and Select All is always
  * available.
+ *
+ * [clipboardHasText] is a lambda, not a value, so the probe is skipped on a non-editable target —
+ * the majority of right-clicks in an OAuth window, and the case where its answer is discarded
+ * anyway. It is not free: see [clipboardHasText] on what a Windows clipboard read can cost.
  */
 internal fun popupMenuEntriesFor(
     contentTypes: List<ContextMenuContentType>,
     selectedText: String,
-    clipboardHasText: Boolean,
+    clipboardHasText: () -> Boolean,
 ): List<PopupMenuEntry> {
     val editable = contentTypes.contains(ContextMenuContentType.EDITABLE)
     val hasSelection = selectedText.isNotEmpty()
     return listOf(
         PopupMenuEntry("Cut", EditorCommand.cut(), editable && hasSelection),
         PopupMenuEntry("Copy", EditorCommand.copy(), hasSelection),
-        PopupMenuEntry("Paste", EditorCommand.paste(), editable && clipboardHasText),
+        PopupMenuEntry("Paste", EditorCommand.paste(), editable && clipboardHasText()),
         PopupMenuEntry("", null, false),
         PopupMenuEntry("Select All", EditorCommand.selectAll(), true),
     )
@@ -202,23 +209,25 @@ internal fun installPopupWindowContextMenu(
 
             val target = frame ?: return@ShowContextMenuCallback
 
-            // Built AFTER tell.close(), so Chromium is already released. That matters for the
-            // clipboard read in particular: the JDK's Windows clipboard open is a retry-with-sleep
-            // loop, so on the one platform this crash was reported on it can take tens of
-            // milliseconds while another process holds the clipboard. Being outside the try also
-            // keeps a throw here from emptying the list, which would suppress the menu entirely.
-            val entries = popupMenuEntriesFor(contentTypes, selectedText, clipboardHasText())
+            // Built AFTER tell.close(), so Chromium is already released before the clipboard read.
+            // Being outside the try also keeps a throw here from emptying the list, which would
+            // suppress the menu entirely.
+            val entries = popupMenuEntriesFor(contentTypes, selectedText, ::clipboardHasText)
             SwingUtilities.invokeLater {
-                // Check-then-act, and safe today only because both frame.dispose() call sites go
-                // through invokeLater, so a disposal cannot land between this check and show().
-                // The catch below keeps that robust rather than merely lucky: a disposal added off
-                // the EDT later would otherwise reduce this to the very race being fixed.
-                if (!shouldShowPopupMenu(view.isShowing, popupBrowser.isClosed, entries)) {
-                    logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
-                    return@invokeLater
-                }
+                // The try wraps the guard as well as the show. `popupBrowser.isClosed` is a call
+                // into JxBrowser on the EDT during teardown - the exact window in which things are
+                // being disposed - so an exception from the check itself would land uncaught on the
+                // EDT, which is the failure class this whole file exists to remove.
                 try {
-                    buildMenu(target, entries).show(view, x, y)
+                    // Check-then-act, and safe today only because both frame.dispose() call sites
+                    // go through invokeLater, so a disposal cannot land between this check and
+                    // show(). The catch keeps that robust rather than merely lucky: a disposal
+                    // added off the EDT later would otherwise reduce this to the race being fixed.
+                    if (!shouldShowPopupMenu(view.isShowing, popupBrowser.isClosed, entries)) {
+                        logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
+                        return@invokeLater
+                    }
+                    buildPopupWindowMenu(target, entries).show(view, x, y)
                 } catch (e: Exception) {
                     logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = e)
                 }
@@ -254,10 +263,14 @@ internal fun installPopupWindowChrome(
     try {
         installPopupWindowContextMenu(popupBrowser, view)
     } catch (e: Exception) {
-        logger.debug(
+        // WARN, not debug: if this install fails the built-in menu stays, and with it the EDT crash
+        // this file exists to remove - live for that popup, for the rest of its life. That is a
+        // different order of failure from the dismissal handler's (a menu that sticks) and needs to
+        // be visible in a log a user would actually send.
+        logger.warn(
             LogCategory.BROWSER,
             "Could not install the popup context menu - keeping JxBrowser's built-in one",
-            mapOf("error" to e.toString()),
+            error = e,
         )
     }
     // Deliberately outside the catch above: if the menu failed to install, the built-in menu is
@@ -267,7 +280,7 @@ internal fun installPopupWindowChrome(
 
 /** Renders [entries] against the frame the click resolved to. */
 @Suppress("TooGenericExceptionCaught") // See installPopupWindowContextMenu - Error must propagate.
-internal fun buildMenu(
+internal fun buildPopupWindowMenu(
     frame: Frame,
     entries: List<PopupMenuEntry>,
 ): JPopupMenu {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -55,8 +55,27 @@ internal fun popupMenuEntriesFor(
     )
 }
 
-/** True when the menu would be nothing but greyed-out items, which is worse than no menu. */
+/**
+ * True when the menu would be nothing but greyed-out items, which is worse than no menu.
+ *
+ * Note this buys nothing today: `Select All` is unconditionally enabled, so
+ * [popupMenuEntriesFor] cannot currently produce a list this rejects. It is a guard against a
+ * future entry set, not live behaviour — what a right-click on a plain page actually shows is a
+ * one-usable-item menu (`Select All`, under three greyed entries).
+ */
 internal fun hasAnyEnabledEntry(entries: List<PopupMenuEntry>): Boolean = entries.any { it.enabled }
+
+/**
+ * Whether the menu should still be shown by the time the EDT gets to it.
+ *
+ * Separated from the callback so the guard that actually prevents the reported crash is testable:
+ * a disposed or hidden view has no location on screen, and asking for one is what threw.
+ */
+internal fun shouldShowPopupMenu(
+    viewShowing: Boolean,
+    browserClosed: Boolean,
+    entries: List<PopupMenuEntry>,
+): Boolean = viewShowing && !browserClosed && hasAnyEnabledEntry(entries)
 
 /**
  * Context menu for the Swing popup windows BOSS opens for `window.open` popups (OAuth, payment).
@@ -82,9 +101,15 @@ internal fun hasAnyEnabledEntry(entries: List<PopupMenuEntry>): Boolean = entrie
  * menu deliberately: it renders only while the view is showing, positions relative to the component
  * instead of from screen coordinates, and offers no spell-check suggestions.
  *
- * Pairs with [FluckEngine.setupSwingPopupDismissOnPageClick], which the caller must also install on
- * the popup browser — without it a Swing menu over a heavyweight browser surface does not close
- * when the user clicks back into the page, because Chromium consumes that press before AWT sees it.
+ * Prefer [installPopupWindowChrome] over calling this directly: the menu is only correct when
+ * paired with the page-click dismissal, and that pairing should not be something a call site can
+ * forget.
+ *
+ * One piece of blocking IPC remains on the EDT by choice: `Frame.execute` in the item's action
+ * listener. Deciding the menu is now free, but running the chosen command is a synchronous
+ * round-trip into the renderer, so a wedged page can still stall the UI thread on Cut/Copy/Paste.
+ * Accepted because it happens after an explicit user action rather than on every right-click, and
+ * it is what JxBrowser's own Swing sample does.
  */
 internal fun installPopupWindowContextMenu(
     popupBrowser: Browser,
@@ -131,7 +156,7 @@ internal fun installPopupWindowContextMenu(
                 // The runCatching below is what keeps that robust rather than merely lucky: a
                 // disposal added off the EDT later would otherwise reduce this to the very race
                 // being fixed.
-                if (!view.isShowing || popupBrowser.isClosed) {
+                if (!shouldShowPopupMenu(view.isShowing, popupBrowser.isClosed, entries)) {
                     logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
                     return@invokeLater
                 }
@@ -145,7 +170,7 @@ internal fun installPopupWindowContextMenu(
 }
 
 /** Renders [entries] against the frame the click resolved to. */
-private fun buildMenu(
+internal fun buildMenu(
     frame: Frame,
     entries: List<PopupMenuEntry>,
 ): JPopupMenu {
@@ -173,4 +198,23 @@ private fun buildMenu(
         )
     }
     return menu
+}
+
+/**
+ * Everything a popup window's browser needs before it is shown.
+ *
+ * The two calls below are a pair, not a sequence: a Swing menu over a heavyweight browser surface
+ * does not close when the user clicks back into the page — Chromium consumes that press before AWT
+ * sees it — so installing the menu without the dismissal produces a menu that sticks. Bundling them
+ * makes that impossible to get wrong at a call site, instead of relying on a comment at each one.
+ *
+ * A popup browser arrives from `params.popupBrowser()` and receives none of the setup a
+ * BOSS-created browser gets, which is why this has to be explicit at all.
+ */
+internal fun installPopupWindowChrome(
+    popupBrowser: Browser,
+    view: Component,
+) {
+    installPopupWindowContextMenu(popupBrowser, view)
+    FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -171,39 +171,29 @@ internal fun installPopupWindowContextMenu(
     popupBrowser.set(
         ShowContextMenuCallback::class.java,
         ShowContextMenuCallback { params, tell ->
-            // Everything needed is read here, while params is still valid, and NOT re-read later:
-            // params belongs to this call only.
-            //
-            // params.frame() is the frame Chromium resolved for the actual click. Using
-            // browser.focusedFrame() instead would answer for the wrong frame inside an iframe -
-            // a lesson already recorded in BrowserHandleImpl - and OAuth and payment pages are
-            // frequently iframed, which is exactly what this menu serves.
-            //
-            // Exception rather than Throwable: a genuinely fatal Error is not this boundary's to
-            // swallow, matching the policy BrowserHandleImpl.deliverContextMenu states for the
-            // same callback path.
-            // Read outside the try on purpose. clipboardHasText() is documented not to throw, but
-            // if it ever did from in there, the catch below would leave `entries` empty while
-            // `frame` was already set - and an empty list means shouldShowPopupMenu suppresses the
-            // menu entirely. Keeping it out here makes "no menu at all" unreachable from this call.
-            val clipboardText = clipboardHasText()
-
+            // Only params reads go in here - params is valid for this call only - and nothing is
+            // derived from them yet. A partial read then degrades to a MINIMAL menu rather than to
+            // none: the list is built below from whatever was captured, and Select All stays
+            // enabled regardless, so a failure costs some greyed items instead of a right-click
+            // that silently does nothing. WARN, not debug: "the menu is wrong" should be
+            // diagnosable from a user's log, unlike the routine teardown races.
             var frame: Frame? = null
-            var entries: List<PopupMenuEntry> = emptyList()
             var x = 0
             var y = 0
+            var contentTypes: List<ContextMenuContentType> = emptyList()
+            var selectedText = ""
             try {
                 val location = params.location()
                 x = location.x()
                 y = location.y()
+                // The frame Chromium resolved for the ACTUAL click. browser.focusedFrame() would
+                // answer for the wrong frame inside an iframe - a lesson already recorded in
+                // BrowserHandleImpl - and iframed OAuth/payment pages are the main case here.
                 frame = params.frame().orElse(null)
-                entries = popupMenuEntriesFor(params.contentTypes(), params.selectedText(), clipboardText)
+                contentTypes = params.contentTypes()
+                selectedText = params.selectedText()
             } catch (e: Exception) {
-                logger.debug(
-                    LogCategory.BROWSER,
-                    "Could not read the popup context-menu target",
-                    mapOf("error" to e.toString()),
-                )
+                logger.warn(LogCategory.BROWSER, "Could not fully read the popup context-menu target", error = e)
             } finally {
                 // Answer on every path: an un-responded callback leaves Chromium waiting and shows
                 // nothing at all. This close() is also what suppresses the built-in menu.
@@ -211,6 +201,13 @@ internal fun installPopupWindowContextMenu(
             }
 
             val target = frame ?: return@ShowContextMenuCallback
+
+            // Built AFTER tell.close(), so Chromium is already released. That matters for the
+            // clipboard read in particular: the JDK's Windows clipboard open is a retry-with-sleep
+            // loop, so on the one platform this crash was reported on it can take tens of
+            // milliseconds while another process holds the clipboard. Being outside the try also
+            // keeps a throw here from emptying the list, which would suppress the menu entirely.
+            val entries = popupMenuEntriesFor(contentTypes, selectedText, clipboardHasText())
             SwingUtilities.invokeLater {
                 // Check-then-act, and safe today only because both frame.dispose() call sites go
                 // through invokeLater, so a disposal cannot land between this check and show().

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenu.kt
@@ -8,6 +8,8 @@ import com.teamdev.jxbrowser.frame.EditorCommand
 import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.menu.ContextMenuContentType
 import java.awt.Component
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
 import javax.swing.JMenuItem
 import javax.swing.JPopupMenu
 import javax.swing.SwingUtilities
@@ -25,6 +27,27 @@ internal data class PopupMenuEntry(
 }
 
 /**
+ * Whether the system clipboard currently holds text that Paste could insert.
+ *
+ * A local AWT call, not Chromium IPC, so it does not reopen the EDT-blocking concern that moved
+ * enablement off `isCommandEnabled`. Defaults to **enabled** when the clipboard cannot be read: it
+ * is briefly lockable by another process on Windows, and a Paste that turns out to be a no-op is a
+ * far smaller annoyance than Paste greyed out on a login form when the user does have something to
+ * paste.
+ */
+internal fun clipboardHasText(): Boolean =
+    try {
+        Toolkit.getDefaultToolkit().systemClipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)
+    } catch (e: IllegalStateException) {
+        logger.debug(
+            LogCategory.BROWSER,
+            "Clipboard unavailable - assuming paste is possible",
+            mapOf("error" to e.toString()),
+        )
+        true
+    }
+
+/**
  * The menu for a right-click, decided entirely from the click target.
  *
  * Pure and derived from [ShowContextMenuCallback.Params] values rather than from the browser,
@@ -37,19 +60,21 @@ internal data class PopupMenuEntry(
  *    on this exact path because "being slow hurts as much as throwing".
  *  - **It is testable** without an engine.
  *
- * Enablement mirrors what the commands would actually do: Cut and Paste need an editable target,
- * Cut and Copy need a selection, and Select All is always available.
+ * Enablement mirrors what each command would actually do: Cut and Paste need an editable target,
+ * Cut and Copy need a selection, Paste needs something on the clipboard, and Select All is always
+ * available.
  */
 internal fun popupMenuEntriesFor(
     contentTypes: List<ContextMenuContentType>,
     selectedText: String,
+    clipboardHasText: Boolean,
 ): List<PopupMenuEntry> {
     val editable = contentTypes.contains(ContextMenuContentType.EDITABLE)
     val hasSelection = selectedText.isNotEmpty()
     return listOf(
         PopupMenuEntry("Cut", EditorCommand.cut(), editable && hasSelection),
         PopupMenuEntry("Copy", EditorCommand.copy(), hasSelection),
-        PopupMenuEntry("Paste", EditorCommand.paste(), editable),
+        PopupMenuEntry("Paste", EditorCommand.paste(), editable && clipboardHasText),
         PopupMenuEntry("", null, false),
         PopupMenuEntry("Select All", EditorCommand.selectAll(), true),
     )
@@ -58,10 +83,10 @@ internal fun popupMenuEntriesFor(
 /**
  * True when the menu would be nothing but greyed-out items, which is worse than no menu.
  *
- * Note this buys nothing today: `Select All` is unconditionally enabled, so
- * [popupMenuEntriesFor] cannot currently produce a list this rejects. It is a guard against a
- * future entry set, not live behaviour — what a right-click on a plain page actually shows is a
- * one-usable-item menu (`Select All`, under three greyed entries).
+ * Note this buys nothing today: `Select All` is unconditionally enabled, so [popupMenuEntriesFor]
+ * cannot currently produce a list this rejects. It is a guard against a future entry set, not live
+ * behaviour — what a right-click on a plain page actually shows is a one-usable-item menu
+ * (`Select All`, under three greyed entries).
  */
 internal fun hasAnyEnabledEntry(entries: List<PopupMenuEntry>): Boolean = entries.any { it.enabled }
 
@@ -97,20 +122,30 @@ internal fun shouldShowPopupMenu(
  *
  * Installing any [ShowContextMenuCallback] suppresses the built-in menu, which is what removes the
  * crash. This substitutes a small editing menu rather than leaving popup windows with nothing —
- * right-click paste into a login form is a reasonable thing to want. It differs from the built-in
- * menu deliberately: it renders only while the view is showing, positions relative to the component
- * instead of from screen coordinates, and offers no spell-check suggestions.
+ * right-click paste into a login form is a reasonable thing to want.
  *
- * Prefer [installPopupWindowChrome] over calling this directly: the menu is only correct when
- * paired with the page-click dismissal, and that pairing should not be something a call site can
- * forget.
+ * Known differences from the menu it replaces, all accepted:
  *
- * One piece of blocking IPC remains on the EDT by choice: `Frame.execute` in the item's action
- * listener. Deciding the menu is now free, but running the chosen command is a synchronous
- * round-trip into the renderer, so a wedged page can still stall the UI thread on Cut/Copy/Paste.
- * Accepted because it happens after an explicit user action rather than on every right-click, and
- * it is what JxBrowser's own Swing sample does.
+ *  - **No spell-check suggestions** — that is what `SuggestionsPopup` was, and it is not worth
+ *    re-implementing for a transient OAuth window.
+ *  - **No Back / Forward / Reload / Print / View source.** Reload in a stuck OAuth window is the
+ *    one worth revisiting if anyone asks.
+ *  - **Mouse-dismiss only.** Escape does not close it and arrows do not navigate it, for the same
+ *    reason the page-click dismissal is needed at all: the popup browser owns the focused native
+ *    surface and has no `PressKeyCallback`, so those keys never reach Swing's
+ *    `MenuSelectionManager`.
+ *  - **One blocking IPC call remains on the EDT** — `Frame.execute` in the action listener.
+ *    Deciding the menu is free, but running the chosen command is a synchronous round-trip, so a
+ *    wedged page can stall the UI thread on Cut/Copy/Paste. Accepted: it follows an explicit user
+ *    action rather than every right-click, and matches JxBrowser's own Swing sample.
+ *
+ * Prefer [installPopupWindowChrome] over calling this directly — the menu is only correct when
+ * paired with the page-click dismissal.
  */
+// Exception, not Throwable, at a callback boundary: a fatal Error (OOM, StackOverflow) is not
+// this code's to swallow, which is exactly what runCatching here would do. detekt keeps this rule
+// on deliberately, so this is an argued exemption rather than a baseline entry.
+@Suppress("TooGenericExceptionCaught")
 internal fun installPopupWindowContextMenu(
     popupBrowser: Browser,
     view: Component,
@@ -125,56 +160,101 @@ internal fun installPopupWindowContextMenu(
             // browser.focusedFrame() instead would answer for the wrong frame inside an iframe -
             // a lesson already recorded in BrowserHandleImpl - and OAuth and payment pages are
             // frequently iframed, which is exactly what this menu serves.
-            val target =
-                runCatching {
-                    Triple(
-                        params.location(),
-                        params.frame().orElse(null),
-                        popupMenuEntriesFor(params.contentTypes(), params.selectedText()),
-                    )
-                }.onFailure {
-                    logger.debug(
-                        LogCategory.BROWSER,
-                        "Could not read the popup context-menu target",
-                        mapOf("error" to it.toString()),
-                    )
-                }.getOrNull()
+            //
+            // Exception rather than Throwable: a genuinely fatal Error is not this boundary's to
+            // swallow, matching the policy BrowserHandleImpl.deliverContextMenu states for the
+            // same callback path.
+            var frame: Frame? = null
+            var entries: List<PopupMenuEntry> = emptyList()
+            var x = 0
+            var y = 0
+            try {
+                val location = params.location()
+                x = location.x()
+                y = location.y()
+                frame = params.frame().orElse(null)
+                entries = popupMenuEntriesFor(params.contentTypes(), params.selectedText(), clipboardHasText())
+            } catch (e: Exception) {
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Could not read the popup context-menu target",
+                    mapOf("error" to e.toString()),
+                )
+            } finally {
+                // Answer on every path: an un-responded callback leaves Chromium waiting and shows
+                // nothing at all. This close() is also what suppresses the built-in menu.
+                tell.close()
+            }
 
-            // Answer unconditionally, including on the failure path: an un-responded callback
-            // leaves Chromium waiting and shows nothing at all. This close() is also what
-            // suppresses JxBrowser's built-in menu.
-            tell.close()
-            if (target == null) return@ShowContextMenuCallback
-            val (location, frame, entries) = target
-            if (frame == null || !hasAnyEnabledEntry(entries)) return@ShowContextMenuCallback
-
-            val x = location.x()
-            val y = location.y()
+            val target = frame ?: return@ShowContextMenuCallback
             SwingUtilities.invokeLater {
                 // Check-then-act, and safe today only because both frame.dispose() call sites go
                 // through invokeLater, so a disposal cannot land between this check and show().
-                // The runCatching below is what keeps that robust rather than merely lucky: a
-                // disposal added off the EDT later would otherwise reduce this to the very race
-                // being fixed.
+                // The catch below keeps that robust rather than merely lucky: a disposal added off
+                // the EDT later would otherwise reduce this to the very race being fixed.
                 if (!shouldShowPopupMenu(view.isShowing, popupBrowser.isClosed, entries)) {
                     logger.debug(LogCategory.BROWSER, "Skipping popup context menu - view is gone")
                     return@invokeLater
                 }
-                runCatching { buildMenu(frame, entries).show(view, x, y) }
-                    .onFailure {
-                        logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = it)
-                    }
+                try {
+                    buildMenu(target, entries).show(view, x, y)
+                } catch (e: Exception) {
+                    logger.warn(LogCategory.BROWSER, "Popup context menu failed to show", error = e)
+                }
             }
         },
     )
 }
 
+/**
+ * Everything a popup window's browser needs before it is shown.
+ *
+ * **Call this after `BrowserView.newInstance(popupBrowser)`.** The view anchors the menu, and
+ * installing before it exists also risks the view's own construction registering a default
+ * `ShowContextMenuCallback` over this one — JxBrowser allows a single callback per type, and a
+ * second registration replaces the first silently, with no compile error.
+ *
+ * The two installs are a pair, not a sequence: a Swing menu over a heavyweight browser surface does
+ * not close when the user clicks back into the page — Chromium consumes that press before AWT sees
+ * it — so the menu without the dismissal is a menu that sticks. Bundling them makes that impossible
+ * to get wrong at a call site.
+ *
+ * Neither install may fail the caller. Both call sites run inside a `try/catch` that closes the
+ * popup browser, and this runs before the window is made visible, so an escaping exception would
+ * mean the OAuth window never opens at all — strictly worse than the crash being fixed. Same
+ * reasoning `FluckEngine.setupSwingPopupDismissOnPageClick` already applies to itself: a browser
+ * that rejects a callback still works, it just keeps the older behaviour.
+ */
+@Suppress("TooGenericExceptionCaught") // See installPopupWindowContextMenu - Error must propagate.
+internal fun installPopupWindowChrome(
+    popupBrowser: Browser,
+    view: Component,
+) {
+    try {
+        installPopupWindowContextMenu(popupBrowser, view)
+    } catch (e: Exception) {
+        logger.debug(
+            LogCategory.BROWSER,
+            "Could not install the popup context menu - keeping JxBrowser's built-in one",
+            mapOf("error" to e.toString()),
+        )
+    }
+    // Deliberately outside the catch above: if the menu failed to install, the built-in menu is
+    // still there and still needs dismissing on an in-page click.
+    FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
+}
+
 /** Renders [entries] against the frame the click resolved to. */
+@Suppress("TooGenericExceptionCaught") // See installPopupWindowContextMenu - Error must propagate.
 internal fun buildMenu(
     frame: Frame,
     entries: List<PopupMenuEntry>,
 ): JPopupMenu {
     val menu = JPopupMenu()
+    // main.kt sets this globally, but state it here too: a lightweight popup paints into the Swing
+    // layer, which sits behind a heavyweight browser surface, and a menu that silently fails to
+    // appear reads as a regression rather than as a bug.
+    menu.isLightWeightPopupEnabled = false
     entries.forEach { entry ->
         val command = entry.command
         if (command == null) {
@@ -185,36 +265,18 @@ internal fun buildMenu(
             JMenuItem(entry.label).apply {
                 isEnabled = entry.enabled
                 addActionListener {
-                    runCatching { frame.execute(command) }
-                        .onFailure {
-                            logger.debug(
-                                LogCategory.BROWSER,
-                                "Popup editor command failed",
-                                mapOf("command" to entry.label, "error" to it.toString()),
-                            )
-                        }
+                    try {
+                        frame.execute(command)
+                    } catch (e: Exception) {
+                        logger.debug(
+                            LogCategory.BROWSER,
+                            "Popup editor command failed",
+                            mapOf("command" to entry.label, "error" to e.toString()),
+                        )
+                    }
                 }
             },
         )
     }
     return menu
-}
-
-/**
- * Everything a popup window's browser needs before it is shown.
- *
- * The two calls below are a pair, not a sequence: a Swing menu over a heavyweight browser surface
- * does not close when the user clicks back into the page — Chromium consumes that press before AWT
- * sees it — so installing the menu without the dismissal produces a menu that sticks. Bundling them
- * makes that impossible to get wrong at a call site, instead of relying on a comment at each one.
- *
- * A popup browser arrives from `params.popupBrowser()` and receives none of the setup a
- * BOSS-created browser gets, which is why this has to be explicit at all.
- */
-internal fun installPopupWindowChrome(
-    popupBrowser: Browser,
-    view: Component,
-) {
-    installPopupWindowContextMenu(popupBrowser, view)
-    FluckEngine.setupSwingPopupDismissOnPageClick(popupBrowser)
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -1,6 +1,10 @@
 package ai.rever.boss.plugin.browser
 
+import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.menu.ContextMenuContentType
+import java.lang.reflect.Proxy
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,17 +22,33 @@ class PopupWindowContextMenuTest {
     private fun entries(
         editable: Boolean,
         selection: String,
+        clipboard: Boolean = true,
     ) = popupMenuEntriesFor(
         contentTypes = if (editable) listOf(ContextMenuContentType.EDITABLE) else listOf(ContextMenuContentType.PAGE),
         selectedText = selection,
+        clipboardHasText = clipboard,
     )
+
+    /**
+     * A do-nothing [Frame]. `buildMenu` only stores it for the action listeners, so a reflection
+     * proxy is enough to render the menu headlessly — the build has no mocking library.
+     */
+    private fun stubFrame(): Frame =
+        Proxy.newProxyInstance(Frame::class.java.classLoader, arrayOf(Frame::class.java)) { _, method, _ ->
+            when (method.returnType) {
+                Boolean::class.javaPrimitiveType -> false
+                else -> null
+            }
+        } as Frame
+
+    // --- menu contents ---
 
     @Test
     fun `the menu is Cut Copy Paste, a separator, then Select All`() {
         // Order and the separator's position are the whole visual contract.
-        val labels = entries(editable = true, selection = "x").map { it.label }
-        assertEquals(listOf("Cut", "Copy", "Paste", "", "Select All"), labels)
-        assertTrue(entries(editable = true, selection = "x")[3].isSeparator)
+        val menu = entries(editable = true, selection = "x")
+        assertEquals(listOf("Cut", "Copy", "Paste", "", "Select All"), menu.map { it.label })
+        assertTrue(menu[3].isSeparator)
     }
 
     @Test
@@ -54,6 +74,14 @@ class PopupWindowContextMenuTest {
     }
 
     @Test
+    fun `Paste needs something on the clipboard`() {
+        // Without this the KDoc's "enablement mirrors what the command would actually do" was a
+        // claim the code did not honour: Paste was offered on any editable target.
+        assertFalse(entries(editable = true, selection = "", clipboard = false).single { it.label == "Paste" }.enabled)
+        assertTrue(entries(editable = true, selection = "", clipboard = true).single { it.label == "Paste" }.enabled)
+    }
+
+    @Test
     fun `Copy works on a read-only page when text is selected`() {
         assertTrue(entries(editable = false, selection = "abc").single { it.label == "Copy" }.enabled)
     }
@@ -71,23 +99,8 @@ class PopupWindowContextMenuTest {
     }
 
     @Test
-    fun `a menu with nothing enabled is never shown`() {
-        // Four greyed-out items is worse than no menu, which is what the caller checks before
-        // showing. Select All keeps every real target above that bar, so this asserts the
-        // predicate itself rather than trying to construct an all-disabled target.
-        assertTrue(hasAnyEnabledEntry(entries(editable = false, selection = "")))
-        assertFalse(hasAnyEnabledEntry(emptyList()))
-        assertFalse(
-            hasAnyEnabledEntry(
-                listOf(PopupMenuEntry("Cut", null, enabled = false), PopupMenuEntry("", null, enabled = false)),
-            ),
-        )
-    }
-
-    @Test
     fun `separators are entries with no command`() {
-        val separator = PopupMenuEntry("", command = null, enabled = false)
-        assertTrue(separator.isSeparator)
+        assertTrue(PopupMenuEntry("", command = null, enabled = false).isSeparator)
         assertFalse(entries(editable = true, selection = "x").single { it.label == "Copy" }.isSeparator)
     }
 
@@ -97,15 +110,34 @@ class PopupWindowContextMenuTest {
     fun `the menu is not shown once the view has stopped showing`() {
         // This is the crash. JxBrowser's built-in menu asked a disposed component for its location
         // on screen; this path refuses to render at all instead.
-        val usable = entries(editable = true, selection = "x")
-        assertFalse(shouldShowPopupMenu(viewShowing = false, browserClosed = false, entries = usable))
+        assertFalse(
+            shouldShowPopupMenu(
+                viewShowing = false,
+                browserClosed = false,
+                entries = entries(editable = true, selection = "x"),
+            ),
+        )
     }
 
     @Test
     fun `the menu is not shown once the popup browser has closed`() {
         // An OAuth popup closes itself when the flow completes, which is the race in the report.
-        val usable = entries(editable = true, selection = "x")
-        assertFalse(shouldShowPopupMenu(viewShowing = true, browserClosed = true, entries = usable))
+        assertFalse(
+            shouldShowPopupMenu(
+                viewShowing = true,
+                browserClosed = true,
+                entries = entries(editable = true, selection = "x"),
+            ),
+        )
+    }
+
+    @Test
+    fun `the menu is not shown when nothing in it would be enabled`() {
+        // Four greyed-out items is worse than no menu. Hand-built because popupMenuEntriesFor
+        // cannot currently produce such a list - Select All is unconditionally enabled.
+        val allDisabled = entries(editable = false, selection = "").map { it.copy(enabled = false) }
+        assertFalse(shouldShowPopupMenu(viewShowing = true, browserClosed = false, entries = allDisabled))
+        assertFalse(shouldShowPopupMenu(viewShowing = true, browserClosed = false, entries = emptyList()))
     }
 
     @Test
@@ -117,5 +149,33 @@ class PopupWindowContextMenuTest {
                 entries = entries(editable = true, selection = "x"),
             ),
         )
+    }
+
+    // --- rendering ---
+
+    @Test
+    fun `entries render in order with the separator between Paste and Select All`() {
+        val menu: JPopupMenu = buildMenu(stubFrame(), entries(editable = true, selection = "x"))
+        val rendered = menu.components.map { (it as? JMenuItem)?.text ?: "<separator>" }
+        assertEquals(listOf("Cut", "Copy", "Paste", "<separator>", "Select All"), rendered)
+    }
+
+    @Test
+    fun `disabled entries render disabled`() {
+        // Read-only page with no selection: only Select All should be clickable.
+        val menu = buildMenu(stubFrame(), entries(editable = false, selection = ""))
+        val enabledLabels =
+            menu.components
+                .filterIsInstance<JMenuItem>()
+                .filter { it.isEnabled }
+                .map { it.text }
+        assertEquals(listOf("Select All"), enabledLabels)
+    }
+
+    @Test
+    fun `the rendered menu is heavyweight so it can paint over the browser surface`() {
+        // A lightweight popup draws into the Swing layer, which sits behind the heavyweight browser
+        // surface - the menu would silently not appear.
+        assertFalse(buildMenu(stubFrame(), entries(editable = true, selection = "x")).isLightWeightPopupEnabled)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -1,8 +1,10 @@
 package ai.rever.boss.plugin.browser
 
 import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
 import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.menu.ContextMenuContentType
+import java.awt.GraphicsEnvironment
 import java.lang.reflect.Proxy
 import javax.swing.JMenuItem
 import javax.swing.JPanel
@@ -28,7 +30,7 @@ class PopupWindowContextMenuTest {
     ) = popupMenuEntriesFor(
         contentTypes = if (editable) listOf(ContextMenuContentType.EDITABLE) else listOf(ContextMenuContentType.PAGE),
         selectedText = selection,
-        clipboardHasText = clipboard,
+        clipboardHasText = { clipboard },
     )
 
     /**
@@ -39,12 +41,13 @@ class PopupWindowContextMenuTest {
      * unboxing the moment the stub landed in a hash collection or an assertion message. Nothing
      * here does that today, but stubs get copied.
      */
-    private fun stubFrame(): Frame =
+    private fun stubFrame(executed: MutableList<Any?> = mutableListOf()): Frame =
         Proxy.newProxyInstance(Frame::class.java.classLoader, arrayOf(Frame::class.java)) { proxy, method, args ->
             when {
                 method.name == "hashCode" -> System.identityHashCode(proxy)
                 method.name == "equals" -> proxy === args?.getOrNull(0)
                 method.name == "toString" -> "stubFrame"
+                method.name == "execute" -> executed.add(args?.getOrNull(0)).let { null }
                 method.returnType == Boolean::class.javaPrimitiveType -> false
                 else -> null
             }
@@ -88,6 +91,33 @@ class PopupWindowContextMenuTest {
         // claim the code did not honour: Paste was offered on any editable target.
         assertFalse(entries(editable = true, selection = "", clipboard = false).single { it.label == "Paste" }.enabled)
         assertTrue(entries(editable = true, selection = "", clipboard = true).single { it.label == "Paste" }.enabled)
+    }
+
+    @Test
+    fun `the clipboard is not probed on a non-editable target`() {
+        // Paste is disabled on a read-only page whatever the clipboard says, so probing it there is
+        // pure latency on the right-click path - and a Windows clipboard read is a retry-with-sleep
+        // loop, not a free call. That is why the parameter is a lambda.
+        var probes = 0
+        popupMenuEntriesFor(
+            contentTypes = listOf(ContextMenuContentType.PAGE),
+            selectedText = "abc",
+            clipboardHasText = {
+                probes++
+                true
+            },
+        )
+        assertEquals(0, probes, "a read-only target should not read the clipboard")
+
+        popupMenuEntriesFor(
+            contentTypes = listOf(ContextMenuContentType.EDITABLE),
+            selectedText = "abc",
+            clipboardHasText = {
+                probes++
+                true
+            },
+        )
+        assertEquals(1, probes, "an editable target must read the clipboard to decide Paste")
     }
 
     @Test
@@ -164,7 +194,7 @@ class PopupWindowContextMenuTest {
 
     @Test
     fun `entries render in order with the separator between Paste and Select All`() {
-        val menu: JPopupMenu = buildMenu(stubFrame(), entries(editable = true, selection = "x"))
+        val menu: JPopupMenu = buildPopupWindowMenu(stubFrame(), entries(editable = true, selection = "x"))
         val rendered = menu.components.map { (it as? JMenuItem)?.text ?: "<separator>" }
         assertEquals(listOf("Cut", "Copy", "Paste", "<separator>", "Select All"), rendered)
     }
@@ -172,7 +202,7 @@ class PopupWindowContextMenuTest {
     @Test
     fun `disabled entries render disabled`() {
         // Read-only page with no selection: only Select All should be clickable.
-        val menu = buildMenu(stubFrame(), entries(editable = false, selection = ""))
+        val menu = buildPopupWindowMenu(stubFrame(), entries(editable = false, selection = ""))
         val enabledLabels =
             menu.components
                 .filterIsInstance<JMenuItem>()
@@ -181,7 +211,76 @@ class PopupWindowContextMenuTest {
         assertEquals(listOf("Select All"), enabledLabels)
     }
 
+    @Test
+    fun `clicking an item runs its command on the frame the click resolved to`() {
+        // The menu renders correctly per the tests above, but rendering a Paste item that is wired
+        // to nothing would pass all of them. This is the one assertion that the menu does anything.
+        val executed = mutableListOf<Any?>()
+        val entries = entries(editable = true, selection = "x")
+        val menu = buildPopupWindowMenu(stubFrame(executed), entries)
+        menu.components
+            .filterIsInstance<JMenuItem>()
+            .single { it.text == "Paste" }
+            .doClick(0)
+        assertEquals<Any?>(entries.single { it.label == "Paste" }.command, executed.singleOrNull())
+    }
+
     // --- install contract ---
+
+    @Test
+    fun `the callback answers Chromium even when reading the click target throws`() {
+        // tell.close() in the finally is the only thing between a params read that throws and a
+        // request nobody answers - not a menu that fails to appear, a renderer left waiting on one.
+        // It is also what suppresses the built-in (crashing) menu, so it has to run on every path.
+        var callback: ShowContextMenuCallback? = null
+        val browser =
+            Proxy.newProxyInstance(
+                Browser::class.java.classLoader,
+                arrayOf(Browser::class.java),
+            ) { proxy, method, args ->
+                when {
+                    method.name == "hashCode" -> {
+                        System.identityHashCode(proxy)
+                    }
+
+                    method.name == "equals" -> {
+                        proxy === args?.getOrNull(0)
+                    }
+
+                    method.name == "toString" -> {
+                        "stubBrowser"
+                    }
+
+                    method.name == "set" -> {
+                        (args?.getOrNull(1) as? ShowContextMenuCallback)?.let { callback = it }
+                        null
+                    }
+
+                    method.returnType == Boolean::class.javaPrimitiveType -> {
+                        false
+                    }
+
+                    else -> {
+                        null
+                    }
+                }
+            } as Browser
+        installPopupWindowContextMenu(browser, JPanel())
+        val installed = requireNotNull(callback) { "no ShowContextMenuCallback was installed" }
+
+        val params =
+            Proxy.newProxyInstance(
+                ShowContextMenuCallback.Params::class.java.classLoader,
+                arrayOf(ShowContextMenuCallback.Params::class.java),
+            ) { _, method, _ ->
+                if (method.name == "location") error("simulated params failure") else null
+            } as ShowContextMenuCallback.Params
+
+        val tell = ShowContextMenuCallback.Action { }
+        installed.on(params, tell)
+
+        assertTrue(tell.isClosed, "Chromium must be answered on the params-failure path too")
+    }
 
     @Test
     fun `a menu-install failure neither propagates nor skips the dismiss handler`() {
@@ -241,9 +340,9 @@ class PopupWindowContextMenuTest {
     fun `clipboard probe defaults to enabled when the clipboard cannot be read`() {
         // On a headless CI agent this exercises the HeadlessException branch - an
         // UnsupportedOperationException, not an IllegalStateException, which is the case round 5
-        // added. On a desktop it just asserts the call is safe. Either way it must not throw.
-        assertTrue(clipboardHasText() || !clipboardHasText())
-        if (java.awt.GraphicsEnvironment.isHeadless()) {
+        // added. On a desktop it only asserts the call is safe: it must not throw.
+        clipboardHasText()
+        if (GraphicsEnvironment.isHeadless()) {
             assertTrue(clipboardHasText(), "headless must default to enabled, not throw or disable")
         }
     }
@@ -252,6 +351,7 @@ class PopupWindowContextMenuTest {
     fun `the rendered menu is heavyweight so it can paint over the browser surface`() {
         // A lightweight popup draws into the Swing layer, which sits behind the heavyweight browser
         // surface - the menu would silently not appear.
-        assertFalse(buildMenu(stubFrame(), entries(editable = true, selection = "x")).isLightWeightPopupEnabled)
+        val menu = buildPopupWindowMenu(stubFrame(), entries(editable = true, selection = "x"))
+        assertFalse(menu.isLightWeightPopupEnabled)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
  * The menu exists because JxBrowser's built-in one crashes the EDT in popup windows
  * (BossConsole-Releases#17). Its contents are decided entirely from the click target so they can be
  * pinned here, and — the reason that matters beyond testability — so that deciding them costs no
- * blocking IPC on the EDT, where a busy renderer would freeze the whole app.
+ * blocking IPC on the JxBrowser callback thread, which would delay the menu on every right-click.
  */
 class PopupWindowContextMenuTest {
     private fun entries(
@@ -32,11 +32,18 @@ class PopupWindowContextMenuTest {
     /**
      * A do-nothing [Frame]. `buildMenu` only stores it for the action listeners, so a reflection
      * proxy is enough to render the menu headlessly — the build has no mocking library.
+     *
+     * `Object`'s methods are handled explicitly: returning null for `hashCode()` would NPE on
+     * unboxing the moment the stub landed in a hash collection or an assertion message. Nothing
+     * here does that today, but stubs get copied.
      */
     private fun stubFrame(): Frame =
-        Proxy.newProxyInstance(Frame::class.java.classLoader, arrayOf(Frame::class.java)) { _, method, _ ->
-            when (method.returnType) {
-                Boolean::class.javaPrimitiveType -> false
+        Proxy.newProxyInstance(Frame::class.java.classLoader, arrayOf(Frame::class.java)) { proxy, method, args ->
+            when {
+                method.name == "hashCode" -> System.identityHashCode(proxy)
+                method.name == "equals" -> proxy === args?.getOrNull(0)
+                method.name == "toString" -> "stubFrame"
+                method.returnType == Boolean::class.javaPrimitiveType -> false
                 else -> null
             }
         } as Frame

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -1,9 +1,11 @@
 package ai.rever.boss.plugin.browser
 
+import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.menu.ContextMenuContentType
 import java.lang.reflect.Proxy
 import javax.swing.JMenuItem
+import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -177,6 +179,73 @@ class PopupWindowContextMenuTest {
                 .filter { it.isEnabled }
                 .map { it.text }
         assertEquals(listOf("Select All"), enabledLabels)
+    }
+
+    // --- install contract ---
+
+    @Test
+    fun `a menu-install failure neither propagates nor skips the dismiss handler`() {
+        // The most consequential bug this change produced: installPopupWindowChrome runs before
+        // the popup window is made visible, inside a caller try/catch that closes the browser, so
+        // a throwing set() meant the OAuth window never opened at all - worse than the crash.
+        // Both halves are asserted: the call is swallowed, AND PressMouseCallback still lands.
+        val installed = mutableListOf<String>()
+        val browser =
+            Proxy.newProxyInstance(
+                Browser::class.java.classLoader,
+                arrayOf(Browser::class.java),
+            ) { proxy, method, args ->
+                when {
+                    method.name == "hashCode" -> {
+                        System.identityHashCode(proxy)
+                    }
+
+                    method.name == "equals" -> {
+                        proxy === args?.getOrNull(0)
+                    }
+
+                    method.name == "toString" -> {
+                        "stubBrowser"
+                    }
+
+                    method.name == "set" -> {
+                        val type = (args?.getOrNull(0) as? Class<*>)?.simpleName.orEmpty()
+                        installed += type
+                        if (type == "ShowContextMenuCallback") error("simulated set() failure")
+                        null
+                    }
+
+                    method.returnType == Boolean::class.javaPrimitiveType -> {
+                        false
+                    }
+
+                    else -> {
+                        null
+                    }
+                }
+            } as Browser
+
+        // Must not throw.
+        installPopupWindowChrome(browser, JPanel())
+
+        assertTrue("ShowContextMenuCallback" in installed, "the menu install should have been attempted")
+        assertTrue(
+            "PressMouseCallback" in installed,
+            "the dismiss handler must still be installed after a menu-install failure",
+        )
+    }
+
+    // --- clipboard ---
+
+    @Test
+    fun `clipboard probe defaults to enabled when the clipboard cannot be read`() {
+        // On a headless CI agent this exercises the HeadlessException branch - an
+        // UnsupportedOperationException, not an IllegalStateException, which is the case round 5
+        // added. On a desktop it just asserts the call is safe. Either way it must not throw.
+        assertTrue(clipboardHasText() || !clipboardHasText())
+        if (java.awt.GraphicsEnvironment.isHeadless()) {
+            assertTrue(clipboardHasText(), "headless must default to enabled, not throw or disable")
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -90,4 +90,32 @@ class PopupWindowContextMenuTest {
         assertTrue(separator.isSeparator)
         assertFalse(entries(editable = true, selection = "x").single { it.label == "Copy" }.isSeparator)
     }
+
+    // --- the guard that actually prevents the reported crash ---
+
+    @Test
+    fun `the menu is not shown once the view has stopped showing`() {
+        // This is the crash. JxBrowser's built-in menu asked a disposed component for its location
+        // on screen; this path refuses to render at all instead.
+        val usable = entries(editable = true, selection = "x")
+        assertFalse(shouldShowPopupMenu(viewShowing = false, browserClosed = false, entries = usable))
+    }
+
+    @Test
+    fun `the menu is not shown once the popup browser has closed`() {
+        // An OAuth popup closes itself when the flow completes, which is the race in the report.
+        val usable = entries(editable = true, selection = "x")
+        assertFalse(shouldShowPopupMenu(viewShowing = true, browserClosed = true, entries = usable))
+    }
+
+    @Test
+    fun `the menu is shown when the view is live and something is enabled`() {
+        assertTrue(
+            shouldShowPopupMenu(
+                viewShowing = true,
+                browserClosed = false,
+                entries = entries(editable = true, selection = "x"),
+            ),
+        )
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -5,6 +5,7 @@ import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
 import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.menu.ContextMenuContentType
 import java.awt.GraphicsEnvironment
+import java.awt.Point
 import java.lang.reflect.Proxy
 import javax.swing.JMenuItem
 import javax.swing.JPanel
@@ -52,6 +53,50 @@ class PopupWindowContextMenuTest {
                 else -> null
             }
         } as Frame
+
+    /**
+     * A [Browser] that records the callback types installed on it, optionally failing one of them.
+     *
+     * Same reflection-proxy technique as [stubFrame], for the same reason: no mocking library.
+     */
+    private fun recordingBrowser(
+        installed: MutableList<String>,
+        failOn: String? = null,
+        captureMenuCallback: ((ShowContextMenuCallback) -> Unit)? = null,
+    ): Browser =
+        Proxy.newProxyInstance(
+            Browser::class.java.classLoader,
+            arrayOf(Browser::class.java),
+        ) { proxy, method, args ->
+            when {
+                method.name == "hashCode" -> {
+                    System.identityHashCode(proxy)
+                }
+
+                method.name == "equals" -> {
+                    proxy === args?.getOrNull(0)
+                }
+
+                method.name == "toString" -> {
+                    "stubBrowser"
+                }
+
+                method.name == "set" -> {
+                    installed += (args?.getOrNull(0) as? Class<*>)?.simpleName.orEmpty()
+                    (args?.getOrNull(1) as? ShowContextMenuCallback)?.let { captureMenuCallback?.invoke(it) }
+                    if (installed.last() == failOn) error("simulated set() failure")
+                    null
+                }
+
+                method.returnType == Boolean::class.javaPrimitiveType -> {
+                    false
+                }
+
+                else -> {
+                    null
+                }
+            }
+        } as Browser
 
     // --- menu contents ---
 
@@ -225,7 +270,48 @@ class PopupWindowContextMenuTest {
         assertEquals<Any?>(entries.single { it.label == "Paste" }.command, executed.singleOrNull())
     }
 
+    @Test
+    fun `nothing is shown against a view that is not showing`() {
+        // The guard was previously only tested as a pure function, so deleting its call site left
+        // every test passing. This drives the real show path: a JPanel that was never realised is
+        // the disposed popup's situation, and rendering into it is what threw in the report.
+        val shown =
+            showPopupMenuIfPossible(
+                view = JPanel(),
+                browserClosed = { false },
+                target = stubFrame(),
+                entries = entries(editable = true, selection = "x"),
+                at = Point(10, 10),
+            )
+        assertFalse(shown, "a view that is not showing must not host a menu")
+    }
+
+    @Test
+    fun `a browser-closed check that throws does not escape onto the EDT`() {
+        // popupBrowser.isClosed is a call into JxBrowser during teardown. An uncaught throw from
+        // the guard itself would be the same failure class this file removes.
+        val shown =
+            showPopupMenuIfPossible(
+                view = JPanel(),
+                browserClosed = { error("simulated teardown") },
+                target = stubFrame(),
+                entries = entries(editable = true, selection = "x"),
+                at = Point(0, 0),
+            )
+        assertFalse(shown)
+    }
+
     // --- install contract ---
+
+    @Test
+    fun `the menu and the dismiss handler are both installed, menu first`() {
+        // They are a pair: a Swing menu over a heavyweight browser surface does not close when the
+        // user clicks back into the page. The failure-path test below covers a throwing install;
+        // this covers the ordinary one, so dropping the dismissal on success would be caught too.
+        val installed = mutableListOf<String>()
+        installPopupWindowChrome(recordingBrowser(installed), JPanel())
+        assertEquals(listOf("ShowContextMenuCallback", "PressMouseCallback"), installed)
+    }
 
     @Test
     fun `the callback answers Chromium even when reading the click target throws`() {
@@ -233,39 +319,10 @@ class PopupWindowContextMenuTest {
         // request nobody answers - not a menu that fails to appear, a renderer left waiting on one.
         // It is also what suppresses the built-in (crashing) menu, so it has to run on every path.
         var callback: ShowContextMenuCallback? = null
-        val browser =
-            Proxy.newProxyInstance(
-                Browser::class.java.classLoader,
-                arrayOf(Browser::class.java),
-            ) { proxy, method, args ->
-                when {
-                    method.name == "hashCode" -> {
-                        System.identityHashCode(proxy)
-                    }
-
-                    method.name == "equals" -> {
-                        proxy === args?.getOrNull(0)
-                    }
-
-                    method.name == "toString" -> {
-                        "stubBrowser"
-                    }
-
-                    method.name == "set" -> {
-                        (args?.getOrNull(1) as? ShowContextMenuCallback)?.let { callback = it }
-                        null
-                    }
-
-                    method.returnType == Boolean::class.javaPrimitiveType -> {
-                        false
-                    }
-
-                    else -> {
-                        null
-                    }
-                }
-            } as Browser
-        installPopupWindowContextMenu(browser, JPanel())
+        installPopupWindowContextMenu(
+            recordingBrowser(mutableListOf(), captureMenuCallback = { callback = it }),
+            JPanel(),
+        )
         val installed = requireNotNull(callback) { "no ShowContextMenuCallback was installed" }
 
         val params =
@@ -289,43 +346,9 @@ class PopupWindowContextMenuTest {
         // a throwing set() meant the OAuth window never opened at all - worse than the crash.
         // Both halves are asserted: the call is swallowed, AND PressMouseCallback still lands.
         val installed = mutableListOf<String>()
-        val browser =
-            Proxy.newProxyInstance(
-                Browser::class.java.classLoader,
-                arrayOf(Browser::class.java),
-            ) { proxy, method, args ->
-                when {
-                    method.name == "hashCode" -> {
-                        System.identityHashCode(proxy)
-                    }
-
-                    method.name == "equals" -> {
-                        proxy === args?.getOrNull(0)
-                    }
-
-                    method.name == "toString" -> {
-                        "stubBrowser"
-                    }
-
-                    method.name == "set" -> {
-                        val type = (args?.getOrNull(0) as? Class<*>)?.simpleName.orEmpty()
-                        installed += type
-                        if (type == "ShowContextMenuCallback") error("simulated set() failure")
-                        null
-                    }
-
-                    method.returnType == Boolean::class.javaPrimitiveType -> {
-                        false
-                    }
-
-                    else -> {
-                        null
-                    }
-                }
-            } as Browser
 
         // Must not throw.
-        installPopupWindowChrome(browser, JPanel())
+        installPopupWindowChrome(recordingBrowser(installed, failOn = "ShowContextMenuCallback"), JPanel())
 
         assertTrue("ShowContextMenuCallback" in installed, "the menu install should have been attempted")
         assertTrue(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/PopupWindowContextMenuTest.kt
@@ -1,0 +1,93 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.menu.ContextMenuContentType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the popup-window context menu's pure parts — no JxBrowser engine required.
+ *
+ * The menu exists because JxBrowser's built-in one crashes the EDT in popup windows
+ * (BossConsole-Releases#17). Its contents are decided entirely from the click target so they can be
+ * pinned here, and — the reason that matters beyond testability — so that deciding them costs no
+ * blocking IPC on the EDT, where a busy renderer would freeze the whole app.
+ */
+class PopupWindowContextMenuTest {
+    private fun entries(
+        editable: Boolean,
+        selection: String,
+    ) = popupMenuEntriesFor(
+        contentTypes = if (editable) listOf(ContextMenuContentType.EDITABLE) else listOf(ContextMenuContentType.PAGE),
+        selectedText = selection,
+    )
+
+    @Test
+    fun `the menu is Cut Copy Paste, a separator, then Select All`() {
+        // Order and the separator's position are the whole visual contract.
+        val labels = entries(editable = true, selection = "x").map { it.label }
+        assertEquals(listOf("Cut", "Copy", "Paste", "", "Select All"), labels)
+        assertTrue(entries(editable = true, selection = "x")[3].isSeparator)
+    }
+
+    @Test
+    fun `Cut and Paste need an editable target`() {
+        // Offering Cut on a read-only page would be a menu item that silently does nothing, which
+        // is the thing this menu is supposed to avoid.
+        val readOnly = entries(editable = false, selection = "selected")
+        assertFalse(readOnly.single { it.label == "Cut" }.enabled)
+        assertFalse(readOnly.single { it.label == "Paste" }.enabled)
+
+        val editable = entries(editable = true, selection = "selected")
+        assertTrue(editable.single { it.label == "Cut" }.enabled)
+        assertTrue(editable.single { it.label == "Paste" }.enabled)
+    }
+
+    @Test
+    fun `Cut and Copy need a selection, Paste does not`() {
+        val noSelection = entries(editable = true, selection = "")
+        assertFalse(noSelection.single { it.label == "Cut" }.enabled)
+        assertFalse(noSelection.single { it.label == "Copy" }.enabled)
+        // Paste depends on the clipboard, not the selection - an empty field is its main use.
+        assertTrue(noSelection.single { it.label == "Paste" }.enabled)
+    }
+
+    @Test
+    fun `Copy works on a read-only page when text is selected`() {
+        assertTrue(entries(editable = false, selection = "abc").single { it.label == "Copy" }.enabled)
+    }
+
+    @Test
+    fun `Select All is always offered`() {
+        for (editable in listOf(true, false)) {
+            for (selection in listOf("", "abc")) {
+                assertTrue(
+                    entries(editable, selection).single { it.label == "Select All" }.enabled,
+                    "Select All should be enabled (editable=$editable, selection='$selection')",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a menu with nothing enabled is never shown`() {
+        // Four greyed-out items is worse than no menu, which is what the caller checks before
+        // showing. Select All keeps every real target above that bar, so this asserts the
+        // predicate itself rather than trying to construct an all-disabled target.
+        assertTrue(hasAnyEnabledEntry(entries(editable = false, selection = "")))
+        assertFalse(hasAnyEnabledEntry(emptyList()))
+        assertFalse(
+            hasAnyEnabledEntry(
+                listOf(PopupMenuEntry("Cut", null, enabled = false), PopupMenuEntry("", null, enabled = false)),
+            ),
+        )
+    }
+
+    @Test
+    fun `separators are entries with no command`() {
+        val separator = PopupMenuEntry("", command = null, enabled = false)
+        assertTrue(separator.isSeparator)
+        assertFalse(entries(editable = true, selection = "x").single { it.label == "Copy" }.isSeparator)
+    }
+}


### PR DESCRIPTION
Fixes the crash reported in risa-labs-inc/BossConsole-Releases#17 (signature `6edf997db774`, BOSS 9.2.64, Windows 11).

```
java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location
    at ...view.swing.internal.menu.SuggestionsPopup.lambda$show$2(SuggestionsPopup.java:104)
```

## Root cause

`SuggestionsPopup` is **JxBrowser's own** Swing context menu — the spell-check suggestions list. It resolves its position from `getLocationOnScreen()` inside an `invokeLater`, so anything that stops the view showing between the right-click and that lambda throws on the EDT.

Two browsers in BOSS were still using that built-in menu, and both live in a Swing `JFrame`:

- `BrowserHandleImpl` — the `window.open`-with-bounds popup windows (OAuth, payment)
- `BrowserFunctions` — a duplicate implementation of the same popup flow

**Tab browsers were never affected.** `BrowserHandleImpl.setupContextMenuHandler` already installs a `ShowContextMenuCallback` and always calls `tell.close()`, which suppresses the built-in menu; the fullscreen Swing view reuses the tab's browser and inherits that suppression.

A popup window is where the race actually bites: an OAuth popup **closes itself** when the flow completes (`BrowserClosed` → `frame.dispose()`), so a right-click landing on that boundary asks a disposed component where it is. The report's log is consistent — repeated `CoreAuthService: Authenticated` entries through the session, and no other Swing browser surface open at the time of the crash.

## Fix

Installing any `ShowContextMenuCallback` suppresses the built-in menu, which is what removes the crash. Rather than leave popup windows with no menu at all — right-click paste into a login form is a reasonable thing to want — this substitutes a small Swing menu:

- **Cut / Copy / Paste / Select All**, driven by `EditorCommand`, with enablement derived from the `ShowContextMenuCallback.Params` of the click — is the target editable, is there a selection, does the clipboard hold text — so it never offers an action that would do nothing. Deliberately *not* `frame.isCommandEnabled`: that would be four synchronous round-trips into Chromium before the menu could be built, on every right-click.
- Rendered **only** when the view `isShowing` and the browser is not closed, checked on the EDT immediately before `show()`, inside a `try/catch`. That guard is the fix. Being component-relative is not itself protection — `JPopupMenu.show(invoker, x, y)` resolves the invoker's location on screen internally — so what makes the failure unreachable is refusing to render against a view that has stopped showing.
- Paired with the page-click dismissal in a single `installPopupWindowChrome`, because a Swing menu over a heavyweight browser surface does not close when the user clicks back into the page: Chromium consumes that press before AWT sees it.
- No spell-check suggestions. That is what `SuggestionsPopup` was for, and it is not worth re-implementing for a transient OAuth window.

## Blast radius

Popup windows only. Tab browsers, the fullscreen view and every non-Windows platform are untouched — this changes only browsers that previously had **no** `ShowContextMenuCallback` and were hosted in a Swing `BrowserView`.

## Not changed, deliberately

`FluckPanelContentProviderImpl` and `DesktopPasskeyBrowserView` also build browsers with no `ShowContextMenuCallback`. Neither is the reported path — neither renders through the Swing `BrowserView` this crash came from — so both are left alone rather than changed speculatively. Tracked in #91, which proposes making the setup universal rather than remembering it per call site.

Converging the tab menu (`document.execCommand` JS against `mainFrame()`) onto the `EditorCommand`-against-the-clicked-frame mechanism this adds is tracked in #92.

## Verification

Compiles; detekt and ktlint clean. 19 unit tests cover the menu's contents and enablement, the guard that prevents the crash, rendering (order, disabled items, heavyweight), that clicking an item reaches `frame.execute`, that `tell.close()` answers Chromium even when reading the click target throws, and that a failed menu install neither propagates to the caller nor skips the dismissal handler.

**Not runtime-verified.** Reproducing needs an OAuth popup plus a right-click timed against its self-close — I could not stage that reliably. The reasoning is from the stack trace, the two unprotected call sites, and the session log; the fix is structural (the crashing code path is no longer reachable) rather than a timing mitigation, which is why I am comfortable proposing it without a live repro. Worth a manual pass by anyone who can trigger an OAuth popup:

- right-click inside it shows Cut/Copy/Paste/Select All, with the right items greyed;
- clicking back into the page dismisses it;
- right-clicking as the popup self-closes does nothing at all rather than crash;
- the menu appears on the **first** right-click — both `PressMouseCallback` and `ShowContextMenuCallback` fire for that press, and the former queues a `clearSelectedPath()`;
- letting the flow complete with the menu open takes the menu down with its owner rather than stranding it on screen;
- **at 125%%/150%% display scaling**, the menu lands under the cursor. `params.location()` feeds straight into `menu.show(view, x, y)`, which reads AWT user space; if JxBrowser reports device pixels under HARDWARE rendering the menu would be offset by the scale factor. This matches JxBrowser own Swing sample so it is probably fine, and the fix if not is `view.graphicsConfiguration.defaultTransform` — not added speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
