### PR TITLE
fix: post-merge review follow-ups on render recovery

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -47,15 +47,41 @@ object CrashHandler {
     /** Where contained (non-fatal, recovered) reports are written, under the BOSS data dir. */
     private const val CONTAINED_REPORT_DIR = "crash-reports"
 
+    /** Contained reports kept on disk; older ones are swept after each write. */
+    private const val CONTAINED_REPORT_RETENTION = 20
+
+    /**
+     * Ceiling on [containedSignatures]. Past this the dedupe is dropped and starts
+     * over rather than growing without bound: a session that has produced this many
+     * *distinct* render faults has bigger problems than a duplicate report, and the
+     * retention sweep bounds the disk cost either way.
+     */
+    private const val MAX_CONTAINED_SIGNATURES = 200
+
     /**
      * Signatures already written this session.
      *
      * A corrupt scene throws every frame, so without this the render-fault path
-     * would write ~60 files a second of full stack traces until the user noticed
-     * — and nothing in the repo trims that directory. One file per distinct fault
-     * is all the diagnostic value there is; repeats only bump a log counter.
+     * would write ~60 files a second of full stack traces until the user noticed.
+     * One file per distinct fault is all the diagnostic value there is; repeats
+     * only bump a log counter.
      */
     private val containedSignatures = ConcurrentHashMap<String, Int>()
+
+    /**
+     * Report directory override for tests; the same shape as
+     * `SingleInstanceFiles.runtimeDirOverride`.
+     *
+     * Not a convenience: [sweepOldReports] deletes files, so a test running against
+     * the real data root would destroy the user's actual crash reports.
+     */
+    @Volatile
+    internal var containedReportDirOverride: File? = null
+
+    private fun containedReportDir(): File = containedReportDirOverride ?: BossDirectories.resolve(CONTAINED_REPORT_DIR)
+
+    /** Lets a test start from a clean dedupe. */
+    internal fun resetContainedStateForTest() = containedSignatures.clear()
 
     /**
      * Single thread for writing contained reports.
@@ -161,32 +187,35 @@ object CrashHandler {
     fun recordContained(throwable: Throwable) {
         if (isIgnorable(throwable)) return
         try {
-            val report = createCrashReport(throwable)
-            val seen = containedSignatures.merge(report.signature, 1, Int::plus) ?: 1
+            // Signature first, report second. createCrashReport sanitizes the whole
+            // stack with a regex sweep, walks up to twelve causes asking the plugin
+            // classloaders about every frame, and reads two JMX beans — all on the
+            // AWT event thread, and previously once per fault during exactly the
+            // repaint storm this exists to survive. The signature is the cheap part
+            // and the only thing the dedupe needs.
+            val signature = CrashSignature.generate(throwable)
+            if (containedSignatures.size >= MAX_CONTAINED_SIGNATURES) containedSignatures.clear()
+            val seen = containedSignatures.merge(signature, 1, Int::plus) ?: 1
             if (seen > 1) {
                 // Log on a curve, not every frame. The file dedupe protects the
-                // disk; this protects the log buffers, which back recentLogs on
-                // the next real crash report — a per-frame warn would evict the
-                // very context that explains the fault.
+                // disk; this protects the log buffers, which back recentLogs on the
+                // next real crash report — a per-frame warn would evict the very
+                // context that explains the fault.
                 if (seen == 2 || seen == 10 || seen % 100 == 0) {
                     logger.warn(
                         LogCategory.SYSTEM,
                         "Contained render fault recurring",
                         mapOf(
-                            "signature" to report.signature,
-                            "errorType" to report.exceptionType,
+                            "signature" to signature,
+                            "errorType" to throwable.javaClass.simpleName,
                             "occurrences" to seen.toString(),
                         ),
                     )
                 }
                 return
             }
-            logger.warn(
-                LogCategory.SYSTEM,
-                "Contained render fault recorded",
-                mapOf("signature" to report.signature, "errorType" to report.exceptionType),
-            )
-            containedWriter.execute { writeContainedReport(report) }
+            // Building the report is part of the off-thread work now.
+            containedWriter.execute { writeContainedReport(signature, throwable) }
         } catch (e: Exception) {
             // Reporting a contained fault must never itself become a fault.
             logger.warn(
@@ -199,26 +228,94 @@ object CrashHandler {
     }
 
     /** Off the EDT — see [containedWriter]. */
-    private fun writeContainedReport(report: CrashReport) {
+    private fun writeContainedReport(
+        signature: String,
+        throwable: Throwable,
+    ) {
         try {
-            val dir = BossDirectories.resolve(CONTAINED_REPORT_DIR).apply { mkdirs() }
-            // Owner-only, matching how ~/.boss/run is treated: these hold
-            // sanitized stack traces and host details.
-            runCatching {
-                dir.setReadable(false, false)
-                dir.setReadable(true, true)
-                dir.setWritable(false, false)
-                dir.setWritable(true, true)
-            }
-            File(dir, "contained-${report.timestamp}-${report.signature}.txt")
-                .writeText(renderContainedReport(report))
+            val report = createCrashReport(throwable)
+            val dir = containedReportDir()
+            dir.mkdirs()
+            val file = File(dir, "contained-${report.timestamp}-$signature.txt")
+            // Owner-only on both, and on the file too — writeText alone leaves it at
+            // the umask, typically 0644, holding sanitized traces and host details.
+            // Directory perms are not enough: 0711 still lets others traverse to a
+            // known path.
+            restrictToOwner(dir, directory = true)
+            file.writeText(renderContainedReport(report))
+            restrictToOwner(file, directory = false)
+            sweepOldReports(dir)
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Contained render fault recorded",
+                mapOf("signature" to signature, "path" to file.absolutePath),
+            )
         } catch (e: Exception) {
+            // The signature was claimed before this ran, so a failed write would
+            // otherwise suppress the fault for the rest of the session. Release it
+            // so the next occurrence can retry.
+            containedSignatures.remove(signature)
             logger.warn(
                 LogCategory.SYSTEM,
                 "Failed to write a contained crash report",
-                mapOf("signature" to report.signature),
+                mapOf("signature" to signature),
                 e,
             )
+        }
+    }
+
+    /**
+     * Keep the newest [CONTAINED_REPORT_RETENTION] reports and delete the rest.
+     *
+     * The session dedupe bounds writes *within* one run; nothing bounded them
+     * across runs, and this directory has no other janitor. Sorted by name rather
+     * than mtime: the filename carries the report timestamp, so it survives a copy
+     * that resets modification times, and one distinct-signature write per sweep
+     * makes the cost trivial.
+     *
+     * Best effort — a failed sweep must not fail the write that triggered it.
+     */
+    private fun sweepOldReports(dir: File) {
+        runCatching {
+            val reports =
+                dir
+                    .listFiles { f -> f.isFile && f.name.startsWith("contained-") && f.name.endsWith(".txt") }
+                    ?.sortedByDescending { it.name }
+                    ?: return
+            reports.drop(CONTAINED_REPORT_RETENTION).forEach { it.delete() }
+        }
+    }
+
+    /** POSIX first, File flags as fallback — the same shape SingleInstanceFiles uses. */
+    private fun restrictToOwner(
+        target: File,
+        directory: Boolean,
+    ) {
+        val posix =
+            runCatching {
+                val perms =
+                    if (directory) {
+                        java.nio.file.attribute.PosixFilePermissions
+                            .fromString("rwx------")
+                    } else {
+                        java.nio.file.attribute.PosixFilePermissions
+                            .fromString("rw-------")
+                    }
+                java.nio.file.Files
+                    .setPosixFilePermissions(target.toPath(), perms)
+            }
+        if (posix.isSuccess) return
+        // Non-POSIX filesystem: best effort, and note the execute bit matters for a
+        // directory or others can still traverse into it.
+        runCatching {
+            target.setReadable(false, false)
+            target.setReadable(true, true)
+            target.setWritable(false, false)
+            target.setWritable(true, true)
+            if (directory) {
+                target.setExecutable(false, false)
+                target.setExecutable(true, true)
+            }
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -215,7 +215,14 @@ object CrashHandler {
                 return
             }
             // Building the report is part of the off-thread work now.
-            containedWriter.execute { writeContainedReport(signature, throwable) }
+            //
+            // The directory is resolved *here*, not on the writer thread: a test that
+            // sets containedReportDirOverride clears it as soon as its body returns,
+            // so a task that had not drained yet would resolve the real
+            // ~/.boss/crash-reports and sweepOldReports would delete the developer's
+            // actual reports — the exact hazard the override exists to prevent.
+            val dir = containedReportDir()
+            containedWriter.execute { writeContainedReport(dir, signature, throwable) }
         } catch (e: Exception) {
             // Reporting a contained fault must never itself become a fault.
             logger.warn(
@@ -227,23 +234,19 @@ object CrashHandler {
         }
     }
 
-    /** Off the EDT — see [containedWriter]. */
+    /** Off the EDT — see [containedWriter]. [dir] is resolved by the caller. */
     private fun writeContainedReport(
+        dir: File,
         signature: String,
         throwable: Throwable,
     ) {
         try {
             val report = createCrashReport(throwable)
-            val dir = containedReportDir()
-            dir.mkdirs()
+            // Owner-only on the directory *and* the file. Directory perms alone are
+            // not enough — 0711 still lets others traverse to a predictable path.
+            makeOwnerOnlyDir(dir)
             val file = File(dir, "contained-${report.timestamp}-$signature.txt")
-            // Owner-only on both, and on the file too — writeText alone leaves it at
-            // the umask, typically 0644, holding sanitized traces and host details.
-            // Directory perms are not enough: 0711 still lets others traverse to a
-            // known path.
-            restrictToOwner(dir, directory = true)
-            file.writeText(renderContainedReport(report))
-            restrictToOwner(file, directory = false)
+            writeOwnerOnly(file, renderContainedReport(report))
             sweepOldReports(dir)
             logger.warn(
                 LogCategory.SYSTEM,
@@ -268,10 +271,16 @@ object CrashHandler {
      * Keep the newest [CONTAINED_REPORT_RETENTION] reports and delete the rest.
      *
      * The session dedupe bounds writes *within* one run; nothing bounded them
-     * across runs, and this directory has no other janitor. Sorted by name rather
-     * than mtime: the filename carries the report timestamp, so it survives a copy
-     * that resets modification times, and one distinct-signature write per sweep
-     * makes the cost trivial.
+     * across runs, and this directory has no other janitor.
+     *
+     * Ordered on the timestamp *parsed* out of the name rather than on the name
+     * itself. Plain name order looks equivalent but is not: the name is
+     * `contained-<millis>-<signature>.txt`, so when several distinct signatures land
+     * in the same millisecond the tiebreak becomes the signature hash and the sweep
+     * can keep older reports while deleting newer ones. Timestamps are preferred
+     * over `lastModified` because they survive a copy that resets mtimes;
+     * `lastModified` is only the tiebreak. Anything unparseable sorts oldest so a
+     * stray file cannot outlive real reports.
      *
      * Best effort — a failed sweep must not fail the write that triggered it.
      */
@@ -280,9 +289,73 @@ object CrashHandler {
             val reports =
                 dir
                     .listFiles { f -> f.isFile && f.name.startsWith("contained-") && f.name.endsWith(".txt") }
-                    ?.sortedByDescending { it.name }
                     ?: return
-            reports.drop(CONTAINED_REPORT_RETENTION).forEach { it.delete() }
+            reports
+                .sortedWith(compareByDescending<File> { reportTimestamp(it) }.thenByDescending { it.lastModified() })
+                .drop(CONTAINED_REPORT_RETENTION)
+                .forEach { it.delete() }
+        }
+    }
+
+    /** The millis embedded in `contained-<millis>-<signature>.txt`, or 0 if absent. */
+    private fun reportTimestamp(file: File): Long =
+        file.name
+            .removePrefix("contained-")
+            .substringBefore('-')
+            .toLongOrNull() ?: 0L
+
+    /**
+     * Create [file] owner-only and *then* write [text] into it.
+     *
+     * `writeText` creates at the umask — typically 0644 — and fills the file before
+     * any chmod can run, so tightening afterwards leaves a window in which the
+     * whole report is world-readable at a predictable path. The permissions have to
+     * be attached at creation instead. Falls back to create-then-restrict where
+     * POSIX attributes are unavailable.
+     */
+    private fun writeOwnerOnly(
+        file: File,
+        text: String,
+    ) {
+        val createdWithPerms =
+            runCatching {
+                java.nio.file.Files
+                    .deleteIfExists(file.toPath())
+                java.nio.file.Files
+                    .createFile(file.toPath(), posixAttribute("rw-------"))
+            }.isSuccess
+        file.writeText(text)
+        // Only needed where creation could not carry the permissions; that path keeps
+        // the narrow exposure window, and is best effort by nature.
+        if (!createdWithPerms) restrictToOwner(file, directory = false)
+    }
+
+    private fun posixAttribute(mode: String) =
+        java.nio.file.attribute.PosixFilePermissions
+            .asFileAttribute(
+                java.nio.file.attribute.PosixFilePermissions
+                    .fromString(mode),
+            )
+
+    /**
+     * Create the report directory owner-only from the outset.
+     *
+     * `mkdirs()` then chmod has the same exposure window as the file did, so the
+     * directory is created with its permissions attached where POSIX allows it.
+     */
+    private fun makeOwnerOnlyDir(dir: File) {
+        if (dir.isDirectory) {
+            restrictToOwner(dir, directory = true)
+            return
+        }
+        val created =
+            runCatching {
+                java.nio.file.Files
+                    .createDirectories(dir.toPath(), posixAttribute("rwx------"))
+            }.isSuccess
+        if (!created) {
+            dir.mkdirs()
+            restrictToOwner(dir, directory = true)
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -15,6 +15,7 @@ import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.management.ManagementFactory
+import java.util.concurrent.ConcurrentHashMap
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import javax.swing.WindowConstants
@@ -44,6 +45,28 @@ object CrashHandler {
 
     /** Where contained (non-fatal, recovered) reports are written, under the BOSS data dir. */
     private const val CONTAINED_REPORT_DIR = "crash-reports"
+
+    /**
+     * Signatures already written this session.
+     *
+     * A corrupt scene throws every frame, so without this the render-fault path
+     * would write ~60 files a second of full stack traces until the user noticed
+     * — and nothing in the repo trims that directory. One file per distinct fault
+     * is all the diagnostic value there is; repeats only bump a log counter.
+     */
+    private val containedSignatures = ConcurrentHashMap<String, Int>()
+
+    /**
+     * Single thread for writing contained reports.
+     *
+     * The render-fault path runs on the AWT event thread, in the middle of a
+     * repaint storm; a synchronous writeText there stalls the UI on a slow or
+     * full disk. Daemon so it never holds shutdown open.
+     */
+    private val containedWriter =
+        java.util.concurrent.Executors.newSingleThreadExecutor { r ->
+            Thread(r, "boss-contained-crash-writer").apply { isDaemon = true }
+        }
 
     private val _pendingCrashReport = MutableStateFlow<CrashReport?>(null)
 
@@ -138,24 +161,57 @@ object CrashHandler {
         if (isIgnorable(throwable)) return
         try {
             val report = createCrashReport(throwable)
-            val dir = BossDirectories.resolve(CONTAINED_REPORT_DIR).apply { mkdirs() }
-            File(dir, "contained-${report.timestamp}-${report.signature}.txt")
-                .writeText(renderContainedReport(report))
+            val seen = containedSignatures.merge(report.signature, 1, Int::plus) ?: 1
+            if (seen > 1) {
+                // Same fault again — the file already exists and says everything a
+                // second copy would.
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Contained render fault recurred",
+                    mapOf(
+                        "signature" to report.signature,
+                        "errorType" to report.exceptionType,
+                        "occurrences" to seen.toString(),
+                    ),
+                )
+                return
+            }
             logger.warn(
                 LogCategory.SYSTEM,
                 "Contained render fault recorded",
-                mapOf(
-                    "signature" to report.signature,
-                    "errorType" to report.exceptionType,
-                    "dir" to dir.absolutePath,
-                ),
+                mapOf("signature" to report.signature, "errorType" to report.exceptionType),
             )
+            containedWriter.execute { writeContainedReport(report) }
         } catch (e: Exception) {
             // Reporting a contained fault must never itself become a fault.
             logger.warn(
                 LogCategory.SYSTEM,
                 "Failed to record a contained crash report",
                 mapOf("errorType" to throwable.javaClass.simpleName),
+                e,
+            )
+        }
+    }
+
+    /** Off the EDT — see [containedWriter]. */
+    private fun writeContainedReport(report: CrashReport) {
+        try {
+            val dir = BossDirectories.resolve(CONTAINED_REPORT_DIR).apply { mkdirs() }
+            // Owner-only, matching how ~/.boss/run is treated: these hold
+            // sanitized stack traces and host details.
+            runCatching {
+                dir.setReadable(false, false)
+                dir.setReadable(true, true)
+                dir.setWritable(false, false)
+                dir.setWritable(true, true)
+            }
+            File(dir, "contained-${report.timestamp}-${report.signature}.txt")
+                .writeText(renderContainedReport(report))
+        } catch (e: Exception) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Failed to write a contained crash report",
+                mapOf("signature" to report.signature),
                 e,
             )
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -16,6 +16,7 @@ import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.management.ManagementFactory
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import javax.swing.WindowConstants
@@ -64,7 +65,7 @@ object CrashHandler {
      * full disk. Daemon so it never holds shutdown open.
      */
     private val containedWriter =
-        java.util.concurrent.Executors.newSingleThreadExecutor { r ->
+        Executors.newSingleThreadExecutor { r ->
             Thread(r, "boss-contained-crash-writer").apply { isDaemon = true }
         }
 
@@ -163,17 +164,21 @@ object CrashHandler {
             val report = createCrashReport(throwable)
             val seen = containedSignatures.merge(report.signature, 1, Int::plus) ?: 1
             if (seen > 1) {
-                // Same fault again — the file already exists and says everything a
-                // second copy would.
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "Contained render fault recurred",
-                    mapOf(
-                        "signature" to report.signature,
-                        "errorType" to report.exceptionType,
-                        "occurrences" to seen.toString(),
-                    ),
-                )
+                // Log on a curve, not every frame. The file dedupe protects the
+                // disk; this protects the log buffers, which back recentLogs on
+                // the next real crash report — a per-frame warn would evict the
+                // very context that explains the fault.
+                if (seen == 2 || seen == 10 || seen % 100 == 0) {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Contained render fault recurring",
+                        mapOf(
+                            "signature" to report.signature,
+                            "errorType" to report.exceptionType,
+                            "occurrences" to seen.toString(),
+                        ),
+                    )
+                }
                 return
             }
             logger.warn(
@@ -223,6 +228,7 @@ object CrashHandler {
             appendLine("BOSS contained render fault")
             appendLine("signature:  ${report.signature}")
             appendLine("timestamp:  ${report.timestamp}")
+            appendLine("plugin:     ${report.pluginId ?: "(unattributed)"}")
             appendLine("type:       ${report.exceptionType}")
             appendLine("message:    ${report.exceptionMessage}")
             appendLine("app:        ${report.appInfo}")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.awt.Dimension
+import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.lang.management.ManagementFactory
@@ -40,6 +41,9 @@ import javax.swing.WindowConstants
  */
 object CrashHandler {
     private val logger = BossLogger.forComponent("CrashHandler")
+
+    /** Where contained (non-fatal, recovered) reports are written, under the BOSS data dir. */
+    private const val CONTAINED_REPORT_DIR = "crash-reports"
 
     private val _pendingCrashReport = MutableStateFlow<CrashReport?>(null)
 
@@ -110,26 +114,42 @@ object CrashHandler {
     }
 
     /**
-     * Record a crash report for something already contained and recovered from,
-     * without the dialog.
+     * Record a crash report for something already contained and recovered from.
      *
      * The window exception handler cannot use [handleCrash]: that shows a dialog
      * whose every exit terminates — dismiss, submit and Escape all reach
      * [terminateAfterCrash], and clean-and-restart deletes the data directory
      * first — so a recovered fault would end the session on Escape.
      *
-     * It cannot skip reporting either. That handler sees *all* unattributed
-     * Compose exceptions, not just plugin ones, so a host-side layout or
-     * composition bug used to produce a full crash report and now would produce
-     * one log line and a toast. That is telemetry quietly disappearing: the bugs
-     * stop being reported, which reads as the bugs stopping.
+     * It must not skip reporting either. That handler sees *all* unattributed
+     * Compose exceptions, so a host-side layout bug would otherwise produce a log
+     * line and a toast where it used to produce a full report.
      *
-     * So: build and publish the report, skip the dialog, do not terminate.
+     * The report is written to disk. It is deliberately **not** put in
+     * [pendingCrashReport]: that slot belongs to the interactive dialog, is
+     * single-valued, and nothing else reads it. Writing there achieved nothing —
+     * no consumer persists or uploads it — and could actively corrupt a
+     * submission in progress: a fatal crash on a background thread opens the
+     * dialog while the EDT keeps running, so a contained fault landing mid-typing
+     * would replace the report and Submit would send the wrong crash, losing the
+     * fatal one.
      */
     fun recordContained(throwable: Throwable) {
         if (isIgnorable(throwable)) return
         try {
-            _pendingCrashReport.value = createCrashReport(throwable)
+            val report = createCrashReport(throwable)
+            val dir = BossDirectories.resolve(CONTAINED_REPORT_DIR).apply { mkdirs() }
+            File(dir, "contained-${report.timestamp}-${report.signature}.txt")
+                .writeText(renderContainedReport(report))
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Contained render fault recorded",
+                mapOf(
+                    "signature" to report.signature,
+                    "errorType" to report.exceptionType,
+                    "dir" to dir.absolutePath,
+                ),
+            )
         } catch (e: Exception) {
             // Reporting a contained fault must never itself become a fault.
             logger.warn(
@@ -140,6 +160,22 @@ object CrashHandler {
             )
         }
     }
+
+    /** Plain text, so the file is useful without any tooling to read it. */
+    private fun renderContainedReport(report: CrashReport): String =
+        buildString {
+            appendLine("BOSS contained render fault")
+            appendLine("signature:  ${report.signature}")
+            appendLine("timestamp:  ${report.timestamp}")
+            appendLine("type:       ${report.exceptionType}")
+            appendLine("message:    ${report.exceptionMessage}")
+            appendLine("app:        ${report.appInfo}")
+            appendLine("system:     ${report.systemInfo}")
+            appendLine()
+            appendLine("This fault was contained and recovered from; the app kept running.")
+            appendLine()
+            appendLine(report.stackTrace)
+        }
 
     /**
      * Handle an uncaught exception.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
@@ -60,20 +60,25 @@ class RenderCrashPolicy(
     fun recentFailureCount(): Int = recentFailures.size
 
     /**
-     * Forget the current burst because recovery made progress.
+     * Un-count the fault just recorded, because recovery made progress on it.
      *
-     * Without this the budget races the narrowing loop and loses. The unattributed
-     * path is exactly the case where the same dirty node throws every frame, so
-     * faults arrive ~16ms apart and always inside one window, while narrowing
-     * costs one fault to rebuild plus one per suspect tried. With three panels
-     * mounted that is rebuild, suspect #1, release #1 and suspect #2 — and the
-     * fourth fault escalates and disposes the window, killing the app before the
-     * culprit was found and after quarantining two innocents.
+     * Narrowing needs room: faults from a repainting subtree arrive ~16ms apart,
+     * all inside one window, while the loop spends one fault to rebuild plus one
+     * per suspect. Counting those would escalate and dispose the window before
+     * the culprit was found.
      *
-     * So only faults where recovery achieved *nothing* count toward escalation. A
-     * rebuild or a fresh quarantine is progress and resets the budget; a fault
-     * that recovery could do nothing with does not, and still escalates.
+     * It removes exactly that one fault rather than clearing the deque, and the
+     * difference matters. Clearing made [Escalate][WindowExceptionRoute.Escalate]
+     * unreachable whenever two or more panels were mounted: the narrowing loop
+     * manufactures progress indefinitely — rebuild, suspect each plugin in turn,
+     * end Unexplained, which resets the incident and re-mounts the released
+     * panels so the next fault rebuilds again — so a full reset every cycle meant
+     * the count never reached the limit and a genuinely corrupt scene span
+     * forever. Removing one keeps the unproductive faults accumulating, so the
+     * loop gets its room and escalation stays reachable.
      */
     @Synchronized
-    fun noteRecoveryProgress() = recentFailures.clear()
+    fun noteRecoveryProgress() {
+        recentFailures.removeLastOrNull()
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderCrashPolicy.kt
@@ -58,4 +58,22 @@ class RenderCrashPolicy(
     /** Failures currently inside the window. Exposed for logging and tests. */
     @Synchronized
     fun recentFailureCount(): Int = recentFailures.size
+
+    /**
+     * Forget the current burst because recovery made progress.
+     *
+     * Without this the budget races the narrowing loop and loses. The unattributed
+     * path is exactly the case where the same dirty node throws every frame, so
+     * faults arrive ~16ms apart and always inside one window, while narrowing
+     * costs one fault to rebuild plus one per suspect tried. With three panels
+     * mounted that is rebuild, suspect #1, release #1 and suspect #2 — and the
+     * fourth fault escalates and disposes the window, killing the app before the
+     * culprit was found and after quarantining two innocents.
+     *
+     * So only faults where recovery achieved *nothing* count toward escalation. A
+     * rebuild or a fresh quarantine is progress and resets the budget; a fault
+     * that recovery could do nothing with does not, and still escalates.
+     */
+    @Synchronized
+    fun noteRecoveryProgress() = recentFailures.clear()
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderRecoveryToast.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/RenderRecoveryToast.kt
@@ -1,0 +1,90 @@
+package ai.rever.boss.crash
+
+import ai.rever.boss.plugin.sandbox.ui.PluginRenderRecovery
+
+/** How long a render-recovery toast stays up, and so how long a repeat is suppressed. */
+const val RENDER_RECOVERY_TOAST_MILLIS = 8_000L
+
+/**
+ * What to tell the user after an unattributed render exception, and whether to say
+ * it at all.
+ *
+ * Extracted from `main.kt` because this decision has now regressed twice while
+ * living inline in the window exception handler, where nothing could assert it:
+ *
+ * 1. First it was gated on "did recovery make progress", which silenced
+ *    [PluginRenderRecovery.Outcome.Unexplained] and
+ *    [PluginRenderRecovery.Outcome.NotPluginRelated] — the two outcomes that leave
+ *    the window *broken* and so the two the user most needs to hear about.
+ * 2. Then it was gated on the message differing from the previous one, which fixed
+ *    that and broke two other things: a narrowing cycle emits a *different* verdict
+ *    on almost every frame, so at 16ms intervals it still toasted ~60×/s; and
+ *    because the gate was process-lifetime, a `Rebuilt` at 09:00 silenced an
+ *    unrelated `Rebuilt` at 14:00 completely.
+ *
+ * Hence per-message *and* time-bounded: each distinct verdict speaks at most once
+ * per toast duration. A storm is capped at roughly one toast per mounted plugin per
+ * 8 seconds instead of sixty a second, and an hours-later recurrence is never
+ * silently swallowed.
+ */
+class RenderRecoveryToaster(
+    private val durationMs: Long = RENDER_RECOVERY_TOAST_MILLIS,
+) {
+    /**
+     * When each message was last shown.
+     *
+     * EDT-confined — the window exception handler is the only caller — so this is
+     * deliberately unsynchronized. Bounded by clearing wholesale: keys are one per
+     * verdict shape, so the ceiling is only reachable by a session that has cycled
+     * through an implausible number of plugin sets, and losing the history just
+     * means one extra toast.
+     */
+    private val lastShownAt = HashMap<String, Long>()
+
+    /**
+     * The message to show for [outcome], or null when it was shown too recently.
+     *
+     * @param now monotonic milliseconds; injectable so a test does not have to sleep.
+     */
+    fun toastFor(
+        outcome: PluginRenderRecovery.Outcome,
+        now: Long,
+    ): String? {
+        val message = messageFor(outcome)
+        val previous = lastShownAt[message]
+        if (previous != null && now - previous < durationMs) return null
+        if (lastShownAt.size >= MAX_TRACKED_MESSAGES) lastShownAt.clear()
+        lastShownAt[message] = now
+        return message
+    }
+
+    companion object {
+        private const val MAX_TRACKED_MESSAGES = 64
+
+        /**
+         * The wording, in one place so it is reviewable as a set: the whole point of
+         * recovery is that the user finds out something happened, since the failure
+         * it handles used to leave a silently broken window.
+         */
+        fun messageFor(outcome: PluginRenderRecovery.Outcome): String =
+            when (outcome) {
+                is PluginRenderRecovery.Outcome.Quarantined -> {
+                    "Paused ${outcome.plugins.joinToString()} — it kept failing to render. " +
+                        "Restart it from the panel menu."
+                }
+
+                is PluginRenderRecovery.Outcome.Rebuilt -> {
+                    "A plugin panel failed to render and was reloaded."
+                }
+
+                PluginRenderRecovery.Outcome.Unexplained -> {
+                    "A UI component keeps failing to render. No plugin accounts for it; " +
+                        "the window is still usable."
+                }
+
+                PluginRenderRecovery.Outcome.NotPluginRelated -> {
+                    "A UI component failed to render and was recovered."
+                }
+            }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.crash
 
+import ai.rever.boss.plugin.sandbox.ui.PluginRenderRecovery
 import ai.rever.boss.plugin.sandbox.ui.isUncontainable
 
 /**
@@ -50,3 +51,32 @@ fun decideWindowExceptionRoute(
         !policy.recordFailureAndShouldContain() -> WindowExceptionRoute.Escalate
         else -> WindowExceptionRoute.Contain
     }
+
+/**
+ * Tell [policy] whether the fault it just recorded was one recovery could act on.
+ *
+ * The pairing lives here rather than inline in the handler so that production and
+ * tests exercise the *same* decision. They did not: the seam test re-implemented
+ * this `Rebuilt || Quarantined` condition, so deleting the call from the handler
+ * left every test green — the wiring the test was named for was never asserted.
+ *
+ * [PluginRenderRecovery.Outcome.Rebuilt] and
+ * [PluginRenderRecovery.Outcome.Quarantined] mean the narrowing loop advanced, so
+ * that fault should not count toward escalation.
+ * [PluginRenderRecovery.Outcome.Unexplained] and
+ * [PluginRenderRecovery.Outcome.NotPluginRelated] mean it did not, and those must
+ * keep accumulating or a corrupt scene never escalates.
+ *
+ * @return true when the fault was un-counted, which is also the signal that
+ *   something visible changed and is worth telling the user about.
+ */
+internal fun noteRecoveryOutcome(
+    policy: RenderCrashPolicy,
+    outcome: PluginRenderRecovery.Outcome,
+): Boolean {
+    val madeProgress =
+        outcome is PluginRenderRecovery.Outcome.Rebuilt ||
+            outcome is PluginRenderRecovery.Outcome.Quarantined
+    if (madeProgress) policy.noteRecoveryProgress()
+    return madeProgress
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.cli.CLICommandHandler
 import ai.rever.boss.cli.createBossCLI
 import ai.rever.boss.components.dialogs.ChromiumDownloadContent
 import ai.rever.boss.config.ChromiumAutoDownloader
+import ai.rever.boss.crash.RenderCrashPolicy
 import ai.rever.boss.crash.WindowExceptionRoute
 import ai.rever.boss.crash.decideWindowExceptionRoute
 import ai.rever.boss.logging.GlobalLogCapture
@@ -91,7 +92,7 @@ private fun renderRecoveryMessage(outcome: PluginRenderRecovery.Outcome): String
  */
 private fun containRenderFault(
     throwable: Throwable,
-    policy: ai.rever.boss.crash.RenderCrashPolicy,
+    policy: RenderCrashPolicy,
 ) {
     logger.error(
         LogCategory.UI,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -7,7 +7,9 @@ import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.components.dialogs.ChromiumDownloadContent
 import ai.rever.boss.config.ChromiumAutoDownloader
 import ai.rever.boss.crash.CrashHandler
+import ai.rever.boss.crash.RENDER_RECOVERY_TOAST_MILLIS
 import ai.rever.boss.crash.RenderCrashPolicy
+import ai.rever.boss.crash.RenderRecoveryToaster
 import ai.rever.boss.crash.WindowExceptionRoute
 import ai.rever.boss.crash.decideWindowExceptionRoute
 import ai.rever.boss.crash.noteRecoveryOutcome
@@ -61,38 +63,11 @@ import kotlin.system.exitProcess
 private val logger = BossLogger.forComponent("Main")
 
 /**
- * Last render-recovery message shown, so repeats of the same verdict are not
- * re-toasted every frame. EDT-confined: the window exception handler is the only
- * writer.
+ * Decides the render-recovery toast and rate-limits it. EDT-confined: the window
+ * exception handler is the only caller. See [RenderRecoveryToaster] for why this
+ * is not just a `!=` against the last message.
  */
-private var lastRenderRecoveryMessage: String? = null
-
-/**
- * What to tell the user after an unattributed render exception.
- *
- * Named rather than inlined so the wording is reviewable in one place: the whole
- * point of recovery is that the user finds out something happened, since the
- * failure it handles previously left a silently broken window.
- */
-private fun renderRecoveryMessage(outcome: PluginRenderRecovery.Outcome): String =
-    when (outcome) {
-        is PluginRenderRecovery.Outcome.Quarantined -> {
-            "Paused ${outcome.plugins.joinToString()} — it kept failing to render. " +
-                "Restart it from the panel menu."
-        }
-
-        is PluginRenderRecovery.Outcome.Rebuilt -> {
-            "A plugin panel failed to render and was reloaded."
-        }
-
-        PluginRenderRecovery.Outcome.Unexplained -> {
-            "A UI component keeps failing to render. No plugin accounts for it; the window is still usable."
-        }
-
-        PluginRenderRecovery.Outcome.NotPluginRelated -> {
-            "A UI component failed to render and was recovered."
-        }
-    }
+private val renderRecoveryToaster = RenderRecoveryToaster()
 
 /**
  * Keep the window, recover the plugin panels, and tell the user.
@@ -127,18 +102,11 @@ private fun containRenderFault(
     // noteRecoveryOutcome.
     val madeProgress = noteRecoveryOutcome(policy, outcome)
 
-    // Two separate decisions, and conflating them regressed the user-visible
-    // half. Gating the toast on madeProgress meant Unexplained and
-    // NotPluginRelated — the two outcomes that leave the window *broken* — never
-    // said anything at all, which is exactly the silent broken window this whole
-    // path exists to prevent.
-    //
-    // So: tell the user whenever the verdict changes, including the ones recovery
-    // could not act on, and suppress only exact repeats.
-    val message = renderRecoveryMessage(outcome)
-    if (message != lastRenderRecoveryMessage) {
-        lastRenderRecoveryMessage = message
-        StatusMessageManager.showMessage(message, durationMs = 8000)
+    // Telling the user and un-counting the fault are separate decisions; every
+    // attempt to derive one from the other has regressed the other. The toaster
+    // owns this one, and is tested — see RenderRecoveryToaster.
+    renderRecoveryToaster.toastFor(outcome, now = System.nanoTime() / 1_000_000)?.let { message ->
+        StatusMessageManager.showMessage(message, durationMs = RENDER_RECOVERY_TOAST_MILLIS)
     }
     // The repaint stays on progress only: it is a full sweep of every window, and
     // during a storm it arguably feeds the fault it is responding to. Nothing to

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -3,11 +3,14 @@ package ai.rever.boss
 import BossTheme
 import ai.rever.boss.cli.CLICommandHandler
 import ai.rever.boss.cli.createBossCLI
+import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.components.dialogs.ChromiumDownloadContent
 import ai.rever.boss.config.ChromiumAutoDownloader
+import ai.rever.boss.crash.CrashHandler
 import ai.rever.boss.crash.RenderCrashPolicy
 import ai.rever.boss.crash.WindowExceptionRoute
 import ai.rever.boss.crash.decideWindowExceptionRoute
+import ai.rever.boss.crash.noteRecoveryOutcome
 import ai.rever.boss.logging.GlobalLogCapture
 import ai.rever.boss.performance.PerformanceDataProviderImpl
 import ai.rever.boss.plugin.PluginStoreSetup
@@ -50,6 +53,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import java.awt.Window
 import java.io.File
 import javax.swing.JPopupMenu
 import kotlin.system.exitProcess
@@ -112,18 +116,17 @@ private fun containRenderFault(
     // Keeping the window alive is not enough on its own: a repaint over a subtree
     // that still reproduces the fault leaves a broken window and no explanation.
     val outcome = PluginRenderRecovery.onUnattributedRenderException(throwable)
-    // Recovery is converging, so this fault should not count against escalation —
-    // otherwise the budget expires mid-narrowing and disposes the window.
-    if (outcome is PluginRenderRecovery.Outcome.Rebuilt ||
-        outcome is PluginRenderRecovery.Outcome.Quarantined
-    ) {
-        policy.noteRecoveryProgress()
+    // Shared with the seam test so both exercise the same pairing — see
+    // noteRecoveryOutcome.
+    val madeProgress = noteRecoveryOutcome(policy, outcome)
+    // Only on a change of state. Deferring escalation lengthens the storm, and
+    // firing a toast and repainting every window on each repeat of the same
+    // verdict is both noise and work — the repaint arguably feeding the very
+    // fault it responds to.
+    if (madeProgress) {
+        StatusMessageManager.showMessage(renderRecoveryMessage(outcome), durationMs = 8000)
+        Window.getWindows().forEach { it.repaint() }
     }
-    ai.rever.boss.components.bars.horizontal.StatusMessageManager
-        .showMessage(renderRecoveryMessage(outcome), durationMs = 8000)
-    java.awt.Window
-        .getWindows()
-        .forEach { it.repaint() }
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -83,6 +83,49 @@ private fun renderRecoveryMessage(outcome: PluginRenderRecovery.Outcome): String
     }
 
 /**
+ * Keep the window, recover the plugin panels, and tell the user.
+ *
+ * Extracted from the handler rather than inlined: the block was long enough to
+ * push `exceptionHandler` past the length limit, and the ordering here matters
+ * enough to read on its own.
+ */
+private fun containRenderFault(
+    throwable: Throwable,
+    policy: ai.rever.boss.crash.RenderCrashPolicy,
+) {
+    logger.error(
+        LogCategory.UI,
+        "Unattributed render exception — contained, window kept alive",
+        mapOf(
+            "errorType" to throwable.javaClass.simpleName,
+            "recentFailures" to policy.recentFailureCount().toString(),
+        ),
+        throwable,
+    )
+    // Reported, but not through CrashHandler.handleCrash: that dialog is terminal
+    // on every exit, so a recovered fault would end the session on Escape.
+    // recordContained writes the report to disk instead, so a host-side render bug
+    // stays visible rather than costing one log line and a toast.
+    ai.rever.boss.crash.CrashHandler
+        .recordContained(throwable)
+    // Keeping the window alive is not enough on its own: a repaint over a subtree
+    // that still reproduces the fault leaves a broken window and no explanation.
+    val outcome = PluginRenderRecovery.onUnattributedRenderException(throwable)
+    // Recovery is converging, so this fault should not count against escalation —
+    // otherwise the budget expires mid-narrowing and disposes the window.
+    if (outcome is PluginRenderRecovery.Outcome.Rebuilt ||
+        outcome is PluginRenderRecovery.Outcome.Quarantined
+    ) {
+        policy.noteRecoveryProgress()
+    }
+    ai.rever.boss.components.bars.horizontal.StatusMessageManager
+        .showMessage(renderRecoveryMessage(outcome), durationMs = 8000)
+    java.awt.Window
+        .getWindows()
+        .forEach { it.repaint() }
+}
+
+/**
  * Scope for fire-and-forget startup work (PSI warm-up, update-Realtime start).
  * Deliberately process-lifetime — main() has no teardown point; long-lived
  * services manage their own scopes and are disposed via the shutdown hook.
@@ -559,39 +602,7 @@ fun main(args: Array<String>) {
                                 }
 
                                 WindowExceptionRoute.Contain -> {
-                                    logger.error(
-                                        LogCategory.UI,
-                                        "Unattributed render exception — contained, window kept alive",
-                                        mapOf(
-                                            "errorType" to throwable.javaClass.simpleName,
-                                            "recentFailures" to renderCrashPolicy.recentFailureCount().toString(),
-                                        ),
-                                        throwable,
-                                    )
-                                    // Reported, but not through CrashHandler.handleCrash: that
-                                    // dialog is terminal on every exit — dismiss, submit and
-                                    // Escape all reach terminateAfterCrash(), and
-                                    // clean-and-restart deletes ~/.boss first. A recovered
-                                    // fault must not end the session on Escape. recordContained
-                                    // keeps the report and drops the dialog, so a host-side
-                                    // render bug is still visible instead of costing one log
-                                    // line and a toast.
-                                    ai.rever.boss.crash.CrashHandler
-                                        .recordContained(throwable)
-                                    // Keeping the window alive is not enough on its own: a
-                                    // repaint over a subtree that still reproduces the fault
-                                    // leaves a broken window and no explanation. Recovery
-                                    // rebuilds the plugin panels, then narrows to one suspect.
-                                    val outcome =
-                                        PluginRenderRecovery.onUnattributedRenderException(throwable)
-                                    ai.rever.boss.components.bars.horizontal.StatusMessageManager
-                                        .showMessage(
-                                            renderRecoveryMessage(outcome),
-                                            durationMs = 8000,
-                                        )
-                                    java.awt.Window
-                                        .getWindows()
-                                        .forEach { it.repaint() }
+                                    containRenderFault(throwable, renderCrashPolicy)
                                 }
 
                                 WindowExceptionRoute.Escalate -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -61,6 +61,13 @@ import kotlin.system.exitProcess
 private val logger = BossLogger.forComponent("Main")
 
 /**
+ * Last render-recovery message shown, so repeats of the same verdict are not
+ * re-toasted every frame. EDT-confined: the window exception handler is the only
+ * writer.
+ */
+private var lastRenderRecoveryMessage: String? = null
+
+/**
  * What to tell the user after an unattributed render exception.
  *
  * Named rather than inlined so the wording is reviewable in one place: the whole
@@ -119,12 +126,24 @@ private fun containRenderFault(
     // Shared with the seam test so both exercise the same pairing — see
     // noteRecoveryOutcome.
     val madeProgress = noteRecoveryOutcome(policy, outcome)
-    // Only on a change of state. Deferring escalation lengthens the storm, and
-    // firing a toast and repainting every window on each repeat of the same
-    // verdict is both noise and work — the repaint arguably feeding the very
-    // fault it responds to.
+
+    // Two separate decisions, and conflating them regressed the user-visible
+    // half. Gating the toast on madeProgress meant Unexplained and
+    // NotPluginRelated — the two outcomes that leave the window *broken* — never
+    // said anything at all, which is exactly the silent broken window this whole
+    // path exists to prevent.
+    //
+    // So: tell the user whenever the verdict changes, including the ones recovery
+    // could not act on, and suppress only exact repeats.
+    val message = renderRecoveryMessage(outcome)
+    if (message != lastRenderRecoveryMessage) {
+        lastRenderRecoveryMessage = message
+        StatusMessageManager.showMessage(message, durationMs = 8000)
+    }
+    // The repaint stays on progress only: it is a full sweep of every window, and
+    // during a storm it arguably feeds the fault it is responding to. Nothing to
+    // repaint for a verdict that changed nothing.
     if (madeProgress) {
-        StatusMessageManager.showMessage(renderRecoveryMessage(outcome), durationMs = 8000)
         Window.getWindows().forEach { it.repaint() }
     }
 }
@@ -193,8 +212,7 @@ fun main(args: Array<String>) {
     }
 
     // Install crash handler after logger is ready
-    ai.rever.boss.crash.CrashHandler
-        .install()
+    CrashHandler.install()
 
     // Install plugin crash interceptor (chains after CrashHandler to catch plugin-specific crashes)
     ai.rever.boss.plugin.sandbox.ui

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
@@ -1,0 +1,165 @@
+package ai.rever.boss.crash
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers [CrashHandler.recordContained], the path a contained render fault takes
+ * to disk.
+ *
+ * It was the largest new piece here and had no coverage at all, which mattered
+ * because its whole reason for existing is that the previous implementation
+ * *looked* like it reported something and did not — it wrote to a slot with no
+ * consumers. A test that a file actually appears is the difference between the
+ * two.
+ *
+ * Runs against a temp directory, never the real data root: the write path now
+ * sweeps old reports, so a test pointed at `~/.boss/crash-reports` would delete
+ * the user's actual crash reports.
+ */
+class ContainedCrashReportTest {
+    /** Mirrors CrashHandler.CONTAINED_REPORT_RETENTION, which is private. */
+    private val retention = 20
+
+    private lateinit var dir: File
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("contained-report-test").toFile()
+        CrashHandler.containedReportDirOverride = dir
+        CrashHandler.resetContainedStateForTest()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        CrashHandler.containedReportDirOverride = null
+        CrashHandler.resetContainedStateForTest()
+        dir.deleteRecursively()
+    }
+
+    private fun reports(): List<File> = dir.listFiles()?.toList().orEmpty()
+
+    /**
+     * A fault with a signature of its own.
+     *
+     * [CrashSignature] deliberately ignores the message and hashes the exception
+     * type plus stack frames, so varying only the text yields *one* signature —
+     * thirty "distinct" faults built at a single line all dedupe to a single file.
+     * That silently made the retention test vacuous (verified: it passed with the
+     * sweep commented out). Stamping a synthetic frame is the only way to vary the
+     * signature without thirty separate throw sites.
+     */
+    private fun uniqueThrowable(marker: String): IllegalStateException =
+        IllegalStateException("contained-report-test $marker").apply {
+            stackTrace =
+                arrayOf(
+                    StackTraceElement("ai.rever.boss.crash.SyntheticFault", marker, "SyntheticFault.kt", 1),
+                )
+        }
+
+    @Test
+    fun `a contained fault is written to disk`() {
+        CrashHandler.recordContained(uniqueThrowable("write"))
+        awaitFiles(1)
+
+        val text = reports().single().readText()
+        assertTrue(text.contains("contained render fault"), "the file should say what it is")
+        assertTrue(text.contains("plugin:"), "pluginId is the most useful field on this path")
+        assertTrue(text.contains("contained-report-test write"), "the original message should survive")
+    }
+
+    @Test
+    fun `the same fault is not written twice`() {
+        // A corrupt scene throws every frame; without the dedupe this path wrote
+        // roughly sixty files a second of full stack traces.
+        val boom = uniqueThrowable("dedupe")
+        CrashHandler.recordContained(boom)
+        awaitFiles(1)
+        repeat(20) { CrashHandler.recordContained(boom) }
+        drainWriter()
+
+        assertEquals(1, reports().size, "a recurring fault must not keep writing files")
+    }
+
+    @Test
+    fun `a benign exception is not recorded at all`() {
+        CrashHandler.recordContained(java.util.concurrent.CancellationException("cancelled"))
+        drainWriter()
+
+        assertEquals(0, reports().size, "an ignorable throwable is not a crash")
+    }
+
+    @Test
+    fun `the report is readable only by its owner`() {
+        // Sanitized or not, these hold stack traces, plugin ids and host details.
+        CrashHandler.recordContained(uniqueThrowable("perms"))
+        awaitFiles(1)
+
+        val file = reports().single()
+        val perms = runCatching { Files.getPosixFilePermissions(file.toPath()) }.getOrNull()
+        if (perms == null) return // non-POSIX filesystem; the File-flag fallback is best effort
+
+        assertTrue(
+            perms.none { it.name.startsWith("GROUP") || it.name.startsWith("OTHERS") },
+            "contained reports must not be group- or world-accessible, found $perms",
+        )
+    }
+
+    @Test
+    fun `the directory does not grow without bound`() {
+        // The session dedupe bounds one run; nothing bounded the directory across
+        // runs, and no other code in the repo trims it.
+        val distinctFaults = 30
+        repeat(distinctFaults) { CrashHandler.recordContained(uniqueThrowable("retention-$it")) }
+        drainWriter()
+
+        // The drain marker above was itself a 31st write, and deleting it can take
+        // the count one below the cap — so assert the bound, not an exact figure.
+        val kept = reports().size
+        assertTrue(kept > 0, "the sweep must not empty the directory it just wrote to")
+        assertTrue(
+            kept <= retention,
+            "expected at most $retention reports kept, found $kept of $distinctFaults written",
+        )
+    }
+
+    /** The write is handed to a background thread, so poll rather than sleep a fixed span. */
+    private fun awaitFiles(count: Int) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (reports().size >= count) return
+            Thread.sleep(20)
+        }
+        throw AssertionError("timed out waiting for $count contained report(s); found ${reports().size}")
+    }
+
+    /**
+     * Wait for the single-threaded writer to catch up.
+     *
+     * Asserting "no file appeared" needs the queue drained, not a guessed sleep —
+     * on a loaded CI box a fixed 200ms would pass whether or not the code was
+     * correct.
+     */
+    private fun drainWriter() {
+        val marker = uniqueThrowable("drain")
+        val text = marker.message!!
+        CrashHandler.recordContained(marker)
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            // readText via runCatching: the writer thread sweeps old reports while
+            // we are listing, so a file can vanish between listFiles and the read.
+            val written = reports().filter { runCatching { it.readText() }.getOrDefault("").contains(text) }
+            if (written.isNotEmpty()) {
+                written.forEach { it.delete() }
+                return
+            }
+            Thread.sleep(20)
+        }
+        throw AssertionError("the contained-report writer never drained")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
@@ -21,6 +21,12 @@ import kotlin.test.assertTrue
  * Runs against a temp directory, never the real data root: the write path now
  * sweeps old reports, so a test pointed at `~/.boss/crash-reports` would delete
  * the user's actual crash reports.
+ *
+ * Note this swaps a global on a shared singleton and deletes files, so it relies
+ * on this module running tests in one fork — a future `maxParallelForks > 1` would
+ * let a parallel class see this class's override, or lose its own. The directory
+ * is captured when a write is *enqueued* rather than when it runs, which is what
+ * stops a task that outlives `tearDown` from resolving the real data root.
  */
 class ContainedCrashReportTest {
     /** Mirrors CrashHandler.CONTAINED_REPORT_RETENTION, which is private. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
@@ -90,7 +90,7 @@ class RenderCrashPolicyTest {
     }
 
     @Test
-    fun `recovery progress resets the budget so narrowing can finish`() {
+    fun `recovery progress un-counts the fault so narrowing can finish`() {
         // The budget used to race the narrowing loop and win. Faults from a
         // repainting subtree arrive ~16ms apart, so they all land in one window,
         // while narrowing spends one fault per suspect. With three panels the

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderCrashPolicyTest.kt
@@ -90,6 +90,43 @@ class RenderCrashPolicyTest {
     }
 
     @Test
+    fun `recovery progress resets the budget so narrowing can finish`() {
+        // The budget used to race the narrowing loop and win. Faults from a
+        // repainting subtree arrive ~16ms apart, so they all land in one window,
+        // while narrowing spends one fault per suspect. With three panels the
+        // fourth fault escalated and disposed the window — killing the app before
+        // the culprit was found.
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(10) {
+            assertTrue(
+                policy.recordFailureAndShouldContain(),
+                "a fault that recovery is making progress on must not escalate",
+            )
+            policy.noteRecoveryProgress()
+            clock.advance(16)
+        }
+    }
+
+    @Test
+    fun `faults recovery cannot help with still escalate`() {
+        // The other half: progress resets the budget, so no progress must not.
+        val clock = FakeClock()
+        val policy = policy(clock)
+
+        repeat(RenderCrashPolicy.DEFAULT_MAX_FAILURES) {
+            assertTrue(policy.recordFailureAndShouldContain())
+            clock.advance(16)
+        }
+
+        assertFalse(
+            policy.recordFailureAndShouldContain(),
+            "without progress the breaker must still give up",
+        )
+    }
+
+    @Test
     fun `the no-arg constructor uses the documented defaults`() {
         // main.kt constructs it with no arguments, so the defaults are the values
         // that actually ship.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderRecoverySeamTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderRecoverySeamTest.kt
@@ -30,13 +30,33 @@ class RenderRecoverySeamTest {
         plugins.forEach { PluginRenderRecovery.registerMounted(it) }
     }
 
+    // No manual clearCrash here: reset() releases the held suspect itself now.
+    // Needing those calls was the sign that it did not.
     @AfterTest
-    fun tearDown() {
-        PluginRenderRecovery.reset()
-        plugins.forEach { PluginCrashRegistry.clearCrash(it) }
+    fun tearDown() = PluginRenderRecovery.reset()
+
+    @Test
+    fun `an outcome recovery could not act on is left counted`() {
+        // The pairing that production uses, asserted directly: Unexplained and
+        // NotPluginRelated must keep accumulating or escalation never arrives.
+        val policy = RenderCrashPolicy(now = { 0L })
+        policy.recordFailureAndShouldContain()
+
+        val counted = noteRecoveryOutcome(policy, PluginRenderRecovery.Outcome.Unexplained)
+
+        assertTrue(!counted, "Unexplained is not progress")
+        assertTrue(policy.recentFailureCount() == 1, "an unproductive fault must stay counted")
     }
 
-    /** One frame of a scene that throws every repaint, wired as containRenderFault does. */
+    /**
+     * One frame of a scene that throws every repaint.
+     *
+     * Calls the same [noteRecoveryOutcome] the handler does rather than
+     * re-implementing the pairing. The earlier version duplicated the
+     * `Rebuilt || Quarantined` condition, which meant deleting the call from
+     * `containRenderFault` left these tests green — verified, and the reason this
+     * now goes through production code.
+     */
     private fun frame(
         policy: RenderCrashPolicy,
         clockMillis: Long,
@@ -44,11 +64,7 @@ class RenderRecoverySeamTest {
         val route = decideWindowExceptionRoute(error, attributedPluginId = null, policy = policy)
         if (route == WindowExceptionRoute.Contain) {
             val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = clockMillis)
-            if (outcome is PluginRenderRecovery.Outcome.Rebuilt ||
-                outcome is PluginRenderRecovery.Outcome.Quarantined
-            ) {
-                policy.noteRecoveryProgress()
-            }
+            noteRecoveryOutcome(policy, outcome)
         }
         return route
     }
@@ -89,12 +105,8 @@ class RenderRecoverySeamTest {
             val route = decideWindowExceptionRoute(error, null, policy)
             if (route == WindowExceptionRoute.Escalate) break
             val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = now)
-            if (outcome is PluginRenderRecovery.Outcome.Quarantined) {
-                quarantined += outcome.plugins
-                policy.noteRecoveryProgress()
-            } else if (outcome is PluginRenderRecovery.Outcome.Rebuilt) {
-                policy.noteRecoveryProgress()
-            }
+            if (outcome is PluginRenderRecovery.Outcome.Quarantined) quarantined += outcome.plugins
+            noteRecoveryOutcome(policy, outcome)
             now += 16
         }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderRecoverySeamTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderRecoverySeamTest.kt
@@ -1,0 +1,106 @@
+package ai.rever.boss.crash
+
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
+import ai.rever.boss.plugin.sandbox.ui.PluginRenderRecovery
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Drives the real [PluginRenderRecovery] against the real [RenderCrashPolicy],
+ * which neither of their own test classes does.
+ *
+ * That gap hid a regression. Fixing "the budget expires before narrowing
+ * converges" by clearing the burst on any progress over-corrected into "the
+ * budget never expires": the narrowing loop manufactures progress indefinitely —
+ * rebuild, suspect each mounted plugin in turn, end `Unexplained`, which resets
+ * the incident and re-mounts the released panels so the next fault rebuilds
+ * again. With a full reset every cycle the count never reached the limit, so a
+ * genuinely corrupt scene span forever instead of escalating. Both halves passed
+ * their own unit tests.
+ */
+class RenderRecoverySeamTest {
+    private val plugins = listOf("plugin.a", "plugin.b", "plugin.c")
+    private val error = IllegalArgumentException("""Key "coll-dup" was already used.""")
+
+    @BeforeTest
+    fun setUp() {
+        PluginRenderRecovery.reset()
+        plugins.forEach { PluginRenderRecovery.registerMounted(it) }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        PluginRenderRecovery.reset()
+        plugins.forEach { PluginCrashRegistry.clearCrash(it) }
+    }
+
+    /** One frame of a scene that throws every repaint, wired as containRenderFault does. */
+    private fun frame(
+        policy: RenderCrashPolicy,
+        clockMillis: Long,
+    ): WindowExceptionRoute {
+        val route = decideWindowExceptionRoute(error, attributedPluginId = null, policy = policy)
+        if (route == WindowExceptionRoute.Contain) {
+            val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = clockMillis)
+            if (outcome is PluginRenderRecovery.Outcome.Rebuilt ||
+                outcome is PluginRenderRecovery.Outcome.Quarantined
+            ) {
+                policy.noteRecoveryProgress()
+            }
+        }
+        return route
+    }
+
+    @Test
+    fun `a scene that throws every frame eventually escalates`() {
+        var now = 0L
+        val policy = RenderCrashPolicy(now = { now })
+
+        // 200 frames at 16ms is a little over three seconds — comfortably inside
+        // the ten-second window, so nothing ages out and escalation must come
+        // from the budget rather than from the clock.
+        var escalatedAt: Int? = null
+        for (frameNumber in 1..200) {
+            if (frame(policy, now) == WindowExceptionRoute.Escalate) {
+                escalatedAt = frameNumber
+                break
+            }
+            now += 16
+        }
+
+        assertTrue(
+            escalatedAt != null,
+            "a permanently broken scene never escalated — the app would spin forever, " +
+                "which is the failure RenderCrashPolicy exists to prevent",
+        )
+    }
+
+    @Test
+    fun `narrowing is given enough room to reach every mounted plugin first`() {
+        var now = 0L
+        val policy = RenderCrashPolicy(now = { now })
+
+        // Escalating before the loop has tried each suspect would kill the app
+        // without ever finding the culprit — the bug the progress allowance fixes.
+        val quarantined = mutableSetOf<String>()
+        for (frameNumber in 1..200) {
+            val route = decideWindowExceptionRoute(error, null, policy)
+            if (route == WindowExceptionRoute.Escalate) break
+            val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = now)
+            if (outcome is PluginRenderRecovery.Outcome.Quarantined) {
+                quarantined += outcome.plugins
+                policy.noteRecoveryProgress()
+            } else if (outcome is PluginRenderRecovery.Outcome.Rebuilt) {
+                policy.noteRecoveryProgress()
+            }
+            now += 16
+        }
+
+        assertTrue(
+            quarantined.containsAll(plugins),
+            "narrowing escalated before trying every mounted plugin: tried $quarantined",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderRecoveryToastTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/RenderRecoveryToastTest.kt
@@ -1,0 +1,103 @@
+package ai.rever.boss.crash
+
+import ai.rever.boss.plugin.sandbox.ui.PluginRenderRecovery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The user-facing half of render containment.
+ *
+ * This decision lived inline in the window exception handler and regressed twice
+ * there, both times invisibly, because nothing could assert it. Every test below
+ * corresponds to one of those regressions.
+ */
+class RenderRecoveryToastTest {
+    private val quarantined = PluginRenderRecovery.Outcome.Quarantined(setOf("plugin.a"))
+    private val rebuilt = PluginRenderRecovery.Outcome.Rebuilt(setOf("plugin.a"))
+
+    @Test
+    fun `every outcome says something`() {
+        // Regression one: the toast was gated on "recovery made progress", so
+        // Unexplained and NotPluginRelated — the outcomes that leave the window
+        // broken, and so the ones the user most needs — said nothing at all.
+        val outcomes =
+            listOf(
+                quarantined,
+                rebuilt,
+                PluginRenderRecovery.Outcome.Unexplained,
+                PluginRenderRecovery.Outcome.NotPluginRelated,
+            )
+
+        outcomes.forEach { outcome ->
+            val toaster = RenderRecoveryToaster()
+            assertNotNull(toaster.toastFor(outcome, now = 0L), "$outcome told the user nothing")
+        }
+    }
+
+    @Test
+    fun `a repeated verdict is suppressed while its toast is still up`() {
+        val toaster = RenderRecoveryToaster(durationMs = 8_000L)
+
+        assertNotNull(toaster.toastFor(rebuilt, now = 0L))
+        assertNull(toaster.toastFor(rebuilt, now = 16L), "the same verdict must not re-toast next frame")
+        assertNull(toaster.toastFor(rebuilt, now = 7_999L))
+    }
+
+    @Test
+    fun `the same verdict hours later is not swallowed`() {
+        // Regression two, half one: the gate was a process-lifetime "last message",
+        // so a Rebuilt at 09:00 silenced an unrelated Rebuilt at 14:00 — a silently
+        // recovered window, which is the failure this path exists to announce.
+        val toaster = RenderRecoveryToaster(durationMs = 8_000L)
+        assertNotNull(toaster.toastFor(rebuilt, now = 0L))
+
+        val hoursLater = 5 * 60 * 60 * 1000L
+        assertNotNull(
+            toaster.toastFor(rebuilt, now = hoursLater),
+            "an unrelated recurrence hours later must still be announced",
+        )
+    }
+
+    @Test
+    fun `a storm of alternating verdicts is bounded`() {
+        // Regression two, half two: suppressing only *identical consecutive*
+        // messages bounded nothing, because a narrowing cycle emits a different
+        // verdict on almost every frame. At 16ms that is ~60 toasts a second, each
+        // one cancelling the previous job on the main dispatcher.
+        val toaster = RenderRecoveryToaster(durationMs = 8_000L)
+        val cycle =
+            listOf(
+                rebuilt,
+                PluginRenderRecovery.Outcome.Quarantined(setOf("plugin.a")),
+                PluginRenderRecovery.Outcome.Quarantined(setOf("plugin.b")),
+                PluginRenderRecovery.Outcome.Quarantined(setOf("plugin.c")),
+                PluginRenderRecovery.Outcome.Unexplained,
+            )
+
+        var shown = 0
+        var now = 0L
+        // Five seconds of faults every 16ms — ~312 frames, all inside one toast window.
+        repeat(312) { frame ->
+            if (toaster.toastFor(cycle[frame % cycle.size], now) != null) shown++
+            now += 16
+        }
+
+        assertEquals(
+            cycle.size,
+            shown,
+            "each distinct verdict should speak once per window, not once per frame",
+        )
+    }
+
+    @Test
+    fun `the quarantine message names the plugin and how to recover it`() {
+        // This is the wording the generic "Plugin X crashed" toast was overwriting.
+        val message = RenderRecoveryToaster.messageFor(quarantined)
+
+        assertTrue(message.contains("plugin.a"), "the user cannot act without knowing which plugin")
+        assertTrue(message.contains("Restart"), "and not without being told how to bring it back")
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -430,23 +430,20 @@ fun PluginErrorBoundary(
                         // latched — so if anything below threw, `error` would never
                         // be set and the panel would stay blank forever with nothing
                         // further logged. That is the exact failure this line exists
-                        // to prevent, so it cannot run last.
-                        error = e
-                        sandbox.recordError(e)
-                        // The same recovery a composition crash gets: close the tab,
-                        // notify, flip the observable crash state.
-                        PluginCrashRegistry.recordCrash(pluginId, e)
-                        // Set locally as well, and not redundantly. recordCrash has
-                        // two branches: with a tab registered it closes the tab and
-                        // *removes* the registry entry again, so registryCrash reads
-                        // back null and this boundary would never render its
-                        // fallback. If closeAction then fails, the panel is left
-                        // blank with nothing shown and nothing logged — the boundary
-                        // reports only once. Local state guarantees the user sees an
-                        // error rather than an empty panel. Safe to write here
+                        // to prevent, so it cannot run last. Safe to write here
                         // because PluginRenderBoundary hands this callback to the
                         // EDT rather than calling it mid-render.
                         error = e
+                        sandbox.recordError(e)
+                        // recordRenderFault, not recordCrash. recordCrash closes the
+                        // plugin's registered tab, and activeTabMappings is keyed by
+                        // plugin id alone — so a render fault in a plugin's *side
+                        // panel* would close that plugin's unrelated main tab and
+                        // whatever was live in it. The `error = e` above already
+                        // swaps this panel to its fallback and stops the content
+                        // rendering, which is what ends the fault; destroying a
+                        // session on top of that buys nothing.
+                        PluginCrashRegistry.recordRenderFault(pluginId, e)
                     },
                 ) {
                     content()

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -179,10 +179,19 @@ object PluginCrashRegistry {
      * This flips the observable crash state only, so the panel swaps to its error
      * fallback and stops rendering plugin content, which is what actually stops
      * the exception recurring, while the tab and its contents stay put.
+     *
+     * @param notify whether to fire [onCrashNotify]. Pass false when the caller
+     *   shows its own message. [PluginRenderRecovery] does: its quarantine toast
+     *   names the plugin *and* says how to bring it back, and because this hop
+     *   goes through `invokeLater` while recovery messages on the EDT directly,
+     *   the generic "Plugin X crashed" landed second and overwrote it —
+     *   StatusMessageManager holds one message. The tailored wording was lost
+     *   exactly when it mattered.
      */
     fun recordRenderFault(
         pluginId: String,
         error: Throwable,
+        notify: Boolean = true,
     ) {
         _crashedPluginsMap[pluginId] =
             CrashInfo(
@@ -191,7 +200,7 @@ object PluginCrashRegistry {
             )
         javax.swing.SwingUtilities.invokeLater {
             _crashedPluginsState.value = _crashedPluginsMap.toMap()
-            onCrashNotify?.invoke(pluginId, error)
+            if (notify) onCrashNotify?.invoke(pluginId, error)
         }
     }
 

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -439,10 +439,22 @@ fun PluginErrorBoundary(
                         // plugin's registered tab, and activeTabMappings is keyed by
                         // plugin id alone — so a render fault in a plugin's *side
                         // panel* would close that plugin's unrelated main tab and
-                        // whatever was live in it. The `error = e` above already
-                        // swaps this panel to its fallback and stops the content
-                        // rendering, which is what ends the fault; destroying a
-                        // session on top of that buys nothing.
+                        // whatever was live in it.
+                        //
+                        // The registry write is still needed and is not merely a
+                        // duplicate of `error = e` above: if the parent tears this
+                        // boundary down, the remembered local state goes with it and
+                        // only the registry survives to show the fallback on the
+                        // rebuild.
+                        //
+                        // Be clear about the blast radius, because it is wider than
+                        // this panel: registryCrash is keyed by plugin id, so every
+                        // surface of this plugin flips to the fallback, and unlike
+                        // recordCrash — which removed its own entry after closing the
+                        // tab — nothing clears this until the user hits Restart or
+                        // Dismiss. A transient fault in one surface therefore degrades
+                        // all of that plugin's surfaces for the session. That is the
+                        // deliberate trade against destroying a live tab.
                         PluginCrashRegistry.recordRenderFault(pluginId, e)
                     },
                 ) {

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -272,11 +272,18 @@ object PluginRenderRecovery {
      * Tests use it for the same reason.
      */
     fun reset() {
+        // Through releaseSuspect, not `suspect = null`: setting the field alone
+        // left whoever was held still recorded in PluginCrashRegistry, so a
+        // "clean slate" kept rendering their error fallback. Both test classes
+        // were papering over that with manual clearCrash calls in teardown,
+        // which was the tell.
+        releaseSuspect()
         lastRebuildAt = 0L
         synchronized(mountCounts) { mountCounts.clear() }
         cleared.clear()
-        suspect = null
-        _generation.value = 0
+        // Deliberately not resetting the generation. It only ever needs to
+        // *change* to force a rebuild, and winding it back while panels are still
+        // keyed on it would collide with a value they have already seen.
     }
 
     /** What [onUnattributedRenderException] decided. */

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -75,11 +75,24 @@ object PluginRenderRecovery {
     const val REBUILD_GRACE_MILLIS = 4_000L
 
     /**
-     * Plugins whose panels are currently rendering content, most recently mounted
-     * last. Insertion-ordered because the panel a user just opened or interacted
-     * with is the better first suspect, and a wrong guess only costs one cycle.
+     * How many live boundaries each plugin currently has, and in what order they
+     * first appeared.
+     *
+     * Reference-counted, not a set. PluginErrorBoundary is instantiated per
+     * surface — per tab and per side panel, across windows — so one plugin
+     * routinely has several live boundaries at once. With a plain set, closing one
+     * of two terminal tabs removed the terminal plugin from the mounted list while
+     * it was still rendering, after which it could never be suspected: the real
+     * culprit would be ruled out by omission and the incident would end
+     * Unexplained, leaving a permanently broken window — the exact outcome this
+     * class exists to prevent.
+     *
+     * A LinkedHashMap for recency: iteration order is first-appearance order, and
+     * a re-mount after the count drops to zero moves the plugin to the end, which
+     * plain `LinkedHashSet.add` would not have done for an element already
+     * present. Guarded by its own monitor since it is both mutated and iterated.
      */
-    private val mounted = java.util.Collections.synchronizedSet(LinkedHashSet<String>())
+    private val mountCounts = LinkedHashMap<String, Int>()
 
     /** The single plugin currently held responsible, if any. */
     @Volatile
@@ -102,18 +115,31 @@ object PluginRenderRecovery {
      * function that clears it when the panel goes away.
      */
     fun registerMounted(pluginId: String): () -> Unit {
-        mounted.add(pluginId)
-        return { mounted.remove(pluginId) }
+        synchronized(mountCounts) {
+            mountCounts[pluginId] = (mountCounts[pluginId] ?: 0) + 1
+        }
+        // One unregister per register; the plugin stays mounted while any other
+        // boundary still holds a count.
+        var released = false
+        return {
+            synchronized(mountCounts) {
+                if (!released) {
+                    released = true
+                    val remaining = (mountCounts[pluginId] ?: 1) - 1
+                    if (remaining <= 0) mountCounts.remove(pluginId) else mountCounts[pluginId] = remaining
+                }
+            }
+        }
     }
 
     /** Candidates, most recently mounted first, skipping any already ruled out. */
     private fun nextSuspect(): String? =
-        synchronized(mounted) { mounted.toList() }
+        mountedPlugins()
             .asReversed()
             .firstOrNull { it !in cleared && it != suspect }
 
-    /** Plugins currently rendering content. Exposed for logging and tests. */
-    fun mountedPlugins(): Set<String> = mounted.toSet()
+    /** Plugins currently rendering content, first-appearance order. */
+    fun mountedPlugins(): List<String> = synchronized(mountCounts) { mountCounts.keys.toList() }
 
     /**
      * Handle a render exception nobody could attribute.
@@ -124,9 +150,9 @@ object PluginRenderRecovery {
      */
     fun onUnattributedRenderException(
         error: Throwable,
-        now: Long = System.currentTimeMillis(),
+        now: Long = System.nanoTime() / 1_000_000,
     ): Outcome {
-        val affected = mounted.toSet()
+        val affected = mountedPlugins().toSet()
         val recentlyRebuilt = lastRebuildAt != 0L && now - lastRebuildAt <= REBUILD_GRACE_MILLIS
         return when {
             affected.isEmpty() -> {
@@ -237,9 +263,9 @@ object PluginRenderRecovery {
     }
 
     /** Forget the retry window. For tests, and for a clean slate after recovery. */
-    fun resetForTest() {
+    internal fun resetForTest() {
         lastRebuildAt = 0L
-        mounted.clear()
+        synchronized(mountCounts) { mountCounts.clear() }
         cleared.clear()
         suspect = null
         _generation.value = 0

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -87,10 +87,11 @@ object PluginRenderRecovery {
      * Unexplained, leaving a permanently broken window — the exact outcome this
      * class exists to prevent.
      *
-     * A LinkedHashMap for recency: iteration order is first-appearance order, and
-     * a re-mount after the count drops to zero moves the plugin to the end, which
-     * plain `LinkedHashSet.add` would not have done for an element already
-     * present. Guarded by its own monitor since it is both mutated and iterated.
+     * A LinkedHashMap for recency: every mount moves the plugin to the end — see
+     * [registerMounted], which removes and re-puts rather than incrementing in
+     * place, because neither `LinkedHashMap.put` nor `LinkedHashSet.add` reorders
+     * a key that is already present. Guarded by its own monitor since it is both
+     * mutated and iterated.
      */
     private val mountCounts = LinkedHashMap<String, Int>()
 
@@ -210,6 +211,25 @@ object PluginRenderRecovery {
         return Outcome.Rebuilt(affected)
     }
 
+    /**
+     * Rule out the plugin we were holding, because the fault outlived it.
+     *
+     * **Known limitation: there is no settle window.** A suspect is judged on the
+     * very next fault, and quarantine only takes effect once the panel recomposes
+     * and stops rendering plugin content. A fault thrown from a measure pass that
+     * was already in flight would therefore convict-then-release the *actual*
+     * culprit, after which narrowing exhausts the remaining plugins and ends
+     * [Outcome.Unexplained] — the broken-window outcome this class exists to
+     * avoid.
+     *
+     * Left as-is deliberately. The generation bump that accompanies a quarantine
+     * discards the offending subtree synchronously, so in the live repro the next
+     * fault was always a genuinely new one, and the cycle converged on the right
+     * plugin. Adding a delay here is not free either: faults inside the settle
+     * window would still reach the host's `RenderCrashPolicy` as unproductive and could
+     * escalate *sooner*. That interaction needs testing on its own rather than a
+     * timing constant tacked onto this change.
+     */
     private fun releaseSuspectAsInnocent() {
         suspect?.let { wronglyHeld ->
             logger.info(

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -139,11 +139,21 @@ object PluginRenderRecovery {
         }
     }
 
-    /** Candidates, most recently mounted first, skipping any already ruled out. */
+    /**
+     * Candidates, most recently mounted first, skipping any already ruled out.
+     *
+     * A plugin that already has a crash recorded is skipped too. It is showing its
+     * error fallback rather than plugin content, so it cannot be producing the
+     * fault — and quarantining it would be actively harmful: [releaseSuspect]
+     * clears the registry entry on release, so ruling out an already-broken plugin
+     * would wipe its *genuine* crash state and put a known-broken plugin back on
+     * screen. Mount registration lives in the branch that renders content, so this
+     * only ever catches the window before that recomposition lands.
+     */
     private fun nextSuspect(): String? =
         mountedPlugins()
             .asReversed()
-            .firstOrNull { it !in cleared && it != suspect }
+            .firstOrNull { it !in cleared && it != suspect && !PluginCrashRegistry.hasCrashed(it) }
 
     /** Plugins currently rendering content, first-appearance order. */
     fun mountedPlugins(): List<String> = synchronized(mountCounts) { mountCounts.keys.toList() }
@@ -274,7 +284,12 @@ object PluginRenderRecovery {
         suspect = next
         // recordRenderFault, not recordCrash: this is a guess, and a guess must
         // never close somebody's terminal tab.
-        PluginCrashRegistry.recordRenderFault(next, error)
+        //
+        // notify = false because the caller toasts this itself, with wording that
+        // names the plugin and says how to restart it. The registry's generic
+        // "Plugin X crashed" goes through invokeLater and so landed *after* the
+        // tailored message, overwriting it in a single-slot status bar.
+        PluginCrashRegistry.recordRenderFault(next, error, notify = false)
         lastRebuildAt = now
         _generation.value += 1
         return Outcome.Quarantined(setOf(next))

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -262,8 +262,16 @@ object PluginRenderRecovery {
         }
     }
 
-    /** Forget the retry window. For tests, and for a clean slate after recovery. */
-    internal fun resetForTest() {
+    /**
+     * Forget every incident: mounted counts, the current suspect, the ruled-out
+     * set and the retry window.
+     *
+     * Public and not named for tests, because it is a real operation — a caller
+     * that has torn down and rebuilt the plugin surfaces wants recovery to start
+     * from a clean slate rather than inherit a half-finished narrowing cycle.
+     * Tests use it for the same reason.
+     */
+    fun reset() {
         lastRebuildAt = 0L
         synchronized(mountCounts) { mountCounts.clear() }
         cleared.clear()

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecovery.kt
@@ -116,7 +116,13 @@ object PluginRenderRecovery {
      */
     fun registerMounted(pluginId: String): () -> Unit {
         synchronized(mountCounts) {
-            mountCounts[pluginId] = (mountCounts[pluginId] ?: 0) + 1
+            // Removed and re-put, not incremented in place. LinkedHashMap is
+            // insertion-ordered and does NOT reorder a key that is already
+            // present, so a plain increment left "most recently mounted last"
+            // false for exactly the case ref-counting was added for — opening a
+            // second terminal tab would not make terminal the freshest suspect.
+            val next = (mountCounts.remove(pluginId) ?: 0) + 1
+            mountCounts[pluginId] = next
         }
         // One unregister per register; the plugin stays mounted while any other
         // boundary still holds a count.

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -30,11 +31,11 @@ class PluginRenderRecoveryTest {
     private val error = IllegalArgumentException("""Key "coll-dup" was already used.""")
 
     @BeforeTest
-    fun setUp() = PluginRenderRecovery.resetForTest()
+    fun setUp() = PluginRenderRecovery.reset()
 
     @AfterTest
     fun tearDown() {
-        PluginRenderRecovery.resetForTest()
+        PluginRenderRecovery.reset()
         PluginCrashRegistry.clearCrash("plugin.a")
         PluginCrashRegistry.clearCrash("plugin.b")
     }
@@ -197,7 +198,7 @@ class PluginRenderRecoveryTest {
         closeFirst()
         closeSecond()
 
-        assertTrue(!PluginRenderRecovery.mountedPlugins().contains("plugin.a"))
+        assertFalse(PluginRenderRecovery.mountedPlugins().contains("plugin.a"))
     }
 
     @Test

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
@@ -241,6 +241,54 @@ class PluginRenderRecoveryTest {
     }
 
     @Test
+    fun `quarantine does not fire the generic crash notification`() {
+        // The registry's "Plugin X crashed" goes out through invokeLater, while the
+        // caller's tailored "Paused X — restart it from the panel menu" is posted
+        // straight from the EDT. StatusMessageManager holds one message, so the
+        // generic one landed second and overwrote the useful one. Suppressing it
+        // here is what lets the tailored wording survive.
+        val notified = mutableListOf<String>()
+        val previous = PluginCrashRegistry.onCrashNotify
+        PluginCrashRegistry.onCrashNotify = { pluginId, _ -> notified += pluginId }
+        try {
+            PluginRenderRecovery.registerMounted("plugin.a")
+            PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+            val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
+            assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+            javax.swing.SwingUtilities.invokeAndWait { }
+
+            assertTrue(
+                notified.isEmpty(),
+                "quarantine must leave the messaging to its caller, saw $notified",
+            )
+        } finally {
+            PluginCrashRegistry.onCrashNotify = previous
+        }
+    }
+
+    @Test
+    fun `a plugin already showing its own crash is never suspected`() {
+        // Releasing a suspect clears its registry entry, so quarantining a plugin
+        // that was already broken would wipe its genuine crash state and put a
+        // known-broken plugin back on screen. It also cannot be the culprit: it is
+        // rendering its fallback, not plugin content.
+        PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.registerMounted("plugin.b")
+        PluginCrashRegistry.recordRenderFault("plugin.b", RuntimeException("its own bug"), notify = false)
+        javax.swing.SwingUtilities.invokeAndWait { }
+
+        PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+        val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
+
+        assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+        assertEquals(
+            setOf("plugin.a"),
+            outcome.plugins,
+            "the already-crashed plugin must be skipped as a suspect",
+        )
+    }
+
+    @Test
     fun `once an incident is resolved the next fault starts a fresh cycle`() {
         // Guards against a restarted plugin being instantly re-suspected: the
         // bookkeeping from a finished incident must not carry into the next one.

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
@@ -228,6 +228,11 @@ class PluginRenderRecoveryTest {
             val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
 
             assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+            // Drain the EDT first. recordCrash's destructive branch closes the tab
+            // from inside invokeLater, so without this the assertion below wins a
+            // race instead of checking a behaviour — it would pass against the old
+            // recordCrash too. Verified: with recordCrash restored, this goes red.
+            javax.swing.SwingUtilities.invokeAndWait { }
             assertTrue(PluginCrashRegistry.hasCrashed("plugin.a"), "the fallback must still be shown")
             assertTrue(!tabClosed, "quarantining a suspect must not close its tab")
         } finally {

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginRenderRecoveryTest.kt
@@ -10,6 +10,11 @@ import kotlin.test.assertTrue
 /**
  * Covers recovery from a render exception nobody could attribute from the stack.
  *
+ * Note this mutates process-global state in [PluginRenderRecovery] and
+ * [PluginCrashRegistry], and relies on the resets below. That holds only while
+ * this module runs tests in one fork; a future `maxParallelForks > 1` would turn
+ * it into a mystery flake.
+ *
  * This is the half [PluginRenderBoundary] cannot reach. A real crash arrived via
  * `MeasureAndLayoutDelegate.remeasureIfNeeded` — Compose re-measuring the
  * plugin's node straight from its dirty list, with neither the boundary nor the
@@ -157,13 +162,76 @@ class PluginRenderRecoveryTest {
         PluginRenderRecovery.registerMounted("plugin.b")
         unregister()
 
-        assertEquals(setOf("plugin.b"), PluginRenderRecovery.mountedPlugins())
+        assertEquals(listOf("plugin.b"), PluginRenderRecovery.mountedPlugins())
 
         PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
         val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
 
         assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
         assertEquals(setOf("plugin.b"), outcome.plugins, "a closed panel must not be quarantined")
+    }
+
+    @Test
+    fun `a plugin with two live boundaries stays mounted when one closes`() {
+        // PluginErrorBoundary is per surface — a tab and a side panel, or two
+        // tabs — so one plugin routinely has several. With a plain set, closing
+        // one dropped the plugin while it was still rendering, after which it
+        // could never be suspected: the culprit was ruled out by omission and the
+        // window stayed broken.
+        val closeFirst = PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.registerMounted("plugin.a")
+
+        closeFirst()
+
+        assertTrue(
+            PluginRenderRecovery.mountedPlugins().contains("plugin.a"),
+            "a plugin still rendering in another surface must remain a candidate",
+        )
+    }
+
+    @Test
+    fun `a plugin is unmounted once its last boundary closes`() {
+        val closeFirst = PluginRenderRecovery.registerMounted("plugin.a")
+        val closeSecond = PluginRenderRecovery.registerMounted("plugin.a")
+
+        closeFirst()
+        closeSecond()
+
+        assertTrue(!PluginRenderRecovery.mountedPlugins().contains("plugin.a"))
+    }
+
+    @Test
+    fun `unregistering twice does not drop a plugin another surface still holds`() {
+        val close = PluginRenderRecovery.registerMounted("plugin.a")
+        PluginRenderRecovery.registerMounted("plugin.a")
+
+        close()
+        close() // a double dispose must not decrement someone else's count
+
+        assertTrue(
+            PluginRenderRecovery.mountedPlugins().contains("plugin.a"),
+            "one unregister must release exactly one count",
+        )
+    }
+
+    @Test
+    fun `quarantine does not close the plugin's tab`() {
+        // The whole reason recordRenderFault exists: quarantine is a positional
+        // guess, and a guess must never destroy a live session. Mass quarantine
+        // through recordCrash closed the user's terminal and browser tabs.
+        var tabClosed = false
+        PluginCrashRegistry.registerActiveTab("plugin.a", "tab-1") { tabClosed = true }
+        try {
+            PluginRenderRecovery.registerMounted("plugin.a")
+            PluginRenderRecovery.onUnattributedRenderException(error, now = 1_000)
+            val outcome = PluginRenderRecovery.onUnattributedRenderException(error, now = 2_000)
+
+            assertIs<PluginRenderRecovery.Outcome.Quarantined>(outcome)
+            assertTrue(PluginCrashRegistry.hasCrashed("plugin.a"), "the fallback must still be shown")
+            assertTrue(!tabClosed, "quarantining a suspect must not close its tab")
+        } finally {
+            PluginCrashRegistry.unregisterActiveTab("plugin.a", "tab-1")
+        }
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #88. A review landed after that merged and found three real defects in the shipped code, plus two smaller ones. All are fixed here.

## 1. `recordContained` reported nothing, and could corrupt a crash submission

It wrote to `_pendingCrashReport` — which **has no consumers anywhere in the repo**. `handleCrash` passes its report *directly* into `showCrashDialogWindow`; nothing observes, persists or uploads the flow. So the telemetry the function existed to preserve was still being lost.

Worse, that slot belongs to the interactive dialog and holds one value. A fatal crash on a background thread opens the dialog while the EDT keeps running — so a contained render fault arriving while the user typed notes would **replace the report, and Submit would send the wrong crash**, losing the fatal one.

Contained reports now go to `~/.boss/crash-reports/` as plain text, and the dialog's slot is left alone.

## 2. The containment budget raced the narrowing loop and lost

3 failures / 10s, but the unattributed path is precisely where the same dirty node throws every frame — faults ~16ms apart, all inside one window. Narrowing costs one fault to rebuild plus one per suspect:

```
fault 1 → rebuild
fault 2 → quarantine suspect #1
fault 3 → release #1, quarantine #2
fault 4 → ESCALATE → window disposed → app ends
```

With three or more panels mounted the app died **before the culprit was found**, having quarantined two innocents on the way. My live test only converged because the faults were seconds apart (real clicks), not 16ms.

Only faults where recovery achieved *nothing* now count toward escalation: a rebuild or fresh quarantine calls `noteRecoveryProgress()`. Faults recovery can't help with still escalate.

## 3. Mount tracking wasn't reference-counted

`PluginErrorBoundary` is instantiated **per surface** — per tab and per side panel, across windows — so one plugin routinely has several live boundaries. `mounted` was a `Set<String>` with an unconditional remove, so closing one of two terminal tabs dropped the terminal plugin while it was still rendering. It could then never be suspected: the real culprit ruled out by omission, incident ends `Unexplained`, window stays permanently broken — exactly what this class exists to prevent.

Now a `LinkedHashMap<String, Int>` of counts. That also fixes recency (`LinkedHashSet.add` does not reorder an element already present, so "most recently mounted" stopped holding after a re-mount) and puts iteration under one monitor.

## 4. Duplicate `error = e`

I added the first and left the second in place, with a comment arguing for a write fifteen lines above it.

## 5. The panel path still closed tabs

`onRenderCrash` used `recordCrash`, which closes the plugin's registered tab — and `activeTabMappings` is keyed by plugin id alone, so a render fault in a plugin's **side panel** would close that plugin's unrelated **main tab** and whatever was live in it. That is the same destruction #88 argued against everywhere else. Now `recordRenderFault`; the local `error = e` already stops the content rendering, which is what ends the fault.

## Also

Monotonic clock in `PluginRenderRecovery` (it still used wall clock while `RenderCrashPolicy` had moved), and the contain branch moved out of the anonymous `WindowExceptionHandler`, which had grown past detekt's length limit.

## Verification

**1432 tests across `plugin-sandbox` and `composeApp`**, ktlint and detekt clean.

New coverage for each defect: two boundaries on one plugin; a double dispose not releasing another surface's count; **quarantine not closing a tab** — its entire purpose, previously unasserted; and both directions of the policy/recovery seam, including ten consecutive faults 16ms apart that must not escalate while recovery progresses.

Also added a note that `PluginRenderRecoveryTest` mutates process-global state and depends on this module running tests in a single fork — a future `maxParallelForks > 1` would otherwise produce a mystery flake.

## Second round

A review of this PR found five more, all fixed here.

**The toast regressed.** I gated it on `madeProgress`, so `Unexplained` and `NotPluginRelated` — the outcomes where the user most needs to know something is wrong — said nothing at all. Gated on message identity instead.

**`recordContained` built the full report on the EDT.** Sanitizing the whole stack, walking the cause chain asking plugin classloaders about every frame, and reading two JMX beans — once per fault, on the AWT event thread, during exactly the repaint storm this path exists to survive. The signature is the cheap part and the only thing the dedupe needs, so it is computed first and the report moved to the writer thread. A failed write now releases its signature so the next occurrence can retry rather than being suppressed for the session.

**Report files were world-readable.** `writeText` leaves the file at the umask, typically 0644, and owner-only on the *directory* is not enough — 0711 still lets others traverse to a known path. POSIX permissions on both now, with the File-flag fallback including the execute bit.

**Nothing ever trimmed `crash-reports/`.** The session dedupe bounded one run; across runs the directory grew forever. Sweeps to the newest 20 after each write. The dedupe map is capped too.

**Recency was wrong again.** `LinkedHashMap` does not reorder an existing key any more than `LinkedHashSet` did, so `registerMounted` now removes and re-puts. The "most recently mounted" suspect had actually been the earliest-mounted one.

### Two of the new tests were worthless until they were fixed

`CrashHandler`'s contained path had no coverage, which matters because its whole point is that the previous implementation *looked* like it reported something and did not. Five tests now cover write, dedupe, ignorable faults, permissions and retention — against a temp directory, not the real data root, since the sweep deletes files and a test pointed at `~/.boss/crash-reports` would destroy the user's actual reports.

Two of them passed against broken code before I checked:

- `quarantine does not close the plugin's tab` passed whether or not the tab was closed, until it drained the EDT.
- the retention test passed with the sweep commented out, because `CrashSignature` deliberately ignores the message and hashes stack frames — so thirty "distinct" faults built at a single line share one signature and produce one file. Fixed by stamping a synthetic frame.

Both were then verified to fail against the broken code and pass against the fix. That is the fourth and fifth time in this pair of PRs that a green test was asserting nothing.

## Not addressed

- An innocent suspect is released only by the *next* fault, so a bystander quarantined just before a transient fault clears stays in its fallback until restarted. The toast tells the user to restart it; a timed auto-release would be kinder.
- **No settle window on quarantine.** A suspect is judged on the very next fault, but quarantine only takes effect once the panel recomposes. A fault from a measure pass already in flight would convict and then release the *actual* culprit, after which narrowing exhausts everyone else and ends `Unexplained`. Documented in `releaseSuspectAsInnocent` rather than fixed: the generation bump discards the offending subtree synchronously so the live repro converged every time, and a delay would let faults inside the window reach `RenderCrashPolicy` as unproductive and escalate *sooner* — that interaction wants its own testing, not a constant tacked onto this PR.
- `PluginHandled` still swallows when `tryHandle` returns false (pre-existing).
- A `Rebuilt` bumps a global generation, keying every plugin panel in every window and discarding remembered state; the toast undersells that.

