### PR TITLE
feat(rbac): least-privilege boss_plugin_admin + enforce plugins.create on publish

### DIFF
--- a/.github/workflows/edge-functions.yml
+++ b/.github/workflows/edge-functions.yml
@@ -58,3 +58,36 @@ jobs:
         # the checks UI instead of disappearing into a green step.
         continue-on-error: true
         run: deno lint
+
+  plugin-store:
+    name: 🧩 Plugin Store function — check & test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: supabase/functions/plugin-store
+    # The passkey job's working-directory means `find . -name '*.ts'` and
+    # `deno test` never leave supabase/functions/passkey, so nothing was running
+    # this function's suite. That matters most for tests/auth-permissions.test.ts:
+    # its wiring guards exist because deleting `requiredPermission` from one of
+    # the five publish handlers leaves every behavioural test green AND
+    # type-checking, so a guard that only runs on a laptop guards nothing.
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: 🔎 Type check
+        run: find . -name '*.ts' -print0 | sort -z | xargs -0 -r deno check
+
+      - name: 🧪 Tests
+        # --allow-read: the wiring guards read routes/*.ts to assert every publish
+        # handler still passes requiredPermission and renders auth.status.
+        run: deno test --allow-all
+
+      - name: 🧹 Lint (advisory)
+        continue-on-error: true
+        run: deno lint

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/PluginStoreApiKeyProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/PluginStoreApiKeyProviderImpl.kt
@@ -11,6 +11,9 @@ import ai.rever.boss.utils.logging.LogCategory
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
+/** Permission required to create, list or revoke Plugin Store API keys. */
+private const val API_KEY_CREATE_PERMISSION = "api_key.create"
+
 /**
  * Implementation of PluginStoreApiKeyProvider that uses PluginStoreClient.
  *
@@ -126,21 +129,24 @@ class PluginStoreApiKeyProviderImpl : PluginStoreApiKeyProvider {
     }
 
     override suspend fun canManageApiKeys(): Boolean {
-        // Check if user is admin via PluginStoreConfig
-        // or has plugin_admin role via AuthStateManager
+        // Mirrors the store's gate on POST/GET/DELETE /api-keys, which requires
+        // `api_key.create`. This used to test for a literal `plugin_admin` role
+        // that no migration ever created, so the branch was dead and the check
+        // collapsed to admin-only.
         val isAdmin = PluginStoreConfig.isAdmin
-        val hasPluginAdminRole = AuthStateManager.currentUser.value?.hasRole("plugin_admin") == true
+        val hasApiKeyPermission =
+            AuthStateManager.currentUser.value?.hasPermission(API_KEY_CREATE_PERMISSION) == true
 
         logger.debug(
             LogCategory.AUTH,
             "Checking API key management permission",
             mapOf(
                 "isAdmin" to isAdmin,
-                "hasPluginAdminRole" to hasPluginAdminRole,
+                "hasApiKeyPermission" to hasApiKeyPermission,
             ),
         )
 
-        return isAdmin || hasPluginAdminRole
+        return isAdmin || hasApiKeyPermission
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginAccessGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginAccessGateTest.kt
@@ -98,4 +98,84 @@ class PluginAccessGateTest {
             ),
         )
     }
+
+    // -----------------------------------------------------------------------
+    // Least-privilege plugin authoring (boss_plugin_admin / plugins.create).
+    //
+    // The authoring permission and the store-wide moderation permission are one
+    // word apart, and the gate is where a mix-up would surface as "Tool Creator
+    // is invisible" or, worse, "a plugin author can moderate the store". Both
+    // directions are pinned.
+    // -----------------------------------------------------------------------
+
+    /** Effective permissions a `boss_plugin_admin` carries: its two, plus the inherited `user.*` baseline. */
+    private val bossPluginAdmin =
+        setOf(
+            "plugins.create",
+            "api_key.create",
+            "user.read",
+            "user.write",
+            "user.update",
+            "user.delete",
+        )
+
+    @Test
+    fun `boss_plugin_admin sees Tool Creator`() {
+        // tool-creator's manifest: requiredPermissions = ["plugins.create", "api_key.create"]
+        assertTrue(
+            pluginAccessAllowed(
+                isAdmin = false,
+                userPermissions = bossPluginAdmin,
+                requiresAdmin = false,
+                requiredPermissions = listOf("plugins.create", "api_key.create"),
+            ),
+        )
+    }
+
+    @Test
+    fun `boss_plugin_admin is denied a moderation-gated plugin`() {
+        assertFalse(
+            pluginAccessAllowed(
+                isAdmin = false,
+                userPermissions = bossPluginAdmin,
+                requiresAdmin = false,
+                requiredPermissions = listOf("plugins.admin.publish"),
+            ),
+        )
+    }
+
+    @Test
+    fun `boss_plugin_admin is denied the secret vault and role tooling`() {
+        // The whole point of the role: authoring, and nothing else.
+        for (required in listOf(
+            listOf("secret.read"),
+            listOf("role.read", "role.assign"),
+            listOf("role.read", "role.create"),
+        )) {
+            assertFalse(
+                pluginAccessAllowed(
+                    isAdmin = false,
+                    userPermissions = bossPluginAdmin,
+                    requiresAdmin = false,
+                    requiredPermissions = required,
+                ),
+                "boss_plugin_admin must not reach a plugin requiring $required",
+            )
+        }
+    }
+
+    @Test
+    fun `holding only the moderation permission does not admit Tool Creator`() {
+        // A pre-migration boss_admin claim set: plugins.admin.publish is NOT a
+        // substitute for plugins.create, which is why a stale JWT makes Tool
+        // Creator disappear until the token refreshes.
+        assertFalse(
+            pluginAccessAllowed(
+                isAdmin = false,
+                userPermissions = setOf("plugins.admin.publish", "api_key.create", "user.read"),
+                requiresAdmin = false,
+                requiredPermissions = listOf("plugins.create", "api_key.create"),
+            ),
+        )
+    }
 }

--- a/docs/RBAC_GUIDE.md
+++ b/docs/RBAC_GUIDE.md
@@ -9,12 +9,24 @@ BOSS implements a comprehensive Role-Based Access Control (RBAC) system using Su
 Roles form a hierarchy (a DAG) where **a parent role inherits the effective permissions of its children**. Inheritance, permission-based plugin gating, and grant delegation are all derived from this single tree.
 
 ```
-        admin              ← inherits everything below (full access)
-       /     \
- boss_admin  finance_admin ← each inherits user
-       \     /
-        user               ← baseline (legacy plugins assume this)
+             admin                    ← inherits everything below (full access)
+            /     \
+    boss_admin    finance_admin       ← each inherits user
+       |    \          |
+boss_plugin_admin \    |               ← plugin authoring only
+       |           \   |
+       +------------ user             ← baseline (legacy plugins assume this)
 ```
+
+`boss_admin --> user` is kept alongside `boss_admin --> boss_plugin_admin --> user`;
+the duplicate path is harmless because `get_role_descendants` uses `UNION`.
+
+**`boss_plugin_admin`** is the least-privilege plugin author: `plugins.create` +
+`api_key.create`, plus the inherited `user.*` baseline. It deliberately holds no
+`plugins.admin.*` moderation permission, no role/finance/RPA verb, and no
+`secret.read`. Note it cannot assign any role despite `user` being a strict
+descendant — `assign_role_to_user` requires `role.assign` first, which this role
+does not have. See migration `20260731000000_plugin_create_permission.sql`.
 
 - **Effective permissions** — a user's permissions = the union of permissions on each assigned role plus all of that role's descendants. Computed by `get_role_descendants(role_id)` (recursive, cycle-safe) and `get_effective_permissions(user_id)`. `authorize(permission)` walks this closure, so a permission granted to `user` is automatically held by `boss_admin`, `finance_admin`, and `admin`.
 - **JWT claim** — `custom_access_token_hook` injects the effective set as the `user_permissions` claim (for both magic-link and passkey logins). The client parses it into `RoleClaims.permissions` / `UserInfo.permissions` (UI/visibility only — server still enforces).

--- a/supabase/functions/plugin-store/routes/api-keys.ts
+++ b/supabase/functions/plugin-store/routes/api-keys.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { PluginStoreContext } from "../types/context.ts"
 import { ErrorResponseSchema } from "../types/schemas.ts"
 import { getUserFromToken } from "../utils/auth.ts"
+import { API_KEY_CREATE_PERMISSION, permissionGateError } from "../utils/permissions.ts"
 import {
   generateApiKey,
   hashApiKey,
@@ -121,6 +122,14 @@ const createApiKeyRoute = createRoute({
         },
       },
     },
+    403: {
+      description: "Caller lacks the api_key.create permission",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
     409: {
       description: "A key with this name already exists",
       content: {
@@ -162,6 +171,11 @@ apiKeys.openapi(createApiKeyRoute, async (ctx) => {
         { success: false, error: "JWT authentication required" },
         401
       )
+    }
+
+    const gateError = permissionGateError(user, API_KEY_CREATE_PERMISSION)
+    if (gateError) {
+      return ctx.json({ success: false, error: gateError }, 403)
     }
 
     // Validate scopes
@@ -307,6 +321,10 @@ apiKeys.openapi(listApiKeysRoute, async (ctx) => {
       )
     }
 
+    // Deliberately NOT gated on api_key.create: listing is scoped to the
+    // caller's own keys, and someone whose role was revoked must still be able
+    // to see what is outstanding in order to revoke it.
+
     // Get all non-revoked keys for this user
     const { data, error } = await supabase
       .from("plugin_api_keys")
@@ -414,6 +432,11 @@ apiKeys.openapi(deleteApiKeyRoute, async (ctx) => {
         401
       )
     }
+
+    // Deliberately NOT gated on api_key.create. Revocation is a safety valve:
+    // gating it behind the permission a user has just lost would strand their
+    // keys, and losing a role is exactly when you most want to revoke. Ownership
+    // (checked below) is what protects this route.
 
     // Get the key to verify ownership
     const { data: existingKey, error: fetchError } = await supabase

--- a/supabase/functions/plugin-store/routes/publish.ts
+++ b/supabase/functions/plugin-store/routes/publish.ts
@@ -28,7 +28,11 @@ import {
   isAllowedExternalJarUrl,
   JarTooLargeError,
 } from "../services/github.ts"
-import { registerDefinedPermissions, validateDeclaredPermissions } from "../utils/permissions.ts"
+import {
+  PLUGIN_CREATE_PERMISSION,
+  registerDefinedPermissions,
+  validateDeclaredPermissions,
+} from "../utils/permissions.ts"
 
 const publish = new OpenAPIHono<{ Variables: PluginStoreContext }>()
 
@@ -76,6 +80,14 @@ const publishPluginRoute = createRoute({
         }
       }
     },
+    403: {
+      description: 'Caller lacks the plugins.create permission, or the API key lacks the publish scope',
+      content: {
+        'application/json': {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
     500: {
       description: 'Internal server error',
       content: {
@@ -95,14 +107,16 @@ publish.openapi(publishPluginRoute, async (ctx) => {
     // Verify authentication (JWT or API key with 'publish' scope)
     const authHeader = ctx.req.header('Authorization')
     const apiKeyHeader = ctx.req.header('X-API-Key')
-    const user = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
+    const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['publish'],
+      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
-    
-    if (!user) {
-      return ctx.json({ success: false, error: 'Authentication required' }, 401)
+
+    if (!auth.ok) {
+      return ctx.json({ success: false, error: auth.error }, auth.status)
     }
+    const user = auth.user
 
     // Reject dangling required permissions before creating any rows.
     const permCheck = await validateDeclaredPermissions(supabase, body)
@@ -251,14 +265,16 @@ publish.openapi(publishVersionRoute, async (ctx) => {
     // Verify authentication (JWT or API key with 'version' scope)
     const authHeader = ctx.req.header('Authorization')
     const apiKeyHeader = ctx.req.header('X-API-Key')
-    const user = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
+    const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['version'],
+      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
-    
-    if (!user) {
-      return ctx.json({ success: false, error: 'Authentication required' }, 401)
+
+    if (!auth.ok) {
+      return ctx.json({ success: false, error: auth.error }, auth.status)
     }
+    const user = auth.user
 
     // Get plugin
     const plugin = await getPlugin(supabase, pluginId)
@@ -414,14 +430,16 @@ publish.openapi(finalizeVersionRoute, async (ctx) => {
     // Verify authentication (JWT or API key with 'finalize' scope)
     const authHeader = ctx.req.header('Authorization')
     const apiKeyHeader = ctx.req.header('X-API-Key')
-    const user = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
+    const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['finalize'],
+      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
-    
-    if (!user) {
-      return ctx.json({ success: false, error: 'Authentication required' }, 401)
+
+    if (!auth.ok) {
+      return ctx.json({ success: false, error: auth.error }, auth.status)
     }
+    const user = auth.user
 
     // Get version
     const version = await getVersionById(supabase, body.versionId)
@@ -605,14 +623,16 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
     // Verify authentication (JWT or API key with 'publish' scope)
     const authHeader = ctx.req.header('Authorization')
     const apiKeyHeader = ctx.req.header('X-API-Key')
-    const user = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
+    const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['publish'],
+      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
-    if (!user) {
-      return ctx.json({ success: false, error: 'Authentication required' }, 401)
+    if (!auth.ok) {
+      return ctx.json({ success: false, error: auth.error }, auth.status)
     }
+    const user = auth.user
 
     // Fetch plugin from GitHub
     console.log(`Fetching plugin from GitHub: ${body.githubUrl}`)
@@ -816,14 +836,16 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
     // Verify authentication
     const authHeader = ctx.req.header('Authorization')
     const apiKeyHeader = ctx.req.header('X-API-Key')
-    const user = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
+    const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['publish'],
+      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
-    if (!user) {
-      return ctx.json({ success: false, error: 'Authentication required' }, 401)
+    if (!auth.ok) {
+      return ctx.json({ success: false, error: auth.error }, auth.status)
     }
+    const user = auth.user
 
     // Resolve the GitHub download URL for the JAR
     const parsed = parseGitHubUrl(body.githubUrl)

--- a/supabase/functions/plugin-store/tests/auth-permissions.test.ts
+++ b/supabase/functions/plugin-store/tests/auth-permissions.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Authorization tests for the publish + API-key gates.
+ *
+ * The five publishing handlers and the three api-keys handlers are thin: they
+ * call into the helpers below and render whatever status those return. So the
+ * decisions worth pinning live here rather than behind an HTTP stack.
+ *
+ * What these lock down:
+ *   - `plugins.create` is required to publish, and admins bypass it.
+ *   - An API key is only as good as its OWNER's CURRENT roles, resolved from the
+ *     database (no JWT claim exists), so a revocation bites immediately.
+ *   - A valid key with the wrong scope is a 403, not the 401 it used to report —
+ *     it is an authenticated caller who is not allowed, not an unknown one.
+ *   - The permission probe fails CLOSED: these gate writes, so a DB outage must
+ *     not become an open door. (Contrast validateDeclaredPermissions, which
+ *     fails open on purpose — it only guards manifest hygiene.)
+ *
+ * Run: deno test --allow-all tests/auth-permissions.test.ts
+ */
+import { assert, assertEquals, assertFalse } from "jsr:@std/assert"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { getAuthenticatedUser, userHasPermission } from "../utils/auth.ts"
+import {
+  API_KEY_CREATE_PERMISSION,
+  PLUGIN_CREATE_PERMISSION,
+  permissionGateError,
+} from "../utils/permissions.ts"
+
+const OWNER_ID = "11111111-1111-1111-1111-111111111111"
+const VALID_KEY = "boss_pk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6" // 40 chars
+
+/** Build a structurally valid JWT whose payload carries the RBAC claims. */
+function jwt(claims: Record<string, unknown>): string {
+  const b64 = (o: unknown) =>
+    btoa(JSON.stringify(o)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+  return `${b64({ alg: "HS256", typ: "JWT" })}.${b64(claims)}.sig`
+}
+
+interface StubOptions {
+  /** Row returned by validate_plugin_api_key; omit to make the key invalid. */
+  apiKey?: { scopes: string[] }
+  /** Result of the user_has_permission probe; "error" simulates a DB failure. */
+  probe?: boolean | "error"
+}
+
+/** Records what the code under test asked the database. */
+interface StubCalls {
+  probed: Array<{ userId: string; permission: string }>
+}
+
+function stubSupabase(opts: StubOptions = {}): { client: SupabaseClient; calls: StubCalls } {
+  const calls: StubCalls = { probed: [] }
+
+  const client = {
+    auth: {
+      // getUserFromToken calls this to verify the token; the claims it acts on
+      // are decoded from the token string itself.
+      getUser: (token: string) =>
+        Promise.resolve(
+          token
+            ? { data: { user: { id: OWNER_ID, email: "owner@test" } }, error: null }
+            : { data: { user: null }, error: new Error("bad token") },
+        ),
+    },
+    from: (_table: string) => ({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: { email: "owner@test" }, error: null }),
+        }),
+      }),
+    }),
+    rpc: (fn: string, args: Record<string, unknown>) => {
+      if (fn === "validate_plugin_api_key") {
+        return Promise.resolve(
+          opts.apiKey
+            ? {
+              data: [{
+                user_id: OWNER_ID,
+                api_key_id: "key-1",
+                key_name: "ci",
+                scopes: opts.apiKey.scopes,
+              }],
+              error: null,
+            }
+            : { data: [], error: null },
+        )
+      }
+      if (fn === "user_has_permission") {
+        calls.probed.push({
+          userId: args.p_user_id as string,
+          permission: args.p_permission as string,
+        })
+        if (opts.probe === "error") {
+          return Promise.resolve({ data: null, error: new Error("connection reset") })
+        }
+        return Promise.resolve({ data: opts.probe === true, error: null })
+      }
+      // update_api_key_last_used and friends
+      return Promise.resolve({ data: null, error: null })
+    },
+  } as unknown as SupabaseClient
+
+  return { client, calls }
+}
+
+// ---------------------------------------------------------------------------
+// Session (JWT) auth
+// ---------------------------------------------------------------------------
+
+Deno.test("JWT holding plugins.create may publish", async () => {
+  const { client } = stubSupabase()
+  const token = jwt({ is_admin: false, user_permissions: ["plugins.create", "api_key.create"] })
+
+  const outcome = await getAuthenticatedUser(client, `Bearer ${token}`, undefined, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assert(outcome.ok)
+  assertEquals(outcome.user.userId, OWNER_ID)
+  assertEquals(outcome.user.jwtPermissions, ["plugins.create", "api_key.create"])
+})
+
+Deno.test("JWT without plugins.create is 403, not 401", async () => {
+  const { client } = stubSupabase()
+  // A plain user: this is exactly what every authenticated caller could do
+  // before plugins.create existed.
+  const token = jwt({ is_admin: false, user_permissions: ["user.read"] })
+
+  const outcome = await getAuthenticatedUser(client, `Bearer ${token}`, undefined, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.reason, "insufficient_permission")
+  assertEquals(outcome.status, 403)
+})
+
+Deno.test("plugins.admin.publish does NOT satisfy the publish gate", async () => {
+  const { client } = stubSupabase()
+  // The moderation permission is deliberately not a substitute: its RLS policy
+  // has no author scoping, so reusing it would re-open store-wide updates.
+  const token = jwt({ is_admin: false, user_permissions: ["plugins.admin.publish"] })
+
+  const outcome = await getAuthenticatedUser(client, `Bearer ${token}`, undefined, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.status, 403)
+})
+
+Deno.test("admin bypasses the permission gate", async () => {
+  const { client, calls } = stubSupabase()
+  const token = jwt({ is_admin: true, user_permissions: [] })
+
+  const outcome = await getAuthenticatedUser(client, `Bearer ${token}`, undefined, {
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assert(outcome.ok)
+  assertEquals(calls.probed.length, 0, "admin short-circuits before any DB probe")
+})
+
+Deno.test("no credentials is 401", async () => {
+  const { client } = stubSupabase()
+
+  const outcome = await getAuthenticatedUser(client, undefined, undefined, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.reason, "unauthenticated")
+  assertEquals(outcome.status, 401)
+})
+
+// ---------------------------------------------------------------------------
+// API-key auth — permissions come from the owner's roles, not a claim
+// ---------------------------------------------------------------------------
+
+Deno.test("API key publishes when its owner still holds plugins.create", async () => {
+  const { client, calls } = stubSupabase({ apiKey: { scopes: ["publish"] }, probe: true })
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assert(outcome.ok)
+  assertEquals(outcome.user.jwtPermissions, null, "API-key auth carries no claim")
+  assertEquals(outcome.user.apiKeyName, "ci")
+  assertEquals(calls.probed, [{ userId: OWNER_ID, permission: PLUGIN_CREATE_PERMISSION }])
+})
+
+Deno.test("API key stops working the moment its owner loses plugins.create", async () => {
+  // Same key, same scope — only the owner's roles changed. This is the property
+  // that makes revocation immediate instead of waiting for key expiry.
+  const { client } = stubSupabase({ apiKey: { scopes: ["publish"] }, probe: false })
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.reason, "insufficient_permission")
+  assertEquals(outcome.status, 403)
+})
+
+Deno.test("API key with the wrong scope is 403 (regression: was 401)", async () => {
+  const { client } = stubSupabase({ apiKey: { scopes: ["version"] }, probe: true })
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.reason, "insufficient_scope")
+  assertEquals(outcome.status, 403)
+})
+
+Deno.test("an unknown API key is still 401", async () => {
+  const { client } = stubSupabase({ probe: true }) // no apiKey row -> not found
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.reason, "unauthenticated")
+  assertEquals(outcome.status, 401)
+})
+
+Deno.test("API key is rejected when allowApiKey is not set", async () => {
+  const { client } = stubSupabase({ apiKey: { scopes: ["publish"] }, probe: true })
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.status, 401)
+})
+
+Deno.test("the permission probe fails closed when the database errors", async () => {
+  const { client } = stubSupabase({ apiKey: { scopes: ["publish"] }, probe: "error" })
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: PLUGIN_CREATE_PERMISSION,
+  })
+
+  assertFalse(outcome.ok)
+  assertEquals(outcome.status, 403)
+})
+
+Deno.test("an admin's API key satisfies a permission, but is still not an admin", async () => {
+  // Two invariants that look contradictory and are not. `user_has_permission`
+  // ORs in is_user_admin(), mirroring authorize()'s admin short-circuit — so an
+  // admin-owned key clears a permission gate. But AuthResult.isAdmin stays
+  // false, which is what routes/admin.ts keys off (and it never accepts API
+  // keys anyway). Pinned so neither half drifts.
+  const { client } = stubSupabase({ apiKey: { scopes: ["publish"] }, probe: true })
+
+  const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
+    allowApiKey: true,
+    requiredScopes: ["publish"],
+    requiredPermission: "some.permission.outside.any.closure",
+  })
+
+  assert(outcome.ok, "the DB probe is the authority on permissions")
+  assertFalse(outcome.user.isAdmin, "an API key is never admin, whoever owns it")
+})
+
+Deno.test("userHasPermission reads the claim for JWT callers without a round trip", async () => {
+  const { client, calls } = stubSupabase({ probe: "error" })
+
+  const held = await userHasPermission(
+    client,
+    { userId: OWNER_ID, email: "", isAdmin: false, jwtPermissions: ["plugins.create"] },
+    PLUGIN_CREATE_PERMISSION,
+  )
+
+  assert(held)
+  assertEquals(calls.probed.length, 0)
+})
+
+// ---------------------------------------------------------------------------
+// JWT-only routes (POST/GET/DELETE /api-keys)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * The tests above prove the gate WORKS; these prove it is CONNECTED.
+ *
+ * Deleting `requiredPermission` from one of the five publish handlers leaves the
+ * whole suite green and still type-checks (verified by mutation: 5 gates -> 4,
+ * 15/15 passing) — the handlers are the only place the wiring exists, and there
+ * is no HTTP harness here to exercise them. Reading the source is the cheap
+ * guard; it costs one file read and catches the one edit most likely to reopen
+ * publishing to every authenticated user.
+ *
+ * If these ever become awkward, replace them with real route tests — do not
+ * simply delete them.
+ */
+const routeSource = (name: string) =>
+  Deno.readTextFileSync(new URL(`../routes/${name}`, import.meta.url))
+
+Deno.test("every publish handler passes requiredPermission to getAuthenticatedUser", () => {
+  const src = routeSource("publish.ts")
+
+  const authCalls = src.match(/getAuthenticatedUser\(/g)?.length ?? 0
+  assertEquals(authCalls, 5, "the five publishing handlers: publish, version, finalize, github, github/metadata")
+
+  const gated = src.match(/requiredPermission:\s*PLUGIN_CREATE_PERMISSION/g)?.length ?? 0
+  assertEquals(
+    gated,
+    authCalls,
+    "a getAuthenticatedUser call without requiredPermission is an ungated publish path",
+  )
+
+  // Each handler must also surface the outcome's own status rather than a
+  // hardcoded 401, or a 403 would be reported as "who are you?".
+  const rendered = src.match(/if \(!auth\.ok\) \{\s*\n\s*return ctx\.json\(\{ success: false, error: auth\.error \}, auth\.status\)/g)
+    ?.length ?? 0
+  assertEquals(rendered, authCalls, "every handler renders auth.status, not a literal")
+})
+
+Deno.test("only api-key CREATION is gated on api_key.create", () => {
+  const src = routeSource("api-keys.ts")
+
+  // POST (create), GET (list), DELETE (revoke)
+  const handlers = src.match(/getUserFromToken\(/g)?.length ?? 0
+  assertEquals(handlers, 3)
+
+  const gated = src.match(/permissionGateError\(user, API_KEY_CREATE_PERMISSION\)/g)?.length ?? 0
+  assertEquals(
+    gated,
+    1,
+    "exactly one gate, on creation. More than one means listing or revoking got gated: " +
+      "revocation is a safety valve, and gating it behind the permission a user just lost " +
+      "strands their keys. Fewer than one means any authenticated user can mint a publish key.",
+  )
+
+  // Pin WHICH handler it is: the create handler is the one validating scopes.
+  // Match the call, not the import at the top of the file.
+  const callIdx = src.indexOf("permissionGateError(user,")
+  const scopesIdx = src.indexOf("areValidScopes(body.scopes)")
+  const firstAuthIdx = src.indexOf("getUserFromToken(supabase")
+  assert(callIdx > firstAuthIdx, "the gate must come after an auth check, not before")
+  assert(callIdx < scopesIdx, "the gate must be in the create handler (the one validating scopes)")
+  assertFalse(
+    src.slice(callIdx, scopesIdx).includes("getUserFromToken("),
+    "another handler starts between the gate and scope validation — the gate is in the wrong one",
+  )
+})
+
+Deno.test("permissionGateError gates API-key management on api_key.create", () => {
+  assertEquals(
+    permissionGateError({ isAdmin: false, permissions: ["api_key.create"] }, API_KEY_CREATE_PERMISSION),
+    null,
+  )
+  assertEquals(
+    permissionGateError({ isAdmin: true, permissions: [] }, API_KEY_CREATE_PERMISSION),
+    null,
+    "admins bypass",
+  )
+  assert(
+    permissionGateError({ isAdmin: false, permissions: ["plugins.create"] }, API_KEY_CREATE_PERMISSION)
+      ?.includes("api_key.create"),
+    "denial names the missing permission",
+  )
+})

--- a/supabase/functions/plugin-store/tests/auth-permissions.test.ts
+++ b/supabase/functions/plugin-store/tests/auth-permissions.test.ts
@@ -337,10 +337,11 @@ Deno.test("every publish handler passes requiredPermission to getAuthenticatedUs
   )
 
   // Each handler must also surface the outcome's own status rather than a
-  // hardcoded 401, or a 403 would be reported as "who are you?".
-  const rendered = src.match(/if \(!auth\.ok\) \{\s*\n\s*return ctx\.json\(\{ success: false, error: auth\.error \}, auth\.status\)/g)
-    ?.length ?? 0
-  assertEquals(rendered, authCalls, "every handler renders auth.status, not a literal")
+  // hardcoded 401, or a 403 would be reported as "who are you?". Matched on the
+  // render call alone rather than the whole `if (!auth.ok) { ... }` block, so a
+  // reformat cannot fail this with a message about permissions.
+  const rendered = src.match(/error:\s*auth\.error\s*\},\s*auth\.status\s*\)/g)?.length ?? 0
+  assertEquals(rendered, authCalls, "every handler renders auth.status, not a hardcoded 401")
 })
 
 Deno.test("only api-key CREATION is gated on api_key.create", () => {

--- a/supabase/functions/plugin-store/utils/auth.ts
+++ b/supabase/functions/plugin-store/utils/auth.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { hashApiKey, isValidApiKeyFormat, type ApiKeyScope } from "./api-key.ts"
+import { permissionDeniedMessage } from "./permissions.ts"
 
 /**
  * Authentication result for both JWT and API key auth
@@ -8,6 +9,16 @@ export interface AuthResult {
   userId: string
   email: string
   isAdmin: boolean
+  /**
+   * Effective RBAC permissions from the JWT `user_permissions` claim.
+   *
+   * `null` when authenticated by API key: there is no token to read a claim
+   * from, so the caller's permissions must be resolved from the key OWNER's
+   * current roles in the database. Use `userHasPermission()` rather than
+   * reading this field — an empty array and `null` mean different things
+   * ("holds nothing" vs "not carried inline").
+   */
+  jwtPermissions: string[] | null
   /** Only set when authenticated via API key */
   apiKeyId?: string
   /** Only set when authenticated via API key */
@@ -24,7 +35,29 @@ export interface AuthOptions {
   allowApiKey?: boolean
   /** Required scopes when using API key (optional) */
   requiredScopes?: ApiKeyScope[]
+  /**
+   * RBAC permission the caller must effectively hold (optional).
+   *
+   * For API-key auth this is checked against the key owner's CURRENT roles, so
+   * revoking a role stops that key immediately rather than at key expiry.
+   */
+  requiredPermission?: string
 }
+
+/**
+ * Why authentication/authorization failed.
+ *
+ * `unauthenticated` maps to 401; the other two are authenticated callers who
+ * are not allowed to do this, and map to 403.
+ */
+export type AuthFailureReason =
+  | "unauthenticated"
+  | "insufficient_scope"
+  | "insufficient_permission"
+
+export type AuthOutcome =
+  | { ok: true; user: AuthResult }
+  | { ok: false; reason: AuthFailureReason; status: 401 | 403; error: string }
 
 // Simple JWT payload decoder (no verification - Supabase already verified)
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
@@ -172,6 +205,9 @@ export async function validateApiKey(
       userId: keyInfo.user_id,
       email: userData?.email || "",
       isAdmin: false, // API keys NEVER have admin access
+      // No JWT, so no user_permissions claim — resolved from the owner's roles
+      // on demand by userHasPermission().
+      jwtPermissions: null,
       apiKeyId: keyInfo.api_key_id,
       apiKeyScopes: keyInfo.scopes,
       apiKeyName: keyInfo.key_name,
@@ -183,6 +219,49 @@ export async function validateApiKey(
 }
 
 /**
+ * Does this caller effectively hold `permission`?
+ *
+ * Session auth reads the JWT `user_permissions` claim (no round trip). API-key
+ * auth asks the database about the key's OWNER via the `user_has_permission`
+ * probe, so a role revoked after the key was minted takes effect immediately.
+ *
+ * Fails CLOSED on an unexpected DB error — unlike validateDeclaredPermissions,
+ * this gates writes, so an outage must not become an open door.
+ *
+ * `data === true` is correct and not an oversight: PostgREST returns a bare
+ * value for a scalar-returning function, which routes/api-keys.ts already relies
+ * on for `get_user_api_key_count` (`RETURNS INTEGER`, compared directly against
+ * MAX_API_KEYS_PER_USER). Only SETOF/TABLE functions come back as arrays, as
+ * `validate_plugin_api_key` does above. Do not "harden" this into an unwrap.
+ */
+export async function userHasPermission(
+  supabase: SupabaseClient,
+  user: AuthResult,
+  permission: string,
+): Promise<boolean> {
+  if (user.isAdmin) return true
+
+  if (user.jwtPermissions !== null) {
+    return user.jwtPermissions.includes(permission)
+  }
+
+  try {
+    const { data, error } = await supabase.rpc("user_has_permission", {
+      p_user_id: user.userId,
+      p_permission: permission,
+    })
+    if (error) {
+      console.error(`user_has_permission(${permission}) RPC error:`, error)
+      return false
+    }
+    return data === true
+  } catch (e) {
+    console.error(`user_has_permission(${permission}) threw:`, e)
+    return false
+  }
+}
+
+/**
  * Combined authentication that checks both JWT and API key
  *
  * Priority: JWT (Authorization header) > API Key (X-API-Key header)
@@ -190,31 +269,44 @@ export async function validateApiKey(
  * Use this for endpoints that should accept both auth methods.
  * For admin-only endpoints, always use getUserFromToken() directly.
  *
+ * Returns a discriminated outcome rather than `AuthResult | null` so callers can
+ * tell "who are you?" (401) from "not allowed" (403). A valid key presented with
+ * the wrong scope used to collapse into the same null as no credentials at all
+ * and was reported as 401; it is an authenticated caller and now yields 403.
+ *
  * @param supabase - Supabase client with service role
  * @param authHeader - Authorization header (Bearer token)
  * @param apiKeyHeader - X-API-Key header
- * @param options - Auth options (allowApiKey, requiredScopes)
- * @returns AuthResult if authenticated, null otherwise
+ * @param options - Auth options (allowApiKey, requiredScopes, requiredPermission)
  */
 export async function getAuthenticatedUser(
   supabase: SupabaseClient,
   authHeader: string | undefined,
   apiKeyHeader: string | undefined,
   options: AuthOptions = {}
-): Promise<AuthResult | null> {
-  const { allowApiKey = false, requiredScopes = [] } = options
+): Promise<AuthOutcome> {
+  const { allowApiKey = false, requiredScopes = [], requiredPermission } = options
+
+  const unauthenticated = {
+    ok: false,
+    reason: "unauthenticated",
+    status: 401,
+    error: "Authentication required",
+  } as const
+
+  let user: AuthResult | null = null
 
   // Try JWT first (preferred)
   const jwtUser = await getUserFromToken(supabase, authHeader)
   if (jwtUser) {
-    return {
-      ...jwtUser,
+    user = {
+      userId: jwtUser.userId,
+      email: jwtUser.email,
+      isAdmin: jwtUser.isAdmin,
+      jwtPermissions: jwtUser.permissions,
       // No API key fields for JWT auth
     }
-  }
-
-  // Try API key if allowed
-  if (allowApiKey && apiKeyHeader) {
+  } else if (allowApiKey && apiKeyHeader) {
     const apiKeyUser = await validateApiKey(supabase, apiKeyHeader)
     if (apiKeyUser) {
       // Check required scopes
@@ -226,14 +318,34 @@ export async function getAuthenticatedUser(
           console.error(
             `API key missing required scopes: ${requiredScopes.join(", ")}`
           )
-          return null
+          return {
+            ok: false,
+            reason: "insufficient_scope",
+            status: 403,
+            error: `API key is missing required scope(s): ${requiredScopes.join(", ")}`,
+          }
         }
       }
-      return apiKeyUser
+      user = apiKeyUser
     }
   }
 
-  return null
+  if (!user) return unauthenticated
+
+  if (requiredPermission && !(await userHasPermission(supabase, user, requiredPermission))) {
+    console.error(
+      `User ${user.userId} lacks required permission ${requiredPermission}` +
+        (user.apiKeyId ? ` (via API key ${user.apiKeyName ?? user.apiKeyId})` : "")
+    )
+    return {
+      ok: false,
+      reason: "insufficient_permission",
+      status: 403,
+      error: permissionDeniedMessage(requiredPermission),
+    }
+  }
+
+  return { ok: true, user }
 }
 
 /**

--- a/supabase/functions/plugin-store/utils/permissions.ts
+++ b/supabase/functions/plugin-store/utils/permissions.ts
@@ -2,6 +2,54 @@ import type { SupabaseClient } from "@supabase/supabase-js"
 import type { PluginManifest } from "../types/plugin.ts"
 
 /**
+ * Permission required to create a plugin or publish a version of one you own.
+ *
+ * Deliberately NOT `plugins.admin.publish`: that permission's RLS policy has no
+ * author scoping, so it authorizes updates to ANY plugin, and it stays reserved
+ * for store-wide moderation (verify / delete / enable / disable).
+ *
+ * Held by the `boss_plugin_admin` role and inherited by `boss_admin` and `admin`
+ * (migration 20260731000000_plugin_create_permission.sql).
+ */
+export const PLUGIN_CREATE_PERMISSION = "plugins.create"
+
+/**
+ * Permission required to create, list or revoke Plugin Store API keys.
+ */
+export const API_KEY_CREATE_PERMISSION = "api_key.create"
+
+/**
+ * The one wording for "you are authenticated, but not allowed to do this".
+ *
+ * Shared so the JWT-only gate below and the combined gate in utils/auth.ts
+ * cannot drift — they denied with different sentences for the same condition.
+ * `installGateError` in routes/download.ts is deliberately separate: it names a
+ * *plugin's* requirements, not an action's, and can list several at once.
+ */
+export function permissionDeniedMessage(permission: string): string {
+  return `This action requires the "${permission}" permission. Ask an admin to grant it.`
+}
+
+/**
+ * Permission gate for routes that authenticate by JWT only (so the caller's
+ * effective permissions are already in the `user_permissions` claim and need no
+ * database round trip). Admins bypass.
+ *
+ * Mirrors `installGateError` in routes/download.ts: returns a human-readable
+ * error string to deny with (403), or null if the caller is allowed.
+ *
+ * For routes that also accept API keys, pass `requiredPermission` to
+ * `getAuthenticatedUser` instead — an API-key caller has no claim to read.
+ */
+export function permissionGateError(
+  user: { isAdmin: boolean; permissions: string[] },
+  permission: string,
+): string | null {
+  if (user.isAdmin || user.permissions.includes(permission)) return null
+  return permissionDeniedMessage(permission)
+}
+
+/**
  * Validate a publishing plugin's declared permissions.
  *
  * Rejects a "dangling" requirement: a `requiredPermissions` entry that is neither

--- a/supabase/migrations/20260731000000_plugin_create_permission.sql
+++ b/supabase/migrations/20260731000000_plugin_create_permission.sql
@@ -1,0 +1,169 @@
+-- ============================================================================
+-- BOSS Database Schema: least-privilege plugin authoring (`boss_plugin_admin`)
+-- ============================================================================
+-- File: 20260731000000_plugin_create_permission.sql
+-- Description:
+--   Adds a `plugins.create` permission and a `boss_plugin_admin` role that can
+--   create plugins and publish versions of plugins it owns -- and nothing else.
+--
+--   Until now the only way to hand out plugin publishing was `boss_admin`, which
+--   also carries role.read/create/assign, secret.read and the whole
+--   plugins.admin.* moderation family. `plugins.admin.publish` is deliberately
+--   NOT reused here: its RLS policy
+--   (20260131000000_plugin_store_admin_policies.sql) has no author scoping, so
+--   it authorizes updates to *any* plugin. It stays a moderation permission.
+--
+--   Hierarchy after this migration (parent --> child):
+--       admin --> boss_admin
+--       admin --> finance_admin
+--       boss_admin --> boss_plugin_admin     (new)
+--       boss_plugin_admin --> user           (new)
+--       boss_admin --> user                  (kept; the diamond is harmless
+--                                             because get_role_descendants
+--                                             uses UNION, not UNION ALL)
+--       finance_admin --> user
+--
+--   Effective permissions for boss_plugin_admin:
+--       plugins.create, api_key.create
+--       + user.read / user.write / user.update / user.delete (inherited)
+--
+--   NOTE ON ORDERING: this migration must reach production BEFORE the edge
+--   function starts enforcing `plugins.create`, and before any plugin manifest
+--   declares it -- `validateDeclaredPermissions` in the plugin-store function
+--   rejects a publish naming a permission that is not in the catalog.
+--
+-- All seed data is idempotent (ON CONFLICT DO NOTHING), so this migration is
+-- safe to re-run.
+-- ============================================================================
+
+
+-- ============================================================================
+-- SECTION 1: Permission catalog
+-- ============================================================================
+
+-- `plugins.create` is is_system so delete_permission() refuses to drop it.
+-- `api_key.create` already exists (seeded non-system by
+-- 20260625000000_role_hierarchy_and_granular_rbac.sql); it now gates real
+-- server-side behaviour, so promote it to is_system as well.
+INSERT INTO "public"."permissions" ("name", "description", "is_system")
+VALUES
+    ('plugins.create', 'Create plugins and publish versions of plugins owned by the caller.', true)
+ON CONFLICT ("name") DO NOTHING;
+
+UPDATE "public"."permissions"
+SET "is_system" = true
+WHERE "name" IN ('plugins.create', 'api_key.create');
+
+
+-- ============================================================================
+-- SECTION 2: Role + grants + hierarchy
+-- ============================================================================
+
+INSERT INTO "public"."roles" ("name", "description", "is_system")
+VALUES
+    ('boss_plugin_admin', 'Plugin author: create plugins and publish versions of plugins they own', true)
+ON CONFLICT ("name") DO NOTHING;
+
+UPDATE "public"."roles" SET "is_system" = true WHERE "name" = 'boss_plugin_admin';
+
+-- DIRECT permissions. Deliberately excludes every plugins.admin.* moderation
+-- permission, all role.* / finance.* / rpa.* verbs, and secret.read.
+INSERT INTO "public"."role_permissions" ("role_id", "permission_id")
+SELECT r."id", p."id"
+FROM (VALUES
+    ('boss_plugin_admin', 'plugins.create'),
+    ('boss_plugin_admin', 'api_key.create')
+) AS grant_map("role_name", "perm_name")
+JOIN "public"."roles" r ON r."name" = grant_map."role_name"
+JOIN "public"."permissions" p ON p."name" = grant_map."perm_name"
+ON CONFLICT ("role_id", "permission_id") DO NOTHING;
+
+-- Slot boss_plugin_admin between boss_admin and user, so boss_admin (and
+-- therefore admin) inherits plugins.create, and boss_plugin_admin inherits
+-- the user.* baseline.
+INSERT INTO "public"."role_hierarchy" ("parent_role_id", "child_role_id")
+SELECT parent."id", child."id"
+FROM (VALUES
+    ('boss_admin',        'boss_plugin_admin'),
+    ('boss_plugin_admin', 'user')
+) AS edge("parent_name", "child_name")
+JOIN "public"."roles" parent ON parent."name" = edge."parent_name"
+JOIN "public"."roles" child  ON child."name"  = edge."child_name"
+ON CONFLICT ("parent_role_id", "child_role_id") DO NOTHING;
+
+
+-- ============================================================================
+-- SECTION 3: Backfill existing plugin authors
+-- ============================================================================
+
+-- Before this change the plugin-store publish endpoints required only
+-- authentication -- any signed-in user could create a plugin and mint a
+-- publish-scoped API key. Enforcing `plugins.create` without a backfill would
+-- silently revoke publishing from every existing non-admin author (and break
+-- their CI keys mid-release). Grant the new role to everyone who has already
+-- authored a plugin or holds a live Plugin Store API key.
+--
+-- One-shot and non-destructive: later revocations are NOT re-applied, because
+-- ON CONFLICT DO NOTHING cannot distinguish "never granted" from "granted then
+-- removed" -- but re-running this migration will re-grant a role that was
+-- revoked from a legacy author. Revoke such users after this migration has
+-- been applied to production.
+INSERT INTO "public"."user_roles" ("user_id", "role_id")
+SELECT DISTINCT legacy_author."id", r."id"
+FROM (
+    SELECT "author_id" AS "id" FROM "public"."plugins" WHERE "author_id" IS NOT NULL
+    UNION
+    SELECT "user_id" AS "id" FROM "public"."plugin_api_keys" WHERE "revoked_at" IS NULL
+) AS legacy_author
+JOIN "public"."roles" r ON r."name" = 'boss_plugin_admin'
+JOIN "auth"."users" au ON au."id" = legacy_author."id"
+ON CONFLICT ("user_id", "role_id") DO NOTHING;
+
+
+-- ============================================================================
+-- SECTION 4: Service-role permission probe
+-- ============================================================================
+
+-- The plugin-store edge function authenticates API-key callers without a JWT,
+-- so it cannot read the `user_permissions` claim -- it has to ask the database
+-- whether the key's OWNER still holds a permission. That is what makes a role
+-- revocation stop API-key publishing immediately instead of at key expiry.
+--
+-- get_effective_permissions is deliberately revoked from PUBLIC/anon/
+-- authenticated (it exposes any user's full authz model) and granted only to
+-- supabase_auth_admin, so the service-role client cannot call it. Rather than
+-- widening that, expose a narrow boolean probe: one user, one permission.
+--
+-- The is_user_admin() clause is deliberate. It mirrors authorize()'s admin
+-- short-circuit (20260625000000_role_hierarchy_and_granular_rbac.sql) and the
+-- client's UserInfo.hasPermission, so all three answer the same question the
+-- same way -- including for a permission outside admin's role closure, such as
+-- one a plugin has just introduced.
+--
+-- This does NOT contradict validateApiKey's "API keys NEVER have admin access".
+-- That invariant is about AuthResult.isAdmin, which stays false: admin-only
+-- routes (functions/plugin-store/routes/admin.ts) call getUserFromToken and
+-- never accept an X-API-Key at all. What this clause means is narrower -- an
+-- admin's API key satisfies a *permission* check, which was already true before
+-- this migration, when publishing required no permission whatsoever.
+CREATE OR REPLACE FUNCTION "public"."user_has_permission"("p_user_id" "uuid", "p_permission" "text")
+RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+    SELECT p_user_id IS NOT NULL
+       AND (
+            public.is_user_admin(p_user_id)
+            OR p_permission = ANY(public.get_effective_permissions(p_user_id))
+       );
+$$;
+
+ALTER FUNCTION "public"."user_has_permission"("p_user_id" "uuid", "p_permission" "text") OWNER TO "postgres";
+
+COMMENT ON FUNCTION "public"."user_has_permission"("p_user_id" "uuid", "p_permission" "text") IS
+    'Does this user effectively hold this permission (admins hold everything)? Narrow service-role probe for callers that have no JWT to read user_permissions from, e.g. Plugin Store API keys.';
+
+-- Same exposure rules as get_effective_permissions: no PostgREST surface. Only
+-- the edge functions (service_role) may ask about another user.
+REVOKE EXECUTE ON FUNCTION "public"."user_has_permission"("uuid", "text") FROM PUBLIC, "anon", "authenticated";
+GRANT EXECUTE ON FUNCTION "public"."user_has_permission"("uuid", "text") TO "service_role";

--- a/supabase/tests/plugin_create_permission_test.sql
+++ b/supabase/tests/plugin_create_permission_test.sql
@@ -1,0 +1,174 @@
+-- pgTAP tests for least-privilege plugin authoring (migration 20260731000000).
+-- Run with: supabase test db
+--
+-- Covers: the boss_plugin_admin direct/effective permission sets, what it must
+-- NOT hold, inheritance up to boss_admin/admin, delegated assignment (it can be
+-- assigned, but cannot itself assign), the backfill query, and the
+-- user_has_permission service-role probe.
+--
+-- Fixtures are created inside the test transaction and rolled back. Inserting an
+-- auth.users row fires handle_new_user(), which assigns the 'user' role.
+
+begin;
+select plan(22);
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+insert into auth.users (id, email) values
+    ('11111111-1111-1111-1111-111111111111', 'pluginadmin@pgtap.test'),
+    ('22222222-2222-2222-2222-222222222222', 'bossadmin@pgtap.test'),
+    ('33333333-3333-3333-3333-333333333333', 'sysadmin@pgtap.test'),
+    ('44444444-4444-4444-4444-444444444444', 'plain@pgtap.test'),
+    ('55555555-5555-5555-5555-555555555555', 'legacyauthor@pgtap.test');
+
+insert into public.user_roles (user_id, role_id)
+select u.id, r.id from auth.users u join public.roles r on
+    (u.email = 'pluginadmin@pgtap.test' and r.name = 'boss_plugin_admin')
+ or (u.email = 'bossadmin@pgtap.test'   and r.name = 'boss_admin')
+ or (u.email = 'sysadmin@pgtap.test'    and r.name = 'admin')
+on conflict do nothing;
+
+-- ---------------------------------------------------------------------------
+-- The role and permission exist, and are protected from deletion
+-- ---------------------------------------------------------------------------
+select ok(
+    exists (select 1 from public.roles where name = 'boss_plugin_admin' and is_system),
+    'boss_plugin_admin exists and is a system role'
+);
+select ok(
+    exists (select 1 from public.permissions where name = 'plugins.create' and is_system),
+    'plugins.create exists and is a system permission'
+);
+select ok(
+    exists (select 1 from public.permissions where name = 'api_key.create' and is_system),
+    'api_key.create was promoted to a system permission'
+);
+
+-- ---------------------------------------------------------------------------
+-- Direct vs effective permission sets
+-- ---------------------------------------------------------------------------
+select set_eq(
+    $$ select p.name from public.role_permissions rp
+       join public.roles r on r.id = rp.role_id
+       join public.permissions p on p.id = rp.permission_id
+       where r.name = 'boss_plugin_admin' $$,
+    $$ values ('plugins.create'),('api_key.create') $$,
+    'boss_plugin_admin DIRECT permissions = {plugins.create, api_key.create}'
+);
+select set_eq(
+    $$ select unnest(public.get_effective_permissions('11111111-1111-1111-1111-111111111111')) $$,
+    $$ values ('plugins.create'),('api_key.create'),
+              ('user.read'),('user.write'),('user.update'),('user.delete') $$,
+    'boss_plugin_admin EFFECTIVE = direct + the inherited user.* baseline'
+);
+
+-- ---------------------------------------------------------------------------
+-- What it must NOT hold. Checked as families, so a permission added to `user`
+-- later cannot quietly widen this role past the intent.
+-- ---------------------------------------------------------------------------
+select is(
+    (select count(*)::int from unnest(public.get_effective_permissions('11111111-1111-1111-1111-111111111111')) perm
+     where perm like 'plugins.admin.%'),
+    0,
+    'boss_plugin_admin holds NO plugins.admin.* moderation permission'
+);
+select is(
+    (select count(*)::int from unnest(public.get_effective_permissions('11111111-1111-1111-1111-111111111111')) perm
+     where perm like 'role.%' or perm like 'finance.%' or perm like 'rpa.%' or perm like 'secret.%'),
+    0,
+    'boss_plugin_admin holds NO role.*, finance.*, rpa.* or secret.* permission'
+);
+
+-- ---------------------------------------------------------------------------
+-- Inheritance upward: boss_admin and admin both reach plugins.create
+-- ---------------------------------------------------------------------------
+select ok(
+    public.get_effective_permissions('22222222-2222-2222-2222-222222222222') @> array['plugins.create']::text[],
+    'boss_admin inherits plugins.create via boss_plugin_admin'
+);
+select ok(
+    public.get_effective_permissions('33333333-3333-3333-3333-333333333333') @> array['plugins.create']::text[],
+    'admin inherits plugins.create (admin -> boss_admin -> boss_plugin_admin)'
+);
+select ok(
+    not (public.get_effective_permissions('44444444-4444-4444-4444-444444444444') @> array['plugins.create']::text[]),
+    'a plain user does NOT get plugins.create'
+);
+select ok(
+    not (public.get_effective_permissions('44444444-4444-4444-4444-444444444444') @> array['api_key.create']::text[]),
+    'a plain user does NOT get api_key.create'
+);
+
+-- ---------------------------------------------------------------------------
+-- authorize() as boss_plugin_admin
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claims', '{"sub":"11111111-1111-1111-1111-111111111111"}', true);
+select is( public.authorize('plugins.create'), true,  'boss_plugin_admin authorize(plugins.create) = true' );
+select is( public.authorize('api_key.create'), true,  'boss_plugin_admin authorize(api_key.create) = true' );
+select is( public.authorize('plugins.admin.publish'), false,
+           'boss_plugin_admin authorize(plugins.admin.publish) = false (moderation stays separate)' );
+select is( public.authorize('secret.read'), false, 'boss_plugin_admin authorize(secret.read) = false' );
+
+-- ---------------------------------------------------------------------------
+-- Delegated assignment. boss_plugin_admin is a grantable TARGET for boss_admin,
+-- but is not itself a grantor: get_grantable_role_ids returns {user}, yet
+-- assign_role_to_user still refuses because the role has no role.assign.
+-- Both halves are asserted -- the grantable set alone would read as "it can
+-- assign user", which is false.
+-- ---------------------------------------------------------------------------
+select set_eq(
+    $$ select name from public.roles where id in (select public.get_grantable_role_ids('11111111-1111-1111-1111-111111111111')) $$,
+    $$ values ('user') $$,
+    'get_grantable_role_ids(boss_plugin_admin) = {user} (its strict descendant)'
+);
+select throws_ok(
+    $$ select public.assign_role_to_user('44444444-4444-4444-4444-444444444444'::uuid, 'user') $$,
+    'P0001',
+    'Permission denied: role.assign required',
+    'boss_plugin_admin still cannot assign user -- it has no role.assign'
+);
+
+select set_config('request.jwt.claims', '{"sub":"22222222-2222-2222-2222-222222222222"}', true);
+select lives_ok(
+    $$ select public.assign_role_to_user('44444444-4444-4444-4444-444444444444'::uuid, 'boss_plugin_admin') $$,
+    'boss_admin may assign boss_plugin_admin (its new strict descendant)'
+);
+
+-- ---------------------------------------------------------------------------
+-- user_has_permission: the service-role probe used for API-key publishing
+-- ---------------------------------------------------------------------------
+select is( public.user_has_permission('11111111-1111-1111-1111-111111111111', 'plugins.create'), true,
+           'user_has_permission(boss_plugin_admin, plugins.create) = true' );
+select is( public.user_has_permission('55555555-5555-5555-5555-555555555555', 'plugins.create'), false,
+           'user_has_permission(plain user, plugins.create) = false' );
+select is( public.user_has_permission('33333333-3333-3333-3333-333333333333', 'plugins.create'), true,
+           'user_has_permission(admin, anything) = true (admin short-circuit)' );
+
+-- ---------------------------------------------------------------------------
+-- Backfill. The migration's one-shot INSERT already ran against the pre-existing
+-- rows, so this re-runs the same statement against a fixture author to prove the
+-- query grants the role rather than to re-observe the migration.
+-- ---------------------------------------------------------------------------
+insert into public.plugins (plugin_id, display_name, author_id, author_name)
+values ('ai.rever.boss.pgtap.legacy', 'pgTAP legacy plugin',
+        '55555555-5555-5555-5555-555555555555', 'legacyauthor');
+
+insert into public.user_roles (user_id, role_id)
+select distinct legacy_author.id, r.id
+from (
+    select author_id as id from public.plugins where author_id is not null
+    union
+    select user_id as id from public.plugin_api_keys where revoked_at is null
+) as legacy_author
+join public.roles r on r.name = 'boss_plugin_admin'
+join auth.users au on au.id = legacy_author.id
+on conflict (user_id, role_id) do nothing;
+
+select ok(
+    public.get_effective_permissions('55555555-5555-5555-5555-555555555555') @> array['plugins.create']::text[],
+    'backfill grants boss_plugin_admin to a pre-existing plugin author'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/rbac_hierarchy_test.sql
+++ b/supabase/tests/rbac_hierarchy_test.sql
@@ -32,13 +32,13 @@ on conflict do nothing;
 -- ---------------------------------------------------------------------------
 select set_eq(
     $$ select name from public.roles where id in (select public.get_role_descendants((select id from public.roles where name='admin'))) $$,
-    $$ values ('admin'),('boss_admin'),('finance_admin'),('user') $$,
-    'descendants(admin) = all four roles'
+    $$ values ('admin'),('boss_admin'),('boss_plugin_admin'),('finance_admin'),('user') $$,
+    'descendants(admin) = all five roles'
 );
 select set_eq(
     $$ select name from public.roles where id in (select public.get_role_descendants((select id from public.roles where name='boss_admin'))) $$,
-    $$ values ('boss_admin'),('user') $$,
-    'descendants(boss_admin) = {boss_admin, user}'
+    $$ values ('boss_admin'),('boss_plugin_admin'),('user') $$,
+    'descendants(boss_admin) = {boss_admin, boss_plugin_admin, user}'
 );
 select set_eq(
     $$ select name from public.roles where id in (select public.get_role_descendants((select id from public.roles where name='finance_admin'))) $$,
@@ -57,7 +57,7 @@ insert into public.role_hierarchy (parent_role_id, child_role_id)
 values ((select id from public.roles where name='user'), (select id from public.roles where name='admin'));
 select set_eq(
     $$ select name from public.roles where id in (select public.get_role_descendants((select id from public.roles where name='admin'))) $$,
-    $$ values ('admin'),('boss_admin'),('finance_admin'),('user') $$,
+    $$ values ('admin'),('boss_admin'),('boss_plugin_admin'),('finance_admin'),('user') $$,
     'descendants(admin) terminates and is unchanged under a cycle'
 );
 delete from public.role_hierarchy
@@ -93,8 +93,8 @@ select ok(
 -- ---------------------------------------------------------------------------
 select set_eq(
     $$ select name from public.roles where id in (select public.get_grantable_role_ids('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')) $$,
-    $$ values ('user') $$,
-    'boss_admin may grant only user (its strict descendant)'
+    $$ values ('boss_plugin_admin'),('user') $$,
+    'boss_admin may grant its strict descendants (boss_plugin_admin, user)'
 );
 select set_eq(
     $$ select name from public.roles where id in (select public.get_grantable_role_ids('cccccccc-cccc-cccc-cccc-cccccccccccc')) $$,
@@ -103,7 +103,7 @@ select set_eq(
 );
 select set_eq(
     $$ select name from public.roles where id in (select public.get_grantable_role_ids('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')) $$,
-    $$ values ('admin'),('boss_admin'),('finance_admin'),('user') $$,
+    $$ values ('admin'),('boss_admin'),('boss_plugin_admin'),('finance_admin'),('user') $$,
     'admin may grant every role'
 );
 


### PR DESCRIPTION
## Why

Shipping a plugin required `boss_admin`, which also carries `role.read`/`role.create`/`role.assign`, `secret.read`, and the whole `plugins.admin.*` moderation family. This adds a role that can create plugins and publish versions of the ones it owns — and nothing else.

**This is a tightening, not a refinement.** The publish endpoints previously checked only *"are you authenticated"* — `routes/publish.ts` gated on auth, an API-key scope, and row ownership, nothing more. Any signed-in user could claim an unused `pluginId` and mint a publish-scoped API key. So the migration **backfills** `boss_plugin_admin` to everyone already in `plugins.author_id` or holding a live `plugin_api_keys` row; without it, every existing non-admin author loses publishing and their CI keys break mid-release.

`plugins.admin.publish` is deliberately **not** reused. Despite the name it is moderation: its RLS policy (`20260131000000_plugin_store_admin_policies.sql:62-64`) has no author scoping, so it authorizes updates to *any* plugin.

## Database

- `plugins.create` permission + `boss_plugin_admin` role, both `is_system`
- Hierarchy `boss_admin → boss_plugin_admin → user`. The existing `boss_admin → user` edge is kept; `get_role_descendants` uses `UNION`, so the diamond is safe.
- `api_key.create` promoted to `is_system` now that it gates real behaviour (it was deletable via `delete_permission`)
- `user_has_permission(uuid, text)` — a narrow SECURITY DEFINER probe granted to `service_role`. `get_effective_permissions` is revoked from everything except `supabase_auth_admin`, and an API-key caller has no JWT to read claims from, so the edge function must ask the database about the key's **owner**. That is what makes a role revocation stop a key immediately instead of at key expiry.

Effective permissions for the new role: `plugins.create`, `api_key.create`, plus the inherited `user.*` baseline. No `plugins.admin.*`, role, finance, RPA or secret permission.

## Enforcement

- All five publish routes require `plugins.create`; ownership checks unchanged.
- **Creating** an API key requires `api_key.create`. **Listing and revoking deliberately do not** — revocation is a safety valve, and gating it behind the permission a user just lost would strand their keys. Ownership already scopes both.
- `getAuthenticatedUser` returns a discriminated outcome instead of `AuthResult | null`, so a valid key with the wrong scope is now **403** rather than the 401 it used to collapse into.
- The permission probe **fails closed** on a DB error — unlike `validateDeclaredPermissions` beside it, which fails open on purpose. These gate writes.

## Client

`PluginStoreApiKeyProviderImpl` tested for a literal `plugin_admin` role that **no migration ever created**, so the branch was dead and the check silently collapsed to admin-only. It now keys off `api_key.create`.

## Tests

- 18 edge-function tests, including two **source-level wiring guards**. Deleting `requiredPermission` from one of the five publish handlers previously left the whole suite green *and* type-checking — confirmed by mutation (5 gates → 4, 15/15 passing). The guards now fail by name.
- 22 new pgTAP assertions, plus **4 existing assertions in `rbac_hierarchy_test.sql` corrected** — the new hierarchy edge changes both descendant sets and both grantable-role sets.
- 4 new host `PluginAccessGateTest` cases pinning the authoring/moderation split in both directions.

`boss_plugin_admin` **cannot assign any role** despite `user` being a strict descendant: `assign_role_to_user` requires `role.assign` *before* consulting `get_grantable_role_ids`, and this role deliberately lacks it. Both halves are asserted separately.

## Verification status

Green locally: `deno check`, 18/18 edge tests, host `ktlintCheck`, `compileKotlinDesktop`, 11/11 `PluginAccessGateTest`.

⚠️ **The pgTAP suite has not been executed.** Docker's daemon is wedged on my machine — the VM will not boot and `docker desktop status` is unreachable while the app reports "already running". The SQL and the 22+4 assertions are reviewed but unrun; the `🧪 Database (pgTAP)` CI job will be their first real execution. Please treat a red result there as expected-to-be-informative rather than surprising.

## Rollout — order matters

1. **This migration** → prod. Backfill runs; `plugins.create` exists.
2. **A real `tool-creator` release** (risa-labs-inc/boss-plugin-tool-creator#TBD). The download gate reads `required_permissions` off the plugin's **store row**, written only at publish. Verified against production: tool-creator's row still reads `['plugins.admin.publish', 'api_key.create']` at v0.1.6, so a fresh `boss_plugin_admin` would 403 installing the one plugin the role exists for.
3. Host + remaining plugin releases.
4. Edge-function deploy (enforcement).
5. Users refresh their token — permissions ride in JWT claims. **A stale token makes Tool Creator vanish rather than grey out** (`DynamicPluginManager` hides, not disables); worth a release note.

Do not grant anyone `boss_plugin_admin` until step 2 lands. Check with:

```bash
curl -s https://api.risaboss.com/functions/v1/plugin-store/ai.rever.boss.plugin.dynamic.toolcreator \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['requiredPermissions'])"
```

## Out of scope, worth follow-ups

- `routes/admin.ts` gates on the `is_admin` JWT claim, so `boss_admin` is locked out of moderation endpoints **despite holding `plugins.admin.*`**. Pre-existing.
- `POST /publish` has no namespace reservation — any `plugins.create` holder can still claim an unused `pluginId`.
- `BossConsoleLite/supabase/functions/plugin-store/` is a stale fork (last touched 2026-05-05 vs this one's 2026-07-20) with no deploy workflow. Deliberately not mirrored.

## Companion PRs

boss-plugin-api · plugin-manager · tool-creator · tool-evolver · BossConsoleRust — all on `plugin-create-perm`.
