### PR TITLE
🐛 fix(browser): favicons stopped updating on Windows because renameTo will not overwrite

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/AtomicFileWrite.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/AtomicFileWrite.kt
@@ -17,9 +17,11 @@ import java.nio.file.StandardCopyOption
  * had an entry — see [ai.rever.boss.cache.FaviconCache].
  *
  * `Files.move` with `REPLACE_EXISTING` is the portable form: on Windows it maps to `MoveFileEx`
- * with `MOVEFILE_REPLACE_EXISTING`. `ATOMIC_MOVE` is requested first because it additionally
- * rules out a torn destination, and is dropped when the filesystem cannot honour it (a cross-volume
- * temp dir, some network shares) rather than failing the write.
+ * with `MOVEFILE_REPLACE_EXISTING`. `ATOMIC_MOVE` is requested first because it additionally rules
+ * out a torn destination, and is retried without when the move would cross a volume — the only
+ * case that raises `AtomicMoveNotSupportedException`. Both callers create their temp file as a
+ * sibling of the target, so that fallback should never fire; it is there for a caller that does
+ * not. Any other refusal is a plain `IOException` and propagates.
  *
  * @throws IOException if the file could not be replaced.
  */
@@ -43,9 +45,11 @@ fun File.atomicMoveFrom(temp: File) {
  * concurrent writers each use their own temp file so bytes can't interleave —
  * last move wins.
  *
- * Shared by the persisted-registry writers (MCP disabled-tools list,
- * system-plugins manifest cache); previously each open-coded this dance
- * with a FIXED temp name, which concurrent writers could clobber.
+ * Shared by everything that persists small state files, including the workspace
+ * layout written on shutdown; `grep atomicWriteText` for the current set rather
+ * than trusting a list here, which has gone stale once already. Callers
+ * previously open-coded this dance with a FIXED temp name, which concurrent
+ * writers could clobber.
  */
 fun File.atomicWriteText(text: String) {
     parentFile?.mkdirs()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/AtomicFileWrite.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/utils/AtomicFileWrite.kt
@@ -2,14 +2,46 @@ package ai.rever.boss.utils
 
 import java.io.File
 import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * Move [temp] onto this file, replacing it if it already exists.
+ *
+ * **Do not use `File.renameTo` for this.** Its behaviour when the destination exists is
+ * platform-dependent, and the platforms disagree in exactly the way that hides the bug during
+ * development: POSIX `rename(2)` replaces the target, so macOS and Linux work, while Win32
+ * `MoveFile` fails with `ERROR_ALREADY_EXISTS`, so Windows silently stops overwriting anything
+ * after the first write. That cost the browser its favicons on Windows for as long as the cache
+ * had an entry — see [ai.rever.boss.cache.FaviconCache].
+ *
+ * `Files.move` with `REPLACE_EXISTING` is the portable form: on Windows it maps to `MoveFileEx`
+ * with `MOVEFILE_REPLACE_EXISTING`. `ATOMIC_MOVE` is requested first because it additionally
+ * rules out a torn destination, and is dropped when the filesystem cannot honour it (a cross-volume
+ * temp dir, some network shares) rather than failing the write.
+ *
+ * @throws IOException if the file could not be replaced.
+ */
+fun File.atomicMoveFrom(temp: File) {
+    try {
+        Files.move(
+            temp.toPath(),
+            toPath(),
+            StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.ATOMIC_MOVE,
+        )
+    } catch (_: AtomicMoveNotSupportedException) {
+        Files.move(temp.toPath(), toPath(), StandardCopyOption.REPLACE_EXISTING)
+    }
+}
 
 /**
  * Write [text] to this file atomically: content goes to a UNIQUE sibling
- * temp file first, then replaces the target via rename (with the
- * delete-and-retry fallback for platforms where rename won't clobber an
- * existing target). A crash mid-write leaves at most a stray temp file,
- * never a truncated target; concurrent writers each use their own temp file
- * so bytes can't interleave — last rename wins.
+ * temp file first, then replaces the target via [atomicMoveFrom]. A crash
+ * mid-write leaves at most a stray temp file, never a truncated target;
+ * concurrent writers each use their own temp file so bytes can't interleave —
+ * last move wins.
  *
  * Shared by the persisted-registry writers (MCP disabled-tools list,
  * system-plugins manifest cache); previously each open-coded this dance
@@ -20,14 +52,9 @@ fun File.atomicWriteText(text: String) {
     val tmp = File.createTempFile("$name.", ".tmp", parentFile)
     try {
         tmp.writeText(text)
-        if (!tmp.renameTo(this)) {
-            delete()
-            if (!tmp.renameTo(this)) {
-                throw IOException("rename ${tmp.name} -> $name failed")
-            }
-        }
+        atomicMoveFrom(tmp)
     } finally {
-        // No-op when the rename moved it away; cleans up on failure paths.
+        // No-op when the move took it away; cleans up on failure paths.
         tmp.delete()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/FaviconCache.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/FaviconCache.kt
@@ -50,16 +50,31 @@ object FaviconCache {
     fun saveFavicon(
         url: String,
         imageBitmap: ImageBitmap,
+    ): String? = saveFavicon(url, imageBitmap, cacheDir)
+
+    /**
+     * [saveFavicon] against an explicit directory, so the branch that decides whether a tab keeps
+     * its icon can be tested without writing to the developer's real `~/.boss` cache.
+     *
+     * **Must not throw.** Everything is inside the `try`, including the cache-key hash and the
+     * cache-file path: the caller is a JxBrowser event listener, and while it happens to be
+     * wrapped today, that is not this function's guarantee to spend.
+     */
+    internal fun saveFavicon(
+        url: String,
+        imageBitmap: ImageBitmap,
+        dir: File,
     ): String? {
-        val cacheKey = generateCacheKey(url)
-        val cacheFile = File(cacheDir, "$cacheKey.png")
+        var cacheFile: File? = null
         var tempFile: File? = null
-        try {
+        return try {
+            val cacheKey = generateCacheKey(url)
+            cacheFile = File(dir, "$cacheKey.png")
             val bufferedImage = imageBitmap.toAwtImage()
 
             // Written to a temp file first so the size limit is checked against the encoded PNG,
             // and so a failure part-way through encoding cannot leave a torn icon in the cache.
-            tempFile = File.createTempFile("favicon_", ".png", cacheDir)
+            tempFile = File.createTempFile("favicon_", ".png", dir)
             ImageIO.write(bufferedImage, "PNG", tempFile)
 
             if (tempFile.length() > MAX_FAVICON_SIZE_BYTES) {
@@ -69,36 +84,57 @@ object FaviconCache {
                     mapOf(
                         "size" to tempFile.length(),
                         "maxSize" to MAX_FAVICON_SIZE_BYTES,
+                        "servedStaleCache" to cacheFile.exists(),
                     ),
                 )
-                return existingKeyOrNull(cacheKey, cacheFile)
+                existingKeyOrNull(cacheKey, cacheFile)
+            } else {
+                // NOT File.renameTo: that does not overwrite an existing file on Windows, so every
+                // favicon after the first for a given URL failed there - and the cache outlives the
+                // process, so "the first" was usually some previous run. See File.atomicMoveFrom.
+                cacheFile.atomicMoveFrom(tempFile)
+                cacheKey
             }
-
-            // NOT File.renameTo: that does not overwrite an existing file on Windows, so every
-            // favicon after the first for a given URL failed there - and the cache outlives the
-            // process, so "the first" was usually some previous run. See File.atomicMoveFrom.
-            cacheFile.atomicMoveFrom(tempFile)
-            return cacheKey
         } catch (e: Exception) {
-            logger.warn(LogCategory.BROWSER, "Error saving favicon", error = e)
-            return existingKeyOrNull(cacheKey, cacheFile)
+            // servedStaleCache separates "favicons are stale" from "favicons are gone" in a log,
+            // which is the distinction that made the Windows rename bug findable at all.
+            logger.warn(
+                LogCategory.BROWSER,
+                "Error saving favicon",
+                mapOf("servedStaleCache" to (cacheFile?.exists() ?: false)),
+                error = e,
+            )
+            cacheFile?.let { existingKeyOrNull(generateCacheKeyOrNull(url), it) }
         } finally {
             // No-op once the move took it away; cleans up every failure path.
             tempFile?.delete()
         }
     }
 
+    /** [generateCacheKey] for the failure path, where hashing may be the thing that failed. */
+    private fun generateCacheKeyOrNull(url: String): String? =
+        try {
+            generateCacheKey(url)
+        } catch (e: Exception) {
+            logger.debug(LogCategory.BROWSER, "Could not hash favicon URL", mapOf("error" to e.toString()))
+            null
+        }
+
     /**
-     * The key when something is already cached for it, else null.
+     * The key when something is already cached under it, else null.
      *
      * Returning null costs the tab its icon rather than merely leaving it stale: it reaches
      * `updateFavicon(null)`, which resets the tab to the default globe. So a save that could not
      * improve on the cache reports what the cache still holds.
+     *
+     * Note the stale icon is then pinned until something rewrites it — `cleanupStaleEntries` only
+     * ages files out after 30 days — so a site that switches to a >100 KB icon keeps showing the
+     * old one for a month. Accepted: an outdated favicon beats none.
      */
     private fun existingKeyOrNull(
-        cacheKey: String,
+        cacheKey: String?,
         cacheFile: File,
-    ): String? = cacheKey.takeIf { cacheFile.exists() }
+    ): String? = cacheKey?.takeIf { cacheFile.exists() }
 
     /**
      * Loads a favicon from the cache.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/FaviconCache.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cache/FaviconCache.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.cache
 
 import ai.rever.boss.plugin.api.TabIcon
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.ui.graphics.ImageBitmap
@@ -39,28 +40,29 @@ object FaviconCache {
     }
 
     /**
-     * Saves a favicon to the cache.
+     * Saves a favicon to the cache, replacing any earlier icon for the same URL.
+     *
      * @param url The URL associated with this favicon (used to generate cache key)
      * @param imageBitmap The favicon ImageBitmap to cache
-     * @return The cache key if successful, null if the favicon exceeds size limit or on error
+     * @return The cache key, or null if the favicon exceeds the size limit and nothing usable is
+     *   already cached for [url]
      */
     fun saveFavicon(
         url: String,
         imageBitmap: ImageBitmap,
     ): String? {
+        val cacheKey = generateCacheKey(url)
+        val cacheFile = File(cacheDir, "$cacheKey.png")
+        var tempFile: File? = null
         try {
-            val cacheKey = generateCacheKey(url)
-            val cacheFile = File(cacheDir, "$cacheKey.png")
-
-            // Convert to AWT BufferedImage
             val bufferedImage = imageBitmap.toAwtImage()
 
-            // Check size before writing
-            val tempFile = File.createTempFile("favicon_", ".png", cacheDir)
+            // Written to a temp file first so the size limit is checked against the encoded PNG,
+            // and so a failure part-way through encoding cannot leave a torn icon in the cache.
+            tempFile = File.createTempFile("favicon_", ".png", cacheDir)
             ImageIO.write(bufferedImage, "PNG", tempFile)
 
             if (tempFile.length() > MAX_FAVICON_SIZE_BYTES) {
-                tempFile.delete()
                 logger.debug(
                     LogCategory.BROWSER,
                     "Favicon too large, skipping cache",
@@ -69,22 +71,34 @@ object FaviconCache {
                         "maxSize" to MAX_FAVICON_SIZE_BYTES,
                     ),
                 )
-                return null
+                return existingKeyOrNull(cacheKey, cacheFile)
             }
 
-            // Move to final location
-            val renamed = tempFile.renameTo(cacheFile)
-            if (!renamed) {
-                tempFile.delete()
-                logger.warn(LogCategory.BROWSER, "Error saving favicon: rename failed")
-                return null
-            }
+            // NOT File.renameTo: that does not overwrite an existing file on Windows, so every
+            // favicon after the first for a given URL failed there - and the cache outlives the
+            // process, so "the first" was usually some previous run. See File.atomicMoveFrom.
+            cacheFile.atomicMoveFrom(tempFile)
             return cacheKey
         } catch (e: Exception) {
             logger.warn(LogCategory.BROWSER, "Error saving favicon", error = e)
-            return null
+            return existingKeyOrNull(cacheKey, cacheFile)
+        } finally {
+            // No-op once the move took it away; cleans up every failure path.
+            tempFile?.delete()
         }
     }
+
+    /**
+     * The key when something is already cached for it, else null.
+     *
+     * Returning null costs the tab its icon rather than merely leaving it stale: it reaches
+     * `updateFavicon(null)`, which resets the tab to the default globe. So a save that could not
+     * improve on the cache reports what the cache still holds.
+     */
+    private fun existingKeyOrNull(
+        cacheKey: String,
+        cacheFile: File,
+    ): String? = cacheKey.takeIf { cacheFile.exists() }
 
     /**
      * Loads a favicon from the cache.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/cache/FaviconCacheTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/cache/FaviconCacheTest.kt
@@ -1,0 +1,136 @@
+package ai.rever.boss.cache
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import java.awt.image.BufferedImage
+import java.io.File
+import java.util.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for what [FaviconCache.saveFavicon] returns, which is the half that decides whether a tab
+ * keeps its icon: the key flows to `updateFavicon`, and a null there resets the tab to the default
+ * globe rather than merely leaving the icon stale.
+ *
+ * Uses the `internal` directory seam — the public entry point resolves through `BossDirectories`
+ * to the developer's real `~/.boss/cache`, which is not somewhere a test should be writing.
+ */
+class FaviconCacheTest {
+    private val dir: File =
+        File.createTempFile("favicon-cache-", "").let {
+            it.delete()
+            it.mkdirs()
+            it
+        }
+
+    @AfterTest
+    fun cleanUp() {
+        dir.deleteRecursively()
+    }
+
+    /** A tiny solid icon — a handful of bytes once PNG-encoded. */
+    private fun smallIcon(rgb: Int): ImageBitmap =
+        BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB)
+            .apply {
+                for (y in 0 until height) {
+                    for (x in 0 until width) setRGB(x, y, rgb)
+                }
+            }.toComposeImageBitmap()
+
+    /** Random noise, which PNG cannot compress, so it clears the 100 KB limit comfortably. */
+    private fun oversizeIcon(): ImageBitmap {
+        val random = Random(20260802L)
+        return BufferedImage(512, 512, BufferedImage.TYPE_INT_ARGB)
+            .apply {
+                for (y in 0 until height) {
+                    for (x in 0 until width) setRGB(x, y, random.nextInt() or (0xFF shl 24))
+                }
+            }.toComposeImageBitmap()
+    }
+
+    private fun cacheFileFor(url: String) = File(dir, "${FaviconCache.generateCacheKey(url)}.png")
+
+    @Test
+    fun `a saved favicon returns its key and lands on disk`() {
+        val key = FaviconCache.saveFavicon(URL, smallIcon(RED), dir)
+
+        assertEquals(FaviconCache.generateCacheKey(URL), key)
+        assertTrue(cacheFileFor(URL).exists())
+    }
+
+    @Test
+    fun `saving twice for the same URL replaces the icon`() {
+        // The reported bug: on Windows the second save failed, returned null, and the tab dropped
+        // back to the default globe even though a perfectly good icon was sitting on disk.
+        FaviconCache.saveFavicon(URL, smallIcon(RED), dir)
+        val first = cacheFileFor(URL).readBytes()
+
+        val key = FaviconCache.saveFavicon(URL, smallIcon(BLUE), dir)
+
+        assertEquals(FaviconCache.generateCacheKey(URL), key, "the second save must not report failure")
+        assertTrue(cacheFileFor(URL).readBytes().isNotEmpty())
+        assertTrue(!cacheFileFor(URL).readBytes().contentEquals(first), "the icon should have been replaced")
+    }
+
+    @Test
+    fun `an oversize favicon keeps the icon already cached`() {
+        FaviconCache.saveFavicon(URL, smallIcon(RED), dir)
+        val cached = cacheFileFor(URL).readBytes()
+
+        val key = FaviconCache.saveFavicon(URL, oversizeIcon(), dir)
+
+        assertEquals(FaviconCache.generateCacheKey(URL), key, "stale beats blank")
+        assertTrue(cacheFileFor(URL).readBytes().contentEquals(cached), "the oversize icon must not be written")
+    }
+
+    @Test
+    fun `an oversize favicon with nothing cached reports no icon`() {
+        val key = FaviconCache.saveFavicon(URL, oversizeIcon(), dir)
+
+        assertNull(key)
+        assertTrue(!cacheFileFor(URL).exists())
+    }
+
+    @Test
+    fun `no temp files are left behind by either outcome`() {
+        // The temp file is a sibling of the target, so a leak accumulates in the favicon cache
+        // itself rather than in the OS temp dir.
+        FaviconCache.saveFavicon(URL, smallIcon(RED), dir)
+        FaviconCache.saveFavicon(URL, oversizeIcon(), dir)
+
+        val strays = dir.listFiles()?.filter { it.name.startsWith("favicon_") }.orEmpty()
+        assertTrue(strays.isEmpty(), "unexpected leftovers: ${strays.map { it.name }}")
+    }
+
+    @Test
+    fun `an unusable cache directory reports no icon rather than throwing`() {
+        // The caller is a JxBrowser event listener; this must not throw at it. A regular file
+        // standing in for the directory makes createTempFile fail.
+        val notADirectory = File(dir, "regular-file").apply { writeText("not a directory") }
+
+        val key = FaviconCache.saveFavicon(URL, smallIcon(RED), notADirectory)
+
+        assertNull(key)
+    }
+
+    @Test
+    fun `different URLs get different keys`() {
+        val first = FaviconCache.saveFavicon(URL, smallIcon(RED), dir)
+        val second = FaviconCache.saveFavicon("https://other.example/", smallIcon(BLUE), dir)
+
+        assertNotNull(first)
+        assertNotNull(second)
+        assertTrue(first != second)
+    }
+
+    private companion object {
+        const val URL = "https://example.com/page"
+        const val RED = 0xFFFF0000.toInt()
+        const val BLUE = 0xFF0000FF.toInt()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/AtomicFileWriteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/AtomicFileWriteTest.kt
@@ -1,0 +1,88 @@
+package ai.rever.boss.utils
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the atomic file-replacement helpers.
+ *
+ * These exist because of a platform split that hides itself during development: `File.renameTo`
+ * replaces an existing destination on macOS and Linux (POSIX `rename(2)`) but fails on Windows
+ * (`MoveFile` returns `ERROR_ALREADY_EXISTS`). The browser's favicon cache open-coded that call, so
+ * on Windows it wrote each icon exactly once and every later save failed — and because the cache
+ * survives restarts, that meant favicons stopped updating entirely.
+ *
+ * The overwrite tests below therefore only *fail* on Windows. They are worth keeping anyway: PR CI
+ * runs `build-test (windows-latest)`, which is precisely the leg that would have caught it.
+ */
+class AtomicFileWriteTest {
+    private val tempDir: File =
+        File.createTempFile("atomic-write-", "").let {
+            it.delete()
+            it.mkdirs()
+            it
+        }
+
+    @AfterTest
+    fun cleanUp() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `atomicMoveFrom replaces a file that already exists`() {
+        // The regression. On Windows this threw before the fix; on POSIX it always passed.
+        val target = File(tempDir, "icon.png").apply { writeText("old") }
+        val temp = File(tempDir, "icon.tmp").apply { writeText("new") }
+
+        target.atomicMoveFrom(temp)
+
+        assertEquals("new", target.readText())
+        assertFalse(temp.exists(), "the source should have been moved, not copied")
+    }
+
+    @Test
+    fun `atomicMoveFrom creates the file when it does not exist`() {
+        val target = File(tempDir, "fresh.png")
+        val temp = File(tempDir, "fresh.tmp").apply { writeText("content") }
+
+        target.atomicMoveFrom(temp)
+
+        assertEquals("content", target.readText())
+    }
+
+    @Test
+    fun `atomicWriteText overwrites existing content`() {
+        val target = File(tempDir, "registry.json")
+
+        target.atomicWriteText("first")
+        assertEquals("first", target.readText())
+
+        target.atomicWriteText("second")
+        assertEquals("second", target.readText())
+    }
+
+    @Test
+    fun `atomicWriteText creates missing parent directories`() {
+        val target = File(tempDir, "nested/deeper/registry.json")
+
+        target.atomicWriteText("value")
+
+        assertEquals("value", target.readText())
+    }
+
+    @Test
+    fun `atomicWriteText leaves no temp files behind`() {
+        // The temp file is a sibling of the target, so a leak would accumulate in the real cache
+        // and config directories rather than in the OS temp dir.
+        val target = File(tempDir, "clean.json")
+
+        repeat(3) { target.atomicWriteText("write $it") }
+
+        val strays = tempDir.listFiles()?.filter { it.name != target.name }.orEmpty()
+        assertTrue(strays.isEmpty(), "unexpected leftovers: ${strays.map { it.name }}")
+    }
+}


### PR DESCRIPTION
Favicons work on macOS and not on Windows. The running app says why, once per page load:

```
WARN [BROWSER] FaviconCache: Error saving favicon: rename failed
```

## Root cause

`FaviconCache.saveFavicon` encodes the PNG to a sibling temp file — so the 100 KB limit is checked against the encoded bytes — and then promotes it with `File.renameTo`.

`renameTo`'s behaviour when the destination already exists is platform-dependent, and the platforms disagree in the direction that hides the bug during development:

| | destination exists |
|---|---|
| macOS / Linux — POSIX `rename(2)` | replaced |
| Windows — Win32 `MoveFile` | **fails**, `ERROR_ALREADY_EXISTS` |

So on Windows a URL's favicon could be written **exactly once, ever**. And `~/.boss/cache/favicon-cache` outlives the process, so "once" had usually already happened in some earlier run — 56 icons cached on the reporting machine, every subsequent save failing.

The failure is worse than "no update". `saveFavicon` returned `null`, the listener passes that to `updateFavicon(null)` → `updateFaviconCacheKey(null)`, and that **resets the tab to the default globe**. A perfectly good cached icon was being discarded by the failure to overwrite it.

## Fix

- **`File.atomicMoveFrom(temp)`**, next to the existing `atomicWriteText`, using `Files.move` with `REPLACE_EXISTING` — `MoveFileEx` + `MOVEFILE_REPLACE_EXISTING` on Windows. `ATOMIC_MOVE` is requested first and dropped when the filesystem cannot honour it (cross-volume temp dir, some network shares) rather than failing the write.
- **`atomicWriteText` now shares it.** It was already correct on Windows via a delete-then-retry fallback, but that fallback leaves a window in which the file does not exist at all; `Files.move` closes it. Equivalent-or-better for all seven callers — MCP disabled-tools list, system-plugins manifest cache, dashboard recent pages, URL history, resolved hosts, self-healing settings, and the workspace layout written on shutdown. That last one is the one worth touching in a Windows smoke test.
- **`saveFavicon` no longer reports "no icon" when it cannot improve on the cache.** Over the size limit, or a genuine I/O failure with an entry already on disk, now returns the existing key. Stale beats blank. The temp file is also cleaned up on every failure path rather than just one.

## Verification

`AtomicFileWriteTest` (5) and `FaviconCacheTest` (7), green. The latter pins the actual behaviour change through an `internal` directory seam: oversize + something cached returns the stale key, oversize + nothing cached returns null, an unusable directory returns null instead of throwing at the JxBrowser listener, and a second save for the same URL replaces the icon. Verified they actually catch the bug rather than merely passing: swapping `Files.move` back to `renameTo` fails 3 of 5 locally with `java.io.IOException: rename failed`, the same message the app logs. They can only fail on Windows, which is exactly why PR CI's `build-test (windows-latest)` leg is where they earn their place.

detekt and ktlint clean.

**Runtime check still worth doing** on a Windows build: visit a site whose icon is already in `~/.boss/cache/favicon-cache`, and confirm the tab keeps its favicon instead of falling back to the globe. No cache wipe needed — the existing entries are valid PNGs, they were just never being replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Follow-up filed from the review's sweep of the remaining `renameTo` call sites: #96 — `FileSystemService.renameFile` has the same bug in an API that explicitly offers `overwrite`, and discards the boolean result, so the failure is reported as success on every platform.
