### PR TITLE
fix(plugins): sign the system-plugin install path, and stop stale sidecars outliving their JARs

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginJarReconciler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginJarReconciler.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.plugin
 import ai.rever.boss.components.plugin.MicrokernelRuntime
 import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.loader.PluginManifestReader
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.utils.Version
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -78,7 +79,13 @@ object PluginJarReconciler {
             for (loser in group) {
                 if (loser.file == winner.file) continue
                 val removed = runCatching { loser.file.delete() }.getOrDefault(false)
-                if (removed) deleted.add(loser.file.name)
+                if (removed) {
+                    deleted.add(loser.file.name)
+                    // A `.sig` must never outlive the JAR it describes: left behind
+                    // it is an orphan now, and a hard load failure later if a JAR of
+                    // the same name lands on the path.
+                    runCatching { PluginSignatureSidecar.delete(loser.file.absolutePath) }
+                }
                 logger.info(
                     LogCategory.SYSTEM,
                     "Removed stale duplicate plugin JAR",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -10,6 +10,7 @@ import ai.rever.boss.plugin.api.LoadedPluginInfo
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
 import ai.rever.boss.plugin.sandbox.TabSandboxRegistry
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
@@ -67,8 +68,12 @@ class PluginLoaderDelegateImpl(
         // to be rejected.
         if (isMicrokernelRuntimeJar(jarPath)) {
             // Clean up the JAR that the installer just downloaded so it doesn't
-            // linger in the plugins directory and confuse a future scan.
+            // linger in the plugins directory and confuse a future scan. The
+            // sidecar goes with it: an uninstall→reinstall of the same version
+            // reuses the filename, so a surviving `.sig` would meet fresh bytes
+            // and hard-fail at load — worse than being unsigned.
             runCatching { File(jarPath).delete() }
+            runCatching { PluginSignatureSidecar.delete(jarPath) }
             logger.info(
                 LogCategory.SYSTEM,
                 "Refusing to install microkernel runtime as a plugin",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -2,10 +2,12 @@ package ai.rever.boss.plugin
 
 import ai.rever.boss.config.GitHubConfig
 import ai.rever.boss.config.SupabaseClientConfig
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.plugin.repository.LocalPluginRepository
 import ai.rever.boss.plugin.repository.PluginRepositoryManager
 import ai.rever.boss.plugin.repository.remote.PluginDownloadCache
+import ai.rever.boss.plugin.repository.remote.PluginStoreClient
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
 import ai.rever.boss.plugin.repository.remote.PluginStoreRealtimeService
 import ai.rever.boss.plugin.repository.remote.RemotePluginRepository
@@ -15,6 +17,7 @@ import ai.rever.boss.services.supabase.SupabaseConfig
 import ai.rever.boss.utils.AppVersion
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.sha256Of
 import io.github.jan.supabase.auth.status.SessionStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -747,6 +750,66 @@ object PluginStoreSetup {
     }
 
     /**
+     * Bind the store's signature to a JAR fetched from GitHub releases, or clear
+     * any stale sidecar when it can't be bound.
+     *
+     * System plugins come straight from GitHub, not from the store, so the store's
+     * signature has to be fetched separately and matched to these exact bytes. The
+     * sha256 comparison is load-bearing, not defensive: the anchor is
+     * `pluginId|version|sha256` (see PluginStoreTrust.versionAnchor), and a
+     * present-but-invalid sidecar hard-fails at load time **regardless** of the
+     * enforcement flag. `POST /github` re-hosts JARs through Supabase Storage, so
+     * the store artifact and the GitHub asset are not guaranteed to be the same
+     * bytes — pairing the store's signature with GitHub's bytes would convert a
+     * working plugin into a permanent load failure. Writing no sidecar is strictly
+     * safer than writing a wrong one, so every failure path clears instead.
+     *
+     * [version] must be the bare version (no `v` prefix) to match the anchor.
+     */
+    private suspend fun persistStoreSignatureSidecar(
+        pluginId: String,
+        version: String,
+        jarFile: File,
+    ) {
+        val signature =
+            try {
+                val info = PluginStoreClient.getDownloadUrl(pluginId, version)
+                val localSha = sha256Of(jarFile)
+                if (info.sha256.equals(localSha, ignoreCase = true)) {
+                    info.signature
+                } else {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "GitHub asset differs from the store artifact — leaving plugin unsigned",
+                        mapOf(
+                            "pluginId" to pluginId,
+                            "version" to version,
+                            "storeSha256" to info.sha256,
+                            "localSha256" to localSha,
+                        ),
+                    )
+                    null
+                }
+            } catch (e: Exception) {
+                // Store unreachable, no row for this version, or a version published
+                // before store signing. Unsigned is the pre-existing state and is
+                // still warn-and-allow; a wrong signature would not be.
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "No store signature available for system plugin",
+                    mapOf(
+                        "pluginId" to pluginId,
+                        "version" to version,
+                        "error" to e.toString(),
+                    ),
+                )
+                null
+            }
+
+        PluginSignatureSidecar.persist(jarFile.absolutePath, signature)
+    }
+
+    /**
      * Download a system plugin from GitHub releases.
      *
      * @param plugin The system plugin info
@@ -956,6 +1019,20 @@ object PluginStoreSetup {
                     )
                 }
 
+                // Bind the store signature to these bytes. Every OTHER install path
+                // writes a `<jar>.sig` sidecar; this one never did, so system
+                // plugins — api, Toolbox, the microkernel runtime, terminal-tab,
+                // editor-tab, fluck-browser — all sit on disk unsigned. That is
+                // invisible only while PluginSignatureEnforcement defaults to
+                // warn-and-allow; the moment it flips (BossConsole#872) every one
+                // of them stops loading. Written before persistence so a JAR is
+                // never registered as installed without its sidecar settled.
+                persistStoreSignatureSidecar(
+                    pluginId = plugin.pluginId,
+                    version = tagName.removePrefix("v"),
+                    jarFile = destFile,
+                )
+
                 // Register in persistence (skip for download-only plugins like microkernel runtime).
                 // Preserve the user's existing `enabled` choice and `sourceUrl` —
                 // `addInstalledPlugin` does removeIf+add, so passing the defaults
@@ -1003,6 +1080,11 @@ object PluginStoreSetup {
                             readPluginManifest(it)?.pluginId == plugin.pluginId
                     }?.forEach { oldFile ->
                         val deleted = oldFile.delete()
+                        // Drop the sidecar with its JAR so it can't outlive it as an
+                        // orphan. Unconditional: if the JAR delete failed (Windows
+                        // lock), a signed JAR that lingers without its sidecar is
+                        // merely unsigned, not invalid.
+                        PluginSignatureSidecar.delete(oldFile.absolutePath)
                         logger.debug(
                             LogCategory.SYSTEM,
                             "Removed old version",
@@ -1365,6 +1447,9 @@ object PluginStoreSetup {
                         ),
                     )
                     oldJar.delete()
+                    // A sidecar outlives the JAR it describes unless it's removed
+                    // with it, leaving orphaned `.sig` files in the plugin dir.
+                    PluginSignatureSidecar.delete(oldJar.absolutePath)
                 }
 
                 // Copy to plugin directory
@@ -1379,6 +1464,13 @@ object PluginStoreSetup {
                 )
 
                 jarFile.copyTo(destFile, overwrite = true)
+
+                // Bundled JARs ship inside the signed, notarized app image and carry
+                // no store signature. Clear rather than leave: this overwrites by
+                // filename, so a store-downloaded JAR of the same name may have left
+                // a sidecar behind — and a sidecar that doesn't match the bytes beside
+                // it is a hard load failure, unlike no sidecar at all.
+                PluginSignatureSidecar.persist(destFile.absolutePath, null)
 
                 logger.info(
                     LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -1107,7 +1107,7 @@ object PluginStoreSetup {
                 // plugins — api, Toolbox, the microkernel runtime, terminal-tab,
                 // editor-tab, fluck-browser — all sit on disk unsigned. That is
                 // invisible only while PluginSignatureEnforcement defaults to
-                // warn-and-allow; the moment it flips (BossConsole#872) every one
+                // warn-and-allow; the moment it flips (BossConsole#102) every one
                 // of them stops loading. Written before persistence so a JAR is
                 // never registered as installed without its sidecar settled.
                 persistStoreSignatureSidecar(destFile)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -455,6 +455,9 @@ object PluginStoreSetup {
                             // classloader — replacing on the fly would break
                             // anything currently holding a class reference).
                             scheduleBackgroundUpdateCheck(systemPlugin, jarFile)
+                            // Reaches the installed base, which a download-only fix
+                            // never would — see backfillSidecarIfMissing.
+                            backfillSidecarIfMissing(jarFile)
                             logger.debug(
                                 LogCategory.SYSTEM,
                                 "System plugin already installed",
@@ -766,47 +769,119 @@ object PluginStoreSetup {
      *
      * [version] must be the bare version (no `v` prefix) to match the anchor.
      */
-    private suspend fun persistStoreSignatureSidecar(
-        pluginId: String,
-        version: String,
-        jarFile: File,
-    ) {
+    private suspend fun persistStoreSignatureSidecar(jarFile: File) {
+        // Key the lookup on the MANIFEST, not the GitHub tag. The store row's
+        // version is the manifest version (publish asserts they match verbatim)
+        // and DynamicPluginLoader re-derives the anchor from manifest.pluginId +
+        // manifest.version at load time — so the tag is the one string in this
+        // chain not guaranteed to agree. A repo tagging `release-1.2.3`, or the
+        // `tag_name` regex missing and falling back to "unknown", would 404 and
+        // leave the plugin permanently unsigned.
+        val manifest = readPluginManifest(jarFile)
+        if (manifest == null) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "System plugin left unsigned — manifest unreadable, cannot key the store lookup",
+                mapOf("file" to jarFile.name),
+            )
+            runCatching { PluginSignatureSidecar.persist(jarFile.absolutePath, null) }
+            return
+        }
+
         val signature =
             try {
-                val info = PluginStoreClient.getDownloadUrl(pluginId, version)
+                val info = PluginStoreClient.getDownloadUrl(manifest.pluginId, manifest.version)
                 val localSha = sha256Of(jarFile)
-                if (info.sha256.equals(localSha, ignoreCase = true)) {
-                    info.signature
-                } else {
-                    logger.warn(
-                        LogCategory.SYSTEM,
-                        "GitHub asset differs from the store artifact — leaving plugin unsigned",
-                        mapOf(
-                            "pluginId" to pluginId,
-                            "version" to version,
-                            "storeSha256" to info.sha256,
-                            "localSha256" to localSha,
-                        ),
-                    )
-                    null
+                resolveSidecarSignature(
+                    storeSha256 = info.sha256,
+                    storeSignature = info.signature,
+                    localSha256 = localSha,
+                ).also {
+                    if (it == null && info.signature != null) {
+                        logger.warn(
+                            LogCategory.SYSTEM,
+                            "System plugin left unsigned — GitHub asset differs from the store artifact",
+                            mapOf(
+                                "pluginId" to manifest.pluginId,
+                                "version" to manifest.version,
+                                "storeSha256" to info.sha256,
+                                "localSha256" to localSha,
+                            ),
+                        )
+                    }
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Structured concurrency: a cancelled startup scope must not be
+                // reported as "no signature available" and must not fall through
+                // into persist().
+                throw e
             } catch (e: Exception) {
-                // Store unreachable, no row for this version, or a version published
-                // before store signing. Unsigned is the pre-existing state and is
-                // still warn-and-allow; a wrong signature would not be.
-                logger.debug(
+                // Store unreachable, no row for this version, a version published
+                // before store signing, or a 403 from the install-permission gate
+                // (PluginStoreConfig.accessToken is populated asynchronously from
+                // the session, so a first-run install can reach the store
+                // unauthenticated). Unsigned is the pre-existing state and is still
+                // warn-and-allow; a wrong signature would not be. Logged at warn
+                // because this is the signal for whether the fleet is ready for the
+                // enforcement flip — it must not be invisible by default.
+                logger.warn(
                     LogCategory.SYSTEM,
-                    "No store signature available for system plugin",
+                    "System plugin left unsigned — no store signature available",
                     mapOf(
-                        "pluginId" to pluginId,
-                        "version" to version,
+                        "pluginId" to manifest.pluginId,
+                        "version" to manifest.version,
                         "error" to e.toString(),
                     ),
                 )
                 null
             }
 
-        PluginSignatureSidecar.persist(jarFile.absolutePath, signature)
+        // PluginSignatureSidecar.write is documented best-effort, but writeText
+        // throws on a full or read-only disk. Uncaught here it would propagate to
+        // the download handler and be reported as a failed install — leaving the
+        // JAR on disk with persistence never updated.
+        runCatching { PluginSignatureSidecar.persist(jarFile.absolutePath, signature) }
+            .onFailure {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Could not write plugin signature sidecar",
+                    mapOf("file" to jarFile.name, "error" to it.toString()),
+                )
+            }
+    }
+
+    /**
+     * The policy: a store signature may be bound to a JAR **only** when the store
+     * agrees about those exact bytes.
+     *
+     * Extracted and internal so the rule is pinned by tests rather than living
+     * inside a network call. It encodes the non-obvious asymmetry that makes this
+     * whole path safe — a *missing* sidecar is warn-and-allow, a *present but
+     * invalid* one hard-fails at load regardless of the enforcement flag. So when
+     * in any doubt, return null: unsigned is recoverable, wrongly-signed is not.
+     */
+    internal fun resolveSidecarSignature(
+        storeSha256: String,
+        storeSignature: String?,
+        localSha256: String,
+    ): String? = if (storeSha256.equals(localSha256, ignoreCase = true)) storeSignature else null
+
+    /**
+     * Give an already-installed system plugin a sidecar it never got.
+     *
+     * Without this the fix only reaches plugins that happen to be re-downloaded:
+     * [ensureSystemPluginsInstalled] returns early once a JAR is on disk, and
+     * [scheduleBackgroundUpdateCheck] only downloads when a strictly newer release
+     * exists. A user already up to date would stay unsigned forever and lose every
+     * system plugin — Toolbox included — the moment enforcement flips.
+     *
+     * Backgrounded: this is startup, and the result only matters for the next load.
+     */
+    private fun backfillSidecarIfMissing(jarFile: File) {
+        if (PluginSignatureSidecar.read(jarFile.absolutePath) != null) return
+        scope.launch {
+            persistStoreSignatureSidecar(jarFile)
+        }
     }
 
     /**
@@ -1002,6 +1077,14 @@ object PluginStoreSetup {
                 // place *before* deleting old versions and *before* updating
                 // persistence so there's never a window where persistence
                 // points to a JAR we've already unlinked.
+                // Clear any existing sidecar BEFORE the bytes change. Settling the
+                // signature afterwards needs a network round trip, and a crash or
+                // force-quit in that window would otherwise leave the old sidecar
+                // beside the new JAR — present-but-invalid, which hard-fails at
+                // load forever, flag or no flag. Clearing first makes the worst
+                // case unsigned, which is merely warn-and-allow.
+                runCatching { PluginSignatureSidecar.delete(destFile.absolutePath) }
+
                 try {
                     java.nio.file.Files.move(
                         tmpFile.toPath(),
@@ -1027,11 +1110,7 @@ object PluginStoreSetup {
                 // warn-and-allow; the moment it flips (BossConsole#872) every one
                 // of them stops loading. Written before persistence so a JAR is
                 // never registered as installed without its sidecar settled.
-                persistStoreSignatureSidecar(
-                    pluginId = plugin.pluginId,
-                    version = tagName.removePrefix("v"),
-                    jarFile = destFile,
-                )
+                persistStoreSignatureSidecar(destFile)
 
                 // Register in persistence (skip for download-only plugins like microkernel runtime).
                 // Preserve the user's existing `enabled` choice and `sourceUrl` —
@@ -1081,10 +1160,11 @@ object PluginStoreSetup {
                     }?.forEach { oldFile ->
                         val deleted = oldFile.delete()
                         // Drop the sidecar with its JAR so it can't outlive it as an
-                        // orphan. Unconditional: if the JAR delete failed (Windows
-                        // lock), a signed JAR that lingers without its sidecar is
-                        // merely unsigned, not invalid.
-                        PluginSignatureSidecar.delete(oldFile.absolutePath)
+                        // orphan — but only when the JAR actually went. A delete
+                        // here fails when the JVM holds a lock (Windows, JAR still
+                        // loaded), and stripping the sidecar off a JAR that is
+                        // staying would turn a signed plugin into an unsigned one.
+                        if (deleted) PluginSignatureSidecar.delete(oldFile.absolutePath)
                         logger.debug(
                             LogCategory.SYSTEM,
                             "Removed old version",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -303,6 +303,15 @@ object PluginStoreSetup {
                         ),
                     )
                     PluginStoreConfig.accessToken = token
+
+                    // Signature backfill waits for this token: the store's
+                    // install-permission gate 403s an unauthenticated caller, so
+                    // running it earlier would fail forever for exactly the
+                    // plugins that need it. Once per process — see
+                    // drainSidecarBackfill.
+                    if (token != null && sidecarBackfillStarted.compareAndSet(false, true)) {
+                        scope.launch { drainSidecarBackfill() }
+                    }
                 }
             }
 
@@ -457,7 +466,7 @@ object PluginStoreSetup {
                             scheduleBackgroundUpdateCheck(systemPlugin, jarFile)
                             // Reaches the installed base, which a download-only fix
                             // never would — see backfillSidecarIfMissing.
-                            backfillSidecarIfMissing(jarFile)
+                            backfillSidecarIfMissing(systemPlugin.pluginId, jarFile)
                             logger.debug(
                                 LogCategory.SYSTEM,
                                 "System plugin already installed",
@@ -767,7 +776,9 @@ object PluginStoreSetup {
      * working plugin into a permanent load failure. Writing no sidecar is strictly
      * safer than writing a wrong one, so every failure path clears instead.
      *
-     * [version] must be the bare version (no `v` prefix) to match the anchor.
+     * Callers must ensure no sidecar is present when this runs: on a manifest read
+     * failure it returns without touching the filesystem rather than clearing, so
+     * a transient read error can't strip a valid signature off a signed JAR.
      */
     private suspend fun persistStoreSignatureSidecar(jarFile: File) {
         // Key the lookup on the MANIFEST, not the GitHub tag. The store row's
@@ -779,23 +790,36 @@ object PluginStoreSetup {
         // leave the plugin permanently unsigned.
         val manifest = readPluginManifest(jarFile)
         if (manifest == null) {
+            // Return rather than clear. Both callers guarantee no sidecar is present
+            // here, so there is nothing to clean up — and clearing would mean a
+            // transient manifest read failure could unsign an already-signed JAR.
             logger.warn(
                 LogCategory.SYSTEM,
                 "System plugin left unsigned — manifest unreadable, cannot key the store lookup",
                 mapOf("file" to jarFile.name),
             )
-            runCatching { PluginSignatureSidecar.persist(jarFile.absolutePath, null) }
             return
         }
+
+        // Hashed once, up front, so the same digest both resolves the signature and
+        // proves afterwards that the bytes never moved underneath us.
+        val resolvedAgainstSha =
+            runCatching { sha256Of(jarFile) }.getOrElse {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "System plugin left unsigned — could not hash the JAR",
+                    mapOf("file" to jarFile.name, "error" to it.toString()),
+                )
+                return
+            }
 
         val signature =
             try {
                 val info = PluginStoreClient.getDownloadUrl(manifest.pluginId, manifest.version)
-                val localSha = sha256Of(jarFile)
                 resolveSidecarSignature(
                     storeSha256 = info.sha256,
                     storeSignature = info.signature,
-                    localSha256 = localSha,
+                    localSha256 = resolvedAgainstSha,
                 ).also {
                     if (it == null && info.signature != null) {
                         logger.warn(
@@ -805,7 +829,7 @@ object PluginStoreSetup {
                                 "pluginId" to manifest.pluginId,
                                 "version" to manifest.version,
                                 "storeSha256" to info.sha256,
-                                "localSha256" to localSha,
+                                "localSha256" to resolvedAgainstSha,
                             ),
                         )
                     }
@@ -836,7 +860,23 @@ object PluginStoreSetup {
                 null
             }
 
-        // PluginSignatureSidecar.write is documented best-effort, but writeText
+        // Bind only if the bytes are still the ones we resolved against. Resolving
+        // a signature involves a network round trip, and another path may replace
+        // the JAR at this exact filename meanwhile (a same-version re-download
+        // reuses the name). Writing then would pair an old signature with new
+        // bytes — present-but-invalid, a permanent load failure, and precisely the
+        // state this whole change exists to prevent. Re-hashing is cheap next to
+        // the round trip that preceded it.
+        if (signature != null && !stillMatchesResolvedBytes(jarFile, resolvedAgainstSha)) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "System plugin left unsigned — JAR changed while its signature was being fetched",
+                mapOf("pluginId" to manifest.pluginId, "version" to manifest.version),
+            )
+            return
+        }
+
+        // PluginSignatureSidecar.write is documented best-effort, but the write
         // throws on a full or read-only disk. Uncaught here it would propagate to
         // the download handler and be reported as a failed install — leaving the
         // JAR on disk with persistence never updated.
@@ -866,8 +906,22 @@ object PluginStoreSetup {
         localSha256: String,
     ): String? = if (storeSha256.equals(localSha256, ignoreCase = true)) storeSignature else null
 
+    /** True when [jarFile] still hashes to [expectedSha256]; false if it moved or is unreadable. */
+    private fun stillMatchesResolvedBytes(
+        jarFile: File,
+        expectedSha256: String,
+    ): Boolean = runCatching { sha256Of(jarFile).equals(expectedSha256, ignoreCase = true) }.getOrDefault(false)
+
+    /** JARs seen without a sidecar, drained once by [drainSidecarBackfill]. */
+    private val sidecarBackfillQueue = java.util.concurrent.ConcurrentLinkedQueue<Pair<String, File>>()
+
+    /** The drain runs at most once per process — see [drainSidecarBackfill]. */
+    private val sidecarBackfillStarted =
+        java.util.concurrent.atomic
+            .AtomicBoolean(false)
+
     /**
-     * Give an already-installed system plugin a sidecar it never got.
+     * Note an already-installed system plugin whose sidecar is missing.
      *
      * Without this the fix only reaches plugins that happen to be re-downloaded:
      * [ensureSystemPluginsInstalled] returns early once a JAR is on disk, and
@@ -875,12 +929,57 @@ object PluginStoreSetup {
      * exists. A user already up to date would stay unsigned forever and lose every
      * system plugin — Toolbox included — the moment enforcement flips.
      *
-     * Backgrounded: this is startup, and the result only matters for the next load.
+     * Only queues. The work is deferred to [drainSidecarBackfill] because doing it
+     * here would run unauthenticated (see that function) and would race the update
+     * check launched immediately before it.
      */
-    private fun backfillSidecarIfMissing(jarFile: File) {
+    private fun backfillSidecarIfMissing(
+        pluginId: String,
+        jarFile: File,
+    ) {
         if (PluginSignatureSidecar.read(jarFile.absolutePath) != null) return
-        scope.launch {
-            persistStoreSignatureSidecar(jarFile)
+        sidecarBackfillQueue.add(pluginId to jarFile)
+    }
+
+    /**
+     * Fetch signatures for queued JARs, once, after the store client is authenticated.
+     *
+     * Deferred rather than run at startup for three reasons, all of which made the
+     * naive version fail exactly where it mattered:
+     *
+     * - **Auth.** [PluginStoreConfig.accessToken] starts null and is only set when
+     *   `sessionStatus` emits, while `ensureSystemPluginsInstalled` runs from
+     *   `initialize()`. The download route 403s an unauthenticated caller for any
+     *   plugin with non-empty `requiredPermissions`, so backfilling at startup would
+     *   deterministically fail for precisely the plugins it targets — every launch,
+     *   forever, never producing a sidecar.
+     * - **Cost.** `getDownloadUrl` is not read-only; it books a row in
+     *   `plugin_downloads`, which feeds the store's default `sortBy = "downloads"`
+     *   ranking. Retrying every launch would fabricate a download per system plugin
+     *   per user forever. Running at most once per process bounds that. A
+     *   signature-only store route would remove it entirely — worth doing, but it's
+     *   an edge-function change and is tracked on BossConsole#102 rather than here.
+     * - **Races.** Draining serially, skipping any plugin whose update check is
+     *   still in flight, keeps this off the JARs [scheduleBackgroundUpdateCheck] is
+     *   replacing underneath it.
+     */
+    private suspend fun drainSidecarBackfill() {
+        withContext(Dispatchers.IO) {
+            while (true) {
+                val (pluginId, jarFile) = sidecarBackfillQueue.poll() ?: break
+
+                // The update path signs whatever it installs, so a JAR it is
+                // currently replacing needs nothing from us — and touching it is
+                // how an orphaned or mismatched sidecar gets created.
+                if (inFlightUpdateChecks[pluginId]?.get() == true) continue
+
+                // Re-check under current state: the JAR may have been replaced or
+                // removed between queueing and now.
+                if (!jarFile.exists()) continue
+                if (PluginSignatureSidecar.read(jarFile.absolutePath) != null) continue
+
+                persistStoreSignatureSidecar(jarFile)
+            }
         }
     }
 
@@ -1102,16 +1201,6 @@ object PluginStoreSetup {
                     )
                 }
 
-                // Bind the store signature to these bytes. Every OTHER install path
-                // writes a `<jar>.sig` sidecar; this one never did, so system
-                // plugins — api, Toolbox, the microkernel runtime, terminal-tab,
-                // editor-tab, fluck-browser — all sit on disk unsigned. That is
-                // invisible only while PluginSignatureEnforcement defaults to
-                // warn-and-allow; the moment it flips (BossConsole#102) every one
-                // of them stops loading. Written before persistence so a JAR is
-                // never registered as installed without its sidecar settled.
-                persistStoreSignatureSidecar(destFile)
-
                 // Register in persistence (skip for download-only plugins like microkernel runtime).
                 // Preserve the user's existing `enabled` choice and `sourceUrl` —
                 // `addInstalledPlugin` does removeIf+add, so passing the defaults
@@ -1130,6 +1219,23 @@ object PluginStoreSetup {
                         installedVersion = tagName.removePrefix("v"),
                     )
                 }
+
+                // Bind the store signature to these bytes. Every OTHER install path
+                // writes a `<jar>.sig` sidecar; this one never did, so system
+                // plugins — api, Toolbox, the microkernel runtime, terminal-tab,
+                // editor-tab, fluck-browser — all sit on disk unsigned. That is
+                // invisible only while PluginSignatureEnforcement defaults to
+                // warn-and-allow; the moment it flips (BossConsole#102) every one
+                // of them stops loading.
+                //
+                // Deliberately AFTER persistence, not before. This is a suspending
+                // network call, so putting it earlier would open the one window the
+                // comment above the move forbids — a JAR on disk that nothing knows
+                // is installed, if the scope is cancelled mid-fetch. There is no
+                // safety cost: the stale sidecar was already cleared before the
+                // move, so the intermediate state is *unsigned*, which is
+                // warn-and-allow by design.
+                persistStoreSignatureSidecar(destFile)
 
                 logger.info(
                     LogCategory.SYSTEM,
@@ -1164,7 +1270,7 @@ object PluginStoreSetup {
                         // here fails when the JVM holds a lock (Windows, JAR still
                         // loaded), and stripping the sidecar off a JAR that is
                         // staying would turn a signed plugin into an unsigned one.
-                        if (deleted) PluginSignatureSidecar.delete(oldFile.absolutePath)
+                        if (deleted) runCatching { PluginSignatureSidecar.delete(oldFile.absolutePath) }
                         logger.debug(
                             LogCategory.SYSTEM,
                             "Removed old version",
@@ -1176,6 +1282,11 @@ object PluginStoreSetup {
                     }
 
                 true
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Cancellation is not a download failure. Swallowing it here would
+                // both mislabel the log and break structured concurrency, since the
+                // caller would see `false` and carry on as though the scope lived.
+                throw e
             } catch (e: Exception) {
                 logger.error(
                     LogCategory.SYSTEM,
@@ -1529,7 +1640,7 @@ object PluginStoreSetup {
                     oldJar.delete()
                     // A sidecar outlives the JAR it describes unless it's removed
                     // with it, leaving orphaned `.sig` files in the plugin dir.
-                    PluginSignatureSidecar.delete(oldJar.absolutePath)
+                    runCatching { PluginSignatureSidecar.delete(oldJar.absolutePath) }
                 }
 
                 // Copy to plugin directory
@@ -1543,14 +1654,17 @@ object PluginStoreSetup {
                     ),
                 )
 
-                jarFile.copyTo(destFile, overwrite = true)
+                // Clear BEFORE the bytes change, for the same reason the download
+                // path does. Bundled JARs ship inside the signed, notarized app
+                // image and carry no store signature, and this overwrites by
+                // filename — so a store-downloaded JAR of the same name may have
+                // left a sidecar behind. Clearing afterwards would leave a crash
+                // window pairing the old signature with new bytes, which is a hard
+                // load failure, unlike no sidecar at all. `copyTo` is not atomic
+                // either, so the window is real.
+                runCatching { PluginSignatureSidecar.delete(destFile.absolutePath) }
 
-                // Bundled JARs ship inside the signed, notarized app image and carry
-                // no store signature. Clear rather than leave: this overwrites by
-                // filename, so a store-downloaded JAR of the same name may have left
-                // a sidecar behind — and a sidecar that doesn't match the bytes beside
-                // it is a hard load failure, unlike no sidecar at all.
-                PluginSignatureSidecar.persist(destFile.absolutePath, null)
+                jarFile.copyTo(destFile, overwrite = true)
 
                 logger.info(
                     LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -788,77 +788,25 @@ object PluginStoreSetup {
         // chain not guaranteed to agree. A repo tagging `release-1.2.3`, or the
         // `tag_name` regex missing and falling back to "unknown", would 404 and
         // leave the plugin permanently unsigned.
+        //
+        // Hashed once, up front, so the same digest both resolves the signature
+        // and proves afterwards that the bytes never moved underneath us.
         val manifest = readPluginManifest(jarFile)
-        if (manifest == null) {
-            // Return rather than clear. Both callers guarantee no sidecar is present
-            // here, so there is nothing to clean up — and clearing would mean a
-            // transient manifest read failure could unsign an already-signed JAR.
+        val resolvedAgainstSha = manifest?.let { runCatching { sha256Of(jarFile) }.getOrNull() }
+        if (manifest == null || resolvedAgainstSha == null) {
+            // Never clear here. Both callers guarantee no sidecar is present, so
+            // there is nothing to clean up — and clearing would let a transient
+            // read failure unsign an already-signed JAR.
             logger.warn(
                 LogCategory.SYSTEM,
-                "System plugin left unsigned — manifest unreadable, cannot key the store lookup",
+                "System plugin left unsigned — could not read or hash the JAR",
                 mapOf("file" to jarFile.name),
             )
             return
         }
 
-        // Hashed once, up front, so the same digest both resolves the signature and
-        // proves afterwards that the bytes never moved underneath us.
-        val resolvedAgainstSha =
-            runCatching { sha256Of(jarFile) }.getOrElse {
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "System plugin left unsigned — could not hash the JAR",
-                    mapOf("file" to jarFile.name, "error" to it.toString()),
-                )
-                return
-            }
-
-        val signature =
-            try {
-                val info = PluginStoreClient.getDownloadUrl(manifest.pluginId, manifest.version)
-                resolveSidecarSignature(
-                    storeSha256 = info.sha256,
-                    storeSignature = info.signature,
-                    localSha256 = resolvedAgainstSha,
-                ).also {
-                    if (it == null && info.signature != null) {
-                        logger.warn(
-                            LogCategory.SYSTEM,
-                            "System plugin left unsigned — GitHub asset differs from the store artifact",
-                            mapOf(
-                                "pluginId" to manifest.pluginId,
-                                "version" to manifest.version,
-                                "storeSha256" to info.sha256,
-                                "localSha256" to resolvedAgainstSha,
-                            ),
-                        )
-                    }
-                }
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                // Structured concurrency: a cancelled startup scope must not be
-                // reported as "no signature available" and must not fall through
-                // into persist().
-                throw e
-            } catch (e: Exception) {
-                // Store unreachable, no row for this version, a version published
-                // before store signing, or a 403 from the install-permission gate
-                // (PluginStoreConfig.accessToken is populated asynchronously from
-                // the session, so a first-run install can reach the store
-                // unauthenticated). Unsigned is the pre-existing state and is still
-                // warn-and-allow; a wrong signature would not be. Logged at warn
-                // because this is the signal for whether the fleet is ready for the
-                // enforcement flip — it must not be invisible by default.
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "System plugin left unsigned — no store signature available",
-                    mapOf(
-                        "pluginId" to manifest.pluginId,
-                        "version" to manifest.version,
-                        "error" to e.toString(),
-                    ),
-                )
-                null
-            }
+        val signature = fetchStoreSignature(manifest.pluginId, manifest.version, resolvedAgainstSha)
+        if (signature == null) return
 
         // Bind only if the bytes are still the ones we resolved against. Resolving
         // a signature involves a network round trip, and another path may replace
@@ -867,28 +815,76 @@ object PluginStoreSetup {
         // bytes — present-but-invalid, a permanent load failure, and precisely the
         // state this whole change exists to prevent. Re-hashing is cheap next to
         // the round trip that preceded it.
-        if (signature != null && !stillMatchesResolvedBytes(jarFile, resolvedAgainstSha)) {
+        if (!stillMatchesResolvedBytes(jarFile, resolvedAgainstSha)) {
             logger.warn(
                 LogCategory.SYSTEM,
                 "System plugin left unsigned — JAR changed while its signature was being fetched",
                 mapOf("pluginId" to manifest.pluginId, "version" to manifest.version),
             )
-            return
+        } else {
+            // The write is documented best-effort, but it throws on a full or
+            // read-only disk. Uncaught it would propagate to the download handler
+            // and be reported as a failed install — leaving the JAR on disk with
+            // persistence never updated.
+            runCatching { PluginSignatureSidecar.write(jarFile.absolutePath, signature) }
+                .onFailure {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Could not write plugin signature sidecar",
+                        mapOf("file" to jarFile.name, "error" to it.toString()),
+                    )
+                }
         }
-
-        // PluginSignatureSidecar.write is documented best-effort, but the write
-        // throws on a full or read-only disk. Uncaught here it would propagate to
-        // the download handler and be reported as a failed install — leaving the
-        // JAR on disk with persistence never updated.
-        runCatching { PluginSignatureSidecar.persist(jarFile.absolutePath, signature) }
-            .onFailure {
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "Could not write plugin signature sidecar",
-                    mapOf("file" to jarFile.name, "error" to it.toString()),
-                )
-            }
     }
+
+    /**
+     * Ask the store for the signature covering [localSha256], or null to leave the
+     * JAR unsigned. Never writes; the caller decides what to do with the answer.
+     */
+    private suspend fun fetchStoreSignature(
+        pluginId: String,
+        version: String,
+        localSha256: String,
+    ): String? =
+        try {
+            val info = PluginStoreClient.getDownloadUrl(pluginId, version)
+            resolveSidecarSignature(
+                storeSha256 = info.sha256,
+                storeSignature = info.signature,
+                localSha256 = localSha256,
+            ).also {
+                if (it == null && info.signature != null) {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "System plugin left unsigned — GitHub asset differs from the store artifact",
+                        mapOf(
+                            "pluginId" to pluginId,
+                            "version" to version,
+                            "storeSha256" to info.sha256,
+                            "localSha256" to localSha256,
+                        ),
+                    )
+                }
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Structured concurrency: a cancelled startup scope must not be
+            // reported as "no signature available" and must not fall through into
+            // a sidecar write.
+            throw e
+        } catch (e: Exception) {
+            // Store unreachable, no row for this version, a version published before
+            // store signing, or a 403 from the install-permission gate. Unsigned is
+            // the pre-existing state and is still warn-and-allow; a wrong signature
+            // would not be. Logged at warn because this is the signal for whether
+            // the fleet is ready for the enforcement flip — it must not be invisible
+            // by default.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "System plugin left unsigned — no store signature available",
+                mapOf("pluginId" to pluginId, "version" to version, "error" to e.toString()),
+            )
+            null
+        }
 
     /**
      * The policy: a store signature may be bound to a JAR **only** when the store
@@ -965,23 +961,28 @@ object PluginStoreSetup {
      */
     private suspend fun drainSidecarBackfill() {
         withContext(Dispatchers.IO) {
-            while (true) {
-                val (pluginId, jarFile) = sidecarBackfillQueue.poll() ?: break
-
-                // The update path signs whatever it installs, so a JAR it is
-                // currently replacing needs nothing from us — and touching it is
-                // how an orphaned or mismatched sidecar gets created.
-                if (inFlightUpdateChecks[pluginId]?.get() == true) continue
-
-                // Re-check under current state: the JAR may have been replaced or
-                // removed between queueing and now.
-                if (!jarFile.exists()) continue
-                if (PluginSignatureSidecar.read(jarFile.absolutePath) != null) continue
-
-                persistStoreSignatureSidecar(jarFile)
-            }
+            generateSequence { sidecarBackfillQueue.poll() }
+                .filter { (pluginId, jarFile) -> stillNeedsSidecar(pluginId, jarFile) }
+                .forEach { (_, jarFile) -> persistStoreSignatureSidecar(jarFile) }
         }
     }
+
+    /**
+     * Whether a queued JAR should still be backfilled, re-evaluated at drain time
+     * rather than when it was queued.
+     *
+     * The update path signs whatever it installs, so a JAR it is currently
+     * replacing needs nothing from us — and touching one mid-replacement is
+     * exactly how an orphaned or mismatched sidecar gets created. The JAR may also
+     * have been removed, or signed by another path, since queueing.
+     */
+    private fun stillNeedsSidecar(
+        pluginId: String,
+        jarFile: File,
+    ): Boolean =
+        inFlightUpdateChecks[pluginId]?.get() != true &&
+            jarFile.exists() &&
+            PluginSignatureSidecar.read(jarFile.absolutePath) == null
 
     /**
      * Download a system plugin from GitHub releases.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/PluginJarReconcilerSidecarTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/PluginJarReconcilerSidecarTest.kt
@@ -1,0 +1,100 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the invariant that a `.sig` never outlives the JAR it describes.
+ *
+ * An orphaned sidecar is not merely untidy: plugin JAR names repeat across
+ * install/uninstall cycles of the same version, so a leftover signature can end
+ * up beside different bytes — which the loader treats as present-but-invalid and
+ * hard-fails, unlike the benign missing-sidecar case.
+ */
+class PluginJarReconcilerSidecarTest {
+    private val temps = mutableListOf<File>()
+
+    @AfterTest
+    fun cleanup() {
+        temps.forEach { it.deleteRecursively() }
+    }
+
+    private fun tempPluginDir(): File =
+        File.createTempFile("reconcile-sidecar", "").let {
+            it.delete()
+            it.mkdirs()
+            temps.add(it)
+            it
+        }
+
+    private fun manifestJar(
+        dir: File,
+        fileName: String,
+        pluginId: String,
+        version: String,
+    ): File {
+        val jar = File(dir, fileName)
+        JarOutputStream(jar.outputStream()).use { out ->
+            out.putNextEntry(JarEntry("META-INF/boss-plugin/plugin.json"))
+            out.write(
+                """
+                {
+                  "manifestVersion": 1,
+                  "pluginId": "$pluginId",
+                  "displayName": "Reconciler Sidecar Test",
+                  "version": "$version",
+                  "apiVersion": "1.0.0",
+                  "mainClass": "com.example.Missing"
+                }
+                """.trimIndent().toByteArray(),
+            )
+            out.closeEntry()
+        }
+        return jar
+    }
+
+    @Test
+    fun `the losing duplicate's sidecar is removed with its jar`() {
+        val dir = tempPluginDir()
+        val pluginId = "ai.rever.boss.plugin.test.reconcile"
+        val older = manifestJar(dir, "test-plugin-1.0.0.jar", pluginId, "1.0.0")
+        val newer = manifestJar(dir, "test-plugin-2.0.0.jar", pluginId, "2.0.0")
+        PluginSignatureSidecar.write(older.absolutePath, "b2xkLXNpZw==")
+        PluginSignatureSidecar.write(newer.absolutePath, "bmV3LXNpZw==")
+
+        val result = PluginJarReconciler.reconcilePluginDir(dir)
+
+        assertTrue(result.deleted.contains(older.name), "expected the older JAR to be reconciled away")
+        assertFalse(older.exists(), "older JAR should be gone")
+        assertFalse(
+            File(PluginSignatureSidecar.pathFor(older.absolutePath)).exists(),
+            "the losing JAR's sidecar must not survive it",
+        )
+        assertTrue(newer.exists(), "winner JAR should survive")
+        assertTrue(
+            File(PluginSignatureSidecar.pathFor(newer.absolutePath)).exists(),
+            "the winner's sidecar must be left alone",
+        )
+    }
+
+    @Test
+    fun `a lone plugin keeps its sidecar`() {
+        val dir = tempPluginDir()
+        val jar = manifestJar(dir, "solo-plugin-1.0.0.jar", "ai.rever.boss.plugin.test.solo", "1.0.0")
+        PluginSignatureSidecar.write(jar.absolutePath, "c29sby1zaWc=")
+
+        PluginJarReconciler.reconcilePluginDir(dir)
+
+        assertTrue(jar.exists())
+        assertTrue(
+            File(PluginSignatureSidecar.pathFor(jar.absolutePath)).exists(),
+            "nothing was deleted, so nothing should have been unsigned",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/SidecarSignaturePolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/SidecarSignaturePolicyTest.kt
@@ -1,0 +1,71 @@
+package ai.rever.boss.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the rule that keeps the system-plugin install path safe: a store signature
+ * may be bound to a JAR only when the store agrees about those exact bytes.
+ *
+ * The asymmetry is the whole point and is easy to "simplify" away — a *missing*
+ * sidecar is warn-and-allow at load, while a *present but invalid* one hard-fails
+ * regardless of PluginSignatureEnforcement. System plugins are fetched from GitHub
+ * releases while signatures come from the store, and `POST /github` re-hosts JARs
+ * through Supabase Storage, so the two artifacts are not guaranteed to be identical
+ * bytes. Guessing turns a working plugin into a permanently unloadable one.
+ */
+class SidecarSignaturePolicyTest {
+    private val sig = "c2lnbmF0dXJl"
+    private val digest = "abc123def456"
+
+    @Test
+    fun `binds the signature when the store agrees about the bytes`() {
+        assertEquals(
+            sig,
+            PluginStoreSetup.resolveSidecarSignature(
+                storeSha256 = digest,
+                storeSignature = sig,
+                localSha256 = digest,
+            ),
+        )
+    }
+
+    @Test
+    fun `digest comparison is case-insensitive`() {
+        // The store returns lowercase hex and sha256Of is lowercase today, but the
+        // anchor is defined on the digest value, not its spelling — an uppercase
+        // digest must not silently drop a valid signature.
+        assertEquals(
+            sig,
+            PluginStoreSetup.resolveSidecarSignature(
+                storeSha256 = digest.uppercase(),
+                storeSignature = sig,
+                localSha256 = digest,
+            ),
+        )
+    }
+
+    @Test
+    fun `refuses to bind a signature to bytes the store does not vouch for`() {
+        assertNull(
+            PluginStoreSetup.resolveSidecarSignature(
+                storeSha256 = digest,
+                storeSignature = sig,
+                localSha256 = "0000000000000000",
+            ),
+        )
+    }
+
+    @Test
+    fun `an unsigned store row stays unsigned even on a digest match`() {
+        // Versions published before store signing have no signature at all.
+        assertNull(
+            PluginStoreSetup.resolveSidecarSignature(
+                storeSha256 = digest,
+                storeSignature = null,
+                localSha256 = digest,
+            ),
+        )
+    }
+}

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginSignatureEnforcement.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginSignatureEnforcement.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference
  * versions are warn-and-allow; note that until this flips, an attacker with
  * DB write access can null the signature column to land in the warn path, so
  * the control's full value materializes only with enforcement on (tracked in
- * BossConsole#872).
+ * BossConsole#102).
  *
  * Gated on configuration rather than a source edit so the flip (and a fast
  * rollback, e.g. if the backfill missed rows) doesn't require cutting a host
@@ -23,7 +23,7 @@ object PluginSignatureEnforcement {
     const val PROPERTY = "boss.plugin.signature.enforce"
     const val ENV_VAR = "BOSS_PLUGIN_SIGNATURE_ENFORCE"
 
-    private const val DEFAULT = false // flips to true per BossConsole#872
+    private const val DEFAULT = false // flips to true per BossConsole#102
 
     private val logger = BossLogger.forComponent("PluginSignatureEnforcement")
 

--- a/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginSignatureSidecar.kt
+++ b/plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginSignatureSidecar.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.plugin.loader
 
 import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 /**
  * A plugin's store signature travels to load time as a `<jar>.sig` sidecar —
@@ -33,12 +36,37 @@ object PluginSignatureSidecar {
         if (!signatureBase64.isNullOrBlank()) write(jarPath, signatureBase64) else delete(jarPath)
     }
 
-    /** Persist the base64 store signature beside [jarPath]. Best-effort. */
+    /**
+     * Persist the base64 store signature beside [jarPath]. Best-effort.
+     *
+     * Written to a temp file and moved into place rather than truncate-then-write:
+     * sidecars are now also written on a background scope *while* plugin loading
+     * reads them, and a read landing mid-write would see truncated base64 — which
+     * is a present-but-invalid signature, i.e. a hard load failure for that
+     * session, not the benign "no signature" case. The move is atomic where the
+     * filesystem supports it and falls back to a plain replace where it doesn't.
+     */
     fun write(
         jarPath: String,
         signatureBase64: String,
     ) {
-        File(pathFor(jarPath)).writeText(signatureBase64)
+        val target = File(pathFor(jarPath))
+        val tmp = File("${target.absolutePath}.tmp")
+        try {
+            tmp.writeText(signatureBase64)
+            try {
+                Files.move(
+                    tmp.toPath(),
+                    target.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE,
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+        } finally {
+            tmp.delete()
+        }
     }
 
     /** The stored base64 signature, or null when no sidecar exists. */

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
@@ -64,7 +64,7 @@ class RemotePluginRepository(
      * newest version should be — a DB-write attacker who bumps an older,
      * legitimately signed version's published_at can serve it as latest and
      * its anchor verifies fine. Accepted residual risk under the same
-     * DB-write threat model tracked in BossConsole#872.
+     * DB-write threat model tracked in BossConsole#102.
      *
      * A rejected artifact triggers [onVerificationFailure] (cleanup: delete
      * the downloaded file, purge the cache entry, …) before throwing; a


### PR DESCRIPTION
## The gap

A plugin's store signature reaches load time as a `<jar>.sig` sidecar. Every install path writes one — `RemotePluginRepository` on both the cache-hit and fresh-download branches (`:350`, `:419`), and Toolbox — **except** the one that installs every system plugin on first run. `PluginStoreSetup.downloadSystemPluginFromGitHub` had no notion of signatures at all (zero matches for `signature`/`sidecar` in the whole file).

So these all sit on disk unsigned right now:

`ai.rever.boss.plugin.api` · Toolbox · microkernel runtime · terminal-tab · editor-tab · fluck-browser

That's invisible today only because `PluginSignatureEnforcement.DEFAULT = false` makes a *missing* sidecar warn-and-allow. When #872 flips it, every system plugin installed by this path stops loading — **including Toolbox**, which is how a user would otherwise recover. This wants to land before the flip so sidecars are on disk fleet-wide by the time enforcement means anything.

## Why the sha256 check is load-bearing, not defensive

System plugins come from GitHub releases, not the store, so the signature must be fetched separately and bound to the bytes we actually downloaded.

The anchor is `pluginId|version|sha256` (`PluginStoreTrust.versionAnchor`), and **a present-but-invalid sidecar hard-fails at load time regardless of the enforcement flag** — unlike a missing one. `POST /github` re-hosts JARs through Supabase Storage, so the store artifact and the GitHub release asset are not guaranteed to be byte-identical. Pairing the store's signature with GitHub's bytes would convert a working plugin into a *permanent* load failure.

So every failure path clears the sidecar rather than guessing:

| Situation | Result |
|---|---|
| Store row found, sha256 matches | Write the signature |
| Store row found, sha256 **differs** | Clear, log a warning naming both digests |
| Store unreachable / no row / pre-signing version | Clear, log at debug |

Unsigned is the pre-existing state and is still tolerated. A wrong signature is not.

## Two adjacent cases of the same hazard

Both produce that present-but-invalid state on their own, independent of the gap above:

- **Bundled-plugin copy** (`copyBundledPluginsToPluginDir`) overwrites by filename with no regard for what was there. A bundled JAR landing where a store-downloaded JAR left a sidecar pairs an old signature with new bytes. Bundled JARs ship inside the signed, notarized app image and carry no store signature — so clear.
- **Both old-version cleanups** deleted JARs and left their `.sig` files behind as orphans.

## Verification

- `:composeApp:compileKotlinDesktop` + `ktlintCheck` — BUILD SUCCESSFUL
- `:composeApp:desktopTest` — BUILD SUCCESSFUL

**No unit test, deliberately.** This is filesystem-and-network wiring over primitives that are already covered (`PluginSignatureSidecarTest`, `LoadTimeSignatureVerificationTest`); a test asserting the branch logic would just restate the branch. The behaviour needs a live install to observe:

```bash
rm -rf ~/.boss/plugins/boss-plugin-terminal-tab-*.jar*   # force a fresh system-plugin install
# launch BOSS, then:
ls -la ~/.boss/plugins/*.sig                              # sidecars should now exist
```

Then confirm enforcement is actually satisfied by running with `-Dboss.plugin.signature.enforce=true` and checking every system plugin still loads. That last step is the one that matters and I have not run it — it needs a real app launch.

## Context

Found while planning the JxBrowser → plugin migration (that work would make the browser a system plugin too, so an unsigned system-plugin path becomes "no browser"). It's a pre-existing, independent problem, so it ships on its own.
