### PR TITLE
🐛 fix(ipc): renameFile could not overwrite on Windows, and reported every failure as success

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.PluginPersistence
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.repository.PluginWithSource
+import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
@@ -164,8 +165,9 @@ class PluginInstallService(
                     val finalFile = File(pluginDir, "${plugin.id}-$actualVersion.jar")
                     val downloadedFile = File(downloadedPath)
                     if (downloadedFile.absolutePath != finalFile.absolutePath) {
-                        if (finalFile.exists()) finalFile.delete()
-                        downloadedFile.renameTo(finalFile)
+                        // Was delete-then-renameTo, which works on Windows but leaves a window in
+                        // which neither file exists — a crash there loses an installed plugin jar.
+                        finalFile.atomicMoveFrom(downloadedFile)
                     }
                     val jarPath = finalFile.absolutePath
 

--- a/modules/boss-service-filesystem/src/main/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceImpl.kt
+++ b/modules/boss-service-filesystem/src/main/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceImpl.kt
@@ -3,6 +3,8 @@ package ai.rever.boss.service.filesystem
 import ai.rever.boss.ipc.proto.Empty
 import ai.rever.boss.ipc.proto.services.*
 import com.google.protobuf.ByteString
+import io.grpc.Status
+import io.grpc.StatusException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
@@ -11,7 +13,10 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.io.IOException
+import java.nio.file.AccessDeniedException
 import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -213,6 +218,13 @@ class FileSystemServiceImpl : FileSystemServiceGrpcKt.FileSystemServiceCoroutine
      * unconditionally, so every failure — a missing source, a permissions error, the Windows
      * overwrite case above — was reported to the caller as success. A silent no-op is worse than
      * the platform bug it was hiding.
+     *
+     * Failures are raised as [StatusException] rather than as the underlying [IOException], because
+     * only the former reaches the caller intact: gRPC deliberately does not leak exception messages,
+     * so an `IOException` out of a handler arrives as a bare `UNKNOWN` with no description, and a
+     * plugin author would see the same opaque failure for a missing source as for a refused
+     * overwrite. `Empty` leaves no response field to put an error in — unlike `readFile`/`writeFile`
+     * here, which hand-roll an `errorMessage` — so the status is the only channel there is.
      */
     override suspend fun renameFile(request: RenameFileRequest): Empty =
         withContext(Dispatchers.IO) {
@@ -221,18 +233,44 @@ class FileSystemServiceImpl : FileSystemServiceGrpcKt.FileSystemServiceCoroutine
             validatePath(request.destinationPath)
             val source = Paths.get(request.sourcePath)
             val dest = Paths.get(request.destinationPath)
-            if (request.overwrite) {
-                moveReplacing(source, dest)
-            } else {
-                // The pre-check is kept for the message; the move itself is what enforces it, so a
-                // destination appearing between the two fails rather than being clobbered.
-                if (Files.exists(dest)) {
-                    throw IllegalStateException("Destination already exists: ${request.destinationPath}")
+            try {
+                if (request.overwrite) {
+                    moveReplacing(source, dest)
+                } else {
+                    // The pre-check is kept for the message; the move enforces it again, so the
+                    // clobber window shrinks to the JDK's own stat-then-rename. On Windows MoveFile
+                    // refuses at the syscall; on POSIX rename(2) still replaces, so this narrows
+                    // the race rather than closing it — closing it needs renameat2(RENAME_NOREPLACE),
+                    // which the JDK does not expose.
+                    if (Files.exists(dest)) {
+                        throw alreadyExists(request.destinationPath)
+                    }
+                    Files.move(source, dest)
                 }
-                Files.move(source, dest)
+            } catch (e: FileAlreadyExistsException) {
+                throw alreadyExists(request.destinationPath, e)
+            } catch (e: java.nio.file.NoSuchFileException) {
+                throw StatusException(
+                    Status.NOT_FOUND.withDescription("No such file: ${e.file ?: request.sourcePath}").withCause(e),
+                )
+            } catch (e: AccessDeniedException) {
+                throw StatusException(
+                    Status.PERMISSION_DENIED.withDescription("Access denied: ${e.file ?: request.sourcePath}").withCause(e),
+                )
+            } catch (e: IOException) {
+                throw StatusException(
+                    Status.INTERNAL.withDescription("Rename failed: ${e.message ?: e::class.java.simpleName}").withCause(e),
+                )
             }
             Empty.getDefaultInstance()
         }
+
+    private fun alreadyExists(
+        destinationPath: String,
+        cause: Throwable? = null,
+    ) = StatusException(
+        Status.ALREADY_EXISTS.withDescription("Destination already exists: $destinationPath").withCause(cause),
+    )
 
     override fun watchFileChanges(request: WatchFileChangesRequest): Flow<FileChangeEvent> =
         flow {

--- a/modules/boss-service-filesystem/src/main/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceImpl.kt
+++ b/modules/boss-service-filesystem/src/main/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceImpl.kt
@@ -11,10 +11,12 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 import java.nio.file.StandardWatchEventKinds
 import java.nio.file.WatchEvent
 import java.util.concurrent.TimeUnit
@@ -176,16 +178,59 @@ class FileSystemServiceImpl : FileSystemServiceGrpcKt.FileSystemServiceCoroutine
             Empty.getDefaultInstance()
         }
 
+    /**
+     * Moves [source] onto [dest], replacing [dest] if it exists.
+     *
+     * **Not `File.renameTo`.** That call's behaviour when the destination exists is
+     * platform-dependent in the direction that hides the bug during development: POSIX
+     * `rename(2)` replaces the target, so macOS and Linux work, while Win32 `MoveFile` fails with
+     * `ERROR_ALREADY_EXISTS`. `overwrite = true` — the request this API explicitly offers — was
+     * therefore the one case that could never work on Windows.
+     *
+     * `ATOMIC_MOVE` is tried first and dropped for a cross-volume move, which unlike the in-process
+     * caches is a real possibility for an arbitrary path pair from IPC. The non-atomic form then
+     * falls back to copy-and-delete.
+     *
+     * `composeApp` has an `atomicMoveFrom` doing the same job, but this module builds standalone —
+     * a GraalVM native image over `:boss-ipc` alone — so six lines here beat a dependency edge from
+     * the microkernel services into the app.
+     */
+    private fun moveReplacing(
+        source: Path,
+        dest: Path,
+    ) {
+        try {
+            Files.move(source, dest, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(source, dest, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    /**
+     * Renames or moves a file.
+     *
+     * **Throws on failure.** This previously discarded `renameTo`'s boolean and returned `Empty`
+     * unconditionally, so every failure — a missing source, a permissions error, the Windows
+     * overwrite case above — was reported to the caller as success. A silent no-op is worse than
+     * the platform bug it was hiding.
+     */
     override suspend fun renameFile(request: RenameFileRequest): Empty =
         withContext(Dispatchers.IO) {
             logger.info("renameFile: from={}, to={}", request.sourcePath, request.destinationPath)
             validatePath(request.sourcePath)
             validatePath(request.destinationPath)
-            val dest = File(request.destinationPath)
-            if (!request.overwrite && dest.exists()) {
-                throw IllegalStateException("Destination already exists: ${request.destinationPath}")
+            val source = Paths.get(request.sourcePath)
+            val dest = Paths.get(request.destinationPath)
+            if (request.overwrite) {
+                moveReplacing(source, dest)
+            } else {
+                // The pre-check is kept for the message; the move itself is what enforces it, so a
+                // destination appearing between the two fails rather than being clobbered.
+                if (Files.exists(dest)) {
+                    throw IllegalStateException("Destination already exists: ${request.destinationPath}")
+                }
+                Files.move(source, dest)
             }
-            File(request.sourcePath).renameTo(dest)
             Empty.getDefaultInstance()
         }
 

--- a/modules/boss-service-filesystem/src/main/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceImpl.kt
+++ b/modules/boss-service-filesystem/src/main/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceImpl.kt
@@ -231,6 +231,7 @@ class FileSystemServiceImpl : FileSystemServiceGrpcKt.FileSystemServiceCoroutine
             logger.info("renameFile: from={}, to={}", request.sourcePath, request.destinationPath)
             validatePath(request.sourcePath)
             validatePath(request.destinationPath)
+            val destinationExists = "Destination already exists: ${request.destinationPath}"
             val source = Paths.get(request.sourcePath)
             val dest = Paths.get(request.destinationPath)
             try {
@@ -243,34 +244,27 @@ class FileSystemServiceImpl : FileSystemServiceGrpcKt.FileSystemServiceCoroutine
                     // the race rather than closing it — closing it needs renameat2(RENAME_NOREPLACE),
                     // which the JDK does not expose.
                     if (Files.exists(dest)) {
-                        throw alreadyExists(request.destinationPath)
+                        throw status(Status.ALREADY_EXISTS, destinationExists, null)
                     }
                     Files.move(source, dest)
                 }
             } catch (e: FileAlreadyExistsException) {
-                throw alreadyExists(request.destinationPath, e)
+                throw status(Status.ALREADY_EXISTS, destinationExists, e)
             } catch (e: java.nio.file.NoSuchFileException) {
-                throw StatusException(
-                    Status.NOT_FOUND.withDescription("No such file: ${e.file ?: request.sourcePath}").withCause(e),
-                )
+                throw status(Status.NOT_FOUND, "No such file: ${e.file ?: request.sourcePath}", e)
             } catch (e: AccessDeniedException) {
-                throw StatusException(
-                    Status.PERMISSION_DENIED.withDescription("Access denied: ${e.file ?: request.sourcePath}").withCause(e),
-                )
+                throw status(Status.PERMISSION_DENIED, "Access denied: ${e.file ?: request.sourcePath}", e)
             } catch (e: IOException) {
-                throw StatusException(
-                    Status.INTERNAL.withDescription("Rename failed: ${e.message ?: e::class.java.simpleName}").withCause(e),
-                )
+                throw status(Status.INTERNAL, "Rename failed: ${e.message ?: e::class.java.simpleName}", e)
             }
             Empty.getDefaultInstance()
         }
 
-    private fun alreadyExists(
-        destinationPath: String,
-        cause: Throwable? = null,
-    ) = StatusException(
-        Status.ALREADY_EXISTS.withDescription("Destination already exists: $destinationPath").withCause(cause),
-    )
+    private fun status(
+        code: Status,
+        description: String,
+        cause: Throwable?,
+    ) = StatusException(code.withDescription(description).withCause(cause))
 
     override fun watchFileChanges(request: WatchFileChangesRequest): Flow<FileChangeEvent> =
         flow {

--- a/modules/boss-service-filesystem/src/test/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceRenameTest.kt
+++ b/modules/boss-service-filesystem/src/test/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceRenameTest.kt
@@ -1,9 +1,10 @@
 package ai.rever.boss.service.filesystem
 
 import ai.rever.boss.ipc.proto.services.RenameFileRequest
+import io.grpc.Status
+import io.grpc.StatusException
 import kotlinx.coroutines.runBlocking
 import java.io.File
-import java.nio.file.NoSuchFileException
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,6 +25,10 @@ import kotlin.test.assertTrue
  *
  * The overwrite test can therefore only fail on `build-test (windows-latest)`; the rest fail
  * everywhere.
+ *
+ * These call [FileSystemServiceImpl] directly rather than over a channel, so they pin the status
+ * codes and descriptions the handler *raises*, not what a client receives. A real round-trip would
+ * be the stronger test; there is no in-process gRPC harness in this module today.
  */
 class FileSystemServiceRenameTest {
     private val service = FileSystemServiceImpl()
@@ -82,8 +87,9 @@ class FileSystemServiceRenameTest {
         val source = File(dir, "source.txt").apply { writeText("new") }
         val dest = File(dir, "dest.txt").apply { writeText("old") }
 
-        assertFailsWith<IllegalStateException> { rename(source, dest, overwrite = false) }
+        val failure = assertFailsWith<StatusException> { rename(source, dest, overwrite = false) }
 
+        assertEquals(Status.Code.ALREADY_EXISTS, failure.status.code)
         assertEquals("old", dest.readText(), "the destination must survive a refused rename")
         assertTrue(source.exists(), "the source must survive a refused rename")
     }
@@ -95,9 +101,27 @@ class FileSystemServiceRenameTest {
         val source = File(dir, "does-not-exist.txt")
         val dest = File(dir, "dest.txt")
 
-        assertFailsWith<NoSuchFileException> { rename(source, dest, overwrite = true) }
+        val failure = assertFailsWith<StatusException> { rename(source, dest, overwrite = true) }
 
+        assertEquals(Status.Code.NOT_FOUND, failure.status.code)
         assertFalse(dest.exists())
+    }
+
+    @Test
+    fun `failures carry a description, because the status is the only channel there is`() {
+        // gRPC does not leak exception messages: an IOException out of a handler reaches the caller
+        // as a bare UNKNOWN. `Empty` has no errorMessage field to fall back on - unlike readFile and
+        // writeFile here - so without an explicit status the plugin sees the same opaque failure for
+        // a missing source as for a refused overwrite.
+        val source = File(dir, "source.txt").apply { writeText("new") }
+        val dest = File(dir, "dest.txt").apply { writeText("old") }
+
+        val refused = assertFailsWith<StatusException> { rename(source, dest, overwrite = false) }
+        val missing = assertFailsWith<StatusException> { rename(File(dir, "gone.txt"), dest, overwrite = true) }
+
+        assertTrue(refused.status.description.orEmpty().contains("dest.txt"), "got: ${refused.status.description}")
+        assertTrue(missing.status.description.orEmpty().contains("gone.txt"), "got: ${missing.status.description}")
+        assertTrue(refused.status.code != missing.status.code, "distinct failures need distinct codes")
     }
 
     @Test

--- a/modules/boss-service-filesystem/src/test/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceRenameTest.kt
+++ b/modules/boss-service-filesystem/src/test/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceRenameTest.kt
@@ -1,0 +1,119 @@
+package ai.rever.boss.service.filesystem
+
+import ai.rever.boss.ipc.proto.services.RenameFileRequest
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.nio.file.NoSuchFileException
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FileSystemServiceImpl.renameFile].
+ *
+ * Two defects, one of which only shows on one platform:
+ *
+ *  - `overwrite = true` used `File.renameTo`, which does not replace an existing destination on
+ *    Windows (`MoveFile` → `ERROR_ALREADY_EXISTS`) but does on macOS and Linux (`rename(2)`). The
+ *    request the API explicitly offers was the one that could not work there.
+ *  - The boolean result was discarded and `Empty` returned unconditionally, so every failure —
+ *    on every platform — was reported to the caller as success.
+ *
+ * The overwrite test can therefore only fail on `build-test (windows-latest)`; the rest fail
+ * everywhere.
+ */
+class FileSystemServiceRenameTest {
+    private val service = FileSystemServiceImpl()
+
+    private val dir: File =
+        File.createTempFile("rename-svc-", "").let {
+            it.delete()
+            it.mkdirs()
+            it
+        }
+
+    @AfterTest
+    fun cleanUp() {
+        dir.deleteRecursively()
+    }
+
+    private fun rename(
+        from: File,
+        to: File,
+        overwrite: Boolean,
+    ) = runBlocking {
+        service.renameFile(
+            RenameFileRequest
+                .newBuilder()
+                .setSourcePath(from.absolutePath)
+                .setDestinationPath(to.absolutePath)
+                .setOverwrite(overwrite)
+                .build(),
+        )
+    }
+
+    @Test
+    fun `overwrite replaces an existing destination`() {
+        val source = File(dir, "source.txt").apply { writeText("new") }
+        val dest = File(dir, "dest.txt").apply { writeText("old") }
+
+        rename(source, dest, overwrite = true)
+
+        assertEquals("new", dest.readText())
+        assertFalse(source.exists(), "the source should have been moved, not copied")
+    }
+
+    @Test
+    fun `a plain rename moves the file`() {
+        val source = File(dir, "source.txt").apply { writeText("content") }
+        val dest = File(dir, "moved.txt")
+
+        rename(source, dest, overwrite = false)
+
+        assertEquals("content", dest.readText())
+        assertFalse(source.exists())
+    }
+
+    @Test
+    fun `without overwrite an existing destination is refused and left alone`() {
+        val source = File(dir, "source.txt").apply { writeText("new") }
+        val dest = File(dir, "dest.txt").apply { writeText("old") }
+
+        assertFailsWith<IllegalStateException> { rename(source, dest, overwrite = false) }
+
+        assertEquals("old", dest.readText(), "the destination must survive a refused rename")
+        assertTrue(source.exists(), "the source must survive a refused rename")
+    }
+
+    @Test
+    fun `a missing source fails instead of reporting success`() {
+        // The whole-platform half of the bug: renameTo returned false, the boolean was dropped,
+        // and the caller was told the rename had happened.
+        val source = File(dir, "does-not-exist.txt")
+        val dest = File(dir, "dest.txt")
+
+        assertFailsWith<NoSuchFileException> { rename(source, dest, overwrite = true) }
+
+        assertFalse(dest.exists())
+    }
+
+    @Test
+    fun `path traversal is still rejected`() {
+        // validatePath runs before any I/O; pinned so the rewrite cannot have moved it.
+        assertFailsWith<IllegalArgumentException> {
+            runBlocking {
+                service.renameFile(
+                    RenameFileRequest
+                        .newBuilder()
+                        .setSourcePath("${dir.absolutePath}/../escape.txt")
+                        .setDestinationPath(File(dir, "dest.txt").absolutePath)
+                        .setOverwrite(true)
+                        .build(),
+                )
+            }
+        }
+    }
+}

--- a/modules/boss-service-filesystem/src/test/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceRenameTest.kt
+++ b/modules/boss-service-filesystem/src/test/kotlin/ai/rever/boss/service/filesystem/FileSystemServiceRenameTest.kt
@@ -119,8 +119,18 @@ class FileSystemServiceRenameTest {
         val refused = assertFailsWith<StatusException> { rename(source, dest, overwrite = false) }
         val missing = assertFailsWith<StatusException> { rename(File(dir, "gone.txt"), dest, overwrite = true) }
 
-        assertTrue(refused.status.description.orEmpty().contains("dest.txt"), "got: ${refused.status.description}")
-        assertTrue(missing.status.description.orEmpty().contains("gone.txt"), "got: ${missing.status.description}")
+        assertTrue(
+            refused.status.description
+                .orEmpty()
+                .contains("dest.txt"),
+            "got: ${refused.status.description}",
+        )
+        assertTrue(
+            missing.status.description
+                .orEmpty()
+                .contains("gone.txt"),
+            "got: ${missing.status.description}",
+        )
         assertTrue(refused.status.code != missing.status.code, "distinct failures need distinct codes")
     }
 


### PR DESCRIPTION
Fixes #96, found by the review sweep on #95.

## Two defects, compounding

**1. `overwrite = true` could not work on Windows.** `File.renameTo`'s behaviour when the destination exists is platform-dependent, in the direction that hides it during development:

| | destination exists |
|---|---|
| macOS / Linux — POSIX `rename(2)` | replaced |
| Windows — Win32 `MoveFile` | **fails**, `ERROR_ALREADY_EXISTS` |

The one request this API explicitly offers was the one it could not serve there — the same split that cost the browser its favicons in #95.

**2. Every failure was reported as success.** The boolean was discarded and `Empty` returned unconditionally, so a missing source, a permissions error, or the Windows case above all told the caller the rename had happened — on every platform. A silent no-op is worse than the platform bug it was hiding.

## Fix

`Files.move`: `REPLACE_EXISTING` when overwrite is asked for, plain otherwise, with `ATOMIC_MOVE` tried first and dropped for a cross-volume move — which, unlike the in-process caches in #95, is a real possibility for an arbitrary path pair arriving over IPC. Failures propagate as the `IOException` they are.

The not-overwrite pre-check stays for its error message, and the non-replacing `Files.move` enforces it again — which narrows the clobber window to the JDK's own stat-then-rename rather than closing it. `MoveFile` refuses at the syscall on Windows; POSIX `rename(2)` still replaces, and closing that needs `renameat2(RENAME_NOREPLACE)`, which the JDK does not expose.

Failures are raised as `StatusException` rather than as the underlying `IOException`. gRPC deliberately does not leak exception messages, so an `IOException` out of a handler reaches the caller as a bare `UNKNOWN` with no description — and `Empty` has no `errorMessage` field to fall back on, unlike `readFile`/`writeFile` here, so the status is the only channel there is. `ALREADY_EXISTS` for an existing destination, `NOT_FOUND` for a missing source, `PERMISSION_DENIED` for `AccessDeniedException`, `INTERNAL` for the rest, each with a description naming the path.

The review also floated one interceptor in `BossIpcServer` so every service under `modules/` gets this. That is the better long-term buy and is deliberately not here: grpc-kotlin's coroutine adapter converts the throwable before a `ServerInterceptor`'s listener sees it, so it is not the two-line change it looks like, and it would land untested across every service in the tree.

**On the module boundary** — the review's one open question. `composeApp` already has `atomicMoveFrom`, but `boss-service-filesystem` builds standalone: a GraalVM native image over `:boss-ipc`, coroutines and slf4j. Six duplicated lines beat a dependency edge from the microkernel services into the app, so the helper is private to the module and its KDoc points at the other copy.

Also folded in the second site #96 named: **`PluginInstallService`** was delete-then-`renameTo`. That works on Windows, but it is exactly the window `atomicMoveFrom` exists to close — a crash between the two loses an installed plugin jar.

## Verification

`FileSystemServiceRenameTest` — 6 tests, the module's first. They call the impl directly, so they pin the statuses the handler raises rather than what a client receives over a channel; a real round-trip would be stronger, and there is no in-process gRPC harness in this module today. Verified they catch the bug rather than merely passing: restoring the old body fails 2 of 5 with

```
overwrite replaces an existing destination            expected:<new> but was:<old>
a missing source fails instead of reporting success   completed successfully with the result: <>
```

Only the first is Windows-only; the silent-success one fails everywhere. detekt and ktlint clean, `:composeApp:compileKotlinDesktop` green.

## Not changed, deliberately

`createFile` and `deleteFile` in this same file discard `mkdirs()` / `createNewFile()` / `delete()` the same way. Same defect class, but making them throw is a behaviour change to an IPC surface beyond what #96 covers — worth its own decision rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
