### PR TITLE
🔒 fix(crash): sanitize the submit-failure message with the right sanitizer

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -395,10 +395,10 @@ internal fun CrashReportDialog(
 
                 if (bodyOverflows) {
                     // Marks the clipped edge. Overlaid rather than stacked below the body so it
-                    // costs no height — see the footer comment.
+                    // costs no layout height — see the footer comment.
                     Divider(
                         color = BossTheme.colors.line,
-                        modifier = Modifier.align(Alignment.BottomCenter),
+                        modifier = Modifier.align(Alignment.BottomStart).testTag(BOUNDARY_RULE_TAG),
                     )
                     VerticalScrollbar(
                         modifier =
@@ -421,6 +421,36 @@ internal fun CrashReportDialog(
 
             // Submit result message
             submitResult?.let { result ->
+                // Keyed on the result, not recomputed per composition: userNotes is read in this
+                // same restartable scope, so every keystroke in the notes field recomposes the
+                // whole dialog — and this runs several regex passes over a string a TLS or proxy
+                // error can make arbitrarily long.
+                val resultMessage =
+                    remember(result) {
+                        when (result) {
+                            is CrashReportService.SubmitResult.Success -> {
+                                if (result.isNewIssue) {
+                                    "Issue created successfully!"
+                                } else {
+                                    "Added to existing issue."
+                                }
+                            }
+
+                            is CrashReportService.SubmitResult.Error -> {
+                                // The text most likely to end up pasted into a public issue, and it
+                                // interpolates a raw exception message.
+                                //
+                                // sanitizeExceptionMessage, not maskUriParams: the latter redacts
+                                // named params inside a `?`/`#` segment, and the case that
+                                // motivates sanitizing here has neither — "Request timeout has
+                                // expired [url=https://…, …]" passed through verbatim. This is also
+                                // what the rest of the window already gets: CrashHandler runs the
+                                // exception message and stack trace through the same function
+                                // before they reach CrashReport.
+                                LogSanitizer.sanitizeExceptionMessage(result.message)
+                            }
+                        }
+                    }
                 Card(
                     backgroundColor =
                         when (result) {
@@ -436,32 +466,7 @@ internal fun CrashReportDialog(
                     // full exception (CrashReportService), which is where it survives.
                     SelectionContainer {
                         Text(
-                            text =
-                                when (result) {
-                                    is CrashReportService.SubmitResult.Success -> {
-                                        if (result.isNewIssue) {
-                                            "Issue created successfully!"
-                                        } else {
-                                            "Added to existing issue."
-                                        }
-                                    }
-
-                                    is CrashReportService.SubmitResult.Error -> {
-                                        // The text most likely to end up pasted into a public
-                                        // issue, and it interpolates a raw exception message.
-                                        //
-                                        // sanitizeExceptionMessage, not maskUriParams: the latter
-                                        // redacts named params inside a `?`/`#` segment, and the
-                                        // case that motivates sanitizing here has neither —
-                                        // "Request timeout has expired [url=https://…, …]" would
-                                        // have passed through verbatim. This is also what the rest
-                                        // of the window already gets: CrashHandler runs the
-                                        // exception message and stack trace through the same
-                                        // function before they reach CrashReport, so the card is no
-                                        // longer the one string held to a weaker standard.
-                                        LogSanitizer.sanitizeExceptionMessage(result.message)
-                                    }
-                                },
+                            text = resultMessage,
                             fontSize = 13.sp,
                             color = BossTheme.colors.onSignal,
                             // This text is the one part of the footer whose length isn't ours: the
@@ -592,6 +597,9 @@ internal fun CrashReportDialog(
 
 /** Present only while the body is clipping content; see `isClipping`. */
 internal const val BODY_SCROLLBAR_TAG = "crash-dialog-body-scrollbar"
+
+/** The rule marking a clipped body edge. Overlaid, so it must never consume layout height. */
+internal const val BOUNDARY_RULE_TAG = "crash-dialog-boundary-rule"
 
 /** Present only while the stack trace pane is clipping content; see `isClipping`. */
 internal const val TRACE_SCROLLBAR_TAG = "crash-dialog-trace-scrollbar"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -452,13 +452,21 @@ internal fun CrashReportDialog(
                                 // exception message and stack trace through the same function
                                 // before they reach CrashReport.
                                 //
-                                // Trade accepted: [PATH] takes the host with it, so a DNS, proxy or
-                                // endpoint failure no longer names the endpoint *here* — only in
-                                // the log. The diagnostic half survives ("Request timeout has
-                                // expired", and request_timeout=… since neither `request` nor
-                                // `timeout` marks a secret), which is what makes this narrower than
-                                // a blunt redaction. A blank message also renders "[no message]"
-                                // rather than an empty card.
+                                // Scope, measured rather than assumed: a host is removed when it
+                                // appears *inside a URL* — filePathPattern swallows everything after
+                                // the scheme colon, which covers ktor's `[url=…]` messages. A bare
+                                // host does not match any location pattern and renders verbatim:
+                                // UnknownHostException.getMessage() is just the hostname, so
+                                // "Failed to submit crash report: proxy.corp.internal" survives
+                                // intact. Harmless for our own public endpoint, not necessarily so
+                                // for a corporate proxy — see #109.
+                                //
+                                // Cost of what it does remove: the endpoint is no longer named
+                                // here, only in the log. The diagnostic half survives ("Request
+                                // timeout has expired", and request_timeout=… since neither
+                                // `request` nor `timeout` marks a secret), which keeps this
+                                // narrower than a blunt redaction. A blank message renders
+                                // "[no message]" where maskUriParams gave "[empty]".
                                 LogSanitizer.sanitizeExceptionMessage(result.message)
                             }
                         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -98,11 +98,10 @@ internal fun CrashReportDialog(
     // the sentinel keeps that first frame honest; derivedStateOf keeps a settling `maxValue` from
     // recomposing the whole dialog when the answer hasn't actually flipped.
     //
-    // Note the one remaining feedback path: `bodyOverflows` adds the rule and its spacer to the
-    // footer, which takes ~17dp from the body, which can only make it *more* likely to overflow.
-    // Monotone, so it cannot oscillate — but it can latch, so content within ~17dp of fitting may
-    // keep its scrollbar after the details collapse again. That is why nothing gated on this may
-    // ever change the body's *width*: narrower is taller, and a second monotone path compounds it.
+    // Nothing gated on this may change the body's size, in either axis. Both the scrollbar and the
+    // boundary rule are overlays inside the body for that reason: a gated element that consumed
+    // layout space would feed back into the measurement deciding whether to show it — monotone, so
+    // never oscillating, but able to latch overflow on for content that sits near the boundary.
     val bodyOverflows by remember { derivedStateOf { bodyScrollState.isClipping() } }
     val traceOverflows by remember { derivedStateOf { stackTraceScrollState.isClipping() } }
 
@@ -395,6 +394,12 @@ internal fun CrashReportDialog(
                 }
 
                 if (bodyOverflows) {
+                    // Marks the clipped edge. Overlaid rather than stacked below the body so it
+                    // costs no height — see the footer comment.
+                    Divider(
+                        color = BossTheme.colors.line,
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                    )
                     VerticalScrollbar(
                         modifier =
                             Modifier
@@ -408,14 +413,10 @@ internal fun CrashReportDialog(
             }
 
             // Pinned footer — the submit result and the action buttons stay visible regardless of
-            // how much the body above has grown or scrolled. The rule is only drawn when the body
-            // is actually clipping something, where it marks the scroll boundary; without it the
-            // footer would look like a stray divider floating in empty space.
-            if (bodyOverflows) {
-                Spacer(modifier = Modifier.height(16.dp))
-                Divider(color = BossTheme.colors.line)
-            }
-
+            // how much the body above has grown or scrolled. The rule marking the scroll boundary
+            // is drawn as an overlay at the bottom of the body above, not as a sibling here: as a
+            // sibling it took ~17dp from the body, and gating that on bodyOverflows fed back into
+            // the measurement deciding it. Same visual, no layout height, no feedback path.
             Spacer(modifier = Modifier.height(16.dp))
 
             // Submit result message
@@ -447,10 +448,18 @@ internal fun CrashReportDialog(
 
                                     is CrashReportService.SubmitResult.Error -> {
                                         // The text most likely to end up pasted into a public
-                                        // issue, and it interpolates a raw exception message —
-                                        // ktor's routinely carry the request URL. The unmasked
-                                        // form still reaches the log, which is where it belongs.
-                                        LogSanitizer.maskUriParams(result.message)
+                                        // issue, and it interpolates a raw exception message.
+                                        //
+                                        // sanitizeExceptionMessage, not maskUriParams: the latter
+                                        // redacts named params inside a `?`/`#` segment, and the
+                                        // case that motivates sanitizing here has neither —
+                                        // "Request timeout has expired [url=https://…, …]" would
+                                        // have passed through verbatim. This is also what the rest
+                                        // of the window already gets: CrashHandler runs the
+                                        // exception message and stack trace through the same
+                                        // function before they reach CrashReport, so the card is no
+                                        // longer the one string held to a weaker standard.
+                                        LogSanitizer.sanitizeExceptionMessage(result.message)
                                     }
                                 },
                             fontSize = 13.sp,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -282,7 +282,8 @@ internal fun CrashReportDialog(
                                             modifier =
                                                 Modifier
                                                     .fillMaxWidth()
-                                                    .heightIn(max = 200.dp)
+                                                    .heightIn(max = TRACE_PANE_MAX_HEIGHT)
+                                                    .testTag(TRACE_PANE_TAG)
                                                     .background(
                                                         BossTheme.colors.panel,
                                                         RoundedCornerShape(4.dp),
@@ -395,7 +396,10 @@ internal fun CrashReportDialog(
 
                 if (bodyOverflows) {
                     // Marks the clipped edge. Overlaid rather than stacked below the body so it
-                    // costs no layout height — see the footer comment.
+                    // costs no layout height — see the footer comment. Same *position* as the old
+                    // sibling rule (the body is at its cap, so the ~17dp freed from the footer goes
+                    // straight back to it), but body content now runs right up to the rule instead
+                    // of leaving a 16dp gap above it.
                     Divider(
                         color = BossTheme.colors.line,
                         modifier = Modifier.align(Alignment.BottomStart).testTag(BOUNDARY_RULE_TAG),
@@ -447,6 +451,14 @@ internal fun CrashReportDialog(
                                 // what the rest of the window already gets: CrashHandler runs the
                                 // exception message and stack trace through the same function
                                 // before they reach CrashReport.
+                                //
+                                // Trade accepted: [PATH] takes the host with it, so a DNS, proxy or
+                                // endpoint failure no longer names the endpoint *here* — only in
+                                // the log. The diagnostic half survives ("Request timeout has
+                                // expired", and request_timeout=… since neither `request` nor
+                                // `timeout` marks a secret), which is what makes this narrower than
+                                // a blunt redaction. A blank message also renders "[no message]"
+                                // rather than an empty card.
                                 LogSanitizer.sanitizeExceptionMessage(result.message)
                             }
                         }
@@ -600,6 +612,21 @@ internal const val BODY_SCROLLBAR_TAG = "crash-dialog-body-scrollbar"
 
 /** The rule marking a clipped body edge. Overlaid, so it must never consume layout height. */
 internal const val BOUNDARY_RULE_TAG = "crash-dialog-boundary-rule"
+
+/** The bounded stack-trace viewport. Tagged so a test can measure the cap itself, not its inner content. */
+internal const val TRACE_PANE_TAG = "crash-dialog-trace-pane"
+
+/**
+ * Height cap on the stack-trace viewport. Bounded so a deep trace takes its own overflow instead of
+ * making the body an endless scroll. Shared with the test rather than duplicated, so moving the cap
+ * can't leave an assertion validating the old number.
+ *
+ * Do not remove it as cosmetic: this pane's `verticalScroll` sits inside the body's, which hands
+ * down an unbounded max height. The `heightIn` is what bounds it, and without it the dialog throws
+ * "Vertically scrollable component was measured with an infinity maximum height constraints"
+ * (confirmed by deleting it — eight tests fail on that, not on a size assertion).
+ */
+internal val TRACE_PANE_MAX_HEIGHT = 200.dp
 
 /** Present only while the stack trace pane is clipping content; see `isClipping`. */
 internal const val TRACE_SCROLLBAR_TAG = "crash-dialog-trace-scrollbar"

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
+import kotlin.math.abs
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -56,11 +57,14 @@ class CrashReportDialogLayoutTest {
          * direction — the alternative, assuming the frame minimum is also the content minimum,
          * validates against headroom no user has.
          */
-
         val WORST_CASE_DECORATION_HEIGHT = 40.dp
         val WORST_CASE_DECORATION_WIDTH = 16.dp
 
-        /** The rule's own 1dp thickness, so "ends at the body's edge" isn't a strict equality. */
+        /**
+         * dp-to-px rounding slack. Both edges compared are anchored to the same Box — the rule by
+         * `Alignment.BottomStart`, the scrollbar by `fillMaxHeight()` — so they land on the same
+         * bottom edge exactly; the rule's 1dp thickness only moves its *top*.
+         */
         val RULE_OVERLAY_TOLERANCE = 2.dp
     }
 
@@ -264,6 +268,8 @@ class CrashReportDialogLayoutTest {
         )
 
         rule.onNodeWithTag(BODY_SCROLLBAR_TAG).assertDoesNotExist()
+        // Shares the gate, so the sentinel would paint a stray rule on frame 1 too.
+        rule.onNodeWithTag(BOUNDARY_RULE_TAG).assertDoesNotExist()
     }
 
     @Test
@@ -346,14 +352,27 @@ class CrashReportDialogLayoutTest {
         // the scroll states aren't observable from here.
         rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).assertExists()
 
-        // Measured on the pane itself, not on the scrollbar inside it: the thumb fills the height
-        // *within* the pane's 8dp padding, so asserting on it would carry 16dp of slack and pass a
-        // cap that had drifted to ~216dp. TRACE_PANE_MAX_HEIGHT is the production constant.
+        // Measured on the pane itself, not the scrollbar inside it: the thumb fills the height
+        // *within* the pane's 8dp padding, so asserting on it would carry 16dp of slack.
+        //
+        // Bounded against the body viewport rather than against TRACE_PANE_MAX_HEIGHT. Asserting a
+        // shared constant against itself is tautological — it holds at any cap value, while the
+        // property it claims to protect does not. This bound is the property that actually matters
+        // and it does not move when the cap is tuned: the pane must leave room in the body for
+        // everything below it.
+        //
+        // Controlled at cap = 400dp, where it fires: "trace pane (400.0dp) fills the body viewport
+        // (268.0dp)". Note it is not what catches an *extreme* cap — at 2000dp the trace stops
+        // clipping inside the pane, so the thumb assertion above fires first. This bound owns the
+        // middle range, where the pane still clips but has eaten the body.
         val paneBounds = rule.onNodeWithTag(TRACE_PANE_TAG).getUnclippedBoundsInRoot()
         val paneHeight = paneBounds.bottom - paneBounds.top
+        val bodyBounds = rule.onNodeWithTag(BODY_SCROLLBAR_TAG).getUnclippedBoundsInRoot()
+        val bodyViewport = bodyBounds.bottom - bodyBounds.top
         assertTrue(
-            paneHeight <= TRACE_PANE_MAX_HEIGHT,
-            "trace pane grew past its cap: ${paneHeight.value}dp",
+            paneHeight < bodyViewport,
+            "trace pane (${paneHeight.value}dp) fills the body viewport (${bodyViewport.value}dp), " +
+                "so a deep trace has become the body's scroll",
         )
 
         // And the body still scrolls past it to reach what's below.
@@ -376,10 +395,13 @@ class CrashReportDialogLayoutTest {
         // (verified by control: a sibling rule passes such an assertion).
         val bodyBottom = rule.onNodeWithTag(BODY_SCROLLBAR_TAG).getUnclippedBoundsInRoot().bottom
         val ruleBottom = rule.onNodeWithTag(BOUNDARY_RULE_TAG).getUnclippedBoundsInRoot().bottom
+        // Two-sided: `<=` alone would also pass a rule pinned to the *top* of the body, which is a
+        // visible bug unrelated to overlay-vs-sibling.
+        val delta = ruleBottom - bodyBottom
         assertTrue(
-            ruleBottom <= bodyBottom + RULE_OVERLAY_TOLERANCE,
-            "rule ends ${(ruleBottom - bodyBottom).value}dp below the body — it is a sibling " +
-                "consuming layout height, not an overlay",
+            abs(delta.value) <= RULE_OVERLAY_TOLERANCE.value,
+            "rule ends ${delta.value}dp from the body's bottom edge — expected it flush with it; " +
+                "below means a sibling consuming layout height, above means it is not at the edge",
         )
     }
 
@@ -390,5 +412,15 @@ class CrashReportDialogLayoutTest {
         // Collapsed, the pane isn't composed at all — so this also pins that the hoisted trace
         // scroll state's stale maxValue never leaks a thumb into the collapsed dialog.
         rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun aBlankFailureMessageRendersThePlaceholderNotAnEmptyCard() {
+        // Unreachable today (every Error interpolates a prefix), but it is the one behaviour the
+        // sanitizer swap changed beyond redaction: maskUriParams answered "[empty]" for blank input,
+        // sanitizeExceptionMessage answers "[no message]".
+        setDialogAtMinimumWindowSize(CrashReportService.SubmitResult.Error(""))
+
+        rule.onNodeWithText("[no message]", substring = true).assertExists()
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
@@ -57,14 +57,11 @@ class CrashReportDialogLayoutTest {
          * validates against headroom no user has.
          */
 
-        /** The stack-trace pane's `heightIn(max = …)` cap. */
-        val TRACE_PANE_CAP = 200.dp
+        val WORST_CASE_DECORATION_HEIGHT = 40.dp
+        val WORST_CASE_DECORATION_WIDTH = 16.dp
 
         /** The rule's own 1dp thickness, so "ends at the body's edge" isn't a strict equality. */
         val RULE_OVERLAY_TOLERANCE = 2.dp
-
-        val WORST_CASE_DECORATION_HEIGHT = 40.dp
-        val WORST_CASE_DECORATION_WIDTH = 16.dp
     }
 
     @get:Rule
@@ -243,11 +240,15 @@ class CrashReportDialogLayoutTest {
         // time waitForIdle() returns, measure has assigned maxValue and both forms agree. The
         // sentinel needs a paused clock; see theBodyScrollbarIsAbsentEvenOnTheFirstFrame.
         rule.onNodeWithTag(BODY_SCROLLBAR_TAG).assertDoesNotExist()
+        // The rule shares the gate, so it must be absent too — otherwise a stray line is drawn
+        // across a dialog with nothing clipped.
+        rule.onNodeWithTag(BOUNDARY_RULE_TAG).assertDoesNotExist()
 
         rule.onNodeWithText("Technical Details").performClick()
         rule.waitForIdle()
 
         rule.onNodeWithTag(BODY_SCROLLBAR_TAG).assertExists()
+        rule.onNodeWithTag(BOUNDARY_RULE_TAG).assertExists()
     }
 
     @Test
@@ -344,10 +345,14 @@ class CrashReportDialogLayoutTest {
         // not named "independently": a pane wired to bodyScrollState would still satisfy this, and
         // the scroll states aren't observable from here.
         rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).assertExists()
-        val paneBounds = rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).getUnclippedBoundsInRoot()
+
+        // Measured on the pane itself, not on the scrollbar inside it: the thumb fills the height
+        // *within* the pane's 8dp padding, so asserting on it would carry 16dp of slack and pass a
+        // cap that had drifted to ~216dp. TRACE_PANE_MAX_HEIGHT is the production constant.
+        val paneBounds = rule.onNodeWithTag(TRACE_PANE_TAG).getUnclippedBoundsInRoot()
         val paneHeight = paneBounds.bottom - paneBounds.top
         assertTrue(
-            paneHeight <= TRACE_PANE_CAP,
+            paneHeight <= TRACE_PANE_MAX_HEIGHT,
             "trace pane grew past its cap: ${paneHeight.value}dp",
         )
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
@@ -56,6 +56,13 @@ class CrashReportDialogLayoutTest {
          * direction — the alternative, assuming the frame minimum is also the content minimum,
          * validates against headroom no user has.
          */
+
+        /** The stack-trace pane's `heightIn(max = …)` cap. */
+        val TRACE_PANE_CAP = 200.dp
+
+        /** The rule's own 1dp thickness, so "ends at the body's edge" isn't a strict equality. */
+        val RULE_OVERLAY_TOLERANCE = 2.dp
+
         val WORST_CASE_DECORATION_HEIGHT = 40.dp
         val WORST_CASE_DECORATION_WIDTH = 16.dp
     }
@@ -313,21 +320,62 @@ class CrashReportDialogLayoutTest {
             ),
         )
 
+        // The card must render — without this the two negative assertions below would also pass
+        // if the Error branch were dropped or initialSubmitResult stopped being wired through.
+        // This substring also documents what sanitizing is meant to *preserve*.
+        rule.onNodeWithText("Request timeout has expired", substring = true).assertExists()
+
         rule.onNodeWithText("api.risaboss.com", substring = true).assertDoesNotExist()
-        rule.onNodeWithText("crash-report]", substring = true).assertDoesNotExist()
+        // Hyphenated, so it matches only the URL path — the "Failed to submit crash report:" prose
+        // has a space. Not "crash-report]": the fixture has a comma there, so that literal appears
+        // nowhere in the input and the assertion could never fail.
+        rule.onNodeWithText("crash-report", substring = true).assertDoesNotExist()
     }
 
     @Test
-    fun theStackTracePaneScrollsIndependentlyOfTheBody() {
+    fun theStackTracePaneIsCappedAndScrollsWithinThatCap() {
         setDialogAtMinimumWindowSize()
         rule.onNodeWithText("Technical Details").performClick()
         rule.waitForIdle()
 
-        // The other load-bearing behaviour of this layout: the trace is capped and scrolls on its
-        // own state, so 60 frames don't turn the body into an endless scroll. Its thumb is present
-        // (the pane is clipping), and the checkbox below it is still only a body-scroll away.
+        // The other load-bearing behaviour of this layout: 60 frames don't turn the body into an
+        // endless scroll, because the pane is bounded and takes the overflow itself. Both halves
+        // are asserted — a thumb (it is clipping) and a height inside the 200dp cap. Deliberately
+        // not named "independently": a pane wired to bodyScrollState would still satisfy this, and
+        // the scroll states aren't observable from here.
         rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).assertExists()
+        val paneBounds = rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).getUnclippedBoundsInRoot()
+        val paneHeight = paneBounds.bottom - paneBounds.top
+        assertTrue(
+            paneHeight <= TRACE_PANE_CAP,
+            "trace pane grew past its cap: ${paneHeight.value}dp",
+        )
+
+        // And the body still scrolls past it to reach what's below.
         rule.onNodeWithText("Include recent activity logs").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun theBoundaryRuleCostsNoLayoutHeight() {
+        setDialogAtMinimumWindowSize()
+        rule.onNodeWithText("Technical Details").performClick()
+        rule.waitForIdle()
+
+        // The invariant the overlay exists for: the rule lives *inside* the body region, so it
+        // adds nothing to the parent Column's height.
+        //
+        // Measured against the body scrollbar, which fillMaxHeight()s inside the same Box and so
+        // ends exactly at the body's bottom edge. Overlaid, the rule ends there too; as a footer
+        // sibling it would sit a spacer's width below it. Note this is *not* measured as a
+        // rule-to-footer gap — that gap is 16dp in both shapes, so it cannot tell them apart
+        // (verified by control: a sibling rule passes such an assertion).
+        val bodyBottom = rule.onNodeWithTag(BODY_SCROLLBAR_TAG).getUnclippedBoundsInRoot().bottom
+        val ruleBottom = rule.onNodeWithTag(BOUNDARY_RULE_TAG).getUnclippedBoundsInRoot().bottom
+        assertTrue(
+            ruleBottom <= bodyBottom + RULE_OVERLAY_TOLERANCE,
+            "rule ends ${(ruleBottom - bodyBottom).value}dp below the body — it is a sibling " +
+                "consuming layout height, not an overlay",
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
@@ -23,9 +23,11 @@ import kotlin.test.assertTrue
 /**
  * Layout guarantees for [CrashReportDialog] at the real crash window's sizes.
  *
- * The dialog is hosted in a JFrame (`CrashHandler.showCrashDialogWindow`) whose *content pane* is
- * 550x700 preferred and 450x500 minimum. Those constants describe the box the dialog is laid out
- * in, not the decorated frame around it, so the sizes below are what the dialog really gets.
+ * The dialog is hosted in a JFrame (`CrashHandler.showCrashDialogWindow`). Its *content pane* is
+ * 550x700 preferred — that size is applied to the ComposePanel, so the dialog gets it exactly — but
+ * the 450x500 minimum is a **frame** dimension, decorations included. The content pane at that
+ * minimum is therefore smaller by the title bar, which is why the sizes below subtract
+ * [WORST_CASE_DECORATION_HEIGHT] rather than using the minimum as-is.
  *
  * A crash report is a lot of content for that box, and expanding "Technical
  * Details" adds ~250dp more — so a body laid out without a scroll region pushes "Report Issue" and
@@ -119,6 +121,27 @@ class CrashReportDialogLayoutTest {
             submitResult,
         )
 
+    /**
+     * Asserts each label is entirely within the window, not merely overlapping it.
+     *
+     * `assertIsDisplayed()` only requires a node's *clipped* bounds to be non-empty, so a button
+     * hanging most of the way off an edge satisfies it. Comparing clipped against unclipped bounds
+     * is what actually rules that out.
+     */
+    private fun assertWhollyOnScreen(
+        vararg labels: String,
+        because: String,
+    ) {
+        for (label in labels) {
+            val node = rule.onNodeWithText(label)
+            assertEquals(
+                node.getUnclippedBoundsInRoot(),
+                node.getBoundsInRoot(),
+                "\"$label\" is not wholly on screen: $because",
+            )
+        }
+    }
+
     @Test
     fun actionButtonsStayVisibleWhenTechnicalDetailsAreExpanded() {
         setDialogAtMinimumWindowSize()
@@ -141,18 +164,12 @@ class CrashReportDialogLayoutTest {
         rule.onNodeWithText("Technical Details").performClick()
         rule.waitForIdle()
 
-        // assertIsDisplayed() only requires a node's *clipped* bounds to be non-empty, so a button
-        // hanging most of the way off an edge still satisfies it. Comparing clipped against
-        // unclipped bounds is what actually rules that out — cheap, and it closes the one soft spot
-        // in the assertions above.
-        for (label in listOf("Clean Data & Restart", "Don't Send", "Report Issue")) {
-            val node = rule.onNodeWithText(label)
-            assertEquals(
-                node.getUnclippedBoundsInRoot(),
-                node.getBoundsInRoot(),
-                "\"$label\" is partially outside the window",
-            )
-        }
+        assertWhollyOnScreen(
+            "Clean Data & Restart",
+            "Don't Send",
+            "Report Issue",
+            because = "the expanded details must not push the footer past an edge",
+        )
     }
 
     @Test
@@ -253,14 +270,12 @@ class CrashReportDialogLayoutTest {
         rule.onNodeWithText("Technical Details").performClick()
         rule.waitForIdle()
 
-        for (label in listOf("Clean Data & Restart", "Don't Send", "Report Issue")) {
-            val node = rule.onNodeWithText(label)
-            assertEquals(
-                node.getUnclippedBoundsInRoot(),
-                node.getBoundsInRoot(),
-                "\"$label\" left the window once a long failure message filled the footer",
-            )
-        }
+        assertWhollyOnScreen(
+            "Clean Data & Restart",
+            "Don't Send",
+            "Report Issue",
+            because = "a long failure message filled the footer",
+        )
     }
 
     @Test
@@ -278,13 +293,49 @@ class CrashReportDialogLayoutTest {
         rule.onNodeWithText("Technical Details").performClick()
         rule.waitForIdle()
 
-        for (label in listOf("Clean Data & Restart", "Close")) {
-            val node = rule.onNodeWithText(label)
-            assertEquals(
-                node.getUnclippedBoundsInRoot(),
-                node.getBoundsInRoot(),
-                "\"$label\" left the window with the success footer's second row present",
-            )
-        }
+        assertWhollyOnScreen(
+            "Clean Data & Restart",
+            "Close",
+            because = "the success footer adds a second button row",
+        )
+    }
+
+    @Test
+    fun aSubmitFailureIsSanitizedBeforeItIsShown() {
+        // This card is selectable and the likeliest thing to be pasted into a public issue, and its
+        // text interpolates a raw exception message. maskUriParams — which this originally used —
+        // only redacts named params inside a `?`/`#` segment, so it returned a ktor timeout message
+        // carrying the request URL completely untouched.
+        setDialogAtMinimumWindowSize(
+            CrashReportService.SubmitResult.Error(
+                "Failed to submit crash report: Request timeout has expired " +
+                    "[url=https://api.risaboss.com/functions/v1/crash-report, request_timeout=15000 ms]",
+            ),
+        )
+
+        rule.onNodeWithText("api.risaboss.com", substring = true).assertDoesNotExist()
+        rule.onNodeWithText("crash-report]", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun theStackTracePaneScrollsIndependentlyOfTheBody() {
+        setDialogAtMinimumWindowSize()
+        rule.onNodeWithText("Technical Details").performClick()
+        rule.waitForIdle()
+
+        // The other load-bearing behaviour of this layout: the trace is capped and scrolls on its
+        // own state, so 60 frames don't turn the body into an endless scroll. Its thumb is present
+        // (the pane is clipping), and the checkbox below it is still only a body-scroll away.
+        rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).assertExists()
+        rule.onNodeWithText("Include recent activity logs").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun theTraceScrollbarIsAbsentWhileTheDetailsAreCollapsed() {
+        setDialogAtMinimumWindowSize()
+
+        // Collapsed, the pane isn't composed at all — so this also pins that the hoisted trace
+        // scroll state's stale maxValue never leaks a thumb into the collapsed dialog.
+        rule.onNodeWithTag(TRACE_SCROLLBAR_TAG).assertDoesNotExist()
     }
 }


### PR DESCRIPTION
Post-merge review follow-ups on #100. The review landed one minute after that PR merged, so none of this was seen before it shipped. One item is a security regression #100 introduced; the rest are refinements it identified.

## The one that matters: wrong sanitizer on the copyable failure message

#100 made the submit-result card selectable and ran it through `LogSanitizer.maskUriParams`. That function redacts a fixed set of **named params inside a `?`/`#` segment** — and the case the code comment cited as the whole reason to sanitize has neither. Measured on that exact message rather than reasoned about:

```
maskUriParams:            Request timeout has expired [url=https://api.risaboss.com/functions/v1/crash-report, request_timeout=15000 ms]
sanitizeExceptionMessage: Request timeout has expired [url=https:[PATH] request_timeout=15000 ms]
```

So the host and full path shipped **verbatim**, in the one string #100 itself flagged as most likely to be pasted into a public issue, and which it had just made selectable. Also passing through untouched: an `SSLHandshakeException` carrying a keystore path under `/Users/<name>/…`, a bare `Bearer eyJ…`, a `ghp_…`, an email in a proxy error.

`sanitizeExceptionMessage` is what the rest of the window already gets — `CrashHandler.kt:564-565` runs the exception message and stack trace through it before they reach `CrashReport` — so this card was the only string in the dialog held to a weaker standard.

`aSubmitFailureIsSanitizedBeforeItIsShown` pins it, and was controlled against the old call:

```
AssertionError: Failed: assertDoesNotExist.
Reason: Did not expect any node but found '1' node that satisfies: (Text ... contains 'api.risaboss.com')
```

## The last feedback path is gone rather than documented

The scroll-boundary rule was a footer sibling gated on `bodyOverflows`, so it consumed ~17dp of the body — and gating a space-consuming element on the measurement that decides whether to show it is a feedback path. Monotone, so it could never oscillate, but it could **latch**: content within ~17dp of fitting kept its scrollbar after the details collapsed again, which quietly undercut #100's claim that a collapsed dialog renders exactly as before.

It's now an overlay at the bottom of the body `Box`, next to the scrollbar — zero layout height, same visual (verified by render), claim unconditional. That's the same trick #100 applied to the scrollbar itself, for the same reason; the rule should have gone with it.

The invariant at the declaration is restated as the general rule instead of a description of the remaining exception: *nothing gated on `bodyOverflows` may change the body's size, in either axis.*

## Coverage the review found missing

- `TRACE_SCROLLBAR_TAG` was applied but never asserted — an unused tag reads as coverage that isn't there. Two tests now use it, and they cover the trace pane's **independent scrolling**, which is #100's second load-bearing behaviour ("a deep trace doesn't turn the body into an endless scroll") and had no test at all.
- The trace thumb is also asserted absent while collapsed, which pins that the hoisted trace scroll state's stale `maxValue` never leaks a thumb into the collapsed dialog.

## Smaller

- The test class KDoc still called the 450x500 minimum a *content-pane* dimension. #100's final commit moved it back to frame terms — which is exactly why `WORST_CASE_DECORATION_*` exists twenty lines below it. Stale doc contradicting the code on the same screen.
- The wholly-on-screen comparison appeared verbatim three times; now one `assertWhollyOnScreen(vararg labels, because:)` carrying the `assertIsDisplayed`-only-checks-clipped-bounds explanation once.

## On the review's open question about font metrics

It asked whether the geometry assertions had been run on all three CI legs or measured only on macOS, estimating ~24dp of slack before `ButtonDefaults.MinWidth` stops absorbing the squeeze. Answer: all three. #100's final commit (`bb2b8f30`) went green on ubuntu, macos and windows, so the margin holds today. It is thin by analysis, and the button-row fix in #104 is what actually removes the risk — noted there.

55 tests in `ai.rever.boss.crash.*`, `detekt` and `ktlintCheck` green. Renders re-checked collapsed and expanded.
