### PR TITLE
fix(browser): check the engine before anything boots it, and fail legibly when it mismatches

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -200,7 +200,11 @@ object ChromiumAutoDownloader {
         // This catches cached Chromium from older versions that didn't set execute bit correctly
         if (System.getProperty("os.name").lowercase().contains("mac")) {
             val executableName = executableNameFile.readText().trim()
-            val executablePath = dir.resolve("$executableName/Contents/MacOS/BOSS").toFile()
+            // executable.name holds the bundle name without its suffix (the branding
+            // workflow writes `basename "$APP_BUNDLE" .app`), so the directory on
+            // disk is "<name>.app". Without it this resolved to a path that never
+            // exists and the permission check below silently never ran.
+            val executablePath = dir.resolve("$executableName.app/Contents/MacOS/$executableName").toFile()
             if (executablePath.exists() && !executablePath.canExecute()) {
                 logger.info(LogCategory.BROWSER, "Chromium executable missing execute permission, will re-download")
                 return false

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -681,6 +681,13 @@ fun main(args: Array<String>) {
                             if (progress.isComplete) {
                                 // Download complete - create window and proceed
                                 WindowManager.createNewWindow()
+                                // The pre-warm was skipped at startup because the engine
+                                // was missing; now that it is installed, warm it so the
+                                // first tab does not pay the full boot.
+                                runCatching {
+                                    ai.rever.boss.plugin.browser.FluckEngine
+                                        .prewarmInBackground()
+                                }
                                 isDownloadingChromium = false
                             }
                         }
@@ -713,6 +720,13 @@ fun main(args: Array<String>) {
                                             downloadProgress = progress
                                             if (progress.isComplete) {
                                                 WindowManager.createNewWindow()
+                                                // The pre-warm was skipped at startup because the engine
+                                                // was missing; now that it is installed, warm it so the
+                                                // first tab does not pay the full boot.
+                                                runCatching {
+                                                    ai.rever.boss.plugin.browser.FluckEngine
+                                                        .prewarmInBackground()
+                                                }
                                                 isDownloadingChromium = false
                                             }
                                         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -423,14 +423,47 @@ fun main(args: Array<String>) {
         logger.warn(LogCategory.SYSTEM, "Proactive browser lock cleanup failed", error = e)
     }
 
+    // Decide whether the installed engine is usable BEFORE anything boots it.
+    //
+    // This has to precede every engine-creating call below, and the ordering is
+    // load-bearing rather than cosmetic. JxBrowser resolves its native toolkit
+    // under Versions/<VersionInfo.chromiumVersion()>, baked into the jar, so an
+    // engine directory left over from an older app version fails the native load
+    // with an UnsatisfiedLinkError. That is recoverable — isChromiumInstalled
+    // spots the mismatch and the download UI below repairs it — but only if the
+    // check runs first. With the check downstream of the pre-warm and of
+    // PasskeyPlatformInit, both booted against the stale engine and threw before
+    // the repair path was ever reached, so shipping a JxBrowser bump broke the
+    // browser for every existing install instead of prompting a download.
+    //
+    // promotePendingInstall must also stay ahead of any engine creation: it
+    // renames the engine directory, which cannot be done safely once a running
+    // engine holds files inside it.
+    ChromiumAutoDownloader.promotePendingInstall()
+
+    val chromiumNeedsDownload = !ChromiumAutoDownloader.isChromiumInstalled()
+    if (chromiumNeedsDownload) {
+        logger.info(
+            LogCategory.SYSTEM,
+            "Installed browser engine missing or mismatched - will prompt for download",
+            mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
+        )
+    }
+
     // Pre-warm the browser engine off the UI thread so the first browser tab
     // opens against an already-running Chromium instead of paying the full
     // engine boot inside its composition. Opt out with BOSS_BROWSER_PREWARM=false.
-    try {
-        ai.rever.boss.plugin.browser.FluckEngine
-            .prewarmInBackground()
-    } catch (e: Exception) {
-        logger.warn(LogCategory.SYSTEM, "Browser engine pre-warm failed to start", error = e)
+    //
+    // Skipped when the engine needs downloading: pre-warming against a mismatched
+    // directory cannot succeed, and its only effect is to raise the very error
+    // the download is about to fix.
+    if (!chromiumNeedsDownload) {
+        try {
+            ai.rever.boss.plugin.browser.FluckEngine
+                .prewarmInBackground()
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Browser engine pre-warm failed to start", error = e)
+        }
     }
 
     // Parse CLI arguments if provided
@@ -529,14 +562,8 @@ fun main(args: Array<String>) {
         )
     logger.debug(LogCategory.SYSTEM, "API key availability", apiKeyStatus.mapValues { if (it.value) "set" else "not set" })
 
-    // Apply any engine install staged from Settings before validating/creating the engine
-    ChromiumAutoDownloader.promotePendingInstall()
-
-    // Check if Chromium needs to be downloaded (for debug/dev builds)
-    val chromiumNeedsDownload = !ChromiumAutoDownloader.isChromiumInstalled()
-    if (chromiumNeedsDownload) {
-        logger.info(LogCategory.SYSTEM, "BOSS-branded Chromium not found - will prompt for download")
-    }
+    // chromiumNeedsDownload was resolved far earlier, above the first engine boot
+    // — see the comment there for why that ordering matters.
 
     // Create initial window BEFORE application{} to prevent auto-recreation
     // This runs once on startup, not during recomposition

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1151,6 +1151,17 @@ object FluckEngine {
 
         val chromiumDir = getChromiumDir()
 
+        // Refuse a mismatched engine with a message that names the cause.
+        //
+        // Left to JxBrowser this surfaces as `UnsatisfiedLinkError: Can't load
+        // library: .../Versions/<x>/Libraries/libtoolkit.dylib` — a path and no
+        // explanation, which cost a full debugging session to trace the first time.
+        // Startup checks the installed version before booting anything, so in the
+        // normal flow this never fires; it exists because that ordering is a
+        // convention a future edit can silently break, and when it does break the
+        // failure should say what is wrong rather than where a file was missing.
+        chromiumVersionMismatch(chromiumDir)?.let { throw IllegalStateException(it) }
+
         // Create directories if they don't exist
         chromiumDir.toFile().mkdirs()
 
@@ -1166,6 +1177,74 @@ object FluckEngine {
      * 1. Bundled BOSS-branded Chromium (in app resources)
      * 2. Cached BOSS-branded Chromium (~/.boss/boss-chromium/)
      */
+
+    /**
+     * Why [chromiumDir] cannot serve this build's JxBrowser, or null if it can.
+     *
+     * JxBrowser loads its native toolkit from
+     * `<executable>.app/Contents/Frameworks/Chromium Framework.framework/Versions/<chromium>/Libraries/`,
+     * where `<chromium>` is [com.teamdev.jxbrowser.VersionInfo.chromiumVersion] —
+     * a value compiled into the jar. So the engine on disk has to carry exactly the
+     * Chromium build this jar was made against; anything else fails at
+     * `System.load` no matter how well-formed the directory is.
+     *
+     * macOS only: the Versions/<chromium> layout is specific to the framework
+     * bundle. Other platforms return null (no claim made) rather than guessing.
+     */
+    internal fun chromiumVersionMismatch(chromiumDir: java.nio.file.Path): String? {
+        val required =
+            com.teamdev.jxbrowser.VersionInfo
+                .chromiumVersion()
+        val versionsDir = frameworkVersionsDir(chromiumDir)
+
+        // Every "can't tell" path yields null: refusing to boot on a guess would be
+        // a worse failure than the cryptic error this exists to replace.
+        return if (versionsDir == null || versionsDir.resolve(required).isDirectory) {
+            null
+        } else {
+            val present =
+                versionsDir
+                    .listFiles()
+                    ?.filter { it.isDirectory && it.name != "Current" }
+                    ?.joinToString(", ") { it.name }
+                    ?.ifEmpty { "none" }
+                    ?: "none"
+            "Installed browser engine does not match this build of BOSS. " +
+                "JxBrowser ${com.teamdev.jxbrowser.VersionInfo.version()} requires Chromium $required, " +
+                "but the engine at $chromiumDir provides: $present. " +
+                "Delete ~/.boss/boss-chromium and restart to re-download the matching engine."
+        }
+    }
+
+    /** The framework's `Versions` directory, or null when this isn't a layout we model. */
+    private fun frameworkVersionsDir(chromiumDir: java.nio.file.Path): java.io.File? {
+        val isMac =
+            System
+                .getProperty("os.name")
+                .orEmpty()
+                .lowercase()
+                .contains("mac")
+        val executableName =
+            if (!isMac) {
+                null
+            } else {
+                runCatching {
+                    chromiumDir
+                        .resolve("executable.name")
+                        .toFile()
+                        .readText()
+                        .trim()
+                }.getOrNull()
+                    ?.takeIf { it.isNotEmpty() }
+            }
+        return executableName
+            ?.let {
+                chromiumDir
+                    .resolve("$it.app/Contents/Frameworks/Chromium Framework.framework/Versions")
+                    .toFile()
+            }?.takeIf { it.isDirectory }
+    }
+
     private fun getChromiumDir(): java.nio.file.Path {
         // Priority 1: Bundled BOSS-branded Chromium (in app resources)
         val bundledDir = getBundledChromiumPath()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1168,7 +1168,15 @@ object FluckEngine {
                 "Refusing to start a mismatched browser engine",
                 mapOf("engineDir" to chromiumDir.toString(), "reason" to reason),
             )
-            throw IllegalStateException(reason)
+            // Record before throwing. initializationError is otherwise only set in
+            // createEngineWithProfile's catch, which this throw precedes — so
+            // initError stayed null, getBrowserState swallowed the exception, and
+            // the tab rendered "Could not initialize browser ... window not ready"
+            // instead of the message written here. Assigning it also arms the
+            // attemptCount short-circuit for this failure.
+            val error = IllegalStateException(reason)
+            initializationError = error
+            throw error
         }
 
         // Create directories if they don't exist

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1160,7 +1160,16 @@ object FluckEngine {
         // normal flow this never fires; it exists because that ordering is a
         // convention a future edit can silently break, and when it does break the
         // failure should say what is wrong rather than where a file was missing.
-        chromiumVersionMismatch(chromiumDir)?.let { throw IllegalStateException(it) }
+        chromiumVersionMismatch(chromiumDir)?.let { reason ->
+            // The path is logged rather than folded into the message: the message
+            // reaches classifyError, which substring-matches it to choose a remedy.
+            logger.error(
+                LogCategory.BROWSER,
+                "Refusing to start a mismatched browser engine",
+                mapOf("engineDir" to chromiumDir.toString(), "reason" to reason),
+            )
+            throw IllegalStateException(reason)
+        }
 
         // Create directories if they don't exist
         chromiumDir.toFile().mkdirs()
@@ -1177,29 +1186,62 @@ object FluckEngine {
      * 1. Bundled BOSS-branded Chromium (in app resources)
      * 2. Cached BOSS-branded Chromium (~/.boss/boss-chromium/)
      */
+    private fun getChromiumDir(): java.nio.file.Path {
+        // Priority 1: Bundled BOSS-branded Chromium (in app resources)
+        val bundledDir = getBundledChromiumPath()
+        if (bundledDir != null && isValidChromiumDir(bundledDir)) {
+            return bundledDir
+        }
+
+        // Priority 2: Cached BOSS-branded Chromium
+        val cachedBrandedDir = BossDirectories.resolve("boss-chromium").toPath()
+        if (isValidChromiumDir(cachedBrandedDir)) {
+            return cachedBrandedDir
+        }
+
+        // No fallback - BOSS-branded Chromium is required
+        throw IllegalStateException(
+            "BOSS-branded Chromium not found. Please restart the app to trigger auto-download, " +
+                "or manually install to ~/.boss/boss-chromium/",
+        )
+    }
 
     /**
-     * Why [chromiumDir] cannot serve this build's JxBrowser, or null if it can.
+     * Why the engine at [chromiumDir] cannot serve this build's JxBrowser, or null
+     * if it can.
      *
      * JxBrowser loads its native toolkit from
      * `<executable>.app/Contents/Frameworks/Chromium Framework.framework/Versions/<chromium>/Libraries/`,
-     * where `<chromium>` is [com.teamdev.jxbrowser.VersionInfo.chromiumVersion] —
-     * a value compiled into the jar. So the engine on disk has to carry exactly the
-     * Chromium build this jar was made against; anything else fails at
-     * `System.load` no matter how well-formed the directory is.
+     * where `<chromium>` is [com.teamdev.jxbrowser.VersionInfo.chromiumVersion] — a
+     * value compiled into the jar. So the engine on disk has to carry exactly the
+     * Chromium build this jar was made against; anything else fails at `System.load`
+     * no matter how well-formed the directory is.
      *
-     * macOS only: the Versions/<chromium> layout is specific to the framework
-     * bundle. Other platforms return null (no claim made) rather than guessing.
+     * macOS only: the `Versions/<chromium>` layout is specific to the framework
+     * bundle. Elsewhere this makes no claim rather than guessing.
      */
-    internal fun chromiumVersionMismatch(chromiumDir: java.nio.file.Path): String? {
+    internal fun chromiumVersionMismatch(chromiumDir: java.nio.file.Path): String? =
+        frameworkVersionsDir(chromiumDir)?.let { chromiumMismatchMessage(it) }
+
+    /**
+     * The mismatch message for an already-located `Versions` directory, or null when
+     * it carries the required build.
+     *
+     * Split from the filesystem/OS probing above so the comparison — the part that
+     * decides whether an engine boots — is exercised on every CI leg rather than
+     * only the macOS one.
+     *
+     * Deliberately omits the engine path. This string reaches [classifyError], which
+     * substring-matches the message for "host", "connect", "license" and friends to
+     * pick a remedy; a home directory containing any of those would be classified as
+     * a network or licensing failure and shown the wrong advice. The path is logged
+     * at the throw site instead.
+     */
+    internal fun chromiumMismatchMessage(versionsDir: java.io.File): String? {
         val required =
             com.teamdev.jxbrowser.VersionInfo
                 .chromiumVersion()
-        val versionsDir = frameworkVersionsDir(chromiumDir)
-
-        // Every "can't tell" path yields null: refusing to boot on a guess would be
-        // a worse failure than the cryptic error this exists to replace.
-        return if (versionsDir == null || versionsDir.resolve(required).isDirectory) {
+        return if (versionsDir.resolve(required).isDirectory) {
             null
         } else {
             val present =
@@ -1210,13 +1252,19 @@ object FluckEngine {
                     ?.ifEmpty { "none" }
                     ?: "none"
             "Installed browser engine does not match this build of BOSS. " +
-                "JxBrowser ${com.teamdev.jxbrowser.VersionInfo.version()} requires Chromium $required, " +
-                "but the engine at $chromiumDir provides: $present. " +
-                "Delete ~/.boss/boss-chromium and restart to re-download the matching engine."
+                "JxBrowser ${com.teamdev.jxbrowser.VersionInfo.version()} needs Chromium $required, " +
+                "but the installed engine provides: $present. " +
+                "Delete the boss-chromium folder in your BOSS data directory and restart " +
+                "to re-download the matching engine."
         }
     }
 
-    /** The framework's `Versions` directory, or null when this isn't a layout we model. */
+    /**
+     * The framework's `Versions` directory, or null when this isn't a layout we model.
+     *
+     * Every "can't tell" answer is null: refusing to boot on a guess would be a worse
+     * failure than the cryptic error this exists to replace.
+     */
     private fun frameworkVersionsDir(chromiumDir: java.nio.file.Path): java.io.File? {
         val isMac =
             System
@@ -1243,26 +1291,6 @@ object FluckEngine {
                     .resolve("$it.app/Contents/Frameworks/Chromium Framework.framework/Versions")
                     .toFile()
             }?.takeIf { it.isDirectory }
-    }
-
-    private fun getChromiumDir(): java.nio.file.Path {
-        // Priority 1: Bundled BOSS-branded Chromium (in app resources)
-        val bundledDir = getBundledChromiumPath()
-        if (bundledDir != null && isValidChromiumDir(bundledDir)) {
-            return bundledDir
-        }
-
-        // Priority 2: Cached BOSS-branded Chromium
-        val cachedBrandedDir = BossDirectories.resolve("boss-chromium").toPath()
-        if (isValidChromiumDir(cachedBrandedDir)) {
-            return cachedBrandedDir
-        }
-
-        // No fallback - BOSS-branded Chromium is required
-        throw IllegalStateException(
-            "BOSS-branded Chromium not found. Please restart the app to trigger auto-download, " +
-                "or manually install to ~/.boss/boss-chromium/",
-        )
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/desktop/CrossDeviceBrowserManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/desktop/CrossDeviceBrowserManager.kt
@@ -18,8 +18,32 @@ class CrossDeviceBrowserManager {
     private var webAuthnEngine: Engine? = null
     private var webAuthnBrowser: Browser? = null
 
-    init {
-        initializeWebAuthnEngine()
+    @Volatile
+    private var webAuthnInitAttempted = false
+
+    /**
+     * Boot the WebAuthn engine on first actual use, not at construction.
+     *
+     * `FluckEngine.engine` is a synchronous, multi-second Chromium boot under a
+     * lock. This class is constructed from `PasskeyPlatformInit.initialize()` on
+     * the pre-UI startup path, so doing it in `init` meant every launch paid for an
+     * engine nothing had asked for yet — and, worse, booted it *before* startup had
+     * checked whether the installed engine matches this build's JxBrowser. A
+     * mismatched engine then threw UnsatisfiedLinkError here, ahead of the download
+     * that would have repaired it.
+     *
+     * Only [openInFluckBrowser] genuinely needs a live engine, and it is a suspend
+     * function on Dispatchers.IO. The other two callers read the engine purely as a
+     * capability flag and return OS-derived answers either way, so they observe
+     * whatever is already initialised and never force a boot.
+     */
+    private fun ensureWebAuthnEngine() {
+        if (webAuthnInitAttempted) return
+        synchronized(this) {
+            if (webAuthnInitAttempted) return
+            webAuthnInitAttempted = true
+            initializeWebAuthnEngine()
+        }
     }
 
     /**
@@ -94,6 +118,11 @@ class CrossDeviceBrowserManager {
         withContext(Dispatchers.IO) {
             return@withContext try {
                 logger.debug(LogCategory.BROWSER, "Preparing URL for embedded Fluck browser", mapOf("url" to url))
+
+                // The one caller that actually needs a live engine. Safe to boot
+                // here: suspend, on Dispatchers.IO, and only once a passkey flow
+                // has genuinely asked for the embedded browser.
+                ensureWebAuthnEngine()
 
                 // Validate that we have a WebAuthn engine available
                 if (webAuthnEngine == null || webAuthnBrowser == null) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/desktop/CrossDeviceBrowserManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/passkey/desktop/CrossDeviceBrowserManager.kt
@@ -15,7 +15,17 @@ import kotlinx.coroutines.withContext
 class CrossDeviceBrowserManager {
     private val logger = BossLogger.forComponent("CrossDeviceBrowserManager")
 
+    // Volatile because initialization moved out of the constructor. These are now
+    // written on whichever thread first calls ensureWebAuthnEngine, while
+    // isExternalAuthenticatorAvailable and showEnhancedCapabilities read them
+    // without holding that lock — so without safe publication a reader could see
+    // webAuthnInitAttempted set but the references still null, or observe a Browser
+    // that isn't fully published. Constructor initialization used to make this a
+    // non-issue.
+    @Volatile
     private var webAuthnEngine: Engine? = null
+
+    @Volatile
     private var webAuthnBrowser: Browser? = null
 
     @Volatile

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.browser
 
 import com.teamdev.jxbrowser.VersionInfo
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
@@ -74,6 +75,36 @@ class ChromiumVersionMismatchTest {
         val message = FluckEngine.chromiumMismatchMessage(versionsDir())
         assertNotNull(message)
         assertTrue(message.contains("none"), "Nothing installed should read as 'none', not as a blank")
+    }
+
+    @Test
+    fun `the full bundle layout resolves through the chromiumDir entry point`() {
+        // Splitting the comparison out left frameworkVersionsDir — the layout
+        // composition — untested on every leg. It assumes executable.name holds the
+        // bundle name WITHOUT its suffix and appends ".app"; if that ever drifts the
+        // preflight silently degrades to a no-op (null, no claim made) and the
+        // defence-in-depth disappears with nothing failing. Genuinely macOS-only, so
+        // skipping on the other two legs is honest here.
+        assumeTrue(
+            System
+                .getProperty("os.name")
+                .orEmpty()
+                .lowercase()
+                .contains("mac"),
+            "The Versions/<chromium> bundle layout is macOS-specific",
+        )
+        val engine = createTempDirectory("engine").toFile()
+        temps.add(engine)
+        File(engine, "executable.name").writeText("BOSS")
+        File(
+            engine,
+            "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions/150.0.7871.47/Libraries",
+        ).mkdirs()
+
+        val message = FluckEngine.chromiumVersionMismatch(engine.toPath())
+
+        assertNotNull(message, "A stale engine must be refused through the real entry point")
+        assertTrue(message.contains("150.0.7871.47"))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -1,11 +1,11 @@
 package ai.rever.boss.plugin.browser
 
 import com.teamdev.jxbrowser.VersionInfo
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -19,49 +19,47 @@ import kotlin.test.assertTrue
  * directory named after the Chromium build compiled into the jar. Startup checks the
  * installed version before booting anything, but that ordering is a convention, and
  * this is what catches it when the convention breaks.
+ *
+ * Asserted against [FluckEngine.chromiumMismatchMessage] rather than the
+ * `chromiumDir` entry point: that one short-circuits on `os.name`, so a macOS-gated
+ * test would assert nothing on two of the three CI legs and sleep through a
+ * regression in the comparison — which is the part that decides whether an engine
+ * boots.
  */
 class ChromiumVersionMismatchTest {
     private val temps = mutableListOf<File>()
-    private val isMac =
-        System
-            .getProperty("os.name")
-            .orEmpty()
-            .lowercase()
-            .contains("mac")
 
     @AfterTest
     fun cleanup() {
         temps.forEach { it.deleteRecursively() }
     }
 
-    /** An engine directory laid out the way the branded bundle is, carrying [chromiumVersion]. */
-    private fun engineDir(chromiumVersion: String?): File {
-        val dir = createTempDirectory("engine").toFile()
+    /** A framework `Versions` directory carrying exactly [chromiumVersions]. */
+    private fun versionsDir(vararg chromiumVersions: String): File {
+        val dir = createTempDirectory("versions").toFile()
         temps.add(dir)
-        File(dir, "executable.name").writeText("BOSS")
-        if (chromiumVersion != null) {
-            File(
-                dir,
-                "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions/$chromiumVersion/Libraries",
-            ).mkdirs()
-        }
+        chromiumVersions.forEach { File(dir, "$it/Libraries").mkdirs() }
         return dir
     }
 
     @Test
     fun `an engine carrying the required Chromium build is accepted`() {
-        assumeTrue(isMac, "The Versions/<chromium> layout is macOS-specific")
-        val dir = engineDir(VersionInfo.chromiumVersion())
-        assertNull(FluckEngine.chromiumVersionMismatch(dir.toPath()))
+        assertNull(FluckEngine.chromiumMismatchMessage(versionsDir(VersionInfo.chromiumVersion())))
+    }
+
+    @Test
+    fun `a Current symlink alongside the required build does not confuse it`() {
+        assertNull(
+            FluckEngine.chromiumMismatchMessage(
+                versionsDir(VersionInfo.chromiumVersion(), "Current"),
+            ),
+        )
     }
 
     @Test
     fun `an engine carrying a different Chromium build is refused, naming both`() {
-        assumeTrue(isMac, "The Versions/<chromium> layout is macOS-specific")
-        // The exact shape of the incident: jar wants 151, disk has 150.
-        val dir = engineDir("150.0.7871.47")
-
-        val message = FluckEngine.chromiumVersionMismatch(dir.toPath())
+        // The exact shape of the incident: the jar wants 151, the disk has 150.
+        val message = FluckEngine.chromiumMismatchMessage(versionsDir("150.0.7871.47"))
 
         assertNotNull(message, "A mismatched engine must be refused before System.load")
         assertTrue(
@@ -72,17 +70,23 @@ class ChromiumVersionMismatchTest {
     }
 
     @Test
-    fun `an unrecognised layout makes no claim`() {
-        assumeTrue(isMac, "The Versions/<chromium> layout is macOS-specific")
-        // Fail open rather than block a directory shape this check does not model —
-        // refusing to boot on a guess would be worse than the error it prevents.
-        assertNull(FluckEngine.chromiumVersionMismatch(engineDir(null).toPath()))
+    fun `an empty Versions directory is refused rather than passed through`() {
+        val message = FluckEngine.chromiumMismatchMessage(versionsDir())
+        assertNotNull(message)
+        assertTrue(message.contains("none"), "Nothing installed should read as 'none', not as a blank")
     }
 
     @Test
-    fun `a directory with no executable name makes no claim`() {
-        val dir = createTempDirectory("engine-bare").toFile()
-        temps.add(dir)
-        assertNull(FluckEngine.chromiumVersionMismatch(dir.toPath()))
+    fun `the message carries no filesystem path`() {
+        // It reaches classifyError, which substring-matches for "host", "connect",
+        // "license" and friends to choose a remedy — so a home directory containing
+        // any of those would be reported as a network or licensing failure. The path
+        // belongs in the log, not here.
+        val dir = versionsDir("150.0.7871.47")
+        val message = assertNotNull(FluckEngine.chromiumMismatchMessage(dir))
+        assertFalse(
+            message.contains(dir.absolutePath),
+            "The engine path must not be interpolated into a message that gets substring-classified",
+        )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -1,0 +1,88 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.VersionInfo
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the preflight that turns an engine/library mismatch into a legible failure.
+ *
+ * Shipping JxBrowser 9.4.0 while users still had the 9.3.0 engine on disk produced
+ * `UnsatisfiedLinkError: Can't load library: .../Versions/150.0.7871.47/Libraries/libtoolkit.dylib`
+ * — a path with no cause — because JxBrowser resolves its native toolkit under a
+ * directory named after the Chromium build compiled into the jar. Startup checks the
+ * installed version before booting anything, but that ordering is a convention, and
+ * this is what catches it when the convention breaks.
+ */
+class ChromiumVersionMismatchTest {
+    private val temps = mutableListOf<File>()
+    private val isMac =
+        System
+            .getProperty("os.name")
+            .orEmpty()
+            .lowercase()
+            .contains("mac")
+
+    @AfterTest
+    fun cleanup() {
+        temps.forEach { it.deleteRecursively() }
+    }
+
+    /** An engine directory laid out the way the branded bundle is, carrying [chromiumVersion]. */
+    private fun engineDir(chromiumVersion: String?): File {
+        val dir = createTempDirectory("engine").toFile()
+        temps.add(dir)
+        File(dir, "executable.name").writeText("BOSS")
+        if (chromiumVersion != null) {
+            File(
+                dir,
+                "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions/$chromiumVersion/Libraries",
+            ).mkdirs()
+        }
+        return dir
+    }
+
+    @Test
+    fun `an engine carrying the required Chromium build is accepted`() {
+        assumeTrue(isMac, "The Versions/<chromium> layout is macOS-specific")
+        val dir = engineDir(VersionInfo.chromiumVersion())
+        assertNull(FluckEngine.chromiumVersionMismatch(dir.toPath()))
+    }
+
+    @Test
+    fun `an engine carrying a different Chromium build is refused, naming both`() {
+        assumeTrue(isMac, "The Versions/<chromium> layout is macOS-specific")
+        // The exact shape of the incident: jar wants 151, disk has 150.
+        val dir = engineDir("150.0.7871.47")
+
+        val message = FluckEngine.chromiumVersionMismatch(dir.toPath())
+
+        assertNotNull(message, "A mismatched engine must be refused before System.load")
+        assertTrue(
+            message.contains(VersionInfo.chromiumVersion()),
+            "The message must name the Chromium build actually required",
+        )
+        assertTrue(message.contains("150.0.7871.47"), "and the one found on disk")
+    }
+
+    @Test
+    fun `an unrecognised layout makes no claim`() {
+        assumeTrue(isMac, "The Versions/<chromium> layout is macOS-specific")
+        // Fail open rather than block a directory shape this check does not model —
+        // refusing to boot on a guess would be worse than the error it prevents.
+        assertNull(FluckEngine.chromiumVersionMismatch(engineDir(null).toPath()))
+    }
+
+    @Test
+    fun `a directory with no executable name makes no claim`() {
+        val dir = createTempDirectory("engine-bare").toFile()
+        temps.add(dir)
+        assertNull(FluckEngine.chromiumVersionMismatch(dir.toPath()))
+    }
+}


### PR DESCRIPTION
## The incident

BOSS 9.3.0 shipped JxBrowser 9.4.0 and broke the browser for **every existing install**. The release has been pulled from both channels (Supabase row deleted, GitHub release drafted); `latest-release` now serves 9.2.65.

The bump itself was correct. The bug is startup ordering, latent long before it.

## Root cause

`main.kt` booted the engine **twice before** checking whether the installed engine matches this build:

| line | |
|---|---|
| 431 | `prewarmInBackground()` — boots the engine |
| 474 | `PasskeyPlatformInit.initialize()` → `CrossDeviceBrowserManager` → `FluckEngine.engine` — synchronous boot |
| 533 | `promotePendingInstall()` |
| **536** | **`isChromiumInstalled()`** ← the guard |

JxBrowser resolves its native toolkit under `Versions/<VersionInfo.chromiumVersion()>`, baked into the jar. Bumping the jar made every existing user's on-disk engine stale, so both early boots threw `UnsatisfiedLinkError` before the guard — and the download that repairs it — was ever reached.

While jar and engine were both 9.3.0 the early boots succeeded, so the ordering never showed. Confirmed on a live affected machine: app carrying JxBrowser 9.4.0 (wants Chromium `151.0.7922.72`), `~/.boss/boss-chromium` holding 9.3.0 (`150.0.7871.47`), pin `null` — the guard *would* have caught it.

## Changes

**The guard moves above both boots.** `promotePendingInstall` needs to lead regardless: it renames the engine directory, which is unsafe once a running engine holds files inside it.

**Pre-warm is skipped when a download is needed.** Warming against a mismatched directory cannot succeed; its only effect is raising the error the download is about to fix.

**`CrossDeviceBrowserManager` no longer boots an engine in its constructor.** It is built from `PasskeyPlatformInit` on the pre-UI path, and `FluckEngine.engine` is a multi-second Chromium boot under a lock. All three consumers read it purely as a null check and return OS-derived answers either way. The boot is now lazy and happens only in `openInFluckBrowser` — suspend, on `Dispatchers.IO`, once a passkey flow actually asks for the embedded browser. The other two never force it.

**Defence in depth:** ordering is a convention a future edit can silently break, so `FluckEngine` preflights. A framework carrying a different Chromium build than the jar needs now throws a message naming both versions and the remedy, instead of `UnsatisfiedLinkError` naming a path and no cause. Every "can't tell" path returns null — refusing to boot on a guess would be worse than the error it replaces.

## Verification

`detekt`, `ktlintCheck`, `desktopTest` green. `ChromiumVersionMismatchTest` covers accept / refuse-and-name-both / unmodelled-layout / no-executable-name.

**How I verified the test bites, and a trap worth knowing:** my first mutation (`if (true)`) failed to *compile*, so the test task never ran — and the previous run's XML, timestamped seconds earlier, read as a clean pass. Only grepping the log for `compileKotlinDesktop FAILED` caught it. The real mutation weakens the version check to a mere existence check, compiles, and fails exactly `an engine carrying a different Chromium build is refused, naming both`.

## Before re-releasing

- **Launch a signed build on a machine with a stale engine** and confirm it prompts a download instead of throwing. That is the exact scenario that broke, and no test covers it — six review rounds on #99 missed this because none of them ran the app.
- **Confirm the JxBrowser licence covers the 9.4.0 build** (keys carry a support-expiry date; 9.4.0 published 2026-07-31). Still unverified.

Related: #118 (Settings can still pin a mismatched engine — this preflight now makes that failure legible, but does not prevent it), #119 (updater OS-compatibility).
