### PR TITLE
fix(browser): make the startup guard and the engine resolver agree (#121)

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -451,10 +451,28 @@ fun main(args: Array<String>) {
     // it and skip the pre-warm despite a perfectly good bundled engine
     // (BossConsole#121). resolveEngineDir applies the same priority order and the
     // same version check the boot will.
-    val chromiumNeedsDownload =
-        !ai.rever.boss.plugin.browser.FluckEngine
+    val hasUsableEngine =
+        ai.rever.boss.plugin.browser.FluckEngine
             .hasUsableEngine()
-    if (chromiumNeedsDownload) {
+
+    // Downloading the same version again cannot help. If the cache is already
+    // stamped with the version we would fetch and the engine is still unusable, the
+    // published archive does not carry the Chromium build this jar needs — exactly
+    // the skew behind the 9.3.0/9.4.0 incident. Re-fetching would then re-download
+    // several hundred MB on every launch and never converge, so start instead and
+    // let the browser surface the specific mismatch.
+    val redownloadWouldRepeat =
+        !hasUsableEngine && ChromiumAutoDownloader.installedVersion() == ChromiumAutoDownloader.effectiveVersion
+
+    val chromiumNeedsDownload = !hasUsableEngine && !redownloadWouldRepeat
+    if (redownloadWouldRepeat) {
+        logger.error(
+            LogCategory.SYSTEM,
+            "Installed engine is stamped with the required version but is still unusable - " +
+                "the published archive does not match this build; not re-downloading",
+            mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
+        )
+    } else if (chromiumNeedsDownload) {
         logger.info(
             LogCategory.SYSTEM,
             "No usable browser engine - will prompt for download",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -451,33 +451,39 @@ fun main(args: Array<String>) {
     // it and skip the pre-warm despite a perfectly good bundled engine
     // (BossConsole#121). resolveEngineDir applies the same priority order and the
     // same version check the boot will.
+    // One read of the cache's health, shared by the resolver and the decision so
+    // the two can never disagree about it.
+    val cacheHealthy = ChromiumAutoDownloader.isChromiumInstalled()
     val hasUsableEngine =
         ai.rever.boss.plugin.browser.FluckEngine
-            .hasUsableEngine()
+            .hasUsableEngine(cacheHealthy)
+    val engineAction =
+        ai.rever.boss.plugin.browser.FluckEngine
+            .engineStartupAction(hasUsableEngine, cacheHealthy)
 
-    // Downloading the same version again cannot help. If the cache is already
-    // stamped with the version we would fetch and the engine is still unusable, the
-    // published archive does not carry the Chromium build this jar needs — exactly
-    // the skew behind the 9.3.0/9.4.0 incident. Re-fetching would then re-download
-    // several hundred MB on every launch and never converge, so start instead and
-    // let the browser surface the specific mismatch.
-    val redownloadWouldRepeat =
-        !hasUsableEngine && ChromiumAutoDownloader.installedVersion() == ChromiumAutoDownloader.effectiveVersion
+    val chromiumNeedsDownload =
+        engineAction == ai.rever.boss.plugin.browser.FluckEngine.EngineStartupAction.Download
+    when (engineAction) {
+        ai.rever.boss.plugin.browser.FluckEngine.EngineStartupAction.BootAndReport -> {
+            logger.error(
+                LogCategory.SYSTEM,
+                "Installed engine is healthy and stamped with the required version but is still " +
+                    "unusable - the published archive does not match this build; not re-downloading",
+                mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
+            )
+        }
 
-    val chromiumNeedsDownload = !hasUsableEngine && !redownloadWouldRepeat
-    if (redownloadWouldRepeat) {
-        logger.error(
-            LogCategory.SYSTEM,
-            "Installed engine is stamped with the required version but is still unusable - " +
-                "the published archive does not match this build; not re-downloading",
-            mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
-        )
-    } else if (chromiumNeedsDownload) {
-        logger.info(
-            LogCategory.SYSTEM,
-            "No usable browser engine - will prompt for download",
-            mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
-        )
+        ai.rever.boss.plugin.browser.FluckEngine.EngineStartupAction.Download -> {
+            logger.info(
+                LogCategory.SYSTEM,
+                "No usable browser engine - will prompt for download",
+                mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
+            )
+        }
+
+        ai.rever.boss.plugin.browser.FluckEngine.EngineStartupAction.Boot -> {
+            Unit
+        }
     }
 
     // Pre-warm the browser engine off the UI thread so the first browser tab
@@ -487,7 +493,11 @@ fun main(args: Array<String>) {
     // Skipped when the engine needs downloading: pre-warming against a mismatched
     // directory cannot succeed, and its only effect is to raise the very error
     // the download is about to fix.
-    if (!chromiumNeedsDownload) {
+    // Gated on hasUsableEngine, not on !chromiumNeedsDownload: in the
+    // BootAndReport case there is no usable engine AND no download, so the latter
+    // would fire a guaranteed-futile boot that burns an attempt and sets an error
+    // — exactly what the comment above says pre-warming must not do.
+    if (hasUsableEngine) {
         try {
             ai.rever.boss.plugin.browser.FluckEngine
                 .prewarmInBackground()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -441,11 +441,23 @@ fun main(args: Array<String>) {
     // engine holds files inside it.
     ChromiumAutoDownloader.promotePendingInstall()
 
-    val chromiumNeedsDownload = !ChromiumAutoDownloader.isChromiumInstalled()
+    // Ask the question we are about to act on: will an engine actually boot?
+    //
+    // isChromiumInstalled() answers a narrower one — "does the *cache* hold the
+    // right engine?" — which is the right input for deciding whether to download,
+    // but wrong for deciding whether to boot. FluckEngine prefers a bundled engine
+    // from the app image and only falls back to the cache, so a release that
+    // bundles one could pass the cache check and still boot something else, or fail
+    // it and skip the pre-warm despite a perfectly good bundled engine
+    // (BossConsole#121). resolveEngineDir applies the same priority order and the
+    // same version check the boot will.
+    val chromiumNeedsDownload =
+        !ai.rever.boss.plugin.browser.FluckEngine
+            .hasUsableEngine()
     if (chromiumNeedsDownload) {
         logger.info(
             LogCategory.SYSTEM,
-            "Installed browser engine missing or mismatched - will prompt for download",
+            "No usable browser engine - will prompt for download",
             mapOf("required" to ChromiumAutoDownloader.effectiveVersion),
         )
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1149,35 +1149,24 @@ object FluckEngine {
         // requested lazily on the first user-initiated screen share, after an in-app
         // rationale dialog (see setupCaptureSessionHandler + ScreenCaptureNotifier).
 
-        val chromiumDir = getChromiumDir()
-
-        // Refuse a mismatched engine with a message that names the cause.
-        //
-        // Left to JxBrowser this surfaces as `UnsatisfiedLinkError: Can't load
-        // library: .../Versions/<x>/Libraries/libtoolkit.dylib` — a path and no
-        // explanation, which cost a full debugging session to trace the first time.
-        // Startup checks the installed version before booting anything, so in the
-        // normal flow this never fires; it exists because that ordering is a
-        // convention a future edit can silently break, and when it does break the
-        // failure should say what is wrong rather than where a file was missing.
-        chromiumVersionMismatch(chromiumDir)?.let { reason ->
-            // The path is logged rather than folded into the message: the message
-            // reaches classifyError, which substring-matches it to choose a remedy.
-            logger.error(
-                LogCategory.BROWSER,
-                "Refusing to start a mismatched browser engine",
-                mapOf("engineDir" to chromiumDir.toString(), "reason" to reason),
-            )
-            // Record before throwing. initializationError is otherwise only set in
-            // createEngineWithProfile's catch, which this throw precedes — so
-            // initError stayed null, getBrowserState swallowed the exception, and
-            // the tab rendered "Could not initialize browser ... window not ready"
-            // instead of the message written here. Assigning it also arms the
-            // attemptCount short-circuit for this failure.
-            val error = IllegalStateException(reason)
-            initializationError = error
-            throw error
-        }
+        // getChromiumDir now returns only a directory that already passed the
+        // version check, so the separate veto that used to sit here can never fire
+        // — resolveEngineDir enforces it structurally instead of by convention.
+        // What remains is making sure its diagnosis reaches the user: this throw
+        // precedes createEngineWithProfile, which is the only other place
+        // initializationError is assigned, so without recording it here initError
+        // stays null, getBrowserState swallows the exception, and the tab renders
+        // "Could not initialize browser ... window not ready" instead of the reason.
+        val chromiumDir =
+            runCatching { getChromiumDir() }.getOrElse { e ->
+                logger.error(
+                    LogCategory.BROWSER,
+                    "No usable browser engine",
+                    mapOf("reason" to (e.message ?: "unknown")),
+                )
+                initializationError = e
+                throw e
+            }
 
         // Create directories if they don't exist
         chromiumDir.toFile().mkdirs()
@@ -1194,12 +1183,33 @@ object FluckEngine {
      * 1. Bundled BOSS-branded Chromium (in app resources)
      * 2. Cached BOSS-branded Chromium (~/.boss/boss-chromium/)
      */
-    private fun getChromiumDir(): java.nio.file.Path =
-        resolveEngineDir()
-            ?: throw IllegalStateException(
+    private fun getChromiumDir(): java.nio.file.Path = resolveEngineDir() ?: throw IllegalStateException(noUsableEngineReason())
+
+    /**
+     * Why no engine could be selected, as specifically as the candidates allow.
+     *
+     * Since [resolveEngineDir] only ever returns a directory that already passed
+     * the version check, the veto inside engine creation can no longer fire — this
+     * is where that diagnosis has to live instead. Without it a stale engine
+     * reports "BOSS-branded Chromium not found", which is both wrong (it is
+     * present, just stale) and names a folder that may not be the offending one.
+     */
+    private fun noUsableEngineReason(): String {
+        val present =
+            listOfNotNull(
+                getBundledChromiumPath(),
+                BossDirectories.resolve("boss-chromium").toPath(),
+            ).filter { isValidChromiumDir(it) }
+
+        return present.firstNotNullOfOrNull { chromiumVersionMismatch(it) }
+            ?: if (present.isNotEmpty()) {
+                "The installed browser engine is not usable with this build of BOSS. " +
+                    "Restart BOSS to download the matching engine."
+            } else {
                 "BOSS-branded Chromium not found. Please restart the app to trigger auto-download, " +
-                    "or manually install to ~/.boss/boss-chromium/",
-            )
+                    "or manually install to ~/.boss/boss-chromium/"
+            }
+    }
 
     /**
      * The engine directory that will actually boot, or null when none can.
@@ -1219,13 +1229,37 @@ object FluckEngine {
      * "is an engine installed?" by inspecting only the cache is what let a mismatched
      * engine boot with the guard reporting everything fine (BossConsole#121).
      */
-    internal fun resolveEngineDir(): java.nio.file.Path? =
-        firstUsableEngineDir(
-            listOfNotNull(
-                getBundledChromiumPath(),
-                BossDirectories.resolve("boss-chromium").toPath(),
-            ),
-        )
+    internal fun resolveEngineDir(): java.nio.file.Path? = firstUsableEngineDir(engineCandidates())
+
+    /**
+     * Engine directories to consider, in priority order.
+     *
+     * The cache is included only when [cacheHealthy] — `isChromiumInstalled()` by
+     * default — because that is the only check that works on EVERY platform: it
+     * compares `version.txt` against `effectiveVersion` unconditionally, and
+     * additionally rejects a macOS binary that has lost its execute bit.
+     *
+     * [chromiumVersionMismatch] cannot stand in for it. `frameworkVersionsDir`
+     * returns null off macOS by design, so the usability predicate collapses to
+     * "executable.name exists" there — a stale Windows/Linux cache would sail
+     * through the guard, pre-warm against the wrong engine, and bring back the
+     * UnsatisfiedLinkError this whole line of work exists to prevent.
+     *
+     * The bundled engine has no `version.txt` to check, but it ships inside the app
+     * image and so is consistent with the jar by construction; on macOS the
+     * framework check covers it anyway.
+     *
+     * Parameters are injectable purely so the rule is testable — the real values
+     * come from `java.home` and the user's home directory, which a test cannot
+     * fabricate.
+     */
+    internal fun engineCandidates(
+        bundled: java.nio.file.Path? = getBundledChromiumPath(),
+        cache: java.nio.file.Path = BossDirectories.resolve("boss-chromium").toPath(),
+        cacheHealthy: Boolean =
+            ai.rever.boss.config.ChromiumAutoDownloader
+                .isChromiumInstalled(),
+    ): List<java.nio.file.Path> = listOfNotNull(bundled, cache.takeIf { cacheHealthy })
 
     /**
      * The first candidate that is well-formed and carries the required Chromium build.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.plugin.tab_types.fluck.DownloadItem
 import ai.rever.boss.components.plugin.tab_types.fluck.DownloadManager
 import ai.rever.boss.components.plugin.tab_types.fluck.DownloadSettings
 import ai.rever.boss.components.plugin.tab_types.fluck.DownloadStatus
+import ai.rever.boss.config.ChromiumAutoDownloader
 import ai.rever.boss.config.JxBrowserConfig
 import ai.rever.boss.platform.FileNameSanitizer
 import ai.rever.boss.platform.FileSystemUtils
@@ -1195,11 +1196,10 @@ object FluckEngine {
      * present, just stale) and names a folder that may not be the offending one.
      */
     private fun noUsableEngineReason(): String {
-        val present =
-            listOfNotNull(
-                getBundledChromiumPath(),
-                BossDirectories.resolve("boss-chromium").toPath(),
-            ).filter { isValidChromiumDir(it) }
+        // Derived from engineCandidates so the reason can never describe a
+        // different set than the one that was searched. cacheHealthy = true so a
+        // cache the resolver skipped can still be named in the diagnosis.
+        val present = engineCandidates(cacheHealthy = true).filter { isValidChromiumDir(it) }
 
         return present.firstNotNullOfOrNull { chromiumVersionMismatch(it) }
             ?: if (present.isNotEmpty()) {
@@ -1229,7 +1229,12 @@ object FluckEngine {
      * "is an engine installed?" by inspecting only the cache is what let a mismatched
      * engine boot with the guard reporting everything fine (BossConsole#121).
      */
-    internal fun resolveEngineDir(): java.nio.file.Path? = firstUsableEngineDir(engineCandidates())
+
+    /** Whether the downloaded cache is well-formed and at the required version. */
+    private fun cacheIsHealthy(): Boolean = ChromiumAutoDownloader.isChromiumInstalled()
+
+    internal fun resolveEngineDir(cacheHealthy: Boolean = cacheIsHealthy()): java.nio.file.Path? =
+        firstUsableEngineDir(engineCandidates(cacheHealthy = cacheHealthy))
 
     /**
      * Engine directories to consider, in priority order.
@@ -1256,9 +1261,7 @@ object FluckEngine {
     internal fun engineCandidates(
         bundled: java.nio.file.Path? = getBundledChromiumPath(),
         cache: java.nio.file.Path = BossDirectories.resolve("boss-chromium").toPath(),
-        cacheHealthy: Boolean =
-            ai.rever.boss.config.ChromiumAutoDownloader
-                .isChromiumInstalled(),
+        cacheHealthy: Boolean = cacheIsHealthy(),
     ): List<java.nio.file.Path> = listOfNotNull(bundled, cache.takeIf { cacheHealthy })
 
     /**
@@ -1271,7 +1274,46 @@ object FluckEngine {
         candidates.firstOrNull { isValidChromiumDir(it) && chromiumVersionMismatch(it) == null }
 
     /** Whether an engine that can actually boot is present. */
-    internal fun hasUsableEngine(): Boolean = resolveEngineDir() != null
+    internal fun hasUsableEngine(cacheHealthy: Boolean): Boolean = resolveEngineDir(cacheHealthy) != null
+
+    /** What startup should do about the engine. */
+    internal enum class EngineStartupAction {
+        /** An engine is present and usable — boot normally. */
+        Boot,
+
+        /** Nothing usable and a fetch can repair it — show the download UI. */
+        Download,
+
+        /**
+         * Nothing usable, but the cache is healthy and already stamped with the
+         * version we would fetch — so the published archive does not carry the
+         * Chromium build this jar needs. Re-fetching would download hundreds of MB
+         * every launch and never converge; start instead and let the browser report
+         * the mismatch.
+         */
+        BootAndReport,
+    }
+
+    /**
+     * The startup decision, as a function of the two things it depends on.
+     *
+     * Extracted from `fun main` because it is the highest-risk logic in this area
+     * and was the only part with no coverage. Keyed on [cacheHealthy] — i.e.
+     * `isChromiumInstalled()` — rather than on version.txt alone: that file still
+     * reads correctly for a cache with a missing `executable.name` or a lost
+     * execute bit, both of which a re-download *does* repair. Suppressing the
+     * download on the version stamp alone turned ordinary local corruption into a
+     * terminal state with no in-app way out.
+     */
+    internal fun engineStartupAction(
+        hasUsableEngine: Boolean,
+        cacheHealthy: Boolean,
+    ): EngineStartupAction =
+        when {
+            hasUsableEngine -> EngineStartupAction.Boot
+            cacheHealthy -> EngineStartupAction.BootAndReport
+            else -> EngineStartupAction.Download
+        }
 
     /**
      * Why the engine at [chromiumDir] cannot serve this build's JxBrowser, or null

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1194,25 +1194,50 @@ object FluckEngine {
      * 1. Bundled BOSS-branded Chromium (in app resources)
      * 2. Cached BOSS-branded Chromium (~/.boss/boss-chromium/)
      */
-    private fun getChromiumDir(): java.nio.file.Path {
-        // Priority 1: Bundled BOSS-branded Chromium (in app resources)
-        val bundledDir = getBundledChromiumPath()
-        if (bundledDir != null && isValidChromiumDir(bundledDir)) {
-            return bundledDir
-        }
+    private fun getChromiumDir(): java.nio.file.Path =
+        resolveEngineDir()
+            ?: throw IllegalStateException(
+                "BOSS-branded Chromium not found. Please restart the app to trigger auto-download, " +
+                    "or manually install to ~/.boss/boss-chromium/",
+            )
 
-        // Priority 2: Cached BOSS-branded Chromium
-        val cachedBrandedDir = BossDirectories.resolve("boss-chromium").toPath()
-        if (isValidChromiumDir(cachedBrandedDir)) {
-            return cachedBrandedDir
-        }
-
-        // No fallback - BOSS-branded Chromium is required
-        throw IllegalStateException(
-            "BOSS-branded Chromium not found. Please restart the app to trigger auto-download, " +
-                "or manually install to ~/.boss/boss-chromium/",
+    /**
+     * The engine directory that will actually boot, or null when none can.
+     *
+     * Candidates in priority order — bundled in the app image, then the downloaded
+     * cache — and a candidate only wins if it is **usable**: well-formed *and*
+     * carrying the Chromium build this jar needs.
+     *
+     * The version check is part of the choice rather than a later veto because the
+     * bundled engine is not repairable. `ChromiumAutoDownloader` writes only to the
+     * cache, so if a stale bundled engine won an unconditional first-priority match,
+     * every download would land in a directory this resolver then ignored — the
+     * repair path could never repair anything. Skipping an unusable candidate lets
+     * the download take effect.
+     *
+     * Exposed so startup can ask the same question it is about to act on. Answering
+     * "is an engine installed?" by inspecting only the cache is what let a mismatched
+     * engine boot with the guard reporting everything fine (BossConsole#121).
+     */
+    internal fun resolveEngineDir(): java.nio.file.Path? =
+        firstUsableEngineDir(
+            listOfNotNull(
+                getBundledChromiumPath(),
+                BossDirectories.resolve("boss-chromium").toPath(),
+            ),
         )
-    }
+
+    /**
+     * The first candidate that is well-formed and carries the required Chromium build.
+     *
+     * Split from [resolveEngineDir] so the selection rule is testable: the real
+     * candidate list starts from `java.home`, which a test cannot fabricate.
+     */
+    internal fun firstUsableEngineDir(candidates: List<java.nio.file.Path>): java.nio.file.Path? =
+        candidates.firstOrNull { isValidChromiumDir(it) && chromiumVersionMismatch(it) == null }
+
+    /** Whether an engine that can actually boot is present. */
+    internal fun hasUsableEngine(): Boolean = resolveEngineDir() != null
 
     /**
      * Why the engine at [chromiumDir] cannot serve this build's JxBrowser, or null
@@ -1259,11 +1284,14 @@ object FluckEngine {
                     ?.joinToString(", ") { it.name }
                     ?.ifEmpty { "none" }
                     ?: "none"
+            // No remedy naming a specific folder: the mismatched engine may be the
+            // one bundled in the app image, which deleting the cache would not touch.
+            // resolveEngineDir now skips an unusable candidate, so a restart genuinely
+            // repairs both cases on its own.
             "Installed browser engine does not match this build of BOSS. " +
                 "JxBrowser ${com.teamdev.jxbrowser.VersionInfo.version()} needs Chromium $required, " +
                 "but the installed engine provides: $present. " +
-                "Delete the boss-chromium folder in your BOSS data directory and restart " +
-                "to re-download the matching engine."
+                "Restart BOSS to download the matching engine."
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -180,6 +180,63 @@ class ChromiumVersionMismatchTest {
     }
 
     @Test
+    fun `the usability predicate alone cannot police the cache off macOS`() {
+        // Pins WHY resolveEngineDir gates the cache on isChromiumInstalled() rather
+        // than relying on the predicate. frameworkVersionsDir returns null off
+        // macOS by design, so chromiumMismatchMessage makes no claim there and the
+        // predicate collapses to "executable.name exists" — a stale Windows/Linux
+        // cache would sail through, pre-warm against the wrong engine, and bring
+        // back the UnsatisfiedLinkError. version.txt is the only cross-platform
+        // version signal, and isChromiumInstalled is the only thing that reads it.
+        val stale = engineBundle("150.0.7871.47")
+
+        if (isMac) {
+            assertNotNull(
+                FluckEngine.chromiumVersionMismatch(stale),
+                "On macOS the framework layout is readable, so the predicate does catch it",
+            )
+        } else {
+            assertNull(
+                FluckEngine.chromiumVersionMismatch(stale),
+                "Off macOS the predicate cannot tell — which is exactly why the cache " +
+                    "candidate must be gated on isChromiumInstalled() instead",
+            )
+        }
+    }
+
+    @Test
+    fun `an unhealthy cache is not offered as a candidate`() {
+        // The regression this PR's first cut shipped: swapping isChromiumInstalled()
+        // for the usability predicate removed the version check on Windows and Linux
+        // entirely, because frameworkVersionsDir makes no claim off macOS. Runs on
+        // every leg — the point is that the gate is applied at all, not what it
+        // decides.
+        val cache = engineBundle("150.0.7871.47")
+
+        assertEquals(
+            emptyList(),
+            FluckEngine.engineCandidates(bundled = null, cache = cache, cacheHealthy = false),
+            "A cache that isChromiumInstalled() rejects must not be a candidate",
+        )
+        assertEquals(
+            listOf(cache),
+            FluckEngine.engineCandidates(bundled = null, cache = cache, cacheHealthy = true),
+            "A healthy cache must still be offered",
+        )
+    }
+
+    @Test
+    fun `the bundled engine outranks the cache`() {
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        val cache = engineBundle(VersionInfo.chromiumVersion())
+
+        assertEquals(
+            listOf(bundled, cache),
+            FluckEngine.engineCandidates(bundled = bundled, cache = cache, cacheHealthy = true),
+        )
+    }
+
+    @Test
     fun `the message carries no filesystem path`() {
         // It reaches classifyError, which substring-matches for "host", "connect",
         // "license" and friends to choose a remedy — so a home directory containing

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -237,6 +237,42 @@ class ChromiumVersionMismatchTest {
     }
 
     @Test
+    fun `a corrupt cache is still downloaded, not written off as archive skew`() {
+        // The regression this PR's second cut shipped. Suppressing the download on
+        // the version stamp alone caught states a re-download DOES repair — a
+        // missing executable.name, or a macOS binary that lost its execute bit —
+        // because version.txt still reads correctly in both. That turned ordinary
+        // local corruption into a terminal state with no in-app way out.
+        assertEquals(
+            FluckEngine.EngineStartupAction.Download,
+            FluckEngine.engineStartupAction(hasUsableEngine = false, cacheHealthy = false),
+        )
+    }
+
+    @Test
+    fun `a healthy cache that is still unusable means archive skew, not a re-download`() {
+        // Healthy and stamped with the version we would fetch, yet unusable: the
+        // published archive does not carry the build this jar needs. Re-fetching
+        // would download hundreds of MB every launch and never converge.
+        assertEquals(
+            FluckEngine.EngineStartupAction.BootAndReport,
+            FluckEngine.engineStartupAction(hasUsableEngine = true.not(), cacheHealthy = true),
+        )
+    }
+
+    @Test
+    fun `a usable engine just boots`() {
+        assertEquals(
+            FluckEngine.EngineStartupAction.Boot,
+            FluckEngine.engineStartupAction(hasUsableEngine = true, cacheHealthy = false),
+        )
+        assertEquals(
+            FluckEngine.EngineStartupAction.Boot,
+            FluckEngine.engineStartupAction(hasUsableEngine = true, cacheHealthy = true),
+        )
+    }
+
+    @Test
     fun `the message carries no filesystem path`() {
         // It reaches classifyError, which substring-matches for "host", "connect",
         // "license" and friends to choose a remedy — so a home directory containing

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -6,6 +6,7 @@ import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -29,6 +30,12 @@ import kotlin.test.assertTrue
  */
 class ChromiumVersionMismatchTest {
     private val temps = mutableListOf<File>()
+    private val isMac =
+        System
+            .getProperty("os.name")
+            .orEmpty()
+            .lowercase()
+            .contains("mac")
 
     @AfterTest
     fun cleanup() {
@@ -105,6 +112,71 @@ class ChromiumVersionMismatchTest {
 
         assertNotNull(message, "A stale engine must be refused through the real entry point")
         assertTrue(message.contains("150.0.7871.47"))
+    }
+
+    @Test
+    fun `an unusable candidate is skipped so a download can repair it`() {
+        // The reason the version check lives inside the resolver rather than acting
+        // as a veto afterwards. ChromiumAutoDownloader writes only to the cache, so
+        // if a stale BUNDLED engine won first priority unconditionally, every
+        // download would land somewhere the resolver then ignored and the repair
+        // path could never repair anything (BossConsole#121).
+        //
+        // Expressed against the predicate the resolver uses, so it holds on every
+        // leg: a directory carrying the wrong Chromium build must not be treated as
+        // usable, while one carrying the right build must.
+        val stale = versionsDir("150.0.7871.47")
+        val good = versionsDir(VersionInfo.chromiumVersion())
+
+        assertNotNull(
+            FluckEngine.chromiumMismatchMessage(stale),
+            "A stale candidate must be rejected, not chosen and then vetoed",
+        )
+        assertNull(
+            FluckEngine.chromiumMismatchMessage(good),
+            "A matching candidate must remain selectable",
+        )
+    }
+
+    /** A full engine bundle at [chromiumVersion], the shape getChromiumDir returns. */
+    private fun engineBundle(chromiumVersion: String): java.nio.file.Path {
+        val dir = createTempDirectory("candidate").toFile()
+        temps.add(dir)
+        File(dir, "executable.name").writeText("BOSS")
+        File(
+            dir,
+            "BOSS.app/Contents/Frameworks/Chromium Framework.framework/Versions/$chromiumVersion/Libraries",
+        ).mkdirs()
+        return dir.toPath()
+    }
+
+    @Test
+    fun `a stale first candidate is skipped in favour of a usable later one`() {
+        assumeTrue(isMac, "Candidate usability is decided by the macOS-only framework layout")
+        // This is the #121 fix. ChromiumAutoDownloader writes only to the cache, so
+        // if a stale BUNDLED engine won first priority unconditionally, every
+        // download would land somewhere the resolver ignored and the repair path
+        // could never repair anything. Order matters: stale first, good second.
+        val stale = engineBundle("150.0.7871.47")
+        val good = engineBundle(VersionInfo.chromiumVersion())
+
+        assertEquals(good, FluckEngine.firstUsableEngineDir(listOf(stale, good)))
+    }
+
+    @Test
+    fun `priority still holds when the first candidate is usable`() {
+        assumeTrue(isMac, "Candidate usability is decided by the macOS-only framework layout")
+        // Skipping must be driven by usability, not by preferring the last entry.
+        val firstGood = engineBundle(VersionInfo.chromiumVersion())
+        val secondGood = engineBundle(VersionInfo.chromiumVersion())
+
+        assertEquals(firstGood, FluckEngine.firstUsableEngineDir(listOf(firstGood, secondGood)))
+    }
+
+    @Test
+    fun `no usable candidate yields null rather than a stale one`() {
+        assumeTrue(isMac, "Candidate usability is decided by the macOS-only framework layout")
+        assertNull(FluckEngine.firstUsableEngineDir(listOf(engineBundle("150.0.7871.47"))))
     }
 
     @Test


### PR DESCRIPTION
Closes #121.

## The divergence

`ChromiumAutoDownloader.isChromiumInstalled()` inspects only `~/.boss/boss-chromium`. `FluckEngine.getChromiumDir()` **prefers a bundled engine** from the app image and only falls back to that cache. #120 promoted the former to the pre-boot guard — so the directory being checked was not necessarily the one that boots.

Three consequences, all newly reachable:

1. **Pre-warm skipped on a false positive.** A bundled install with an absent or stale cache sets the flag, skipping the warm-up despite a perfectly good bundled engine — reintroducing the cold start the pre-warm exists to remove.
2. **A passing guard proved nothing** about the engine that actually boots.
3. **A mismatched *bundled* engine could not be repaired.** The download writes to the cache, which the resolver kept ignoring in favour of the bundled directory.

## The fix

Startup now asks the question it is about to act on. `resolveEngineDir()` applies the same priority order and the same version check the boot will, and `hasUsableEngine()` drives both the download prompt and the pre-warm.

Consequence 3 is fixed by making the version check part of the **choice** rather than a veto after it: a candidate wins only if it is well-formed *and* carries the required Chromium build. An unusable bundled engine is skipped, so the downloaded cache can take over. Without that, every download lands somewhere the resolver ignores and the repair path can never repair anything.

`isChromiumInstalled()` is deliberately left alone — *"does the cache hold the right engine?"* is still the right input for deciding **what to download**. It was only ever the wrong input for deciding **whether to boot**.

The mismatch message drops its "delete the boss-chromium folder" remedy, since the offending engine may be the bundled one, which deleting the cache would not touch. A restart now repairs both cases unaided.

## Tests

Selection is split into `firstUsableEngineDir(candidates)` because the real candidate list starts from `java.home` and cannot be fabricated in a test. Three ordering tests cover it — stale-first-then-good, priority when the first is usable, none usable — alongside the existing predicate tests. **10 tests, 0 skipped** on macOS.

Mutation-verified, with the compile check that a previous round taught me to include: dropping the version check from selection (the pre-#121 behaviour) compiles cleanly — `0` occurrences of `compileKotlinDesktop FAILED` — and fails exactly `a stale first candidate is skipped in favour of a usable later one` and `no usable candidate yields null rather than a stale one`.

## Context

Last item before 9.3.0 can be re-published. The other two gates are closed: a signed build was tested against a deliberately stale engine and took the download path with zero `UnsatisfiedLinkError` (`installed=9.3.0, required=9.4.0` → downloaded → `Browser engine pre-warmed | {durationMs=3127}`), which also proves the production licence covers the 9.4.0 build.

**Not covered by that test, or this one:** an actual release built with `BRANDED_CHROMIUM_AVAILABLE`, i.e. one that really does bundle an engine. The local build had none, so the bundled branch is exercised only by unit tests here. Worth one packaged-release check before publishing.
