### PR TITLE
fix(browser,release): stamp the bundled engine so one version rule covers both candidates (#123)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,13 @@ jobs:
         # Apple is stubbed, so this runs on ubuntu with no credentials.
         run: bash scripts/test/test-notarize-dmg.sh
 
+      - name: 🧪 Bundled Chromium version stamp
+        # Release builds only run on publish, so nothing else exercises the
+        # bundling steps before they ship. version.txt is the only cross-platform
+        # signal of which Chromium build a bundled engine carries — without it an
+        # engine gets no version check at all off macOS (BossConsole#123).
+        run: bash scripts/test/test-bundled-chromium-stamp.sh
+
       - name: 🧪 JxBrowser auto-release detector tests
         # GitHub and Artifact Registry are stubbed so every decision path is
         # deterministic and does not consume credentials.

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -264,6 +264,10 @@ jobs:
       - name: 🔍 Get JxBrowser Version
         run: |
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (macOS)
@@ -292,6 +296,12 @@ jobs:
             CHROMIUM_DIR="$APP_PATH/Contents/Resources/chromium"
             mkdir -p "$CHROMIUM_DIR"
             cp -r branded-chromium/* "$CHROMIUM_DIR/" 2>/dev/null || true
+
+            # Same stamp as release.yml. macOS-only here, so FluckEngine's framework
+            # probe already covers this bundle — but the resolver treats the stamp as
+            # authoritative when present, and leaving the one remaining bundling site
+            # unstamped is how the next reader concludes stamping is optional.
+            echo -n "$JXBROWSER_VERSION" > "$CHROMIUM_DIR/version.txt"
             rm -f "$CHROMIUM_DIR"/*.zip 2>/dev/null || true
           fi
 
@@ -382,6 +392,10 @@ jobs:
         shell: bash
         run: |
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (Windows)
@@ -408,6 +422,9 @@ jobs:
             mkdir -p "$APP_DIR/chromium"
             cp -r branded-chromium/* "$APP_DIR/chromium/" 2>/dev/null || true
             rm -f "$APP_DIR/chromium"/*.zip 2>/dev/null || true
+            # Same stamp as release.yml — the only cross-platform signal of which
+            # Chromium build this engine carries (BossConsole#123).
+            echo -n "$JXBROWSER_VERSION" > "$APP_DIR/chromium/version.txt"
           fi
 
       - name: 🏗️ Package Windows MSI
@@ -512,6 +529,10 @@ jobs:
       - name: 🔍 Get JxBrowser Version
         run: |
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (Linux)
@@ -535,6 +556,9 @@ jobs:
               mkdir -p "$APP_DIR/lib/chromium"
               cp -r branded-chromium/* "$APP_DIR/lib/chromium/" 2>/dev/null || true
               rm -f "$APP_DIR/lib/chromium"/*.zip 2>/dev/null || true
+              # Same stamp as release.yml — the only cross-platform signal of which
+              # Chromium build this engine carries (BossConsole#123).
+              echo -n "$JXBROWSER_VERSION" > "$APP_DIR/lib/chromium/version.txt"
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,6 +520,14 @@ jobs:
             cp -r branded-chromium/* "$CHROMIUM_DIR/" 2>/dev/null || true
             rm -f "$CHROMIUM_DIR"/*.zip 2>/dev/null || true
 
+            # Stamp the version the app expects. version.txt is otherwise written
+            # only by ChromiumAutoDownloader, so a bundled engine carried none and
+            # got no version check at all off macOS, where the framework-layout
+            # probe makes no claim (BossConsole#123). Without it a mis-built
+            # release ships a stale bundled engine that wins first priority and
+            # cannot be repaired by a download.
+            echo -n "$JXBROWSER_VERSION" > "$CHROMIUM_DIR/version.txt"
+
             echo "✅ Branded Chromium bundled at: $CHROMIUM_DIR"
             ls -la "$CHROMIUM_DIR"
           else
@@ -728,6 +736,14 @@ jobs:
             cp -r branded-chromium/* "$CHROMIUM_DIR/" 2>/dev/null || true
             rm -f "$CHROMIUM_DIR"/*.zip 2>/dev/null || true
 
+            # Stamp the version the app expects. version.txt is otherwise written
+            # only by ChromiumAutoDownloader, so a bundled engine carried none and
+            # got no version check at all off macOS, where the framework-layout
+            # probe makes no claim (BossConsole#123). Without it a mis-built
+            # release ships a stale bundled engine that wins first priority and
+            # cannot be repaired by a download.
+            echo -n "$JXBROWSER_VERSION" > "$CHROMIUM_DIR/version.txt"
+
             echo "✅ Chromium bundled into app structure"
             ls -la "$CHROMIUM_DIR"
           else
@@ -914,6 +930,14 @@ jobs:
             cp -r branded-chromium/* "$CHROMIUM_DIR/" 2>/dev/null || true
             rm -f "$CHROMIUM_DIR"/*.zip 2>/dev/null || true
 
+            # Stamp the version the app expects. version.txt is otherwise written
+            # only by ChromiumAutoDownloader, so a bundled engine carried none and
+            # got no version check at all off macOS, where the framework-layout
+            # probe makes no claim (BossConsole#123). Without it a mis-built
+            # release ships a stale bundled engine that wins first priority and
+            # cannot be repaired by a download.
+            echo -n "$JXBROWSER_VERSION" > "$CHROMIUM_DIR/version.txt"
+
             echo "✅ Chromium bundled into app structure"
             ls -la "$CHROMIUM_DIR"
           else
@@ -1092,6 +1116,14 @@ jobs:
             # Copy branded Chromium files
             cp -r branded-chromium/* "$CHROMIUM_DIR/" 2>/dev/null || true
             rm -f "$CHROMIUM_DIR"/*.zip 2>/dev/null || true
+
+            # Stamp the version the app expects. version.txt is otherwise written
+            # only by ChromiumAutoDownloader, so a bundled engine carried none and
+            # got no version check at all off macOS, where the framework-layout
+            # probe makes no claim (BossConsole#123). Without it a mis-built
+            # release ships a stale bundled engine that wins first priority and
+            # cannot be repaired by a download.
+            echo -n "$JXBROWSER_VERSION" > "$CHROMIUM_DIR/version.txt"
 
             echo "✅ Branded Chromium bundled at: $CHROMIUM_DIR"
             ls -la "$CHROMIUM_DIR"
@@ -1354,6 +1386,10 @@ jobs:
             New-Item -ItemType Directory -Force -Path $CHROMIUM_DIR | Out-Null
             Copy-Item -Path 'branded-chromium/*' -Destination $CHROMIUM_DIR -Recurse -Force -ErrorAction SilentlyContinue
             Remove-Item -Path "$CHROMIUM_DIR/*.zip" -Force -ErrorAction SilentlyContinue
+            # Stamp the version the app expects — see the POSIX bundling steps.
+            # No BOM and no trailing newline: the reader trims, but Set-Content
+            # would prepend a UTF-8 BOM that a plain string compare would fail on.
+            [System.IO.File]::WriteAllText("$CHROMIUM_DIR/version.txt", $env:JXBROWSER_VERSION)
             Write-Host "Branded Chromium bundled at: $CHROMIUM_DIR"
             Get-ChildItem $CHROMIUM_DIR
           } else {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,6 +460,13 @@ jobs:
           # Extract JxBrowser version from libs.versions.toml for Chromium URL
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
           echo "JxBrowser version: $JXBROWSER_VERSION"
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            echo "  A silent miss here writes an EMPTY version.txt into the bundled engine,"
+            echo "  which the app reads as 'no stamp' and lets through unchecked - reverting"
+            echo "  to the state BossConsole#123 fixed, on a fully green release build."
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (macOS)
@@ -699,6 +706,13 @@ jobs:
           # Extract JxBrowser version from libs.versions.toml for Chromium URL
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
           echo "JxBrowser version: $JXBROWSER_VERSION"
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            echo "  A silent miss here writes an EMPTY version.txt into the bundled engine,"
+            echo "  which the app reads as 'no stamp' and lets through unchecked - reverting"
+            echo "  to the state BossConsole#123 fixed, on a fully green release build."
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (Linux)
@@ -893,6 +907,13 @@ jobs:
           # Extract JxBrowser version from libs.versions.toml for Chromium URL
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
           echo "JxBrowser version: $JXBROWSER_VERSION"
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            echo "  A silent miss here writes an EMPTY version.txt into the bundled engine,"
+            echo "  which the app reads as 'no stamp' and lets through unchecked - reverting"
+            echo "  to the state BossConsole#123 fixed, on a fully green release build."
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (Linux ARM64)
@@ -1072,6 +1093,13 @@ jobs:
           # Extract JxBrowser version from libs.versions.toml for Chromium URL
           JXBROWSER_VERSION=$(grep '^jxbrowser = "' gradle/libs.versions.toml | sed 's/.*= "\(.*\)"/\1/')
           echo "JxBrowser version: $JXBROWSER_VERSION"
+          if [[ -z "$JXBROWSER_VERSION" ]]; then
+            echo "::error::Could not extract jxbrowser version from gradle/libs.versions.toml"
+            echo "  A silent miss here writes an EMPTY version.txt into the bundled engine,"
+            echo "  which the app reads as 'no stamp' and lets through unchecked - reverting"
+            echo "  to the state BossConsole#123 fixed, on a fully green release build."
+            exit 1
+          fi
           echo "JXBROWSER_VERSION=$JXBROWSER_VERSION" >> $GITHUB_ENV
 
       - name: 📥 Download Branded Chromium (Windows)
@@ -1349,6 +1377,9 @@ jobs:
             $JXBROWSER_VERSION = $matches[1]
             Write-Host "JxBrowser version: $JXBROWSER_VERSION"
             "JXBROWSER_VERSION=$JXBROWSER_VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          } else {
+            Write-Error "Could not extract jxbrowser version from gradle/libs.versions.toml - an empty stamp would silently disable the bundled-engine version check (BossConsole#123)"
+            exit 1
           }
 
       - name: 📥 Download Branded Chromium (Windows ARM64)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -74,8 +74,19 @@ object ChromiumAutoDownloader {
     fun getPendingChromiumDir(): Path = BossDirectories.resolve("boss-chromium.pending").toPath()
 
     /** The version of the currently installed engine, or null if none/unknown. */
-    fun installedVersion(): String? {
-        val versionFile = getChromiumDir().resolve(VERSION_FILE).toFile()
+    fun installedVersion(): String? = installedVersionAt(getChromiumDir())
+
+    /**
+     * The version stamp in [dir], or null when there isn't one.
+     *
+     * Generalised from the cache-only reader so the bundled engine can be checked
+     * with the same rule. The stamp is the only version signal that works on every
+     * platform — the framework-layout probe FluckEngine uses is macOS-specific — so
+     * without it a bundled engine gets no version check at all off macOS
+     * (BossConsole#123).
+     */
+    fun installedVersionAt(dir: Path): String? {
+        val versionFile = dir.resolve(VERSION_FILE).toFile()
         return try {
             if (versionFile.exists()) versionFile.readText().trim().takeIf { it.isNotEmpty() } else null
         } catch (e: Exception) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1230,6 +1230,11 @@ object FluckEngine {
      * engine boot with the guard reporting everything fine (BossConsole#121).
      */
 
+    /** Paths already reported as stale, so the warning is not repeated per call. */
+    private val warnedStalePaths =
+        java.util.concurrent.ConcurrentHashMap
+            .newKeySet<String>()
+
     /** Whether the downloaded cache is well-formed and at the required version. */
     private fun cacheIsHealthy(): Boolean = ChromiumAutoDownloader.isChromiumInstalled()
 
@@ -1250,9 +1255,11 @@ object FluckEngine {
      * through the guard, pre-warm against the wrong engine, and bring back the
      * UnsatisfiedLinkError this whole line of work exists to prevent.
      *
-     * The bundled engine has no `version.txt` to check, but it ships inside the app
-     * image and so is consistent with the jar by construction; on macOS the
-     * framework check covers it anyway.
+     * The bundled engine is checked by [bundledStampIsAcceptable] instead. It gets a
+     * `version.txt` of its own, written by every bundling site in `release.yml`, so
+     * the same cross-platform signal covers both candidates. Before that stamp
+     * existed this paragraph claimed the bundled engine was "consistent with the jar
+     * by construction" — the assumption BossConsole#123 disproved.
      *
      * Parameters are injectable purely so the rule is testable — the real values
      * come from `java.home` and the user's home directory, which a test cannot
@@ -1306,7 +1313,11 @@ object FluckEngine {
     ): Boolean {
         val stamped = ChromiumAutoDownloader.installedVersionAt(bundled)
         val acceptable = stamped == null || stamped == required
-        if (!acceptable) {
+        // Once per path: engineCandidates is called from hasUsableEngine at startup,
+        // from getChromiumDir on every initializeEngine attempt (which retries), and
+        // from the diagnosis — so a stale bundle otherwise logs the same WARN several
+        // times a launch and reads like several distinct faults during triage.
+        if (!acceptable && warnedStalePaths.add(bundled.toString())) {
             logger.warn(
                 LogCategory.BROWSER,
                 "Ignoring bundled browser engine stamped with a different version",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1262,7 +1262,42 @@ object FluckEngine {
         bundled: java.nio.file.Path? = getBundledChromiumPath(),
         cache: java.nio.file.Path = BossDirectories.resolve("boss-chromium").toPath(),
         cacheHealthy: Boolean = cacheIsHealthy(),
-    ): List<java.nio.file.Path> = listOfNotNull(bundled, cache.takeIf { cacheHealthy })
+    ): List<java.nio.file.Path> =
+        listOfNotNull(
+            bundled?.takeIf { bundledStampIsAcceptable(it) },
+            cache.takeIf { cacheHealthy },
+        )
+
+    /**
+     * Whether a bundled engine's version stamp permits using it.
+     *
+     * Deliberately more lenient than the cache's check, and the asymmetry is the
+     * point. The cache is written by us, so a *missing* `version.txt` there means a
+     * broken extraction and `isChromiumInstalled()` rejects it. A bundled engine is
+     * copied in at packaging time and older app images predate stamping entirely,
+     * so a missing stamp here means "can't tell" and is allowed through — the same
+     * fail-open rule the framework probe uses.
+     *
+     * What this does catch is a stamp that is *present and wrong*, which is the only
+     * signal available off macOS: `frameworkVersionsDir` returns null there, so
+     * without this a mis-built release ships a stale bundled engine that wins first
+     * priority, is never checked, and cannot be repaired by a download — the
+     * download writes to the cache, which the resolver then never reaches
+     * (BossConsole#123).
+     */
+    private fun bundledStampIsAcceptable(bundled: java.nio.file.Path): Boolean {
+        val stamped = ChromiumAutoDownloader.installedVersionAt(bundled)
+        val required = ChromiumAutoDownloader.effectiveVersion
+        val acceptable = stamped == null || stamped == required
+        if (!acceptable) {
+            logger.warn(
+                LogCategory.BROWSER,
+                "Ignoring bundled browser engine stamped with a different version",
+                mapOf("stamped" to (stamped ?: "none"), "required" to required),
+            )
+        }
+        return acceptable
+    }
 
     /**
      * The first candidate that is well-formed and carries the required Chromium build.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1195,11 +1195,11 @@ object FluckEngine {
      * reports "BOSS-branded Chromium not found", which is both wrong (it is
      * present, just stale) and names a folder that may not be the offending one.
      */
-    private fun noUsableEngineReason(): String {
-        // Derived from engineCandidates so the reason can never describe a
-        // different set than the one that was searched. cacheHealthy = true so a
-        // cache the resolver skipped can still be named in the diagnosis.
-        val present = engineCandidates(cacheHealthy = true).filter { isValidChromiumDir(it) }
+    internal fun noUsableEngineReason(locations: List<java.nio.file.Path> = engineLocations()): String {
+        // Derived from engineLocations, NOT engineCandidates: a diagnosis has to
+        // describe the engines that were rejected, and the candidate list has by
+        // definition already dropped them.
+        val present = locations.filter { isValidChromiumDir(it) }
 
         return present.firstNotNullOfOrNull { chromiumVersionMismatch(it) }
             ?: if (present.isNotEmpty()) {
@@ -1262,11 +1262,26 @@ object FluckEngine {
         bundled: java.nio.file.Path? = getBundledChromiumPath(),
         cache: java.nio.file.Path = BossDirectories.resolve("boss-chromium").toPath(),
         cacheHealthy: Boolean = cacheIsHealthy(),
+        required: String = ChromiumAutoDownloader.effectiveVersion,
     ): List<java.nio.file.Path> =
         listOfNotNull(
-            bundled?.takeIf { bundledStampIsAcceptable(it) },
+            bundled?.takeIf { bundledStampIsAcceptable(it, required) },
             cache.takeIf { cacheHealthy },
         )
+
+    /**
+     * Every place an engine may live, unfiltered.
+     *
+     * Separate from [engineCandidates] because the diagnosis needs to see engines
+     * the selection rule *rejected* — that is the whole point of a diagnosis. With
+     * both derived from the filtered list, a stale bundled engine was excluded and
+     * the reason fell through to "BOSS-branded Chromium not found" while it sat
+     * right there, reintroducing exactly the wrong-message problem #122 removed.
+     */
+    internal fun engineLocations(
+        bundled: java.nio.file.Path? = getBundledChromiumPath(),
+        cache: java.nio.file.Path = BossDirectories.resolve("boss-chromium").toPath(),
+    ): List<java.nio.file.Path> = listOfNotNull(bundled, cache)
 
     /**
      * Whether a bundled engine's version stamp permits using it.
@@ -1285,9 +1300,11 @@ object FluckEngine {
      * download writes to the cache, which the resolver then never reaches
      * (BossConsole#123).
      */
-    private fun bundledStampIsAcceptable(bundled: java.nio.file.Path): Boolean {
+    private fun bundledStampIsAcceptable(
+        bundled: java.nio.file.Path,
+        required: String = ChromiumAutoDownloader.effectiveVersion,
+    ): Boolean {
         val stamped = ChromiumAutoDownloader.installedVersionAt(bundled)
-        val required = ChromiumAutoDownloader.effectiveVersion
         val acceptable = stamped == null || stamped == required
         if (!acceptable) {
             logger.warn(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.browser
 
+import ai.rever.boss.config.ChromiumAutoDownloader
 import com.teamdev.jxbrowser.VersionInfo
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import java.io.File
@@ -269,6 +270,55 @@ class ChromiumVersionMismatchTest {
         assertEquals(
             FluckEngine.EngineStartupAction.Boot,
             FluckEngine.engineStartupAction(hasUsableEngine = true, cacheHealthy = true),
+        )
+    }
+
+    /** Writes a version stamp into [dir], as packaging and the downloader both do. */
+    private fun stamp(
+        dir: java.nio.file.Path,
+        version: String,
+    ) = File(dir.toFile(), "version.txt").writeText(version)
+
+    @Test
+    fun `a bundled engine stamped with a different version is not a candidate`() {
+        // The #123 fix. Off macOS the framework probe makes no claim, so before
+        // packaging wrote a stamp a stale BUNDLED engine won first priority with no
+        // check at all — and could not be repaired, because the download writes to
+        // the cache the resolver then never reached. Runs on every leg: the stamp is
+        // the only cross-platform version signal, which is the whole point.
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        stamp(bundled, "0.0.0-not-this-build")
+
+        assertEquals(
+            emptyList(),
+            FluckEngine.engineCandidates(bundled = bundled, cache = bundled, cacheHealthy = false),
+            "A bundled engine stamped for a different build must be skipped",
+        )
+    }
+
+    @Test
+    fun `a bundled engine stamped with the required version is kept`() {
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        stamp(bundled, ChromiumAutoDownloader.effectiveVersion)
+
+        assertEquals(
+            listOf(bundled),
+            FluckEngine.engineCandidates(bundled = bundled, cache = bundled, cacheHealthy = false),
+        )
+    }
+
+    @Test
+    fun `an unstamped bundled engine is still allowed through`() {
+        // Deliberately more lenient than the cache, which treats a missing stamp as
+        // a broken extraction. App images built before packaging stamped carry no
+        // version.txt, and refusing those would make every such user re-download
+        // for no reason — so "can't tell" stays fail-open, matching the framework
+        // probe's rule.
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+
+        assertEquals(
+            listOf(bundled),
+            FluckEngine.engineCandidates(bundled = bundled, cache = bundled, cacheHealthy = false),
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -400,6 +400,68 @@ class ChromiumVersionMismatchTest {
     }
 
     @Test
+    fun `a stale-stamped bundled engine yields to the downloaded cache`() {
+        // The behaviour #123 is actually about, which the filter tests did not
+        // reach: they all passed cacheHealthy = false and asserted an empty list,
+        // so none showed the repair path working. Runs on every leg — the cache is
+        // gated on cacheHealthy, not on the macOS framework probe.
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        stamp(bundled, "0.0.0-not-this-build")
+        val cache = engineBundle(VersionInfo.chromiumVersion())
+        stamp(cache, requiredVersion)
+
+        assertEquals(
+            listOf(cache),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = cache,
+                cacheHealthy = true,
+                required = requiredVersion,
+            ),
+            "A stale bundled engine must step aside so the downloaded cache can be used",
+        )
+    }
+
+    @Test
+    fun `a trailing newline in the stamp is tolerated`() {
+        // echo -n is tidy, not load-bearing: installedVersionAt trims. Pinning it
+        // means a future bundling site using plain echo does not silently produce a
+        // stamp that never matches.
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        stamp(bundled, "$requiredVersion\n")
+
+        assertEquals(
+            listOf(bundled),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = bundled,
+                cacheHealthy = false,
+                required = requiredVersion,
+            ),
+        )
+    }
+
+    @Test
+    fun `a BOM-prefixed stamp is not accepted`() {
+        // Why the PowerShell site uses WriteAllText rather than Set-Content: U+FEFF
+        // is not Character.isWhitespace, so trim() does not remove it and the
+        // comparison fails. Without this the reason lives only in a workflow comment.
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        stamp(bundled, "\uFEFF$requiredVersion")
+
+        assertEquals(
+            emptyList(),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = bundled,
+                cacheHealthy = false,
+                required = requiredVersion,
+            ),
+            "A BOM-prefixed stamp must not silently pass as a match",
+        )
+    }
+
+    @Test
     fun `the message carries no filesystem path`() {
         // It reaches classifyError, which substring-matches for "host", "connect",
         // "license" and friends to choose a remedy — so a home directory containing

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ChromiumVersionMismatchTest.kt
@@ -1,6 +1,5 @@
 package ai.rever.boss.plugin.browser
 
-import ai.rever.boss.config.ChromiumAutoDownloader
 import com.teamdev.jxbrowser.VersionInfo
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import java.io.File
@@ -30,6 +29,14 @@ import kotlin.test.assertTrue
  * boots.
  */
 class ChromiumVersionMismatchTest {
+    /**
+     * A fixed required version. Reading ChromiumAutoDownloader.effectiveVersion
+     * here would force BrowserEngineSettingsManager's init, which reads — and on a
+     * redundant pin rewrites — the developer's real ~/.boss config. Tests must not
+     * mutate real user state.
+     */
+    private val requiredVersion = "9.9.9-test"
+
     private val temps = mutableListOf<File>()
     private val isMac =
         System
@@ -291,7 +298,12 @@ class ChromiumVersionMismatchTest {
 
         assertEquals(
             emptyList(),
-            FluckEngine.engineCandidates(bundled = bundled, cache = bundled, cacheHealthy = false),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = bundled,
+                cacheHealthy = false,
+                required = requiredVersion,
+            ),
             "A bundled engine stamped for a different build must be skipped",
         )
     }
@@ -299,11 +311,16 @@ class ChromiumVersionMismatchTest {
     @Test
     fun `a bundled engine stamped with the required version is kept`() {
         val bundled = engineBundle(VersionInfo.chromiumVersion())
-        stamp(bundled, ChromiumAutoDownloader.effectiveVersion)
+        stamp(bundled, requiredVersion)
 
         assertEquals(
             listOf(bundled),
-            FluckEngine.engineCandidates(bundled = bundled, cache = bundled, cacheHealthy = false),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = bundled,
+                cacheHealthy = false,
+                required = requiredVersion,
+            ),
         )
     }
 
@@ -318,8 +335,68 @@ class ChromiumVersionMismatchTest {
 
         assertEquals(
             listOf(bundled),
-            FluckEngine.engineCandidates(bundled = bundled, cache = bundled, cacheHealthy = false),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = bundled,
+                cacheHealthy = false,
+                required = requiredVersion,
+            ),
         )
+    }
+
+    @Test
+    fun `the diagnosis can still see an engine the selection rule rejected`() {
+        // engineLocations is deliberately unfiltered. Deriving the "no usable
+        // engine" reason from the candidate list instead would hide a stale
+        // bundled engine and report "not found" while it sat right there — the
+        // wrong-message problem #122 removed, reintroduced for the bundled case.
+        val bundled = engineBundle(VersionInfo.chromiumVersion())
+        stamp(bundled, "0.0.0-not-this-build")
+        val cache = engineBundle(VersionInfo.chromiumVersion())
+
+        assertEquals(
+            emptyList(),
+            FluckEngine.engineCandidates(
+                bundled = bundled,
+                cache = cache,
+                cacheHealthy = false,
+                required = requiredVersion,
+            ),
+            "precondition: the stale bundled engine is rejected as a candidate",
+        )
+        assertEquals(
+            listOf(bundled, cache),
+            FluckEngine.engineLocations(bundled = bundled, cache = cache),
+            "but both remain visible to the diagnosis",
+        )
+    }
+
+    @Test
+    fun `a present-but-stale engine is never reported as not found`() {
+        // The defect this PR's own review caught: deriving the reason from the
+        // FILTERED candidate list hid a rejected bundled engine, so the user was
+        // told "BOSS-branded Chromium not found" while it sat right there. Asserts
+        // on the reason itself rather than on the helpers, because swapping which
+        // list it reads is invisible to a helper-level test — verified: it was.
+        val stale = engineBundle("150.0.7871.47")
+
+        val reason = FluckEngine.noUsableEngineReason(listOf(stale))
+
+        assertFalse(
+            reason.contains("not found"),
+            "An engine that is present and merely stale must not be reported as missing",
+        )
+        if (isMac) {
+            assertTrue(
+                reason.contains("150.0.7871.47"),
+                "On macOS the framework layout is readable, so name the build found",
+            )
+        }
+    }
+
+    @Test
+    fun `a genuinely absent engine is still reported as not found`() {
+        assertTrue(FluckEngine.noUsableEngineReason(emptyList()).contains("not found"))
     }
 
     @Test

--- a/scripts/test/test-bundled-chromium-stamp.sh
+++ b/scripts/test/test-bundled-chromium-stamp.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Guards the bundled-engine version stamp in release.yml.
+#
+# version.txt is the ONLY cross-platform signal of which Chromium build an engine
+# carries: FluckEngine's other check reads a macOS framework layout and makes no
+# claim elsewhere. So on Windows and Linux an unstamped bundled engine gets no
+# version check at all — it wins first priority, is never questioned, and cannot
+# be repaired, because the download writes to the cache the resolver then never
+# reaches (BossConsole#123).
+#
+# Release builds only run on publish, so nothing else exercises these steps before
+# they ship. This asserts the invariant by reading the workflow: every site that
+# copies branded Chromium into an app image must stamp version.txt in the same
+# block. It exists so adding a sixth platform, or reordering an existing step,
+# cannot silently drop the stamp.
+#
+# Run: bash scripts/test/test-bundled-chromium-stamp.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="$HERE/../../.github/workflows/release.yml"
+
+pass=0; fail=0
+ok()  { echo "  ok: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+[[ -f "$WORKFLOW" ]] || { echo "FATAL: $WORKFLOW not found" >&2; exit 1; }
+
+# A "bundling site" copies the unpacked branded-chromium into the app image.
+# Both spellings appear: POSIX shell on macOS/Linux/Windows-x64, PowerShell on
+# Windows-arm64.
+BUNDLE_RE='cp -r branded-chromium/\*|Copy-Item -Path .branded-chromium/\*'
+# A "stamp" WRITES version.txt — matched on the write itself, not the filename.
+# The word alone also appears in the comment above each stamp, so a filename match
+# is satisfied by the prose and passes with the actual write deleted. (Verified:
+# it did exactly that.) Same trap as matching "rm -rf" inside a comment that says
+# "before an irreversible rm -rf".
+STAMP_RE='> *"\$CHROMIUM_DIR/version\.txt"|WriteAllText\("\$CHROMIUM_DIR/version\.txt"'
+
+# while-read rather than mapfile: macOS ships bash 3.2, and a guard that only
+# runs on the CI box is a guard nobody can check before pushing.
+bundle_lines=""
+while IFS= read -r n; do
+    bundle_lines="$bundle_lines $n"
+done < <(grep -nE "$BUNDLE_RE" "$WORKFLOW" | cut -d: -f1)
+# shellcheck disable=SC2086
+set -- $bundle_lines
+bundle_count=$#
+
+if (( bundle_count == 0 )); then
+    bad "no bundling sites found — the matcher has drifted from the workflow"
+else
+    ok "found $bundle_count bundling site(s)"
+fi
+
+# Each site must stamp within the same block. 15 lines is generous for the
+# copy/cleanup/stamp sequence while still being local to the step.
+WINDOW=15
+for line in $bundle_lines; do
+    end=$(( line + WINDOW ))
+    if sed -n "${line},${end}p" "$WORKFLOW" | grep -qE "$STAMP_RE"; then
+        ok "bundling site at line $line stamps version.txt"
+    else
+        bad "bundling site at line $line does NOT stamp version.txt within $WINDOW lines — \
+an engine bundled without a stamp gets no version check off macOS"
+    fi
+done
+
+# Set-Content would prepend a UTF-8 BOM, which a plain string compare against the
+# stamp fails on. The Kotlin reader trims whitespace, not a BOM.
+if grep -nE "Set-Content.*version\.txt" "$WORKFLOW" >/dev/null 2>&1; then
+    bad "PowerShell stamp uses Set-Content — it writes a UTF-8 BOM; use [System.IO.File]::WriteAllText"
+else
+    ok "no BOM-producing Set-Content used for the stamp"
+fi
+
+# The stamp must carry the version the build actually fetched, not a literal.
+stamp_lines=$(grep -cE "$STAMP_RE" "$WORKFLOW" || true)
+if grep -E "$STAMP_RE" "$WORKFLOW" | grep -qE 'JXBROWSER_VERSION'; then
+    ok "stamps reference JXBROWSER_VERSION rather than a hardcoded value"
+else
+    bad "no stamp references JXBROWSER_VERSION — a hardcoded version would go stale silently"
+fi
+
+echo
+echo "passed: $pass, failed: $fail (version.txt mentions: $stamp_lines)"
+(( fail == 0 )) || exit 1

--- a/scripts/test/test-bundled-chromium-stamp.sh
+++ b/scripts/test/test-bundled-chromium-stamp.sh
@@ -19,13 +19,15 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKFLOW="$HERE/../../.github/workflows/release.yml"
+WORKFLOWS="$HERE/../../.github/workflows/release.yml $HERE/../../.github/workflows/release-lite.yml"
 
 pass=0; fail=0
 ok()  { echo "  ok: $1"; pass=$((pass + 1)); }
 bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
 
-[[ -f "$WORKFLOW" ]] || { echo "FATAL: $WORKFLOW not found" >&2; exit 1; }
+for w in $WORKFLOWS; do
+    [[ -f "$w" ]] || { echo "FATAL: $w not found" >&2; exit 1; }
+done
 
 # A "bundling site" copies the unpacked branded-chromium into the app image.
 # Both spellings appear: POSIX shell on macOS/Linux/Windows-x64, PowerShell on
@@ -36,10 +38,16 @@ BUNDLE_RE='cp -r branded-chromium/\*|Copy-Item -Path .branded-chromium/\*'
 # is satisfied by the prose and passes with the actual write deleted. (Verified:
 # it did exactly that.) Same trap as matching "rm -rf" inside a comment that says
 # "before an irreversible rm -rf".
-STAMP_RE='> *"\$CHROMIUM_DIR/version\.txt"|WriteAllText\("\$CHROMIUM_DIR/version\.txt"'
+# Matches a redirect or WriteAllText into any path ending in version.txt. Not tied
+# to one variable name: release-lite stamps "$APP_DIR/chromium/version.txt" while
+# release.yml uses "$CHROMIUM_DIR/...", and a matcher pinned to the latter reported
+# genuinely-stamped sites as unstamped.
+STAMP_RE='> *"[^"]*version\.txt"|WriteAllText\("[^"]*version\.txt"'
 
 # while-read rather than mapfile: macOS ships bash 3.2, and a guard that only
 # runs on the CI box is a guard nobody can check before pushing.
+for WORKFLOW in $WORKFLOWS; do
+echo "--- $(basename "$WORKFLOW") ---"
 bundle_lines=""
 while IFS= read -r n; do
     bundle_lines="$bundle_lines $n"
@@ -76,13 +84,25 @@ else
 fi
 
 # The stamp must carry the version the build actually fetched, not a literal.
-stamp_lines=$(grep -cE "$STAMP_RE" "$WORKFLOW" || true)
 if grep -E "$STAMP_RE" "$WORKFLOW" | grep -qE 'JXBROWSER_VERSION'; then
     ok "stamps reference JXBROWSER_VERSION rather than a hardcoded value"
 else
     bad "no stamp references JXBROWSER_VERSION — a hardcoded version would go stale silently"
 fi
 
+# An empty JXBROWSER_VERSION writes an empty version.txt, which the app reads as
+# "no stamp" and lets through — silently reverting to the unchecked behaviour on a
+# green release build. Every extraction must fail loudly instead.
+extractions=$(grep -cE "JXBROWSER_VERSION=\\\$\(grep|\\\$JXBROWSER_VERSION = \\\$matches" "$WORKFLOW" || true)
+guards=$(grep -cE '\-z "\$JXBROWSER_VERSION"|Could not extract jxbrowser version' "$WORKFLOW" || true)
+if (( guards >= extractions && extractions > 0 )); then
+    ok "all $extractions version extraction(s) guarded against an empty result"
+else
+    bad "only $guards guard(s) for $extractions extraction(s) — an empty version silently disables the stamp"
+fi
+
+done
+
 echo
-echo "passed: $pass, failed: $fail (version.txt mentions: $stamp_lines)"
+echo "passed: $pass, failed: $fail"
 (( fail == 0 )) || exit 1


### PR DESCRIPTION
Closes #123.

## The gap

`version.txt` was written by exactly one place — `ChromiumAutoDownloader`, when it extracts a downloaded archive into `~/.boss/boss-chromium`. A **bundled** engine, copied into the app image at packaging time, never got one.

#122 established the selection rule as *"a candidate wins only if it's well-formed **and** carries the Chromium build this jar needs."* But the two candidates were checked by different mechanisms:

| candidate | version check | works on |
|---|---|---|
| cache | `isChromiumInstalled()` reads `version.txt` | **every platform** |
| bundled | `chromiumVersionMismatch()` reads the framework's `Versions/<chromium>` dir | **macOS only** |

`frameworkVersionsDir` returns `null` off macOS by design — that layout is a macOS framework bundle. So on Windows and Linux the bundled candidate got **no version check at all**: a stale bundled engine wins first priority, is never questioned, and cannot be repaired, because the download writes to the cache the resolver then never reaches. That's consequence 3 of #121, still live on two platforms.

Worth stating plainly: **all five platform jobs bundle an engine** — macOS `Contents/Resources/chromium`, Linux `lib/chromium`, Windows `chromium` — each fetched from `chromium-v$JXBROWSER_VERSION`. So this was not a macOS-only concern; it was unchecked on the majority of platforms.

## The fix

Every bundling site in `release.yml` now writes `version.txt` with the `JXBROWSER_VERSION` it fetched — the same stamp the downloader writes. Five sites: macOS, Linux x64, Linux arm64, Windows x64 (POSIX shell) and Windows arm64 (PowerShell). The PowerShell site uses `[System.IO.File]::WriteAllText` rather than `Set-Content`, which would prepend a UTF-8 BOM that a plain string compare would fail on.

`installedVersion()` is generalised to `installedVersionAt(dir)` so one reader serves both candidates, and `engineCandidates` filters the bundled path on it. The selection rule is now platform-independent instead of resting on a macOS-only probe.

## The deliberate asymmetry

The bundled check is **more lenient** than the cache's, and that's the point:

- **Cache**, missing stamp → rejected. We write that file, so its absence means a broken extraction.
- **Bundled**, missing stamp → allowed. App images built before this change carry none, and refusing them would make every such user re-download several hundred MB for no reason.

So "can't tell" stays fail-open — the same rule the framework probe already uses. What this catches is a stamp that is *present and wrong*.

## Tests

19 tests, 0 skipped. The three new ones are OS-free, which is the whole point — the stamp is the cross-platform signal, unlike the macOS-gated framework tests.

Mutation-verified with the compile check: removing the bundled filter compiles cleanly (`0` occurrences of `compileKotlinDesktop FAILED`) and fails exactly `a bundled engine stamped with a different version is not a candidate`.

## Scope note

This makes a stale bundled engine **detectable and repairable**. It does not prevent one being built — that still implies a mis-built release, since packaging fetches the archive keyed on `JXBROWSER_VERSION`. The value is that such a release now degrades to a download instead of an unexplained broken browser on Windows and Linux.

`release.yml` changes are not exercised by PR CI (release builds only run on publish), so the stamping itself is verified by reading, not by execution — worth a glance at the first packaged build.
