### PR TITLE
fix(browser): name the engine version while downloading, and offer the restart a staged install needs

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ChromiumDownloadDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ChromiumDownloadDialog.kt
@@ -14,6 +14,32 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 /**
+ * The status line for the engine download dialog.
+ *
+ * Pure so the wording is pinned by tests: this dialog blocks the entire app for a
+ * several-hundred-MB fetch, and what triggers it is an engine/jar mismatch — so
+ * naming the version is the difference between "why is this happening" and an
+ * answer. It went unnamed until someone ran the app and asked.
+ */
+internal fun engineDownloadStatus(
+    engineLabel: String,
+    isExtracting: Boolean,
+    totalBytes: Long,
+): String =
+    when {
+        // isExtracting arrives with totalBytes still set from the download, so this
+        // branch has to come first or the dialog claims it is still downloading
+        // while it unpacks.
+        isExtracting -> "Extracting $engineLabel\u2026"
+
+        totalBytes > 0 -> "Installing $engineLabel\u2026"
+
+        // "Connecting to download X" drops the object of the connection; the sibling
+        // progress text in Settings uses a real ellipsis, so match it here too.
+        else -> "Connecting to the download server for $engineLabel\u2026"
+    }
+
+/**
  * The actual download UI content - a Surface with progress info.
  */
 @Composable

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BrowserEngineSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BrowserEngineSettings.kt
@@ -257,10 +257,16 @@ fun BrowserEngineSettings() {
                     // at startup — until then the download has changed nothing the
                     // user can see, which reads like the install silently failed.
                     SettingsButtonRow(
-                        label = status,
+                        label = "Staged — restart to apply",
                         buttonText = "Restart BOSS",
                         onClick = { ApplicationRestarter.restartApplication() },
-                        description = "Applies the staged engine. Unsaved work in open tabs is lost.",
+                        // Verified rather than assumed: restartApplication exits via
+                        // exitProcess, which runs the shutdown hook, and that hook
+                        // calls LastSessionCoordinator.saveOnProcessExit — so tabs do
+                        // come back. Saying "unsaved work is lost" here would have
+                        // been false, and would have talked people out of the one
+                        // action that makes their download take effect.
+                        description = "$status BOSS reopens with your tabs restored; running terminal processes end.",
                     )
                 } else {
                     SettingsInfoRow(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BrowserEngineSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BrowserEngineSettings.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.config.BrowserEngineSettingsManager
 import ai.rever.boss.config.ChromiumAutoDownloader
 import ai.rever.boss.config.ChromiumReleaseSource
 import ai.rever.boss.config.EngineVersionListing
+import ai.rever.boss.utils.ApplicationRestarter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -71,6 +72,12 @@ fun BrowserEngineSettings() {
     var versionsError by remember { mutableStateOf<String?>(null) }
     var installProgress by remember { mutableStateOf<ChromiumAutoDownloader.DownloadProgress?>(null) }
     var installStatus by remember { mutableStateOf<String?>(null) }
+
+    // Separate from installStatus so a completed stage can offer the restart it
+    // requires. The message alone rendered as a description on an empty-value row —
+    // easy to miss after a several-hundred-MB download, and the staged engine does
+    // nothing at all until the app is restarted.
+    var stagedAwaitingRestart by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         try {
@@ -203,6 +210,7 @@ fun BrowserEngineSettings() {
                     buttonText = if (selectedVersion == installedVersion) "Reinstall" else "Install",
                     onClick = {
                         installStatus = null
+                        stagedAwaitingRestart = false
                         installProgress = ChromiumAutoDownloader.DownloadProgress(0, 0)
                         val versionToInstall = selectedVersion
                         val overrideToPersist = selectedOverride
@@ -225,7 +233,8 @@ fun BrowserEngineSettings() {
                                         BrowserEngineSettingsManager.updateSettings(
                                             BrowserEngineSettingsData(selectedVersion = overrideToPersist),
                                         )
-                                        "Engine $versionToInstall downloaded — restart BOSS to apply."
+                                        stagedAwaitingRestart = true
+                                        "Engine $versionToInstall is staged. It is not in use until BOSS restarts."
                                     },
                                     onFailure = { e ->
                                         "Install failed: ${e.message ?: "unknown error"}"
@@ -242,11 +251,24 @@ fun BrowserEngineSettings() {
 
             installStatus?.let { status ->
                 Spacer(modifier = Modifier.height(8.dp))
-                SettingsInfoRow(
-                    label = "Status",
-                    value = "",
-                    description = status,
-                )
+                if (stagedAwaitingRestart) {
+                    // An action, not a note. A staged engine sits in
+                    // boss-chromium.pending and is swapped in by promotePendingInstall
+                    // at startup — until then the download has changed nothing the
+                    // user can see, which reads like the install silently failed.
+                    SettingsButtonRow(
+                        label = status,
+                        buttonText = "Restart BOSS",
+                        onClick = { ApplicationRestarter.restartApplication() },
+                        description = "Applies the staged engine. Unsaved work in open tabs is lost.",
+                    )
+                } else {
+                    SettingsInfoRow(
+                        label = "Status",
+                        value = "",
+                        description = status,
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BrowserEngineSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BrowserEngineSettings.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.settings.sections
 
+import ai.rever.boss.components.dialogs.ConfirmationDialog
 import ai.rever.boss.components.settings.shared.SettingsButtonRow
 import ai.rever.boss.components.settings.shared.SettingsDropdown
 import ai.rever.boss.components.settings.shared.SettingsInfoRow
@@ -43,6 +44,70 @@ private data class InstalledVersion(
  * a staged install succeeds, so browsing the dropdown never changes what the next
  * launch downloads.
  */
+
+/**
+ * What Settings shows after a staged engine install.
+ *
+ * A sealed type rather than a message plus a flag: those were two `mutableStateOf`s
+ * encoding one outcome, kept consistent only by convention, so "staged but failed"
+ * was representable. Here it isn't.
+ *
+ * [Staged.appliesOnRestart] is the part that matters. `updateSettings` runs
+ * `withoutUnusablePin()`, which drops any `selectedVersion` that isn't the bundled
+ * version — so staging a *non-default* engine persists no pin, and the next launch
+ * promotes it, finds it doesn't match `effectiveVersion`, and re-downloads the
+ * default. Offering "Restart BOSS" there would cost the user their session and a
+ * several-hundred-MB download to end up exactly where they started.
+ */
+internal sealed interface StagedInstallOutcome {
+    data class Staged(
+        val version: String,
+        val appliesOnRestart: Boolean,
+    ) : StagedInstallOutcome
+
+    data class Failed(
+        val message: String,
+    ) : StagedInstallOutcome
+}
+
+/** The message for an outcome. Derived, never stored alongside it. */
+internal fun StagedInstallOutcome.message(defaultVersion: String): String =
+    when (this) {
+        is StagedInstallOutcome.Failed -> {
+            message
+        }
+
+        is StagedInstallOutcome.Staged -> {
+            if (appliesOnRestart) {
+                "Engine $version is staged. It is not in use until BOSS restarts."
+            } else {
+                "Engine $version is staged, but this build requires $defaultVersion — " +
+                    "it will be replaced on the next launch."
+            }
+        }
+    }
+
+/** Whether this outcome should offer the restart that completes it. */
+internal fun StagedInstallOutcome.offersRestart(): Boolean = this is StagedInstallOutcome.Staged && appliesOnRestart
+
+internal fun stagedInstallOutcome(
+    version: String,
+    defaultVersion: String,
+    result: Result<*>,
+): StagedInstallOutcome =
+    result.fold(
+        onSuccess = {
+            StagedInstallOutcome.Staged(
+                version = version,
+                // Only a default-version stage survives to be used.
+                appliesOnRestart = version == defaultVersion,
+            )
+        },
+        onFailure = { e ->
+            StagedInstallOutcome.Failed(e.message ?: "unknown error")
+        },
+    )
+
 @Composable
 fun BrowserEngineSettings() {
     val settings by BrowserEngineSettingsManager.currentSettings.collectAsState()
@@ -71,13 +136,22 @@ fun BrowserEngineSettings() {
     var versionListing by remember { mutableStateOf<EngineVersionListing?>(null) }
     var versionsError by remember { mutableStateOf<String?>(null) }
     var installProgress by remember { mutableStateOf<ChromiumAutoDownloader.DownloadProgress?>(null) }
-    var installStatus by remember { mutableStateOf<String?>(null) }
+    // One state, so "staged but failed" is unrepresentable.
+    var outcome by remember { mutableStateOf<StagedInstallOutcome?>(null) }
+    var confirmingRestart by remember { mutableStateOf(false) }
 
-    // Separate from installStatus so a completed stage can offer the restart it
-    // requires. The message alone rendered as a description on an empty-value row —
-    // easy to miss after a several-hundred-MB download, and the staged engine does
-    // nothing at all until the app is restarted.
-    var stagedAwaitingRestart by remember { mutableStateOf(false) }
+    // Seeded from disk, not just from the install that happened in this composition:
+    // both flags used to be plain `remember`, so closing and reopening Settings lost
+    // the pending state while boss-chromium.pending still sat on disk — leaving no
+    // indication a restart was owed and inviting a second install.
+    val pendingStagedVersion =
+        produceState<String?>(initialValue = null) {
+            value =
+                withContext(Dispatchers.IO) {
+                    val dir = ChromiumAutoDownloader.getPendingChromiumDir()
+                    if (dir.toFile().exists()) ChromiumAutoDownloader.installedVersionAt(dir) else null
+                }
+        }.value
 
     LaunchedEffect(Unit) {
         try {
@@ -209,8 +283,8 @@ fun BrowserEngineSettings() {
                     label = "Download and stage the selected version",
                     buttonText = if (selectedVersion == installedVersion) "Reinstall" else "Install",
                     onClick = {
-                        installStatus = null
-                        stagedAwaitingRestart = false
+                        outcome = null
+                        confirmingRestart = false
                         installProgress = ChromiumAutoDownloader.DownloadProgress(0, 0)
                         val versionToInstall = selectedVersion
                         val overrideToPersist = selectedOverride
@@ -225,21 +299,14 @@ fun BrowserEngineSettings() {
                                     }
                                 }
                             installProgress = null
-                            installStatus =
-                                result.fold(
-                                    onSuccess = {
-                                        // Persist the pin only now, so an abandoned dropdown
-                                        // selection never changes what the next launch boots.
-                                        BrowserEngineSettingsManager.updateSettings(
-                                            BrowserEngineSettingsData(selectedVersion = overrideToPersist),
-                                        )
-                                        stagedAwaitingRestart = true
-                                        "Engine $versionToInstall is staged. It is not in use until BOSS restarts."
-                                    },
-                                    onFailure = { e ->
-                                        "Install failed: ${e.message ?: "unknown error"}"
-                                    },
+                            if (result.isSuccess) {
+                                // Persist the pin only now, so an abandoned dropdown
+                                // selection never changes what the next launch boots.
+                                BrowserEngineSettingsManager.updateSettings(
+                                    BrowserEngineSettingsData(selectedVersion = overrideToPersist),
                                 )
+                            }
+                            outcome = stagedInstallOutcome(versionToInstall, defaultVersion, result)
                         }
                     },
                     description =
@@ -249,32 +316,60 @@ fun BrowserEngineSettings() {
                 )
             }
 
-            installStatus?.let { status ->
+            // Either an outcome from this session, or a stage left pending by an
+            // earlier one that this Settings view never saw.
+            val effectiveOutcome =
+                outcome
+                    ?: pendingStagedVersion?.let { staged ->
+                        StagedInstallOutcome.Staged(
+                            version = staged,
+                            appliesOnRestart = staged == defaultVersion,
+                        )
+                    }
+
+            effectiveOutcome?.let { current ->
                 Spacer(modifier = Modifier.height(8.dp))
-                if (stagedAwaitingRestart) {
-                    // An action, not a note. A staged engine sits in
-                    // boss-chromium.pending and is swapped in by promotePendingInstall
-                    // at startup — until then the download has changed nothing the
-                    // user can see, which reads like the install silently failed.
+                if (current.offersRestart()) {
+                    // An action, not a note: a staged engine sits in
+                    // boss-chromium.pending and does nothing until
+                    // promotePendingInstall swaps it in at startup, so a missed note
+                    // reads like the install failed and invites a second one.
                     SettingsButtonRow(
                         label = "Staged — restart to apply",
                         buttonText = "Restart BOSS",
-                        onClick = { ApplicationRestarter.restartApplication() },
-                        // Verified rather than assumed: restartApplication exits via
-                        // exitProcess, which runs the shutdown hook, and that hook
-                        // calls LastSessionCoordinator.saveOnProcessExit — so tabs do
-                        // come back. Saying "unsaved work is lost" here would have
-                        // been false, and would have talked people out of the one
-                        // action that makes their download take effect.
-                        description = "$status BOSS reopens with your tabs restored; running terminal processes end.",
+                        // Confirmed, not immediate. This quits the app ~500ms later
+                        // with no undo, and the repo already handles that this way
+                        // (see FluckBrowserSettings' Restart Required dialog); a
+                        // single unconfirmed click sitting directly under Install is
+                        // too easy to hit by accident.
+                        onClick = { confirmingRestart = true },
+                        isDestructive = true,
+                        description =
+                            current.message(defaultVersion) +
+                                " BOSS reopens with your tabs restored; running terminal processes end.",
                     )
                 } else {
                     SettingsInfoRow(
                         label = "Status",
                         value = "",
-                        description = status,
+                        description = current.message(defaultVersion),
                     )
                 }
+            }
+
+            if (confirmingRestart) {
+                ConfirmationDialog(
+                    title = "Restart Required",
+                    message =
+                        "BOSS will close and reopen to apply the staged browser engine. " +
+                            "Your tabs are restored; running terminal processes end.",
+                    confirmText = "Restart Now",
+                    onConfirm = {
+                        confirmingRestart = false
+                        ApplicationRestarter.scheduleRestart(delayMillis = 500)
+                    },
+                    onDismiss = { confirmingRestart = false },
+                )
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -755,11 +755,11 @@ fun main(args: Array<String>) {
                                 // anyone asks when it appears unexpectedly — an engine
                                 // mismatch is exactly what triggers it.
                                 status =
-                                    when {
-                                        downloadProgress.isExtracting -> "Extracting $engineLabel..."
-                                        downloadProgress.totalBytes > 0 -> "Installing $engineLabel..."
-                                        else -> "Connecting to download $engineLabel..."
-                                    },
+                                    ai.rever.boss.components.dialogs.engineDownloadStatus(
+                                        engineLabel = engineLabel,
+                                        isExtracting = downloadProgress.isExtracting,
+                                        totalBytes = downloadProgress.totalBytes,
+                                    ),
                                 error = downloadProgress.error,
                                 onCancel = { exitApplication() },
                                 onRetry = {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -461,6 +461,11 @@ fun main(args: Array<String>) {
         ai.rever.boss.plugin.browser.FluckEngine
             .engineStartupAction(hasUsableEngine, cacheHealthy)
 
+    // Named in the download dialog: it blocks the whole app for a several-hundred-MB
+    // fetch, and which engine it is turns out to be the first thing anyone asks when
+    // it appears unexpectedly — an engine mismatch is exactly what triggers it.
+    val engineLabel = "BOSS Browser Engine ${ChromiumAutoDownloader.effectiveVersion}"
+
     val chromiumNeedsDownload =
         engineAction == ai.rever.boss.plugin.browser.FluckEngine.EngineStartupAction.Download
     when (engineAction) {
@@ -744,11 +749,16 @@ fun main(args: Array<String>) {
                                 progress = downloadProgress.progressFraction,
                                 downloadedMB = downloadProgress.downloadedMB,
                                 totalMB = downloadProgress.totalMB,
+                                // Name the version being fetched. This dialog blocks
+                                // the whole app for a several-hundred-MB download, and
+                                // which engine it is turns out to be the first thing
+                                // anyone asks when it appears unexpectedly — an engine
+                                // mismatch is exactly what triggers it.
                                 status =
                                     when {
-                                        downloadProgress.isExtracting -> "Extracting files..."
-                                        downloadProgress.totalBytes > 0 -> "Installing BOSS Browser Engine..."
-                                        else -> "Connecting to download server..."
+                                        downloadProgress.isExtracting -> "Extracting $engineLabel..."
+                                        downloadProgress.totalBytes > 0 -> "Installing $engineLabel..."
+                                        else -> "Connecting to download $engineLabel..."
                                     },
                                 error = downloadProgress.error,
                                 onCancel = { exitApplication() },

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/EngineDownloadUxTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/EngineDownloadUxTest.kt
@@ -1,0 +1,98 @@
+package ai.rever.boss.components
+
+import ai.rever.boss.components.dialogs.engineDownloadStatus
+import ai.rever.boss.components.settings.sections.message
+import ai.rever.boss.components.settings.sections.offersRestart
+import ai.rever.boss.components.settings.sections.stagedInstallOutcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the two engine-download messages users actually act on.
+ *
+ * Both gaps these cover were found by running the app, not by reading it — the
+ * download dialog never said which engine it was fetching, and Settings offered a
+ * note where it needed a restart. Neither path had any coverage, so nothing would
+ * have caught the wording silently reverting.
+ */
+class EngineDownloadUxTest {
+    /** An exception whose message really is null — the case the fallback exists for. */
+    private class NoMessageException : RuntimeException(null as String?)
+
+    private val label = "BOSS Browser Engine 9.4.0"
+
+    @Test
+    fun `every download phase names the engine version`() {
+        // The whole point: an unnamed dialog blocking the app for several hundred MB
+        // is what prompted this. Each phase must carry the label.
+        val phases =
+            listOf(
+                engineDownloadStatus(label, isExtracting = false, totalBytes = 0),
+                engineDownloadStatus(label, isExtracting = false, totalBytes = 1),
+                engineDownloadStatus(label, isExtracting = true, totalBytes = 1),
+            )
+
+        phases.forEach { status ->
+            assertTrue(status.contains("9.4.0"), "phase must name the version: $status")
+        }
+        assertEquals(phases.size, phases.toSet().size, "each phase must be distinguishable")
+    }
+
+    @Test
+    fun `extracting takes precedence over byte progress`() {
+        // isExtracting arrives with totalBytes still set from the download, so the
+        // order of the branches is load-bearing — reversed, the dialog would claim
+        // it is still downloading while it unpacks.
+        assertTrue(
+            engineDownloadStatus(label, isExtracting = true, totalBytes = 999).startsWith("Extracting"),
+        )
+    }
+
+    @Test
+    fun `a staged install offers the restart that completes it`() {
+        val outcome = stagedInstallOutcome("9.4.0", "9.4.0", Result.success(Unit))
+
+        assertTrue(outcome.offersRestart(), "a staged engine is inert until BOSS restarts")
+        assertTrue(outcome.message("9.4.0").contains("9.4.0"))
+        assertTrue(
+            outcome.message("9.4.0").contains("not in use", ignoreCase = true),
+            "the message must state the present fact, not just instruct",
+        )
+    }
+
+    @Test
+    fun `a non-default version is staged but must not offer a restart`() {
+        // The blocker: updateSettings drops any pin that isn't the bundled version,
+        // so a non-default stage is promoted at next launch, found not to match
+        // effectiveVersion, and replaced by a full re-download. Offering "Restart
+        // BOSS" there costs the user their session and several hundred MB to end up
+        // exactly where they started.
+        val outcome = stagedInstallOutcome("9.3.0", "9.4.0", Result.success(Unit))
+
+        assertFalse(outcome.offersRestart(), "restarting would not apply this engine")
+        val message = outcome.message("9.4.0")
+        assertTrue(message.contains("9.3.0") && message.contains("9.4.0"), "name both versions: $message")
+        assertTrue(message.contains("replaced"), "say what will actually happen: $message")
+    }
+
+    @Test
+    fun `a failed install does not offer a restart`() {
+        // Nothing was staged, so restarting changes nothing — offering it would read
+        // as "we fixed it" when we did not.
+        val failure = IllegalStateException("disk full")
+        val outcome = stagedInstallOutcome("9.4.0", "9.4.0", Result.failure<Unit>(failure))
+
+        assertFalse(outcome.offersRestart())
+        assertTrue(outcome.message("9.4.0").contains("disk full"), "the reason must survive")
+    }
+
+    @Test
+    fun `a failure with no message still says something`() {
+        val outcome = stagedInstallOutcome("9.4.0", "9.4.0", Result.failure<Unit>(NoMessageException()))
+
+        assertFalse(outcome.offersRestart())
+        assertTrue(outcome.message("9.4.0").contains("unknown error"))
+    }
+}


### PR DESCRIPTION
Two gaps found by running the merged build, not by reading it.

## 1. The download dialog never named the version

It blocks the whole app for a several-hundred-MB fetch, and the thing that triggers it is an engine/jar mismatch — so *"which engine is this, and why is it happening now"* is the first question it raises. Previously all three phases were anonymous:

```
Connecting to download server...
Installing BOSS Browser Engine...
Extracting files...
```

Now each names it, e.g. `Installing BOSS Browser Engine 9.4.0...`. The label is hoisted next to the other pre-UI engine state so the three branches stay readable.

## 2. Settings offered a note where it needed an action

The restart message existed, but rendered as the `description` of an empty-value `SettingsInfoRow` — a muted line immediately after a long download. That matters more than it sounds: a staged engine sits in `boss-chromium.pending` and does **nothing** until `promotePendingInstall` swaps it in at next startup. A missed note reads like the install silently failed, which invites a second install.

A successful stage now renders a `SettingsButtonRow` with a **Restart BOSS** action, and the wording states the present fact rather than an instruction — *"Engine 9.4.0 is staged. It is not in use until BOSS restarts."* — with the cost spelled out in the description ("Unsaved work in open tabs is lost").

`stagedAwaitingRestart` is tracked separately from `installStatus` so a *failed* install still renders as a plain note, and it resets when a new install begins.

## Verification

`detekt`, `ktlintCheck`, `desktopTest` green. These are presentation changes on paths with no existing test coverage; the behaviour they describe (staging, `promotePendingInstall`) is unchanged and already covered. Worth a look in the running app rather than trusting the diff.
