### PR TITLE
docs(deps): record the ktor 3.5.x outcome and its coupling to supabase

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,13 +27,23 @@ kotlinx-datetime = "0.8.0-0.6.x-compat"
 kotlinx-serialization = "1.11.0"
 # ktor is NOT shared with plugins (no io.ktor prefix in defaultSharedPackages),
 # so a plugin's bundled ktor is unaffected by this pin; it constrains the host's
-# own client stack only.
+# own client stack only. The one mechanism that could change that is a plugin
+# opting in via manifest sharedPackages — checked across boss_plugins, and the
+# only manifest declaring any is boss-plugin-api, for its own package. If a
+# plugin ever declares io.ktor, this pin becomes a cross-repo change.
 #
-# 3.5.0 arrived as an automated bump (#736) and was reverted. The reason on
-# record was plugin compatibility, which cannot be right — the host's ktor never
-# reaches a plugin. NO host-side diagnosis was ever recorded, so there is no
-# known reason this cannot move: treat the next 3.5.x bump as worth trying, and
-# if it fails, write down what broke here.
+# 3.5.0 arrived as an automated bump (#736) and was reverted, citing plugin
+# compatibility with no host-side diagnosis recorded — which the isolation above
+# says cannot have been the reason. 3.5.1 was retried in #113 and landed clean
+# (build-test green on all three OSes); nothing broke, so that revert should not
+# be read as a standing objection to 3.5.x.
+#
+# This pin is COUPLED to `supabase`: supabase-kt depends on ktor directly
+# (3.6.0 -> 3.4.3, 3.7.0 -> 3.5.1). Bump the two together. Taking a supabase
+# bump alone leaves the host's direct ktor deps on the old version while
+# ktor-server-core/cio resolve forward transitively, which is how you end up
+# with mixed ktor artifacts on one classpath. Check what the supabase Gradle
+# module metadata requires before moving either line.
 ktor = "3.5.1"
 logback = "1.5.38"
 precompose = "1.6.2"


### PR DESCRIPTION
The note above `ktor` in `libs.versions.toml` described a 3.4.3 pin and asked whoever moved it to "write down what broke here." #113 moved it to 3.5.1 and nothing broke, so the note now reads as though the bump is still untried.

Comment-only change — no version values move. TOML re-parses (36 versions).

### What the new note records

**The plugin-isolation claim, plus the loophole the old one omitted.** `io.ktor` is absent from `PluginClassLoader.defaultSharedPackages`, so the host's ktor does not reach plugins — that part was right. But a plugin can opt into any package via `manifest.sharedPackages`, which `PluginClassLoaderManager` unions into the shared set. Checked across every `plugin.json` in `boss_plugins`: only `boss-plugin-api` declares one, for its own package. The isolation holds today, and the note now says what would end it.

**The outcome of the retry.** #736 auto-bumped to 3.5.0 and was reverted citing plugin compatibility, with no host-side diagnosis recorded — which the isolation above rules out as the cause. 3.5.1 was retried in #113 and landed clean, `build-test` green on ubuntu/macos/windows. Recorded so that revert isn't re-read as a standing objection to 3.5.x.

**The coupling that is easy to miss.** `supabase-kt` depends on ktor directly:

| supabase-kt | requires ktor |
|---|---|
| 3.6.0 | 3.4.3 |
| 3.7.0 | 3.5.1 |

Those matched the old and new pins exactly, which is not a coincidence — the two lines have to move together. Taking a supabase bump alone leaves the host's direct `ktor-*` deps on the old version while `ktor-server-core`/`ktor-server-cio` resolve forward transitively, mixing ktor artifacts on one classpath. That was the actual trap in today's dependency sweep: #112 (supabase 3.7.0) had to land *after* #113 (ktor 3.5.1), not before.

### Verification

- `tomllib` parses the file; every version value byte-identical to `main`.
- `defaultSharedPackages` read at `plugin-platform/plugin-loader/src/desktopMain/kotlin/ai/rever/boss/plugin/loader/PluginClassLoader.kt:82`; manifest union at `PluginClassLoaderManager.kt:239`.
- ktor requirements read from `auth-kt` Gradle module metadata on Maven Central for both supabase versions.
