### PR TITLE
fix(kernel): reap out-of-process plugin children on host exit

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -305,7 +305,7 @@
     <ID>LongMethod:GlobalSearchDialog.kt$@Composable private fun SearchDialogHeader( fileCount: Int, isIndexing: Boolean, onClose: () -&gt; Unit, )</ID>
     <ID>LongMethod:GlobalSearchDialog.kt$@Composable private fun SearchInputField( query: String, onQueryChange: (String) -&gt; Unit, focusRequester: FocusRequester, isSearching: Boolean, )</ID>
     <ID>LongMethod:KernelBootstrap.kt$KernelBootstrap$fun initialize()</ID>
-    <ID>LongMethod:KernelBootstrap.kt$KernelBootstrap$private fun spawnServices( registry: ProcessRegistry, spawner: ProcessSpawner, )</ID>
+    <ID>LongMethod:KernelBootstrap.kt$KernelBootstrap$private fun spawnServices(spawner: ProcessSpawner)</ID>
     <ID>LongMethod:KeyCaptureDialog.kt$@Composable fun KeyCaptureDialog( actionId: String, actionDescription: String, context: ShortcutContext, category: String, currentBinding: KeyBinding?, onKeyCaptured: (KeyBinding) -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
     <ID>LongMethod:KeymapData.kt$fun getKeyboardShortcuts(): List&lt;KeyboardShortcut&gt;</ID>
     <ID>LongMethod:KeymapImportExport.kt$@Composable fun KeymapImportExport( onImport: suspend (String) -&gt; Boolean, modifier: Modifier = Modifier, )</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -273,55 +273,46 @@ class DefaultPlugin(
                         }
                 logger.info(LogCategory.SYSTEM, "OOP spawner: BOSS_MODE resolved", mapOf("bossMode" to (bossMode ?: "null")))
                 if (bossMode == "KERNEL") {
-                    // Get kernel IPC address from KernelBootstrap.instance (not env var,
-                    // since BOSS_KERNEL_IPC_ADDR is only set for child processes)
-                    val kernelAddr =
-                        System.getenv("BOSS_KERNEL_IPC_ADDR")
-                            ?: try {
-                                val companionCls = Class.forName("ai.rever.boss.kernel.KernelBootstrap\$Companion")
-                                val companion = bootstrapCls.getDeclaredField("Companion").get(null)
-                                val getInstance = companionCls.getMethod("getInstance")
-                                val kernelInstance = getInstance.invoke(companion)
-                                logger.info(
-                                    LogCategory.SYSTEM,
-                                    "OOP spawner: KernelBootstrap.instance",
-                                    mapOf("isNull" to (kernelInstance == null)),
-                                )
-                                if (kernelInstance != null) {
-                                    bootstrapCls.getMethod("getKernelAddress").invoke(kernelInstance) as? String
-                                } else {
-                                    null
-                                }
-                            } catch (e: Exception) {
-                                logger.warn(LogCategory.SYSTEM, "OOP spawner: kernel addr failed", mapOf("error" to e.toString()))
-                                null
-                            }
-                            ?: ""
-                    logger.info(LogCategory.SYSTEM, "OOP spawner: kernelAddr resolved", mapOf("addr" to kernelAddr))
-                    if (kernelAddr.isNotEmpty()) {
-                        val processSpawner =
-                            processSpawnerCls
-                                .getConstructor(String::class.java, java.io.File::class.java)
-                                .newInstance(
-                                    kernelAddr,
-                                    java.io.File(
-                                        try {
-                                            val dirsCls2 = Class.forName("ai.rever.boss.plugin.pathutils.BossDirectories")
-                                            val dirsInst2 = dirsCls2.getDeclaredField("INSTANCE").get(null)
-                                            (dirsCls2.getMethod("getRootDir").invoke(dirsInst2) as java.io.File).absolutePath
-                                        } catch (_: Exception) {
-                                            "${System.getProperty("user.home")}/.boss"
-                                        },
-                                        "logs",
-                                    ),
-                                )
+                    // Reuse the kernel's own ProcessSpawner rather than building a second one.
+                    //
+                    // ProcessSpawner registers everything it spawns, and only the instance
+                    // KernelBootstrap built is wired to the ProcessRegistry that the JVM shutdown
+                    // hook reaps. A second spawner here would have no registry, so its plugin
+                    // children stayed invisible to that hook - which is how a whole cohort of
+                    // child JVMs leaked on every host exit. One spawner owns registration
+                    // process-wide, or the invariant is only true for one of two instances.
+                    val kernelSpawner =
+                        try {
+                            val companionCls = Class.forName("ai.rever.boss.kernel.KernelBootstrap\$Companion")
+                            val companion = bootstrapCls.getDeclaredField("Companion").get(null)
+                            val kernelInstance = companionCls.getMethod("getInstance").invoke(companion)
+                            logger.info(
+                                LogCategory.SYSTEM,
+                                "OOP spawner: KernelBootstrap.instance",
+                                mapOf("isNull" to (kernelInstance == null)),
+                            )
+                            kernelInstance?.let { bootstrapCls.getMethod("getProcessSpawner").invoke(it) }
+                        } catch (e: Exception) {
+                            logger.warn(
+                                LogCategory.SYSTEM,
+                                "OOP spawner: kernel spawner lookup failed",
+                                mapOf("error" to e.toString()),
+                            )
+                            null
+                        }
+                    logger.info(
+                        LogCategory.SYSTEM,
+                        "OOP spawner: kernel spawner resolved",
+                        mapOf("isNull" to (kernelSpawner == null)),
+                    )
+                    if (kernelSpawner != null) {
                         spawnerCls
                             .getConstructor(
                                 processSpawnerCls,
                                 String::class.java,
                                 String::class.java,
                             ).newInstance(
-                                processSpawner,
+                                kernelSpawner,
                                 windowId ?: "",
                                 windowProjectState?.selectedProject?.value?.path ?: "",
                             ) as OutOfProcessPluginSpawner

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -127,7 +127,7 @@ class OutOfProcessPluginSpawnerImpl(
 
                 val config =
                     ProcessConfig(
-                        processId = "plugin-$pluginId",
+                        processId = processIdOf(pluginId),
                         processType = ProcessType.PLUGIN,
                         displayName = manifest.displayName,
                         mainClass = "ai.rever.boss.plugin.runtime.PluginProcessMainKt",
@@ -149,15 +149,8 @@ class OutOfProcessPluginSpawnerImpl(
                     runtimeClasspath,
                 )
 
-                // spawn() enters the child in the kernel registry, which is what the JVM shutdown
-                // hook in KernelBootstrap reaps on exit. This class used to keep its handles only
-                // in managedProcesses below, so the hook iterated a list that never contained a
-                // plugin, killed nothing, and every host exit - a clean Cmd+Q included - stranded
-                // the whole cohort as PPID-1 orphans that outlived the host indefinitely.
-                //
-                // The child's own gRPC registration reaches only the registry's *manifest* map
-                // (see KernelServiceImpl.onProcessRegistered), which is why waitForReady below
-                // could see a child that getAllProcesses() could not.
+                // spawn() enters the child in the kernel registry, which is what the shutdown hook
+                // reaps. See ProcessSpawner's KDoc for why registration lives there.
                 val managedProcess = processSpawner.spawn(config)
                 managedProcesses[pluginId] = managedProcess
 
@@ -205,20 +198,19 @@ class OutOfProcessPluginSpawnerImpl(
      * Tear down everything [spawn] may have created for a plugin whose startup failed.
      */
     private fun cleanupFailedSpawn(pluginId: String) {
-        kernelRegistry()?.unregister(processIdOf(pluginId))
         runCatching { stateBridges.remove(pluginId)?.dispose() }
         runCatching { pluginChannels.remove(pluginId)?.shutdownNow() }
-        runCatching { managedProcesses.remove(pluginId)?.destroyForcibly() }
+        // Kill first, drop the registry entry second: while the child is alive the registry entry
+        // is the only thing that would let a host exit reap it.
+        val process = managedProcesses.remove(pluginId)
+        runCatching { process?.destroyForcibly() }
+        process?.let { kernelRegistry()?.unregisterIfSame(processIdOf(pluginId), it) }
     }
 
     override suspend fun terminate(pluginId: String): Result<Unit> =
         withContext(Dispatchers.IO) {
+            val process = managedProcesses.remove(pluginId)
             try {
-                // Drop the registry entry before killing the child. This is a deliberate
-                // termination, so leaving the entry in place would hand a dead handle to
-                // anything that iterates the registry afterwards.
-                kernelRegistry()?.unregister(processIdOf(pluginId))
-
                 // Dispose state bridge
                 stateBridges.remove(pluginId)?.dispose()
 
@@ -232,7 +224,6 @@ class OutOfProcessPluginSpawnerImpl(
                 }
 
                 // Destroy process
-                val process = managedProcesses.remove(pluginId)
                 if (process != null) {
                     logger.info("Terminating plugin process: id={}, pid={}", pluginId, process.pid)
                     process.destroy()
@@ -250,10 +241,15 @@ class OutOfProcessPluginSpawnerImpl(
                 Result.success(Unit)
             } catch (e: Exception) {
                 // Force kill if graceful shutdown failed
-                managedProcesses[pluginId]?.destroyForcibly()
-                managedProcesses.remove(pluginId)
+                process?.destroyForcibly()
                 logger.warn("Force-killed plugin process: id={}", pluginId, e)
                 Result.success(Unit)
+            } finally {
+                // Registry entry goes last, and only if it is still this process. "Registered
+                // implies reapable" has to hold for as long as the child is alive, so a host exit
+                // part-way through an unload still reaps it; and removing by id alone could evict
+                // a replacement that a concurrent respawn had already registered.
+                process?.let { kernelRegistry()?.unregisterIfSame(processIdOf(pluginId), it) }
             }
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.loader.PluginManifestReader
 import ai.rever.boss.process.ManagedProcess
 import ai.rever.boss.process.ProcessConfig
+import ai.rever.boss.process.ProcessRegistry
 import ai.rever.boss.process.ProcessSpawner
 import ai.rever.boss.process.ProcessType
 import ai.rever.boss.process.RestartPolicy
@@ -151,6 +152,17 @@ class OutOfProcessPluginSpawnerImpl(
                 val managedProcess = processSpawner.spawn(config)
                 managedProcesses[pluginId] = managedProcess
 
+                // Publish the child to the kernel registry. That registry is what the JVM
+                // shutdown hook in KernelBootstrap reaps on exit, and until this call existed
+                // no plugin child was ever in it: the hook iterated an empty list, killed
+                // nothing, and every host exit - including a clean Cmd+Q - stranded the whole
+                // cohort as PPID-1 orphans that then outlived the host indefinitely.
+                //
+                // The child's gRPC registration only reaches the registry's *manifest* map
+                // (see KernelServiceImpl.onProcessRegistered), which is why waitForReady below
+                // can see it while getAllProcesses() could not.
+                kernelRegistry()?.register(processIdOf(pluginId), managedProcess)
+
                 // Wait for the child process to register with the kernel
                 waitForReady(pluginId, managedProcess, config.startupTimeoutMs)
 
@@ -182,14 +194,33 @@ class OutOfProcessPluginSpawnerImpl(
                     manifest.pluginId,
                     e,
                 )
+                // A waitForReady timeout leaves a child that started but never registered -
+                // still alive, and no longer referenced by anything that would kill it. Reap
+                // it here rather than let a failed spawn become another orphan.
+                cleanupFailedSpawn(manifest.pluginId)
                 Result.failure(e)
             }
         }
     }
 
+    /**
+     * Tear down everything [spawn] may have created for a plugin whose startup failed.
+     */
+    private fun cleanupFailedSpawn(pluginId: String) {
+        kernelRegistry()?.unregister(processIdOf(pluginId))
+        runCatching { stateBridges.remove(pluginId)?.dispose() }
+        runCatching { pluginChannels.remove(pluginId)?.shutdownNow() }
+        runCatching { managedProcesses.remove(pluginId)?.destroyForcibly() }
+    }
+
     override suspend fun terminate(pluginId: String): Result<Unit> =
         withContext(Dispatchers.IO) {
             try {
+                // Drop the registry entry before killing the child. This is a deliberate
+                // termination, so leaving the entry in place would hand a dead handle to
+                // anything that iterates the registry afterwards.
+                kernelRegistry()?.unregister(processIdOf(pluginId))
+
                 // Dispose state bridge
                 stateBridges.remove(pluginId)?.dispose()
 
@@ -280,8 +311,8 @@ class OutOfProcessPluginSpawnerImpl(
         timeoutMs: Long,
     ) {
         withTimeout(timeoutMs) {
-            val processId = "plugin-$pluginId"
-            val registry = KernelBootstrap.instance?.processRegistry
+            val processId = processIdOf(pluginId)
+            val registry = kernelRegistry()
 
             while (true) {
                 if (!process.isAlive) {
@@ -325,3 +356,17 @@ class OutOfProcessPluginSpawnerImpl(
             ?.absolutePath
     }
 }
+
+/**
+ * Kernel-side process id for a plugin. Must stay in step with the `processId` that
+ * [OutOfProcessPluginSpawnerImpl.spawn] puts in its [ProcessConfig] - the registry is keyed by it.
+ */
+private fun processIdOf(pluginId: String): String = "plugin-$pluginId"
+
+/**
+ * The kernel's process registry, or null when the kernel is not up.
+ *
+ * Resolved per call rather than cached: the spawner is constructed while KERNEL mode is still
+ * bootstrapping, so a value captured at construction time would pin null forever.
+ */
+private fun kernelRegistry(): ProcessRegistry? = KernelBootstrap.instance?.processRegistry

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -149,19 +149,17 @@ class OutOfProcessPluginSpawnerImpl(
                     runtimeClasspath,
                 )
 
+                // spawn() enters the child in the kernel registry, which is what the JVM shutdown
+                // hook in KernelBootstrap reaps on exit. This class used to keep its handles only
+                // in managedProcesses below, so the hook iterated a list that never contained a
+                // plugin, killed nothing, and every host exit - a clean Cmd+Q included - stranded
+                // the whole cohort as PPID-1 orphans that outlived the host indefinitely.
+                //
+                // The child's own gRPC registration reaches only the registry's *manifest* map
+                // (see KernelServiceImpl.onProcessRegistered), which is why waitForReady below
+                // could see a child that getAllProcesses() could not.
                 val managedProcess = processSpawner.spawn(config)
                 managedProcesses[pluginId] = managedProcess
-
-                // Publish the child to the kernel registry. That registry is what the JVM
-                // shutdown hook in KernelBootstrap reaps on exit, and until this call existed
-                // no plugin child was ever in it: the hook iterated an empty list, killed
-                // nothing, and every host exit - including a clean Cmd+Q - stranded the whole
-                // cohort as PPID-1 orphans that then outlived the host indefinitely.
-                //
-                // The child's gRPC registration only reaches the registry's *manifest* map
-                // (see KernelServiceImpl.onProcessRegistered), which is why waitForReady below
-                // can see it while getAllProcesses() could not.
-                kernelRegistry()?.register(processIdOf(pluginId), managedProcess)
 
                 // Wait for the child process to register with the kernel
                 waitForReady(pluginId, managedProcess, config.startupTimeoutMs)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/OutOfProcessPluginSpawnerImpl.kt
@@ -352,15 +352,23 @@ class OutOfProcessPluginSpawnerImpl(
 }
 
 /**
- * Kernel-side process id for a plugin. Must stay in step with the `processId` that
- * [OutOfProcessPluginSpawnerImpl.spawn] puts in its [ProcessConfig] - the registry is keyed by it.
+ * Kernel-side process id for a plugin. The kernel registry is keyed by it.
+ *
+ * **Not window-scoped.** This spawner is per-window but the registry is process-wide, so two windows
+ * running the same out-of-process plugin produce the same id and the second registration evicts the
+ * first while its child is still alive - leaving that child unreapable on host exit. `terminate()` is
+ * unaffected (each spawner keeps its own [managedProcesses]), so this only bites at exit.
+ * [ProcessRegistry.register] logs a warning when it evicts a live handle, which is how this shows up.
+ * Putting the window id in here is the real fix and needs the child side to agree, since the runtime
+ * reports state under the process id it was given.
  */
 private fun processIdOf(pluginId: String): String = "plugin-$pluginId"
 
 /**
  * The kernel's process registry, or null when the kernel is not up.
  *
- * Resolved per call rather than cached: the spawner is constructed while KERNEL mode is still
- * bootstrapping, so a value captured at construction time would pin null forever.
+ * Resolved per call rather than cached, for symmetry with the other lookups. In practice it cannot
+ * be null here: `DefaultPlugin` obtains this spawner's [ProcessSpawner] *from*
+ * `KernelBootstrap.instance`, so the instance and its registry both exist before this class does.
  */
 private fun kernelRegistry(): ProcessRegistry? = KernelBootstrap.instance?.processRegistry

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -15,6 +15,7 @@ import ai.rever.boss.ipc.services.StateServiceImpl
 import ai.rever.boss.kernel.services.*
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.plugin.api.*
+import ai.rever.boss.process.ManagedProcess
 import ai.rever.boss.process.ProcessConfig
 import ai.rever.boss.process.ProcessFailure
 import ai.rever.boss.process.ProcessMode
@@ -92,48 +93,121 @@ private fun resolveServiceJar(
 private val reapLogger = LoggerFactory.getLogger("KernelReaper")
 
 /**
+ * True while [reapChildren] is running, so recovery paths know to stand down.
+ *
+ * Stopping supervision closes the *detection* path but not the *action* path: the failure collector
+ * runs on the kernel's own scope, which a reap deliberately does not cancel, and a `handleFailure`
+ * already in flight can sit for the orchestrator-advice timeout and then respawn a child *after* the
+ * reap took its snapshot. A shared flow with buffered failures can also deliver one after the
+ * cancel. Either way the exiting host gains a child nothing will reap.
+ */
+@Volatile
+private var reaping = false
+
+/** Whether a reap is in progress. Recovery must not spawn anything while this is true. */
+internal fun isReaping(): Boolean = reaping
+
+/**
  * Stop supervising children, then kill every registered one inside [gracePeriodMs] total.
  *
- * Supervision goes first because each [ManagedProcess.destroy] below is indistinguishable from a
- * crash to the monitor, whose failure handler respawns - reaping while it still watches can hand an
- * exiting host a fresh generation of children to strand.
+ * Supervision goes first because each kill below is indistinguishable from a crash to the monitor,
+ * whose failure handler respawns - reaping while it still watches can hand an exiting host a fresh
+ * generation of children to strand. [reaping] covers the in-flight remainder.
  *
- * The kills are issued to everything up front and then awaited against a single shared deadline,
- * rather than destroy-then-wait per process. Per-process waiting made exit cost scale with the
- * cohort - N plugins meant up to 2N seconds - and the OS caps how long a shutdown hook may run, so
- * a hook cut off partway down the list stranded the tail. That is the orphan symptom this whole
- * change exists to remove, arriving by a different route.
+ * Kills are issued to everything up front and then awaited against a single deadline set *before*
+ * the first one goes out, rather than destroy-then-wait per process. Per-process waiting made exit
+ * cost scale with the cohort - N plugins meant up to 2N seconds - and the OS caps how long a
+ * shutdown hook may run, so a hook cut off partway down the list stranded the tail. That is the
+ * orphan symptom this whole change exists to remove, arriving by a different route.
+ *
+ * The kills go through [Process] directly rather than `ManagedProcess.destroy()`, which shuts the
+ * child's IPC channel down first and blocks up to 5s per child awaiting termination. Done inside the
+ * destroy loop that is a serial, unbounded cost ahead of the deadline - the very thing the deadline
+ * exists to bound. Channels are closed without waiting once the children are gone.
+ *
+ * The remaining budget is divided among the children still being waited on, so one hung child cannot
+ * consume the whole grace period and send everything behind it straight to a forced kill.
  */
 internal fun reapChildren(
     monitor: ProcessMonitor?,
     registry: ProcessRegistry?,
     gracePeriodMs: Long = 3_000,
 ) {
-    runCatching { monitor?.stopSupervision() }
+    reaping = true
+    try {
+        runCatching { monitor?.stopSupervision() }
 
-    val children = registry?.getAllProcesses().orEmpty()
-    if (children.isEmpty()) return
+        val children = registry?.getAllProcesses().orEmpty()
+        if (children.isEmpty()) return
 
-    reapLogger.info("Reaping {} child process(es)", children.size)
-    children.forEach { runCatching { it.destroy() } }
+        reapLogger.info("Reaping {} child process(es)", children.size)
+        val deadline = System.currentTimeMillis() + gracePeriodMs
+        children.forEach { runCatching { it.process.destroy() } }
 
-    val deadline = System.currentTimeMillis() + gracePeriodMs
-    children.forEach { child ->
-        val budget = deadline - System.currentTimeMillis()
-        if (budget <= 0) return@forEach
-        try {
-            child.process.waitFor(budget, TimeUnit.MILLISECONDS)
-        } catch (_: InterruptedException) {
-            Thread.currentThread().interrupt()
-            return@forEach
-        } catch (_: Exception) {
-            // Fall through to the force-kill pass.
+        children.forEachIndexed { index, child ->
+            val remainingChildren = children.size - index
+            val remainingBudget = deadline - System.currentTimeMillis()
+            if (remainingBudget <= 0) return@forEachIndexed
+            val share = (remainingBudget / remainingChildren).coerceAtLeast(1)
+            try {
+                child.process.waitFor(share, TimeUnit.MILLISECONDS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return@forEachIndexed
+            } catch (_: Exception) {
+                // Fall through to the force-kill pass.
+            }
         }
-    }
 
-    children.filter { it.isAlive }.forEach {
-        reapLogger.warn("Force-killing process: {}", it.config.processId)
-        runCatching { it.destroyForcibly() }
+        children.filter { it.isAlive }.forEach {
+            reapLogger.warn("Force-killing process: {}", it.config.processId)
+            runCatching { it.process.destroyForcibly() }
+        }
+
+        // Children are dead, so nothing is going to answer on these. Close them without waiting.
+        children.forEach { runCatching { it.ipcClient?.shutdown(timeoutMs = 0) } }
+    } finally {
+        reaping = false
+    }
+}
+
+private val recoveryLogger = LoggerFactory.getLogger("KernelRecovery")
+
+/**
+ * The process to bring back, or null when recovery should stand down.
+ *
+ * The reap check is the one that is easy to miss: a reap has already snapshotted the registry and is
+ * killing everything, so a respawn now registers a child *after* that snapshot and nothing will reap
+ * it - the orphan this whole change removes. Stopping supervision does not cover it, because the
+ * caller may have been parked awaiting orchestrator advice when the reap began.
+ */
+internal fun respawnCandidate(
+    registry: ProcessRegistry,
+    processId: String,
+): ManagedProcess? {
+    val process = registry.getProcess(processId)
+    return when {
+        isReaping() -> {
+            recoveryLogger.info("Not respawning {} - a reap is in progress", processId)
+            null
+        }
+
+        process == null -> {
+            null
+        }
+
+        registry.getRestartCount(processId) >= process.config.maxRestarts -> {
+            recoveryLogger.error(
+                "Process {} exceeded max restarts ({}), not respawning",
+                processId,
+                process.config.maxRestarts,
+            )
+            null
+        }
+
+        else -> {
+            process
+        }
     }
 }
 
@@ -516,16 +590,8 @@ class KernelBootstrap(
         processId: String,
         jvmArgsOverride: List<String>? = null,
     ) {
-        val process = registry.getProcess(processId) ?: return
+        val process = respawnCandidate(registry, processId) ?: return
         val restartCount = registry.getRestartCount(processId)
-        if (restartCount >= process.config.maxRestarts) {
-            logger.error(
-                "Process {} exceeded max restarts ({}), not respawning",
-                processId,
-                process.config.maxRestarts,
-            )
-            return
-        }
 
         val config =
             if (jvmArgsOverride != null) process.config.copy(jvmArgs = jvmArgsOverride) else process.config
@@ -779,22 +845,28 @@ class KernelBootstrap(
         wireEventBridges(IpcEventBridgeImpl(null, scope))
 
         // 2. Stop supervision and shut down every child against one shared deadline.
+        //
+        //    This drops the old PLUGIN -> APP -> ORCHESTRATOR -> SERVICE tier ordering. That
+        //    ordering bought nothing in practice: all four batches of SIGTERMs went out
+        //    back-to-back with no wait between tiers, so no tier was actually down before the next
+        //    was signalled. Reintroducing it would mean a wait per tier, and therefore an exit cost
+        //    that scales with the number of tiers.
         reapChildren(processMonitor, processRegistry)
 
-        // 6. Stop IPC server
+        // 3. Stop IPC server
         ipcServer?.stop()
 
-        // 6b. Close remote UI surfaces. The registry is process-wide and outlives this bootstrap, so a
+        // 4. Close remote UI surfaces. The registry is process-wide and outlives this bootstrap, so a
         // restart would otherwise come up still holding claims from processes that are now dead.
         RemoteUiSurfaceRegistry.shared.clear()
 
-        // 6c. Close the orchestrator channel. Nothing else owns it, so a mode switch or in-process
+        // 5. Close the orchestrator channel. Nothing else owns it, so a mode switch or in-process
         // restart would otherwise leak the channel and its threads.
         orchestratorClient?.second?.shutdown()
         orchestratorClient = null
         serviceAddresses.clear()
 
-        // 7. Cancel scope
+        // 6. Cancel scope
         scope.cancel()
 
         logger.info("KERNEL mode shut down complete")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -89,6 +89,54 @@ private fun resolveServiceJar(
         ?: File(installedDir, jarName).path
 }
 
+private val reapLogger = LoggerFactory.getLogger("KernelReaper")
+
+/**
+ * Stop supervising children, then kill every registered one inside [gracePeriodMs] total.
+ *
+ * Supervision goes first because each [ManagedProcess.destroy] below is indistinguishable from a
+ * crash to the monitor, whose failure handler respawns - reaping while it still watches can hand an
+ * exiting host a fresh generation of children to strand.
+ *
+ * The kills are issued to everything up front and then awaited against a single shared deadline,
+ * rather than destroy-then-wait per process. Per-process waiting made exit cost scale with the
+ * cohort - N plugins meant up to 2N seconds - and the OS caps how long a shutdown hook may run, so
+ * a hook cut off partway down the list stranded the tail. That is the orphan symptom this whole
+ * change exists to remove, arriving by a different route.
+ */
+internal fun reapChildren(
+    monitor: ProcessMonitor?,
+    registry: ProcessRegistry?,
+    gracePeriodMs: Long = 3_000,
+) {
+    runCatching { monitor?.stopSupervision() }
+
+    val children = registry?.getAllProcesses().orEmpty()
+    if (children.isEmpty()) return
+
+    reapLogger.info("Reaping {} child process(es)", children.size)
+    children.forEach { runCatching { it.destroy() } }
+
+    val deadline = System.currentTimeMillis() + gracePeriodMs
+    children.forEach { child ->
+        val budget = deadline - System.currentTimeMillis()
+        if (budget <= 0) return@forEach
+        try {
+            child.process.waitFor(budget, TimeUnit.MILLISECONDS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return@forEach
+        } catch (_: Exception) {
+            // Fall through to the force-kill pass.
+        }
+    }
+
+    children.filter { it.isAlive }.forEach {
+        reapLogger.warn("Force-killing process: {}", it.config.processId)
+        runCatching { it.destroyForcibly() }
+    }
+}
+
 private val notifyLogger = LoggerFactory.getLogger("KernelRepairNotice")
 
 /**
@@ -256,20 +304,7 @@ class KernelBootstrap(
             Thread({
                 try {
                     logger.info("JVM shutdown hook: cleaning up child processes...")
-                    // Stop supervision before reaping. Each destroy below is indistinguishable
-                    // from a crash to the monitor, whose failure handler respawns - so reaping
-                    // while it still watches can hand an exiting host a fresh generation of
-                    // children to strand.
-                    runCatching { processMonitor?.stopAll() }
-                    processRegistry?.getAllProcesses()?.forEach { process ->
-                        try {
-                            process.destroy()
-                            process.process.waitFor(2, TimeUnit.SECONDS)
-                            if (process.isAlive) process.destroyForcibly()
-                        } catch (_: Exception) {
-                            process.destroyForcibly()
-                        }
-                    }
+                    reapChildren(processMonitor, processRegistry)
                     ipcServer?.stop()
                 } catch (_: Exception) {
                 }
@@ -289,8 +324,13 @@ class KernelBootstrap(
                     val process = registry.getProcess(id)
                     if (process != null) {
                         if (force) process.destroyForcibly() else process.destroy()
-                        // Don't unregister — process monitor will detect the exit and
-                        // trigger auto-respawn if restartPolicy == ON_FAILURE
+                        // Don't unregister — for a SERVICE/APP/ORCHESTRATOR the process monitor
+                        // will detect the exit and trigger auto-respawn if
+                        // restartPolicy == ON_FAILURE.
+                        //
+                        // PLUGIN is the exception: it is not health-supervised, so nothing
+                        // respawns it despite its config also saying ON_FAILURE, and the global
+                        // monitor prunes the dead entry instead.
                         true
                     } else {
                         false
@@ -734,34 +774,12 @@ class KernelBootstrap(
 
         logger.info("Shutting down KERNEL mode...")
 
-        // 1. Stop process monitor
-        processMonitor?.stopAll()
-
-        // 2. Clear event bridges
+        // 1. Clear event bridges. Before reaping, because step 2 no longer cancels `scope` and
+        //    this still needs it.
         wireEventBridges(IpcEventBridgeImpl(null, scope))
 
-        // 3. Shut down all child processes (apps first, then services)
-        processRegistry?.getProcessesByType(ProcessType.PLUGIN)?.forEach { it.destroy() }
-        processRegistry?.getProcessesByType(ProcessType.APP)?.forEach { it.destroy() }
-        processRegistry?.getProcessesByType(ProcessType.ORCHESTRATOR)?.forEach { it.destroy() }
-        processRegistry?.getProcessesByType(ProcessType.SERVICE)?.forEach { it.destroy() }
-
-        // 4. Wait for graceful shutdown with 2s per-process timeout
-        processRegistry?.getAllProcesses()?.forEach { process ->
-            try {
-                if (!process.process.waitFor(2, TimeUnit.SECONDS)) {
-                    logger.warn("Process did not exit in 2s: {}", process.config.processId)
-                }
-            } catch (_: InterruptedException) {
-                Thread.currentThread().interrupt()
-            }
-        }
-
-        // 5. Force kill any remaining
-        processRegistry?.getAllProcesses()?.filter { it.isAlive }?.forEach {
-            logger.warn("Force-killing process: {}", it.config.processId)
-            it.destroyForcibly()
-        }
+        // 2. Stop supervision and shut down every child against one shared deadline.
+        reapChildren(processMonitor, processRegistry)
 
         // 6. Stop IPC server
         ipcServer?.stop()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -256,6 +256,11 @@ class KernelBootstrap(
             Thread({
                 try {
                     logger.info("JVM shutdown hook: cleaning up child processes...")
+                    // Stop supervision before reaping. Each destroy below is indistinguishable
+                    // from a crash to the monitor, whose failure handler respawns - so reaping
+                    // while it still watches can hand an exiting host a fresh generation of
+                    // children to strand.
+                    runCatching { processMonitor?.stopAll() }
                     processRegistry?.getAllProcesses()?.forEach { process ->
                         try {
                             process.destroy()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/KernelBootstrap.kt
@@ -15,7 +15,6 @@ import ai.rever.boss.ipc.services.StateServiceImpl
 import ai.rever.boss.kernel.services.*
 import ai.rever.boss.kernel.ui.RemoteUiSurfaceRegistry
 import ai.rever.boss.plugin.api.*
-import ai.rever.boss.process.ManagedProcess
 import ai.rever.boss.process.ProcessConfig
 import ai.rever.boss.process.ProcessFailure
 import ai.rever.boss.process.ProcessMode
@@ -246,7 +245,8 @@ class KernelBootstrap(
         // Create infrastructure
         kernelAddress = IpcAddressResolver.kernelAddress()
         val registry = ProcessRegistry()
-        val spawner = ProcessSpawner(kernelAddress!!)
+        // The spawner registers everything it spawns, so no call site can forget to.
+        val spawner = ProcessSpawner(kernelAddress!!, registry = registry)
         processRegistry = registry
         processSpawner = spawner
         processMonitor = ProcessMonitor(registry, scope)
@@ -342,7 +342,7 @@ class KernelBootstrap(
         }
 
         // Spawn child services (M7 fix — structure in place)
-        spawnServices(registry, spawner)
+        spawnServices(spawner)
 
         // Store singleton for DefaultPlugin to access via reflection
         instance = this
@@ -497,8 +497,9 @@ class KernelBootstrap(
             if (jvmArgsOverride != null) ", tuned: $jvmArgsOverride" else "",
         )
         try {
-            val newProcess = spawner.spawn(config)
-            registry.register(processId, newProcess, registry.getManifest(processId))
+            // spawn() registers the replacement itself. The manifest survives because a respawn
+            // never unregisters, so it is still keyed under this processId.
+            spawner.spawn(config)
             registry.incrementRestartCount(processId)
         } catch (e: Exception) {
             logger.error("Respawn failed for {}: {}", processId, e.message)
@@ -512,10 +513,7 @@ class KernelBootstrap(
      * them under the app's resources; in development, build them with:
      *   ./gradlew :boss-orchestrator:fatJar :boss-service-auth:fatJar
      */
-    private fun spawnServices(
-        registry: ProcessRegistry,
-        spawner: ProcessSpawner,
-    ) {
+    private fun spawnServices(spawner: ProcessSpawner) {
         val bossDataDir =
             System.getenv("BOSS_DATA_DIR")
                 ?: try {
@@ -544,7 +542,6 @@ class KernelBootstrap(
 
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = ORCHESTRATOR_PROCESS_ID,
                 processType = ProcessType.ORCHESTRATOR,
@@ -560,7 +557,6 @@ class KernelBootstrap(
 
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-service-auth",
                 processType = ProcessType.SERVICE,
@@ -577,7 +573,6 @@ class KernelBootstrap(
         val masteryOrchestratorJar = resolveServiceJar(bossDataDir, "boss-mastery-orchestrator-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-mastery-orchestrator",
                 processType = ProcessType.SERVICE,
@@ -594,7 +589,6 @@ class KernelBootstrap(
         val workspaceJar = resolveServiceJar(bossDataDir, "boss-service-workspace-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-service-workspace",
                 processType = ProcessType.SERVICE,
@@ -611,7 +605,6 @@ class KernelBootstrap(
         val settingsJar = resolveServiceJar(bossDataDir, "boss-service-settings-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-service-settings",
                 processType = ProcessType.SERVICE,
@@ -628,7 +621,6 @@ class KernelBootstrap(
         val filesystemJar = resolveServiceJar(bossDataDir, "boss-service-filesystem-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-service-filesystem",
                 processType = ProcessType.SERVICE,
@@ -645,7 +637,6 @@ class KernelBootstrap(
         val terminalJar = resolveServiceJar(bossDataDir, "boss-app-terminal-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-app-terminal",
                 processType = ProcessType.APP,
@@ -662,7 +653,6 @@ class KernelBootstrap(
         val editorJar = resolveServiceJar(bossDataDir, "boss-app-editor-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-app-editor",
                 processType = ProcessType.APP,
@@ -679,7 +669,6 @@ class KernelBootstrap(
         val browserJar = resolveServiceJar(bossDataDir, "boss-app-browser-all.jar")
         spawnIfJarExists(
             spawner,
-            registry,
             ProcessConfig(
                 processId = "boss-app-browser",
                 processType = ProcessType.APP,
@@ -696,14 +685,12 @@ class KernelBootstrap(
 
     private fun spawnIfJarExists(
         spawner: ProcessSpawner,
-        registry: ProcessRegistry,
         config: ProcessConfig,
         jarPath: String,
     ) {
         if (java.io.File(jarPath).exists()) {
             try {
-                val process: ManagedProcess = spawner.spawn(config)
-                registry.register(config.processId, process)
+                spawner.spawn(config)
                 processMonitor?.startMonitoring(config.processId)
                 logger.info("Spawned service: {} at {}", config.processId, jarPath)
             } catch (e: Exception) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/KernelReflectionContractTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/KernelReflectionContractTest.kt
@@ -1,0 +1,79 @@
+package ai.rever.boss.kernel
+
+import ai.rever.boss.process.ProcessSpawner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The reflective contract `DefaultPlugin` depends on to wire out-of-process plugins.
+ *
+ * `DefaultPlugin.dynamicPluginManager` reaches the kernel entirely through `Class.forName` and
+ * `getConstructor`/`getMethod`, because `composeApp`'s common source set cannot depend on the
+ * desktop-only process manager. Reflection means the compiler checks none of it: renaming a class,
+ * adding a constructor parameter, or changing a getter leaves every other test green while the host
+ * silently falls back to in-process plugins at runtime, logged once as
+ * `OOP spawner: unexpected error` and swallowed.
+ *
+ * That is not hypothetical. Adding a third parameter to [ProcessSpawner] removed the
+ * `(String, File)` constructor that `DefaultPlugin` looked up - Kotlin emits only the full-arity
+ * constructor plus a synthetic defaults bridge, with no `@JvmOverloads` - so out-of-process plugins
+ * would have stopped spawning entirely, in the same change that set out to stop them leaking.
+ *
+ * Each test below mirrors one reflective lookup in `DefaultPlugin` exactly. Keep them in step with
+ * that call site: if a lookup here needs updating, the runtime behaviour changed.
+ */
+class KernelReflectionContractTest {
+    @Test
+    fun `KernelBootstrap Companion getInstance resolves`() {
+        val bootstrapCls = Class.forName("ai.rever.boss.kernel.KernelBootstrap")
+        val companionCls = Class.forName("ai.rever.boss.kernel.KernelBootstrap\$Companion")
+
+        // DefaultPlugin reads the Companion off the static field, then calls getInstance() on it.
+        val companionField = bootstrapCls.getDeclaredField("Companion")
+        assertTrue(companionField.get(null) != null, "KernelBootstrap.Companion must be reachable")
+        companionCls.getMethod("getInstance")
+    }
+
+    @Test
+    fun `KernelBootstrap getProcessSpawner resolves and returns a ProcessSpawner`() {
+        val bootstrapCls = Class.forName("ai.rever.boss.kernel.KernelBootstrap")
+
+        // The plugin side reuses this spawner rather than building its own, because only this one
+        // is wired to the registry the shutdown hook reaps.
+        val getter = bootstrapCls.getMethod("getProcessSpawner")
+
+        assertEquals(
+            ProcessSpawner::class.java,
+            getter.returnType,
+            "DefaultPlugin passes this straight into OutOfProcessPluginSpawnerImpl's constructor",
+        )
+    }
+
+    @Test
+    fun `OutOfProcessPluginSpawnerImpl constructor resolves`() {
+        val spawnerCls = Class.forName("ai.rever.boss.components.plugin.OutOfProcessPluginSpawnerImpl")
+        val processSpawnerCls = Class.forName("ai.rever.boss.process.ProcessSpawner")
+
+        // Exactly DefaultPlugin's lookup. A defaulted Kotlin parameter added here would NOT keep
+        // this three-arg form alive without @JvmOverloads.
+        spawnerCls.getConstructor(
+            processSpawnerCls,
+            String::class.java,
+            String::class.java,
+        )
+    }
+
+    @Test
+    fun `ProcessSpawner is constructible with the registry it must carry`() {
+        // Not a DefaultPlugin lookup any more - it reuses the kernel's instance - but the kernel
+        // itself builds this, and a spawner without a registry registers nothing.
+        val ctor =
+            ProcessSpawner::class.java.getConstructor(
+                String::class.java,
+                java.io.File::class.java,
+                Class.forName("ai.rever.boss.process.ProcessRegistry"),
+            )
+        assertEquals(3, ctor.parameterCount)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ReapChildrenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ReapChildrenTest.kt
@@ -1,0 +1,159 @@
+package ai.rever.boss.kernel
+
+import ai.rever.boss.process.ManagedProcess
+import ai.rever.boss.process.ProcessConfig
+import ai.rever.boss.process.ProcessMonitor
+import ai.rever.boss.process.ProcessRegistry
+import ai.rever.boss.process.ProcessType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the JVM shutdown hook does with the kernel's children.
+ *
+ * Two properties, both of which used to be wrong:
+ *
+ * 1. Supervision stops before anything is killed. Every `destroy()` looks like a crash to the
+ *    monitor, whose failure handler respawns, so reaping while it still watches can hand an exiting
+ *    host a fresh generation of children.
+ * 2. The cost does not scale with the cohort. Kills go out to everything first and are awaited
+ *    against one shared deadline; the previous destroy-then-wait-2s per process meant N plugins
+ *    could add 2N seconds to a Cmd+Q, and the OS caps how long a shutdown hook runs - a hook cut
+ *    off part-way down the list stranded the tail, which is the orphan symptom all over again.
+ */
+class ReapChildrenTest {
+    /** A process that ignores `destroy()` for [ignoreDestroys] calls, to force the wait path. */
+    private class FakeProcess(
+        private val pidValue: Long,
+        private val ignoreDestroys: Int = 0,
+    ) : Process() {
+        private var alive = true
+        private var destroys = 0
+        var forciblyKilled = false
+            private set
+
+        override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+
+        override fun getInputStream(): InputStream = InputStream.nullInputStream()
+
+        override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+
+        override fun waitFor(): Int = 0
+
+        override fun waitFor(
+            timeout: Long,
+            unit: TimeUnit,
+        ): Boolean {
+            // Blocks for the whole timeout while alive, exactly as the real Process does. A fake
+            // that returned immediately would make the shared-deadline test unable to fail: with no
+            // blocking, per-process waiting costs the same as one shared budget.
+            if (!alive) return true
+            Thread.sleep(unit.toMillis(timeout))
+            return !alive
+        }
+
+        override fun exitValue(): Int = if (alive) throw IllegalThreadStateException() else 0
+
+        override fun destroy() {
+            destroys++
+            if (destroys > ignoreDestroys) alive = false
+        }
+
+        override fun destroyForcibly(): Process {
+            forciblyKilled = true
+            alive = false
+            return this
+        }
+
+        override fun isAlive(): Boolean = alive
+
+        override fun pid(): Long = pidValue
+    }
+
+    private fun managed(
+        id: String,
+        process: Process,
+    ) = ManagedProcess(
+        config =
+            ProcessConfig(
+                processId = id,
+                processType = ProcessType.PLUGIN,
+                displayName = id,
+                mainClass = "Main",
+            ),
+        process = process,
+        ipcAddress = "unix:///tmp/$id",
+    )
+
+    @Test
+    fun `every registered child is killed`() {
+        val registry = ProcessRegistry()
+        val processes = (1..16).map { FakeProcess(it.toLong()) }
+        processes.forEachIndexed { i, p -> registry.register("plugin-$i", managed("plugin-$i", p)) }
+
+        reapChildren(monitor = null, registry = registry)
+
+        assertTrue(processes.none { it.isAlive }, "a surviving child is an orphan")
+    }
+
+    @Test
+    fun `a child that ignores destroy is force-killed`() {
+        val registry = ProcessRegistry()
+        val stubborn = FakeProcess(99, ignoreDestroys = Int.MAX_VALUE)
+        registry.register("plugin-stubborn", managed("plugin-stubborn", stubborn))
+
+        reapChildren(monitor = null, registry = registry, gracePeriodMs = 50)
+
+        assertTrue(stubborn.forciblyKilled, "SIGTERM being ignored must escalate")
+        assertFalse(stubborn.isAlive)
+    }
+
+    @Test
+    fun `the grace period is shared, not per process`() {
+        val registry = ProcessRegistry()
+        // All stubborn, so every one of them exercises the wait path.
+        repeat(24) { i ->
+            val stubborn = FakeProcess(i.toLong(), ignoreDestroys = Int.MAX_VALUE)
+            registry.register("plugin-$i", managed("plugin-$i", stubborn))
+        }
+
+        val started = System.currentTimeMillis()
+        reapChildren(monitor = null, registry = registry, gracePeriodMs = 200)
+        val elapsed = System.currentTimeMillis() - started
+
+        // Per-process waiting would be 24 x 200ms = 4.8s. The shared deadline keeps it flat.
+        assertTrue(elapsed < 2_000, "reap took ${elapsed}ms - the deadline is not being shared")
+    }
+
+    @Test
+    fun `supervision is stopped so a kill cannot be read as a crash`() {
+        val registry = ProcessRegistry()
+        val scope = CoroutineScope(SupervisorJob())
+        val monitor = ProcessMonitor(registry, scope)
+        registry.register("plugin-a", managed("plugin-a", FakeProcess(7)))
+        monitor.startGlobalMonitor(checkIntervalMs = 10)
+
+        reapChildren(monitor = monitor, registry = registry, gracePeriodMs = 50)
+
+        // stopSupervision, not stopAll: the kernel passes its own scope in and still uses it after
+        // reaping (the event bridge, the failure collector), so reaping must not cancel it.
+        assertTrue(scope.isActive, "reapChildren must not cancel a scope it does not own")
+        scope.cancel()
+    }
+
+    @Test
+    fun `an empty registry is a no-op`() {
+        reapChildren(monitor = null, registry = ProcessRegistry())
+        reapChildren(monitor = null, registry = null)
+        assertEquals(0, ProcessRegistry().getAllProcesses().size)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ReapChildrenTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/kernel/ReapChildrenTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.TimeUnit
@@ -82,11 +83,12 @@ class ReapChildrenTest {
     private fun managed(
         id: String,
         process: Process,
+        type: ProcessType = ProcessType.PLUGIN,
     ) = ManagedProcess(
         config =
             ProcessConfig(
                 processId = id,
-                processType = ProcessType.PLUGIN,
+                processType = type,
                 displayName = id,
                 mainClass = "Main",
             ),
@@ -139,15 +141,113 @@ class ReapChildrenTest {
         val registry = ProcessRegistry()
         val scope = CoroutineScope(SupervisorJob())
         val monitor = ProcessMonitor(registry, scope)
-        registry.register("plugin-a", managed("plugin-a", FakeProcess(7)))
+        val failures = mutableListOf<String>()
+        scope.launch { monitor.failures.collect { failures += it.processId } }
+
+        // A SERVICE, because PLUGIN is exempt from supervision and so could not report a failure
+        // even if supervision were still running - the test would pass for the wrong reason.
+        registry.register("svc-a", managed("svc-a", FakeProcess(7), ProcessType.SERVICE))
         monitor.startGlobalMonitor(checkIntervalMs = 10)
+        Thread.sleep(100) // let the monitor attach before anything is killed
 
         reapChildren(monitor = monitor, registry = registry, gracePeriodMs = 50)
+        Thread.sleep(300) // give a surviving monitor time to notice and report
 
+        assertTrue(
+            failures.isEmpty(),
+            "the reap's own kills were reported as crashes, which is what triggers a respawn: $failures",
+        )
         // stopSupervision, not stopAll: the kernel passes its own scope in and still uses it after
         // reaping (the event bridge, the failure collector), so reaping must not cancel it.
         assertTrue(scope.isActive, "reapChildren must not cancel a scope it does not own")
         scope.cancel()
+    }
+
+    @Test
+    fun `recovery stands down while a reap is in progress`() {
+        // stopSupervision closes the detection path; this is the action path. A handleFailure parked
+        // awaiting orchestrator advice can outlive the cancel and respawn a child after the reap's
+        // snapshot, leaving the exiting host a child nothing reaps.
+        assertFalse(isReaping(), "no reap in flight at rest")
+
+        val registry = ProcessRegistry()
+        val observed = mutableListOf<Boolean>()
+        val slow =
+            object : Process() {
+                override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+
+                override fun getInputStream(): InputStream = InputStream.nullInputStream()
+
+                override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+
+                override fun waitFor(): Int = 0
+
+                override fun waitFor(
+                    timeout: Long,
+                    unit: TimeUnit,
+                ): Boolean {
+                    observed += isReaping()
+                    return true
+                }
+
+                override fun exitValue(): Int = 0
+
+                override fun destroy() = Unit
+
+                override fun isAlive(): Boolean = false
+
+                override fun pid(): Long = 4242
+            }
+        registry.register("plugin-slow", managed("plugin-slow", slow))
+
+        reapChildren(monitor = null, registry = registry, gracePeriodMs = 100)
+
+        assertEquals(listOf(true), observed, "isReaping() must be true for the duration of the reap")
+        assertFalse(isReaping(), "and false again afterwards")
+    }
+
+    @Test
+    fun `recovery refuses to respawn during a reap`() {
+        val registry = ProcessRegistry()
+        val alive = FakeProcess(31, ignoreDestroys = Int.MAX_VALUE)
+        registry.register("svc-x", managed("svc-x", alive, ProcessType.SERVICE))
+
+        // Outside a reap it is a respawn candidate...
+        assertEquals("svc-x", respawnCandidate(registry, "svc-x")?.config?.processId)
+
+        // ...and during one it must not be, or the exiting host gains a child nothing reaps.
+        var candidateDuringReap: ManagedProcess? = null
+        val probe =
+            object : Process() {
+                override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+
+                override fun getInputStream(): InputStream = InputStream.nullInputStream()
+
+                override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+
+                override fun waitFor(): Int = 0
+
+                override fun waitFor(
+                    timeout: Long,
+                    unit: TimeUnit,
+                ): Boolean {
+                    candidateDuringReap = respawnCandidate(registry, "svc-x")
+                    return true
+                }
+
+                override fun exitValue(): Int = 0
+
+                override fun destroy() = Unit
+
+                override fun isAlive(): Boolean = false
+
+                override fun pid(): Long = 32
+            }
+        registry.register("svc-probe", managed("svc-probe", probe, ProcessType.SERVICE))
+
+        reapChildren(monitor = null, registry = registry, gracePeriodMs = 100)
+
+        assertEquals(null, candidateDuringReap, "respawn must stand down while a reap is in progress")
     }
 
     @Test

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessMonitor.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessMonitor.kt
@@ -59,6 +59,13 @@ class ProcessMonitor(
 
     /**
      * Start the global monitor that watches for new/removed processes.
+     *
+     * [ProcessType.PLUGIN] is deliberately left alone. Plugin children get their health,
+     * restart budget and in-process fallback from `PluginProcessMonitor` on the host side,
+     * and attaching this monitor too would make every plugin doubly supervised: a plugin the
+     * operator disables exits on purpose, which reads here as a crash and comes back through
+     * the kernel's respawn path. Plugins are still registered - the registry is what the
+     * shutdown hook reaps on exit - they are just not health-supervised from here.
      */
     fun startGlobalMonitor(checkIntervalMs: Long = 2_000) {
         globalMonitorJob =
@@ -66,6 +73,7 @@ class ProcessMonitor(
                 while (isActive) {
                     // Check all registered processes
                     registry.getAllProcesses().forEach { process ->
+                        if (process.config.processType == ProcessType.PLUGIN) return@forEach
                         if (!monitorJobs.containsKey(process.config.processId) ||
                             monitorJobs[process.config.processId]?.isActive != true
                         ) {

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessMonitor.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessMonitor.kt
@@ -60,17 +60,20 @@ class ProcessMonitor(
     /**
      * Start the global monitor that watches for new/removed processes.
      *
-     * [ProcessType.PLUGIN] is not health-supervised. Plugin children get their health, restart
-     * budget and in-process fallback from `PluginProcessMonitor` on the host side, and attaching
-     * this monitor too would make every plugin doubly supervised: a plugin the operator disables
-     * exits on purpose, which reads here as a crash and comes back through the kernel's respawn
-     * path. Plugins are still registered, because the registry is what the shutdown hook reaps.
+     * [ProcessType.PLUGIN] is not health-supervised here. Plugin health is `PluginProcessMonitor`'s
+     * responsibility on the host side - note that it is written but **not yet wired up**, so today
+     * a crashed out-of-process plugin gets no restart and no in-process fallback from anywhere.
+     * Supervising plugins from here is still the wrong answer to that: a plugin the operator
+     * disables exits on purpose, which would read as a crash and come back through the kernel's
+     * respawn path. Plugins are registered regardless, because the registry is what the shutdown
+     * hook reaps.
      *
-     * They are instead *reaped* from the registry once dead. Only a deliberate terminate
-     * unregisters a plugin, so a plugin that died on its own - crashed, or out of restart budget
-     * and left at FAILED - would otherwise sit in the registry for the rest of the session, with
+     * Dead plugins are instead *pruned*. Only a deliberate terminate unregisters one, so a plugin
+     * that died on its own would otherwise sit in the registry for the rest of the session, with
      * [ProcessRegistry.getAllProcesses] handing out a dead handle and processCount over-reporting
-     * it as live.
+     * it as live. The removal is compare-and-remove ([ProcessRegistry.unregisterIfSame]) because
+     * `getAllProcesses` hands back a snapshot: a respawn between the snapshot and the removal would
+     * otherwise cost the live replacement its registry entry, orphaning it.
      */
     fun startGlobalMonitor(checkIntervalMs: Long = 2_000) {
         globalMonitorJob =
@@ -79,7 +82,9 @@ class ProcessMonitor(
                     // Check all registered processes
                     registry.getAllProcesses().forEach { process ->
                         if (process.config.processType == ProcessType.PLUGIN) {
-                            if (!process.isAlive) registry.unregister(process.config.processId)
+                            if (!process.isAlive) {
+                                registry.unregisterIfSame(process.config.processId, process)
+                            }
                             return@forEach
                         }
                         if (!monitorJobs.containsKey(process.config.processId) ||
@@ -94,12 +99,24 @@ class ProcessMonitor(
     }
 
     /**
-     * Stop all monitoring.
+     * Stop all health supervision, leaving [scope] usable.
+     *
+     * This is what a caller that *passed in* its own scope wants: [stopAll] cancels that scope,
+     * which for `KernelBootstrap` means taking down its IPC event bridge and failure-handler
+     * collector as a side effect of stopping monitoring.
      */
-    fun stopAll() {
+    fun stopSupervision() {
         globalMonitorJob?.cancel()
         monitorJobs.values.forEach { it.cancel() }
         monitorJobs.clear()
+    }
+
+    /**
+     * Stop monitoring and cancel [scope]. Only for a caller that owns the scope - if you passed one
+     * in, use [stopSupervision] and cancel your own scope when you are ready.
+     */
+    fun stopAll() {
+        stopSupervision()
         scope.cancel()
     }
 

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessMonitor.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessMonitor.kt
@@ -60,12 +60,17 @@ class ProcessMonitor(
     /**
      * Start the global monitor that watches for new/removed processes.
      *
-     * [ProcessType.PLUGIN] is deliberately left alone. Plugin children get their health,
-     * restart budget and in-process fallback from `PluginProcessMonitor` on the host side,
-     * and attaching this monitor too would make every plugin doubly supervised: a plugin the
-     * operator disables exits on purpose, which reads here as a crash and comes back through
-     * the kernel's respawn path. Plugins are still registered - the registry is what the
-     * shutdown hook reaps on exit - they are just not health-supervised from here.
+     * [ProcessType.PLUGIN] is not health-supervised. Plugin children get their health, restart
+     * budget and in-process fallback from `PluginProcessMonitor` on the host side, and attaching
+     * this monitor too would make every plugin doubly supervised: a plugin the operator disables
+     * exits on purpose, which reads here as a crash and comes back through the kernel's respawn
+     * path. Plugins are still registered, because the registry is what the shutdown hook reaps.
+     *
+     * They are instead *reaped* from the registry once dead. Only a deliberate terminate
+     * unregisters a plugin, so a plugin that died on its own - crashed, or out of restart budget
+     * and left at FAILED - would otherwise sit in the registry for the rest of the session, with
+     * [ProcessRegistry.getAllProcesses] handing out a dead handle and processCount over-reporting
+     * it as live.
      */
     fun startGlobalMonitor(checkIntervalMs: Long = 2_000) {
         globalMonitorJob =
@@ -73,7 +78,10 @@ class ProcessMonitor(
                 while (isActive) {
                     // Check all registered processes
                     registry.getAllProcesses().forEach { process ->
-                        if (process.config.processType == ProcessType.PLUGIN) return@forEach
+                        if (process.config.processType == ProcessType.PLUGIN) {
+                            if (!process.isAlive) registry.unregister(process.config.processId)
+                            return@forEach
+                        }
                         if (!monitorJobs.containsKey(process.config.processId) ||
                             monitorJobs[process.config.processId]?.isActive != true
                         ) {

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessRegistry.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessRegistry.kt
@@ -27,7 +27,20 @@ class ProcessRegistry {
         process: ManagedProcess,
         manifest: ProcessManifest? = null,
     ) {
-        processes[id] = process
+        val replaced = processes.put(id, process)
+        // Replacing a *dead* handle is normal - that is what a respawn does. Replacing a live one
+        // means two callers picked the same process id, and the evicted child becomes invisible to
+        // the shutdown hook while still running, i.e. an orphan. The known way to reach this is two
+        // windows spawning the same out-of-process plugin, since `plugin-<id>` carries no window
+        // discriminator while the registry is process-wide.
+        if (replaced != null && replaced !== process && replaced.isAlive) {
+            logger.warn(
+                "Registered id={} replaced a LIVE handle (pid={} -> {}); the evicted child will not be reaped",
+                id,
+                replaced.pid,
+                process.pid,
+            )
+        }
         manifest?.let { manifests[id] = it }
         _processCount.value = processes.size
         logger.info("Registered process: id={}, type={}, pid={}", id, process.config.processType, process.pid)

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessRegistry.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessRegistry.kt
@@ -41,6 +41,26 @@ class ProcessRegistry {
         logger.info("Unregistered process: id={}", id)
     }
 
+    /**
+     * Remove [id], but only while it still maps to [process]. Returns whether it did.
+     *
+     * For callers acting on a process handle they read earlier: a plain [unregister] removes by id,
+     * so a respawn that re-registered the same id in between would have its live replacement
+     * dropped instead - and since this registry is what the shutdown hook reaps, dropping a live
+     * child is exactly how one becomes an orphan.
+     */
+    fun unregisterIfSame(
+        id: String,
+        process: ManagedProcess,
+    ): Boolean {
+        if (!processes.remove(id, process)) return false
+        manifests.remove(id)
+        restartCounts.remove(id)
+        _processCount.value = processes.size
+        logger.info("Unregistered process: id={}", id)
+        return true
+    }
+
     fun getProcess(id: String): ManagedProcess? = processes[id]
 
     fun getManifest(id: String): ProcessManifest? = manifests[id]

--- a/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessSpawner.kt
+++ b/modules/boss-process-manager/src/main/kotlin/ai/rever/boss/process/ProcessSpawner.kt
@@ -14,6 +14,11 @@ import java.io.File
  * - BOSS_PROCESS_TYPE: Process type (SERVICE, APP, PLUGIN)
  *
  * Process stdout/stderr are redirected to log files under $BOSS_DATA_DIR/logs/{processId}/
+ *
+ * Everything spawned here is entered into [registry], because the registry is what the kernel's
+ * shutdown hook reaps on exit. Registration used to be each caller's job, and the caller that
+ * forgot - the out-of-process plugin spawner - leaked a full cohort of child JVMs on every host
+ * exit for months. Owning it here makes that class of bug impossible for every call site.
  */
 class ProcessSpawner(
     private val kernelIpcAddress: String,
@@ -23,14 +28,19 @@ class ProcessSpawner(
                 ?: "${System.getProperty("user.home")}/.boss",
             "logs",
         ),
+    private val registry: ProcessRegistry? = null,
 ) {
     private val logger = LoggerFactory.getLogger(ProcessSpawner::class.java)
 
     /**
-     * Spawn a new child process from the given configuration.
+     * Spawn a new child process from the given configuration and register it.
      *
      * If a native image path is specified and the binary exists, it runs natively.
      * Otherwise falls back to JVM mode.
+     *
+     * The returned process is already in [registry], so callers must not register it again.
+     * Removing it is still the caller's job: only the caller knows the difference between a
+     * deliberate termination and a crash.
      */
     fun spawn(config: ProcessConfig): ManagedProcess {
         val processLogDir = File(logDir, config.processId).also { it.mkdirs() }
@@ -82,6 +92,7 @@ class ProcessSpawner(
             ipcAddress = ipcAddress,
         ).also {
             it.ipcClient = BossIpcClient(ipcAddress)
+            registry?.register(config.processId, it)
         }
     }
 

--- a/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessMonitorSupervisionTest.kt
+++ b/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessMonitorSupervisionTest.kt
@@ -1,0 +1,134 @@
+package ai.rever.boss.process
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Which registered processes the global monitor attaches health supervision to.
+ *
+ * Plugin children are in the registry so the kernel's shutdown hook can reap them on exit,
+ * but their health belongs to `PluginProcessMonitor` on the host side. If this monitor
+ * supervised them too, a plugin the operator disables would exit on purpose, read as a crash
+ * here, and come back through the kernel's respawn path behind the operator's back.
+ */
+class ProcessMonitorSupervisionTest {
+    /** A [Process] whose liveness the test controls. */
+    private class FakeProcess(
+        private val pidValue: Long,
+    ) : Process() {
+        private var alive = true
+        private var exit = 0
+
+        fun die(exitCode: Int) {
+            exit = exitCode
+            alive = false
+        }
+
+        override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+
+        override fun getInputStream(): InputStream = InputStream.nullInputStream()
+
+        override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+
+        override fun waitFor(): Int = exit
+
+        override fun waitFor(
+            timeout: Long,
+            unit: TimeUnit,
+        ): Boolean = !alive
+
+        override fun exitValue(): Int = if (alive) throw IllegalThreadStateException() else exit
+
+        override fun destroy() = die(143)
+
+        override fun isAlive(): Boolean = alive
+
+        override fun pid(): Long = pidValue
+    }
+
+    private fun managed(
+        id: String,
+        type: ProcessType,
+        process: Process,
+    ) = ManagedProcess(
+        config =
+            ProcessConfig(
+                processId = id,
+                processType = type,
+                displayName = id,
+                mainClass = "Main",
+                heartbeatIntervalMs = 100,
+            ),
+        process = process,
+        ipcAddress = "unix:///tmp/$id",
+    )
+
+    /**
+     * Run the global monitor over a single registered process of [type], kill it, and return
+     * every failure the monitor reported.
+     */
+    private fun failuresAfterDeath(type: ProcessType): List<ProcessFailure> {
+        val seen = mutableListOf<ProcessFailure>()
+        runTest {
+            val registry = ProcessRegistry()
+            val monitor = ProcessMonitor(registry, backgroundScope)
+            backgroundScope.launch { monitor.failures.collect { seen += it } }
+
+            val proc = FakeProcess(4242)
+            registry.register("p1", managed("p1", type, proc))
+
+            monitor.startGlobalMonitor(checkIntervalMs = 10)
+            advanceTimeBy(50)
+            proc.die(exitCode = 9)
+            advanceTimeBy(500)
+        }
+        return seen
+    }
+
+    @Test
+    fun `a dead service is reported as a failure`() {
+        val failures = failuresAfterDeath(ProcessType.SERVICE)
+
+        // Reported repeatedly, not once: monitorProcess breaks out on death but leaves the
+        // registry entry behind, so the global monitor re-attaches on its next tick and reports
+        // again. In the real kernel the failure handler respawns or unregisters, which ends it.
+        // This test pins that a service death is seen at all, not how many times.
+        assertTrue(failures.isNotEmpty(), "a service death must reach the kernel's failure path")
+        assertTrue(
+            failures.all { it.processId == "p1" && it.exitCode == 9 && it.reason == FailureReason.PROCESS_EXIT },
+            "unexpected failure contents: $failures",
+        )
+    }
+
+    @Test
+    fun `a dead plugin is not reported - PluginProcessMonitor owns plugin health`() {
+        assertEquals(
+            emptyList(),
+            failuresAfterDeath(ProcessType.PLUGIN),
+            "a plugin exit must not reach the kernel's respawn path",
+        )
+    }
+
+    @Test
+    fun `plugins stay in the registry so the shutdown hook can still reap them`() {
+        val registry = ProcessRegistry()
+        val proc = FakeProcess(6262)
+        registry.register("plugin-y", managed("plugin-y", ProcessType.PLUGIN, proc))
+
+        // Exactly what the kernel's JVM shutdown hook iterates.
+        val reapable = registry.getAllProcesses()
+        assertEquals(listOf("plugin-y"), reapable.map { it.config.processId })
+
+        assertTrue(proc.isAlive)
+        reapable.forEach { it.destroy() }
+        assertFalse(proc.isAlive, "the hook's destroy must reach a registered plugin child")
+    }
+}

--- a/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessMonitorSupervisionTest.kt
+++ b/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessMonitorSupervisionTest.kt
@@ -117,6 +117,45 @@ class ProcessMonitorSupervisionTest {
         )
     }
 
+    /**
+     * Run the global monitor over one registered process of [type] and return the registry ids
+     * still present after it dies.
+     */
+    private fun registeredIdsAfterDeath(
+        type: ProcessType,
+        kill: Boolean,
+    ): List<String> {
+        var remaining = emptyList<String>()
+        runTest {
+            val registry = ProcessRegistry()
+            val monitor = ProcessMonitor(registry, backgroundScope)
+
+            val proc = FakeProcess(7272)
+            registry.register("p1", managed("p1", type, proc))
+
+            monitor.startGlobalMonitor(checkIntervalMs = 10)
+            advanceTimeBy(50)
+            if (kill) proc.die(exitCode = 1)
+            advanceTimeBy(500)
+
+            remaining = registry.getAllProcesses().map { it.config.processId }
+        }
+        return remaining
+    }
+
+    @Test
+    fun `a dead plugin is pruned from the registry`() {
+        // Only a deliberate terminate unregisters a plugin, so a plugin that crashed or ran out of
+        // restart budget would otherwise leave a dead handle in the registry for the whole session
+        // and keep processCount over-reporting it.
+        assertEquals(emptyList(), registeredIdsAfterDeath(ProcessType.PLUGIN, kill = true))
+    }
+
+    @Test
+    fun `a live plugin is left in the registry`() {
+        assertEquals(listOf("p1"), registeredIdsAfterDeath(ProcessType.PLUGIN, kill = false))
+    }
+
     @Test
     fun `plugins stay in the registry so the shutdown hook can still reap them`() {
         val registry = ProcessRegistry()

--- a/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessMonitorSupervisionTest.kt
+++ b/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessMonitorSupervisionTest.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -154,6 +156,34 @@ class ProcessMonitorSupervisionTest {
     @Test
     fun `a live plugin is left in the registry`() {
         assertEquals(listOf("p1"), registeredIdsAfterDeath(ProcessType.PLUGIN, kill = false))
+    }
+
+    @Test
+    fun `pruning a dead plugin cannot evict a live replacement under the same id`() {
+        // getAllProcesses() hands back a snapshot, so the prune decides on a handle it read earlier.
+        // If a respawn registers a new child under the same id in between, removing by id alone
+        // would drop the live one - out of the registry that is the only thing the shutdown hook
+        // can see, making it exactly the orphan this whole change exists to prevent.
+        runTest {
+            val registry = ProcessRegistry()
+            val monitor = ProcessMonitor(registry, backgroundScope)
+
+            val dead = FakeProcess(1111)
+            registry.register("plugin-x", managed("plugin-x", ProcessType.PLUGIN, dead))
+            dead.die(exitCode = 1)
+
+            // The replacement lands before the monitor gets to act on its snapshot.
+            val liveReplacement = managed("plugin-x", ProcessType.PLUGIN, FakeProcess(2222))
+            registry.register("plugin-x", liveReplacement)
+
+            monitor.startGlobalMonitor(checkIntervalMs = 10)
+            advanceTimeBy(500)
+
+            val survivor = registry.getProcess("plugin-x")
+            assertNotNull(survivor, "the live replacement must still be registered")
+            assertSame(liveReplacement, survivor, "the dead handle's prune took the live one with it")
+            assertTrue(survivor.isAlive)
+        }
     }
 
     @Test

--- a/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessSpawnerRegistrationTest.kt
+++ b/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessSpawnerRegistrationTest.kt
@@ -5,8 +5,8 @@ import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 /**
  * Every spawned process lands in the registry.
@@ -99,6 +99,8 @@ class ProcessSpawnerRegistrationTest {
         val process = spawner(registry = null).spawn(config("no-registry", ProcessType.SERVICE))
         spawned += process
 
-        assertNotNull(process.pid)
+        // pid is a non-nullable Long, so assertNotNull here could never fail - assert the process
+        // actually started instead.
+        assertTrue(process.pid > 0, "a real child process should have been started")
     }
 }

--- a/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessSpawnerRegistrationTest.kt
+++ b/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessSpawnerRegistrationTest.kt
@@ -31,9 +31,12 @@ class ProcessSpawnerRegistrationTest {
     /**
      * A config that runs a real but trivially short-lived process.
      *
-     * `nativeImagePath` points at this JVM's own `java` binary, which exists and is executable on
-     * every platform CI runs on. Invoked with no arguments it prints usage and exits, so the test
-     * spawns something real without depending on a shell or a built fat JAR.
+     * `nativeImagePath` points at this JVM's own `java` binary. On POSIX that path exists and is
+     * executable, so the child runs natively and exits immediately after printing usage. On Windows
+     * `findJavaExecutable()` may yield a path without `.exe`, which fails `buildCommand`'s
+     * `exists()` check and falls back to JVM mode with the placeholder main class below - a real
+     * process is still spawned and still has to be registered, which is all these tests assert.
+     * Either way the test needs no shell and no built fat JAR.
      */
     private fun config(
         id: String,

--- a/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessSpawnerRegistrationTest.kt
+++ b/modules/boss-process-manager/src/test/kotlin/ai/rever/boss/process/ProcessSpawnerRegistrationTest.kt
@@ -1,0 +1,104 @@
+package ai.rever.boss.process
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+/**
+ * Every spawned process lands in the registry.
+ *
+ * This is the invariant the kernel's shutdown hook depends on: it reaps by iterating
+ * [ProcessRegistry.getAllProcesses], so a process that is spawned but not registered can never be
+ * killed on exit. Registration used to be each caller's job and the out-of-process plugin spawner
+ * did not do it, which stranded a full cohort of plugin JVMs on every host exit - 434 of them,
+ * holding 27 GB, on one machine. Owning registration inside [ProcessSpawner] is what makes that
+ * unrepeatable, and these tests are what keep it that way.
+ */
+class ProcessSpawnerRegistrationTest {
+    private val logDir: File = Files.createTempDirectory("spawner-test-logs").toFile()
+    private val spawned = mutableListOf<ManagedProcess>()
+
+    @AfterTest
+    fun cleanUp() {
+        spawned.forEach { runCatching { it.destroyForcibly() } }
+        logDir.deleteRecursively()
+    }
+
+    /**
+     * A config that runs a real but trivially short-lived process.
+     *
+     * `nativeImagePath` points at this JVM's own `java` binary, which exists and is executable on
+     * every platform CI runs on. Invoked with no arguments it prints usage and exits, so the test
+     * spawns something real without depending on a shell or a built fat JAR.
+     */
+    private fun config(
+        id: String,
+        type: ProcessType,
+    ) = ProcessConfig(
+        processId = id,
+        processType = type,
+        displayName = id,
+        mainClass = "unused.WhenNativeImageIsSet",
+        nativeImagePath = ProcessSpawner.findJavaExecutable(),
+    )
+
+    private fun spawner(registry: ProcessRegistry?) =
+        ProcessSpawner(
+            kernelIpcAddress = "unix:///tmp/boss-spawner-test-kernel.sock",
+            logDir = logDir,
+            registry = registry,
+        )
+
+    @Test
+    fun `a spawned plugin child is registered`() {
+        val registry = ProcessRegistry()
+
+        val process = spawner(registry).spawn(config("plugin-under-test", ProcessType.PLUGIN))
+        spawned += process
+
+        assertSame(
+            process,
+            registry.getProcess("plugin-under-test"),
+            "an unregistered plugin child is invisible to the shutdown hook and leaks on exit",
+        )
+    }
+
+    @Test
+    fun `a spawned service is registered`() {
+        val registry = ProcessRegistry()
+
+        val process = spawner(registry).spawn(config("svc-under-test", ProcessType.SERVICE))
+        spawned += process
+
+        assertSame(process, registry.getProcess("svc-under-test"))
+    }
+
+    @Test
+    fun `a registered child is reachable by what the shutdown hook iterates`() {
+        val registry = ProcessRegistry()
+        val spawner = spawner(registry)
+
+        spawned += spawner.spawn(config("plugin-a", ProcessType.PLUGIN))
+        spawned += spawner.spawn(config("svc-b", ProcessType.SERVICE))
+
+        assertEquals(
+            listOf("plugin-a", "svc-b"),
+            registry.getAllProcesses().map { it.config.processId }.sorted(),
+        )
+        assertEquals(2, registry.processCount.value)
+    }
+
+    @Test
+    fun `spawning without a registry still works`() {
+        // KERNEL mode always supplies one, but the parameter is optional and the fallback must not
+        // be a crash on a null registry.
+        val process = spawner(registry = null).spawn(config("no-registry", ProcessType.SERVICE))
+        spawned += process
+
+        assertNotNull(process.pid)
+    }
+}


### PR DESCRIPTION
## The problem

The reaper was not missing, it was **blind**.

`KernelBootstrap` installs a JVM shutdown hook that kills children by iterating `processRegistry.getAllProcesses()`. Plugin children were never in that map:

- `ProcessSpawner.spawn()` does not register. The only caller that does is `KernelBootstrap.spawnIfJarExists()`, used for kernel *services*.
- `OutOfProcessPluginSpawnerImpl.spawn()` kept its handles in a private map of its own.
- A child's gRPC registration reaches the registry's **separate `manifests` map** (via `KernelServiceImpl.onProcessRegistered` -> `updateManifest`), which is what `waitForReady()` polls. `getAllProcesses()` returns `processes.values`. So every plugin child was manifest-visible and process-invisible.

The hook ran, found nothing, killed nothing. Same blindness in `KernelBootstrap.shutdown()`, which filters `getProcessesByType(PLUGIN)`. The only code that could kill a plugin child was `terminate()`, reachable only from explicit unload/disable and the crash monitor - so **every host exit stranded the whole cohort, a clean Cmd+Q included.**

Measured on one developer machine after 19 days of uptime: **434 orphaned plugin JVMs, 27 GB resident, 45,547 threads** (92% of all threads on the box), accumulated over ~28 host launches spanning four api releases, with the compressor holding 71 GB and swap 98% full. Killing them returned 80 GB of free RAM and shrank the swap file from 74.8 GB to 5.1 GB.

Note KERNEL mode is only ever active for `gradlew run` from a checkout - `embeddedConfigKeys` does not bake `BOSS_MODE`, so packaged builds run MONOLITH and were never affected.

## The fix

- **Register each plugin child** with the kernel registry at spawn; unregister on `terminate()` and on a failed spawn.
- **Reap a child whose startup timed out.** A `waitForReady` timeout left a live JVM that nothing referenced - a second, quieter instance of the same leak.
- **Exempt `PLUGIN` from `ProcessMonitor.startGlobalMonitor`.** This is the hazard registration introduces: the global monitor attaches health supervision to everything in the registry and its failure handler respawns. `PluginProcessMonitor` already owns plugin health, restart budget and in-process fallback, so supervising here too would read a deliberately disabled plugin's clean exit as a crash and bring it back behind the operator. Plugins stay registered - the registry is what the hook reaps - they are just not health-supervised from the kernel. This preserves today's behaviour exactly, since plugins were never registered before.
- **Stop supervision before the shutdown hook reaps**, so the hook's own kills cannot be mistaken for crashes and answered with a fresh generation of children.

## This is one half

The child's half is risa-labs-inc/boss-microkernel-runtime#9: a `ProcessHandle.onExit` watchdog so an orphan exits on its own. Needed because a shutdown hook cannot run when the host is SIGKILLed or dies in native code. The two are independent and can merge in either order.

## Testing

`ProcessMonitorSupervisionTest` (3 tests) pins the exemption using a `Process` fake whose liveness the test controls:

- a dead **service** still reaches the kernel's failure path (positive control - without this the exemption test could pass for the wrong reason);
- a dead **plugin** does not;
- a registered plugin is reachable by exactly what the shutdown hook iterates, and `destroy()` reaches it.

The service test asserts a death is seen *at all* rather than seen once: `monitorProcess` breaks out on death but leaves the registry entry, so the global monitor re-attaches and re-reports each tick until the failure handler respawns or unregisters. That is pre-existing behaviour, not something this PR changes.

Green: `:boss-process-manager:test`, `:composeApp:compileKotlinDesktop`, aggregate `ktlintCheck` and `detekt`.