### PR TITLE
chore(startup): drop the dead LLM env-key probe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,11 +70,26 @@ SUPABASE_URL=https://api.risaboss.com
 SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_FUNCTION_URL=https://api.risaboss.com/functions/v1
 GITHUB_TOKEN=ghp_your_token_here  # Optional, 60 req/hr without
-OPENAI_API_KEY=sk-your-key-here  # Optional, enables AI self-healing in RepairEngine
 MACOS_DEVELOPER_ID=Developer ID Application: ...  # Optional, signs local packaging
 ```
 
 **Priority**: Environment variables > System properties > local.properties > Embedded build config
+
+### AI credentials are not configured here
+
+`OPENAI_API_KEY` used to be listed above as a `local.properties` key that enabled AI
+self-healing. Nothing has ever read it from that file - it is an **environment variable**, and
+the priority order above does not apply to it.
+
+- **AI providers** (chat, agents, plugin AI features) are owned entirely by the
+  **secret-manager** plugin: `Settings → AI Providers`. The host has no provider list; it
+  relays the plugin's through `PluginContext.llmProvider`. See that plugin's `AGENTS.md`.
+- **AI self-healing / repair** is the one credential the host still resolves itself, because
+  `SelfHealingSettingsManager` runs before any window or plugin exists and so cannot reach the
+  plugin's store. It reads `AI_REPAIR_API_KEY`, then the provider's own variable
+  (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / …), then the legacy `~/.boss/llm_settings.json` and
+  its `.migrated` sibling - all as **env vars / files, never local.properties**. A key rotated
+  in Settings → AI Providers does not reach it.
 
 There are NO credential fallbacks in source (public repo). Packaged builds get
 the JxBrowser license and Supabase settings baked in by the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -597,15 +597,13 @@ fun main(args: Array<String>) {
         ),
     )
 
-    // Log API key availability (without exposing values)
-    val apiKeyStatus =
-        mapOf(
-            "ANTHROPIC_API_KEY" to (System.getenv("ANTHROPIC_API_KEY") != null),
-            "OPENAI_API_KEY" to (System.getenv("OPENAI_API_KEY") != null),
-            "TOGETHER_API_KEY" to (System.getenv("TOGETHER_API_KEY") != null),
-            "CUSTOM_LLM_API_KEY" to (System.getenv("CUSTOM_LLM_API_KEY") != null),
-        )
-    logger.debug(LogCategory.SYSTEM, "API key availability", apiKeyStatus.mapValues { if (it.value) "set" else "not set" })
+    // NOTE: there used to be an "API key availability" probe here, logging whether four LLM
+    // provider environment variables were set. It is gone because the host no longer owns any
+    // provider list — the secret-manager plugin does, and it knows seven providers plus custom,
+    // resolving each from `-D` properties, `launchctl getenv` and `~/.boss/env_vars` as well as
+    // the environment. A hardcoded four-name probe here could only ever disagree with it. The
+    // one credential the host itself still resolves is the AI-repair key, and
+    // SelfHealingSettings reports its own readiness.
 
     // chromiumNeedsDownload was resolved far earlier, above the first engine boot
     // — see the comment there for why that ordering matters.


### PR DESCRIPTION
`main.kt` logged whether `ANTHROPIC/OPENAI/TOGETHER/CUSTOM_LLM_API_KEY` were set. Values never
leaked — it logged "set"/"not set" — but the host no longer owns a provider list at all.
secret-manager does, and it knows seven providers plus custom, resolving each from `-D` properties,
`launchctl getenv` and `~/.boss/env_vars` as well as the environment. A hardcoded four-name probe
here could only ever disagree with it, and it was the last LLM env read outside the self-healing
path.

Also corrects `AGENTS.md`, which listed `OPENAI_API_KEY` under `local.properties` as the way to
enable AI self-healing. Nothing has ever read it from that file: it is an env var, so the documented
"env > system property > local.properties" priority does not apply to it. Replaced with where AI
credentials actually live — Settings → AI Providers for everything, and the `AI_REPAIR_API_KEY`
env-var chain for the repair path, which resolves before any plugin exists and so cannot reach the
plugin's store.

Deliberately out of scope: `SelfHealingSettingsManager` and `boss-orchestrator` still resolve the
AI-repair key themselves. That path runs in `init{}` before any window or plugin exists, and
`KernelBootstrap` reads the child env once at spawn, so moving it onto the plugin-owned provider
needs its own design.

Verified: `:composeApp:compileKotlinDesktop` and `:composeApp:ktlintCheck` green.