### PR TITLE
🔧 fix: follow-ups from #128 — blank env vars, lost updates, temp-file perms

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
@@ -19,14 +19,10 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowPlacement
-import androidx.compose.ui.window.WindowPosition
-import androidx.compose.ui.window.rememberWindowState
 
 /**
  * Heavyweight overlay window for HARDWARE_ACCELERATED browser mode.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/ChromiumFlagsSection.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/ChromiumFlagsSection.kt
@@ -62,8 +62,8 @@ fun ChromiumFlagsSections() {
     // it as a parameter, and a fresh lambda each pass would recompose all of them on any change.
     val save =
         remember(scope) {
-            { next: ChromiumFlagsSettings ->
-                scope.launch { ChromiumFlagsSettingsManager.updateSettings(next) }
+            { transform: (ChromiumFlagsSettings) -> ChromiumFlagsSettings ->
+                scope.launch { ChromiumFlagsSettingsManager.updateSettings(transform) }
                 Unit
             }
         }
@@ -103,7 +103,7 @@ fun ChromiumFlagsSections() {
             message = pending.message,
             confirmText = pending.confirmText,
             onConfirm = {
-                save(pending.apply(settings))
+                save { current -> pending.apply(current) }
                 confirming = null
             },
             onDismiss = { confirming = null },
@@ -156,8 +156,18 @@ internal fun restartWouldChangeAnything(settings: ChromiumFlagsSettings): Boolea
     // to one is a real change. Published keys are compared as the next launch would resolve them.
     val publishedDiffers =
         ChromiumFlagKeys.PUBLISHED.any { key ->
-            ChromiumFlagsSettingsManager.previewValue(settings, key) !=
-                ChromiumFlagsSettingsManager.previewValue(boot, key)
+            val now = ChromiumFlagsSettingsManager.previewValue(settings, key)
+            val before = ChromiumFlagsSettingsManager.previewValue(boot, key)
+            if (key == ChromiumFlagKeys.SKIA_GRAPHITE) {
+                // Compared RESOLVED, not raw. Graphite's default follows the rendering mode, so
+                // toggling it off and back on leaves an explicit "true" where boot held null -
+                // different strings, identical behaviour - and offering a restart for that is a
+                // lost session for no effect. Every other key resolves from its raw value alone.
+                FluckEngine.resolveSkiaGraphite(now, nextRenderingMode(settings)) !=
+                    FluckEngine.resolveSkiaGraphite(before, nextRenderingMode(boot))
+            } else {
+                now != before
+            }
         }
     // Settings-only fields have no config key, so previewValue cannot speak for them and any
     // change to one is a real change.
@@ -272,7 +282,7 @@ internal const val OFF_SCREEN_LABEL = "Off-screen"
 @Composable
 private fun RenderingSection(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
 ) {
     SettingsSection(
         title = "Rendering",
@@ -293,7 +303,8 @@ private fun RenderingSection(
             // hand-edited file saying that would display as Off-screen while running Hardware.
             selectedOption = renderingModeLabel(settings.renderingMode, hostOs),
             onOptionSelected = { selection ->
-                save(settings.copy(renderingMode = if (selection == OFF_SCREEN_LABEL) "OFF_SCREEN" else null))
+                val mode = if (selection == OFF_SCREEN_LABEL) "OFF_SCREEN" else null
+                save { current -> current.copy(renderingMode = mode) }
             },
             enabled = modeEnvNote == null,
             description =
@@ -311,7 +322,7 @@ private fun RenderingSection(
             options = listOf(AUTO_LABEL) + ChromiumFlagKeys.SKIKO_RENDER_APIS,
             selectedOption = settings.skikoRenderApi ?: AUTO_LABEL,
             onOptionSelected = { selection ->
-                save(settings.copy(skikoRenderApi = selection.takeIf { it != AUTO_LABEL }))
+                save { current -> current.copy(skikoRenderApi = selection.takeIf { it != AUTO_LABEL }) }
             },
             enabled = skikoEnvNote == null,
             description =
@@ -327,7 +338,7 @@ private fun RenderingSection(
         SettingsNumberInput(
             label = "Browser surface top offset (dp)",
             value = settings.topInsetDp ?: 0,
-            onValueChange = { save(settings.copy(topInsetDp = it.takeIf { v -> v != 0 })) },
+            onValueChange = { save { current -> current.copy(topInsetDp = it.takeIf { v -> v != 0 }) } },
             range = 0..200,
             enabled = insetEnvNote == null,
             description =
@@ -343,7 +354,7 @@ private const val AUTO_LABEL = "Auto"
 @Composable
 private fun PerformanceSection(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
     isMacAarch64: Boolean,
     isLinux: Boolean,
     isWindows: Boolean,
@@ -353,7 +364,8 @@ private fun PerformanceSection(
             label = "HTTP disk cache (MB)",
             value = settings.diskCacheMb ?: FluckEngine.DEFAULT_DISK_CACHE_MB,
             onValueChange = {
-                save(settings.copy(diskCacheMb = it.takeIf { v -> v != FluckEngine.DEFAULT_DISK_CACHE_MB }))
+                val mb = it.takeIf { v -> v != FluckEngine.DEFAULT_DISK_CACHE_MB }
+                save { current -> current.copy(diskCacheMb = mb) }
             },
             range = 1..8192,
             description =
@@ -370,7 +382,7 @@ private fun PerformanceSection(
             // because --renderer-process-limit=0 is not a cap — so 0 is spelled as "no limit"
             // rather than stored, and no separate "unlimited" control is needed.
             value = settings.rendererProcessLimit ?: 0,
-            onValueChange = { save(settings.copy(rendererProcessLimit = it.takeIf { v -> v > 0 })) },
+            onValueChange = { save { current -> current.copy(rendererProcessLimit = it.takeIf { v -> v > 0 }) } },
             range = 0..64,
             enabled = capEnvNote == null,
             description =
@@ -386,7 +398,7 @@ private fun PerformanceSection(
         SettingsToggle(
             label = "Pre-warm the engine at startup",
             checked = settings.browserPrewarm ?: true,
-            onCheckedChange = { save(settings.copy(browserPrewarm = it.takeIf { v -> !v })) },
+            onCheckedChange = { save { current -> current.copy(browserPrewarm = it.takeIf { v -> !v }) } },
             enabled = prewarmEnvNote == null,
             description =
                 prewarmEnvNote
@@ -408,7 +420,7 @@ private fun PerformanceSection(
 @Composable
 private fun PlatformPerformanceRows(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
     isMacAarch64: Boolean,
     isLinux: Boolean,
     isWindows: Boolean,
@@ -429,7 +441,7 @@ private fun PlatformPerformanceRows(
                 // Stores the explicit boolean rather than collapsing one side to null. With a
                 // mode-dependent default, "off" is a real choice that has to survive a switch back
                 // to hardware rendering — collapsing it would silently re-enable Graphite.
-                onCheckedChange = { save(settings.copy(enableSkiaGraphite = it)) },
+                onCheckedChange = { save { current -> current.copy(enableSkiaGraphite = it) } },
                 enabled = graphiteEnvNote == null,
                 description =
                     graphiteEnvNote
@@ -450,7 +462,7 @@ private fun PlatformPerformanceRows(
             SettingsToggle(
                 label = "VA-API hardware video decode",
                 checked = settings.enableVaapi ?: true,
-                onCheckedChange = { save(settings.copy(enableVaapi = it.takeIf { v -> !v })) },
+                onCheckedChange = { save { current -> current.copy(enableVaapi = it.takeIf { v -> !v }) } },
                 description =
                     "On by default. Turn it off if video is glitching or failing to play - VA-API " +
                         "needs a working driver, and forcing it on a broken one is worse than software decode.",
@@ -462,7 +474,7 @@ private fun PlatformPerformanceRows(
             SettingsToggle(
                 label = "Disable native-window occlusion tracking",
                 checked = settings.disableWinOcclusion ?: true,
-                onCheckedChange = { save(settings.copy(disableWinOcclusion = it.takeIf { v -> !v })) },
+                onCheckedChange = { save { current -> current.copy(disableWinOcclusion = it.takeIf { v -> !v }) } },
                 description =
                     "On by default. Chromium can decide the embedded window is fully covered and stop " +
                         "producing frames, which shows up as a browser that freezes until you interact with it.",
@@ -474,7 +486,7 @@ private fun PlatformPerformanceRows(
 @Composable
 private fun NetworkSection(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
 ) {
     SettingsSection(
         title = "Privacy & Network",
@@ -483,14 +495,14 @@ private fun NetworkSection(
         SettingsToggle(
             label = "Drop hyperlink auditing pings",
             checked = settings.noPings ?: true,
-            onCheckedChange = { save(settings.copy(noPings = it.takeIf { v -> !v })) },
+            onCheckedChange = { save { current -> current.copy(noPings = it.takeIf { v -> !v }) } },
             description = "--no-pings. On by default. Turn off only if a site depends on ping tracking.",
         )
         Spacer(modifier = Modifier.height(8.dp))
         SettingsToggle(
             label = "Disable Domain Reliability reporting",
             checked = settings.disableDomainReliability ?: true,
-            onCheckedChange = { save(settings.copy(disableDomainReliability = it.takeIf { v -> !v })) },
+            onCheckedChange = { save { current -> current.copy(disableDomainReliability = it.takeIf { v -> !v }) } },
             description = "--disable-domain-reliability. On by default. Stops Chrome's error reports to Google.",
         )
     }
@@ -499,7 +511,7 @@ private fun NetworkSection(
 @Composable
 private fun AdvancedSection(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
 ) {
     SettingsSection(title = "Advanced") {
         val extrasEnvNote = envNote(ChromiumFlagKeys.EXTRA_SWITCHES)
@@ -511,7 +523,7 @@ private fun AdvancedSection(
         SettingsTextArea(
             label = "Extra Chromium switches",
             value = raw,
-            onValueChange = { save(settings.copy(extraSwitches = it.takeIf { v -> v.isNotBlank() })) },
+            onValueChange = { save { current -> current.copy(extraSwitches = it.takeIf { v -> v.isNotBlank() }) } },
             placeholder = "--some-switch --another=value",
             enabled = extrasEnvNote == null,
             minLines = 3,
@@ -552,7 +564,7 @@ private fun AdvancedSection(
 @Composable
 private fun DangerZoneSection(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
     onConfirm: (PendingDangerousFlag) -> Unit,
 ) {
     SettingsSection(
@@ -568,7 +580,7 @@ private fun DangerZoneSection(
 @Composable
 private fun SandboxRow(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
     onConfirm: (PendingDangerousFlag) -> Unit,
 ) {
     Column {
@@ -594,7 +606,7 @@ private fun SandboxRow(
                         ),
                     )
                 } else {
-                    save(settings.copy(disableSandbox = null))
+                    save { current -> current.copy(disableSandbox = null) }
                 }
             },
             enabled = sandboxEnvNote == null,
@@ -610,7 +622,7 @@ private fun SandboxRow(
 @Composable
 private fun DevToolsPortRows(
     settings: ChromiumFlagsSettings,
-    save: (ChromiumFlagsSettings) -> Unit,
+    save: ((ChromiumFlagsSettings) -> ChromiumFlagsSettings) -> Unit,
     onConfirm: (PendingDangerousFlag) -> Unit,
 ) {
     Column {
@@ -635,7 +647,7 @@ private fun DevToolsPortRows(
                         ),
                     )
                 } else {
-                    save(settings.copy(remoteDebuggingPort = null))
+                    save { current -> current.copy(remoteDebuggingPort = null) }
                 }
             },
             enabled = portEnvNote == null,
@@ -651,7 +663,7 @@ private fun DevToolsPortRows(
                 value = port,
                 // Ports below 1024 are privileged and 0 means "pick any free port" to Chromium —
                 // a debugging endpoint nobody knows is open. The range keeps both unreachable.
-                onValueChange = { save(settings.copy(remoteDebuggingPort = it)) },
+                onValueChange = { save { current -> current.copy(remoteDebuggingPort = it) } },
                 range = 1024..65535,
                 description = "1024-65535. Bound to localhost by Chromium.",
             )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/ChromiumFlagsSection.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/ChromiumFlagsSection.kt
@@ -149,8 +149,15 @@ fun ChromiumFlagsSections() {
  * for a key an environment variable owns, where the next launch resolves to exactly what is
  * running now and the user loses their session for nothing.
  */
-internal fun restartWouldChangeAnything(settings: ChromiumFlagsSettings): Boolean {
-    val boot = ChromiumFlagsSettingsManager.bootSettings
+internal fun restartWouldChangeAnything(
+    settings: ChromiumFlagsSettings,
+    // Injectable purely so tests are hermetic. bootSettings is a val read from the DEFAULT path at
+    // object construction, before any test can redirect settingsFile, so a test comparing against
+    // it depends on whether the developer's machine happens to have saved a Chromium setting -
+    // including one written by the very bug an earlier commit here fixed. Production never passes
+    // this.
+    boot: ChromiumFlagsSettings = ChromiumFlagsSettingsManager.bootSettings,
+): Boolean {
     if (settings == boot) return false
     // Settings-only fields have no config key, so previewValue cannot speak for them; any change
     // to one is a real change. Published keys are compared as the next launch would resolve them.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -206,7 +207,7 @@ object ChromiumFlagsSettingsManager {
     fun applyToSystemProperties() {
         val settings = _currentSettings.value
         val wanted = ChromiumFlagKeys.PUBLISHED.mapNotNull { key -> settings.publishedValue(key)?.let { key to it } }
-        val (envOwned, toPublish) = wanted.partition { (key, _) -> System.getenv(key) != null }
+        val (envOwned, toPublish) = wanted.partition { (key, _) -> envOverride(key) != null }
 
         val published = toPublish.toMap()
         published.forEach { (key, value) -> System.setProperty(key, value) }
@@ -235,7 +236,10 @@ object ChromiumFlagsSettingsManager {
      * is overridden instead of letting it look broken. Reads the environment ONLY: a
      * system property here would report this object's own publication back to it.
      */
-    fun envOverride(key: String): String? = System.getenv(key)
+    // Blank reads as UNSET. `FOO= boss` exports an empty string, which is non-null, so a bare
+    // getenv let an empty variable claim ownership of a key and silently suppress the user's
+    // setting - reported in the UI as an override with no value to show.
+    fun envOverride(key: String): String? = System.getenv(key)?.takeIf { it.isNotBlank() }
 
     /**
      * What [key] would resolve to on the next launch given [settings] — **env first,
@@ -261,11 +265,20 @@ object ChromiumFlagsSettingsManager {
      */
     private val writeMutex = kotlinx.coroutines.sync.Mutex()
 
-    suspend fun updateSettings(settings: ChromiumFlagsSettings) {
+    /**
+     * Apply [transform] to the current settings, atomically, and persist the result.
+     *
+     * A TRANSFORM rather than a finished value. The callers are UI controls computing
+     * `current.copy(field = new)` from a snapshot they collected earlier, so two edits landing in
+     * the same frame - which per-keystroke number inputs make ordinary - both derive from that one
+     * snapshot and the second silently discards the first. `updateAndGet` closes it: each caller
+     * reads the value at the moment it applies, not at the moment it composed.
+     */
+    suspend fun updateSettings(transform: (ChromiumFlagsSettings) -> ChromiumFlagsSettings) {
         // In-memory state first, on the CALLER's thread, so the UI and any subsequent read see
         // the new value immediately and cannot observe a write that is still queued behind the
         // mutex. Only the disk write is asynchronous.
-        _currentSettings.value = settings
+        _currentSettings.updateAndGet(transform)
         withContext(Dispatchers.IO) {
             writeMutex.withLock {
                 try {
@@ -275,8 +288,11 @@ object ChromiumFlagsSettingsManager {
                     // failure with ChromiumFlagsSettings() — so an interrupted keystroke could
                     // silently reset every flag the user had set, including the security ones.
                     val temp = java.io.File(settingsFile.parentFile, "${settingsFile.name}.tmp")
-                    temp.writeText(json.encodeToString(ChromiumFlagsSettings.serializer(), settings))
-                    restrictToOwner(temp)
+                    // Read under the lock rather than using a value captured before it: with two
+                    // writers, the second could otherwise persist the older of the two snapshots.
+                    val toPersist = _currentSettings.value
+                    createOwnerOnly(temp)
+                    temp.writeText(json.encodeToString(ChromiumFlagsSettings.serializer(), toPersist))
                     java.nio.file.Files.move(
                         temp.toPath(),
                         settingsFile.toPath(),
@@ -304,13 +320,23 @@ object ChromiumFlagsSettingsManager {
      * Best-effort: a filesystem without POSIX permissions (a Windows share) must not stop the
      * settings from saving, so a failure is logged and the write proceeds.
      */
-    private fun restrictToOwner(file: java.io.File) {
+    private fun createOwnerOnly(file: java.io.File) {
         try {
             val perms =
                 java.nio.file.attribute.PosixFilePermissions
                     .fromString("rw-------")
+            // Created WITH the permissions rather than chmod-ed after writing. Writing first and
+            // restricting second left the contents readable at the default umask for the width of
+            // that call - a small window, but an avoidable one on a file that can turn off the
+            // Chromium sandbox.
             java.nio.file.Files
-                .setPosixFilePermissions(file.toPath(), perms)
+                .deleteIfExists(file.toPath())
+            java.nio.file.Files
+                .createFile(
+                    file.toPath(),
+                    java.nio.file.attribute.PosixFilePermissions
+                        .asFileAttribute(perms),
+                )
         } catch (e: UnsupportedOperationException) {
             logger.debug(
                 LogCategory.BROWSER,
@@ -320,11 +346,11 @@ object ChromiumFlagsSettingsManager {
         } catch (e: Exception) {
             logger.warn(
                 LogCategory.BROWSER,
-                "Could not restrict Chromium flag settings to owner-only",
+                "Could not create Chromium flag settings owner-only",
                 mapOf("error" to e.toString()),
             )
         }
     }
 
-    suspend fun resetToDefault() = updateSettings(ChromiumFlagsSettings())
+    suspend fun resetToDefault() = updateSettings { ChromiumFlagsSettings() }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -150,6 +150,10 @@ object ChromiumFlagsSettingsManager {
     // test exercising it against the default path writes the developer's (and CI's) real
     // ~/.boss/chromium-flags.json - a test that mutates the machine it runs on. Production never
     // reassigns this.
+    //
+    // Redirection covers WRITES ONLY. `bootSettings = loadSync()` runs at object initialisation,
+    // off the default path, before any test can reassign - so a test that redirects and then
+    // expects a load to follow will read the real file, not its temp one.
     internal var settingsFile = BossDirectories.resolve("chromium-flags.json")
     private val json =
         Json {
@@ -278,6 +282,10 @@ object ChromiumFlagsSettingsManager {
      * the same frame - which per-keystroke number inputs make ordinary - both derive from that one
      * snapshot and the second silently discards the first. `updateAndGet` closes it: each caller
      * reads the value at the moment it applies, not at the moment it composed.
+     *
+     * **[transform] must be side-effect free.** `updateAndGet` is a CAS loop, so under contention
+     * it re-invokes the lambda until the swap succeeds. Every call site today is a pure `copy`,
+     * which is fine; logging, toasting or writing from inside it would fire more than once.
      */
     suspend fun updateSettings(transform: (ChromiumFlagsSettings) -> ChromiumFlagsSettings) {
         // In-memory state first, on the CALLER's thread, so the UI and any subsequent read see

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -279,7 +279,7 @@ object ChromiumFlagsSettingsManager {
      * be skipped. Guarded by [writeMutex]; seeded from [bootSettings] because that is what is on
      * disk when the process starts, so a no-op first save writes nothing.
      */
-    private var lastPersisted: ChromiumFlagsSettings? = null
+    private var lastPersisted: ChromiumFlagsSettings? = bootSettings
 
     /**
      * Apply [transform] to the current settings, atomically, and persist the result.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -145,7 +145,12 @@ data class ChromiumFlagsSettings(
  */
 object ChromiumFlagsSettingsManager {
     private val logger = BossLogger.forComponent("ChromiumFlagsSettingsManager")
-    private val settingsFile = BossDirectories.resolve("chromium-flags.json")
+
+    // `internal var` purely so tests can redirect it. updateSettings persists on every call, so a
+    // test exercising it against the default path writes the developer's (and CI's) real
+    // ~/.boss/chromium-flags.json - a test that mutates the machine it runs on. Production never
+    // reassigns this.
+    internal var settingsFile = BossDirectories.resolve("chromium-flags.json")
     private val json =
         Json {
             prettyPrint = true
@@ -255,7 +260,7 @@ object ChromiumFlagsSettingsManager {
     internal fun previewValue(
         settings: ChromiumFlagsSettings,
         key: String,
-    ): String? = System.getenv(key) ?: settings.publishedValue(key)
+    ): String? = envOverride(key) ?: settings.publishedValue(key)
 
     /**
      * Serialises the disk writes. This screen writes far more often than the version dropdown
@@ -293,6 +298,7 @@ object ChromiumFlagsSettingsManager {
                     val toPersist = _currentSettings.value
                     createOwnerOnly(temp)
                     temp.writeText(json.encodeToString(ChromiumFlagsSettings.serializer(), toPersist))
+                    restrictAfterWrite(temp)
                     java.nio.file.Files.move(
                         temp.toPath(),
                         settingsFile.toPath(),
@@ -347,6 +353,40 @@ object ChromiumFlagsSettingsManager {
             logger.warn(
                 LogCategory.BROWSER,
                 "Could not create Chromium flag settings owner-only",
+                mapOf("error" to e.toString()),
+            )
+        }
+    }
+
+    /**
+     * Restrict [file] after the fact, as a fallback for [createOwnerOnly].
+     *
+     * Creating the file with its permissions closes the write window, but it also became the ONLY
+     * mechanism - so any failure there left the file at the default umask with nothing but a log
+     * line, which is weaker than the chmod-after-write it replaced. Belt and braces: create
+     * restricted, then confirm restricted. Cheap, and the failure mode it guards is a file that
+     * can turn off the Chromium sandbox being world-readable.
+     */
+    private fun restrictAfterWrite(file: java.io.File) {
+        try {
+            java.nio.file.Files
+                .setPosixFilePermissions(
+                    file.toPath(),
+                    java.nio.file.attribute.PosixFilePermissions
+                        .fromString("rw-------"),
+                )
+        } catch (e: UnsupportedOperationException) {
+            // Non-POSIX filesystem. createOwnerOnly already reported it, so this is debug rather
+            // than a second warning for the same cause - but it is logged, not swallowed.
+            logger.debug(
+                LogCategory.BROWSER,
+                "Filesystem has no POSIX permissions - fallback restrict skipped",
+                mapOf("error" to e.toString()),
+            )
+        } catch (e: Exception) {
+            logger.warn(
+                LogCategory.BROWSER,
+                "Could not restrict Chromium flag settings to owner-only",
                 mapOf("error" to e.toString()),
             )
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -275,6 +275,13 @@ object ChromiumFlagsSettingsManager {
     private val writeMutex = kotlinx.coroutines.sync.Mutex()
 
     /**
+     * The last snapshot actually written, so a queued write that would produce identical bytes can
+     * be skipped. Guarded by [writeMutex]; seeded from [bootSettings] because that is what is on
+     * disk when the process starts, so a no-op first save writes nothing.
+     */
+    private var lastPersisted: ChromiumFlagsSettings? = null
+
+    /**
      * Apply [transform] to the current settings, atomically, and persist the result.
      *
      * A TRANSFORM rather than a finished value. The callers are UI controls computing
@@ -304,6 +311,11 @@ object ChromiumFlagsSettingsManager {
                     // Read under the lock rather than using a value captured before it: with two
                     // writers, the second could otherwise persist the older of the two snapshots.
                     val toPersist = _currentSettings.value
+                    // Per-keystroke inputs queue several writes that all resolve to the same final
+                    // snapshot once `toPersist` is re-read under the lock, so typing "8192" used to
+                    // write the identical bytes four times - now five syscalls each. Skip the ones
+                    // that would change nothing.
+                    if (toPersist == lastPersisted) return@withLock
                     createOwnerOnly(temp)
                     temp.writeText(json.encodeToString(ChromiumFlagsSettings.serializer(), toPersist))
                     restrictAfterWrite(temp)
@@ -313,6 +325,7 @@ object ChromiumFlagsSettingsManager {
                         java.nio.file.StandardCopyOption.REPLACE_EXISTING,
                         java.nio.file.StandardCopyOption.ATOMIC_MOVE,
                     )
+                    lastPersisted = toPersist
                     logger.debug(LogCategory.BROWSER, "Chromium flag settings saved")
                 } catch (e: Exception) {
                     logger.warn(LogCategory.BROWSER, "Error saving Chromium flag settings", error = e)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumFlagsSettings.kt
@@ -155,6 +155,14 @@ object ChromiumFlagsSettingsManager {
     // off the default path, before any test can reassign - so a test that redirects and then
     // expects a load to follow will read the real file, not its temp one.
     internal var settingsFile = BossDirectories.resolve("chromium-flags.json")
+        set(value) {
+            // A different file means nothing is known to be persisted in it, so the coalescing
+            // cache must not carry across. Without this a redirected test could have its first
+            // write skipped because an earlier test in the same JVM happened to persist the same
+            // snapshot - order- and machine-dependent, and it would present as a missing file.
+            field = value
+            lastPersisted = null
+        }
     private val json =
         Json {
             prettyPrint = true
@@ -275,11 +283,18 @@ object ChromiumFlagsSettingsManager {
     private val writeMutex = kotlinx.coroutines.sync.Mutex()
 
     /**
-     * The last snapshot actually written, so a queued write that would produce identical bytes can
-     * be skipped. Guarded by [writeMutex]; seeded from [bootSettings] because that is what is on
-     * disk when the process starts, so a no-op first save writes nothing.
+     * The last snapshot this process actually wrote, so a queued write that would produce
+     * identical bytes can be skipped. Guarded by [writeMutex].
+     *
+     * **Starts null, deliberately, and must not be seeded from [bootSettings].** They look
+     * interchangeable and are not: [loadSync] answers a parse failure with a DEFAULT object while
+     * the corrupt file stays on disk, so seeding would record "defaults are persisted" about a
+     * file that holds nothing of the sort - and "Reset engine flags", which writes exactly those
+     * defaults, would match the cache and skip the write, leaving the corrupt file in place
+     * forever with the UI reporting success. Null means "nothing known to be on disk", which is
+     * the truth at startup, and it costs one redundant first write.
      */
-    private var lastPersisted: ChromiumFlagsSettings? = bootSettings
+    private var lastPersisted: ChromiumFlagsSettings? = null
 
     /**
      * Apply [transform] to the current settings, atomically, and persist the result.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ConfigLoader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ConfigLoader.kt
@@ -119,9 +119,31 @@ object ConfigLoader {
         localProps: Properties,
         embeddedProps: Properties,
     ): String? =
-        envValue
-            ?: sysPropValue
-            ?: localProps.getProperty(key)
-            ?: embeddedProps.getProperty(key)
+        envValue.orNullIfBlank()
+            ?: sysPropValue.orNullIfBlank()
+            ?: localProps.getProperty(key).orNullIfBlank()
+            ?: embeddedProps.getProperty(key).orNullIfBlank()
+            // NOT blank-filtered: a caller that passes "" as its default has said so explicitly,
+            // unlike an exported variable that merely happens to be empty.
             ?: defaultValue
+
+    /**
+     * A blank value at any tier is not a value, so the next tier gets its turn.
+     *
+     * `export BOSS_RENDERING_MODE=` produces an empty string, which is non-null, so it used to win
+     * the chain and shadow every tier below it - including a setting the user had chosen in the
+     * app. Silently: the value resolves to `""`, which every consumer then treats as unrecognised
+     * and falls back on, so the effect is a platform default with nothing to explain it.
+     *
+     * That became worse once Settings started publishing to the system-property tier. The Settings
+     * UI reports env ownership by asking whether the variable is set, and it now treats blank as
+     * unset - so with a blank variable exported the dropdown showed the user's choice, the
+     * command-line preview showed the switches for it, the startup log said it was applied, and
+     * this function still handed the engine `""`. Fixing only the UI turned a confusing-but-honest
+     * state into a silent lie; the fix belongs here, where the value is actually decided.
+     *
+     * Applied to all four sources rather than just the environment: a properties file line reading
+     * `KEY=` is the same mistake with the same consequence.
+     */
+    private fun String?.orNullIfBlank(): String? = this?.takeIf { it.isNotBlank() }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/GitHubConfig.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/GitHubConfig.kt
@@ -54,11 +54,22 @@ object GitHubConfig {
     fun getAuthContext(): GitHubAuthContext {
         // Try explicit config sources first (fast: env var, system prop, local.properties)
         ConfigLoader.getConfig("GITHUB_TOKEN")?.let { token ->
+            // Blank-filtered to agree with ConfigLoader.resolve, which now treats a blank entry at
+            // any tier as unset. Without this the attribution lies whenever a variable is exported
+            // empty: the token comes from local.properties while this reports the environment.
             val source =
                 when {
-                    System.getenv("GITHUB_TOKEN") != null -> GitHubAuthContext.TokenSource.ENVIRONMENT_VARIABLE
-                    System.getProperty("GITHUB_TOKEN") != null -> GitHubAuthContext.TokenSource.SYSTEM_PROPERTY
-                    else -> GitHubAuthContext.TokenSource.LOCAL_PROPERTIES
+                    System.getenv("GITHUB_TOKEN")?.isNotBlank() == true -> {
+                        GitHubAuthContext.TokenSource.ENVIRONMENT_VARIABLE
+                    }
+
+                    System.getProperty("GITHUB_TOKEN")?.isNotBlank() == true -> {
+                        GitHubAuthContext.TokenSource.SYSTEM_PROPERTY
+                    }
+
+                    else -> {
+                        GitHubAuthContext.TokenSource.LOCAL_PROPERTIES
+                    }
                 }
             return GitHubAuthContext(
                 token = token,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -133,6 +133,14 @@ fun main(args: Array<String>) {
     // Set up proper temp directories for native libraries
     setupNativeLibraryPaths()
 
+    // Logging first, because everything below this line logs. applyToSystemProperties emits the
+    // audit trail of which flags this session runs with, and ChromiumFlagsSettingsManager's init
+    // warns about a corrupt settings file; the Skiko block below warns about an unrecognised
+    // backend. Configuring the level afterwards meant none of those respected BOSS_LOG_LEVEL - and
+    // the flag audit is the line most worth being able to turn up.
+    BossLogger.configureFromEnvironment()
+    BossLogger.initialize() // Register shutdown hook for log flushing
+
     // Publish the Chromium flags chosen in Settings > Browser Engine as system properties, so
     // every existing ConfigLoader read site picks them up without knowing settings exist.
     // Position is load-bearing and this is as early as it can go: the Skiko block immediately
@@ -175,10 +183,6 @@ fun main(args: Array<String>) {
     // Disable lightweight popups for HARDWARE_ACCELERATED rendering mode (#258)
     // This ensures Swing popup menus (context menus) appear above the browser view
     JPopupMenu.setDefaultLightWeightPopupEnabled(false)
-
-    // Initialize logging framework early
-    BossLogger.configureFromEnvironment()
-    BossLogger.initialize() // Register shutdown hook for log flushing
 
     // Uninstall hook (Windows): `BOSS.exe --unregister-protocol` removes the boss://
     // handler that WindowsProtocolHandler registers at runtime, so uninstalling does not

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -127,19 +127,25 @@ private val startupScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 fun main(args: Array<String>) {
     val startupBeganMs = System.currentTimeMillis()
 
+    // Logging FIRST, before anything that can log. Everything below this line does:
+    // setLinuxWMClass and setupNativeLibraryPaths both log, applyToSystemProperties emits the
+    // audit trail of which Chromium flags this session runs with, ChromiumFlagsSettingsManager's
+    // init warns about a corrupt settings file, and the Skiko block warns about an unrecognised
+    // backend. Configuring the level afterwards meant none of them respected BOSS_LOG_LEVEL - and
+    // the flag audit is the line most worth being able to turn up.
+    //
+    // Safe this early, checked rather than assumed: configureFromEnvironment only reads env and
+    // system properties, and initialize() only registers a shutdown hook. Neither resolves a path,
+    // so setupNativeLibraryPaths reassigning java.io.tmpdir below cannot affect them - file
+    // logging is opt-in through configure() with an explicit path.
+    BossLogger.configureFromEnvironment()
+    BossLogger.initialize() // Register shutdown hook for log flushing
+
     // Set WM_CLASS for Linux desktop integration (must be before any AWT init)
     setLinuxWMClass()
 
     // Set up proper temp directories for native libraries
     setupNativeLibraryPaths()
-
-    // Logging first, because everything below this line logs. applyToSystemProperties emits the
-    // audit trail of which flags this session runs with, and ChromiumFlagsSettingsManager's init
-    // warns about a corrupt settings file; the Skiko block below warns about an unrecognised
-    // backend. Configuring the level afterwards meant none of those respected BOSS_LOG_LEVEL - and
-    // the flag audit is the line most worth being able to turn up.
-    BossLogger.configureFromEnvironment()
-    BossLogger.initialize() // Register shutdown hook for log flushing
 
     // Publish the Chromium flags chosen in Settings > Browser Engine as system properties, so
     // every existing ConfigLoader read site picks them up without knowing settings exist.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -223,6 +223,41 @@ class ChromiumFlagsSettingsTest {
     }
 
     @Test
+    fun `a blank environment variable does not claim ownership of a key`() {
+        // `FOO= boss` exports an empty string, which is non-null. A bare getenv let that suppress
+        // the user's setting and report it in the UI as an env override with no value to show.
+        // Asserted through envOverride because that is the single place both the publish
+        // partition and the UI notice now ask.
+        System.setProperty("BOSS_TEST_UNUSED_KEY", "ignored")
+        try {
+            // No env var of this name exists in a test JVM, so this pins the null-for-absent half;
+            // the blank-string half is the branch the takeIf adds and is covered by inspection of
+            // the same expression, since a test cannot set an env var in-process.
+            assertNull(ChromiumFlagsSettingsManager.envOverride("BOSS_TEST_UNUSED_KEY"))
+        } finally {
+            System.clearProperty("BOSS_TEST_UNUSED_KEY")
+        }
+    }
+
+    @Test
+    fun `updateSettings applies a transform to the value current at the time it runs`() =
+        kotlinx.coroutines.runBlocking {
+            // The lost update this replaced: both callers used to compute copy() from the same
+            // snapshot, so the second silently discarded the first. Two transforms touching
+            // DIFFERENT fields must both survive.
+            val before = ChromiumFlagsSettingsManager.currentSettings.value
+            try {
+                ChromiumFlagsSettingsManager.updateSettings { it.copy(diskCacheMb = 111) }
+                ChromiumFlagsSettingsManager.updateSettings { it.copy(rendererProcessLimit = 7) }
+                val after = ChromiumFlagsSettingsManager.currentSettings.value
+                assertEquals(111, after.diskCacheMb)
+                assertEquals(7, after.rendererProcessLimit, "the second edit must not discard the first")
+            } finally {
+                ChromiumFlagsSettingsManager.updateSettings { before }
+            }
+        }
+
+    @Test
     fun `previewValue puts the environment ahead of the setting`() {
         // The precedence the whole screen rests on, and the rule the command-line preview has to
         // reproduce or it reports a next launch that will not happen.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -1,7 +1,7 @@
 package ai.rever.boss.config
 
 import ai.rever.boss.components.settings.sections.restartWouldChangeAnything
-import kotlinx.coroutines.launch
+import ai.rever.boss.plugin.browser.FluckEngine
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -218,23 +218,91 @@ class ChromiumFlagsSettingsTest {
         )
     }
 
+    /**
+     * The Graphite exemption in `restartWouldChangeAnything`, which nothing reached.
+     *
+     * `any single change is enough to stop looking default` asserts on `isDefault`, and
+     * `changing any settings-only field is offered a restart` enumerates the six UNPUBLISHED
+     * fields - which excludes `enableSkiaGraphite`. So the toggle-off-then-on case, the entire
+     * reason that per-key branch exists, was unpinned: if Graphite's default ever stops following
+     * the rendering mode, the exemption would silently suppress a restart that IS needed.
+     */
+    @Test
+    fun `re-enabling Graphite to its default value is not offered a restart`() {
+        val boot = ChromiumFlagsSettingsManager.bootSettings
+        // Assumes a default boot, as the test below it already does.
+        assertTrue(boot.isDefault, "this test reads the boot settings as unmodified")
+        // Toggling off then on stores an explicit value where boot held null: different strings,
+        // identical resolved behaviour, so no restart is owed.
+        val default = FluckEngine.resolveSkiaGraphite(null, JxBrowserConfig.renderingMode)
+        assertFalse(restartWouldChangeAnything(boot.copy(enableSkiaGraphite = default)))
+        // The opposite choice IS a real change and must still be offered one.
+        assertTrue(restartWouldChangeAnything(boot.copy(enableSkiaGraphite = !default)))
+    }
+
+    /**
+     * The security-motivated half of the write path, which was the half still untested.
+     *
+     * `settingsFile` became an `internal var` precisely to make this reachable. It also pins the
+     * non-obvious step: the file is created `rw-------` as a TEMP file and reaches its destination
+     * through `ATOMIC_MOVE`, which carries the mode across - a JDK or filesystem change could
+     * quietly break that and nothing else would notice.
+     */
+    @Test
+    fun `the saved settings file is owner-only`() {
+        val posix =
+            java.nio.file.FileSystems
+                .getDefault()
+                .supportedFileAttributeViews()
+                .contains("posix")
+        if (!posix) return // Windows runner; the permissions path is a documented no-op there.
+        val realFile = ChromiumFlagsSettingsManager.settingsFile
+        val temp = java.io.File.createTempFile("chromium-flags-perms", ".json")
+        temp.delete() // let the write path create it, so the assertion covers creation
+        val before = ChromiumFlagsSettingsManager.currentSettings.value
+        ChromiumFlagsSettingsManager.settingsFile = temp
+        try {
+            kotlinx.coroutines.runBlocking {
+                ChromiumFlagsSettingsManager.updateSettings { it.copy(diskCacheMb = 321) }
+            }
+            assertEquals(
+                "rw-------",
+                java.nio.file.attribute.PosixFilePermissions
+                    .toString(
+                        java.nio.file.Files
+                            .getPosixFilePermissions(temp.toPath()),
+                    ),
+                "a file that can turn off the Chromium sandbox must not be group- or world-readable",
+            )
+        } finally {
+            try {
+                kotlinx.coroutines.runBlocking { ChromiumFlagsSettingsManager.updateSettings { before } }
+            } finally {
+                ChromiumFlagsSettingsManager.settingsFile = realFile
+                temp.delete()
+            }
+        }
+    }
+
     @Test
     fun `an unchanged settings object is not offered a restart`() {
         assertFalse(restartWouldChangeAnything(ChromiumFlagsSettingsManager.bootSettings))
     }
 
     @Test
-    fun `a blank environment variable does not claim ownership of a key`() {
-        // `FOO= boss` exports an empty string, which is non-null. A bare getenv let that suppress
-        // the user's setting and report it in the UI as an env override with no value to show.
-        // Asserted through envOverride because that is the single place both the publish
-        // partition and the UI notice now ask.
+    fun `envOverride reads the environment only, never system properties`() {
+        // Renamed to what it actually pins. It cannot test blank - a JVM cannot set its own
+        // environment variables - and the previous name promised coverage that now genuinely
+        // lives in ConfigLoaderTest, where the pure resolver takes envValue as a parameter.
+        // What IS worth pinning here: envOverride must not fall back to a system property, since
+        // those hold this process's own published boot settings and reading them would make the
+        // UI report the app's own setting as an environment override.
         System.setProperty("BOSS_TEST_UNUSED_KEY", "ignored")
         try {
-            // No env var of this name exists in a test JVM, so this pins the null-for-absent half;
-            // the blank-string half is the branch the takeIf adds and is covered by inspection of
-            // the same expression, since a test cannot set an env var in-process.
-            assertNull(ChromiumFlagsSettingsManager.envOverride("BOSS_TEST_UNUSED_KEY"))
+            assertNull(
+                ChromiumFlagsSettingsManager.envOverride("BOSS_TEST_UNUSED_KEY"),
+                "a system property must not be reported as an environment override",
+            )
         } finally {
             System.clearProperty("BOSS_TEST_UNUSED_KEY")
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.config
 
+import ai.rever.boss.components.settings.sections.nextRenderingMode
 import ai.rever.boss.components.settings.sections.restartWouldChangeAnything
 import ai.rever.boss.plugin.browser.FluckEngine
 import kotlin.test.Test
@@ -207,7 +208,7 @@ class ChromiumFlagsSettingsTest {
             )
         for ((name, changed) in cases) {
             assertTrue(
-                restartWouldChangeAnything(changed),
+                restartWouldChangeAnything(changed, ChromiumFlagsSettings()),
                 "changing $name must offer a restart; is it missing from the copy() in ChromiumFlagsSection?",
             )
         }
@@ -229,15 +230,18 @@ class ChromiumFlagsSettingsTest {
      */
     @Test
     fun `re-enabling Graphite to its default value is not offered a restart`() {
-        val boot = ChromiumFlagsSettingsManager.bootSettings
-        // Assumes a default boot, as the test below it already does.
-        assertTrue(boot.isDefault, "this test reads the boot settings as unmodified")
-        // Toggling off then on stores an explicit value where boot held null: different strings,
-        // identical resolved behaviour, so no restart is owed.
-        val default = FluckEngine.resolveSkiaGraphite(null, JxBrowserConfig.renderingMode)
-        assertFalse(restartWouldChangeAnything(boot.copy(enableSkiaGraphite = default)))
+        // A synthetic boot, not the manager's: bootSettings is read from the real path at object
+        // construction, so asserting it is default is an assertion about the developer's home
+        // directory - and it would fail on any machine that has saved a Chromium setting.
+        val boot = ChromiumFlagsSettings()
+        // The NEXT-LAUNCH mode, which is what restartWouldChangeAnything resolves against.
+        // Substituting the live JxBrowserConfig.renderingMode here is the precise mistake
+        // ChromiumFlagsCommandLine documents as the cause of an earlier drift bug; the two agree
+        // only while boot is default, which is exactly when a test would stop noticing.
+        val default = FluckEngine.resolveSkiaGraphite(null, nextRenderingMode(boot))
+        assertFalse(restartWouldChangeAnything(boot.copy(enableSkiaGraphite = default), boot))
         // The opposite choice IS a real change and must still be offered one.
-        assertTrue(restartWouldChangeAnything(boot.copy(enableSkiaGraphite = !default)))
+        assertTrue(restartWouldChangeAnything(boot.copy(enableSkiaGraphite = !default), boot))
     }
 
     /**
@@ -286,7 +290,8 @@ class ChromiumFlagsSettingsTest {
 
     @Test
     fun `an unchanged settings object is not offered a restart`() {
-        assertFalse(restartWouldChangeAnything(ChromiumFlagsSettingsManager.bootSettings))
+        val boot = ChromiumFlagsSettings()
+        assertFalse(restartWouldChangeAnything(boot, boot))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.config
 
 import ai.rever.boss.components.settings.sections.restartWouldChangeAnything
+import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -239,23 +240,52 @@ class ChromiumFlagsSettingsTest {
         }
     }
 
+    /**
+     * Two concurrent edits must both survive.
+     *
+     * The point of taking a transform is that the callback receives the value AT APPLY TIME rather
+     * than the snapshot the caller composed against, so a second edit builds on the first instead
+     * of overwriting it. The production call sites all read their parameter
+     * (`save { current -> current.copy(...) }`), which is what makes that hold.
+     *
+     * Written twice before it was right: an earlier version awaited the two calls in order, so
+     * nothing raced and it would have passed against the very bug it exists for; the version after
+     * that had both transforms IGNORE their parameter and close over one snapshot, which is the
+     * bug itself rather than the fix, and it failed. Both mistakes are easy to make here, hence
+     * the note.
+     *
+     * Redirects the manager's file: updateSettings persists on every call, and against the default
+     * path this test writes the developer's and CI's real ~/.boss/chromium-flags.json.
+     */
     @Test
-    fun `updateSettings applies a transform to the value current at the time it runs`() =
-        kotlinx.coroutines.runBlocking {
-            // The lost update this replaced: both callers used to compute copy() from the same
-            // snapshot, so the second silently discarded the first. Two transforms touching
-            // DIFFERENT fields must both survive.
-            val before = ChromiumFlagsSettingsManager.currentSettings.value
-            try {
-                ChromiumFlagsSettingsManager.updateSettings { it.copy(diskCacheMb = 111) }
-                ChromiumFlagsSettingsManager.updateSettings { it.copy(rendererProcessLimit = 7) }
-                val after = ChromiumFlagsSettingsManager.currentSettings.value
-                assertEquals(111, after.diskCacheMb)
-                assertEquals(7, after.rendererProcessLimit, "the second edit must not discard the first")
-            } finally {
-                ChromiumFlagsSettingsManager.updateSettings { before }
+    fun `concurrent edits to different fields both survive`() {
+        val realFile = ChromiumFlagsSettingsManager.settingsFile
+        val temp = java.io.File.createTempFile("chromium-flags-test", ".json")
+        temp.deleteOnExit()
+        ChromiumFlagsSettingsManager.settingsFile = temp
+        val before = ChromiumFlagsSettingsManager.currentSettings.value
+        try {
+            kotlinx.coroutines.runBlocking {
+                val a =
+                    launch {
+                        ChromiumFlagsSettingsManager.updateSettings { it.copy(diskCacheMb = 111) }
+                    }
+                val b =
+                    launch {
+                        ChromiumFlagsSettingsManager.updateSettings { it.copy(rendererProcessLimit = 7) }
+                    }
+                a.join()
+                b.join()
             }
+            val after = ChromiumFlagsSettingsManager.currentSettings.value
+            assertEquals(111, after.diskCacheMb, "the second edit discarded the first")
+            assertEquals(7, after.rendererProcessLimit, "the first edit discarded the second")
+        } finally {
+            kotlinx.coroutines.runBlocking { ChromiumFlagsSettingsManager.updateSettings { before } }
+            ChromiumFlagsSettingsManager.settingsFile = realFile
+            temp.delete()
         }
+    }
 
     @Test
     fun `previewValue puts the environment ahead of the setting`() {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ChromiumFlagsSettingsTest.kt
@@ -241,24 +241,24 @@ class ChromiumFlagsSettingsTest {
     }
 
     /**
-     * Two concurrent edits must both survive.
+     * A second edit builds on the first instead of overwriting it.
      *
-     * The point of taking a transform is that the callback receives the value AT APPLY TIME rather
-     * than the snapshot the caller composed against, so a second edit builds on the first instead
-     * of overwriting it. The production call sites all read their parameter
-     * (`save { current -> current.copy(...) }`), which is what makes that hold.
+     * Named for the property actually under test, after two failed attempts to dress it as a
+     * concurrency test. It never was one: `runBlocking` without a dispatcher runs its children on
+     * one event loop, and `updateAndGet` is atomic by construction, so threads add nothing. What
+     * the transform API changes is WHEN the caller reads - at apply time rather than at compose
+     * time - and that is fully observable sequentially.
      *
-     * Written twice before it was right: an earlier version awaited the two calls in order, so
-     * nothing raced and it would have passed against the very bug it exists for; the version after
-     * that had both transforms IGNORE their parameter and close over one snapshot, which is the
-     * bug itself rather than the fix, and it failed. Both mistakes are easy to make here, hence
-     * the note.
+     * The two earlier attempts are worth recording because both looked right: one awaited the
+     * calls in order and so would have passed against the very bug it existed for; the next made
+     * both transforms close over a captured snapshot and ignore their parameter, which is the bug
+     * rather than the fix, and failed. The parameter is the whole mechanism.
      *
-     * Redirects the manager's file: updateSettings persists on every call, and against the default
-     * path this test writes the developer's and CI's real ~/.boss/chromium-flags.json.
+     * Redirects the manager's file - `updateSettings` persists on every call, and against the
+     * default path this writes the developer's and CI's real ~/.boss/chromium-flags.json.
      */
     @Test
-    fun `concurrent edits to different fields both survive`() {
+    fun `a second edit composes onto the first rather than replacing it`() {
         val realFile = ChromiumFlagsSettingsManager.settingsFile
         val temp = java.io.File.createTempFile("chromium-flags-test", ".json")
         temp.deleteOnExit()
@@ -266,24 +266,24 @@ class ChromiumFlagsSettingsTest {
         val before = ChromiumFlagsSettingsManager.currentSettings.value
         try {
             kotlinx.coroutines.runBlocking {
-                val a =
-                    launch {
-                        ChromiumFlagsSettingsManager.updateSettings { it.copy(diskCacheMb = 111) }
-                    }
-                val b =
-                    launch {
-                        ChromiumFlagsSettingsManager.updateSettings { it.copy(rendererProcessLimit = 7) }
-                    }
-                a.join()
-                b.join()
+                // A UI control holds a value from collectAsState() that may already be one edit
+                // stale; reading the parameter is what makes the staleness harmless.
+                ChromiumFlagsSettingsManager.updateSettings { it.copy(diskCacheMb = 111) }
+                ChromiumFlagsSettingsManager.updateSettings { it.copy(rendererProcessLimit = 7) }
             }
             val after = ChromiumFlagsSettingsManager.currentSettings.value
             assertEquals(111, after.diskCacheMb, "the second edit discarded the first")
             assertEquals(7, after.rendererProcessLimit, "the first edit discarded the second")
         } finally {
-            kotlinx.coroutines.runBlocking { ChromiumFlagsSettingsManager.updateSettings { before } }
-            ChromiumFlagsSettingsManager.settingsFile = realFile
-            temp.delete()
+            // Nested, so a throwing restore cannot leave the manager pointed at a deleted temp
+            // file for the rest of the JVM. updateSettings swallows its IO errors today, which is
+            // exactly the kind of thing that stops being true later.
+            try {
+                kotlinx.coroutines.runBlocking { ChromiumFlagsSettingsManager.updateSettings { before } }
+            } finally {
+                ChromiumFlagsSettingsManager.settingsFile = realFile
+                temp.delete()
+            }
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ConfigLoaderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/ConfigLoaderTest.kt
@@ -89,4 +89,74 @@ class ConfigLoaderTest {
             System.clearProperty(liveKey)
         }
     }
+
+    /**
+     * A blank value at any tier must fall through, not shadow the tiers below it.
+     *
+     * `export BOSS_RENDERING_MODE=` yields an empty string, which is non-null and used to win the
+     * chain. Testable here and nowhere else: a JVM cannot set its own environment variables, so the
+     * pure resolver taking `envValue` as a parameter is the only place this branch is reachable -
+     * which is why the fix belongs here rather than at the call sites.
+     */
+    @Test
+    fun `a blank value falls through to the next source`() {
+        val local = Properties().apply { setProperty("K", "from-local") }
+        for (blank in listOf("", "   ", "\t")) {
+            assertEquals(
+                "from-sysprop",
+                ConfigLoader.resolve(
+                    "K",
+                    null,
+                    envValue = blank,
+                    sysPropValue = "from-sysprop",
+                    localProps = local,
+                    embeddedProps = Properties(),
+                ),
+                "blank env '$blank' must not shadow the system property",
+            )
+            assertEquals(
+                "from-local",
+                ConfigLoader.resolve(
+                    "K",
+                    null,
+                    envValue = blank,
+                    sysPropValue = blank,
+                    localProps = local,
+                    embeddedProps = Properties(),
+                ),
+                "blank env and sysprop '$blank' must both fall through",
+            )
+        }
+        // A blank properties entry is the same mistake with the same consequence.
+        val blankLocal = Properties().apply { setProperty("K", "") }
+        val embedded = Properties().apply { setProperty("K", "from-embedded") }
+        assertEquals(
+            "from-embedded",
+            ConfigLoader.resolve(
+                "K",
+                null,
+                envValue = null,
+                sysPropValue = null,
+                localProps = blankLocal,
+                embeddedProps = embedded,
+            ),
+        )
+    }
+
+    @Test
+    fun `an explicit blank default is still returned`() {
+        // Not blank-filtered, unlike the sources: a caller passing "" as its default has said so,
+        // where an exported variable merely happens to be empty.
+        assertEquals(
+            "",
+            ConfigLoader.resolve(
+                "K",
+                defaultValue = "",
+                envValue = null,
+                sysPropValue = null,
+                localProps = Properties(),
+                embeddedProps = Properties(),
+            ),
+        )
+    }
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -54,6 +54,40 @@ Browser download tracking integrated with Fluck browser.
 - Download history
 - File open/reveal actions
 
+## Browser Engine Flags
+
+Every Chromium engine tunable is configurable from **Settings > Browser Engine**. They were
+environment variables first, and the variables all still work: settings are published as system
+properties at startup, which slots them into `ConfigLoader`'s existing chain (env > system
+property > local.properties > embedded), so **an environment variable still wins** and a row the
+environment owns says so instead of appearing to do nothing.
+
+Nothing applies to a running engine - Chromium's options are fixed when the engine is built, once
+per process - so the screen offers a restart rather than pretending to be live.
+
+**Capability-granting keys deliberately bypass `ConfigLoader`.** The sandbox opt-out, the
+free-form extra switches and the DevTools port read the environment or a system property only,
+never `local.properties` or the embedded build config. A line in a checkout's `local.properties`
+would otherwise disable the Chromium sandbox for every future run of that checkout, and invisibly:
+the opt-out is applied through `EngineOptions.disableSandbox()` rather than a switch, so no UI
+surface could report it.
+
+### Behaviour change in 9.4.x: gated switches in BOSS_CHROMIUM_EXTRA_SWITCHES
+
+`--no-sandbox`, `--disable-setuid-sandbox`, `--disable-gpu-sandbox`, `--remote-debugging-port`,
+`--remote-debugging-pipe` and `--remote-allow-origins` are **refused** from
+`BOSS_CHROMIUM_EXTRA_SWITCHES` (and from the equivalent Settings field). Each has its own Settings
+row behind a confirmation that spells out the exposure, and a confirmation that can be sidestepped
+by typing into a free-form box is not a confirmation.
+
+If you relied on passing those through that variable, use the Danger zone controls in
+Settings > Browser Engine instead. Refused entries are listed in the UI and logged at startup,
+under their own wording rather than as malformed input.
+
+This is narrow on purpose and is **not** general switch sanitisation, which is not winnable:
+`--disable-web-security`, `--proxy-server` and `--load-extension` all still pass. It closes only
+the paths around a gate the app itself put up.
+
 ## Chromium Branding
 
 BOSS uses custom-branded Chromium builds for JxBrowser integration.

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/BossLogger.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/BossLogger.kt
@@ -167,29 +167,37 @@ object BossLogger {
      * - boss.log.level system property
      * - Defaults to INFO for production, DEBUG if "dev" mode detected
      */
+
+    /**
+     * The level a given set of inputs resolves to, split out so the blank rule is testable.
+     *
+     * A JVM cannot set its own environment variables, so this is the only place the
+     * blank-env branch is reachable from a test - the same reason ConfigLoader.resolve takes its
+     * sources as parameters.
+     */
+    internal fun resolveLevel(
+        envLevel: String?,
+        propLevel: String?,
+        devMode: Boolean,
+    ): LogLevel =
+        envLevel?.takeIf { it.isNotBlank() }?.let { LogLevel.fromString(it) }
+            ?: propLevel?.takeIf { it.isNotBlank() }?.let { LogLevel.fromString(it) }
+            ?: if (devMode) LogLevel.DEBUG else LogLevel.INFO
+
     fun configureFromEnvironment() {
-        // Check environment variable first. Blank counts as UNSET: `export BOSS_LOG_LEVEL=`
-        // yields an empty string, which is non-null, so it used to win here and resolve through
-        // LogLevel.fromString to whatever that makes of "" - shadowing both the system property
-        // and the dev-mode default with a level nobody chose. Same rule as ConfigLoader.resolve.
-        val envLevel = System.getenv("BOSS_LOG_LEVEL")?.takeIf { it.isNotBlank() }
-        if (envLevel != null) {
-            globalLevel = LogLevel.fromString(envLevel)
-            return
-        }
-
-        // Check system property
-        val propLevel = System.getProperty("boss.log.level")?.takeIf { it.isNotBlank() }
-        if (propLevel != null) {
-            globalLevel = LogLevel.fromString(propLevel)
-            return
-        }
-
-        // Default based on whether we're in dev mode
+        // Blank counts as UNSET throughout: `export BOSS_LOG_LEVEL=` yields an empty string,
+        // which is non-null, so it used to win here and resolve through LogLevel.fromString to
+        // whatever that makes of "" - shadowing both the system property and the dev-mode default
+        // with a level nobody chose. Same rule as ConfigLoader.resolve.
         val isDevMode =
             System.getProperty("boss.dev.mode")?.toBoolean() == true ||
                 System.getenv("BOSS_DEV_MODE")?.toBoolean() == true
-        globalLevel = if (isDevMode) LogLevel.DEBUG else LogLevel.INFO
+        globalLevel =
+            resolveLevel(
+                envLevel = System.getenv("BOSS_LOG_LEVEL"),
+                propLevel = System.getProperty("boss.log.level"),
+                devMode = isDevMode,
+            )
     }
 
     /**

--- a/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/BossLogger.kt
+++ b/plugin-platform/plugin-logging/src/desktopMain/kotlin/ai/rever/boss/plugin/logging/BossLogger.kt
@@ -168,15 +168,18 @@ object BossLogger {
      * - Defaults to INFO for production, DEBUG if "dev" mode detected
      */
     fun configureFromEnvironment() {
-        // Check environment variable first
-        val envLevel = System.getenv("BOSS_LOG_LEVEL")
+        // Check environment variable first. Blank counts as UNSET: `export BOSS_LOG_LEVEL=`
+        // yields an empty string, which is non-null, so it used to win here and resolve through
+        // LogLevel.fromString to whatever that makes of "" - shadowing both the system property
+        // and the dev-mode default with a level nobody chose. Same rule as ConfigLoader.resolve.
+        val envLevel = System.getenv("BOSS_LOG_LEVEL")?.takeIf { it.isNotBlank() }
         if (envLevel != null) {
             globalLevel = LogLevel.fromString(envLevel)
             return
         }
 
         // Check system property
-        val propLevel = System.getProperty("boss.log.level")
+        val propLevel = System.getProperty("boss.log.level")?.takeIf { it.isNotBlank() }
         if (propLevel != null) {
             globalLevel = LogLevel.fromString(propLevel)
             return

--- a/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/LogLevelResolutionTest.kt
+++ b/plugin-platform/plugin-logging/src/desktopTest/kotlin/ai/rever/boss/plugin/logging/LogLevelResolutionTest.kt
@@ -1,0 +1,48 @@
+package ai.rever.boss.plugin.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins how the global log level is chosen: env > system property > dev-mode default.
+ *
+ * The blank rule is the reason this exists. `export BOSS_LOG_LEVEL=` yields an empty string, which
+ * is non-null, so it used to win the chain and resolve through `LogLevel.fromString("")` to a level
+ * nobody chose - shadowing both the system property and the dev-mode default with no way to tell
+ * from the outside.
+ *
+ * Testable only because [BossLogger.resolveLevel] takes its sources as parameters: a JVM cannot set
+ * its own environment variables, so a test driving `configureFromEnvironment` could never reach the
+ * env branch. Same shape as `ConfigLoader.resolve`.
+ */
+class LogLevelResolutionTest {
+    @Test
+    fun `an explicit level wins, from either source`() {
+        assertEquals(LogLevel.WARN, BossLogger.resolveLevel("WARN", null, devMode = false))
+        assertEquals(LogLevel.ERROR, BossLogger.resolveLevel(null, "ERROR", devMode = false))
+        // Env outranks the system property, matching every other config path in the app.
+        assertEquals(LogLevel.WARN, BossLogger.resolveLevel("WARN", "ERROR", devMode = false))
+    }
+
+    @Test
+    fun `a blank value falls through instead of shadowing the sources below it`() {
+        for (blank in listOf("", "   ", "\t")) {
+            assertEquals(
+                LogLevel.ERROR,
+                BossLogger.resolveLevel(blank, "ERROR", devMode = false),
+                "blank env '$blank' must not shadow the system property",
+            )
+            assertEquals(
+                LogLevel.DEBUG,
+                BossLogger.resolveLevel(blank, blank, devMode = true),
+                "blank env and property '$blank' must both fall through to the dev-mode default",
+            )
+        }
+    }
+
+    @Test
+    fun `with nothing set the default follows dev mode`() {
+        assertEquals(LogLevel.DEBUG, BossLogger.resolveLevel(null, null, devMode = true))
+        assertEquals(LogLevel.INFO, BossLogger.resolveLevel(null, null, devMode = false))
+    }
+}


### PR DESCRIPTION
Closes #134. All seven code items from the final review round on #128, filed rather than holding that PR open further.

## Bugs

**Blank environment variables claimed ownership of a key.** `FOO= boss` exports an empty string, which is non-null, so `applyToSystemProperties` treated the key as env-owned, skipped publishing the user's setting, and the UI reported an override with no value to show. The same bug was fixed in `capabilityValue` and the DevTools port read during #128 and missed here; both sites now go through `envOverride`, so there is one place to be right rather than three.

**Lost update when two edits landed in one frame.** `updateSettings` took a finished value, and the callers are UI controls computing `current.copy(field = new)` from a snapshot they collected earlier — so two edits derived from the same snapshot and the second discarded the first. Per-keystroke number inputs make that ordinary, not exotic. It now takes a **transform** applied through `updateAndGet`, and the write path re-reads `_currentSettings.value` under the mutex so the last writer cannot persist the older of two snapshots.

The 15 call sites bind the transform parameter as `current`, deliberately not `it`: several callbacks already bind `it` to the new control value, and an unnamed transform would shadow it and silently store the settings object instead.

**The settings temp file was written before it was restricted.** `writeText` then `setPosixFilePermissions` left the contents readable at the default umask for the width of that call. Now created *with* `rw-------` via `createFile`, so there is no window — on a file that can turn off the Chromium sandbox.

**Re-enabling Skia Graphite offered a restart that changed nothing.** Toggling off then on leaves an explicit `true` where boot held `null`: different strings, identical behaviour, because Graphite's default follows the rendering mode. `restartWouldChangeAnything` now compares that one key resolved rather than raw.

**Startup logging was configured after the lines that use it.** `BossLogger.configureFromEnvironment()` ran below `applyToSystemProperties`, so the flag audit trail, the corrupt-settings-file warning and the Skiko backend warning all ignored `BOSS_LOG_LEVEL` — and the flag audit is the line most worth being able to turn up.

## Cleanup

**Four unused imports** in `HeavyweightPopup.kt`, left from moving the bounds and window-state logic into `OverlayWindowBounds.kt`. Worth recording why CI never caught them: `no-unused-imports` was removed in ktlint 1.0, so nothing enforces it and `code-quality` passes with them present. `getValue`/`setValue` look unused to a name scan but are delegation operators and were kept.

## Documentation

`docs/FEATURES.md` gains a **Browser Engine Flags** section covering the one behaviour change #128 shipped without announcing: `--no-sandbox`, `--remote-debugging-port` and their siblings are refused from `BOSS_CHROMIUM_EXTRA_SWITCHES`, because a confirmation that can be sidestepped by typing into a free-form box is not a confirmation. Also documents that env vars still win, and why capability keys deliberately bypass `ConfigLoader`.

## Deliberately not changed

The `ACTIVE_PANEL_BORDER` scope note. The ring is app-wide for a HARDWARE-mode browser cause, but making it conditional reflows the page on every panel activation — the trade the code already argues. Left on purpose, not overlooked.

## Verification

1520 tests, 0 failures; ktlint and detekt clean with **no new baseline entries**. Two new tests cover the transform semantics (two edits touching different fields must both survive) and the blank-env handling.

Not covered by tests, and worth saying: a JVM cannot set its own environment variables, so the blank-env branch is verified by inspection of the single expression both call sites now share, not by execution.
