### PR TITLE
fix(overlays): route every dialog and overlay above the HARDWARE browser surface

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -365,7 +365,7 @@ internal fun BossAppScaffold(
             // MRU tab-switcher overlay (Ctrl+Tab in most-recently-used mode)
             TabCycleOverlayHost(
                 data = state.tabCycleOverlay,
-                modifier = Modifier.align(Alignment.Center),
+                alignment = Alignment.Center,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -20,6 +20,7 @@ import ai.rever.boss.git.GitOperationResult
 import ai.rever.boss.git.GitService
 import ai.rever.boss.git.GitStashInfo
 import ai.rever.boss.platform.rememberDirectoryPicker
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.services.supabase.AuthService
 import ai.rever.boss.utils.extractFileName
@@ -522,7 +523,7 @@ fun BossDraggableComponent.BossTopLeftBar(
 
     // Deleted project dialog
     deletedProjectName?.let { projectName ->
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { deletedProjectName = null },
             title = { Text("Project Not Found") },
             text = { Text("The project \"$projectName\" no longer exists. It has been removed from the recent projects list.") },
@@ -611,7 +612,7 @@ fun BossDraggableComponent.BossTopLeftBar(
 
     // Git error dialog
     gitErrorMessage?.let { errorMsg ->
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { gitErrorMessage = null },
             title = { Text("Git Error") },
             text = { Text(errorMsg) },
@@ -625,7 +626,7 @@ fun BossDraggableComponent.BossTopLeftBar(
 
     // Git success dialog
     gitSuccessMessage?.let { successMsg ->
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { gitSuccessMessage = null },
             title = { Text("Git Operation Successful") },
             text = { Text(successMsg) },
@@ -855,7 +856,7 @@ private fun CreateBranchDialog(
     var branchName by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
 
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Create New Branch") },
         text = {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/BookmarkDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/BookmarkDialog.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.components.bookmarks.BookmarkCollection
 import ai.rever.boss.components.workspaces.extractPanels
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -27,7 +28,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlin.math.min
 
@@ -59,7 +59,7 @@ fun BookmarkDialog(
     // Workspace section expand/collapse state
     var workspacesSectionExpanded by remember { mutableStateOf(false) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CLIInstallationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CLIInstallationDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.CLIInstallResult
 import ai.rever.boss.utils.CLIInstaller
@@ -14,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.launch
 
 /**
@@ -40,7 +40,7 @@ fun CLIInstallationDialog(onDismiss: () -> Unit) {
         }
     }
 
-    Dialog(onDismissRequest = {
+    BossDialog(onDismissRequest = {
         // Only allow dismiss if not installing
         if (installState !is InstallState.Installing) {
             onDismiss()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CloneProjectDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CloneProjectDialog.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.dialogs
 import ai.rever.boss.git.GitOperationResult
 import ai.rever.boss.git.GitService
 import ai.rever.boss.platform.rememberDirectoryPicker
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.project.ProjectCreationService
 import ai.rever.boss.utils.logging.BossLogger
@@ -23,7 +24,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.launch
 import java.io.File
@@ -48,7 +48,7 @@ fun CloneProjectDialog(
 ) {
     var cloneStep by remember { mutableStateOf<CloneStep>(CloneStep.Configuration) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = {
             // Only allow dismiss if not cloning
             if (cloneStep !is CloneStep.Cloning) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CollectionSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CollectionSelectionDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.components.bookmarks.BookmarkCollection
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -23,7 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -59,7 +59,7 @@ fun CollectionSelectionDialog(
     // Selected collections state
     var selectedCollections by remember { mutableStateOf<Set<String>>(emptySet()) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CommitDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CommitDialog.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.git.GitFileStatus
 import ai.rever.boss.git.GitFileStatusType
 import ai.rever.boss.git.GitOperationResult
 import ai.rever.boss.git.GitService
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.window.LocalWindowGitState
 import ai.rever.boss.window.LocalWindowId
@@ -27,7 +28,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.launch
 import ai.rever.boss.plugin.git.GitOperationResult.Error as GitError
 import ai.rever.boss.plugin.git.GitOperationResult.Success as GitSuccess
@@ -88,7 +88,7 @@ fun CommitDialog(
     val unstagedFiles = fileStatus.filter { it.isUnstaged || it.indexStatus == GitFileStatusType.UNTRACKED }
     val hasChangesToCommit = stagedFiles.isNotEmpty()
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Surface(
             modifier =
                 Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ConfirmationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ConfirmationDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,7 +13,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -40,7 +40,7 @@ fun ConfirmationDialog(
 ) {
     val colors = BossTheme.colors
     val radii = BossTheme.radius
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CrossDeviceAuthenticationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/CrossDeviceAuthenticationDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.services.supabase.AuthService
 import ai.rever.boss.utils.FluckTabCreator
@@ -20,7 +21,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
@@ -108,7 +108,7 @@ fun CrossDeviceAuthenticationDialog(
         }
     }
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Card(
             modifier =
                 Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/GlobalSearchDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/GlobalSearchDialog.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.components.workspaces.WorkspaceManager
 import ai.rever.boss.icons.FileIcons
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.search.GlobalSearchService
@@ -54,7 +55,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -246,7 +246,7 @@ fun GlobalSearchDialog(
         }
     }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ImportDataDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ImportDataDialog.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.platform.rememberFilePicker
 import ai.rever.boss.plugin.api.BookmarkDataProvider
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.services.auth.AuthStateManager
 import ai.rever.boss.services.bookmarks.BookmarkAPIAccess
@@ -28,7 +29,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -165,7 +165,7 @@ private fun DialogShell(
     onDismiss: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    Dialog(onDismissRequest = { if (dismissable) onDismiss() }) {
+    BossDialog(onDismissRequest = { if (dismissable) onDismiss() }) {
         Card(
             modifier = Modifier.width(DIALOG_WIDTH).padding(BossTheme.space.lg),
             elevation = BossTheme.elevation.popover,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/LogoutConfirmationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/LogoutConfirmationDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.services.supabase.AuthService
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
@@ -10,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.launch
 
 @Composable
@@ -19,7 +19,7 @@ fun LogoutConfirmationDialog(onDismiss: () -> Unit) {
     val coroutineScope = rememberCoroutineScope()
     val currentUser by AuthService.currentUser.collectAsState()
 
-    Dialog(onDismissRequest = { if (!isLoading) onDismiss() }) {
+    BossDialog(onDismissRequest = { if (!isLoading) onDismiss() }) {
         Card(
             modifier =
                 Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NameInputDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NameInputDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -23,7 +23,7 @@ fun NewCollectionDialog(
 ) {
     var collectionName by remember { mutableStateOf("") }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(
@@ -114,7 +114,7 @@ fun NewWorkspaceDialog(
 ) {
     var workspaceName by remember { mutableStateOf("") }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewProjectWizardDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewProjectWizardDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.platform.rememberDirectoryPicker
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.project.ProjectCreationService
@@ -38,7 +39,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
@@ -64,7 +64,7 @@ fun NewProjectWizardDialog(
 ) {
     var wizardStep by remember { mutableStateOf<WizardStep>(WizardStep.TemplateSelection) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = {
             // Only allow dismiss if not creating
             if (wizardStep !is WizardStep.Creating) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -4,7 +4,6 @@ import ContextMenuBackground
 import ContextMenuBorder
 import ai.rever.boss.components.overlays.ContextMenu
 import ai.rever.boss.components.overlays.ContextMenuItem
-import ai.rever.boss.components.overlays.OverlayModal
 import ai.rever.boss.components.plugin.panels.left_top.ProjectState
 import ai.rever.boss.components.plugin.panels.left_top.directoryHasChildren
 import ai.rever.boss.components.plugin.panels.left_top.scanDirectory
@@ -24,6 +23,7 @@ import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabType
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.SystemUtils
 import ai.rever.boss.utils.extractFileName
@@ -33,7 +33,6 @@ import ai.rever.boss.window.Project
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -291,929 +290,915 @@ fun NewTabDialog(
         }
     }
 
-    // Full-screen overlay with scrim. OverlayModal renders this in a separate always-on-top
-    // window when the browser is a heavyweight GPU surface (HARDWARE_ACCELERATED), because a
-    // plain Popup would be drawn UNDER the page; it falls back to exactly the centered Popup
-    // below on OFF_SCREEN. Routed here rather than at the three call sites so every one of them
-    // gets it.
-    OverlayModal(onDismissRequest = onDismiss) {
+    // BossDialog renders this in a separate always-on-top window when the browser is a heavyweight
+    // GPU surface (HARDWARE_ACCELERATED), because a plain Popup would be drawn UNDER the page; it
+    // falls back to an ordinary Compose Dialog on OFF_SCREEN. Routed here rather than at the three
+    // call sites so every one of them gets it.
+    //
+    // The scrim and centering that used to be hand-rolled here now belong to BossDialog, so every
+    // dialog in the app gets the same ones rather than this one being a special case.
+    BossDialog(onDismissRequest = onDismiss) {
+        // Dialog content with ContextMenu styling
         Box(
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.4f))
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                    ) { onDismiss() },
-            contentAlignment = Alignment.Center,
+                    .width(500.dp)
+                    .background(
+                        color = ContextMenuBackground,
+                        shape = RoundedCornerShape(8.dp),
+                    ).border(
+                        width = 1.dp,
+                        color = ContextMenuBorder,
+                        shape = RoundedCornerShape(8.dp),
+                    ).onKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+                            onDismiss()
+                            true
+                        } else {
+                            false
+                        }
+                    },
         ) {
-            // Dialog content with ContextMenu styling
-            Box(
-                modifier =
-                    Modifier
-                        .width(500.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                        ) { /* Consume click to prevent dismissing */ }
-                        .background(
-                            color = ContextMenuBackground,
-                            shape = RoundedCornerShape(8.dp),
-                        ).border(
-                            width = 1.dp,
-                            color = ContextMenuBorder,
-                            shape = RoundedCornerShape(8.dp),
-                        ).onKeyEvent { event ->
-                            if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
-                                onDismiss()
-                                true
-                            } else {
-                                false
-                            }
-                        },
+            Column(
+                modifier = Modifier.padding(16.dp),
             ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                ) {
-                    // Title
-                    Text(
-                        text = "New Tab",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = BossTheme.colors.textPrimary,
-                        modifier = Modifier.padding(bottom = 16.dp),
-                    )
+                // Title
+                Text(
+                    text = "New Tab",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = BossTheme.colors.textPrimary,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
 
-                    if (availableTypes.isEmpty() && pluginTypes.isEmpty()) {
-                        // Empty state when no tab plugins are enabled
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .height(120.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = "No tab types available. Enable a tab plugin or install one from the Plugin Store.",
-                                color = BossTheme.colors.textSecondary,
-                                fontSize = 13.sp,
+                if (availableTypes.isEmpty() && pluginTypes.isEmpty()) {
+                    // Empty state when no tab plugins are enabled
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(120.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "No tab types available. Enable a tab plugin or install one from the Plugin Store.",
+                            color = BossTheme.colors.textSecondary,
+                            fontSize = 13.sp,
+                        )
+                    }
+                } else {
+                    // Type selector
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        if (TabType.URL in availableTypes) {
+                            TabTypeOption(
+                                icon = Icons.Default.Language,
+                                label = "URL",
+                                isSelected = selectedPluginType == null && selectedType == TabType.URL,
+                                onClick = {
+                                    // Save current text before switching
+                                    when (selectedType) {
+                                        TabType.FILE -> {
+                                            fileText = inputText
+                                        }
+
+                                        TabType.JUPYTER -> {
+                                            jupyterName = inputText
+                                        }
+
+                                        else -> {}
+                                    }
+                                    selectedPluginType = null
+                                    selectedType = TabType.URL
+                                    inputText = urlText
+                                },
+                                modifier = Modifier.weight(1f),
                             )
                         }
-                    } else {
-                        // Type selector
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            if (TabType.URL in availableTypes) {
-                                TabTypeOption(
-                                    icon = Icons.Default.Language,
-                                    label = "URL",
-                                    isSelected = selectedPluginType == null && selectedType == TabType.URL,
-                                    onClick = {
-                                        // Save current text before switching
-                                        when (selectedType) {
-                                            TabType.FILE -> {
-                                                fileText = inputText
-                                            }
 
-                                            TabType.JUPYTER -> {
-                                                jupyterName = inputText
-                                            }
-
-                                            else -> {}
+                        if (TabType.FILE in availableTypes) {
+                            TabTypeOption(
+                                icon = Icons.AutoMirrored.Filled.InsertDriveFile,
+                                label = "File",
+                                isSelected = selectedPluginType == null && selectedType == TabType.FILE,
+                                onClick = {
+                                    // Save current text before switching
+                                    when (selectedType) {
+                                        TabType.URL -> {
+                                            urlText = inputText
                                         }
-                                        selectedPluginType = null
-                                        selectedType = TabType.URL
-                                        inputText = urlText
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
 
-                            if (TabType.FILE in availableTypes) {
-                                TabTypeOption(
-                                    icon = Icons.AutoMirrored.Filled.InsertDriveFile,
-                                    label = "File",
-                                    isSelected = selectedPluginType == null && selectedType == TabType.FILE,
-                                    onClick = {
-                                        // Save current text before switching
-                                        when (selectedType) {
-                                            TabType.URL -> {
-                                                urlText = inputText
-                                            }
-
-                                            TabType.JUPYTER -> {
-                                                jupyterName = inputText
-                                            }
-
-                                            else -> {}
+                                        TabType.JUPYTER -> {
+                                            jupyterName = inputText
                                         }
-                                        selectedPluginType = null
-                                        selectedType = TabType.FILE
-                                        inputText = fileText
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
 
-                            if (TabType.TERMINAL in availableTypes) {
-                                TabTypeOption(
-                                    icon = Icons.Outlined.Terminal,
-                                    label = "Terminal",
-                                    isSelected = selectedPluginType == null && selectedType == TabType.TERMINAL,
-                                    onClick = {
-                                        // Save current text before switching
-                                        when (selectedType) {
-                                            TabType.URL -> {
-                                                urlText = inputText
-                                            }
-
-                                            TabType.FILE -> {
-                                                fileText = inputText
-                                            }
-
-                                            TabType.JUPYTER -> {
-                                                jupyterName = inputText
-                                            }
-
-                                            else -> {}
-                                        }
-                                        selectedPluginType = null
-                                        selectedType = TabType.TERMINAL
-                                        inputText = terminalCommand
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
-
-                            // Plugin-registered tab types that opted into the dialog
-                            // via TabTypeInfo.newTabSpec — fully dynamic, no host
-                            // change needed for a new tab type to appear here.
-                            for (pluginType in pluginTypes) {
-                                TabTypeOption(
-                                    icon = pluginType.icon,
-                                    label = pluginType.displayName,
-                                    isSelected = selectedPluginType == pluginType.typeId,
-                                    onClick = {
-                                        when (selectedType) {
-                                            TabType.URL -> {
-                                                urlText = inputText
-                                            }
-
-                                            TabType.FILE -> {
-                                                fileText = inputText
-                                            }
-
-                                            TabType.JUPYTER -> {
-                                                jupyterName = inputText
-                                            }
-
-                                            else -> {}
-                                        }
-                                        selectedPluginType = pluginType.typeId
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
-
-                            if (TabType.JUPYTER in availableTypes) {
-                                TabTypeOption(
-                                    // Matches JupyterTabInfo's default tab icon for a consistent identity.
-                                    icon = Icons.Outlined.Code,
-                                    label = "Jupyter",
-                                    isSelected = selectedPluginType == null && selectedType == TabType.JUPYTER,
-                                    onClick = {
-                                        when (selectedType) {
-                                            TabType.URL -> {
-                                                urlText = inputText
-                                            }
-
-                                            TabType.FILE -> {
-                                                fileText = inputText
-                                            }
-
-                                            TabType.TERMINAL -> {
-                                                terminalCommand = inputText
-                                            }
-
-                                            else -> {}
-                                        }
-                                        selectedType = TabType.JUPYTER
-                                        inputText = jupyterName
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
+                                        else -> {}
+                                    }
+                                    selectedPluginType = null
+                                    selectedType = TabType.FILE
+                                    inputText = fileText
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
                         }
 
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        // Input field
-                        Column {
-                            // Plugin tab type input — one generic field driven by the
-                            // type's NewTabSpec; the plugin validates via createTabInfo.
-                            if (selectedPluginTypeInfo != null) {
-                                val spec = selectedPluginTypeInfo.newTabSpec!!
-                                val pluginFocusRequester = remember { FocusRequester() }
-                                LaunchedEffect(selectedPluginType) {
-                                    pluginFocusRequester.requestFocus()
-                                }
-                                OutlinedTextField(
-                                    value = pluginInput,
-                                    onValueChange = { pluginInput = it },
-                                    label = {
-                                        Text(
-                                            spec.inputLabel + if (spec.inputOptional) " (optional)" else "",
-                                            color = BossTheme.colors.textSecondary,
-                                        )
-                                    },
-                                    placeholder = {
-                                        Text(
-                                            spec.inputPlaceholder,
-                                            color = BossTheme.colors.textMuted,
-                                        )
-                                    },
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .focusRequester(pluginFocusRequester)
-                                            .onPreviewKeyEvent { event ->
-                                                if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
-                                                    confirmPluginTab()
-                                                    true
-                                                } else {
-                                                    false
-                                                }
-                                            },
-                                    colors =
-                                        TextFieldDefaults.outlinedTextFieldColors(
-                                            textColor = BossTheme.colors.textPrimary,
-                                            cursorColor = BossTheme.colors.textPrimary,
-                                            focusedBorderColor = BossTheme.colors.signal,
-                                            unfocusedBorderColor = BossTheme.colors.line,
-                                            backgroundColor = BossTheme.colors.panel,
-                                        ),
-                                    singleLine = true,
-                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                    keyboardActions = KeyboardActions(onDone = { confirmPluginTab() }),
-                                )
-                            } else if (selectedType == TabType.TERMINAL) {
-                                // Terminal command input
-                                LaunchedEffect(selectedType) {
-                                    if (selectedType == TabType.TERMINAL) {
-                                        terminalFocusRequester.requestFocus()
-                                    }
-                                }
-                                OutlinedTextField(
-                                    value = terminalCommand,
-                                    onValueChange = { newValue ->
-                                        terminalCommand = newValue
-                                        inputText = newValue
-                                    },
-                                    label = {
-                                        Text(
-                                            "Initial command (optional)",
-                                            color = BossTheme.colors.textSecondary,
-                                        )
-                                    },
-                                    placeholder = {
-                                        Text(
-                                            "e.g., npm run dev",
-                                            color = BossTheme.colors.textMuted,
-                                        )
-                                    },
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .focusRequester(terminalFocusRequester)
-                                            .onPreviewKeyEvent { event ->
-                                                if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
-                                                    handleCreateTab(selectedType, terminalCommand, onCreateTab, onDismiss)
-                                                    true
-                                                } else {
-                                                    false
-                                                }
-                                            },
-                                    colors =
-                                        TextFieldDefaults.outlinedTextFieldColors(
-                                            textColor = BossTheme.colors.textPrimary,
-                                            cursorColor = BossTheme.colors.textPrimary,
-                                            focusedBorderColor = BossTheme.colors.signal,
-                                            unfocusedBorderColor = BossTheme.colors.line,
-                                            backgroundColor = BossTheme.colors.panel,
-                                        ),
-                                    singleLine = true,
-                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                    keyboardActions =
-                                        KeyboardActions(
-                                            onDone = {
-                                                handleCreateTab(selectedType, terminalCommand, onCreateTab, onDismiss)
-                                            },
-                                        ),
-                                )
-                            } else if (selectedType == TabType.JUPYTER) {
-                                // Optional notebook name (blank = a new untitled notebook)
-                                val jupyterFocusRequester = remember { FocusRequester() }
-                                LaunchedEffect(selectedType) {
-                                    if (selectedType == TabType.JUPYTER) jupyterFocusRequester.requestFocus()
-                                }
-                                OutlinedTextField(
-                                    value = inputText,
-                                    onValueChange = { inputText = it },
-                                    label = { Text("Notebook name (optional)", color = BossTheme.colors.textSecondary) },
-                                    placeholder = { Text("e.g., analysis", color = BossTheme.colors.textMuted) },
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .focusRequester(jupyterFocusRequester)
-                                            .onPreviewKeyEvent { event ->
-                                                if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
-                                                    handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
-                                                    true
-                                                } else {
-                                                    false
-                                                }
-                                            },
-                                    colors =
-                                        TextFieldDefaults.outlinedTextFieldColors(
-                                            textColor = BossTheme.colors.textPrimary,
-                                            cursorColor = BossTheme.colors.textPrimary,
-                                            focusedBorderColor = BossTheme.colors.signal,
-                                            unfocusedBorderColor = BossTheme.colors.line,
-                                            backgroundColor = BossTheme.colors.panel,
-                                        ),
-                                    singleLine = true,
-                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                    keyboardActions =
-                                        KeyboardActions(
-                                            onDone = { handleCreateTab(selectedType, inputText, onCreateTab, onDismiss) },
-                                        ),
-                                )
-                            } else if (selectedType == TabType.FILE) {
-                                // Current project/folder selector (uses global recent projects)
-                                // Note: In NewTabDialog we don't have window context, so we use the most recent project
-                                val recentProjects by ProjectState.recentProjects.collectAsState()
-                                var selectedProject by remember {
-                                    mutableStateOf(
-                                        recentProjects.firstOrNull()
-                                            ?: Project("No Project", "", 0L),
-                                    )
-                                }
-                                // Update selectedProject when recentProjects changes
-                                LaunchedEffect(recentProjects) {
-                                    if (selectedProject.path.isEmpty() && recentProjects.isNotEmpty()) {
-                                        selectedProject = recentProjects.first()
-                                    }
-                                }
-                                var showFolderDropdown by remember { mutableStateOf(false) }
-                                var buttonHeight by remember { mutableStateOf(0) }
-
-                                // File tree state
-                                var fileTree by remember { mutableStateOf<FileNodeData?>(null) }
-                                var expandedPaths by remember { mutableStateOf(setOf<String>()) }
-                                var isLoadingTree by remember { mutableStateOf(false) }
-                                val coroutineScope = rememberCoroutineScope()
-
-                                // Load file tree when project changes
-                                LaunchedEffect(selectedProject.path) {
-                                    if (selectedProject.path.isNotEmpty()) {
-                                        isLoadingTree = true
-                                        fileTree =
-                                            try {
-                                                withContext(Dispatchers.IO) {
-                                                    scanDirectory(selectedProject.path)
-                                                }
-                                            } catch (e: Exception) {
-                                                newTabDialogLogger.warn(LogCategory.FILE, "Error scanning directory", error = e)
-                                                null
-                                            }
-                                        isLoadingTree = false
-                                    } else {
-                                        fileTree = null
-                                    }
-                                }
-
-                                // Directory picker for selecting new folder
-                                val directoryPicker =
-                                    rememberDirectoryPicker { path ->
-                                        path?.let {
-                                            val projectName = it.extractFileName().ifEmpty { "Unknown" }
-                                            val newProject =
-                                                Project(
-                                                    name = projectName,
-                                                    path = it,
-                                                )
-                                            // Update local state and recent projects list
-                                            selectedProject = newProject
-                                            ProjectState.updateRecentProjects(newProject)
-                                            // Clear expanded paths for new folder
-                                            expandedPaths = emptySet()
+                        if (TabType.TERMINAL in availableTypes) {
+                            TabTypeOption(
+                                icon = Icons.Outlined.Terminal,
+                                label = "Terminal",
+                                isSelected = selectedPluginType == null && selectedType == TabType.TERMINAL,
+                                onClick = {
+                                    // Save current text before switching
+                                    when (selectedType) {
+                                        TabType.URL -> {
+                                            urlText = inputText
                                         }
-                                    }
 
-                                // Show "Open Project" button when no project is selected
-                                if (selectedProject.path.isEmpty()) {
-                                    Box(
+                                        TabType.FILE -> {
+                                            fileText = inputText
+                                        }
+
+                                        TabType.JUPYTER -> {
+                                            jupyterName = inputText
+                                        }
+
+                                        else -> {}
+                                    }
+                                    selectedPluginType = null
+                                    selectedType = TabType.TERMINAL
+                                    inputText = terminalCommand
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+
+                        // Plugin-registered tab types that opted into the dialog
+                        // via TabTypeInfo.newTabSpec — fully dynamic, no host
+                        // change needed for a new tab type to appear here.
+                        for (pluginType in pluginTypes) {
+                            TabTypeOption(
+                                icon = pluginType.icon,
+                                label = pluginType.displayName,
+                                isSelected = selectedPluginType == pluginType.typeId,
+                                onClick = {
+                                    when (selectedType) {
+                                        TabType.URL -> {
+                                            urlText = inputText
+                                        }
+
+                                        TabType.FILE -> {
+                                            fileText = inputText
+                                        }
+
+                                        TabType.JUPYTER -> {
+                                            jupyterName = inputText
+                                        }
+
+                                        else -> {}
+                                    }
+                                    selectedPluginType = pluginType.typeId
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+
+                        if (TabType.JUPYTER in availableTypes) {
+                            TabTypeOption(
+                                // Matches JupyterTabInfo's default tab icon for a consistent identity.
+                                icon = Icons.Outlined.Code,
+                                label = "Jupyter",
+                                isSelected = selectedPluginType == null && selectedType == TabType.JUPYTER,
+                                onClick = {
+                                    when (selectedType) {
+                                        TabType.URL -> {
+                                            urlText = inputText
+                                        }
+
+                                        TabType.FILE -> {
+                                            fileText = inputText
+                                        }
+
+                                        TabType.TERMINAL -> {
+                                            terminalCommand = inputText
+                                        }
+
+                                        else -> {}
+                                    }
+                                    selectedType = TabType.JUPYTER
+                                    inputText = jupyterName
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // Input field
+                    Column {
+                        // Plugin tab type input — one generic field driven by the
+                        // type's NewTabSpec; the plugin validates via createTabInfo.
+                        if (selectedPluginTypeInfo != null) {
+                            val spec = selectedPluginTypeInfo.newTabSpec!!
+                            val pluginFocusRequester = remember { FocusRequester() }
+                            LaunchedEffect(selectedPluginType) {
+                                pluginFocusRequester.requestFocus()
+                            }
+                            OutlinedTextField(
+                                value = pluginInput,
+                                onValueChange = { pluginInput = it },
+                                label = {
+                                    Text(
+                                        spec.inputLabel + if (spec.inputOptional) " (optional)" else "",
+                                        color = BossTheme.colors.textSecondary,
+                                    )
+                                },
+                                placeholder = {
+                                    Text(
+                                        spec.inputPlaceholder,
+                                        color = BossTheme.colors.textMuted,
+                                    )
+                                },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(pluginFocusRequester)
+                                        .onPreviewKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                                                confirmPluginTab()
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        },
+                                colors =
+                                    TextFieldDefaults.outlinedTextFieldColors(
+                                        textColor = BossTheme.colors.textPrimary,
+                                        cursorColor = BossTheme.colors.textPrimary,
+                                        focusedBorderColor = BossTheme.colors.signal,
+                                        unfocusedBorderColor = BossTheme.colors.line,
+                                        backgroundColor = BossTheme.colors.panel,
+                                    ),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                keyboardActions = KeyboardActions(onDone = { confirmPluginTab() }),
+                            )
+                        } else if (selectedType == TabType.TERMINAL) {
+                            // Terminal command input
+                            LaunchedEffect(selectedType) {
+                                if (selectedType == TabType.TERMINAL) {
+                                    terminalFocusRequester.requestFocus()
+                                }
+                            }
+                            OutlinedTextField(
+                                value = terminalCommand,
+                                onValueChange = { newValue ->
+                                    terminalCommand = newValue
+                                    inputText = newValue
+                                },
+                                label = {
+                                    Text(
+                                        "Initial command (optional)",
+                                        color = BossTheme.colors.textSecondary,
+                                    )
+                                },
+                                placeholder = {
+                                    Text(
+                                        "e.g., npm run dev",
+                                        color = BossTheme.colors.textMuted,
+                                    )
+                                },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(terminalFocusRequester)
+                                        .onPreviewKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                                                handleCreateTab(selectedType, terminalCommand, onCreateTab, onDismiss)
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        },
+                                colors =
+                                    TextFieldDefaults.outlinedTextFieldColors(
+                                        textColor = BossTheme.colors.textPrimary,
+                                        cursorColor = BossTheme.colors.textPrimary,
+                                        focusedBorderColor = BossTheme.colors.signal,
+                                        unfocusedBorderColor = BossTheme.colors.line,
+                                        backgroundColor = BossTheme.colors.panel,
+                                    ),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                keyboardActions =
+                                    KeyboardActions(
+                                        onDone = {
+                                            handleCreateTab(selectedType, terminalCommand, onCreateTab, onDismiss)
+                                        },
+                                    ),
+                            )
+                        } else if (selectedType == TabType.JUPYTER) {
+                            // Optional notebook name (blank = a new untitled notebook)
+                            val jupyterFocusRequester = remember { FocusRequester() }
+                            LaunchedEffect(selectedType) {
+                                if (selectedType == TabType.JUPYTER) jupyterFocusRequester.requestFocus()
+                            }
+                            OutlinedTextField(
+                                value = inputText,
+                                onValueChange = { inputText = it },
+                                label = { Text("Notebook name (optional)", color = BossTheme.colors.textSecondary) },
+                                placeholder = { Text("e.g., analysis", color = BossTheme.colors.textMuted) },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(jupyterFocusRequester)
+                                        .onPreviewKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                                                handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        },
+                                colors =
+                                    TextFieldDefaults.outlinedTextFieldColors(
+                                        textColor = BossTheme.colors.textPrimary,
+                                        cursorColor = BossTheme.colors.textPrimary,
+                                        focusedBorderColor = BossTheme.colors.signal,
+                                        unfocusedBorderColor = BossTheme.colors.line,
+                                        backgroundColor = BossTheme.colors.panel,
+                                    ),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                keyboardActions =
+                                    KeyboardActions(
+                                        onDone = { handleCreateTab(selectedType, inputText, onCreateTab, onDismiss) },
+                                    ),
+                            )
+                        } else if (selectedType == TabType.FILE) {
+                            // Current project/folder selector (uses global recent projects)
+                            // Note: In NewTabDialog we don't have window context, so we use the most recent project
+                            val recentProjects by ProjectState.recentProjects.collectAsState()
+                            var selectedProject by remember {
+                                mutableStateOf(
+                                    recentProjects.firstOrNull()
+                                        ?: Project("No Project", "", 0L),
+                                )
+                            }
+                            // Update selectedProject when recentProjects changes
+                            LaunchedEffect(recentProjects) {
+                                if (selectedProject.path.isEmpty() && recentProjects.isNotEmpty()) {
+                                    selectedProject = recentProjects.first()
+                                }
+                            }
+                            var showFolderDropdown by remember { mutableStateOf(false) }
+                            var buttonHeight by remember { mutableStateOf(0) }
+
+                            // File tree state
+                            var fileTree by remember { mutableStateOf<FileNodeData?>(null) }
+                            var expandedPaths by remember { mutableStateOf(setOf<String>()) }
+                            var isLoadingTree by remember { mutableStateOf(false) }
+                            val coroutineScope = rememberCoroutineScope()
+
+                            // Load file tree when project changes
+                            LaunchedEffect(selectedProject.path) {
+                                if (selectedProject.path.isNotEmpty()) {
+                                    isLoadingTree = true
+                                    fileTree =
+                                        try {
+                                            withContext(Dispatchers.IO) {
+                                                scanDirectory(selectedProject.path)
+                                            }
+                                        } catch (e: Exception) {
+                                            newTabDialogLogger.warn(LogCategory.FILE, "Error scanning directory", error = e)
+                                            null
+                                        }
+                                    isLoadingTree = false
+                                } else {
+                                    fileTree = null
+                                }
+                            }
+
+                            // Directory picker for selecting new folder
+                            val directoryPicker =
+                                rememberDirectoryPicker { path ->
+                                    path?.let {
+                                        val projectName = it.extractFileName().ifEmpty { "Unknown" }
+                                        val newProject =
+                                            Project(
+                                                name = projectName,
+                                                path = it,
+                                            )
+                                        // Update local state and recent projects list
+                                        selectedProject = newProject
+                                        ProjectState.updateRecentProjects(newProject)
+                                        // Clear expanded paths for new folder
+                                        expandedPaths = emptySet()
+                                    }
+                                }
+
+                            // Show "Open Project" button when no project is selected
+                            if (selectedProject.path.isEmpty()) {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .height(200.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Button(
+                                        onClick = { directoryPicker.pickDirectory() },
+                                        colors =
+                                            ButtonDefaults.buttonColors(
+                                                backgroundColor = BossTheme.colors.signal,
+                                                contentColor = BossTheme.colors.onSignal,
+                                            ),
+                                        shape = RoundedCornerShape(4.dp),
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.FolderOpen,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp),
+                                        )
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Text("Open Project")
+                                    }
+                                }
+                            } else {
+                                // Folder selector dropdown
+                                Box(modifier = Modifier.fillMaxWidth()) {
+                                    OutlinedButton(
+                                        onClick = { showFolderDropdown = true },
                                         modifier =
                                             Modifier
                                                 .fillMaxWidth()
-                                                .height(200.dp),
-                                        contentAlignment = Alignment.Center,
+                                                .onGloballyPositioned { coordinates ->
+                                                    buttonHeight = coordinates.size.height
+                                                },
+                                        colors =
+                                            ButtonDefaults.outlinedButtonColors(
+                                                backgroundColor = BossTheme.colors.panel,
+                                                contentColor = BossTheme.colors.textPrimary,
+                                            ),
+                                        border =
+                                            ButtonDefaults.outlinedBorder.copy(
+                                                brush =
+                                                    androidx.compose.ui.graphics
+                                                        .SolidColor(BossTheme.colors.line),
+                                            ),
+                                        shape = RoundedCornerShape(4.dp),
                                     ) {
-                                        Button(
-                                            onClick = { directoryPicker.pickDirectory() },
-                                            colors =
-                                                ButtonDefaults.buttonColors(
-                                                    backgroundColor = BossTheme.colors.signal,
-                                                    contentColor = BossTheme.colors.onSignal,
-                                                ),
-                                            shape = RoundedCornerShape(4.dp),
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Default.FolderOpen,
-                                                contentDescription = null,
-                                                modifier = Modifier.size(18.dp),
-                                            )
-                                            Spacer(modifier = Modifier.width(8.dp))
-                                            Text("Open Project")
-                                        }
+                                        Icon(
+                                            imageVector = Icons.Outlined.Folder,
+                                            contentDescription = "Folder",
+                                            tint = BossTheme.colors.signalText,
+                                            modifier = Modifier.size(18.dp),
+                                        )
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Text(
+                                            text = selectedProject.name,
+                                            color = BossTheme.colors.textPrimary,
+                                            modifier = Modifier.weight(1f),
+                                        )
+                                        Icon(
+                                            imageVector = Icons.Default.ArrowDropDown,
+                                            contentDescription = "Expand",
+                                            tint = BossTheme.colors.textSecondary,
+                                        )
                                     }
-                                } else {
-                                    // Folder selector dropdown
-                                    Box(modifier = Modifier.fillMaxWidth()) {
-                                        OutlinedButton(
-                                            onClick = { showFolderDropdown = true },
-                                            modifier =
-                                                Modifier
-                                                    .fillMaxWidth()
-                                                    .onGloballyPositioned { coordinates ->
-                                                        buttonHeight = coordinates.size.height
-                                                    },
-                                            colors =
-                                                ButtonDefaults.outlinedButtonColors(
-                                                    backgroundColor = BossTheme.colors.panel,
-                                                    contentColor = BossTheme.colors.textPrimary,
-                                                ),
-                                            border =
-                                                ButtonDefaults.outlinedBorder.copy(
-                                                    brush =
-                                                        androidx.compose.ui.graphics
-                                                            .SolidColor(BossTheme.colors.line),
-                                                ),
-                                            shape = RoundedCornerShape(4.dp),
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Outlined.Folder,
-                                                contentDescription = "Folder",
-                                                tint = BossTheme.colors.signalText,
-                                                modifier = Modifier.size(18.dp),
-                                            )
-                                            Spacer(modifier = Modifier.width(8.dp))
-                                            Text(
-                                                text = selectedProject.name,
-                                                color = BossTheme.colors.textPrimary,
-                                                modifier = Modifier.weight(1f),
-                                            )
-                                            Icon(
-                                                imageVector = Icons.Default.ArrowDropDown,
-                                                contentDescription = "Expand",
-                                                tint = BossTheme.colors.textSecondary,
-                                            )
-                                        }
 
-                                        if (showFolderDropdown) {
-                                            ContextMenu(
-                                                items =
-                                                    buildList {
-                                                        // Recent projects
-                                                        recentProjects.forEach { project ->
-                                                            add(
-                                                                ContextMenuItem(
-                                                                    text = project.name,
-                                                                    icon = Icons.Outlined.Folder,
-                                                                    onClick = {
-                                                                        selectedProject = project
-                                                                        expandedPaths = emptySet()
-                                                                    },
-                                                                ),
-                                                            )
-                                                        }
-                                                        // Divider if there are recent projects
-                                                        if (recentProjects.isNotEmpty()) {
-                                                            add(ContextMenuItem(isDivider = true))
-                                                        }
-                                                        // Browse option
+                                    if (showFolderDropdown) {
+                                        ContextMenu(
+                                            items =
+                                                buildList {
+                                                    // Recent projects
+                                                    recentProjects.forEach { project ->
                                                         add(
                                                             ContextMenuItem(
-                                                                text = "Browse...",
-                                                                icon = Icons.Default.FolderOpen,
-                                                                onClick = { directoryPicker.pickDirectory() },
+                                                                text = project.name,
+                                                                icon = Icons.Outlined.Folder,
+                                                                onClick = {
+                                                                    selectedProject = project
+                                                                    expandedPaths = emptySet()
+                                                                },
                                                             ),
                                                         )
-                                                    },
-                                                offset = IntOffset(0, buttonHeight),
-                                                modifier = Modifier.widthIn(min = 200.dp),
-                                                onDismissRequest = { showFolderDropdown = false },
+                                                    }
+                                                    // Divider if there are recent projects
+                                                    if (recentProjects.isNotEmpty()) {
+                                                        add(ContextMenuItem(isDivider = true))
+                                                    }
+                                                    // Browse option
+                                                    add(
+                                                        ContextMenuItem(
+                                                            text = "Browse...",
+                                                            icon = Icons.Default.FolderOpen,
+                                                            onClick = { directoryPicker.pickDirectory() },
+                                                        ),
+                                                    )
+                                                },
+                                            offset = IntOffset(0, buttonHeight),
+                                            modifier = Modifier.widthIn(min = 200.dp),
+                                            onDismissRequest = { showFolderDropdown = false },
+                                        )
+                                    }
+                                }
+
+                                Spacer(modifier = Modifier.height(8.dp))
+
+                                // File tree browser
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .height(200.dp)
+                                            .background(
+                                                color = BossTheme.colors.panel,
+                                                shape = RoundedCornerShape(4.dp),
+                                            ).border(
+                                                width = 1.dp,
+                                                color = ContextMenuBorder,
+                                                shape = RoundedCornerShape(4.dp),
+                                            ),
+                                ) {
+                                    if (isLoadingTree) {
+                                        Box(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            CircularProgressIndicator(
+                                                modifier = Modifier.size(24.dp),
+                                                color = BossTheme.colors.signal,
+                                                strokeWidth = 2.dp,
                                             )
                                         }
-                                    }
+                                    } else if (fileTree != null && fileTree?.children?.isNotEmpty() == true) {
+                                        Column(
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxSize()
+                                                    .verticalScroll(rememberScrollState())
+                                                    .padding(4.dp),
+                                        ) {
+                                            fileTree?.children?.forEach { node ->
+                                                DialogFileTreeItem(
+                                                    node = node,
+                                                    level = 0,
+                                                    expandedPaths = expandedPaths,
+                                                    onToggleExpanded = { path ->
+                                                        if (expandedPaths.contains(path)) {
+                                                            // Collapse - just remove from expanded set
+                                                            expandedPaths = expandedPaths - path
+                                                        } else {
+                                                            // Expand - add to expanded set and load children
+                                                            expandedPaths = expandedPaths + path
 
-                                    Spacer(modifier = Modifier.height(8.dp))
-
-                                    // File tree browser
-                                    Box(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .height(200.dp)
-                                                .background(
-                                                    color = BossTheme.colors.panel,
-                                                    shape = RoundedCornerShape(4.dp),
-                                                ).border(
-                                                    width = 1.dp,
-                                                    color = ContextMenuBorder,
-                                                    shape = RoundedCornerShape(4.dp),
-                                                ),
-                                    ) {
-                                        if (isLoadingTree) {
-                                            Box(
-                                                modifier = Modifier.fillMaxSize(),
-                                                contentAlignment = Alignment.Center,
-                                            ) {
-                                                CircularProgressIndicator(
-                                                    modifier = Modifier.size(24.dp),
-                                                    color = BossTheme.colors.signal,
-                                                    strokeWidth = 2.dp,
-                                                )
-                                            }
-                                        } else if (fileTree != null && fileTree?.children?.isNotEmpty() == true) {
-                                            Column(
-                                                modifier =
-                                                    Modifier
-                                                        .fillMaxSize()
-                                                        .verticalScroll(rememberScrollState())
-                                                        .padding(4.dp),
-                                            ) {
-                                                fileTree?.children?.forEach { node ->
-                                                    DialogFileTreeItem(
-                                                        node = node,
-                                                        level = 0,
-                                                        expandedPaths = expandedPaths,
-                                                        onToggleExpanded = { path ->
-                                                            if (expandedPaths.contains(path)) {
-                                                                // Collapse - just remove from expanded set
-                                                                expandedPaths = expandedPaths - path
-                                                            } else {
-                                                                // Expand - add to expanded set and load children
-                                                                expandedPaths = expandedPaths + path
-
-                                                                // Load children if needed
-                                                                val currentTree = fileTree
-                                                                if (currentTree != null) {
-                                                                    val targetNode = FileTreeUtils.findNodeByPath(currentTree, path)
-                                                                    if (targetNode?.isDirectory == true && targetNode.children.isEmpty()) {
-                                                                        // Need to load children
-                                                                        coroutineScope.launch {
-                                                                            try {
-                                                                                val scannedNode =
-                                                                                    withContext(Dispatchers.IO) {
-                                                                                        scanDirectoryWithDepth(
-                                                                                            path,
-                                                                                            maxDepth = 1,
-                                                                                            startDepth = 0,
+                                                            // Load children if needed
+                                                            val currentTree = fileTree
+                                                            if (currentTree != null) {
+                                                                val targetNode = FileTreeUtils.findNodeByPath(currentTree, path)
+                                                                if (targetNode?.isDirectory == true && targetNode.children.isEmpty()) {
+                                                                    // Need to load children
+                                                                    coroutineScope.launch {
+                                                                        try {
+                                                                            val scannedNode =
+                                                                                withContext(Dispatchers.IO) {
+                                                                                    scanDirectoryWithDepth(
+                                                                                        path,
+                                                                                        maxDepth = 1,
+                                                                                        startDepth = 0,
+                                                                                    )
+                                                                                }
+                                                                            if (scannedNode != null) {
+                                                                                val loadedChildren =
+                                                                                    scannedNode.children.map { child ->
+                                                                                        if (child.isDirectory) {
+                                                                                            val hasKids =
+                                                                                                try {
+                                                                                                    directoryHasChildren(child.path)
+                                                                                                } catch (e: Exception) {
+                                                                                                    logDirProbeFailure(child.path, e)
+                                                                                                    false
+                                                                                                }
+                                                                                            child.copy(hasChildren = hasKids)
+                                                                                        } else {
+                                                                                            child
+                                                                                        }
+                                                                                    }
+                                                                                fileTree =
+                                                                                    FileTreeUtils.updateNodeAtPath(
+                                                                                        currentTree,
+                                                                                        path,
+                                                                                    ) { existingNode ->
+                                                                                        existingNode.copy(
+                                                                                            children = loadedChildren,
+                                                                                            hasChildren = loadedChildren.isNotEmpty(),
                                                                                         )
                                                                                     }
-                                                                                if (scannedNode != null) {
-                                                                                    val loadedChildren =
-                                                                                        scannedNode.children.map { child ->
-                                                                                            if (child.isDirectory) {
-                                                                                                val hasKids =
-                                                                                                    try {
-                                                                                                        directoryHasChildren(child.path)
-                                                                                                    } catch (e: Exception) {
-                                                                                                        logDirProbeFailure(child.path, e)
-                                                                                                        false
-                                                                                                    }
-                                                                                                child.copy(hasChildren = hasKids)
-                                                                                            } else {
-                                                                                                child
-                                                                                            }
-                                                                                        }
-                                                                                    fileTree =
-                                                                                        FileTreeUtils.updateNodeAtPath(
-                                                                                            currentTree,
-                                                                                            path,
-                                                                                        ) { existingNode ->
-                                                                                            existingNode.copy(
-                                                                                                children = loadedChildren,
-                                                                                                hasChildren = loadedChildren.isNotEmpty(),
-                                                                                            )
-                                                                                        }
-                                                                                }
-                                                                            } catch (e: Exception) {
-                                                                                newTabDialogLogger.warn(
-                                                                                    LogCategory.FILE,
-                                                                                    "Error loading folder children",
-                                                                                    error = e,
-                                                                                )
                                                                             }
+                                                                        } catch (e: Exception) {
+                                                                            newTabDialogLogger.warn(
+                                                                                LogCategory.FILE,
+                                                                                "Error loading folder children",
+                                                                                error = e,
+                                                                            )
                                                                         }
                                                                     }
                                                                 }
                                                             }
-                                                        },
-                                                        onFileClick = { file ->
-                                                            inputText = file.path
-                                                            fileText = file.path
-                                                        },
-                                                    )
-                                                }
-                                            }
-                                        } else if (fileTree != null && fileTree?.children?.isEmpty() == true) {
-                                            // Empty folder (hidden files like .git are excluded)
-                                            Box(
-                                                modifier = Modifier.fillMaxSize(),
-                                                contentAlignment = Alignment.Center,
-                                            ) {
-                                                Column(
-                                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                                ) {
-                                                    Text(
-                                                        text = "No visible files",
-                                                        color = BossTheme.colors.textSecondary,
-                                                        fontSize = 13.sp,
-                                                    )
-                                                    Text(
-                                                        text = "(hidden files and build folders are excluded)",
-                                                        color = BossTheme.colors.textMuted,
-                                                        fontSize = 11.sp,
-                                                    )
-                                                }
-                                            }
-                                        } else {
-                                            Box(
-                                                modifier = Modifier.fillMaxSize(),
-                                                contentAlignment = Alignment.Center,
-                                            ) {
-                                                Text(
-                                                    text = "Unable to load files",
-                                                    color = BossTheme.colors.textSecondary,
-                                                    fontSize = 13.sp,
+                                                        }
+                                                    },
+                                                    onFileClick = { file ->
+                                                        inputText = file.path
+                                                        fileText = file.path
+                                                    },
                                                 )
                                             }
                                         }
-                                    }
-
-                                    Spacer(modifier = Modifier.height(8.dp))
-
-                                    // File input with browse button
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                    ) {
-                                        OutlinedTextField(
-                                            value = inputText,
-                                            onValueChange = { newValue ->
-                                                inputText = newValue
-                                                fileText = newValue
-                                            },
-                                            label = {
+                                    } else if (fileTree != null && fileTree?.children?.isEmpty() == true) {
+                                        // Empty folder (hidden files like .git are excluded)
+                                        Box(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            Column(
+                                                horizontalAlignment = Alignment.CenterHorizontally,
+                                            ) {
                                                 Text(
-                                                    "File path",
+                                                    text = "No visible files",
                                                     color = BossTheme.colors.textSecondary,
+                                                    fontSize = 13.sp,
                                                 )
-                                            },
-                                            placeholder = {
                                                 Text(
-                                                    "Select a file above or enter path",
+                                                    text = "(hidden files and build folders are excluded)",
                                                     color = BossTheme.colors.textMuted,
+                                                    fontSize = 11.sp,
                                                 )
-                                            },
-                                            modifier =
-                                                Modifier
-                                                    .weight(1f)
-                                                    .focusRequester(focusRequester)
-                                                    .onPreviewKeyEvent { event ->
-                                                        if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                                            }
+                                        }
+                                    } else {
+                                        Box(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            Text(
+                                                text = "Unable to load files",
+                                                color = BossTheme.colors.textSecondary,
+                                                fontSize = 13.sp,
+                                            )
+                                        }
+                                    }
+                                }
+
+                                Spacer(modifier = Modifier.height(8.dp))
+
+                                // File input with browse button
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    OutlinedTextField(
+                                        value = inputText,
+                                        onValueChange = { newValue ->
+                                            inputText = newValue
+                                            fileText = newValue
+                                        },
+                                        label = {
+                                            Text(
+                                                "File path",
+                                                color = BossTheme.colors.textSecondary,
+                                            )
+                                        },
+                                        placeholder = {
+                                            Text(
+                                                "Select a file above or enter path",
+                                                color = BossTheme.colors.textMuted,
+                                            )
+                                        },
+                                        modifier =
+                                            Modifier
+                                                .weight(1f)
+                                                .focusRequester(focusRequester)
+                                                .onPreviewKeyEvent { event ->
+                                                    if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                                                        handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
+                                                        true
+                                                    } else {
+                                                        false
+                                                    }
+                                                },
+                                        colors =
+                                            TextFieldDefaults.outlinedTextFieldColors(
+                                                textColor = BossTheme.colors.textPrimary,
+                                                cursorColor = BossTheme.colors.textPrimary,
+                                                focusedBorderColor = BossTheme.colors.signal,
+                                                unfocusedBorderColor = BossTheme.colors.line,
+                                                backgroundColor = BossTheme.colors.panel,
+                                            ),
+                                        singleLine = true,
+                                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                        keyboardActions =
+                                            KeyboardActions(
+                                                onDone = {
+                                                    handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
+                                                },
+                                            ),
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    IconButton(
+                                        onClick = { filePicker.pickFile() },
+                                        modifier = Modifier.size(48.dp),
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.FolderOpen,
+                                            contentDescription = "Browse files",
+                                            tint = BossTheme.colors.textSecondary,
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            // URL input
+                            OutlinedTextField(
+                                value = inputText,
+                                onValueChange = { newValue ->
+                                    inputText = newValue
+                                    urlText = newValue
+                                },
+                                label = {
+                                    Text(
+                                        "Enter URL or search term",
+                                        color = BossTheme.colors.textSecondary,
+                                    )
+                                },
+                                placeholder = {
+                                    Text(
+                                        "https://example.com or search...",
+                                        color = BossTheme.colors.textMuted,
+                                    )
+                                },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(focusRequester)
+                                        .onPreviewKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown) {
+                                                when (event.key) {
+                                                    Key.DirectionDown -> {
+                                                        // Always consume arrow keys to prevent cursor movement in text field
+                                                        if (showUrlDropdown && urlSuggestions.isNotEmpty()) {
+                                                            selectedSuggestionIndex =
+                                                                (selectedSuggestionIndex + 1).coerceAtMost(urlSuggestions.size - 1)
+                                                        }
+                                                        true
+                                                    }
+
+                                                    Key.DirectionUp -> {
+                                                        // Always consume arrow keys to prevent cursor movement in text field
+                                                        if (showUrlDropdown && urlSuggestions.isNotEmpty()) {
+                                                            selectedSuggestionIndex = (selectedSuggestionIndex - 1).coerceAtLeast(-1)
+                                                        }
+                                                        true
+                                                    }
+
+                                                    Key.Enter -> {
+                                                        if (selectedSuggestionIndex >= 0 &&
+                                                            selectedSuggestionIndex < urlSuggestions.size
+                                                        ) {
+                                                            val suggestion = urlSuggestions[selectedSuggestionIndex]
+                                                            inputText = suggestion.url
+                                                            urlText = suggestion.url
+                                                            showUrlDropdown = false
                                                             handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
                                                             true
                                                         } else {
                                                             false
                                                         }
-                                                    },
-                                            colors =
-                                                TextFieldDefaults.outlinedTextFieldColors(
-                                                    textColor = BossTheme.colors.textPrimary,
-                                                    cursorColor = BossTheme.colors.textPrimary,
-                                                    focusedBorderColor = BossTheme.colors.signal,
-                                                    unfocusedBorderColor = BossTheme.colors.line,
-                                                    backgroundColor = BossTheme.colors.panel,
-                                                ),
-                                            singleLine = true,
-                                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                            keyboardActions =
-                                                KeyboardActions(
-                                                    onDone = {
-                                                        handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
-                                                    },
-                                                ),
-                                        )
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        IconButton(
-                                            onClick = { filePicker.pickFile() },
-                                            modifier = Modifier.size(48.dp),
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Default.FolderOpen,
-                                                contentDescription = "Browse files",
-                                                tint = BossTheme.colors.textSecondary,
-                                            )
-                                        }
-                                    }
-                                }
-                            } else {
-                                // URL input
-                                OutlinedTextField(
-                                    value = inputText,
-                                    onValueChange = { newValue ->
-                                        inputText = newValue
-                                        urlText = newValue
-                                    },
-                                    label = {
-                                        Text(
-                                            "Enter URL or search term",
-                                            color = BossTheme.colors.textSecondary,
-                                        )
-                                    },
-                                    placeholder = {
-                                        Text(
-                                            "https://example.com or search...",
-                                            color = BossTheme.colors.textMuted,
-                                        )
-                                    },
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .focusRequester(focusRequester)
-                                            .onPreviewKeyEvent { event ->
-                                                if (event.type == KeyEventType.KeyDown) {
-                                                    when (event.key) {
-                                                        Key.DirectionDown -> {
-                                                            // Always consume arrow keys to prevent cursor movement in text field
-                                                            if (showUrlDropdown && urlSuggestions.isNotEmpty()) {
-                                                                selectedSuggestionIndex =
-                                                                    (selectedSuggestionIndex + 1).coerceAtMost(urlSuggestions.size - 1)
-                                                            }
+                                                    }
+
+                                                    Key.Escape -> {
+                                                        if (showUrlDropdown) {
+                                                            showUrlDropdown = false
                                                             true
-                                                        }
-
-                                                        Key.DirectionUp -> {
-                                                            // Always consume arrow keys to prevent cursor movement in text field
-                                                            if (showUrlDropdown && urlSuggestions.isNotEmpty()) {
-                                                                selectedSuggestionIndex = (selectedSuggestionIndex - 1).coerceAtLeast(-1)
-                                                            }
-                                                            true
-                                                        }
-
-                                                        Key.Enter -> {
-                                                            if (selectedSuggestionIndex >= 0 &&
-                                                                selectedSuggestionIndex < urlSuggestions.size
-                                                            ) {
-                                                                val suggestion = urlSuggestions[selectedSuggestionIndex]
-                                                                inputText = suggestion.url
-                                                                urlText = suggestion.url
-                                                                showUrlDropdown = false
-                                                                handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
-                                                                true
-                                                            } else {
-                                                                false
-                                                            }
-                                                        }
-
-                                                        Key.Escape -> {
-                                                            if (showUrlDropdown) {
-                                                                showUrlDropdown = false
-                                                                true
-                                                            } else {
-                                                                false
-                                                            }
-                                                        }
-
-                                                        else -> {
+                                                        } else {
                                                             false
                                                         }
                                                     }
-                                                } else {
-                                                    false
-                                                }
-                                            },
-                                    colors =
-                                        TextFieldDefaults.outlinedTextFieldColors(
-                                            textColor = BossTheme.colors.textPrimary,
-                                            cursorColor = BossTheme.colors.textPrimary,
-                                            focusedBorderColor = BossTheme.colors.signal,
-                                            unfocusedBorderColor = BossTheme.colors.line,
-                                            backgroundColor = BossTheme.colors.panel,
-                                        ),
-                                    singleLine = true,
-                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                    keyboardActions =
-                                        KeyboardActions(
-                                            onDone = {
-                                                if (selectedSuggestionIndex >= 0 && selectedSuggestionIndex < urlSuggestions.size) {
-                                                    val suggestion = urlSuggestions[selectedSuggestionIndex]
-                                                    handleCreateTab(selectedType, suggestion.url, onCreateTab, onDismiss)
-                                                } else {
-                                                    handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
-                                                }
-                                            },
-                                        ),
-                                )
 
-                                // URL suggestions dropdown
-                                if (showUrlDropdown) {
-                                    Box(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .heightIn(max = 200.dp)
-                                                .background(
-                                                    color = ContextMenuBackground,
-                                                    shape = RoundedCornerShape(0.dp, 0.dp, 4.dp, 4.dp),
-                                                ).border(
-                                                    width = 1.dp,
-                                                    color = ContextMenuBorder,
-                                                    shape = RoundedCornerShape(0.dp, 0.dp, 4.dp, 4.dp),
-                                                ),
-                                    ) {
-                                        LazyColumn(state = listState) {
-                                            itemsIndexed(urlSuggestions) { index, suggestion ->
-                                                Row(
-                                                    modifier =
-                                                        Modifier
-                                                            .fillMaxWidth()
-                                                            .background(
-                                                                if (index == selectedSuggestionIndex) {
-                                                                    BossTheme.colors.signal.copy(alpha = 0.2f)
-                                                                } else {
-                                                                    Color.Transparent
-                                                                },
-                                                            ).clickable {
-                                                                inputText = suggestion.url
-                                                                urlText = suggestion.url
-                                                                showUrlDropdown = false
-                                                                handleCreateTab(TabType.URL, suggestion.url, onCreateTab, onDismiss)
-                                                            }.padding(horizontal = 16.dp, vertical = 10.dp),
-                                                    verticalAlignment = Alignment.CenterVertically,
-                                                ) {
-                                                    Icon(
-                                                        imageVector =
-                                                            if (suggestion.isSearchSuggestion) {
-                                                                Icons.Default.Search
+                                                    else -> {
+                                                        false
+                                                    }
+                                                }
+                                            } else {
+                                                false
+                                            }
+                                        },
+                                colors =
+                                    TextFieldDefaults.outlinedTextFieldColors(
+                                        textColor = BossTheme.colors.textPrimary,
+                                        cursorColor = BossTheme.colors.textPrimary,
+                                        focusedBorderColor = BossTheme.colors.signal,
+                                        unfocusedBorderColor = BossTheme.colors.line,
+                                        backgroundColor = BossTheme.colors.panel,
+                                    ),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                keyboardActions =
+                                    KeyboardActions(
+                                        onDone = {
+                                            if (selectedSuggestionIndex >= 0 && selectedSuggestionIndex < urlSuggestions.size) {
+                                                val suggestion = urlSuggestions[selectedSuggestionIndex]
+                                                handleCreateTab(selectedType, suggestion.url, onCreateTab, onDismiss)
+                                            } else {
+                                                handleCreateTab(selectedType, inputText, onCreateTab, onDismiss)
+                                            }
+                                        },
+                                    ),
+                            )
+
+                            // URL suggestions dropdown
+                            if (showUrlDropdown) {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .heightIn(max = 200.dp)
+                                            .background(
+                                                color = ContextMenuBackground,
+                                                shape = RoundedCornerShape(0.dp, 0.dp, 4.dp, 4.dp),
+                                            ).border(
+                                                width = 1.dp,
+                                                color = ContextMenuBorder,
+                                                shape = RoundedCornerShape(0.dp, 0.dp, 4.dp, 4.dp),
+                                            ),
+                                ) {
+                                    LazyColumn(state = listState) {
+                                        itemsIndexed(urlSuggestions) { index, suggestion ->
+                                            Row(
+                                                modifier =
+                                                    Modifier
+                                                        .fillMaxWidth()
+                                                        .background(
+                                                            if (index == selectedSuggestionIndex) {
+                                                                BossTheme.colors.signal.copy(alpha = 0.2f)
                                                             } else {
-                                                                Icons.Default.History
+                                                                Color.Transparent
                                                             },
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(18.dp),
-                                                        tint = BossTheme.colors.textSecondary,
+                                                        ).clickable {
+                                                            inputText = suggestion.url
+                                                            urlText = suggestion.url
+                                                            showUrlDropdown = false
+                                                            handleCreateTab(TabType.URL, suggestion.url, onCreateTab, onDismiss)
+                                                        }.padding(horizontal = 16.dp, vertical = 10.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                Icon(
+                                                    imageVector =
+                                                        if (suggestion.isSearchSuggestion) {
+                                                            Icons.Default.Search
+                                                        } else {
+                                                            Icons.Default.History
+                                                        },
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(18.dp),
+                                                    tint = BossTheme.colors.textSecondary,
+                                                )
+                                                Spacer(modifier = Modifier.width(12.dp))
+                                                Column(modifier = Modifier.weight(1f)) {
+                                                    Text(
+                                                        text = suggestion.title.ifEmpty { suggestion.url },
+                                                        fontSize = 14.sp,
+                                                        color = BossTheme.colors.textPrimary,
+                                                        maxLines = 1,
                                                     )
-                                                    Spacer(modifier = Modifier.width(12.dp))
-                                                    Column(modifier = Modifier.weight(1f)) {
+                                                    if (suggestion.title.isNotEmpty()) {
                                                         Text(
-                                                            text = suggestion.title.ifEmpty { suggestion.url },
-                                                            fontSize = 14.sp,
-                                                            color = BossTheme.colors.textPrimary,
+                                                            text = suggestion.url,
+                                                            fontSize = 12.sp,
+                                                            color = BossTheme.colors.textSecondary,
                                                             maxLines = 1,
                                                         )
-                                                        if (suggestion.title.isNotEmpty()) {
-                                                            Text(
-                                                                text = suggestion.url,
-                                                                fontSize = 12.sp,
-                                                                color = BossTheme.colors.textSecondary,
-                                                                maxLines = 1,
-                                                            )
+                                                    }
+                                                }
+                                                IconButton(
+                                                    onClick = {
+                                                        UrlHistoryProvider.deleteUrl(suggestion.url)
+                                                        // Update suggestions
+                                                        urlSuggestions = urlSuggestions.filterNot { it.url == suggestion.url }
+                                                        if (urlSuggestions.isEmpty()) {
+                                                            showUrlDropdown = false
                                                         }
-                                                    }
-                                                    IconButton(
-                                                        onClick = {
-                                                            UrlHistoryProvider.deleteUrl(suggestion.url)
-                                                            // Update suggestions
-                                                            urlSuggestions = urlSuggestions.filterNot { it.url == suggestion.url }
-                                                            if (urlSuggestions.isEmpty()) {
-                                                                showUrlDropdown = false
-                                                            }
-                                                        },
-                                                        modifier = Modifier.size(24.dp),
-                                                    ) {
-                                                        Icon(
-                                                            imageVector = Icons.Default.Close,
-                                                            contentDescription = "Delete",
-                                                            modifier = Modifier.size(16.dp),
-                                                            tint = BossTheme.colors.textSecondary,
-                                                        )
-                                                    }
+                                                    },
+                                                    modifier = Modifier.size(24.dp),
+                                                ) {
+                                                    Icon(
+                                                        imageVector = Icons.Default.Close,
+                                                        contentDescription = "Delete",
+                                                        modifier = Modifier.size(16.dp),
+                                                        tint = BossTheme.colors.textSecondary,
+                                                    )
                                                 }
                                             }
                                         }
@@ -1221,65 +1206,65 @@ fun NewTabDialog(
                                 }
                             }
                         }
-                    } // end availableTypes.isNotEmpty() else
+                    }
+                } // end availableTypes.isNotEmpty() else
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-                    // Buttons
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically,
+                // Buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        colors =
+                            ButtonDefaults.textButtonColors(
+                                contentColor = BossTheme.colors.textSecondary,
+                            ),
                     ) {
-                        TextButton(
-                            onClick = onDismiss,
-                            colors =
-                                ButtonDefaults.textButtonColors(
-                                    contentColor = BossTheme.colors.textSecondary,
-                                ),
-                        ) {
-                            Text("Cancel")
-                        }
+                        Text("Cancel")
+                    }
 
-                        Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
 
-                        Button(
-                            onClick = {
-                                if (selectedPluginTypeInfo != null) {
-                                    confirmPluginTab()
-                                } else {
-                                    val input = if (selectedType == TabType.TERMINAL) terminalCommand else inputText
-                                    handleCreateTab(selectedType, input, onCreateTab, onDismiss)
+                    Button(
+                        onClick = {
+                            if (selectedPluginTypeInfo != null) {
+                                confirmPluginTab()
+                            } else {
+                                val input = if (selectedType == TabType.TERMINAL) terminalCommand else inputText
+                                handleCreateTab(selectedType, input, onCreateTab, onDismiss)
+                            }
+                        },
+                        enabled =
+                            if (selectedPluginTypeInfo != null) {
+                                selectedPluginTypeInfo.newTabSpec!!.inputOptional || pluginInput.isNotBlank()
+                            } else {
+                                availableTypes.isNotEmpty() &&
+                                    (selectedType == TabType.TERMINAL || selectedType == TabType.JUPYTER || inputText.isNotBlank())
+                            },
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                backgroundColor = BossTheme.colors.signal,
+                                contentColor = BossTheme.colors.onSignal,
+                                disabledBackgroundColor = BossTheme.colors.raised,
+                                disabledContentColor = BossTheme.colors.textMuted,
+                            ),
+                    ) {
+                        Text(
+                            if (selectedPluginTypeInfo != null) {
+                                selectedPluginTypeInfo.newTabSpec!!.confirmLabel
+                            } else {
+                                when (selectedType) {
+                                    TabType.URL -> "Fluck it"
+                                    TabType.FILE -> "Open"
+                                    TabType.TERMINAL -> "Open Terminal"
+                                    TabType.JUPYTER -> "New Notebook"
                                 }
                             },
-                            enabled =
-                                if (selectedPluginTypeInfo != null) {
-                                    selectedPluginTypeInfo.newTabSpec!!.inputOptional || pluginInput.isNotBlank()
-                                } else {
-                                    availableTypes.isNotEmpty() &&
-                                        (selectedType == TabType.TERMINAL || selectedType == TabType.JUPYTER || inputText.isNotBlank())
-                                },
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    backgroundColor = BossTheme.colors.signal,
-                                    contentColor = BossTheme.colors.onSignal,
-                                    disabledBackgroundColor = BossTheme.colors.raised,
-                                    disabledContentColor = BossTheme.colors.textMuted,
-                                ),
-                        ) {
-                            Text(
-                                if (selectedPluginTypeInfo != null) {
-                                    selectedPluginTypeInfo.newTabSpec!!.confirmLabel
-                                } else {
-                                    when (selectedType) {
-                                        TabType.URL -> "Fluck it"
-                                        TabType.FILE -> "Open"
-                                        TabType.TERMINAL -> "Open Terminal"
-                                        TabType.JUPYTER -> "New Notebook"
-                                    }
-                                },
-                            )
-                        }
+                        )
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ProjectOpenModeDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ProjectOpenModeDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.window.Project
 import androidx.compose.foundation.layout.*
@@ -16,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -34,7 +34,7 @@ fun ProjectOpenModeDialog(
     onOpenInCurrentWindow: (Project) -> Unit,
     onOpenInNewWindow: (Project) -> Unit,
 ) {
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ProjectSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ProjectSelectionDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.components.plugin.panels.left_top.ProjectState
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.window.LocalWindowProjectState
 import ai.rever.boss.window.Project
@@ -23,7 +24,6 @@ import androidx.compose.ui.input.key.*
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -50,7 +50,7 @@ fun ProjectSelectionDialog(
         return
     }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/RemoveBookmarkConfirmationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/RemoveBookmarkConfirmationDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 @Composable
@@ -21,7 +21,7 @@ fun RemoveBookmarkConfirmationDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/RenameDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/RenameDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -32,7 +32,7 @@ fun RenameDialog(
 ) {
     var newName by remember { mutableStateOf(currentName) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ShortcutHelpDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/ShortcutHelpDialog.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.dialogs
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -23,7 +24,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -62,7 +62,7 @@ fun ShortcutHelpDialog(
             filtered.groupBy { it.category }.toSortedMap()
         }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/TerminalLinkOpenDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/TerminalLinkOpenDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.dialogs
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.terminal.TerminalLinkOpenMode
 import androidx.compose.foundation.clickable
@@ -22,7 +23,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -47,7 +47,7 @@ fun TerminalLinkOpenDialog(
 ) {
     var rememberChoice by remember { mutableStateOf(false) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/TopOfMindDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/TopOfMindDialog.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.components.window_panel.SplitViewState
 import ai.rever.boss.components.workspaces.WorkspaceManager
 import ai.rever.boss.plugin.api.TabIcon
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.topofmind.ActiveTab
 import ai.rever.boss.topofmind.TopOfMindStateHolder
@@ -31,7 +32,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -103,7 +103,7 @@ fun TopOfMindDialog(
         }
     }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/WorkspaceSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/WorkspaceSelectionDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.dialogs
 
 import ai.rever.boss.components.workspaces.extractPanels
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -22,7 +23,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -45,7 +45,7 @@ fun WorkspaceSelectionDialog(
     // Map of workspace name -> panel ID (null = auto/active panel)
     var workspacePanelSelections by remember { mutableStateOf(preselectedWorkspaces) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties =
             DialogProperties(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -78,12 +78,16 @@ fun ContextMenu(
     onDismissRequest: () -> Unit,
 ) {
     val heavyweight = OverlayConfig.heavyweightPopup
-    if (OverlayConfig.useHeavyweightPopups && heavyweight != null) {
+    if (routeOverlayHeavyweight(heavyweight != null) && heavyweight != null) {
         // HARDWARE_ACCELERATED browser: a lightweight Compose Popup renders BEHIND the
         // browser's native surface, so a right-click menu over a page would be hidden by
         // the page it belongs to. Route it through a heavyweight window instead. Dormant
         // wherever OFF_SCREEN is the mode (macOS, Linux) - the flag is false there, so
         // this branch is never taken and those platforms keep the exact Popup below.
+        //
+        // Also dormant in a window with no browser surface (Settings): the heavyweight window
+        // is sized to LocalAwtWindow, which is still the MAIN window there, so its scrim would
+        // land over the wrong window. See routeOverlayHeavyweight.
         //
         // NOTE: [alignment] is not honoured on this path - the heavyweight window positions
         // from the cursor, not from an alignment within a parent layout. No caller passes a

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -4,6 +4,7 @@ import ContextMenuBackground
 import ContextMenuBorder
 import ContextMenuHover
 import ai.rever.boss.platform.ContextMenuHandler
+import ai.rever.boss.plugin.ui.BossPopupAnchoring
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
@@ -28,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
@@ -94,7 +96,10 @@ fun ContextMenu(
         // non-default today, so this is latent rather than a live bug, but a caller that did
         // would get different placement per platform. Honouring it means teaching
         // HeavyweightPopup about window-space anchors first.
-        heavyweight(onDismissRequest, offset, true) {
+        // Cursor anchoring: a context menu is opened by a click, so the pointer IS the intended
+        // position and no window-space conversion is needed. IntRect.Zero because this path never
+        // consults the anchor.
+        heavyweight(onDismissRequest, IntRect.Zero, BossPopupAnchoring.Cursor, offset, true) {
             ContextMenuContent(
                 items = items,
                 modifier = modifier,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/DraggingItemOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/DraggingItemOverlay.kt
@@ -3,7 +3,6 @@ package ai.rever.boss.components.overlays
 import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
@@ -11,8 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
+
+/** The ghost icon's size. Shared with the ghost's own window, which must match it exactly. */
+private val GHOST_ICON_SIZE = 22.dp
 
 // Overlay composable to draw the ghost item following the pointer
 @Composable
@@ -29,22 +32,27 @@ fun BossDraggableComponent.DraggingItemOverlay() {
         val currentPosition = startPosition + delta
 
         // Calculate the offset to center the ghost icon on the pointer
-        val iconSizePx = with(LocalDensity.current) { 22.dp.toPx() }
+        val iconSizePx = with(LocalDensity.current) { GHOST_ICON_SIZE.toPx() }
         val centeredOffset = Offset(currentPosition.x - iconSizePx / 2, currentPosition.y - iconSizePx / 2)
 
-        Box(
-            modifier =
-                Modifier
-                    // Position the ghost based on calculated absolute position, centered
-                    .offset { centeredOffset.round() }
-                    .alpha(0.7f), // Apply transparency
+        // Under HARDWARE the browser's native surface paints over the Compose scene, so this ghost
+        // disappeared as soon as the drag crossed a page. OverlayGhost gives it its own
+        // cursor-tracking window there; on OFF_SCREEN it is the same offset Box as before.
+        OverlayGhost(
+            size = DpSize(GHOST_ICON_SIZE, GHOST_ICON_SIZE),
+            // Position the ghost based on calculated absolute position, centered
+            windowOffset = { centeredOffset.round() },
         ) {
-            Icon(
-                imageVector = item.icon,
-                contentDescription = null, // Decorative
-                modifier = Modifier.size(22.dp), // Match icon size
-                tint = BossTheme.colors.textPrimary,
-            )
+            Box(
+                modifier = Modifier.alpha(0.7f), // Apply transparency
+            ) {
+                Icon(
+                    imageVector = item.icon,
+                    contentDescription = null, // Decorative
+                    modifier = Modifier.size(GHOST_ICON_SIZE), // Match icon size
+                    tint = BossTheme.colors.textPrimary,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.DialogProperties
 
 /**
  * Routing for app overlays (context menus, dropdowns) so they can render correctly above a
@@ -72,6 +73,7 @@ object OverlayConfig {
      */
     var heavyweightModal: (
         @Composable (
+            properties: DialogProperties,
             onDismissRequest: () -> Unit,
             content: @Composable () -> Unit,
         ) -> Unit

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -1,25 +1,36 @@
 package ai.rever.boss.components.overlays
 
+import ai.rever.boss.plugin.ui.BossOverlayHost
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
+import ai.rever.boss.plugin.ui.shouldRouteHeavyweight
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
 
 /**
  * Routing for app overlays (context menus, dropdowns) so they can render correctly above a
  * HEAVYWEIGHT browser surface when JxBrowser runs in HARDWARE_ACCELERATED mode.
  *
- * On OFF_SCREEN (the macOS/Linux default) the browser is lightweight, so ordinary Compose `Popup`s
- * layer correctly and [useHeavyweightPopups] stays false — nothing changes. When the desktop entry
- * point detects HARDWARE_ACCELERATED mode (the Windows default, see
- * `JxBrowserConfig.renderingMode`) it sets [useHeavyweightPopups] = true and injects the renderers
- * below. This indirection keeps the platform-specific window code in desktopMain while letting
- * common UI opt into it without an expect/actual.
+ * On OFF_SCREEN the browser is lightweight, so ordinary Compose `Popup`s layer correctly and
+ * [useHeavyweightPopups] stays false — nothing changes. When the desktop entry point detects
+ * HARDWARE_ACCELERATED mode (see `JxBrowserConfig.renderingMode`) it sets [useHeavyweightPopups] =
+ * true and injects the renderers below. This indirection keeps the platform-specific window code in
+ * desktopMain while letting common UI opt into it without an expect/actual.
  *
  * Ported from BossConsoleLite, where HARDWARE was defaulted first and the Windows fleet hit the
  * regressions this fixes. Why the mode changed at all:
  * benchmarks/speedometer/win/WINDOWS.md.
+ *
+ * **MODALS live in [BossOverlayHost], not here.** Dynamic plugins draw dialogs too, and they cannot
+ * see this module - they compile against `ai.rever.boss.plugin.ui`. So the modal registry moved down
+ * into plugin-ui-core and the three modal-related properties below are now forwarding accessors, so
+ * that the host and every plugin share one switch, one renderer and one popup counter rather than
+ * two sets that can disagree. Popups, tooltips, HUDs and drag ghosts stay host-only.
  */
 object OverlayConfig {
     /**
@@ -29,9 +40,14 @@ object OverlayConfig {
      * enough. Composables read it directly, and it is NOT snapshot state — flipping it at runtime
      * would not recompose anything that is already on screen. If a runtime toggle is ever wanted,
      * this has to become a `mutableStateOf` first.
+     *
+     * Forwards to [BossOverlayHost.useHeavyweightOverlays] so plugins see the same value.
      */
-    @Volatile
-    var useHeavyweightPopups: Boolean = false
+    var useHeavyweightPopups: Boolean
+        get() = BossOverlayHost.useHeavyweightOverlays
+        set(value) {
+            BossOverlayHost.useHeavyweightOverlays = value
+        }
 
     /**
      * Platform-injected heavyweight popup renderer. Renders [content] in a separate always-on-top
@@ -48,17 +64,22 @@ object OverlayConfig {
     )? = null
 
     /**
-     * Platform-injected heavyweight MODAL renderer — for centered, full-window dialogs (e.g. the
-     * new-tab dialog) rather than cursor-anchored menus. Renders [content] in a separate
-     * always-on-top window matching the parent window's bounds. Null until injected; callers fall
-     * back to a normal centered Popup.
+     * Platform-injected heavyweight MODAL renderer — for centered, full-window dialogs rather than
+     * cursor-anchored menus. Renders [content] in a separate always-on-top window matching the
+     * parent window's bounds.
+     *
+     * Forwards to [BossOverlayHost.modalRenderer]; `BossDialog` is what reads it.
      */
     var heavyweightModal: (
         @Composable (
             onDismissRequest: () -> Unit,
             content: @Composable () -> Unit,
         ) -> Unit
-    )? = null
+    )?
+        get() = BossOverlayHost.modalRenderer
+        set(value) {
+            BossOverlayHost.modalRenderer = value
+        }
 
     /**
      * Platform-injected heavyweight TOOLTIP renderer — shows a short text tooltip in a tiny,
@@ -74,6 +95,37 @@ object OverlayConfig {
     var hideHeavyweightTooltip: (() -> Unit)? = null
 
     /**
+     * Platform-injected heavyweight HUD renderer - a parent-sized, transparent, **non-focusable**
+     * window that places [content] at [alignment] with no scrim and no dismissal of its own.
+     *
+     * Separate from [heavyweightModal] because a HUD is not a modal: the Ctrl+Tab switcher is up
+     * only while a key is held, so the window must not take focus (that would cut off the very key
+     * stream driving it) and must not dismiss on focus loss. Null until injected; callers fall back
+     * to drawing in place.
+     */
+    var heavyweightHud: (
+        @Composable (
+            alignment: Alignment,
+            content: @Composable () -> Unit,
+        ) -> Unit
+    )? = null
+
+    /**
+     * Platform-injected heavyweight GHOST renderer - a **content-sized**, non-focusable window of
+     * [size] that follows the cursor, offset by a gap so the pointer never lands on it.
+     *
+     * The gap is load-bearing rather than cosmetic: the JVM has no portable click-through, so a
+     * ghost sitting under the cursor would swallow the drag that is moving it. Null until injected;
+     * callers fall back to drawing in place.
+     */
+    var heavyweightGhost: (
+        @Composable (
+            size: DpSize,
+            content: @Composable () -> Unit,
+        ) -> Unit
+    )? = null
+
+    /**
      * How many heavyweight POPUP windows are currently open.
      *
      * Exists so a heavyweight MODAL can tell "the user clicked away" from "a child overlay of mine
@@ -84,34 +136,73 @@ object OverlayConfig {
      *
      * Maintained by [ai.rever.boss.components.overlays.HeavyweightPopup] for its own lifetime and
      * read by the modal before it acts on focus loss. Only ever touched on the UI thread, so a
-     * plain Int is enough; it is @Volatile for the same safe-publication reason as
-     * [useHeavyweightPopups].
+     * plain Int is enough.
+     *
+     * Forwards to [BossOverlayHost.openHeavyweightPopups]: a plugin's dialog can host a host-drawn
+     * context menu, so the counter has to be the same one on both sides.
      */
-    @Volatile
-    var openHeavyweightPopups: Int = 0
+    var openHeavyweightPopups: Int
+        get() = BossOverlayHost.openHeavyweightPopups
+        set(value) {
+            BossOverlayHost.openHeavyweightPopups = value
+        }
 }
 
 /**
- * A modal overlay (full-window scrim + centered content) that layers correctly above the browser.
- * In HARDWARE_ACCELERATED mode (useHeavyweightPopups) it routes through the injected heavyweight
- * window; otherwise it's an ordinary centered Popup. Drop-in replacement for a centered modal
- * Popup — [content] keeps drawing its own scrim/centering exactly as before.
+ * Whether an overlay with a [hasRenderer] renderer should escape into its own window here.
+ *
+ * One helper for every non-modal overlay in the host, sharing [shouldRouteHeavyweight] with
+ * `BossDialog` so the rule cannot drift between them. The [LocalHeavyweightOverlays] half is the
+ * part that is easy to forget: without it a right-click menu or a status card opened from the
+ * Settings window routes into a window sized to the MAIN window, and lands over the wrong one.
  */
 @Composable
-fun OverlayModal(
-    onDismissRequest: () -> Unit,
+internal fun routeOverlayHeavyweight(hasRenderer: Boolean): Boolean =
+    shouldRouteHeavyweight(
+        useHeavyweightOverlays = OverlayConfig.useHeavyweightPopups,
+        hasRenderer = hasRenderer,
+        hostNeedsHeavyweight = LocalHeavyweightOverlays.current,
+    )
+
+/**
+ * A transient status card (the Ctrl+Tab switcher) placed at [alignment], layered above the browser.
+ *
+ * Not a modal: it takes no focus, draws no scrim and has no dismissal of its own - it is shown for
+ * exactly as long as the caller composes it. On the lightweight path that is a plain aligned `Box`
+ * in the calling scope, which is what this used to be unconditionally.
+ */
+@Composable
+fun BoxScope.OverlayHud(
+    alignment: Alignment,
     content: @Composable () -> Unit,
 ) {
-    val hw = OverlayConfig.heavyweightModal
-    if (OverlayConfig.useHeavyweightPopups && hw != null) {
-        hw(onDismissRequest, content)
+    val hw = OverlayConfig.heavyweightHud
+    if (routeOverlayHeavyweight(hw != null) && hw != null) {
+        hw(alignment) { content() }
     } else {
-        Popup(
-            alignment = Alignment.Center,
-            onDismissRequest = onDismissRequest,
-            properties = PopupProperties(focusable = true),
-        ) {
-            content()
-        }
+        Box(modifier = Modifier.align(alignment)) { content() }
+    }
+}
+
+/**
+ * A drag ghost of [size] following the pointer, layered above the browser.
+ *
+ * [windowOffset] positions it on the lightweight path, in the calling layout's coordinates, exactly
+ * as the ghosts did before. The heavyweight path ignores it and reads the cursor directly: the
+ * ghost's own window has to be placed in SCREEN coordinates, and converting from a Compose offset
+ * means going through the content pane rather than the window (via the window it is off by the
+ * title-bar height), which reading the cursor avoids entirely.
+ */
+@Composable
+fun OverlayGhost(
+    size: DpSize,
+    windowOffset: () -> IntOffset,
+    content: @Composable () -> Unit,
+) {
+    val hw = OverlayConfig.heavyweightGhost
+    if (routeOverlayHeavyweight(hw != null) && hw != null) {
+        hw(size) { content() }
+    } else {
+        Box(modifier = Modifier.offset { windowOffset() }) { content() }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.ui.BossOverlayHost
+import ai.rever.boss.plugin.ui.BossPopupAnchoring
 import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
 import ai.rever.boss.plugin.ui.shouldRouteHeavyweight
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -58,6 +60,8 @@ object OverlayConfig {
     var heavyweightPopup: (
         @Composable (
             onDismissRequest: () -> Unit,
+            anchorInWindow: IntRect,
+            anchoring: BossPopupAnchoring,
             offset: IntOffset,
             focusable: Boolean,
             content: @Composable () -> Unit,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -62,7 +62,11 @@ object OverlayConfig {
             focusable: Boolean,
             content: @Composable () -> Unit,
         ) -> Unit
-    )? = null
+    )?
+        get() = BossOverlayHost.popupRenderer
+        set(value) {
+            BossOverlayHost.popupRenderer = value
+        }
 
     /**
      * Platform-injected heavyweight MODAL renderer — for centered, full-window dialogs rather than

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/TabDraggingOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/TabDraggingOverlay.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -24,9 +23,14 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+
+/** The ghost card's size. Shared with the ghost's own window, which must match it exactly. */
+private val GHOST_WIDTH = 180.dp
+private val GHOST_HEIGHT = 32.dp
 
 /**
  * Overlay composable to draw a ghost tab following the pointer during drag.
@@ -41,8 +45,8 @@ fun TabDraggableComponent.TabDraggingOverlay() {
 
     // Offset to position the ghost tab with its left edge near the cursor
     val density = LocalDensity.current
-    val tabWidthPx = with(density) { 180.dp.toPx() }
-    val tabHeightPx = with(density) { 32.dp.toPx() }
+    val tabWidthPx = with(density) { GHOST_WIDTH.toPx() }
+    val tabHeightPx = with(density) { GHOST_HEIGHT.toPx() }
 
     // Position slightly offset from cursor so user can see where they're dropping
     val offsetPosition =
@@ -51,66 +55,74 @@ fun TabDraggableComponent.TabDraggingOverlay() {
             currentPosition.y - tabHeightPx / 2,
         )
 
-    Box(
-        modifier =
-            Modifier
-                .offset { IntOffset(offsetPosition.x.toInt(), offsetPosition.y.toInt()) }
-                .shadow(8.dp, RoundedCornerShape(4.dp))
-                .width(180.dp)
-                .height(32.dp)
-                .background(BossTheme.colors.raised.copy(alpha = 0.95f), RoundedCornerShape(4.dp))
-                .border(1.dp, BossTheme.colors.signal, RoundedCornerShape(4.dp))
-                .alpha(0.9f),
+    // OverlayGhost puts the ghost in its own cursor-tracking window under HARDWARE, where the
+    // browser's native surface would otherwise paint over it - so the ghost used to vanish for
+    // exactly the part of the drag that crosses a page. On OFF_SCREEN this is the same offset Box
+    // it has always been.
+    OverlayGhost(
+        size = DpSize(GHOST_WIDTH, GHOST_HEIGHT),
+        windowOffset = { IntOffset(offsetPosition.x.toInt(), offsetPosition.y.toInt()) },
     ) {
-        Row(
+        Box(
             modifier =
                 Modifier
-                    .padding(horizontal = 8.dp)
-                    .align(Alignment.CenterStart),
-            verticalAlignment = Alignment.CenterVertically,
+                    .shadow(8.dp, RoundedCornerShape(4.dp))
+                    .width(GHOST_WIDTH)
+                    .height(GHOST_HEIGHT)
+                    .background(BossTheme.colors.raised.copy(alpha = 0.95f), RoundedCornerShape(4.dp))
+                    .border(1.dp, BossTheme.colors.signal, RoundedCornerShape(4.dp))
+                    .alpha(0.9f),
         ) {
-            // Tab icon
-            when (val icon = dragging.icon) {
-                is ai.rever.boss.plugin.api.TabIcon.Vector -> {
-                    Icon(
-                        imageVector = icon.imageVector,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = BossTheme.colors.textPrimary,
-                    )
+            Row(
+                modifier =
+                    Modifier
+                        .padding(horizontal = 8.dp)
+                        .align(Alignment.CenterStart),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Tab icon
+                when (val icon = dragging.icon) {
+                    is ai.rever.boss.plugin.api.TabIcon.Vector -> {
+                        Icon(
+                            imageVector = icon.imageVector,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = BossTheme.colors.textPrimary,
+                        )
+                    }
+
+                    is ai.rever.boss.plugin.api.TabIcon.Image -> {
+                        Icon(
+                            painter = icon.painter,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = BossTheme.colors.textPrimary,
+                        )
+                    }
+
+                    null -> {
+                        // Use default icon from tabInfo
+                        Icon(
+                            imageVector = dragging.tabInfo.icon,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = BossTheme.colors.textPrimary,
+                        )
+                    }
                 }
 
-                is ai.rever.boss.plugin.api.TabIcon.Image -> {
-                    Icon(
-                        painter = icon.painter,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = BossTheme.colors.textPrimary,
-                    )
-                }
+                Spacer(modifier = Modifier.width(8.dp))
 
-                null -> {
-                    // Use default icon from tabInfo
-                    Icon(
-                        imageVector = dragging.tabInfo.icon,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = BossTheme.colors.textPrimary,
-                    )
-                }
+                // Tab title
+                Text(
+                    text = dragging.title,
+                    color = BossTheme.colors.textPrimary,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
             }
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            // Tab title
-            Text(
-                text = dragging.title,
-                color = BossTheme.colors.textPrimary,
-                fontSize = 12.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f, fill = false),
-            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeyCaptureDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeyCaptureDialog.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.settings.keymap
 
 import ai.rever.boss.keymap.model.KeyBinding
 import ai.rever.boss.keymap.model.ShortcutContext
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.SystemUtils
 import androidx.compose.foundation.background
@@ -23,7 +24,6 @@ import androidx.compose.ui.input.key.*
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 
 /**
  * Dialog for capturing keyboard shortcuts.
@@ -48,7 +48,7 @@ fun KeyCaptureDialog(
         focusRequester.requestFocus()
     }
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Surface(
             modifier =
                 Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeymapImportExport.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/KeymapImportExport.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.settings.keymap
 
 import ai.rever.boss.keymap.KeymapSettingsManager
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -18,7 +19,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.launch
 
 /**
@@ -158,7 +158,7 @@ private fun ExportDialog(onDismiss: () -> Unit) {
     val exportedJson = KeymapSettingsManager.exportToJson()
     var copied by remember { mutableStateOf(false) }
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Surface(
             modifier =
                 Modifier
@@ -253,7 +253,7 @@ private fun ImportDialog(
     var jsonInput by remember { mutableStateOf("") }
     var showError by remember { mutableStateOf(false) }
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Surface(
             modifier =
                 Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/PresetSelector.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/PresetSelector.kt
@@ -2,6 +2,8 @@ package ai.rever.boss.components.settings.keymap
 
 import ai.rever.boss.keymap.model.KeymapSettings
 import ai.rever.boss.keymap.presets.KeymapPresets
+import ai.rever.boss.plugin.ui.BossAlertDialog
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -21,7 +23,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.launch
 
 /**
@@ -183,7 +184,7 @@ private fun PresetMenuDialog(
 ) {
     val presets = KeymapPresets.getAvailablePresets()
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Surface(
             modifier = Modifier.width(450.dp),
             shape = RoundedCornerShape(12.dp),
@@ -289,7 +290,7 @@ private fun ResetConfirmationDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Reset to Default Keymap?", color = BossTheme.colors.textPrimary) },
         text = {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/ShortcutTestDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/settings/keymap/ShortcutTestDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.settings.keymap
 
 import ai.rever.boss.keymap.model.KeymapSettings
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -17,7 +18,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.launch
 
 /**
@@ -59,7 +59,7 @@ fun ShortcutTestDialog(
             )
         }
 
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Surface(
             modifier =
                 Modifier

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/TabCycleOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/TabCycleOverlay.kt
@@ -4,6 +4,7 @@ import ContextMenuBackground
 import ContextMenuBorder
 import ContextMenuHover
 import ai.rever.boss.components.common.rememberFaviconLoader
+import ai.rever.boss.components.overlays.OverlayHud
 import ai.rever.boss.plugin.api.TabIcon
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.ui.BossTheme
@@ -11,6 +12,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -46,12 +48,15 @@ private const val OVERLAY_REVEAL_DELAY_MS = 180L
  * (press-and-release within the delay) doesn't flash the switcher. Renders nothing in
  * positional mode, where [data] stays null.
  *
- * Call this from within a `Box` and pass `Modifier.align(...)` to position the card.
+ * Call this from within a `Box`; [alignment] positions the card in it. The card goes through
+ * [OverlayHud] rather than being drawn straight into the scaffold, because under HARDWARE the
+ * browser's native surface paints over the Compose scene - so the switcher was invisible over a
+ * browser tab, which is exactly when it is used.
  */
 @Composable
-fun TabCycleOverlayHost(
+fun BoxScope.TabCycleOverlayHost(
     data: TabCycleOverlayData?,
-    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
 ) {
     var visible by remember { mutableStateOf(false) }
     LaunchedEffect(data == null) {
@@ -63,7 +68,9 @@ fun TabCycleOverlayHost(
         }
     }
     if (data != null && visible) {
-        TabCycleOverlay(data = data, modifier = modifier)
+        OverlayHud(alignment = alignment) {
+            TabCycleOverlay(data = data)
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/wizard/WizardDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/wizard/WizardDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.wizard
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -31,7 +32,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -80,7 +80,7 @@ fun WizardDialog(
     maxHeight: Dp = 600.dp,
     content: @Composable () -> Unit,
 ) {
-    Dialog(
+    BossDialog(
         onDismissRequest = {
             if (dismissOnClickOutside) {
                 onDismiss()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/ConfigurationDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/ConfigurationDialogs.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.workspaces
 
 import ai.rever.boss.platform.rememberFilePicker
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -29,7 +30,7 @@ fun SaveWorkspaceDialog(
 ) {
     var name by remember { mutableStateOf("") }
 
-    androidx.compose.material.AlertDialog(
+    BossAlertDialog(
         onDismissRequest = onDismiss,
         title = { androidx.compose.material.Text("Save Workspace") },
         text = {
@@ -92,7 +93,7 @@ fun DeleteWorkspaceDialog(
 ) {
     var selectedWorkspace by remember { mutableStateOf<String?>(null) }
 
-    androidx.compose.material.AlertDialog(
+    BossAlertDialog(
         onDismissRequest = onDismiss,
         title = { androidx.compose.material.Text("Delete Workspace") },
         text = {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/DowngradeWarningDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/DowngradeWarningDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.updater
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.Version
 import androidx.compose.foundation.BorderStroke
@@ -14,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 
 /**
  * Warning dialog shown before downgrading to an older version
@@ -26,7 +26,7 @@ fun DowngradeWarningDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    Dialog(onDismissRequest = onDismiss) {
+    BossDialog(onDismissRequest = onDismiss) {
         Card(
             modifier = Modifier.width(500.dp),
             backgroundColor = BossTheme.colors.panel,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateAvailableDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateAvailableDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.updater
 
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -52,7 +53,7 @@ fun UpdateAvailableDialog(
                 .getOrNull()
                 ?.takeIf { it.isNotEmpty() }
         }
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = onLater,
         modifier = Modifier.widthIn(min = 360.dp, max = 480.dp),
         title = {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/VersionSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/VersionSelectionDialog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.updater
 
 import ai.rever.boss.components.common.BossSearchBar
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.Version
 import ai.rever.boss.utils.logging.BossLogger
@@ -21,7 +22,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 private val logger = BossLogger.forComponent("VersionSelectionDialog")
@@ -57,7 +57,7 @@ fun VersionSelectionDialog(
                 }
         }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
@@ -1,0 +1,198 @@
+package ai.rever.boss.components.overlays
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.rememberWindowState
+import java.awt.GraphicsEnvironment
+import java.awt.MouseInfo
+import java.awt.Rectangle
+import java.awt.Toolkit
+
+/**
+ * How far from the cursor the ghost sits - below-right normally, above-left at a screen edge (see
+ * [clampGhostToScreens]).
+ *
+ * NOT cosmetic. A non-focusable AWT window still receives mouse events, and the JVM has no portable
+ * click-through, so a ghost drawn under the pointer would swallow the drag that is moving it and the
+ * drop would never land. The gap keeps the pointer outside the window for the whole drag. It also
+ * matches [SwingTooltip], which places itself off the cursor for the same reason.
+ */
+private const val GHOST_GAP_PX = 16
+
+/**
+ * Heavyweight drag-ghost host for HARDWARE_ACCELERATED browser mode.
+ *
+ * Renders [content] in a small transparent, undecorated, always-on-top, non-focusable window of
+ * [size] that tracks the cursor, so a drag ghost stays visible while it crosses the heavyweight
+ * JxBrowser surface instead of disappearing behind the page. Injected into
+ * [OverlayConfig.heavyweightGhost].
+ *
+ * **Content-sized, not parent-sized**, which is the one hard difference from [HeavyweightHud]. A
+ * parent-sized ghost window would cover the whole app and eat the pointer events that constitute the
+ * drag, ending it the moment it began.
+ *
+ * Position is read from [MouseInfo] on the frame clock rather than from the caller's Compose
+ * coordinates. Two reasons: the cursor is authoritative for something that follows the cursor, and
+ * converting window coordinates to screen coordinates has to go through the CONTENT PANE rather than
+ * the window (via the window it is off by the title-bar height) - a conversion this sidesteps
+ * entirely.
+ */
+@Composable
+fun HeavyweightGhost(
+    size: DpSize,
+    content: @Composable () -> Unit,
+) {
+    val screens = remember { screenRects() }
+    // Place it correctly on the FIRST frame. Leaving the initial position at the origin and letting
+    // the frame loop below correct it shows the ghost at the top-left corner for one frame, which
+    // reads as a flicker at the start of every drag.
+    val initial =
+        remember(size, screens) {
+            val cursor = runCatching { MouseInfo.getPointerInfo()?.location }.getOrNull()
+            clampGhostToScreens(
+                cursorX = cursor?.x ?: 0,
+                cursorY = cursor?.y ?: 0,
+                width = size.width.value.toInt(),
+                height = size.height.value.toInt(),
+                screens = screens,
+            )
+        }
+    val state =
+        rememberWindowState(size = size, position = WindowPosition(initial.first.dp, initial.second.dp))
+
+    // Drive from the frame clock, not from recomposition: the ghost has to keep up with the pointer
+    // whether or not anything it reads has changed, and the caller's drag state lives in a different
+    // subtree. Only assign when the point actually moves - each assignment is a native setLocation,
+    // and a still pointer should cost nothing.
+    LaunchedEffect(size) {
+        var last: Pair<Int, Int>? = initial
+        while (true) {
+            withFrameNanos { }
+            val cursor = runCatching { MouseInfo.getPointerInfo()?.location }.getOrNull() ?: continue
+            val placed =
+                clampGhostToScreens(
+                    cursorX = cursor.x,
+                    cursorY = cursor.y,
+                    width = size.width.value.toInt(),
+                    height = size.height.value.toInt(),
+                    screens = screens,
+                )
+            if (placed != last) {
+                last = placed
+                state.position = WindowPosition(placed.first.dp, placed.second.dp)
+            }
+        }
+    }
+
+    Window(
+        onCloseRequest = {},
+        state = state,
+        undecorated = true,
+        transparent = true,
+        alwaysOnTop = true,
+        focusable = false,
+        resizable = false,
+    ) {
+        EnsureOverlayWindowTransparent(window)
+        Box(modifier = Modifier.fillMaxSize()) {
+            content()
+        }
+    }
+}
+
+/**
+ * Where a ghost of [width] x [height] goes for a cursor at ([cursorX], [cursorY]): offset from the
+ * pointer, and inside the working area of whichever monitor the pointer is on.
+ *
+ * Below-right by default. When that would spill off an edge the ghost **flips to the other side of
+ * the cursor** rather than being pulled back across it - pulling back is what a plain clamp does, and
+ * near the right edge it slides the window under the pointer, which is exactly the state
+ * [GHOST_GAP_PX] exists to prevent. Flipping keeps the pointer outside the ghost on every edge, so
+ * the gap guarantee holds everywhere and not just mid-screen.
+ *
+ * Pure so the placement can be pinned by a test, which is the only part of this reachable without a
+ * display.
+ */
+internal fun clampGhostToScreens(
+    cursorX: Int,
+    cursorY: Int,
+    width: Int,
+    height: Int,
+    screens: List<IntArray>,
+): Pair<Int, Int> {
+    val screen =
+        screens.firstOrNull { it.contains(cursorX, cursorY) }
+            ?: screens.firstOrNull()
+            ?: return Pair(cursorX + GHOST_GAP_PX, cursorY + GHOST_GAP_PX)
+    return Pair(
+        flipOrClamp(cursorX, width, screen[0], screen[2]),
+        flipOrClamp(cursorY, height, screen[1], screen[3]),
+    )
+}
+
+/** Whether this `[x, y, width, height]` rect holds the point ([x], [y]). */
+private fun IntArray.contains(
+    x: Int,
+    y: Int,
+): Boolean = x >= this[0] && x < this[0] + this[2] && y >= this[1] && y < this[1] + this[3]
+
+/**
+ * One axis of the placement: [cursor] + gap, flipped to `cursor - gap - extent` when that does not
+ * fit, and clamped only if NEITHER side does.
+ *
+ * Both candidates are tested against both ends of the range, not just the far one. A cursor that is
+ * outside the monitor entirely - which happens when a display is unplugged mid-drag and the cached
+ * rects no longer describe where the pointer is - otherwise passes the far-edge test trivially and
+ * the ghost is placed thousands of pixels off-screen, invisible for the rest of the drag.
+ *
+ * The final `coerceIn` is the neither-side-fits case, i.e. a ghost bigger than the monitor. It uses
+ * `coerceAtLeast(origin)` on the upper bound because an inverted range makes `coerceIn` throw, and an
+ * exception here would take the whole drag gesture down with it.
+ */
+private fun flipOrClamp(
+    cursor: Int,
+    extent: Int,
+    origin: Int,
+    available: Int,
+): Int {
+    val limit = origin + available
+
+    fun fits(candidate: Int) = candidate >= origin && candidate + extent <= limit
+    val after = cursor + GHOST_GAP_PX
+    val before = cursor - GHOST_GAP_PX - extent
+    return when {
+        fits(after) -> after
+        fits(before) -> before
+        else -> after.coerceIn(origin, (limit - extent).coerceAtLeast(origin))
+    }
+}
+
+/**
+ * Every monitor's working area as `[x, y, width, height]`, i.e. bounds minus insets (taskbar, dock,
+ * menu bar). Read once per ghost: monitors do not come and go mid-drag.
+ */
+private fun screenRects(): List<IntArray> =
+    runCatching {
+        GraphicsEnvironment
+            .getLocalGraphicsEnvironment()
+            .screenDevices
+            .map { device ->
+                val bounds: Rectangle = device.defaultConfiguration.bounds
+                val insets = Toolkit.getDefaultToolkit().getScreenInsets(device.defaultConfiguration)
+                intArrayOf(
+                    bounds.x + insets.left,
+                    bounds.y + insets.top,
+                    bounds.width - insets.left - insets.right,
+                    bounds.height - insets.top - insets.bottom,
+                )
+            }
+    }.getOrDefault(emptyList())

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightHud.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightHud.kt
@@ -1,0 +1,54 @@
+package ai.rever.boss.components.overlays
+
+import ai.rever.boss.plugin.browser.LocalAwtWindow
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.window.Window
+
+/**
+ * Heavyweight HUD host for HARDWARE_ACCELERATED browser mode.
+ *
+ * Renders [content] at [alignment] inside a transparent, undecorated, always-on-top window covering
+ * the parent window, so a transient status card layers ABOVE the heavyweight JxBrowser surface
+ * instead of behind the page. Injected into [OverlayConfig.heavyweightHud]; the Ctrl+Tab MRU
+ * switcher is the caller.
+ *
+ * **`focusable = false` is the whole point, and is what makes this a separate renderer from
+ * [HeavyweightModal].** The switcher exists only while Ctrl is held: the moment this window took
+ * focus, the key stream driving it would go to the overlay instead of the app and the overlay would
+ * never advance or close. For the same reason there is no scrim, no click handling and no
+ * focus-loss dismissal here - the HUD has no dismissal of its own, it is shown exactly as long as
+ * the caller composes it.
+ *
+ * Accepted cost: the window covers the parent while it is up, and a non-focusable AWT window still
+ * receives mouse events (the JVM has no portable click-through), so a click landing during the hold
+ * hits the overlay rather than the app. That window is a keypress long, and the alternative -
+ * sizing to the content - cannot be done without knowing the content's size before composing it.
+ */
+@Composable
+fun HeavyweightHud(
+    alignment: Alignment,
+    content: @Composable () -> Unit,
+) {
+    val parent = LocalAwtWindow.current
+    val bounds = rememberOverlayParentBounds(parent)
+    val state = rememberOverlayWindowState(bounds)
+
+    Window(
+        onCloseRequest = {},
+        state = state,
+        undecorated = true,
+        transparent = true,
+        alwaysOnTop = true,
+        focusable = false,
+        resizable = false,
+    ) {
+        EnsureOverlayWindowTransparent(window)
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = alignment) {
+            content()
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightModal.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightModal.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Window
 
 /**
@@ -40,6 +41,7 @@ import androidx.compose.ui.window.Window
  */
 @Composable
 fun HeavyweightModal(
+    properties: DialogProperties,
     onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -56,7 +58,11 @@ fun HeavyweightModal(
         focusable = true,
         resizable = false,
         onKeyEvent = { event ->
-            if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+            // dismissOnBackPress is what Compose maps Escape to, and only this window can honour it:
+            // Escape is handled here, not by anything inside the content. A caller that passed
+            // dismissOnBackPress = false used to get an Escape-proof dialog on the lightweight path
+            // and an Escape-dismissable one here.
+            if (properties.dismissOnBackPress && event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
                 onDismissRequest()
                 true
             } else {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -131,6 +132,7 @@ fun HeavyweightPopup(
 
         ScrimmedContent(
             contentOffset = contentOffset,
+            anchorWidthDp = if (anchoring == BossPopupAnchoring.AnchorBounds) anchorInWindow.width else null,
             windowWidth = bounds?.get(2),
             windowHeight = bounds?.get(3),
             onDismissRequest = onDismissRequest,
@@ -193,6 +195,13 @@ private fun DismissOnFocusLoss(
 @Composable
 private fun ScrimmedContent(
     contentOffset: IntOffset,
+    /**
+     * Width to IMPOSE on the content, for an anchored popup. Distinct from the local
+     * `contentWidthDp` below, which is the width the content MEASURED at - naming both the same
+     * shadowed this parameter, so the content was constrained to the width it already had (the whole
+     * overlay window) and anchored popups stayed full-width no matter what the anchor reported.
+     */
+    anchorWidthDp: Int?,
     windowWidth: Int?,
     windowHeight: Int?,
     onDismissRequest: () -> Unit,
@@ -251,7 +260,18 @@ private fun ScrimmedContent(
             modifier =
                 Modifier
                     .absoluteOffset(x = clamped.x.dp, y = clamped.y.dp)
-                    .onGloballyPositioned { contentSize = it.size }
+                    // An anchored popup is given its anchor's width, so a caller that wrote
+                    // fillMaxWidth() against its own layout still means that and not the width of
+                    // the whole overlay window - which is what it would otherwise inherit, since
+                    // this window covers the parent. The URL-bar suggestion list stretched edge to
+                    // edge without this.
+                    .then(
+                        if (anchorWidthDp != null && anchorWidthDp > 0) {
+                            Modifier.width(anchorWidthDp.dp)
+                        } else {
+                            Modifier
+                        },
+                    ).onGloballyPositioned { contentSize = it.size }
                     // Swallow clicks that land on the menu's own background or padding. Without
                     // this they fall through to the scrim and dismiss the menu out from under a
                     // user who was aiming at an item.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
+import ai.rever.boss.plugin.ui.BossPopupAnchoring
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -20,6 +21,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
@@ -58,6 +60,8 @@ import androidx.compose.ui.window.Window
 @Composable
 fun HeavyweightPopup(
     onDismissRequest: () -> Unit,
+    anchorInWindow: IntRect,
+    anchoring: BossPopupAnchoring,
     offset: IntOffset,
     focusable: Boolean,
     content: @Composable () -> Unit,
@@ -83,7 +87,23 @@ fun HeavyweightPopup(
     val state = rememberOverlayWindowState(bounds)
 
     // Where the content sits INSIDE the overlay window.
-    val contentOffset = contentOffsetFor(cursor?.x, cursor?.y, offset, bounds?.get(0), bounds?.get(1))
+    //
+    // The overlay window is placed at the parent FRAME's origin, while Compose measures
+    // anchorInWindow against the CONTENT PANE. On a decorated window those differ by the title bar,
+    // so an anchored popup placed without this correction sits too high by exactly that much - the
+    // same off-by-a-title-bar that the pinch-zoom gate had to solve. Read the inset from the content
+    // pane rather than assuming a value.
+    val contentInset = remember(parent) { contentPaneInset(parent) }
+    val contentOffset =
+        when (anchoring) {
+            BossPopupAnchoring.AnchorBounds -> {
+                anchoredContentOffset(anchorInWindow, contentInset.first, contentInset.second)
+            }
+
+            BossPopupAnchoring.Cursor -> {
+                contentOffsetFor(cursor?.x, cursor?.y, offset, bounds?.get(0), bounds?.get(1))
+            }
+        }
 
     Window(
         onCloseRequest = onDismissRequest,
@@ -282,3 +302,32 @@ internal fun contentOffsetFor(
     } else {
         anchor
     }
+
+/**
+ * Where an [BossPopupAnchoring.AnchorBounds] popup sits inside the overlay window: directly below the
+ * anchor, shifted by the parent's content-pane inset.
+ *
+ * Pure so the correction can be pinned by a test, because getting it wrong is invisible in code review
+ * and shows up as a popup floating a title-bar's height away from the control it belongs to.
+ */
+internal fun anchoredContentOffset(
+    anchorInWindow: IntRect,
+    insetX: Int,
+    insetY: Int,
+): IntOffset = IntOffset(anchorInWindow.left + insetX, anchorInWindow.bottom + insetY)
+
+/**
+ * The parent's content-pane origin relative to its frame origin, as `(dx, dy)`.
+ *
+ * Zero when the window is undecorated, has no content pane, or cannot be measured - all of which are
+ * the "no correction needed" answer rather than an error, so this stays quiet. `locationOnScreen`
+ * throws for a window that is not showing, hence the runCatching.
+ */
+private fun contentPaneInset(parent: java.awt.Window?): Pair<Int, Int> {
+    val pane = (parent as? javax.swing.RootPaneContainer)?.contentPane ?: return 0 to 0
+    return runCatching {
+        val frameAt = parent.locationOnScreen
+        val paneAt = pane.locationOnScreen
+        (paneAt.x - frameAt.x) to (paneAt.y - frameAt.y)
+    }.getOrDefault(0 to 0)
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/GenericDialogHost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/GenericDialogHost.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin.providers
 
 import ai.rever.boss.plugin.api.DialogButton
 import ai.rever.boss.plugin.api.DialogChoiceItem
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -93,7 +94,7 @@ private fun TextInputDialog(request: DialogRequest.TextInput) {
         focusRequester.requestFocus()
     }
 
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = { request.result.complete(null) },
         title = { Text(request.title) },
         text = {
@@ -151,7 +152,7 @@ private fun TextInputDialog(request: DialogRequest.TextInput) {
 
 @Composable
 private fun ConfirmationDialog(request: DialogRequest.Confirmation) {
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = { request.result.complete(false) },
         title = { Text(request.title) },
         text = { Text(request.message) },
@@ -182,7 +183,7 @@ private fun ConfirmationDialog(request: DialogRequest.Confirmation) {
 private fun SingleChoiceDialog(request: DialogRequest.SingleChoice) {
     var selectedIndex by remember { mutableStateOf(request.selectedIndex) }
 
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = { request.result.complete(null) },
         title = { Text(request.title) },
         text = {
@@ -253,7 +254,7 @@ private fun MultiChoiceDialog(request: DialogRequest.MultiChoice) {
         selectedItems.addAll(request.choices.filter { it.isSelected }.map { it.id })
     }
 
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = { request.result.complete(null) },
         title = { Text(request.title) },
         text = {
@@ -333,7 +334,7 @@ private fun MultiChoiceDialog(request: DialogRequest.MultiChoice) {
 
 @Composable
 private fun AlertDialogWrapper(request: DialogRequest.Alert) {
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = { request.result.complete(Unit) },
         title = { Text(request.title) },
         text = { Text(request.message) },
@@ -347,7 +348,7 @@ private fun AlertDialogWrapper(request: DialogRequest.Alert) {
 
 @Composable
 private fun ThreeButtonDialog(request: DialogRequest.ThreeButton) {
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = { request.result.complete(DialogButton.CANCELLED) },
         title = { Text(request.title) },
         text = { Text(request.message) },
@@ -378,7 +379,7 @@ private fun ProgressDialog(request: DialogRequest.Progress) {
     val progress by request.handle.progress.collectAsState()
     val message by request.handle.message.collectAsState()
 
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = {
             if (request.cancellable) {
                 request.handle.cancel()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/remote/RemoteWidgetRenderer.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.components.plugin.remote
 
+import ai.rever.boss.components.overlays.ContextMenu
+import ai.rever.boss.components.overlays.ContextMenuItem
 import ai.rever.boss.plugin.ui.BossColorScheme
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.ui.sdk.*
@@ -225,15 +227,22 @@ private fun RenderNode(
                     text = selected,
                     modifier = Modifier.clickable { expanded = true },
                 )
-                DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                    options.forEachIndexed { index, option ->
-                        DropdownMenuItem(onClick = {
-                            expanded = false
-                            onEvent(node.id, WidgetEvent.Selection(option, index))
-                        }) {
-                            Text(option)
-                        }
-                    }
+                // ContextMenu, not Material's DropdownMenu: this renders in the main window, where
+                // under HARDWARE the browser's native surface paints over the Compose scene. A
+                // DropdownMenu is a lightweight Popup and opened behind the page; ContextMenu
+                // routes through the heavyweight popup window. Material gives no injection point,
+                // so the widget has to change rather than the menu.
+                if (expanded) {
+                    ContextMenu(
+                        items =
+                            options.mapIndexed { index, option ->
+                                ContextMenuItem(
+                                    text = option,
+                                    onClick = { onEvent(node.id, WidgetEvent.Selection(option, index)) },
+                                )
+                            },
+                        onDismissRequest = { expanded = false },
+                    )
                 }
             }
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultBrowserSection.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultBrowserSection.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.settings.sections
 
 import ai.rever.boss.components.settings.shared.SettingsSection
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.DefaultBrowserManager
 import androidx.compose.foundation.BorderStroke
@@ -299,7 +300,7 @@ fun DefaultBrowserSection() {
 
     // Success Dialog
     if (showSuccessDialog) {
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { showSuccessDialog = false },
             title = {
                 Text(
@@ -328,7 +329,7 @@ fun DefaultBrowserSection() {
 
     // Instructions Dialog (platform-aware)
     if (showInstructionsDialog) {
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { showInstructionsDialog = false },
             title = {
                 Text(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/FluckBrowserSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/FluckBrowserSettings.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.components.settings.shared.SettingsTheme.TextSecondary
 import ai.rever.boss.components.settings.shared.SettingsToggle
 import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.BrowserSettingsManager
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.terminal.ExistingSplitTargetMode
 import ai.rever.boss.terminal.TerminalLinkOpenMode
 import ai.rever.boss.terminal.TerminalLinkSettingsManager
@@ -335,7 +336,7 @@ fun FluckBrowserSettings() {
 
     // Restart dialog
     if (showRestartDialog) {
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { showRestartDialog = false },
             title = {
                 Text(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/ProfileManagementSection.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/ProfileManagementSection.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.settings.sections
 import ai.rever.boss.components.settings.shared.SettingsSection
 import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.BrowserSettingsManager
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -159,7 +160,7 @@ fun ProfileManagementSection(
 
     // New Profile Dialog
     if (showNewProfileDialog) {
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = {
                 showNewProfileDialog = false
                 newProfileName = ""

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SecuritySettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SecuritySettings.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.settings.sections
 
 import ai.rever.boss.components.settings.shared.SettingsSection
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.services.passkey.PasskeyInfo
 import ai.rever.boss.services.passkey.PasskeyState
@@ -644,7 +645,7 @@ fun SecuritySettings() {
 
     // Show remove passkey confirmation dialog
     showRemovePasskeyDialog?.let { passkey ->
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { showRemovePasskeyDialog = null },
             title = {
                 Text(
@@ -775,7 +776,7 @@ private fun PasskeyEnrollmentDialog(
     var isEnrolling by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
-    AlertDialog(
+    BossAlertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
@@ -16,7 +16,9 @@ import ai.rever.boss.components.settings.sidebar.SettingsSidebar
 import ai.rever.boss.config.BrowserEngineSettingsManager
 import ai.rever.boss.focusmode.FocusModeSettingsManager
 import ai.rever.boss.performance.PerformanceSettingsManager
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossThemeController
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
 import ai.rever.boss.run.RunnerSettingsManager
 import ai.rever.boss.scrollbar.ScrollbarSettingsManager
 import ai.rever.boss.startup.StartupSettingsManager
@@ -61,8 +63,18 @@ actual fun SettingsWindow(
                     position = WindowPosition.Aligned(Alignment.Center),
                 ),
         ) {
-            BossTheme {
-                SettingsContent(initialSection = initialSection)
+            // Opt this window's dialogs back OUT of heavyweight overlays.
+            //
+            // SettingsWindow is composed from inside the main window's subtree (BossAppDialogs), so
+            // it inherits LocalHeavyweightOverlays = true from BossWindow. There is no browser
+            // surface here to escape, and routing anyway would be actively wrong: the heavyweight
+            // window measures LocalAwtWindow, which is still the MAIN window, so a settings dialog
+            // would open centered over the main window and - being always-on-top, and deliberately
+            // not dismissed by focus moving within the same application - keep floating above it.
+            CompositionLocalProvider(LocalHeavyweightOverlays provides false) {
+                BossTheme {
+                    SettingsContent(initialSection = initialSection)
+                }
             }
         }
     }
@@ -172,7 +184,7 @@ private fun SettingsContent(initialSection: String? = null) {
 
     // Reset confirmation dialog
     if (showResetConfirmation) {
-        AlertDialog(
+        BossAlertDialog(
             onDismissRequest = { showResetConfirmation = false },
             title = {
                 Text(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -418,9 +418,9 @@ fun main(args: Array<String>) {
             ai.rever.boss.components.overlays
                 .HeavyweightPopup(onDismiss, popupOffset, focusable, popupContent)
         }
-    ai.rever.boss.components.overlays.OverlayConfig.heavyweightModal = { onDismiss, modalContent ->
+    ai.rever.boss.components.overlays.OverlayConfig.heavyweightModal = { properties, onDismiss, modalContent ->
         ai.rever.boss.components.overlays
-            .HeavyweightModal(onDismiss, modalContent)
+            .HeavyweightModal(properties, onDismiss, modalContent)
     }
     ai.rever.boss.components.overlays.OverlayConfig.heavyweightTooltip = { text ->
         ai.rever.boss.components.overlays.SwingTooltip

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -414,9 +414,9 @@ fun main(args: Array<String>) {
     // unchanged platforms cannot regress. See JxBrowserConfig.renderingMode and
     // benchmarks/speedometer/win/WINDOWS.md.
     ai.rever.boss.components.overlays.OverlayConfig.heavyweightPopup =
-        { onDismiss, popupOffset, focusable, popupContent ->
+        { onDismiss, anchorInWindow, anchoring, popupOffset, focusable, popupContent ->
             ai.rever.boss.components.overlays
-                .HeavyweightPopup(onDismiss, popupOffset, focusable, popupContent)
+                .HeavyweightPopup(onDismiss, anchorInWindow, anchoring, popupOffset, focusable, popupContent)
         }
     ai.rever.boss.components.overlays.OverlayConfig.heavyweightModal = { properties, onDismiss, modalContent ->
         ai.rever.boss.components.overlays

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -430,6 +430,21 @@ fun main(args: Array<String>) {
         ai.rever.boss.components.overlays.SwingTooltip
             .hide()
     }
+    ai.rever.boss.components.overlays.OverlayConfig.heavyweightHud = { alignment, hudContent ->
+        ai.rever.boss.components.overlays
+            .HeavyweightHud(alignment, hudContent)
+    }
+    ai.rever.boss.components.overlays.OverlayConfig.heavyweightGhost = { size, ghostContent ->
+        ai.rever.boss.components.overlays
+            .HeavyweightGhost(size, ghostContent)
+    }
+    // plugin-ui-core owns the modal registry (plugins draw dialogs too) and depends on nothing but
+    // Compose, so it cannot log. Give it this logger instead: the condition it reports is a dialog
+    // that silently fell back to lightweight and is now hidden behind the page, which is invisible
+    // on screen and would otherwise have to be diagnosed from a screenshot.
+    ai.rever.boss.plugin.ui.BossOverlayHost.diagnostics = { message ->
+        logger.warn(LogCategory.UI, message)
+    }
     ai.rever.boss.components.overlays.OverlayConfig.useHeavyweightPopups =
         ai.rever.boss.config.JxBrowserConfig.renderingMode ==
         com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ScreenCapturePickerDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/ScreenCapturePickerDialog.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.cache.loadHighQualityFavicon
 import ai.rever.boss.components.common.rememberFaviconLoader
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.plugin.api.TabIcon
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -33,7 +34,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.teamdev.jxbrowser.capture.AudioCaptureMode
 
@@ -62,7 +62,7 @@ fun ScreenCapturePickerDialog(
     var selectedSource by remember { mutableStateOf<ScreenCaptureNotifier.CaptureSourceItem?>(null) }
     var includeAudio by remember { mutableStateOf(true) }
 
-    Dialog(
+    BossDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(dismissOnClickOutside = true, dismissOnBackPress = true),
     ) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -13,8 +13,10 @@ import ai.rever.boss.plugin.browser.FluckEngine
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.plugin.browser.ScreenCaptureNotifier
 import ai.rever.boss.plugin.browser.ScreenCapturePickerDialog
+import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.plugin.ui.BossThemeController
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
 import ai.rever.boss.services.terminal.TerminalAPIAccess
 import ai.rever.boss.updater.UpdateCoordinator
 import ai.rever.boss.utils.CLIInstaller
@@ -26,7 +28,6 @@ import ai.rever.boss.window.WindowType
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
@@ -900,7 +901,15 @@ fun ApplicationScope.BossWindow(
 
         // Provide the AWT window via LocalAwtWindow for multi-window support
         // This ensures JxBrowser instances get the correct window handle for their containing window
-        CompositionLocalProvider(LocalAwtWindow provides window) {
+        //
+        // LocalHeavyweightOverlays marks this as a window that HOSTS a browser surface, which is
+        // what makes its dialogs escape into always-on-top windows under HARDWARE. It is provided
+        // here rather than defaulted on, because secondary windows (Settings) are composed from
+        // inside this subtree and must opt back out - see SettingsWindow.
+        CompositionLocalProvider(
+            LocalAwtWindow provides window,
+            LocalHeavyweightOverlays provides true,
+        ) {
             // Create independent component context for this window
             // Each window gets its own Decompose context tree
             with(createBossAppContext) {
@@ -942,7 +951,7 @@ fun ApplicationScope.BossWindow(
         if (showResetBrowserDialog) {
             var isResetting by remember { mutableStateOf(false) }
 
-            AlertDialog(
+            BossAlertDialog(
                 onDismissRequest = {
                     if (!isResetting) {
                         showResetBrowserDialog = false
@@ -1061,7 +1070,7 @@ fun ApplicationScope.BossWindow(
         if (showResetTerminalDialog) {
             var isResetting by remember { mutableStateOf(false) }
 
-            AlertDialog(
+            BossAlertDialog(
                 onDismissRequest = {
                     if (!isResetting) {
                         showResetTerminalDialog = false
@@ -1213,7 +1222,7 @@ fun ApplicationScope.BossWindow(
         // Screen Recording permission rationale — explains why, before the macOS prompt.
         val permissionRationale by ScreenCaptureNotifier.permissionRationale.collectAsState()
         if (permissionRationale != null) {
-            AlertDialog(
+            BossAlertDialog(
                 onDismissRequest = { ScreenCaptureNotifier.resolvePermissionRationale(false) },
                 title = { Text("Allow screen sharing?") },
                 text = {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/BossAlertDialogComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/BossAlertDialogComposeTest.kt
@@ -1,0 +1,124 @@
+package ai.rever.boss.components.overlays
+
+import ai.rever.boss.plugin.ui.BossAlertDialog
+import ai.rever.boss.plugin.ui.BossOverlayHost
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What [BossAlertDialog] has to keep doing after replacing Material 2's `AlertDialog`.
+ *
+ * Material's own body could not be reused - `AlertDialogContent` and its baseline layout are
+ * `internal`, and the desktop `dialogProvider` hook that once allowed injecting a container was
+ * removed - so the card is rebuilt here from the design-system tokens. That makes it OUR layout, and
+ * 25 host call sites now depend on it presenting the same three regions Material did. These tests
+ * pin exactly that contract: title, text, and both buttons all reach the screen, and each button
+ * still invokes its own lambda.
+ *
+ * Deliberately on the LIGHTWEIGHT path. The heavyweight path is a separate always-on-top OS window,
+ * which a Compose test scene has no way to host; which of the two is chosen is pinned separately and
+ * without a display by `BossDialogRoutingTest`.
+ */
+class BossAlertDialogComposeTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private var savedUseHeavyweight = false
+
+    @Before
+    fun forceLightweightPath() {
+        savedUseHeavyweight = BossOverlayHost.useHeavyweightOverlays
+        BossOverlayHost.useHeavyweightOverlays = false
+    }
+
+    @After
+    fun restoreOverlayMode() {
+        BossOverlayHost.useHeavyweightOverlays = savedUseHeavyweight
+    }
+
+    @Test
+    fun `title, text and both buttons are all shown`() {
+        rule.setContent {
+            BossAlertDialog(
+                onDismissRequest = {},
+                title = { Text("Reset Browser") },
+                text = { Text("This clears cookies and cache.") },
+                dismissButton = { TextButton(onClick = {}) { Text("Cancel") } },
+                confirmButton = { TextButton(onClick = {}) { Text("Reset") } },
+            )
+        }
+
+        rule.onNodeWithText("Reset Browser").assertIsDisplayed()
+        rule.onNodeWithText("This clears cookies and cache.").assertIsDisplayed()
+        rule.onNodeWithText("Cancel").assertIsDisplayed()
+        rule.onNodeWithText("Reset").assertIsDisplayed()
+    }
+
+    @Test
+    fun `each button invokes its own action, and neither is the dismiss request`() {
+        val clicks = mutableListOf<String>()
+        rule.setContent {
+            BossAlertDialog(
+                onDismissRequest = { clicks += "dismissRequest" },
+                title = { Text("Discard changes?") },
+                dismissButton = { TextButton(onClick = { clicks += "cancel" }) { Text("Cancel") } },
+                confirmButton = { TextButton(onClick = { clicks += "discard" }) { Text("Discard") } },
+            )
+        }
+
+        rule.onNodeWithText("Discard").performClick()
+        rule.onNodeWithText("Cancel").performClick()
+
+        // Order matters as much as membership: the confirm button is rendered last (rightmost), and a
+        // shim that swapped the two would put the destructive action where Cancel belongs.
+        assertEquals(listOf("discard", "cancel"), clicks)
+    }
+
+    @Test
+    fun `a dialog with no text renders from the title alone`() {
+        // Material allows a title-only or text-only dialog and several host call sites use it, so the
+        // rebuilt card must not assume both regions are present.
+        rule.setContent {
+            BossAlertDialog(
+                onDismissRequest = {},
+                title = { Text("Git Operation Successful") },
+                confirmButton = { TextButton(onClick = {}) { Text("OK") } },
+            )
+        }
+
+        rule.onNodeWithText("Git Operation Successful").assertIsDisplayed()
+        rule.onNodeWithText("OK").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the buttons overload hands the whole action area to the caller`() {
+        // GenericDialogHost's three-button plugin dialog is the reason this overload exists.
+        val clicks = mutableListOf<String>()
+        rule.setContent {
+            BossAlertDialog(
+                onDismissRequest = {},
+                title = { Text("Unsaved work") },
+                buttons = {
+                    TextButton(onClick = { clicks += "save" }) { Text("Save") }
+                    TextButton(onClick = { clicks += "discard" }) { Text("Discard") }
+                    TextButton(onClick = { clicks += "cancel" }) { Text("Keep editing") }
+                },
+            )
+        }
+
+        rule.onNodeWithText("Save").assertIsDisplayed()
+        rule.onNodeWithText("Discard").assertIsDisplayed()
+        rule.onNodeWithText("Keep editing").performClick()
+        assertTrue(clicks == listOf("cancel"), "expected only the clicked button to fire, got $clicks")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
@@ -1,0 +1,127 @@
+package ai.rever.boss.components.overlays
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Where a heavyweight drag ghost's window is placed.
+ *
+ * Two properties matter and only one of them is cosmetic.
+ *
+ * The load-bearing one is that the POINTER STAYS OUTSIDE THE GHOST. A non-focusable AWT window still
+ * receives mouse events, and the JVM has no portable click-through, so a ghost window under the
+ * pointer swallows the drag that is moving it: the ghost follows the cursor and the drop never lands.
+ * That is why the placement flips to the other side of the cursor at a screen edge instead of being
+ * pulled back across it, and why nearly every case below re-asserts the invariant.
+ *
+ * The other is the CLAMP, which keeps the ghost on the monitor the pointer is on rather than spilling
+ * over a taskbar or onto the wrong display.
+ */
+class HeavyweightGhostPlacementTest {
+    private companion object {
+        /** A single 1920x1080 monitor at the origin with a 25px menu bar. */
+        val SINGLE = listOf(intArrayOf(0, 25, 1920, 1055))
+
+        /** The same, plus a second monitor to its right whose origin is NOT (0, 0). */
+        val DUAL = SINGLE + listOf(intArrayOf(1920, 0, 1280, 800))
+
+        const val GHOST_W = 180
+        const val GHOST_H = 32
+    }
+
+    private fun place(
+        x: Int,
+        y: Int,
+        screens: List<IntArray> = SINGLE,
+    ) = clampGhostToScreens(cursorX = x, cursorY = y, width = GHOST_W, height = GHOST_H, screens = screens)
+
+    /** The invariant the gap exists for: a pointer inside the ghost eats its own drag. */
+    private fun assertPointerOutside(
+        cursorX: Int,
+        cursorY: Int,
+        placed: Pair<Int, Int>,
+    ) {
+        val (gx, gy) = placed
+        val inside = cursorX >= gx && cursorX < gx + GHOST_W && cursorY >= gy && cursorY < gy + GHOST_H
+        assertFalse(inside, "pointer ($cursorX, $cursorY) landed inside the ghost at $placed")
+    }
+
+    @Test
+    fun `mid-screen, the ghost sits below-right of the cursor`() {
+        val placed = place(600, 400)
+        assertTrue(placed.first > 600 && placed.second > 400, "expected below-right, got $placed")
+        assertPointerOutside(600, 400, placed)
+    }
+
+    @Test
+    fun `at the right edge it flips to the cursor's left rather than sliding under it`() {
+        // This is the case a plain clamp gets wrong. Clamping to (1920 - 180) = 1740 with the cursor at
+        // 1900 puts the pointer inside the ghost, which would stall the drag in the last 180px of the
+        // screen. Flipping puts the ghost entirely left of the cursor instead.
+        val placed = place(1900, 400)
+        assertTrue(placed.first + GHOST_W <= 1900, "ghost should end left of the cursor, got $placed")
+        assertTrue(placed.first >= 0, "ghost should stay on screen, got $placed")
+        assertPointerOutside(1900, 400, placed)
+    }
+
+    @Test
+    fun `at the bottom edge it flips above the cursor, clear of the menu-bar-adjusted floor`() {
+        val placed = place(600, 1070)
+        assertTrue(placed.second + GHOST_H <= 1070, "ghost should end above the cursor, got $placed")
+        assertPointerOutside(600, 1070, placed)
+    }
+
+    @Test
+    fun `a bottom edge that still fits below the cursor is left below it`() {
+        // Only flip when it is actually needed: 25 + 1055 = 1080 is the floor, and a cursor at 1000
+        // leaves room for 16 + 32 underneath.
+        val placed = place(600, 1000)
+        assertEquals(1016, placed.second)
+    }
+
+    @Test
+    fun `the ghost is clamped to the monitor the pointer is on, not the primary one`() {
+        // The trap: clamping against the primary screen's rect would drag a ghost on the second
+        // monitor back to x < 1920, i.e. onto the wrong display entirely.
+        val placed = place(2000, 300, DUAL)
+        assertTrue(placed.first >= 1920, "ghost jumped back to the primary monitor: $placed")
+        assertPointerOutside(2000, 300, placed)
+    }
+
+    @Test
+    fun `the second monitor's own origin is respected, not treated as zero`() {
+        // Cursor at the second monitor's top-left. An axis computed from width/height without adding
+        // the monitor's origin would place the ghost at (16, 16) on the PRIMARY screen.
+        val placed = place(1920, 0, DUAL)
+        assertEquals(Pair(1936, 16), placed)
+    }
+
+    @Test
+    fun `a pointer on no known monitor is pulled back onto one, not left off-screen`() {
+        // Monitors can be unplugged mid-drag, and the coordinates are then off every rect we cached.
+        // The near-edge half of the fit test is what catches this: a cursor far to the LEFT satisfies
+        // "does not run past the right edge" trivially, so testing only the far edge would leave the
+        // ghost thousands of pixels off-screen and invisible for the rest of the drag.
+        val placed = place(-5000, -5000, DUAL)
+        assertEquals(Pair(0, 25), placed)
+    }
+
+    @Test
+    fun `a ghost larger than the monitor pins inside it instead of inverting the range`() {
+        // Neither the offset nor the flip fits, so both axes fall through to the clamp. coerceIn throws
+        // on an inverted range, and an exception here would take the whole drag gesture down with it.
+        // 100 wide cannot hold 180, so x pins to the origin; 60 tall can hold 32, so y pins to 60 - 32.
+        val tiny = listOf(intArrayOf(0, 0, 100, 60))
+        val placed = clampGhostToScreens(cursorX = 50, cursorY = 30, width = GHOST_W, height = GHOST_H, screens = tiny)
+        assertEquals(Pair(0, 28), placed)
+    }
+
+    @Test
+    fun `with no monitors at all it still returns the offset point`() {
+        val placed =
+            clampGhostToScreens(cursorX = 40, cursorY = 60, width = GHOST_W, height = GHOST_H, screens = emptyList())
+        assertEquals(Pair(56, 76), placed)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.components.overlays
 
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -123,5 +125,57 @@ class HeavyweightGhostPlacementTest {
         val placed =
             clampGhostToScreens(cursorX = 40, cursorY = 60, width = GHOST_W, height = GHOST_H, screens = emptyList())
         assertEquals(Pair(56, 76), placed)
+    }
+}
+
+/**
+ * Where an anchored heavyweight popup sits, i.e. the content-pane correction.
+ *
+ * The overlay window is placed at the parent FRAME's origin, while Compose measures an anchor against
+ * the CONTENT PANE. On a decorated window those differ by the title bar, so an anchored popup placed
+ * without the correction floats a title-bar's height above the control it belongs to. That is the same
+ * off-by-a-title-bar the pinch-zoom gate had to solve, it is invisible in review, and it is the reason
+ * the URL-bar suggestion list needed this rather than cursor placement.
+ */
+class AnchoredPopupPlacementTest {
+    private companion object {
+        /** A URL bar 28dp tall, 40px down the content pane. */
+        val URL_BAR = IntRect(left = 120, top = 40, right = 620, bottom = 68)
+        const val TITLE_BAR = 28
+    }
+
+    @Test
+    fun `an anchored popup opens directly below the anchor, not over it`() {
+        val at = anchoredContentOffset(URL_BAR, insetX = 0, insetY = TITLE_BAR)
+        assertEquals(URL_BAR.bottom + TITLE_BAR, at.y)
+        assertTrue(at.y > URL_BAR.top, "popup must not cover the control it belongs to")
+    }
+
+    @Test
+    fun `it lines up with the anchor's left edge`() {
+        val at = anchoredContentOffset(URL_BAR, insetX = 0, insetY = TITLE_BAR)
+        assertEquals(URL_BAR.left, at.x)
+    }
+
+    @Test
+    fun `the title-bar inset is added, which is the whole point`() {
+        // Without the correction the popup would land at the anchor's own y, i.e. a title bar too
+        // high - overlapping the URL bar rather than sitting under it.
+        val corrected = anchoredContentOffset(URL_BAR, insetX = 0, insetY = TITLE_BAR)
+        val uncorrected = anchoredContentOffset(URL_BAR, insetX = 0, insetY = 0)
+        assertEquals(TITLE_BAR, corrected.y - uncorrected.y)
+    }
+
+    @Test
+    fun `an undecorated window needs no correction and gets none`() {
+        // Zero inset is the correct answer for an undecorated window, not a failure to measure.
+        val at = anchoredContentOffset(URL_BAR, insetX = 0, insetY = 0)
+        assertEquals(IntOffset(URL_BAR.left, URL_BAR.bottom), at)
+    }
+
+    @Test
+    fun `a horizontal inset is honoured too, for platforms that have one`() {
+        val at = anchoredContentOffset(URL_BAR, insetX = 8, insetY = TITLE_BAR)
+        assertEquals(URL_BAR.left + 8, at.x)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightOverlayTest.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.browser.parseTopInsetDp
 import ai.rever.boss.plugin.browser.pointerInsideBounds
 import ai.rever.boss.plugin.browser.shouldAllowPinch
 import ai.rever.boss.plugin.browser.shouldRetainSurface
+import ai.rever.boss.plugin.ui.BossOverlayHost
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.IntOffset
@@ -274,6 +275,8 @@ class HeavyweightOverlayTest {
         OverlayConfig.heavyweightModal = null
         OverlayConfig.heavyweightTooltip = null
         OverlayConfig.hideHeavyweightTooltip = null
+        OverlayConfig.heavyweightHud = null
+        OverlayConfig.heavyweightGhost = null
         OverlayConfig.openHeavyweightPopups = 0
     }
 
@@ -281,13 +284,31 @@ class HeavyweightOverlayTest {
     fun `overlay renderers default to null so callers fall back to Compose popups`() {
         // useHeavyweightPopups can be true while the renderers are null: any entry point that does
         // not run main.kt's wiring (a test host, a tool) reaches exactly that state. The null
-        // checks in ContextMenu / OverlayModal are what stand between that and no menus at all,
+        // checks in ContextMenu / BossDialog are what stand between that and no menus at all,
         // so the defaults they rely on are pinned here.
         assertFalse(OverlayConfig.useHeavyweightPopups)
         assertNull(OverlayConfig.heavyweightPopup)
         assertNull(OverlayConfig.heavyweightModal)
         assertNull(OverlayConfig.heavyweightTooltip)
         assertNull(OverlayConfig.hideHeavyweightTooltip)
+        assertNull(OverlayConfig.heavyweightHud)
+        assertNull(OverlayConfig.heavyweightGhost)
+        assertEquals(0, OverlayConfig.openHeavyweightPopups)
+    }
+
+    @Test
+    fun `the modal switch and popup counter are the same ones plugins see`() {
+        // OverlayConfig's modal properties are forwarding accessors onto BossOverlayHost, which is
+        // what plugin-drawn dialogs read. If that forwarding is ever replaced by a second backing
+        // field, the host would route heavyweight while every plugin dialog silently stayed behind
+        // the page - the exact bug this path exists to fix, and invisible from either side.
+        OverlayConfig.useHeavyweightPopups = true
+        assertTrue(BossOverlayHost.useHeavyweightOverlays)
+
+        OverlayConfig.openHeavyweightPopups = 3
+        assertEquals(3, BossOverlayHost.openHeavyweightPopups)
+
+        BossOverlayHost.openHeavyweightPopups = 0
         assertEquals(0, OverlayConfig.openHeavyweightPopups)
     }
 

--- a/plugin-platform/plugin-ui-core/build.gradle.kts
+++ b/plugin-platform/plugin-ui-core/build.gradle.kts
@@ -50,6 +50,11 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
                 implementation(libs.junit.jupiter)
+                // Compose's UI test API is JUnit 4 only, and this module runs on the JUnit
+                // Platform, so the vintage engine is what actually executes it - same pairing
+                // composeApp uses.
+                implementation(compose.desktop.uiTestJUnit4)
+                runtimeOnly(libs.junit.vintage.engine)
             }
         }
     }

--- a/plugin-platform/plugin-ui-core/build.gradle.kts
+++ b/plugin-platform/plugin-ui-core/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.risaboss"
-version = "1.0.7"
+version = "1.0.8"
 
 kotlin {
     compilerOptions {
@@ -44,7 +44,19 @@ kotlin {
                 implementation(compose.desktop.currentOs)
             }
         }
+
+        named("desktopTest") {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(kotlin("test-junit5"))
+                implementation(libs.junit.jupiter)
+            }
+        }
     }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 mavenPublishing {

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -1,0 +1,278 @@
+package ai.rever.boss.plugin.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * Whether the window hosting this composition is one that needs heavyweight overlays.
+ *
+ * Default false, provided `true` by the host's main application window only. Secondary windows
+ * (Settings, the first-run setup window) contain no browser surface, and routing their dialogs
+ * through an always-on-top window sized to the *main* window would place them over the wrong
+ * window and leave them floating above it, since a heavyweight modal deliberately does not dismiss
+ * when focus moves to another window of the same application.
+ */
+val LocalHeavyweightOverlays = staticCompositionLocalOf { false }
+
+/**
+ * The routing decision for any overlay that can escape into its own window, as a pure function so
+ * it can be pinned by a test.
+ *
+ * All three conditions are required and each rules out a different failure:
+ *  - [useHeavyweightOverlays]: OFF_SCREEN installs keep the lightweight path untouched.
+ *  - [hasRenderer]: nothing was injected, so there is nowhere to route to.
+ *  - [hostNeedsHeavyweight]: this window has no browser surface to escape (see
+ *    [LocalHeavyweightOverlays]).
+ *
+ * Public because the host routes its own non-modal overlays (context menus, the Ctrl+Tab HUD, drag
+ * ghosts) through the same rule, and duplicating it is how the three would drift apart.
+ */
+fun shouldRouteHeavyweight(
+    useHeavyweightOverlays: Boolean,
+    hasRenderer: Boolean,
+    hostNeedsHeavyweight: Boolean,
+): Boolean = useHeavyweightOverlays && hasRenderer && hostNeedsHeavyweight
+
+/**
+ * Scrim opacity for a heavyweight modal.
+ *
+ * Matches what the new-tab dialog has shipped with, and it is load-bearing evidence elsewhere: the
+ * host's `EnsureOverlayWindowTransparent` identifies an overlay window that came up opaque by the
+ * mid-grey this alpha composites to over an opaque light background. Changing it invalidates that
+ * diagnosis.
+ */
+private const val SCRIM_ALPHA = 0.4f
+
+/**
+ * A modal dialog that layers correctly above a GPU-composited browser surface.
+ *
+ * Drop-in replacement for `androidx.compose.ui.window.Dialog`: [content] is a self-contained,
+ * intrinsically-sized card, and this composable supplies the scrim and the centering on both
+ * paths. On the lightweight path Compose's own `Dialog` provides them; on the heavyweight path
+ * they are drawn here, so the two look the same.
+ *
+ * The scrim is not decoration on the heavyweight path, it is the primary dismissal mechanism: a
+ * click on the page does NOT produce an AWT focus transition (Chromium's native child window takes
+ * focus without one), so focus loss alone never sees it. A modal without a scrim would not dismiss
+ * on an in-page click.
+ *
+ * @param onDismissRequest Called on Escape, on a click outside the card, or when focus leaves the
+ *   application. Not called when the caller's own buttons close the dialog.
+ * @param properties `dismissOnClickOutside` is honoured on both paths; `dismissOnBackPress` maps
+ *   to Escape, which the heavyweight window handles itself.
+ */
+@Composable
+fun BossDialog(
+    onDismissRequest: () -> Unit,
+    properties: DialogProperties = DialogProperties(),
+    content: @Composable () -> Unit,
+) {
+    val renderer = BossOverlayHost.modalRenderer
+    if (BossOverlayHost.useHeavyweightOverlays && renderer == null) {
+        BossOverlayHost.reportMissingModalRenderer()
+    }
+    val heavyweight =
+        shouldRouteHeavyweight(
+            useHeavyweightOverlays = BossOverlayHost.useHeavyweightOverlays,
+            hasRenderer = renderer != null,
+            hostNeedsHeavyweight = LocalHeavyweightOverlays.current,
+        )
+    if (heavyweight && renderer != null) {
+        renderer(onDismissRequest) {
+            ScrimmedModalContent(
+                dismissOnClickOutside = properties.dismissOnClickOutside,
+                onDismissRequest = onDismissRequest,
+                content = content,
+            )
+        }
+    } else {
+        Dialog(onDismissRequest = onDismissRequest, properties = properties, content = content)
+    }
+}
+
+/**
+ * Full-window scrim with the card centered on it.
+ *
+ * The card carries a no-op click handler so a click inside it is consumed rather than falling
+ * through to the scrim and dismissing the dialog the user is filling in.
+ */
+@Composable
+private fun ScrimmedModalContent(
+    dismissOnClickOutside: Boolean,
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val scrimInteraction = remember { MutableInteractionSource() }
+    val cardInteraction = remember { MutableInteractionSource() }
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = SCRIM_ALPHA))
+                .then(
+                    if (dismissOnClickOutside) {
+                        Modifier.clickable(
+                            interactionSource = scrimInteraction,
+                            indication = null,
+                            onClick = onDismissRequest,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier.clickable(
+                    interactionSource = cardInteraction,
+                    indication = null,
+                    onClick = {},
+                ),
+        ) {
+            content()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Alert dialog
+// ---------------------------------------------------------------------------
+
+/** Width of a BOSS alert card, matching the house confirmation dialog. */
+private val AlertWidth: Dp = 400.dp
+
+/**
+ * A title/text/buttons dialog in the BOSS design system, layered above the browser surface.
+ *
+ * The parameter list is deliberately Material 2's `AlertDialog`, name for name and in the same
+ * order, so migrating a call site is a rename and nothing else. Material could not simply be
+ * wrapped: its `AlertDialogContent` and baseline layout are `internal`, and the desktop
+ * `dialogProvider` hook that once allowed exactly this was removed. Since the body had to be
+ * rebuilt, it is built from the design-system tokens rather than Material's metrics - the same
+ * card as `ConfirmationDialog`, so the two read as one family.
+ *
+ * [title] and [text] stay caller-supplied composables. This wraps them in the default type and
+ * content color, so a caller that styles its own `Text` keeps whatever it set.
+ *
+ * @param confirmButton The primary action. Rendered last, i.e. rightmost.
+ * @param dismissButton The secondary action, rendered to the left of [confirmButton].
+ * @param shape Card shape; null takes the design system's dialog radius.
+ * @param backgroundColor Card fill; [Color.Unspecified] takes the theme's panel color.
+ * @param contentColor Default content color; [Color.Unspecified] takes the theme's primary text.
+ */
+@Composable
+fun BossAlertDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: (@Composable () -> Unit)? = null,
+    title: (@Composable () -> Unit)? = null,
+    text: (@Composable () -> Unit)? = null,
+    shape: Shape? = null,
+    backgroundColor: Color = Color.Unspecified,
+    contentColor: Color = Color.Unspecified,
+    properties: DialogProperties = DialogProperties(),
+) {
+    BossAlertDialog(
+        onDismissRequest = onDismissRequest,
+        buttons = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                if (dismissButton != null) {
+                    dismissButton()
+                    Spacer(Modifier.width(BossTheme.space.sm))
+                }
+                confirmButton()
+            }
+        },
+        modifier = modifier,
+        title = title,
+        text = text,
+        shape = shape,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        properties = properties,
+    )
+}
+
+/**
+ * [BossAlertDialog] with the button area fully under the caller's control.
+ *
+ * Mirrors Material 2's `buttons` overload. Use it when the actions are not a confirm/dismiss pair:
+ * three buttons, a progress row, or no buttons at all.
+ */
+@Composable
+fun BossAlertDialog(
+    onDismissRequest: () -> Unit,
+    buttons: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    title: (@Composable () -> Unit)? = null,
+    text: (@Composable () -> Unit)? = null,
+    shape: Shape? = null,
+    backgroundColor: Color = Color.Unspecified,
+    contentColor: Color = Color.Unspecified,
+    properties: DialogProperties = DialogProperties(),
+) {
+    val colors = BossTheme.colors
+    val space = BossTheme.space
+    BossDialog(onDismissRequest = onDismissRequest, properties = properties) {
+        Surface(
+            modifier =
+                modifier
+                    .width(AlertWidth)
+                    .wrapContentHeight(),
+            shape = shape ?: BossTheme.radius.dialogShape,
+            color = backgroundColor.takeOrElse { colors.panel },
+            contentColor = contentColor.takeOrElse { colors.textPrimary },
+        ) {
+            Column(modifier = Modifier.padding(space.xl)) {
+                if (title != null) {
+                    CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
+                        ProvideTextStyle(BossTheme.type.title, title)
+                    }
+                }
+                if (title != null && text != null) {
+                    Spacer(Modifier.height(space.md))
+                }
+                if (text != null) {
+                    CompositionLocalProvider(LocalContentColor provides colors.textSecondary) {
+                        ProvideTextStyle(BossTheme.type.body, text)
+                    }
+                }
+                Spacer(Modifier.height(space.xl))
+                buttons()
+            }
+        }
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
@@ -115,7 +117,9 @@ private const val SCRIM_ALPHA = 0.4f
  * @param onDismissRequest Called on Escape, on a click outside the card, or when focus leaves the
  *   application. Not called when the caller's own buttons close the dialog.
  * @param properties `dismissOnClickOutside` is honoured on both paths; `dismissOnBackPress` maps
- *   to Escape, which the heavyweight window handles itself.
+ *   to Escape, which the heavyweight window handles itself. Every OTHER property, including
+ *   `usePlatformDefaultWidth`, is IGNORED on the heavyweight path - the card is intrinsically sized
+ *   there and there is no platform dialog to configure.
  */
 @Composable
 fun BossDialog(
@@ -206,9 +210,15 @@ internal fun ScrimmedModalContent(
     // only read inside the effect, so a plain holder would do; kept as state so the pointer handler
     // and the timer share one obvious source of truth.
     val pointerDown = remember { mutableStateOf(false) }
+    // Retries rather than asking once. A single shot has no recovery path: if this window sees a
+    // press whose release is delivered somewhere else - pointer dragged out and released over another
+    // window or another application - `armed` would stay false forever and the loop below would eat
+    // every event, leaving the dialog permanently mouse-dead with only Escape as a way out.
     LaunchedEffect(Unit) {
-        delay(INPUT_ARM_DELAY_MS)
-        if (shouldArmModalInput(pointerDown.value)) armed = true
+        while (!armed) {
+            delay(INPUT_ARM_DELAY_MS)
+            if (shouldArmModalInput(pointerDown.value)) armed = true
+        }
     }
     Box(
         modifier =
@@ -222,18 +232,27 @@ internal fun ScrimmedModalContent(
                     awaitPointerEventScope {
                         while (!armed) {
                             val event = awaitPointerEvent(PointerEventPass.Initial)
-                            pointerDown.value = event.changes.any { it.pressed }
+                            // Exit clears a stale press: the release for it will be delivered to
+                            // whatever the pointer moved onto, never to this window.
+                            pointerDown.value =
+                                event.type != PointerEventType.Exit && event.changes.any { it.pressed }
                             if (shouldArmModalInput(pointerDown.value)) armed = true
                             event.changes.forEach { it.consume() }
                         }
                     }
                 }.then(
                     if (dismissOnClickOutside) {
-                        Modifier.clickable(
-                            interactionSource = scrimInteraction,
-                            indication = null,
-                            onClick = onDismissRequest,
-                        )
+                        // canFocus = false for the same reason as the card: `clickable` installs a
+                        // focus target with Enter/Space semantics, so a full-window scrim would join
+                        // the dialog's traversal order and dismiss it from the keyboard - surprising
+                        // in a dialog with text fields - and announce itself to accessibility.
+                        Modifier
+                            .focusProperties { canFocus = false }
+                            .clickable(
+                                interactionSource = scrimInteraction,
+                                indication = null,
+                                onClick = onDismissRequest,
+                            )
                     } else {
                         Modifier
                     },
@@ -404,6 +423,9 @@ fun BossPopup(
     content: @Composable () -> Unit,
 ) {
     val renderer = BossOverlayHost.popupRenderer
+    if (BossOverlayHost.useHeavyweightOverlays && renderer == null) {
+        SideEffect { BossOverlayHost.reportMissingPopupRenderer() }
+    }
     val heavyweight =
         shouldRouteHeavyweight(
             useHeavyweightOverlays = BossOverlayHost.useHeavyweightOverlays,
@@ -414,31 +436,75 @@ fun BossPopup(
     // BossPopupAnchoring.AnchorBounds has something real to anchor to. Measured here rather than
     // asked of the caller: a caller cannot convert its own layout position into window space without
     // reaching for LocalAwtWindow, which plugin code should not have to do. The Box contributes no
-    // size, so it is layout-neutral wherever it is placed.
-    var anchorInWindow by remember { mutableStateOf(IntRect.Zero) }
+    // size, so it is layout-neutral wherever it is placed - see the layout modifier below, which is
+    // what makes that true rather than merely intended.
+    // Position and width arrive from two different callbacks with no guaranteed order between
+    // them, so neither computes the rect. Both are state, and the rect is DERIVED during
+    // composition - which also means a later measurement updates it, rather than whichever
+    // callback happened to run last winning.
     val density = LocalDensity.current.density
+    // NULL until measured, which is a distinct state from "measured at the origin". The renderer used
+    // to be invoked on the very first composition, before onGloballyPositioned had run, so an anchored
+    // popup was placed at the window origin with no width and then snapped into place - a visible
+    // flash in the top-left corner for as long as the overlay window took to appear.
+    var anchorPositionPx by remember { mutableStateOf<Offset?>(null) }
+    var measuredWidthPx by remember { mutableStateOf(0) }
+    val anchorInWindow =
+        anchorPositionPx?.let { anchorRectInDp(it, IntSize(measuredWidthPx, 0), density) }
     Box(
         modifier =
             Modifier
-                // fillMaxWidth so the probe ADOPTS the caller's width, rather than trying to read it
-                // back off the parent. Walking up with parentLayoutCoordinates does not reliably land
-                // on the caller's layout - modifier nodes have coordinates of their own - and it
-                // returned a zero width, which let the content inherit the overlay window's width and
-                // then get clamped to x = 0. Filling is deterministic and needs no traversal.
+                // Measure at the caller's full width, then report 0x0 to the parent.
                 //
-                // Layout-safe because the probe renders nothing on this path: it has zero height, and
-                // its parent's width is already decided by the caller. Height stays zero, so the
-                // anchor's bottom is its top, which is what "open below the anchor" means for a
-                // zero-height probe placed where the popup should start.
-                .fillMaxWidth()
+                // The width has to be ADOPTED rather than read back: walking up with
+                // parentLayoutCoordinates does not reliably land on the caller's layout - modifier
+                // nodes have coordinates of their own - and returned zero, which let the content
+                // inherit the overlay window's width instead of the anchor's.
+                //
+                // But adopting it with fillMaxWidth() is NOT layout-neutral, despite reporting no
+                // height: fillMaxWidth sets minWidth = maxWidth, so the probe claims the full width
+                // from its parent. In a Row it starves later siblings; in a Column with
+                // Arrangement.spacedBy it adds a phantom gap; and on the lightweight path it becomes
+                // the Popup's anchor parent, changing placement even for OFF_SCREEN installs that
+                // never route heavyweight. Compose's own Popup emits a genuine 0x0 node, and this is
+                // documented as a drop-in for it, so it must too. Measuring and then reporting 0x0
+                // gets the width without any of that.
+                //
+                // ORDER MATTERS. onGloballyPositioned must sit OUTSIDE the layout modifier: modifiers
+                // wrap left to right, so placing it inside made it observe the collapsed content
+                // rather than the placed node, and it reported the origin with zero size. Outside, it
+                // sees the node as the PARENT sees it - correct position, zero size - and the width
+                // comes from the measurement captured within.
                 .onGloballyPositioned { coordinates ->
-                    anchorInWindow =
-                        anchorRectInDp(coordinates.positionInWindow(), coordinates.size, density)
+                    anchorPositionPx = coordinates.positionInWindow()
+                }.layout { measurable, constraints ->
+                    val placeable = measurable.measure(constraints)
+                    // The CONSTRAINT, not the placeable. On the heavyweight path this Box has no
+                    // inline content - the renderer opens a window - so the placeable measures 0 and
+                    // the anchor would report no width at all. maxWidth is what the caller is
+                    // offering, which is the width the popup should adopt. Unbounded (a scrolling
+                    // parent) has no such answer, so fall back to whatever the content measured.
+                    measuredWidthPx =
+                        if (constraints.hasBoundedWidth) constraints.maxWidth else placeable.width
+                    // Report 0x0 but still PLACE the child: the lightweight path nests a real Popup
+                    // in here, and an unplaced subtree would never compose it.
+                    layout(0, 0) { placeable.place(0, 0) }
                 },
     ) {
-        if (heavyweight && renderer != null) {
-            renderer(onDismissRequest, anchorInWindow, anchoring, offset, focusable, content)
-        } else {
+        // An anchored popup waits for its anchor. Cursor anchoring never reads it, so that path must
+        // NOT wait - it would delay every context menu by a frame for no reason.
+        val placeable =
+            anchoring != BossPopupAnchoring.AnchorBounds || anchorInWindow != null
+        if (heavyweight && renderer != null && placeable) {
+            renderer(
+                onDismissRequest,
+                anchorInWindow ?: IntRect.Zero,
+                anchoring,
+                offset,
+                focusable,
+                content,
+            )
+        } else if (!heavyweight || renderer == null) {
             Popup(
                 onDismissRequest = onDismissRequest,
                 offset = offset,
@@ -510,3 +576,7 @@ enum class BossPopupAnchoring {
      */
     AnchorBounds,
 }
+
+// Treat this enum as OPEN when matching on it: it crosses the plugin boundary and the host compiles
+// its own copy, so a third constant added later reaches plugins built against two constants. Always
+// include an else branch, for the same reason `LlmApiFormat` documents in the api repo.

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,6 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
@@ -40,6 +42,15 @@ import kotlinx.coroutines.delay
 
 /**
  * Whether the window hosting this composition is one that needs heavyweight overlays.
+ *
+ * **This declaration must stay in a file named `BossDialog.kt`.** Kotlin derives a top-level
+ * declaration's JVM facade class from the FILE name, so the api dump records it as
+ * `BossDialogKt.getLocalHeavyweightOverlays`. Moving it to `BossOverlayHost.kt` - its conceptual
+ * home, and where a maintainer would naturally put it - renames the symbol to
+ * `BossOverlayHostKt.getLocalHeavyweightOverlays`, and plugins compiled against the old name fail
+ * with NoClassDefFoundError at first use while `apiCheck` stays green in the api repo. The same trap
+ * applies to `shouldRouteHeavyweight` and to both `BossAlertDialog` overloads, whose `Color`
+ * parameters additionally mangle their JVM names.
  *
  * Default false, provided `true` by the host's main application window only. Secondary windows
  * (Settings, the first-run setup window) contain no browser surface, and routing their dialogs
@@ -103,8 +114,11 @@ fun BossDialog(
     content: @Composable () -> Unit,
 ) {
     val renderer = BossOverlayHost.modalRenderer
-    if (BossOverlayHost.useHeavyweightOverlays && renderer == null) {
-        BossOverlayHost.reportMissingModalRenderer()
+    val missingRenderer = BossOverlayHost.useHeavyweightOverlays && renderer == null
+    // SideEffect, not a bare call: composition can be re-run, skipped or abandoned, and a report
+    // should describe a composition that actually committed.
+    if (missingRenderer) {
+        SideEffect { BossOverlayHost.reportMissingModalRenderer() }
     }
     val heavyweight =
         shouldRouteHeavyweight(
@@ -113,7 +127,7 @@ fun BossDialog(
             hostNeedsHeavyweight = LocalHeavyweightOverlays.current,
         )
     if (heavyweight && renderer != null) {
-        renderer(onDismissRequest) {
+        renderer(properties, onDismissRequest) {
             ScrimmedModalContent(
                 dismissOnClickOutside = properties.dismissOnClickOutside,
                 onDismissRequest = onDismissRequest,
@@ -134,6 +148,17 @@ fun BossDialog(
 internal const val INPUT_ARM_DELAY_MS = 200L
 
 /**
+ * Whether a freshly-opened modal should start accepting pointer input.
+ *
+ * One input, deliberately: **a held button vetoes arming, whichever signal is asking.** Both callers
+ * - the pointer handler and the [INPUT_ARM_DELAY_MS] timer - ask the same question, and the timer
+ * having elapsed is never a reason to override a press. Writing that as a named, tested function is
+ * the point; an earlier version let the timer arm unconditionally and reinstated the very bug the
+ * guard exists for, only intermittently.
+ */
+internal fun shouldArmModalInput(pointerDown: Boolean): Boolean = !pointerDown
+
+/**
  * Full-window scrim with the card centered on it.
  *
  * The card carries a no-op click handler so a click inside it is consumed rather than falling
@@ -146,11 +171,17 @@ internal const val INPUT_ARM_DELAY_MS = 200L
  * beneath the pointer and chose it - the user picked an option they never aimed at. The lightweight
  * path cannot do this: it draws inside the existing window, whose press it already saw.
  *
- * Two arming rules, because either one alone loses a click:
- *  - any pointer event with no button held arms it, which covers the in-flight release and any
- *    stray movement;
- *  - a [INPUT_ARM_DELAY_MS] timer arms it too, for a dialog opened from the keyboard or a menu,
- *    where no pointer event may ever arrive and the first real click would otherwise be eaten.
+ * Two arming rules, and the ORDER of precedence between them is the whole correctness argument:
+ *  - a pointer event with no button held arms it. That is the real signal, and it covers both the
+ *    in-flight release and any stray movement.
+ *  - the [INPUT_ARM_DELAY_MS] timer arms it ONLY IF no button is held at that moment. It exists
+ *    purely for a dialog opened from the keyboard or a menu, where no pointer event may ever arrive
+ *    and the first real click would otherwise be eaten.
+ *
+ * The timer must not arm unconditionally. A deliberate modifier-click is easily held longer than
+ * 200ms, and the new window's first-frame latency counts against that budget too, so an
+ * unconditional timer can expire while the button is still down - reinstating the reported bug and
+ * making it rarer, which is worse than leaving it. See [shouldArmModalInput].
  */
 @Composable
 internal fun ScrimmedModalContent(
@@ -161,9 +192,13 @@ internal fun ScrimmedModalContent(
     val scrimInteraction = remember { MutableInteractionSource() }
     val cardInteraction = remember { MutableInteractionSource() }
     var armed by remember { mutableStateOf(false) }
+    // Tracks the button state the timer has to consult. Not snapshot-observed for recomposition,
+    // only read inside the effect, so a plain holder would do; kept as state so the pointer handler
+    // and the timer share one obvious source of truth.
+    val pointerDown = remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         delay(INPUT_ARM_DELAY_MS)
-        armed = true
+        if (shouldArmModalInput(pointerDown.value)) armed = true
     }
     Box(
         modifier =
@@ -177,7 +212,8 @@ internal fun ScrimmedModalContent(
                     awaitPointerEventScope {
                         while (!armed) {
                             val event = awaitPointerEvent(PointerEventPass.Initial)
-                            if (event.changes.none { it.pressed }) armed = true
+                            pointerDown.value = event.changes.any { it.pressed }
+                            if (shouldArmModalInput(pointerDown.value)) armed = true
                             event.changes.forEach { it.consume() }
                         }
                     }
@@ -196,11 +232,13 @@ internal fun ScrimmedModalContent(
     ) {
         Box(
             modifier =
-                Modifier.clickable(
-                    interactionSource = cardInteraction,
-                    indication = null,
-                    onClick = {},
-                ),
+                Modifier
+                    .focusProperties { canFocus = false }
+                    .clickable(
+                        interactionSource = cardInteraction,
+                        indication = null,
+                        onClick = {},
+                    ),
         ) {
             content()
         }

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -395,13 +395,28 @@ fun BossAlertDialog(
 /**
  * An anchored, non-modal overlay that layers correctly above a GPU-composited browser surface.
  *
- * Drop-in replacement for `androidx.compose.ui.window.Popup`, and the counterpart to [BossDialog] for
+ * Same shape as `androidx.compose.ui.window.Popup` for the parameters it exposes, and the
+ * counterpart to [BossDialog] for
  * everything that is not a modal: a context menu, a dropdown, an autocomplete list. `BossDialog`
  * cannot stand in for these - it centers its content, draws a scrim, and takes focus.
  *
- * **[focusable] is the parameter to think about.** A suggestion list under a text field must pass
- * `false`, or the popup steals focus from the field and the user cannot keep typing. A menu that
- * handles its own arrow keys wants `true`.
+ * The surface is deliberately narrower than `Popup`: no `alignment`, and `PopupProperties` is
+ * constructed internally. That is a decision rather than an oversight, because adding a parameter to
+ * this `@Composable` later is pinned by the binary-compatibility validator in two repos and costs a
+ * coordinated host and api release.
+ *
+ * **[focusable] is the parameter to think about, and it defaults to `false` to match `Popup`.** A
+ * suggestion list under a text field needs `false`, or the popup steals focus and the user cannot
+ * keep typing. A menu that handles its own arrow keys wants `true` and must say so. The default
+ * deliberately mirrors `PopupProperties()` rather than being chosen on merit: this is documented as a
+ * rename-only migration, and a default that disagreed with `Popup` would make a mechanical rename
+ * silently start stealing focus - the exact failure this parameter exists to prevent.
+ *
+ * **Dismissal with `focusable = false` is weaker on the lightweight path.** A non-focusable desktop
+ * `Popup` does not receive key events, so Escape cannot reach it, and outside-click dismissal is tied
+ * to focusability there. The heavyweight renderer owns dismissal itself and is unaffected. Since the
+ * api jar's own body is the lightweight path on an older host, a `focusable = false` popup should not
+ * rely on Escape - drive it from the anchoring control's own key handling, as the URL bar does.
  *
  * [offset] is relative to the anchoring layout. It is honoured exactly on the lightweight path; the
  * heavyweight renderer currently prefers the cursor, because converting a layout-relative offset to
@@ -412,13 +427,14 @@ fun BossAlertDialog(
  * the parameter is already here, so a renderer that learns true window-space anchoring needs no api
  * change. Do not rely on cursor placement.
  *
- * @param onDismissRequest Called on a click outside, on Escape, or when focus leaves the application.
+ * @param onDismissRequest Called on a click outside, on Escape, or when focus leaves the
+ *   application - subject to the `focusable = false` caveat above on the lightweight path.
  */
 @Composable
 fun BossPopup(
     onDismissRequest: () -> Unit,
     offset: IntOffset = IntOffset.Zero,
-    focusable: Boolean = true,
+    focusable: Boolean = false,
     anchoring: BossPopupAnchoring = BossPopupAnchoring.Cursor,
     content: @Composable () -> Unit,
 ) {

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -34,14 +34,18 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
 
 /**
  * Whether the window hosting this composition is one that needs heavyweight overlays.
@@ -393,6 +397,7 @@ fun BossPopup(
     onDismissRequest: () -> Unit,
     offset: IntOffset = IntOffset.Zero,
     focusable: Boolean = true,
+    anchoring: BossPopupAnchoring = BossPopupAnchoring.Cursor,
     content: @Composable () -> Unit,
 ) {
     val renderer = BossOverlayHost.popupRenderer
@@ -402,14 +407,60 @@ fun BossPopup(
             hasRenderer = renderer != null,
             hostNeedsHeavyweight = LocalHeavyweightOverlays.current,
         )
-    if (heavyweight && renderer != null) {
-        renderer(onDismissRequest, offset, focusable, content)
-    } else {
-        Popup(
-            onDismissRequest = onDismissRequest,
-            offset = offset,
-            properties = PopupProperties(focusable = focusable),
-            content = content,
-        )
+    // A zero-size probe that reports where this popup sits in the window, so
+    // BossPopupAnchoring.AnchorBounds has something real to anchor to. Measured here rather than
+    // asked of the caller: a caller cannot convert its own layout position into window space without
+    // reaching for LocalAwtWindow, which plugin code should not have to do. The Box contributes no
+    // size, so it is layout-neutral wherever it is placed.
+    var anchorInWindow by remember { mutableStateOf(IntRect.Zero) }
+    Box(
+        modifier =
+            Modifier.onGloballyPositioned { coordinates ->
+                val bounds = coordinates.boundsInWindow()
+                anchorInWindow =
+                    IntRect(
+                        left = bounds.left.roundToInt(),
+                        top = bounds.top.roundToInt(),
+                        right = bounds.right.roundToInt(),
+                        bottom = bounds.bottom.roundToInt(),
+                    )
+            },
+    ) {
+        if (heavyweight && renderer != null) {
+            renderer(onDismissRequest, anchorInWindow, anchoring, offset, focusable, content)
+        } else {
+            Popup(
+                onDismissRequest = onDismissRequest,
+                offset = offset,
+                properties = PopupProperties(focusable = focusable),
+                content = content,
+            )
+        }
     }
+}
+
+/**
+ * Where a [BossPopup] places itself on the heavyweight path.
+ *
+ * The lightweight path always anchors to the calling layout, because that is what Compose's `Popup`
+ * does; this only distinguishes the two on the heavyweight path, where the overlay is its own window
+ * and something has to choose.
+ */
+enum class BossPopupAnchoring {
+    /**
+     * At the pointer. Correct for anything the user opened by clicking - a context menu, a
+     * right-click menu - where the cursor IS the intended position and no coordinate conversion is
+     * needed. This is the default because it is the common case and the safe one.
+     */
+    Cursor,
+
+    /**
+     * Below the calling layout, wherever that sits in the window.
+     *
+     * For a control anchored to something other than the pointer: a suggestion list under a URL bar
+     * is the case that forced this to exist, since the user is typing and the cursor may be anywhere
+     * on screen. Costs a window-space conversion the host has to get right - see the content-pane
+     * note in `HeavyweightPopup` - which is why it is opt-in rather than the default.
+     */
+    AnchorBounds,
 }

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -35,9 +35,12 @@ import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.delay
 
 /**
@@ -356,5 +359,57 @@ fun BossAlertDialog(
                 buttons()
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Anchored popup
+// ---------------------------------------------------------------------------
+
+/**
+ * An anchored, non-modal overlay that layers correctly above a GPU-composited browser surface.
+ *
+ * Drop-in replacement for `androidx.compose.ui.window.Popup`, and the counterpart to [BossDialog] for
+ * everything that is not a modal: a context menu, a dropdown, an autocomplete list. `BossDialog`
+ * cannot stand in for these - it centers its content, draws a scrim, and takes focus.
+ *
+ * **[focusable] is the parameter to think about.** A suggestion list under a text field must pass
+ * `false`, or the popup steals focus from the field and the user cannot keep typing. A menu that
+ * handles its own arrow keys wants `true`.
+ *
+ * [offset] is relative to the anchoring layout. It is honoured exactly on the lightweight path; the
+ * heavyweight renderer currently prefers the cursor, because converting a layout-relative offset to
+ * screen coordinates has to go through the content pane rather than the window and is off by the
+ * title-bar height otherwise. For a menu opened by a click the two coincide. For a control anchored
+ * somewhere the pointer is not - a suggestion list under a text field being the case that exposes it
+ * - the cursor currently wins, and that is a host-side limitation rather than part of this contract:
+ * the parameter is already here, so a renderer that learns true window-space anchoring needs no api
+ * change. Do not rely on cursor placement.
+ *
+ * @param onDismissRequest Called on a click outside, on Escape, or when focus leaves the application.
+ */
+@Composable
+fun BossPopup(
+    onDismissRequest: () -> Unit,
+    offset: IntOffset = IntOffset.Zero,
+    focusable: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    val renderer = BossOverlayHost.popupRenderer
+    val heavyweight =
+        shouldRouteHeavyweight(
+            useHeavyweightOverlays = BossOverlayHost.useHeavyweightOverlays,
+            hasRenderer = renderer != null,
+            hostNeedsHeavyweight = LocalHeavyweightOverlays.current,
+        )
+    if (heavyweight && renderer != null) {
+        renderer(onDismissRequest, offset, focusable, content)
+    } else {
+        Popup(
+            onDismissRequest = onDismissRequest,
+            offset = offset,
+            properties = PopupProperties(focusable = focusable),
+            content = content,
+        )
     }
 }

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -19,17 +19,24 @@ import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.delay
 
 /**
  * Whether the window hosting this composition is one that needs heavyweight overlays.
@@ -119,25 +126,62 @@ fun BossDialog(
 }
 
 /**
+ * How long a freshly-opened heavyweight modal refuses pointer input.
+ *
+ * Short enough to be imperceptible, long enough to outlast the release of the click that opened the
+ * dialog. See [ScrimmedModalContent] for what goes wrong without it.
+ */
+internal const val INPUT_ARM_DELAY_MS = 200L
+
+/**
  * Full-window scrim with the card centered on it.
  *
  * The card carries a no-op click handler so a click inside it is consumed rather than falling
  * through to the scrim and dismissing the dialog the user is filling in.
+ *
+ * **Input is refused until the pointer is known to be idle**, which is not belt-and-braces: a
+ * heavyweight modal is a new window that appears directly UNDER the cursor, and the click that
+ * opened it may still be in flight. Cmd-clicking a link in a terminal opened the link dialog with
+ * the mouse button still down, and the release then landed on whichever option happened to sit
+ * beneath the pointer and chose it - the user picked an option they never aimed at. The lightweight
+ * path cannot do this: it draws inside the existing window, whose press it already saw.
+ *
+ * Two arming rules, because either one alone loses a click:
+ *  - any pointer event with no button held arms it, which covers the in-flight release and any
+ *    stray movement;
+ *  - a [INPUT_ARM_DELAY_MS] timer arms it too, for a dialog opened from the keyboard or a menu,
+ *    where no pointer event may ever arrive and the first real click would otherwise be eaten.
  */
 @Composable
-private fun ScrimmedModalContent(
+internal fun ScrimmedModalContent(
     dismissOnClickOutside: Boolean,
     onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     val scrimInteraction = remember { MutableInteractionSource() }
     val cardInteraction = remember { MutableInteractionSource() }
+    var armed by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        delay(INPUT_ARM_DELAY_MS)
+        armed = true
+    }
     Box(
         modifier =
             Modifier
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = SCRIM_ALPHA))
-                .then(
+                // Initial pass, so this runs BEFORE the scrim's and the card's own handlers and can
+                // take the event away from them entirely.
+                .pointerInput(armed) {
+                    if (armed) return@pointerInput
+                    awaitPointerEventScope {
+                        while (!armed) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            if (event.changes.none { it.pressed }) armed = true
+                            event.changes.forEach { it.consume() }
+                        }
+                    }
+                }.then(
                     if (dismissOnClickOutside) {
                         Modifier.clickable(
                             interactionSource = scrimInteraction,

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
@@ -36,6 +37,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -413,17 +415,11 @@ fun BossPopup(
     // reaching for LocalAwtWindow, which plugin code should not have to do. The Box contributes no
     // size, so it is layout-neutral wherever it is placed.
     var anchorInWindow by remember { mutableStateOf(IntRect.Zero) }
+    val density = LocalDensity.current.density
     Box(
         modifier =
             Modifier.onGloballyPositioned { coordinates ->
-                val bounds = coordinates.boundsInWindow()
-                anchorInWindow =
-                    IntRect(
-                        left = bounds.left.roundToInt(),
-                        top = bounds.top.roundToInt(),
-                        right = bounds.right.roundToInt(),
-                        bottom = bounds.bottom.roundToInt(),
-                    )
+                anchorInWindow = anchorRectInDp(coordinates.boundsInWindow(), density)
             },
     ) {
         if (heavyweight && renderer != null) {
@@ -437,6 +433,31 @@ fun BossPopup(
             )
         }
     }
+}
+
+/**
+ * The anchor rect converted from Compose PIXELS to AWT logical units (dp).
+ *
+ * The unit change is the entire point and is easy to miss: `boundsInWindow()` is in pixels, while the
+ * host places overlay content with `absoluteOffset(x.dp, y.dp)` in logical units. Passing pixels
+ * straight through put the URL-bar suggestion list at roughly double its intended position on a 2x
+ * display - correct on a 1x screen, visibly wrong on every Retina one, which is exactly the class of
+ * bug the host's own popup code already carries a warning about.
+ *
+ * Pure, and separate from the composable, so the conversion is pinned by a test at more than one
+ * scale factor rather than only by looking at a 1x screen.
+ */
+internal fun anchorRectInDp(
+    boundsPx: Rect,
+    density: Float,
+): IntRect {
+    if (density <= 0f) return IntRect.Zero
+    return IntRect(
+        left = (boundsPx.left / density).roundToInt(),
+        top = (boundsPx.top / density).roundToInt(),
+        right = (boundsPx.right / density).roundToInt(),
+        bottom = (boundsPx.bottom / density).roundToInt(),
+    )
 }
 
 /**

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -29,18 +29,19 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -418,9 +419,22 @@ fun BossPopup(
     val density = LocalDensity.current.density
     Box(
         modifier =
-            Modifier.onGloballyPositioned { coordinates ->
-                anchorInWindow = anchorRectInDp(coordinates.boundsInWindow(), density)
-            },
+            Modifier
+                // fillMaxWidth so the probe ADOPTS the caller's width, rather than trying to read it
+                // back off the parent. Walking up with parentLayoutCoordinates does not reliably land
+                // on the caller's layout - modifier nodes have coordinates of their own - and it
+                // returned a zero width, which let the content inherit the overlay window's width and
+                // then get clamped to x = 0. Filling is deterministic and needs no traversal.
+                //
+                // Layout-safe because the probe renders nothing on this path: it has zero height, and
+                // its parent's width is already decided by the caller. Height stays zero, so the
+                // anchor's bottom is its top, which is what "open below the anchor" means for a
+                // zero-height probe placed where the popup should start.
+                .fillMaxWidth()
+                .onGloballyPositioned { coordinates ->
+                    anchorInWindow =
+                        anchorRectInDp(coordinates.positionInWindow(), coordinates.size, density)
+                },
     ) {
         if (heavyweight && renderer != null) {
             renderer(onDismissRequest, anchorInWindow, anchoring, offset, focusable, content)
@@ -438,27 +452,38 @@ fun BossPopup(
 /**
  * The anchor rect converted from Compose PIXELS to AWT logical units (dp).
  *
- * The unit change is the entire point and is easy to miss: `boundsInWindow()` is in pixels, while the
+ * The unit change is the entire point and is easy to miss: layout coordinates are in pixels, while the
  * host places overlay content with `absoluteOffset(x.dp, y.dp)` in logical units. Passing pixels
  * straight through put the URL-bar suggestion list at roughly double its intended position on a 2x
  * display - correct on a 1x screen, visibly wrong on every Retina one, which is exactly the class of
  * bug the host's own popup code already carries a warning about.
  *
+ * Takes position and size rather than a Rect because the caller must use `positionInWindow()`, which
+ * is UNCLIPPED. `boundsInWindow()` clips, and a zero-size probe then collapses to an empty rect at the
+ * origin - which placed the suggestion list in the screen's top-left corner rather than under the URL
+ * bar.
+ *
  * Pure, and separate from the composable, so the conversion is pinned by a test at more than one
  * scale factor rather than only by looking at a 1x screen.
  */
 internal fun anchorRectInDp(
-    boundsPx: Rect,
+    positionPx: Offset,
+    sizePx: IntSize,
     density: Float,
 ): IntRect {
-    if (density <= 0f) return IntRect.Zero
+    if (density <= 0f || !positionPx.isValid()) return IntRect.Zero
+    val left = (positionPx.x / density).roundToInt()
+    val top = (positionPx.y / density).roundToInt()
     return IntRect(
-        left = (boundsPx.left / density).roundToInt(),
-        top = (boundsPx.top / density).roundToInt(),
-        right = (boundsPx.right / density).roundToInt(),
-        bottom = (boundsPx.bottom / density).roundToInt(),
+        left = left,
+        top = top,
+        right = left + (sizePx.width / density).roundToInt(),
+        bottom = top + (sizePx.height / density).roundToInt(),
     )
 }
+
+/** Guards against the Unspecified/NaN offset a detached or not-yet-placed layout reports. */
+private fun Offset.isValid(): Boolean = !x.isNaN() && !y.isNaN()
 
 /**
  * Where a [BossPopup] places itself on the heavyweight path.

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -89,6 +89,7 @@ object BossOverlayHost {
     var popupRenderer: (
         @Composable (
             onDismissRequest: () -> Unit,
+            // In AWT LOGICAL UNITS (dp), not pixels - the host places overlay content in dp.
             anchorInWindow: IntRect,
             anchoring: BossPopupAnchoring,
             offset: IntOffset,

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -20,15 +20,24 @@ import androidx.compose.runtime.Composable
  * vars are enough. Composables read them directly and they are NOT snapshot state - flipping one
  * at runtime would not recompose anything already on screen.
  *
- * **This file exists twice, and the SIGNATURES must stay identical.** plugin-ui-core is the copy
- * that RUNS: `PluginClassLoader.defaultSharedPackages` lists `ai.rever.boss.plugin.ui.`, so a plugin
- * classloader resolves this package parent-first from the host and the host's copy is the one whose
- * fields the startup injection actually writes. The `boss-plugin-api` copy exists only so plugins
- * compile; its bodies are a stand-in nothing ever executes, and they differ where that package has
- * not been synced (it predates the design-system tokens). Signatures are the part that must match,
- * for the reason `BossTheme` documents about overloads versus defaulted parameters: one that differs
- * links at build time and is missing at runtime, which the binary-compatibility validator rejects as
- * a whole-plugin failure.
+ * **This file exists twice, and the SIGNATURES must stay identical.** On a host that has this class
+ * compiled in, plugin-ui-core is the copy that runs: `ai.rever.boss.plugin.ui.` is in
+ * `PluginClassLoader.defaultSharedPackages`, so a plugin resolves it parent-first from the host, and
+ * the host's copy is the one the startup injection writes to.
+ *
+ * The `boss-plugin-api` copy is NOT dead code, which is worth stating because it looks like it. On an
+ * OLDER host these types are absent, and `ApiClassLoader` then serves them out of the installed api
+ * jar - that is what makes them reachable at all there, and it is why `minApiVersion` rather than
+ * `minBossVersion` is the gate a plugin should declare (see ApiClassLoader's own doc: brand-new types
+ * ship via the jar, member additions to host-compiled types do not). On that path the api jar's
+ * bodies really do execute, with nothing having injected a renderer, so they must degrade cleanly:
+ * `BossDialog` falls back to a plain Compose `Dialog`, which is the pre-fix behaviour rather than a
+ * crash. Their layout constants differ from the host's only because that package predates the
+ * design-system tokens.
+ *
+ * Signatures are the part that must match, for the reason `BossTheme` documents about overloads
+ * versus defaulted parameters: one that differs links at build time and is missing at runtime, which
+ * the binary-compatibility validator rejects as a whole-plugin failure.
  */
 object BossOverlayHost {
     /** True when modals must escape into heavyweight windows (HARDWARE_ACCELERATED browser). */

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -137,15 +137,6 @@ object BossOverlayHost {
     @Volatile
     private var reportedMissingRenderer = false
 
-    /**
-     * Report the null-renderer condition described on [diagnostics], at most once per process.
-     *
-     * Public rather than `internal` on purpose. Kotlin mangles an internal member's JVM name with the
-     * MODULE name, so the two copies of this file would emit `reportMissingModalRenderer$...` under
-     * two different suffixes - a gratuitous descriptor difference in the one file whose contract is
-     * that its signatures match. Nothing outside the routing composables should call this.
-     */
-
     /** Reported at most once per process, for the same reason as the modal one. */
     @Volatile
     private var reportedMissingPopupRenderer = false
@@ -167,6 +158,14 @@ object BossOverlayHost {
         )
     }
 
+    /**
+     * Report the null-renderer condition described on [diagnostics], at most once per process.
+     *
+     * Public rather than `internal` on purpose. Kotlin mangles an internal member's JVM name with the
+     * MODULE name, so the two copies of this file would emit `reportMissingModalRenderer$...` under
+     * two different suffixes - a gratuitous descriptor difference in the one file whose contract is
+     * that its signatures match. Nothing outside the routing composables should call this.
+     */
     fun reportMissingModalRenderer() {
         if (reportedMissingRenderer) return
         reportedMissingRenderer = true

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -88,6 +89,8 @@ object BossOverlayHost {
     var popupRenderer: (
         @Composable (
             onDismissRequest: () -> Unit,
+            anchorInWindow: IntRect,
+            anchoring: BossPopupAnchoring,
             offset: IntOffset,
             focusable: Boolean,
             content: @Composable () -> Unit,

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -1,0 +1,95 @@
+package ai.rever.boss.plugin.ui
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Where a modal surface goes when the browser is GPU-composited.
+ *
+ * Under JxBrowser's HARDWARE_ACCELERATED rendering mode the browser view is **not a node in the
+ * Compose scene**: Chromium attaches its own native child window to the AWT window handle, and
+ * that foreign surface composites *above* everything Compose paints. An ordinary Compose `Dialog`
+ * therefore renders BEHIND the page it belongs to. Escaping it means putting the dialog in a
+ * separate always-on-top OS window.
+ *
+ * The window code is platform-specific and lives in the host (`HeavyweightModal`), so it is
+ * INJECTED here rather than depended on. This object is the single registry that both the host's
+ * own dialogs and dynamic plugins route through, which is why it sits in plugin-ui-core: plugins
+ * compile against this package and resolve it, at runtime, to the host's copy.
+ *
+ * Every field is WRITE-ONCE at startup, before any composition, which is why plain `@Volatile`
+ * vars are enough. Composables read them directly and they are NOT snapshot state - flipping one
+ * at runtime would not recompose anything already on screen.
+ *
+ * **This file exists twice, and the SIGNATURES must stay identical.** plugin-ui-core is the copy
+ * that RUNS: `PluginClassLoader.defaultSharedPackages` lists `ai.rever.boss.plugin.ui.`, so a plugin
+ * classloader resolves this package parent-first from the host and the host's copy is the one whose
+ * fields the startup injection actually writes. The `boss-plugin-api` copy exists only so plugins
+ * compile; its bodies are a stand-in nothing ever executes, and they differ where that package has
+ * not been synced (it predates the design-system tokens). Signatures are the part that must match,
+ * for the reason `BossTheme` documents about overloads versus defaulted parameters: one that differs
+ * links at build time and is missing at runtime, which the binary-compatibility validator rejects as
+ * a whole-plugin failure.
+ */
+object BossOverlayHost {
+    /** True when modals must escape into heavyweight windows (HARDWARE_ACCELERATED browser). */
+    @Volatile
+    var useHeavyweightOverlays: Boolean = false
+
+    /**
+     * Platform-injected modal renderer: shows [content] in a separate always-on-top window
+     * covering the parent window. Null until injected; callers fall back to a Compose `Dialog`.
+     */
+    @Volatile
+    var modalRenderer: (
+        @Composable (
+            onDismissRequest: () -> Unit,
+            content: @Composable () -> Unit,
+        ) -> Unit
+    )? = null
+
+    /**
+     * How many heavyweight POPUP windows are currently open.
+     *
+     * Lets a heavyweight modal tell "the user clicked away" from "a child overlay of mine took
+     * focus": both are separate always-on-top windows, so a dropdown opening inside a modal fires
+     * the modal's `windowLostFocus` and would otherwise dismiss the dialog the dropdown belongs
+     * to. Maintained by the host's popup renderer and read by the host's modal renderer; it lives
+     * here so there is one counter rather than one per module.
+     */
+    @Volatile
+    var openHeavyweightPopups: Int = 0
+
+    /**
+     * Optional sink for "this overlay degraded" messages, wired by the host to its logger.
+     *
+     * This module deliberately depends on nothing but Compose, so it cannot log on its own. The
+     * one condition worth reporting is a null [modalRenderer] while [useHeavyweightOverlays] is
+     * true: the dialog silently falls back to lightweight and is drawn behind the page, which is
+     * the exact bug this file exists to fix, with nothing on screen to say so. That happens if a
+     * plugin ever links its own copy of this class instead of the host's.
+     */
+    @Volatile
+    var diagnostics: ((String) -> Unit)? = null
+
+    /** Reported at most once per process; a per-frame warning would drown the log. */
+    @Volatile
+    private var reportedMissingRenderer = false
+
+    /**
+     * Report the null-renderer condition described on [diagnostics], at most once per process.
+     *
+     * Public rather than `internal` on purpose. Kotlin mangles an internal member's JVM name with the
+     * MODULE name, so the two copies of this file would emit `reportMissingModalRenderer$...` under
+     * two different suffixes - a gratuitous descriptor difference in the one file whose contract is
+     * that its signatures match. Nothing outside the routing composables should call this.
+     */
+    fun reportMissingModalRenderer() {
+        if (reportedMissingRenderer) return
+        reportedMissingRenderer = true
+        diagnostics?.invoke(
+            "Heavyweight overlays are enabled but no modal renderer is registered - dialogs will " +
+                "render behind the browser surface. The BossOverlayHost being read is probably not " +
+                "the host's copy.",
+        )
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -113,6 +113,10 @@ object BossOverlayHost {
      * for safe publication to readers, not to make the arithmetic safe. Do not write it from a
      * background thread, and do not "fix" it to `AtomicInteger` casually - that changes the
      * descriptor and needs a coordinated host and api release.
+     *
+     * **HOST-OWNED. Plugins must not write this.** It is public only because the host's popup
+     * renderer lives in a different module; a lost decrement from anywhere leaves every host modal
+     * unable to dismiss on focus loss.
      */
     @Volatile
     var openHeavyweightPopups: Int = 0
@@ -141,6 +145,28 @@ object BossOverlayHost {
      * two different suffixes - a gratuitous descriptor difference in the one file whose contract is
      * that its signatures match. Nothing outside the routing composables should call this.
      */
+
+    /** Reported at most once per process, for the same reason as the modal one. */
+    @Volatile
+    private var reportedMissingPopupRenderer = false
+
+    /**
+     * The [reportMissingModalRenderer] counterpart for popups.
+     *
+     * A separate function rather than a parameter on that one: this surface is pinned by the
+     * binary-compatibility validator in two repos, so changing an existing descriptor costs a
+     * coordinated host and api release while adding one is free. Added now for exactly that reason -
+     * a popup rendering behind the browser would otherwise produce nothing in the log at all.
+     */
+    fun reportMissingPopupRenderer() {
+        if (reportedMissingPopupRenderer) return
+        reportedMissingPopupRenderer = true
+        diagnostics?.invoke(
+            "Heavyweight overlays are enabled but no popup renderer is registered - menus and " +
+                "dropdowns will render behind the browser surface.",
+        )
+    }
+
     fun reportMissingModalRenderer() {
         if (reportedMissingRenderer) return
         reportedMissingRenderer = true

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -67,6 +68,28 @@ object BossOverlayHost {
         @Composable (
             properties: DialogProperties,
             onDismissRequest: () -> Unit,
+            content: @Composable () -> Unit,
+        ) -> Unit
+    )? = null
+
+    /**
+     * Platform-injected POPUP renderer: shows [content] in a separate always-on-top window anchored
+     * near [offset]. Null until injected; callers fall back to a Compose `Popup`.
+     *
+     * Separate from [modalRenderer] because a popup is not a modal, and the differences are the whole
+     * reason a plugin cannot fake one with `BossDialog`: it is anchored rather than centered, it draws
+     * no scrim, and with `focusable = false` it does not take focus - which is what a URL-bar
+     * suggestion list needs, since the text field must keep focus while the user types.
+     *
+     * Signature matches the host's own popup renderer so the same window implementation serves the
+     * host's context menus and a plugin's, rather than two that can drift.
+     */
+    @Volatile
+    var popupRenderer: (
+        @Composable (
+            onDismissRequest: () -> Unit,
+            offset: IntOffset,
+            focusable: Boolean,
             content: @Composable () -> Unit,
         ) -> Unit
     )? = null

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossOverlayHost.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.DialogProperties
 
 /**
  * Where a modal surface goes when the browser is GPU-composited.
@@ -27,13 +28,19 @@ import androidx.compose.runtime.Composable
  *
  * The `boss-plugin-api` copy is NOT dead code, which is worth stating because it looks like it. On an
  * OLDER host these types are absent, and `ApiClassLoader` then serves them out of the installed api
- * jar - that is what makes them reachable at all there, and it is why `minApiVersion` rather than
- * `minBossVersion` is the gate a plugin should declare (see ApiClassLoader's own doc: brand-new types
+ * jar - that is what makes them reachable at all there (see ApiClassLoader's own doc: brand-new types
  * ship via the jar, member additions to host-compiled types do not). On that path the api jar's
  * bodies really do execute, with nothing having injected a renderer, so they must degrade cleanly:
- * `BossDialog` falls back to a plain Compose `Dialog`, which is the pre-fix behaviour rather than a
- * crash. Their layout constants differ from the host's only because that package predates the
- * design-system tokens.
+ * `BossDialog` falls back to a plain Compose `Dialog`. Their layout constants differ from the host's
+ * only because that package predates the design-system tokens.
+ *
+ * **Which gate a plugin should declare, stated once so the two answers stop competing:**
+ * `minApiVersion: 1.0.72` is what makes the symbols RESOLVE, and it is the minimum a plugin needs to
+ * install and run. It does not promise the dialog is in front of the browser - on a host without
+ * these types compiled in, the api jar's fallback is the pre-fix, occluded dialog. A plugin that
+ * merely wants to compile and behave no worse than before needs only `minApiVersion`. A plugin whose
+ * feature DEPENDS on the dialog actually clearing the browser surface must additionally gate on the
+ * `minBossVersion` of the release that carries the host's copy.
  *
  * Signatures are the part that must match, for the reason `BossTheme` documents about overloads
  * versus defaulted parameters: one that differs links at build time and is missing at runtime, which
@@ -47,10 +54,18 @@ object BossOverlayHost {
     /**
      * Platform-injected modal renderer: shows [content] in a separate always-on-top window
      * covering the parent window. Null until injected; callers fall back to a Compose `Dialog`.
+     *
+     * Takes the caller's `DialogProperties` because the renderer is the only thing that can honour
+     * some of them. `dismissOnBackPress` maps to Escape, and Escape is handled by the window itself
+     * rather than by anything inside it - a renderer that never saw the properties silently made
+     * every heavyweight dialog Escape-dismissable regardless. Passed at the boundary rather than
+     * added later on purpose: this signature is pinned by the binary-compatibility validator in two
+     * repos at once, so widening it after release costs a coordinated host and api release.
      */
     @Volatile
     var modalRenderer: (
         @Composable (
+            properties: DialogProperties,
             onDismissRequest: () -> Unit,
             content: @Composable () -> Unit,
         ) -> Unit
@@ -64,6 +79,13 @@ object BossOverlayHost {
      * the modal's `windowLostFocus` and would otherwise dismiss the dialog the dropdown belongs
      * to. Maintained by the host's popup renderer and read by the host's modal renderer; it lives
      * here so there is one counter rather than one per module.
+     *
+     * **UI-thread only.** `++`/`--` on a plain Int are not atomic, and a lost decrement would leave a
+     * modal permanently unable to dismiss on focus loss. Every writer is a Compose
+     * `DisposableEffect` on the UI thread, so the contract holds by construction; `@Volatile` is here
+     * for safe publication to readers, not to make the arithmetic safe. Do not write it from a
+     * background thread, and do not "fix" it to `AtomicInteger` casually - that changes the
+     * descriptor and needs a coordinated host and api release.
      */
     @Volatile
     var openHeavyweightPopups: Int = 0

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
@@ -1,8 +1,11 @@
 package ai.rever.boss.plugin.ui
 
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.IntRect
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 /**
  * Pins which modals escape into a heavyweight window.
@@ -103,5 +106,40 @@ class ModalInputArmingRuleTest {
         for (askedByTimer in listOf(true, false)) {
             assertFalse(shouldArmModalInput(pointerDown = true), "armed while pressed (timer=$askedByTimer)")
         }
+    }
+}
+
+/**
+ * The px-to-dp conversion for a popup's anchor.
+ *
+ * Compose measures layout in PIXELS; the host places overlay content in AWT LOGICAL UNITS. Shipping
+ * the raw pixel rect put the URL-bar suggestion list at roughly double its intended position on a 2x
+ * display - and looked perfectly correct on a 1x one, which is why this is tested at several scale
+ * factors rather than eyeballed on one screen.
+ */
+class AnchorRectConversionTest {
+    @Test
+    fun `at 1x the numbers are unchanged, which is why the bug hid`() {
+        val r = anchorRectInDp(Rect(120f, 40f, 620f, 68f), density = 1f)
+        assertEquals(IntRect(120, 40, 620, 68), r)
+    }
+
+    @Test
+    fun `at 2x every edge halves`() {
+        val r = anchorRectInDp(Rect(240f, 80f, 1240f, 136f), density = 2f)
+        assertEquals(IntRect(120, 40, 620, 68), r)
+    }
+
+    @Test
+    fun `a 150 percent display is handled, not just integral scales`() {
+        val r = anchorRectInDp(Rect(180f, 60f, 930f, 102f), density = 1.5f)
+        assertEquals(IntRect(120, 40, 620, 68), r)
+    }
+
+    @Test
+    fun `a nonsensical density yields an empty rect rather than a divide by zero`() {
+        // An anchor at the origin degrades to cursor-like placement; NaN coordinates would propagate
+        // into a window position and put the popup somewhere unrecoverable.
+        assertEquals(IntRect.Zero, anchorRectInDp(Rect(10f, 10f, 20f, 20f), density = 0f))
     }
 }

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
@@ -1,0 +1,77 @@
+package ai.rever.boss.plugin.ui
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins which modals escape into a heavyweight window.
+ *
+ * Composing a `Window` needs a display, so [shouldRouteHeavyweight] is the only part of the
+ * decision a unit test can reach - and it is the part where every regression would land, because
+ * each of its three inputs suppresses the heavyweight path for a different reason.
+ */
+class BossDialogRoutingTest {
+    @Test
+    fun `a browser-hosting window with a registered renderer routes heavyweight`() {
+        assertTrue(
+            shouldRouteHeavyweight(
+                useHeavyweightOverlays = true,
+                hasRenderer = true,
+                hostNeedsHeavyweight = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `OFF_SCREEN installs keep the lightweight path, so they cannot regress`() {
+        assertFalse(
+            shouldRouteHeavyweight(
+                useHeavyweightOverlays = false,
+                hasRenderer = true,
+                hostNeedsHeavyweight = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `with nothing injected there is nowhere to route to, so it falls back`() {
+        assertFalse(
+            shouldRouteHeavyweight(
+                useHeavyweightOverlays = true,
+                hasRenderer = false,
+                hostNeedsHeavyweight = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a secondary window stays lightweight even under HARDWARE`() {
+        // Settings and the first-run setup window host no browser surface. An always-on-top window
+        // sized to the MAIN window would cover the wrong window and then keep floating over it,
+        // because a heavyweight modal deliberately survives focus moving to another window of the
+        // same application.
+        assertFalse(
+            shouldRouteHeavyweight(
+                useHeavyweightOverlays = true,
+                hasRenderer = true,
+                hostNeedsHeavyweight = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `the missing-renderer diagnostic fires once, not once per frame`() {
+        val messages = mutableListOf<String>()
+        val previous = BossOverlayHost.diagnostics
+        try {
+            BossOverlayHost.diagnostics = { messages += it }
+            repeat(5) { BossOverlayHost.reportMissingModalRenderer() }
+        } finally {
+            BossOverlayHost.diagnostics = previous
+        }
+        // A dialog recomposes freely; a per-composition warning would bury the log it is meant to
+        // surface in.
+        assertTrue(messages.size <= 1, "expected at most one report, got ${messages.size}")
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
@@ -1,7 +1,8 @@
 package ai.rever.boss.plugin.ui
 
-import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -120,26 +121,45 @@ class ModalInputArmingRuleTest {
 class AnchorRectConversionTest {
     @Test
     fun `at 1x the numbers are unchanged, which is why the bug hid`() {
-        val r = anchorRectInDp(Rect(120f, 40f, 620f, 68f), density = 1f)
+        val r = anchorRectInDp(Offset(120f, 40f), IntSize(500, 28), density = 1f)
         assertEquals(IntRect(120, 40, 620, 68), r)
     }
 
     @Test
-    fun `at 2x every edge halves`() {
-        val r = anchorRectInDp(Rect(240f, 80f, 1240f, 136f), density = 2f)
+    fun `at 2x position and size both halve`() {
+        val r = anchorRectInDp(Offset(240f, 80f), IntSize(1000, 56), density = 2f)
         assertEquals(IntRect(120, 40, 620, 68), r)
     }
 
     @Test
     fun `a 150 percent display is handled, not just integral scales`() {
-        val r = anchorRectInDp(Rect(180f, 60f, 930f, 102f), density = 1.5f)
+        val r = anchorRectInDp(Offset(180f, 60f), IntSize(750, 42), density = 1.5f)
         assertEquals(IntRect(120, 40, 620, 68), r)
     }
 
     @Test
+    fun `the anchor keeps its width, which is what the content is sized to`() {
+        // The list stretched edge to edge because a zero-width anchor left the content inheriting
+        // the overlay window's width. Width has to survive the conversion.
+        val r = anchorRectInDp(Offset(240f, 80f), IntSize(1000, 0), density = 2f)
+        assertEquals(500, r.width)
+    }
+
+    @Test
+    fun `a zero-height anchor still reports its position, so the popup opens there`() {
+        // The anchor Box wraps a zero-size probe, so zero height is the NORMAL case, not an error.
+        val r = anchorRectInDp(Offset(240f, 80f), IntSize(1000, 0), density = 2f)
+        assertEquals(40, r.top)
+        assertEquals(40, r.bottom)
+    }
+
+    @Test
     fun `a nonsensical density yields an empty rect rather than a divide by zero`() {
-        // An anchor at the origin degrades to cursor-like placement; NaN coordinates would propagate
-        // into a window position and put the popup somewhere unrecoverable.
-        assertEquals(IntRect.Zero, anchorRectInDp(Rect(10f, 10f, 20f, 20f), density = 0f))
+        assertEquals(IntRect.Zero, anchorRectInDp(Offset(10f, 10f), IntSize(10, 10), density = 0f))
+    }
+
+    @Test
+    fun `an unplaced layout reporting NaN does not become a NaN window position`() {
+        assertEquals(IntRect.Zero, anchorRectInDp(Offset(Float.NaN, Float.NaN), IntSize(10, 10), density = 2f))
     }
 }

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossDialogRoutingTest.kt
@@ -75,3 +75,33 @@ class BossDialogRoutingTest {
         assertTrue(messages.size <= 1, "expected at most one report, got ${messages.size}")
     }
 }
+
+/**
+ * The arming rule for a freshly-opened modal, which is where the user-visible regression lives.
+ *
+ * A heavyweight modal is a new window placed over the cursor, so the click that opened it is still in
+ * flight. The first version of this guard let a 200ms timer arm it unconditionally: a modifier-click
+ * held longer than that - plus the window's own first-frame latency - expired the timer while the
+ * button was still down, and the release then chose whichever option sat under the pointer. That is
+ * the reported bug, reintroduced intermittently, which is worse than not guarding at all.
+ */
+class ModalInputArmingRuleTest {
+    @Test
+    fun `a held button vetoes arming, even once the timer has elapsed`() {
+        assertFalse(shouldArmModalInput(pointerDown = true))
+    }
+
+    @Test
+    fun `an idle pointer arms it`() {
+        assertTrue(shouldArmModalInput(pointerDown = false))
+    }
+
+    @Test
+    fun `the veto does not depend on which signal is asking`() {
+        // Both the pointer handler and the timer call this with the same question, so there is no
+        // path on which "the timer fired" outranks "a button is down".
+        for (askedByTimer in listOf(true, false)) {
+            assertFalse(shouldArmModalInput(pointerDown = true), "armed while pressed (timer=$askedByTimer)")
+        }
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossPopupAnchorLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossPopupAnchorLayoutTest.kt
@@ -1,0 +1,85 @@
+package ai.rever.boss.plugin.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * What a [BossPopup] actually reports as its anchor, measured through real Compose layout.
+ *
+ * This exists because three separate placement bugs shipped past compile, 1561 unit tests, detekt and
+ * ktlint, and were caught only by looking at the screen. Every one of them lived in the layout
+ * boundary rather than in arithmetic: a clipped rect that collapsed to the origin, a `fillMaxWidth()`
+ * that was reparented into the overlay window, and a coordinate traversal that did not reach the
+ * caller. Pure-function tests cannot see any of that, so this reproduces the exact structure the
+ * browser plugin uses - a half-width, top-centred, y-offset anchor Box - and asserts on the values the
+ * renderer is handed.
+ */
+class BossPopupAnchorLayoutTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @After
+    fun resetRegistry() {
+        BossOverlayHost.useHeavyweightOverlays = false
+        BossOverlayHost.popupRenderer = null
+    }
+
+    private fun captureAnchor(): IntRect? {
+        var captured: IntRect? = null
+        BossOverlayHost.useHeavyweightOverlays = true
+        BossOverlayHost.popupRenderer = { _, anchorInWindow, _, _, _, _ -> captured = anchorInWindow }
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                // The browser plugin's structure: a half-width anchor, centred, pushed below the
+                // toolbar. The popup content is deliberately non-trivial so a wrong parent shows up.
+                Box(Modifier.size(width = 1000.dp, height = 800.dp)) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth(0.5f)
+                                .align(Alignment.TopCenter)
+                                .offset(y = 38.dp),
+                    ) {
+                        BossPopup(
+                            onDismissRequest = {},
+                            focusable = false,
+                            anchoring = BossPopupAnchoring.AnchorBounds,
+                        ) {
+                            Text("suggestion")
+                        }
+                    }
+                }
+            }
+        }
+        rule.waitForIdle()
+        return captured
+    }
+
+    @Test
+    fun `the anchor carries the caller's width, which is what the content is sized to`() {
+        val anchor = requireNotNull(captureAnchor()) { "renderer was never invoked" }
+        // Zero width is the failure that let the list stretch edge to edge: with no width to apply,
+        // the content inherited the overlay window's and was then clamped to x = 0.
+        assertEquals(500, anchor.width, "anchor width should be half of the 1000dp parent, got $anchor")
+    }
+
+    @Test
+    fun `the anchor carries the caller's position`() {
+        val anchor = requireNotNull(captureAnchor()) { "renderer was never invoked" }
+        assertEquals(250, anchor.left, "a half-width TopCenter box starts a quarter in, got $anchor")
+        assertEquals(38, anchor.top, "the y offset is where the list opens, got $anchor")
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossPopupAnchorLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossPopupAnchorLayoutTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -8,13 +9,18 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * What a [BossPopup] actually reports as its anchor, measured through real Compose layout.
@@ -81,5 +87,121 @@ class BossPopupAnchorLayoutTest {
         val anchor = requireNotNull(captureAnchor()) { "renderer was never invoked" }
         assertEquals(250, anchor.left, "a half-width TopCenter box starts a quarter in, got $anchor")
         assertEquals(38, anchor.top, "the y offset is where the list opens, got $anchor")
+    }
+}
+
+/**
+ * That the anchor probe is genuinely layout-neutral.
+ *
+ * It was not: the width was adopted with `fillMaxWidth()`, which sets `minWidth = maxWidth` and so
+ * claims the caller's full width. That starves later siblings in a `Row`, adds a phantom gap in a
+ * `Column` with `Arrangement.spacedBy`, and - because the lightweight `Popup` is nested inside the
+ * probe - changes anchoring even on OFF_SCREEN installs that never route heavyweight. `BossPopup` is
+ * documented as a drop-in for `Popup`, which emits a genuine 0x0 node, so this is part of the
+ * contract rather than a detail.
+ */
+class BossPopupLayoutNeutralityTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @After
+    fun resetRegistry() {
+        BossOverlayHost.useHeavyweightOverlays = false
+        BossOverlayHost.popupRenderer = null
+    }
+
+    @Test
+    fun `a sibling after the popup keeps its position`() {
+        BossOverlayHost.useHeavyweightOverlays = true
+        BossOverlayHost.popupRenderer = { _, _, _, _, _, _ -> }
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                Row(Modifier.size(width = 1000.dp, height = 100.dp)) {
+                    BossPopup(onDismissRequest = {}, anchoring = BossPopupAnchoring.AnchorBounds) {
+                        Text("popup")
+                    }
+                    Text("sibling", modifier = Modifier.testTag("sibling"))
+                }
+            }
+        }
+        rule.waitForIdle()
+        // A probe claiming the full width would push this off the right edge entirely.
+        rule.onNodeWithTag("sibling").assertIsDisplayed()
+        val left = rule.onNodeWithTag("sibling").getUnclippedBoundsInRoot().left
+        assertTrue(left.value < 50f, "sibling should start at the row's left edge, was at $left")
+    }
+}
+
+/**
+ * That an anchored popup is never handed an unmeasured anchor.
+ *
+ * Reported from a live session: the suggestion list flashed in the top-left corner at full width for
+ * a couple of hundred milliseconds before snapping into place. The renderer was invoked on the first
+ * composition, before `onGloballyPositioned` had run, so it was placed at the window origin with no
+ * width - and the overlay window's own creation latency made that visible rather than a single frame.
+ *
+ * Asserts on EVERY invocation, not just the last: a single bad first call is exactly the bug, and
+ * checking the final value would pass while the flash remained.
+ */
+class BossPopupFirstFrameTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @After
+    fun resetRegistry() {
+        BossOverlayHost.useHeavyweightOverlays = false
+        BossOverlayHost.popupRenderer = null
+    }
+
+    @Test
+    fun `an anchored popup is never placed at the origin, not even on the first frame`() {
+        val seen = mutableListOf<IntRect>()
+        BossOverlayHost.useHeavyweightOverlays = true
+        BossOverlayHost.popupRenderer = { _, anchorInWindow, _, _, _, _ -> seen += anchorInWindow }
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                Box(Modifier.size(width = 1000.dp, height = 800.dp)) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth(0.5f)
+                                .align(Alignment.TopCenter)
+                                .offset(y = 38.dp),
+                    ) {
+                        BossPopup(
+                            onDismissRequest = {},
+                            focusable = false,
+                            anchoring = BossPopupAnchoring.AnchorBounds,
+                        ) {
+                            Text("suggestion")
+                        }
+                    }
+                }
+            }
+        }
+        rule.waitForIdle()
+        assertTrue(seen.isNotEmpty(), "renderer should eventually be invoked")
+        assertTrue(
+            seen.none { it == IntRect.Zero },
+            "an unmeasured anchor reached the renderer, which is the top-left flash: $seen",
+        )
+    }
+
+    @Test
+    fun `cursor anchoring is not delayed, since it never reads the anchor`() {
+        var invoked = false
+        BossOverlayHost.useHeavyweightOverlays = true
+        BossOverlayHost.popupRenderer = { _, _, _, _, _, _ -> invoked = true }
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                Box(Modifier.size(200.dp)) {
+                    BossPopup(onDismissRequest = {}, anchoring = BossPopupAnchoring.Cursor) {
+                        Text("menu")
+                    }
+                }
+            }
+        }
+        rule.waitForIdle()
+        assertTrue(invoked, "a cursor-anchored menu must not wait for a measurement it never uses")
     }
 }

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/ModalInputArmingTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/ModalInputArmingTest.kt
@@ -1,0 +1,116 @@
+package ai.rever.boss.plugin.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * A freshly-opened heavyweight modal must not act on the click that opened it.
+ *
+ * The bug this pins came from a real gesture: cmd-clicking a link in a terminal opens the link
+ * dialog, and because a heavyweight modal is a NEW WINDOW placed under the cursor, the release of
+ * that same click landed on whichever option happened to sit beneath the pointer and chose it. The
+ * user selected an option they never aimed at, and which one depended purely on where the link
+ * happened to be on screen.
+ *
+ * Tested through [ScrimmedModalContent] directly, which is why it is `internal` rather than private:
+ * the guard lives on the heavyweight path, and that path is a real OS window a Compose test scene
+ * cannot host. Composing the scrim content on its own exercises the same modifier chain.
+ *
+ * `mainClock.autoAdvance = false` is load-bearing. The arming timer is a `LaunchedEffect` + `delay`,
+ * so with the clock advancing automatically it would fire before the test could click and the first
+ * assertion would pass vacuously.
+ */
+class ModalInputArmingTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private fun option(onClick: () -> Unit): @Composable () -> Unit =
+        {
+            Box(
+                Modifier
+                    .size(120.dp)
+                    .clickable(onClick = onClick),
+            ) { Text(OPTION) }
+        }
+
+    @Test
+    fun `a click landing before the arming delay is swallowed`() {
+        var chosen = 0
+        var dismissed = 0
+        rule.mainClock.autoAdvance = false
+        rule.setContent {
+            ScrimmedModalContent(
+                dismissOnClickOutside = true,
+                onDismissRequest = { dismissed++ },
+                content = option { chosen++ },
+            )
+        }
+        // One frame, so the tree exists, but nowhere near INPUT_ARM_DELAY_MS.
+        rule.mainClock.advanceTimeByFrame()
+
+        rule.onNodeWithText(OPTION).performClick()
+
+        assertEquals(0, chosen, "the option fired from the click that opened the dialog")
+        assertEquals(0, dismissed, "the scrim dismissed from the click that opened the dialog")
+    }
+
+    @Test
+    fun `a click after the arming delay works normally`() {
+        var chosen = 0
+        rule.mainClock.autoAdvance = false
+        rule.setContent {
+            ScrimmedModalContent(
+                dismissOnClickOutside = true,
+                onDismissRequest = {},
+                content = option { chosen++ },
+            )
+        }
+        // Past the timer, which is the other half of the contract: the guard must open up on its own
+        // for a dialog reached from the keyboard or a menu, where no pointer event ever arrives to arm
+        // it and a permanently deaf dialog would be far worse than the bug it fixes.
+        rule.mainClock.advanceTimeBy(INPUT_ARM_DELAY_MS + FRAME_SLACK_MS)
+
+        rule.onNodeWithText(OPTION).performClick()
+
+        assertEquals(1, chosen)
+    }
+
+    @Test
+    fun `dismiss-on-click-outside is disabled independently of arming`() {
+        // Guards the other branch of the same modifier chain: with dismissOnClickOutside off, no
+        // amount of waiting should make the scrim dismissible.
+        var dismissed = 0
+        var chosen = 0
+        rule.setContent {
+            ScrimmedModalContent(
+                dismissOnClickOutside = false,
+                onDismissRequest = { dismissed++ },
+                content = option { chosen++ },
+            )
+        }
+        rule.mainClock.advanceTimeBy(INPUT_ARM_DELAY_MS + FRAME_SLACK_MS)
+
+        rule.onNodeWithText(OPTION).performClick()
+
+        assertEquals(1, chosen, "the card stopped receiving clicks")
+        assertEquals(0, dismissed, "dismissOnClickOutside = false still dismissed")
+    }
+
+    private companion object {
+        const val OPTION = "Existing Split"
+
+        /** A couple of frames past the timer, so the arming recomposition has actually landed. */
+        const val FRAME_SLACK_MS = 64L
+    }
+}

--- a/scripts/sync-plugin-api-overlay-mirror.py
+++ b/scripts/sync-plugin-api-overlay-mirror.py
@@ -1,0 +1,91 @@
+"""Sync the plugin-ui-core overlay files into the boss-plugin-api copy.
+
+WHOLE FILE, deliberately. A previous sync spliced only from the "Anchored popup" marker
+onwards, so fixes inside ScrimmedModalContent - the retrying arm timer, the Exit
+press-clearing, the scrim's canFocus - never reached the api copy, which is the copy that
+actually EXECUTES on an older host via ApiClassLoader. Substituting a known list is the
+only shape that fails loudly when the host file changes shape.
+"""
+import pathlib, sys
+
+H = pathlib.Path("plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui")
+A = pathlib.Path("/Users/kshivang/Development/Boss/.worktrees/boss-plugin-api-overlay-dialogs/src/main/kotlin/ai/rever/boss/plugin/ui")
+
+# BossOverlayHost is identical in both copies.
+(A / "BossOverlayHost.kt").write_text((H / "BossOverlayHost.kt").read_text())
+
+s = (H / "BossDialog.kt").read_text()
+
+# The api package predates the design-system tokens, so BossAlertDialog's body uses the
+# values they resolve to. Every substitution must fire; a miss means the host file moved
+# and this script needs updating rather than silently producing a divergent copy.
+subs = [
+    ("    val colors = BossTheme.colors\n    val space = BossTheme.space\n", ""),
+    ("shape = shape ?: BossTheme.radius.dialogShape,", "shape = shape ?: RoundedCornerShape(DIALOG_RADIUS),"),
+    ("color = backgroundColor.takeOrElse { colors.panel },", "color = backgroundColor.takeOrElse { BossThemeColors.SurfaceColor },"),
+    ("contentColor = contentColor.takeOrElse { colors.textPrimary },", "contentColor = contentColor.takeOrElse { BossThemeColors.TextPrimary },"),
+    ("Column(modifier = Modifier.padding(space.xl)) {", "Column(modifier = Modifier.padding(CARD_PADDING)) {"),
+    ("CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {", "CompositionLocalProvider(LocalContentColor provides BossThemeColors.TextPrimary) {"),
+    ("ProvideTextStyle(BossTheme.type.title, title)", "ProvideTextStyle(TITLE_STYLE, title)"),
+    ("CompositionLocalProvider(LocalContentColor provides colors.textSecondary) {", "CompositionLocalProvider(LocalContentColor provides BossThemeColors.TextSecondary) {"),
+    ("ProvideTextStyle(BossTheme.type.body, text)", "ProvideTextStyle(BODY_STYLE, text)"),
+    ("Spacer(Modifier.height(space.md))", "Spacer(Modifier.height(TITLE_TEXT_GAP))"),
+    ("Spacer(Modifier.height(space.xl))", "Spacer(Modifier.height(CARD_PADDING))"),
+    ("Spacer(Modifier.width(BossTheme.space.sm))", "Spacer(Modifier.width(BUTTON_GAP))"),
+]
+missing = [old for old, _ in subs if old not in s]
+if missing:
+    sys.exit("host file changed shape; these no longer match:\n  " + "\n  ".join(repr(m) for m in missing))
+for old, new in subs:
+    s = s.replace(old, new)
+
+tokens = '''// ---------------------------------------------------------------------------
+// Design-system stand-ins.
+//
+// The host's copy reads BossTheme.space / .radius / .type. This copy of the package predates those
+// tokens, so the values they resolve to are inlined. This body is NOT dead: ApiClassLoader serves
+// these types from the jar on a host that lacks them compiled in, so it is what runs on the fallback
+// path. Colors go through BossThemeColors, the indirection layer the rest of this package uses.
+// ---------------------------------------------------------------------------
+
+/** BossRadii.dialog */
+private val DIALOG_RADIUS: Dp = 8.dp
+
+/** BossSpacing.xl */
+private val CARD_PADDING: Dp = 24.dp
+
+/** BossSpacing.md */
+private val TITLE_TEXT_GAP: Dp = 12.dp
+
+/** BossSpacing.sm */
+private val BUTTON_GAP: Dp = 8.dp
+
+/** bossTypography().title */
+private val TITLE_STYLE = TextStyle(fontWeight = FontWeight.SemiBold, fontSize = 16.sp)
+
+/** bossTypography().body */
+private val BODY_STYLE = TextStyle(fontWeight = FontWeight.Normal, fontSize = 13.sp)
+
+'''
+anchor = "/** Width of a BOSS alert card, matching the house confirmation dialog. */"
+assert anchor in s, "AlertWidth anchor missing"
+s = s.replace(anchor, tokens + anchor, 1)
+
+extra = ["import androidx.compose.foundation.shape.RoundedCornerShape\n",
+         "import androidx.compose.ui.text.TextStyle\n",
+         "import androidx.compose.ui.text.font.FontWeight\n",
+         "import androidx.compose.ui.unit.sp\n"]
+for imp in extra:
+    if imp not in s:
+        i = s.index("import "); s = s[:i] + imp + s[i:]
+
+# Sort the import block, which review #2 flagged as unsorted relative to its siblings.
+lines = s.split("\n")
+first = next(i for i, l in enumerate(lines) if l.startswith("import "))
+last = max(i for i, l in enumerate(lines) if l.startswith("import "))
+imports = sorted({l for l in lines[first:last + 1] if l.startswith("import ")})
+lines[first:last + 1] = imports
+s = "\n".join(lines)
+
+(A / "BossDialog.kt").write_text(s)
+print("synced whole file; %d substitutions applied, imports sorted" % len(subs))


### PR DESCRIPTION
## Why

#128 flipped JxBrowser to `HARDWARE_ACCELERATED` on every platform. Under HARDWARE the browser view is **not a node in the Compose scene**: Chromium attaches its own native child window to the AWT window handle, and that surface composites *above* everything Compose paints.

#128 solved this for three overlay classes - context menus, hover tooltips, and one modal (`NewTabDialog`). Every other modal surface was left rendering behind the page it belongs to: the "Open Link" dialog, all 25 Material `AlertDialog`s, the Ctrl+Tab switcher, and both drag ghosts.

## What

The routing primitive moves into `plugin-ui-core`, because plugins draw overlays too and cannot see `composeApp`. `OverlayConfig`'s modal switch, popup renderer and popup counter become forwarding accessors onto `BossOverlayHost`, so host and plugins share one registry rather than two that can drift. `main.kt`'s injection is otherwise unchanged.

- **`BossDialog`** - drop-in for `Dialog`; owns the scrim and centering, so all 30 call sites are a rename and `NewTabDialog` stops hand-rolling its own.
- **`BossAlertDialog`** - Material 2 offers no injection point (`AlertDialogContent` and its baseline layout are `internal`; the desktop `dialogProvider` hook is gone), so the card is rebuilt from design-system tokens with Material's parameter list kept name for name. 25 sites, including `GenericDialogHost`, which fixes every plugin-*requested* dialog with no plugin release.
- **`LocalHeavyweightOverlays`** - only a browser-hosting window routes heavyweight. Without it a Settings dialog opens over the **main** window (the overlay measures `LocalAwtWindow`) and then floats above it, since a heavyweight modal deliberately survives focus moving within the app. `ContextMenu` had the same latent bug and gets the same gate.
- **`HeavyweightHud`** - non-focusable, so a held Ctrl keeps reaching the app.
- **`HeavyweightGhost`** - content-sized, cursor-offset. A parent-sized ghost window would eat the drag; the JVM has no portable click-through, so placement **flips to the other side of the cursor** at a screen edge rather than being pulled back under it.
- **Anchored popups** - `BossPopupAnchoring.AnchorBounds` places content below the caller's window-space bounds, corrected by the parent's content-pane inset. Needed for the browser plugin's URL-bar suggestion list, where the cursor is the wrong anchor because the user is typing.
- **Input guard** - a modal ignores the click that opened it. Reported live: cmd-clicking a terminal link opened the dialog and the release chose whichever option sat under the pointer.
- `RemoteWidgetRenderer`'s dropdown moves to `ContextMenu`, already routed.

## The bugs worth reading about

**The content-pane inset.** The overlay window sits at the parent **frame** origin while Compose measures anchors against the **content pane**. Without correcting, an anchored popup sits a title-bar too high and overlaps its own anchor - the same off-by-a-title-bar the pinch-zoom gate had to solve.

**A shadowed parameter.** `ScrimmedContent` already had a local `contentWidthDp` (the width the content *measured at*, for clamping); the new parameter carrying the width to *impose* took the same name. The local won, so content was constrained to the width it already had - the whole overlay window - which silently swallowed three upstream fixes. detekt reported it the run it was introduced, as "Condition is always 'true'", and that warning was the bug.

## Testing

`compileKotlinDesktop`, repo-wide `detekt` + `ktlintCheck` clean. **1563 tests, 0 failures**, including `BossPopupAnchorLayoutTest`, which reproduces the browser plugin's real anchor structure - the earlier tests pinned arithmetic, which is not where any of the placement bugs lived.

Verified on a live HARDWARE build (`mode=HARDWARE_ACCELERATED, override=default, os=mac os x`): no linkage errors, and neither degradation warning (`could not measure its parent window`, `came up opaque`). URL-bar suggestion placement confirmed on screen.

## Reviewer's manual pass

Over a loaded page: Cmd+T (including its folder dropdown and Browse picker, which the focus-loss filter protects); Ctrl+Tab held; drag a tab across the browser area - ghost visible **and the drop must land**; Reset Browser; Settings dialogs centred on the Settings window and not floating above the main one.

## Depends on

boss-plugin-api#28 - release first, so hosts serve api 1.0.72 and plugins declaring `minApiVersion: 1.0.72` can install.

## Follow-up

~57 plugin-authored overlay sites remain across the other plugin repos, plus BossTerm and BossEditor. codebase, tool-evolver and fluck-browser are done as the first adopters.