### PR TITLE
Attribute plugin callbacks at the call, and pin that the wiring exists

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -4,6 +4,7 @@ import ContextMenuBackground
 import ContextMenuBorder
 import ContextMenuHover
 import ai.rever.boss.platform.ContextMenuHandler
+import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
@@ -177,7 +178,14 @@ private fun ContextMenuContent(
                                         Modifier
                                     } else {
                                         Modifier.clickable {
-                                            item.onClick()
+                                            // Attributed at the call, not at the item: a plugin's
+                                            // onClick is a lambda the plugin registered and the HOST
+                                            // invokes, so by the time it throws there is nothing
+                                            // plugin-shaped on the stack and the crash gets blamed on
+                                            // BOSS. Doing it here rather than while mapping the items
+                                            // costs no allocation, so the items stay equal across
+                                            // recompositions and Compose can still skip this subtree.
+                                            PluginExecutionBoundary.invokeAttributed(item.onClick)
                                             onDismissRequest()
                                         }
                                     },
@@ -389,7 +397,8 @@ private fun SubMenuContent(
                                     Modifier
                                 } else {
                                     Modifier.clickable {
-                                        subItem.onClick()
+                                        // Submenu items are plugin-owned just as often; see above.
+                                        PluginExecutionBoundary.invokeAttributed(subItem.onClick)
                                         onDismissRequest()
                                     }
                                 },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -193,7 +193,12 @@ private fun ContextMenuContent(
                                             try {
                                                 PluginExecutionBoundary.invokeAttributed(item.onClick)
                                             } finally {
-                                                onDismissRequest()
+                                                // runCatching: if dismissing throws while a plugin
+                                                // exception is in flight, a bare call replaces it -
+                                                // and with it the attribution tag - so the crash gets
+                                                // blamed on BOSS, the exact failure this exists to
+                                                // prevent.
+                                                runCatching { onDismissRequest() }
                                             }
                                         }
                                     },
@@ -409,7 +414,7 @@ private fun SubMenuContent(
                                         try {
                                             PluginExecutionBoundary.invokeAttributed(subItem.onClick)
                                         } finally {
-                                            onDismissRequest()
+                                            runCatching { onDismissRequest() }
                                         }
                                     }
                                 },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -185,8 +185,16 @@ private fun ContextMenuContent(
                                             // BOSS. Doing it here rather than while mapping the items
                                             // costs no allocation, so the items stay equal across
                                             // recompositions and Compose can still skip this subtree.
-                                            PluginExecutionBoundary.invokeAttributed(item.onClick)
-                                            onDismissRequest()
+                                            // finally, because invokeAttributed rethrows: a plugin
+                                            // action that throws used to take the app with it, so the
+                                            // menu went too. Now the crash is survivable, and without
+                                            // this the menu stays on screen over the crash dialog and
+                                            // outlives the plugin it belongs to.
+                                            try {
+                                                PluginExecutionBoundary.invokeAttributed(item.onClick)
+                                            } finally {
+                                                onDismissRequest()
+                                            }
                                         }
                                     },
                                 ).background(
@@ -398,8 +406,11 @@ private fun SubMenuContent(
                                 } else {
                                     Modifier.clickable {
                                         // Submenu items are plugin-owned just as often; see above.
-                                        PluginExecutionBoundary.invokeAttributed(subItem.onClick)
-                                        onDismissRequest()
+                                        try {
+                                            PluginExecutionBoundary.invokeAttributed(subItem.onClick)
+                                        } finally {
+                                            onDismissRequest()
+                                        }
                                     }
                                 },
                             ).background(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -1643,13 +1643,12 @@ private class DefaultContextMenuProvider : ContextMenuProvider {
                 text = label,
                 icon = icon,
                 subMenu = subMenu?.map { it.toContextMenuItem() },
-                // The exact boundary this exists for. ContextMenu invokes onClick bare from a
-                // Compose click handler, so a plugin action that throws reaches the global
-                // uncaught handler with nothing plugin-shaped left on the stack - the host frames
-                // that called it are all that remains, and the crash gets blamed on BOSS. The
-                // lambda's own class was loaded by the plugin's classloader, which is what
-                // wrapPluginCallback reads; host-owned items are returned unwrapped.
-                onClick = PluginExecutionBoundary.wrapPluginCallback(onClick),
+                // Passed through unwrapped, deliberately. Attribution happens where
+                // ContextMenu actually invokes it (PluginExecutionBoundary.invokeAttributed),
+                // which costs no allocation - wrapping here handed back a fresh closure per
+                // item per recomposition, so the items compared unequal every time and Compose
+                // could never skip the menu subtree.
+                onClick = onClick,
             )
         }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -80,7 +80,6 @@ import ai.rever.boss.plugin.api.ZoomSettingsProvider
 import ai.rever.boss.plugin.browser.BrowserService
 import ai.rever.boss.plugin.loader.PluginLoadException
 import ai.rever.boss.plugin.pathutils.BossDirectories
-import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import ai.rever.boss.plugin.sandbox.PluginSandboxManager
 import ai.rever.boss.plugin.sandbox.PluginSandboxManagerImpl
 import ai.rever.boss.plugin.sandbox.SandboxConfig

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.crash.PluginCrashRecovery
 import ai.rever.boss.crash.PluginCrashRecoveryCoordinator
 import ai.rever.boss.crash.PluginRecoverySteps
+import ai.rever.boss.crash.displayPluginId
 import ai.rever.boss.plugin.PluginLoaderDelegateImpl
 import ai.rever.boss.plugin.PluginPersistence
 import ai.rever.boss.plugin.api.PluginContext
@@ -118,14 +119,14 @@ actual object PluginLoaderDelegateSetup {
                     // at the next launch.
                     override fun notifyDisabling(pluginId: String) =
                         StatusMessageManager.showMessage(
-                            "Plugin '${displayId(pluginId)}' crashed and is being disabled. " +
+                            "Plugin '${displayPluginId(pluginId)}' crashed and is being disabled. " +
                                 "Re-enable it from Toolbox.",
                             durationMs = CRASH_NOTICE_MILLIS,
                         )
 
                     override fun notifyDisableIncomplete(pluginId: String) =
                         StatusMessageManager.showMessage(
-                            "Plugin '${displayId(pluginId)}' could not be fully disabled and may return " +
+                            "Plugin '${displayPluginId(pluginId)}' could not be fully disabled and may return " +
                                 "on restart. Disable it from Toolbox.",
                             durationMs = CRASH_NOTICE_MILLIS,
                         )
@@ -183,22 +184,6 @@ actual object PluginLoaderDelegateSetup {
      * one failed recovery does not poison the next.
      */
     private val recoveryScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-
-    /**
-     * A plugin id fit to drop into a sentence a user reads.
-     *
-     * The id comes from a plugin-supplied manifest, and the status bar holds one
-     * message at a time: a long or newline-bearing id pushes the rest of the
-     * sentence - including where to undo this - out of view. Control characters go
-     * for the same reason.
-     */
-    private fun displayId(pluginId: String): String {
-        val flattened = pluginId.filter { it.isLetterOrDigit() || it in ".-_:" }
-        return if (flattened.length <= MAX_DISPLAYED_ID) flattened else flattened.take(MAX_DISPLAYED_ID) + "..."
-    }
-
-    /** Comfortably fits the real ids (`ai.rever.boss.plugin.dynamic.terminaltab` is 43). */
-    private const val MAX_DISPLAYED_ID = 60
 
     /** Long enough to read a sentence naming a plugin and where to re-enable it. */
     private const val CRASH_NOTICE_MILLIS = 12_000L

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -67,9 +67,10 @@ actual object PluginLoaderDelegateSetup {
         // SplitViewStateRegistry.getAllStates(), and disableEverywhere iterates every
         // live manager. That is a property of the delegate, not of this seam, so it
         // is worth stating rather than re-deriving.
-        if (PluginCrashRecovery.handler == null) {
-            PluginCrashRecovery.handler = createCrashRecovery(delegate)
-        }
+        // installIfAbsent, not check-then-set: register() runs per window and two
+        // windows opening together could both build a coordinator. The loser was
+        // harmless (they are equivalent), but a compare-and-set says so.
+        PluginCrashRecovery.installIfAbsent { createCrashRecovery(delegate) }
 
         logger.debug(LogCategory.SYSTEM, "PluginLoaderDelegate registered successfully")
     }
@@ -117,14 +118,15 @@ actual object PluginLoaderDelegateSetup {
                     // at the next launch.
                     override fun notifyDisabling(pluginId: String) =
                         StatusMessageManager.showMessage(
-                            "Plugin '$pluginId' crashed and is being disabled. Re-enable it from Toolbox.",
+                            "Plugin '${displayId(pluginId)}' crashed and is being disabled. " +
+                                "Re-enable it from Toolbox.",
                             durationMs = CRASH_NOTICE_MILLIS,
                         )
 
                     override fun notifyDisableIncomplete(pluginId: String) =
                         StatusMessageManager.showMessage(
-                            "Plugin '$pluginId' could not be fully disabled and may return on restart. " +
-                                "Disable it from Toolbox.",
+                            "Plugin '${displayId(pluginId)}' could not be fully disabled and may return " +
+                                "on restart. Disable it from Toolbox.",
                             durationMs = CRASH_NOTICE_MILLIS,
                         )
                 },
@@ -156,6 +158,9 @@ actual object PluginLoaderDelegateSetup {
     ): Boolean {
         if (isInstalled(pluginId)) {
             setEnabled(pluginId, false)
+            // True because an entry existed to update. setPluginEnabled returns Unit,
+            // so this cannot observe the write itself - the branch below is the one
+            // that can fail, and does.
             return true
         }
         // No entry to update. A jar dropped into the plugins directory by hand has
@@ -178,6 +183,22 @@ actual object PluginLoaderDelegateSetup {
      * one failed recovery does not poison the next.
      */
     private val recoveryScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    /**
+     * A plugin id fit to drop into a sentence a user reads.
+     *
+     * The id comes from a plugin-supplied manifest, and the status bar holds one
+     * message at a time: a long or newline-bearing id pushes the rest of the
+     * sentence - including where to undo this - out of view. Control characters go
+     * for the same reason.
+     */
+    private fun displayId(pluginId: String): String {
+        val flattened = pluginId.filter { it.isLetterOrDigit() || it in ".-_:" }
+        return if (flattened.length <= MAX_DISPLAYED_ID) flattened else flattened.take(MAX_DISPLAYED_ID) + "..."
+    }
+
+    /** Comfortably fits the real ids (`ai.rever.boss.plugin.dynamic.terminaltab` is 43). */
+    private const val MAX_DISPLAYED_ID = 60
 
     /** Long enough to read a sentence naming a plugin and where to re-enable it. */
     private const val CRASH_NOTICE_MILLIS = 12_000L

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CauseChain.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CauseChain.kt
@@ -1,37 +1,16 @@
 package ai.rever.boss.crash
 
-/**
- * How far any cause walk in this package goes.
- *
- * One fact, not four. This bound existed in four near-identical loops -
- * `isIgnorable`, `attributePluginId`, the uncontainable check and the render
- * route - three of which carried a comment saying they matched the others, which
- * is what a duplicated invariant looks like just before it stops matching. It did
- * stop matching: the cause-chain fix landed on one of the two uncontainable checks
- * and left its twin flat, so the same wrapped `OutOfMemoryError` escalated in one
- * place and was contained in the other.
- */
-internal const val MAX_CAUSE_DEPTH = 12
+import ai.rever.boss.plugin.sandbox.causeChain
 
 /**
- * This throwable and its causes, nearest first, bounded and cycle-guarded.
+ * Re-exported so this package keeps reading as it did, with one implementation
+ * behind it.
  *
- * Wrapping is routine on these paths - an `InvocationTargetException` from a
- * reflective call, a `CompletionException` from a future, Compose's own wrappers -
- * so a question worth asking about a throwable is nearly always worth asking about
- * its causes too.
- *
- * The cycle guard is identity-based and not optional: `initCause` cannot build a
- * loop but an overridden `getCause` can, and a crash handler that hangs is worse
- * than one that misattributes. Eager rather than a `Sequence` because every caller
- * consumes the whole thing and one of them needs it reversed.
+ * The walk lives in `plugin-sandbox` because attribution needs it too and
+ * composeApp depends on that module, not the reverse. Keeping a typealias-style
+ * shim here means the crash package's four callers did not all have to grow an
+ * import from another module's package - and, more to the point, there is now
+ * exactly one bound and one cycle guard rather than a comment in each copy
+ * claiming they match.
  */
-internal fun Throwable.causeChain(max: Int = MAX_CAUSE_DEPTH): List<Throwable> {
-    val chain = ArrayList<Throwable>(max)
-    var current: Throwable? = this
-    while (current != null && chain.size < max && chain.none { it === current }) {
-        chain.add(current)
-        current = current.cause
-    }
-    return chain
-}
+internal fun Throwable.chainOfCauses(): List<Throwable> = causeChain()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashDisposition.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashDisposition.kt
@@ -50,7 +50,7 @@ fun classifyCrash(
 ): CrashDisposition =
     when {
         pluginId.isNullOrBlank() -> CrashDisposition.FatalHost
-        anyCauseIsUncontainable(throwable) -> CrashDisposition.FatalHost
+        throwable.hasUncontainableCause() -> CrashDisposition.FatalHost
         !recoveryAvailable -> CrashDisposition.FatalHost
         else -> CrashDisposition.RecoverablePlugin(pluginId)
     }
@@ -69,4 +69,4 @@ fun classifyCrash(
  * Shared with [decideWindowExceptionRoute] through [causeChain], because the two
  * carve-outs are worthless unless they agree - and for one round they did not.
  */
-internal fun anyCauseIsUncontainable(throwable: Throwable): Boolean = throwable.causeChain().any { isUncontainable(it) }
+internal fun Throwable.hasUncontainableCause(): Boolean = chainOfCauses().any { isUncontainable(it) }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashDisposition.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashDisposition.kt
@@ -66,7 +66,7 @@ fun classifyCrash(
  * and tear down tabs across every window on an already-exhausted heap, which is
  * the exact thing the carve-out exists to prevent.
  *
- * Shared with [decideWindowExceptionRoute] through [causeChain], because the two
+ * Shared with [decideWindowExceptionRoute] through [chainOfCauses], because the two
  * carve-outs are worthless unless they agree - and for one round they did not.
  */
 internal fun Throwable.hasUncontainableCause(): Boolean = chainOfCauses().any { isUncontainable(it) }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -654,13 +654,11 @@ object CrashHandler {
     }
 
     /**
-     * Decide what a crash *is*, given who we could blame and whether the plugin
-     * layer is in a position to act.
-     *
-     * Split out so the dialog and the tests classify through the same call.
+     * Decide what a crash *is*, from a report - a convenience for tests, which have
+     * one in hand. Production classifies once in [handleCrash] and threads the
+     * disposition onward, so the dialog cannot be built from a different answer
+     * than the one the dialog-slot decision used.
      */
-
-    /** Convenience for tests, which have a report in hand; production threads the id. */
     internal fun dispositionFor(
         throwable: Throwable,
         report: CrashReport,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -129,12 +129,16 @@ object CrashHandler {
     private val _pendingCrashReport = MutableStateFlow<CrashReport?>(null)
 
     /**
-     * Pending crash report to display in the UI.
-     * Observe this in BossApp to show the crash dialog.
+     * The crash currently being reported, for the submit path to attach notes to.
+     *
+     * Single-valued and NOT a UI trigger: the dialog is shown directly, in its own
+     * JFrame, by [showCrashDialogWindow] - nothing observes this to decide whether
+     * to render. That matters because [recordContained] deliberately does not write
+     * here: a contained fault landing mid-typing would replace the report and
+     * Submit would send the wrong crash.
      */
     val pendingCrashReport: StateFlow<CrashReport?> = _pendingCrashReport.asStateFlow()
 
-    private var originalHandler: Thread.UncaughtExceptionHandler? = null
     private var isInstalled = false
 
     /**
@@ -174,9 +178,6 @@ object CrashHandler {
      */
     fun install() {
         if (isInstalled) return
-
-        // Store original handler to chain to it later
-        originalHandler = Thread.getDefaultUncaughtExceptionHandler()
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             handleCrash(thread, throwable)
@@ -537,10 +538,10 @@ object CrashHandler {
             // If already on EDT, show directly; otherwise use invokeAndWait to ensure
             // the dialog is shown before the app can exit
             if (SwingUtilities.isEventDispatchThread()) {
-                showCrashDialogWindow(report, throwable)
+                showCrashDialogWindow(report, throwable, disposition)
             } else {
                 SwingUtilities.invokeAndWait {
-                    showCrashDialogWindow(report, throwable)
+                    showCrashDialogWindow(report, throwable, disposition)
                 }
             }
             // Throwable, not Exception. This block claims the dialog slot and the
@@ -658,6 +659,8 @@ object CrashHandler {
      *
      * Split out so the dialog and the tests classify through the same call.
      */
+
+    /** Convenience for tests, which have a report in hand; production threads the id. */
     internal fun dispositionFor(
         throwable: Throwable,
         report: CrashReport,
@@ -725,11 +728,14 @@ object CrashHandler {
     private fun showCrashDialogWindow(
         report: CrashReport,
         throwable: Throwable,
+        // Passed in rather than recomputed. Both computations call canRecover,
+        // which asks the live managers, so a concurrent unload landing between them
+        // could build the dialog with a different disposition than the one the slot
+        // decision used. Attribution is already threaded through for exactly this
+        // reason. (The failure direction was safe - recoverable to fatal - but
+        // "safe" is not the same as "agrees with itself".)
+        disposition: CrashDisposition,
     ) {
-        // Outside the try: the failure path below has to know whether this crash
-        // was survivable, and a crash we could have recovered from must not become
-        // fatal merely because the window that would have said so failed to open.
-        val disposition = dispositionFor(throwable, report)
         // frame and controller are built OUTSIDE the try so the failure path can
         // reach them. Declared inside, the catch could only call resolveCrash
         // directly - and a throw landing after `isVisible = true` (toFront and

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -199,7 +199,7 @@ object CrashHandler {
      * dependency on ktor/coroutines here.
      */
     internal fun isIgnorable(throwable: Throwable): Boolean =
-        throwable.causeChain().any { t ->
+        throwable.chainOfCauses().any { t ->
             val name = t.javaClass.name
             val msg = t.message ?: ""
             val benign =
@@ -877,7 +877,7 @@ object CrashHandler {
         PluginExecutionBoundary.currentPluginId()?.let { return it }
         return try {
             // Root cause first: the crash origin outranks the layers that wrapped it.
-            for (cause in throwable.causeChain().asReversed()) {
+            for (cause in throwable.chainOfCauses().asReversed()) {
                 (cause.javaClass.classLoader as? PluginClassLoader)?.let { return it.pluginId }
                 for (frame in cause.stackTrace) {
                     PluginClassLoader.findPluginForClass(frame.className)?.let { return it }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -216,7 +216,7 @@ internal fun CrashReportDialog(
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text =
-                        "BOSS keeps running. '$recoverablePluginId' will be disabled - " +
+                        "BOSS keeps running. '${displayPluginId(recoverablePluginId)}' will be disabled - " +
                             "your other tabs and plugins are unaffected. Re-enable it from Toolbox.",
                     fontSize = 13.sp,
                     color = BossTheme.colors.textSecondary,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
@@ -7,6 +7,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
+ * The lookup the host installs into [ai.rever.boss.plugin.sandbox.PluginExecutionBoundary].
+ *
+ * A named function rather than a lambda at the call site, so a test can hold the
+ * same object production installs. Written inline, the only thing pinning it was
+ * that `main` happened to call it - delete that line and every test still passes
+ * while attribution silently reverts to the spoofable duck-typed fallback. That is
+ * the same unpinned-wiring bug this change set exists to close, one layer up.
+ */
+internal fun hostPluginIdResolver(): (ClassLoader) -> String? =
+    { loader -> (loader as? ai.rever.boss.plugin.loader.PluginClassLoader)?.pluginId }
+
+/**
  * A plugin id fit to drop into a sentence a user reads.
  *
  * The id comes from a plugin-supplied manifest and every display site shares one

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
@@ -100,9 +100,12 @@ object PluginCrashRecovery {
      * relying on it.
      */
     fun installIfAbsent(build: () -> PluginCrashRecoveryHandler) {
-        // updateAndGet, not check-then-CAS: the latter evaluated build() before the
-        // compare, so two windows racing still both constructed a coordinator and
-        // only the write was atomic - which is not what this said it did.
+        // What this guarantees: exactly one handler is ever *installed*, and once
+        // installed it is never replaced. Not that build() runs once - updateAndGet
+        // re-runs its function on CAS contention, so a race can still construct a
+        // coordinator that is then discarded. That is fine because construction is
+        // pure; claiming otherwise is what the previous two versions of this comment
+        // got wrong.
         installed.updateAndGet { existing -> existing ?: build() }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
@@ -7,6 +7,27 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
+ * A plugin id fit to drop into a sentence a user reads.
+ *
+ * The id comes from a plugin-supplied manifest and every display site shares one
+ * status-bar slot, so a long or control-character-bearing id pushes the rest of
+ * the sentence - including where to undo this - out of view. Falls back to a
+ * placeholder rather than rendering `Plugin '' crashed` when nothing survives the
+ * filter.
+ */
+internal fun displayPluginId(pluginId: String): String {
+    val flattened = pluginId.filter { it.isLetterOrDigit() || it in ".-_:" }
+    return when {
+        flattened.isBlank() -> "unknown plugin"
+        flattened.length <= MAX_DISPLAYED_ID -> flattened
+        else -> flattened.take(MAX_DISPLAYED_ID) + "..."
+    }
+}
+
+/** Comfortably fits the real ids (`ai.rever.boss.plugin.dynamic.terminaltab` is 43). */
+private const val MAX_DISPLAYED_ID = 60
+
+/**
  * Takes a crashed plugin out of the running app so the app can keep running.
  *
  * @return true when recovery took effect. False means the crash could not be
@@ -67,7 +88,10 @@ object PluginCrashRecovery {
      * relying on it.
      */
     fun installIfAbsent(build: () -> PluginCrashRecoveryHandler) {
-        if (installed.get() == null) installed.compareAndSet(null, build())
+        // updateAndGet, not check-then-CAS: the latter evaluated build() before the
+        // compare, so two windows racing still both constructed a coordinator and
+        // only the write was atomic - which is not what this said it did.
+        installed.updateAndGet { existing -> existing ?: build() }
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/PluginCrashRecovery.kt
@@ -50,8 +50,25 @@ fun interface PluginCrashRecoveryHandler {
 object PluginCrashRecovery {
     private val logger = BossLogger.forComponent("PluginCrashRecovery")
 
-    @Volatile
-    var handler: PluginCrashRecoveryHandler? = null
+    private val installed =
+        java.util.concurrent.atomic
+            .AtomicReference<PluginCrashRecoveryHandler?>(null)
+
+    var handler: PluginCrashRecoveryHandler?
+        get() = installed.get()
+        set(value) = installed.set(value)
+
+    /**
+     * Install [build]'s result only if nothing is installed yet.
+     *
+     * The desktop wiring runs once per window, and a plain `if (handler == null)`
+     * let two windows opening together both construct a coordinator. Harmless -
+     * they are equivalent - but a compare-and-set states the intent instead of
+     * relying on it.
+     */
+    fun installIfAbsent(build: () -> PluginCrashRecoveryHandler) {
+        if (installed.get() == null) installed.compareAndSet(null, build())
+    }
 
     /**
      * Whether [pluginId] could actually be recovered right now.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
@@ -29,7 +29,7 @@ enum class WindowExceptionRoute {
  * Order matters and is the point of this function:
  *
  * 1. **Attributed** to a plugin — the interceptor already knows what to do.
- * 2. **Uncontainable** ([anyCauseIsUncontainable], the whole cause chain and not
+ * 2. **Uncontainable** ([hasUncontainableCause], the whole cause chain and not
  *    just the top - a wrapped OutOfMemoryError is still an OutOfMemoryError, and
  *    this check was flat while its twin in [classifyCrash] was not) — escalate
  *    before anything else. The
@@ -50,7 +50,7 @@ fun decideWindowExceptionRoute(
 ): WindowExceptionRoute =
     when {
         attributedPluginId != null -> WindowExceptionRoute.PluginHandled
-        anyCauseIsUncontainable(throwable) -> WindowExceptionRoute.Escalate
+        throwable.hasUncontainableCause() -> WindowExceptionRoute.Escalate
         !policy.recordFailureAndShouldContain() -> WindowExceptionRoute.Escalate
         else -> WindowExceptionRoute.Contain
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -215,9 +215,11 @@ fun main(args: Array<String>) {
     // somebody else's - and attribution now decides which plugin gets disabled and
     // written out of installed.json. A type check against a class only the host
     // constructs cannot be forged. Installed before any plugin loads.
-    ai.rever.boss.plugin.sandbox.PluginExecutionBoundary.installPluginIdResolver { loader ->
-        (loader as? ai.rever.boss.plugin.loader.PluginClassLoader)?.pluginId
-    }
+    ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
+        .installPluginIdResolver(
+            ai.rever.boss.crash
+                .hostPluginIdResolver(),
+        )
 
     // Register notification callback for plugin crashes.
     // Tab closing is handled directly by PluginCrashRegistry via the closeAction

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -209,6 +209,16 @@ fun main(args: Array<String>) {
     ai.rever.boss.plugin.sandbox.ui
         .installCrashInterceptor()
 
+    // Teach the attribution boundary how to identify a plugin classloader for real.
+    // Without this it falls back to asking the loader for its own id, which a plugin
+    // that defines classes through a nested loader of its own could answer with
+    // somebody else's - and attribution now decides which plugin gets disabled and
+    // written out of installed.json. A type check against a class only the host
+    // constructs cannot be forged. Installed before any plugin loads.
+    ai.rever.boss.plugin.sandbox.PluginExecutionBoundary.pluginIdResolver = { loader ->
+        (loader as? ai.rever.boss.plugin.loader.PluginClassLoader)?.pluginId
+    }
+
     // Register notification callback for plugin crashes.
     // Tab closing is handled directly by PluginCrashRegistry via the closeAction
     // registered in BossMainPanelContent. This callback only shows the status message.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -215,7 +215,7 @@ fun main(args: Array<String>) {
     // somebody else's - and attribution now decides which plugin gets disabled and
     // written out of installed.json. A type check against a class only the host
     // constructs cannot be forged. Installed before any plugin loads.
-    ai.rever.boss.plugin.sandbox.PluginExecutionBoundary.pluginIdResolver = { loader ->
+    ai.rever.boss.plugin.sandbox.PluginExecutionBoundary.installPluginIdResolver { loader ->
         (loader as? ai.rever.boss.plugin.loader.PluginClassLoader)?.pluginId
     }
 
@@ -223,9 +223,16 @@ fun main(args: Array<String>) {
     // Tab closing is handled directly by PluginCrashRegistry via the closeAction
     // registered in BossMainPanelContent. This callback only shows the status message.
     ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry.onCrashNotify = { pluginId, error ->
-        val errorMsg = error.message?.take(60) ?: error.javaClass.simpleName
+        // Both halves are plugin-controlled and share one status-bar slot: the id
+        // comes from a manifest, and the message from plugin code. A newline or a
+        // few hundred characters in either pushes the rest of the line out of view.
+        val errorMsg =
+            (error.message ?: error.javaClass.simpleName)
+                .map { if (it.isISOControl()) ' ' else it }
+                .joinToString("")
+                .take(60)
         ai.rever.boss.components.bars.horizontal.StatusMessageManager.showMessage(
-            "Plugin '$pluginId' crashed: $errorMsg",
+            "Plugin '${ai.rever.boss.crash.displayPluginId(pluginId)}' crashed: $errorMsg",
             durationMs = 8000,
         )
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/ContextMenuAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/ContextMenuAttributionTest.kt
@@ -1,0 +1,121 @@
+package ai.rever.boss.components.overlays
+
+import ai.rever.boss.crash.pluginprobe.PluginProbeJar
+import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.rightClick
+import androidx.compose.ui.unit.dp
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins that a context-menu action is invoked **inside its plugin's attribution
+ * scope**, through the real `contextMenu` modifier.
+ *
+ * This is the one production seam plugin crash recovery rests on, and it is the
+ * kind that fails silently. `PluginExecutionBoundaryTest` proves the attribution
+ * machinery works; nothing proved it was *called*. Delete the `invokeAttributed`
+ * call in `ContextMenu.kt` and every one of those tests still passes while every
+ * plugin callback quietly becomes unattributed - and the next plugin crash takes
+ * the whole app down again, which is the bug the feature exists to fix. Same shape
+ * as the `noteRecoveryOutcome` wiring bug `WindowExceptionRoute` documents.
+ *
+ * The action is a **genuinely plugin-defined lambda**, loaded from a real jar
+ * through a real `PluginClassLoader`. A host-owned lambda would attribute to
+ * nobody whether or not the wiring exists, so the assertion would be vacuous - it
+ * has to be a lambda the boundary can actually resolve.
+ */
+class ContextMenuAttributionTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private companion object {
+        const val TARGET_TAG = "context-menu-target"
+        const val ITEM_LABEL = "Plugin action"
+    }
+
+    private val probe = PluginProbeJar.open(javaClass.classLoader)
+
+    @After
+    fun tearDown() = probe.close()
+
+    @Test
+    fun `a plugin's context-menu action runs inside that plugin's scope`() {
+        // Read from INSIDE the plugin-owned callback: the sink is host-owned, so it
+        // sees whatever scope the call was made in. Null means nobody established
+        // one, which is exactly what deleting the wiring produces.
+        var scopeInsideAction: String? = "never invoked"
+        val pluginAction =
+            probe.action(
+                "probeReporter",
+                java.util.function.Consumer<String?> {
+                    scopeInsideAction = PluginExecutionBoundary.currentPluginId()
+                },
+            )
+        val items = listOf(ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction))
+
+        rule.setContent {
+            Box(
+                modifier =
+                    Modifier
+                        .size(200.dp)
+                        .testTag(TARGET_TAG)
+                        .contextMenu(items = items),
+            )
+        }
+        rule.onNodeWithTag(TARGET_TAG).performMouseInput { rightClick() }
+        rule.waitForIdle()
+        rule.onNodeWithText(ITEM_LABEL).performClick()
+        rule.waitForIdle()
+
+        assertEquals(
+            PluginProbeJar.PLUGIN_ID,
+            scopeInsideAction,
+            "the menu must invoke a plugin action inside that plugin's attribution scope",
+        )
+    }
+
+    @Test
+    fun `the scope does not outlive the action`() {
+        // The menu runs on the EDT, which is pooled and long-lived: a scope left
+        // behind would blame this plugin for the next unrelated crash on that thread.
+        var scopeInsideAction: String? = null
+        val pluginAction =
+            probe.action(
+                "probeReporter",
+                java.util.function.Consumer<String?> {
+                    scopeInsideAction = PluginExecutionBoundary.currentPluginId()
+                },
+            )
+        val items = listOf(ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction))
+
+        rule.setContent {
+            Box(
+                modifier =
+                    Modifier
+                        .size(200.dp)
+                        .testTag(TARGET_TAG)
+                        .contextMenu(items = items),
+            )
+        }
+        rule.onNodeWithTag(TARGET_TAG).performMouseInput { rightClick() }
+        rule.waitForIdle()
+        rule.onNodeWithText(ITEM_LABEL).performClick()
+        rule.waitForIdle()
+
+        assertEquals(PluginProbeJar.PLUGIN_ID, scopeInsideAction, "precondition: the action did run attributed")
+        rule.runOnIdle {
+            assertEquals(null, PluginExecutionBoundary.currentPluginId(), "and nothing is left on the thread")
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/ContextMenuAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/ContextMenuAttributionTest.kt
@@ -42,6 +42,7 @@ class ContextMenuAttributionTest {
     private companion object {
         const val TARGET_TAG = "context-menu-target"
         const val ITEM_LABEL = "Plugin action"
+        const val HOST_ITEM_LABEL = "Host action"
     }
 
     private val probe = PluginProbeJar.open(javaClass.classLoader)
@@ -58,9 +59,7 @@ class ContextMenuAttributionTest {
         val pluginAction =
             probe.action(
                 "probeReporter",
-                java.util.function.Consumer<String?> {
-                    scopeInsideAction = PluginExecutionBoundary.currentPluginId()
-                },
+                Runnable { scopeInsideAction = PluginExecutionBoundary.currentPluginId() },
             )
         val items = listOf(ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction))
 
@@ -87,17 +86,29 @@ class ContextMenuAttributionTest {
 
     @Test
     fun `the scope does not outlive the action`() {
-        // The menu runs on the EDT, which is pooled and long-lived: a scope left
-        // behind would blame this plugin for the next unrelated crash on that thread.
-        var scopeInsideAction: String? = null
+        // The dispatching thread is pooled and long-lived, so a scope left behind
+        // would blame this plugin for the next unrelated crash on it.
+        //
+        // Observed from a SECOND click rather than from runOnIdle: the scope is
+        // thread-local and runOnIdle lands on the AWT event thread while the click
+        // dispatches on the test worker, so a check there passes whether or not the
+        // scope leaked - exactly the vacuity this suite exists to avoid. Verified,
+        // not assumed: asserting the two threads matched failed with
+        // "expected Test worker but was AWT-EventQueue-0".
+        var pluginThread: Thread? = null
+        var hostThread: Thread? = null
+        var scopeOnSecondClick: String? = "never invoked"
         val pluginAction =
-            probe.action(
-                "probeReporter",
-                java.util.function.Consumer<String?> {
-                    scopeInsideAction = PluginExecutionBoundary.currentPluginId()
-                },
+            probe.action("probeReporter", Runnable { pluginThread = Thread.currentThread() })
+        val hostAction = {
+            hostThread = Thread.currentThread()
+            scopeOnSecondClick = PluginExecutionBoundary.currentPluginId()
+        }
+        val items =
+            listOf(
+                ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction),
+                ContextMenuItem(text = HOST_ITEM_LABEL, onClick = hostAction),
             )
-        val items = listOf(ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction))
 
         rule.setContent {
             Box(
@@ -108,14 +119,18 @@ class ContextMenuAttributionTest {
                         .contextMenu(items = items),
             )
         }
+        clickMenuItem(ITEM_LABEL)
+        clickMenuItem(HOST_ITEM_LABEL)
+
+        assertEquals(pluginThread, hostThread, "precondition: both actions ran on the same thread")
+        assertEquals(null, scopeOnSecondClick, "the plugin's scope must not still be on that thread")
+    }
+
+    /** Right-click the target and pick [label]. */
+    private fun clickMenuItem(label: String) {
         rule.onNodeWithTag(TARGET_TAG).performMouseInput { rightClick() }
         rule.waitForIdle()
-        rule.onNodeWithText(ITEM_LABEL).performClick()
+        rule.onNodeWithText(label).performClick()
         rule.waitForIdle()
-
-        assertEquals(PluginProbeJar.PLUGIN_ID, scopeInsideAction, "precondition: the action did run attributed")
-        rule.runOnIdle {
-            assertEquals(null, PluginExecutionBoundary.currentPluginId(), "and nothing is left on the thread")
-        }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
@@ -150,6 +150,19 @@ class CrashHandlerAttributionTest {
     }
 
     @Test
+    fun `the resolver main installs identifies a real plugin classloader`() {
+        // The intersection nothing else covers: PluginExecutionBoundaryTest pins
+        // resolver + fake loader, the tests above pin real loader + no resolver. A
+        // typo in the `as?` cast would live exactly here - and because an installed
+        // resolver's answer is final including null, that typo would silently make
+        // every plugin callback unattributed rather than fail loudly.
+        val resolver = hostPluginIdResolver()
+
+        assertEquals(PLUGIN_ID, resolver(probe.loader))
+        assertNull(resolver(javaClass.classLoader), "a host classloader is not a plugin")
+    }
+
+    @Test
     fun `a host-owned object resolves to no plugin`() {
         assertNull(PluginExecutionBoundary.pluginIdOfOwner(this))
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashHandlerAttributionTest.kt
@@ -1,11 +1,9 @@
 package ai.rever.boss.crash
 
+import ai.rever.boss.crash.pluginprobe.PluginProbeJar
 import ai.rever.boss.plugin.loader.PluginClassLoader
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
-import java.io.File
 import java.lang.reflect.InvocationTargetException
-import java.util.jar.JarEntry
-import java.util.jar.JarOutputStream
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,48 +21,20 @@ import kotlin.test.assertTrue
  */
 class CrashHandlerAttributionTest {
     private companion object {
-        const val PLUGIN_ID = "test.plugin.probe"
+        const val PLUGIN_ID = PluginProbeJar.PLUGIN_ID
 
         /** Deliberately different from [PLUGIN_ID], so "the tag won" is distinguishable. */
         const val BOUNDARY_PLUGIN_ID = "test.plugin.boundary"
-        const val PROBE_CLASS = "ai.rever.boss.crash.pluginprobe.PluginProbe"
-        const val EXCEPTION_CLASS = "ai.rever.boss.crash.pluginprobe.ProbeException"
-
-        /** File facade holding `probeAction()`, whose lambda is the thing under test. */
-        const val PROBE_KT_CLASS = "ai.rever.boss.crash.pluginprobe.PluginProbeKt"
+        const val PROBE_CLASS = PluginProbeJar.PROBE_CLASS
+        const val EXCEPTION_CLASS = PluginProbeJar.EXCEPTION_CLASS
     }
 
-    private val jarFile: File = buildProbeJar()
-    private val loader =
-        PluginClassLoader(
-            pluginId = PLUGIN_ID,
-            urls = arrayOf(jarFile.toURI().toURL()),
-            parent = javaClass.classLoader,
-        )
+    /** Shared with the context-menu wiring test; see [PluginProbeJar]. */
+    private val probe = PluginProbeJar.open(javaClass.classLoader)
+    private val loader get() = probe.loader
 
     @AfterTest
-    fun tearDown() {
-        loader.close()
-        jarFile.delete()
-    }
-
-    /** Copy the fixture .class files from the test classpath into a jar. */
-    private fun buildProbeJar(): File {
-        val jar = File.createTempFile("plugin-probe", ".jar")
-        JarOutputStream(jar.outputStream()).use { out ->
-            for (className in listOf(PROBE_CLASS, EXCEPTION_CLASS, PROBE_KT_CLASS)) {
-                val resource = className.replace('.', '/') + ".class"
-                val bytes =
-                    checkNotNull(javaClass.classLoader.getResourceAsStream(resource)) {
-                        "fixture class $resource not on test classpath"
-                    }.use { it.readBytes() }
-                out.putNextEntry(JarEntry(resource))
-                out.write(bytes)
-                out.closeEntry()
-            }
-        }
-        return jar
-    }
+    fun tearDown() = probe.close()
 
     /** Invoke PluginProbe.<method>() via the plugin loader and return the cause. */
     private fun throwFromPlugin(method: String): Throwable {
@@ -174,11 +144,7 @@ class CrashHandlerAttributionTest {
         // silently un-attributed, with no visible failure until a session dies over
         // a plugin's bug. This is the callback shape the whole feature is built on:
         // ContextMenuItemData.onClick is exactly this.
-        val facade = loader.loadClass(PROBE_KT_CLASS)
-        assertEquals(loader, facade.classLoader, "the facade must be plugin-defined")
-
-        @Suppress("UNCHECKED_CAST")
-        val action = facade.getMethod("probeAction").invoke(null) as () -> Unit
+        val action = probe.action("probeAction")
 
         assertEquals(PLUGIN_ID, PluginExecutionBoundary.pluginIdOfOwner(action))
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashRecoveryTest.kt
@@ -310,7 +310,7 @@ class CrashRecoveryTest {
     }
 
     @Test
-    fun `a crash arriving during recovery does not re-enter it`() {
+    fun `the quarantine marker is not yet set when recovery starts scanning managers`() {
         // The window is gone but resolve is still running. A crash landing here
         // used to be able to open a second dialog for a plugin already being
         // recovered; the quarantine marker is set before the unload starts, so the
@@ -347,8 +347,11 @@ class CrashRecoveryTest {
 
         controller(recoverable).dismiss()
 
-        // isKnown runs before the marker would be set if marking came last, so this
-        // fails unless recover() marks up front.
+        // Named for what it asserts. isKnown runs before the marker is set, so the
+        // marker is NOT what protects this instant - the dialog slot is, and
+        // finish() releases that only after resolve returns. The test that pins the
+        // protection is `the dialog slot is only released once recovery has
+        // quarantined the plugin`; this one pins the ordering that test relies on.
         assertEquals(false, seenDuringRecovery, "the observation point is before the marker is set")
         assertEquals(emptyList(), exitCodes)
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbe.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbe.kt
@@ -28,3 +28,14 @@ class ProbeException : RuntimeException("custom probe exception")
  * session dies over a plugin's bug.
  */
 fun probeAction(): () -> Unit = { throw IllegalStateException("probe lambda boom") }
+
+/**
+ * A plugin-owned callback that reports back through a host-owned sink.
+ *
+ * The lambda's class is defined by the plugin loader, so `pluginIdOfOwner`
+ * resolves it; the sink is host-owned and reads the *current* attribution scope
+ * from inside the call. That combination is what makes "was this invoked inside
+ * its plugin's scope?" observable from a test without plugin code needing to
+ * reach host internals.
+ */
+fun probeReporter(sink: java.util.function.Consumer<String?>): () -> Unit = { sink.accept("invoked") }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbe.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbe.kt
@@ -34,8 +34,9 @@ fun probeAction(): () -> Unit = { throw IllegalStateException("probe lambda boom
  *
  * The lambda's class is defined by the plugin loader, so `pluginIdOfOwner`
  * resolves it; the sink is host-owned and reads the *current* attribution scope
- * from inside the call. That combination is what makes "was this invoked inside
+ * from inside the call. A Runnable, because nothing is passed through it - what the
+ * test learns comes from what it observes while running. That combination is what makes "was this invoked inside
  * its plugin's scope?" observable from a test without plugin code needing to
  * reach host internals.
  */
-fun probeReporter(sink: java.util.function.Consumer<String?>): () -> Unit = { sink.accept("invoked") }
+fun probeReporter(sink: Runnable): () -> Unit = { sink.run() }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbeJar.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbeJar.kt
@@ -59,7 +59,9 @@ object PluginProbeJar {
         ): () -> Unit {
             val facade = loader.loadClass(FACADE_CLASS)
             check(facade.classLoader == loader) { "the facade must be plugin-defined, or this proves nothing" }
-            val method = facade.methods.first { it.name == function }
+            // single, not first: getMethods() order is unspecified, so an added
+            // overload would otherwise be picked arbitrarily and silently.
+            val method = facade.methods.single { it.name == function }
             return method.invoke(null, *args) as () -> Unit
         }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbeJar.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/pluginprobe/PluginProbeJar.kt
@@ -1,0 +1,71 @@
+package ai.rever.boss.crash.pluginprobe
+
+import ai.rever.boss.plugin.loader.PluginClassLoader
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+
+/**
+ * Builds a real plugin jar out of the fixture classes and loads it through a real
+ * [PluginClassLoader].
+ *
+ * Shared by the attribution tests because the thing being pinned - that a lambda
+ * compiled inside plugin code reports the plugin's classloader - cannot be faked
+ * without also faking the answer. Kotlin lambdas are `invokedynamic` hidden
+ * classes, and only a genuinely plugin-defined host class gives them a
+ * plugin-defined loader.
+ */
+object PluginProbeJar {
+    const val PLUGIN_ID = "test.plugin.probe"
+    const val PROBE_CLASS = "ai.rever.boss.crash.pluginprobe.PluginProbe"
+    const val EXCEPTION_CLASS = "ai.rever.boss.crash.pluginprobe.ProbeException"
+
+    /** File facade holding the top-level fixture functions. */
+    const val FACADE_CLASS = "ai.rever.boss.crash.pluginprobe.PluginProbeKt"
+
+    /** The jar plus a loader over it; close the loader and delete the jar when done. */
+    fun open(parent: ClassLoader): Handle {
+        val jar = File.createTempFile("plugin-probe", ".jar")
+        JarOutputStream(jar.outputStream()).use { out ->
+            for (className in listOf(PROBE_CLASS, EXCEPTION_CLASS, FACADE_CLASS)) {
+                val resource = className.replace('.', '/') + ".class"
+                val bytes =
+                    checkNotNull(parent.getResourceAsStream(resource)) {
+                        "fixture class $resource not on test classpath"
+                    }.use { it.readBytes() }
+                out.putNextEntry(JarEntry(resource))
+                out.write(bytes)
+                out.closeEntry()
+            }
+        }
+        val loader =
+            PluginClassLoader(
+                pluginId = PLUGIN_ID,
+                urls = arrayOf(jar.toURI().toURL()),
+                parent = parent,
+            )
+        return Handle(jar, loader)
+    }
+
+    class Handle(
+        private val jar: File,
+        val loader: PluginClassLoader,
+    ) {
+        /** A plugin-defined lambda from [FACADE_CLASS], by function name. */
+        @Suppress("UNCHECKED_CAST")
+        fun action(
+            function: String,
+            vararg args: Any?,
+        ): () -> Unit {
+            val facade = loader.loadClass(FACADE_CLASS)
+            check(facade.classLoader == loader) { "the facade must be plugin-defined, or this proves nothing" }
+            val method = facade.methods.first { it.name == function }
+            return method.invoke(null, *args) as () -> Unit
+        }
+
+        fun close() {
+            loader.close()
+            jar.delete()
+        }
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/CauseChain.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/CauseChain.kt
@@ -1,0 +1,38 @@
+package ai.rever.boss.plugin.sandbox
+
+/**
+ * How far any cause walk goes.
+ *
+ * One fact, not several. This bound lived in four near-identical loops, three of
+ * them carrying a comment claiming they matched the others - and they stopped
+ * matching, which is how a cause-chain fix landed on one uncontainable check and
+ * left its twin flat, so the same wrapped OutOfMemoryError escalated in one place
+ * and was contained in the other.
+ *
+ * It lives in this module rather than in composeApp because attribution needs it
+ * too and composeApp depends on plugin-sandbox, not the reverse.
+ */
+const val MAX_CAUSE_DEPTH = 12
+
+/**
+ * This throwable and its causes, nearest first, bounded and cycle-guarded.
+ *
+ * Wrapping is routine on these paths - an `InvocationTargetException` from a
+ * reflective call, a `CompletionException` from a future, Compose's own wrappers -
+ * so a question worth asking about a throwable is nearly always worth asking about
+ * its causes too.
+ *
+ * The cycle guard is identity-based and not optional: `initCause` cannot build a
+ * loop but an overridden `getCause` can, and a crash handler that hangs is worse
+ * than one that misattributes. Eager rather than a `Sequence` because every caller
+ * consumes the whole thing and one of them needs it reversed.
+ */
+fun Throwable.causeChain(max: Int = MAX_CAUSE_DEPTH): List<Throwable> {
+    val chain = ArrayList<Throwable>(max)
+    var current: Throwable? = this
+    while (current != null && chain.size < max && chain.none { it === current }) {
+        chain.add(current)
+        current = current.cause
+    }
+    return chain
+}

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundary.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.plugin.sandbox
 
+import ai.rever.boss.plugin.logging.BossLogger
+import ai.rever.boss.plugin.logging.LogCategory
 import java.util.Collections
 import java.util.WeakHashMap
 
@@ -47,6 +49,8 @@ import java.util.WeakHashMap
  * Thread-safe: crashes arrive on whichever thread was running plugin code.
  */
 object PluginExecutionBoundary {
+    private val logger = BossLogger.forComponent("PluginExecutionBoundary")
+
     /**
      * Plugin ids currently being executed on this thread, innermost last.
      *
@@ -66,22 +70,6 @@ object PluginExecutionBoundary {
         Collections.synchronizedMap(WeakHashMap<Throwable, String>())
 
     /**
-     * Cache of owning-class → owning plugin, including **misses**.
-     *
-     * [wrapPluginCallback] runs per context-menu item per recomposition, on the
-     * event thread, and for a host-owned lambda - the common case - an uncached
-     * miss builds and throws a reflective exception, whose cost is filling in a
-     * stack trace.
-     *
-     * A [ClassValue] rather than a synchronized map: lookups are lock-free, so the
-     * hit path takes no global monitor on the EDT, and each entry is held by the
-     * Class it is keyed on, so it dies with the class and its classloader when a
-     * plugin is unloaded. A `ConcurrentHashMap<ClassLoader, …>` would have pinned
-     * unloaded plugin classloaders; a `WeakHashMap` fixed that but put a lock back
-     * on the hot path. Null values are cached, which is the point.
-     */
-
-    /**
      * The host's authoritative loader → plugin id lookup, installed at startup.
      *
      * Attribution now selects which plugin gets **disabled and written out of
@@ -97,21 +85,56 @@ object PluginExecutionBoundary {
      * duck-typing below stays as the fallback for tests and for any context where
      * nothing has been installed.
      */
-    @Volatile
-    private var resolver: ((ClassLoader) -> String?)? = null
+    private val resolverRef =
+        java.util.concurrent.atomic
+            .AtomicReference<((ClassLoader) -> String?)?>(null)
 
     /** Bumped on every install so [ownerPluginIds] cannot serve a pre-install answer. */
     private val resolverGeneration =
         java.util.concurrent.atomic
             .AtomicInteger(0)
 
-    var pluginIdResolver: ((ClassLoader) -> String?)?
-        get() = resolver
-        set(value) {
-            resolver = value
+    /**
+     * Install the host's resolver. **First install wins; later ones are ignored.**
+     *
+     * Not a settable property, and that is the point. This object is public and
+     * `ai.rever.boss.plugin.sandbox` is not among `PluginClassLoader`'s
+     * `defaultSharedPackages`, so a plugin's child-first miss delegates to the
+     * parent and hands the plugin *this* singleton. A public setter would therefore
+     * let any plugin write `pluginIdResolver = { "some.rival" }` and reroute every
+     * attribution in the process at once - a shorter route to the outcome the
+     * resolver exists to prevent, and one that does not even require the attacker
+     * to be the plugin that crashes.
+     *
+     * [tag] and [wrapPluginCallback] are public and can also lie, but each of those
+     * lies about a single throwable; this would have been global and permanent.
+     */
+    fun installPluginIdResolver(resolver: (ClassLoader) -> String?) {
+        if (resolverRef.compareAndSet(null, resolver)) {
             resolverGeneration.incrementAndGet()
+        } else {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Ignoring a second plugin-id resolver install - the first one stands",
+            )
         }
+    }
 
+    /**
+     * Cache of owning-class → owning plugin, including **misses**.
+     *
+     * [invokeAttributed] runs per context-menu click and [pluginIdOfOwner] is on
+     * that path, so for a host-owned lambda - the common case - an uncached miss
+     * would build and throw a reflective exception, whose cost is filling in a
+     * stack trace.
+     *
+     * A [ClassValue] rather than a synchronized map: lookups are lock-free, so the
+     * hit path takes no global monitor on the EDT, and each entry is held by the
+     * Class it is keyed on, so it dies with the class and its classloader when a
+     * plugin is unloaded. A `ConcurrentHashMap<ClassLoader, …>` would have pinned
+     * unloaded plugin classloaders; a `WeakHashMap` fixed that but put a lock back
+     * on the hot path. Null values are cached, which is the point.
+     */
     private val ownerPluginIds =
         object : ClassValue<Resolved>() {
             override fun computeValue(type: Class<*>): Resolved =
@@ -255,7 +278,7 @@ object PluginExecutionBoundary {
      * has neither member, and attribution must never break the call it describes.
      */
     private fun resolvePluginId(loader: ClassLoader): String? {
-        pluginIdResolver?.let { authoritative ->
+        resolverRef.get()?.let { authoritative ->
             // Installed in production: a type check the host owns. Its answer is
             // final, including a null - falling through to duck-typing here would
             // hand back the spoofing route the resolver exists to close.
@@ -288,26 +311,33 @@ object PluginExecutionBoundary {
      * Returns [action] **unchanged** when it is host-owned, so wrapping every menu
      * item costs one cached class lookup and no extra frame for host items.
      *
-     * A plugin-owned action does get a fresh wrapper per call, which costs Compose
-     * the ability to skip a subtree whose items would otherwise compare equal.
-     * Caching wrappers is not as easy as it looks: a wrapper captures the action it
-     * wraps, so an action-keyed weak map is a strong reference from value to key
-     * and never collects. The durable fix is to wrap once at registration time
-     * rather than per mapping call; until then the per-call cost is one allocation.
+     * A plugin-owned action does get a fresh wrapper per call, so prefer
+     * [invokeAttributed] wherever the host owns the call: it allocates nothing and
+     * leaves item identity intact, which is what lets Compose skip a menu subtree.
+     * (Caching wrappers instead is a trap - a wrapper captures the action it wraps,
+     * so an action-keyed weak map is a strong reference from value to key and never
+     * collects.) This remains for callers that must hand a wrapped callback onward.
      */
     fun wrapPluginCallback(action: () -> Unit): () -> Unit {
         val pluginId = pluginIdOfOwner(action) ?: return action
         return { runAttributed(pluginId) { action() } }
     }
 
-    /** Drop every recorded tag. For tests; production entries expire with their throwable. */
-    internal fun resetForTest() {
+    /**
+     * Reset to a known state, optionally installing [resolver].
+     *
+     * One internal entry point rather than a separate test setter: production
+     * installs through [installPluginIdResolver], which is first-install-wins, so a
+     * test needs a way to replace one - and this is the only place that should have
+     * it.
+     */
+    internal fun resetForTest(resolver: ((ClassLoader) -> String?)? = null) {
         tags.clear()
-        pluginIdResolver = null
-        // ownerPluginIds is deliberately not reset: a ClassValue entry is keyed on
-        // the Class, so it can only be stale if the class itself changed, which
-        // cannot happen within a run. Clearing it would need a per-class remove and
-        // buy nothing.
+        resolverRef.set(resolver)
+        resolverGeneration.incrementAndGet()
+        // ownerPluginIds needs no explicit clear: its entries carry the resolver
+        // generation, which the line above bumps, so every cached answer is
+        // recomputed on the next read. (ClassValue cannot be bulk-cleared anyway.)
         executing.remove()
     }
 }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundary.kt
@@ -48,13 +48,6 @@ import java.util.WeakHashMap
  */
 object PluginExecutionBoundary {
     /**
-     * How far [attributionFor] walks a cause chain. Matches the bound
-     * `CrashHandler.isIgnorable` and `attributePluginId` already use, and stops a
-     * self-referential chain from spinning.
-     */
-    private const val MAX_CAUSE_DEPTH = 12
-
-    /**
      * Plugin ids currently being executed on this thread, innermost last.
      *
      * A stack rather than a single slot because plugin code calls back into the
@@ -87,10 +80,56 @@ object PluginExecutionBoundary {
      * unloaded plugin classloaders; a `WeakHashMap` fixed that but put a lock back
      * on the hot path. Null values are cached, which is the point.
      */
-    private val ownerPluginIds =
-        object : ClassValue<String?>() {
-            override fun computeValue(type: Class<*>): String? = type.classLoader?.let(::resolvePluginId)
+
+    /**
+     * The host's authoritative loader → plugin id lookup, installed at startup.
+     *
+     * Attribution now selects which plugin gets **disabled and written out of
+     * `installed.json`**, not merely which one a report is labelled with, so
+     * "whatever this classloader claims its id is" is too weak a question. A plugin
+     * that defines classes through a nested loader of its own - a scripting engine,
+     * an embedded framework - controls what that loader answers, and could get an
+     * unrelated plugin disabled by crashing.
+     *
+     * The host installs `{ (it as? PluginClassLoader)?.pluginId }`, which is a type
+     * check against a class only the host constructs, so the answer cannot be
+     * forged. This module keeps no dependency on `plugin-loader`; the reflective
+     * duck-typing below stays as the fallback for tests and for any context where
+     * nothing has been installed.
+     */
+    @Volatile
+    private var resolver: ((ClassLoader) -> String?)? = null
+
+    /** Bumped on every install so [ownerPluginIds] cannot serve a pre-install answer. */
+    private val resolverGeneration =
+        java.util.concurrent.atomic
+            .AtomicInteger(0)
+
+    var pluginIdResolver: ((ClassLoader) -> String?)?
+        get() = resolver
+        set(value) {
+            resolver = value
+            resolverGeneration.incrementAndGet()
         }
+
+    private val ownerPluginIds =
+        object : ClassValue<Resolved>() {
+            override fun computeValue(type: Class<*>): Resolved =
+                Resolved(resolverGeneration.get(), type.classLoader?.let(::resolvePluginId))
+        }
+
+    /**
+     * A cached answer, stamped with the resolver that produced it.
+     *
+     * ClassValue entries cannot be enumerated or bulk-cleared, so without the stamp
+     * a class first seen before the host installed its resolver would keep the
+     * duck-typed answer for the life of the process - and every test that installs
+     * one would depend on which test ran first.
+     */
+    private data class Resolved(
+        val generation: Int,
+        val pluginId: String?,
+    )
 
     /**
      * Run [block] as [pluginId], tagging anything that escapes.
@@ -153,18 +192,7 @@ object PluginExecutionBoundary {
      * wrapper — so a tag on any link in the chain answers for the whole chain.
      * Nearest tag first, so an inner plugin outranks an outer wrapper.
      */
-    fun attributionFor(throwable: Throwable): String? {
-        var current: Throwable? = throwable
-        var depth = 0
-        val seen = ArrayList<Throwable>(MAX_CAUSE_DEPTH)
-        while (current != null && depth < MAX_CAUSE_DEPTH && seen.none { it === current }) {
-            tags[current]?.let { return it }
-            seen.add(current)
-            current = current.cause
-            depth++
-        }
-        return null
-    }
+    fun attributionFor(throwable: Throwable): String? = throwable.causeChain().firstNotNullOfOrNull { tags[it] }
 
     /**
      * The plugin this thread is executing right now, innermost first, or null.
@@ -191,7 +219,19 @@ object PluginExecutionBoundary {
      * Resolved reflectively so this module keeps no dependency on
      * `plugin-loader`, and cached per classloader - see [ownerPluginIds].
      */
-    fun pluginIdOfOwner(owner: Any?): String? = owner?.let { ownerPluginIds.get(it.javaClass) }
+    fun pluginIdOfOwner(owner: Any?): String? {
+        val type = owner?.javaClass ?: return null
+        val cached = ownerPluginIds.get(type)
+        // Recomputed once when the resolver changed since this class was last seen.
+        val fresh =
+            if (cached.generation == resolverGeneration.get()) {
+                cached
+            } else {
+                ownerPluginIds.remove(type)
+                ownerPluginIds.get(type)
+            }
+        return fresh.pluginId
+    }
 
     /**
      * Ask a classloader for its plugin id: **getter first**, then a public field.
@@ -214,9 +254,16 @@ object PluginExecutionBoundary {
      * written in Java. Failures are swallowed on both branches: a host classloader
      * has neither member, and attribution must never break the call it describes.
      */
-    private fun resolvePluginId(loader: ClassLoader): String? =
-        runCatching { loader.javaClass.getMethod("getPluginId").invoke(loader) as? String }.getOrNull()
+    private fun resolvePluginId(loader: ClassLoader): String? {
+        pluginIdResolver?.let { authoritative ->
+            // Installed in production: a type check the host owns. Its answer is
+            // final, including a null - falling through to duck-typing here would
+            // hand back the spoofing route the resolver exists to close.
+            return runCatching { authoritative(loader) }.getOrNull()
+        }
+        return runCatching { loader.javaClass.getMethod("getPluginId").invoke(loader) as? String }.getOrNull()
             ?: runCatching { loader.javaClass.getField("pluginId").get(loader) as? String }.getOrNull()
+    }
 
     /**
      * Invoke a plugin-supplied callback with its plugin in scope, allocating nothing.
@@ -256,6 +303,7 @@ object PluginExecutionBoundary {
     /** Drop every recorded tag. For tests; production entries expire with their throwable. */
     internal fun resetForTest() {
         tags.clear()
+        pluginIdResolver = null
         // ownerPluginIds is deliberately not reset: a ClassValue entry is keyed on
         // the Class, so it can only be stale if the class itself changed, which
         // cannot happen within a run. Clearing it would need a per-class remove and

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundary.kt
@@ -128,6 +128,13 @@ object PluginExecutionBoundary {
      * First tag wins. A throwable crossing several boundaries on its way out
      * (plugin panel factory → sandboxed registry → plugin lifecycle) should keep
      * the innermost attribution, which is the one closest to the fault.
+     *
+     * **Caveat: a reused throwable keeps its first tag.** Some libraries throw a
+     * cached, stackless singleton, and a strongly-held one never leaves the weak
+     * map either. It would carry whichever plugin threw it first, for the life of
+     * the process. Low probability, and the failure direction is "wrong plugin
+     * disabled, app survives" rather than "session lost" - but if a real case turns
+     * up, keying on identity plus a timestamp is the way out.
      */
     fun tag(
         throwable: Throwable,
@@ -210,6 +217,23 @@ object PluginExecutionBoundary {
     private fun resolvePluginId(loader: ClassLoader): String? =
         runCatching { loader.javaClass.getMethod("getPluginId").invoke(loader) as? String }.getOrNull()
             ?: runCatching { loader.javaClass.getField("pluginId").get(loader) as? String }.getOrNull()
+
+    /**
+     * Invoke a plugin-supplied callback with its plugin in scope, allocating nothing.
+     *
+     * The counterpart to [wrapPluginCallback], and the better shape wherever the
+     * host owns the *call* rather than merely holding the reference. Wrapping at
+     * mapping time hands back a fresh closure every time, which for a context menu
+     * means a new one per item per recomposition - the items then compare unequal
+     * and Compose cannot skip the subtree. Attributing at the moment of invocation
+     * costs one cached class lookup and no allocation at all, and covers every
+     * callback that reaches the call site rather than only those that happened to
+     * be built through a wrapping factory.
+     */
+    fun invokeAttributed(action: () -> Unit) {
+        val pluginId = pluginIdOfOwner(action)
+        if (pluginId == null) action() else runAttributed(pluginId) { action() }
+    }
 
     /**
      * Wrap a plugin-supplied callback so a throwable escaping it is attributed.

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginCrashInterceptor.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginCrashInterceptor.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.sandbox.ui
 
 import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
+import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -236,6 +237,25 @@ object PluginCrashInterceptor {
         throwable: Throwable,
         thread: Thread? = null,
     ): String? {
+        // Strategy 0: what the execution boundary recorded before the throw.
+        //
+        // Consulted first because it is the only exact source - the host tagged the
+        // throwable while calling into the plugin, rather than inferring from frames
+        // that may already be gone. Without it the two attributions in this codebase
+        // could disagree about the same throwable: CrashHandler would say "plugin x"
+        // from the tag while this said "nobody", and the render router would then
+        // Contain or Escalate instead of handing it to the plugin's boundary. Two
+        // copies of one decision drifting apart is the failure this change set spent
+        // several rounds removing elsewhere.
+        //
+        // Still filtered by `interceptors`: this function answers "which registered
+        // boundary should handle it", and a tag naming a plugin with no live
+        // boundary is not an answer to that question.
+        PluginExecutionBoundary
+            .attributionFor(throwable)
+            ?.takeIf { interceptors.containsKey(it) }
+            ?.let { return it }
+
         // Strategy 1: Check thread name for plugin sandbox threads
         val threadName = thread?.name ?: Thread.currentThread().name
         for (pluginId in interceptors.keys) {

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundaryTest.kt
@@ -194,6 +194,40 @@ class PluginExecutionBoundaryTest {
     }
 
     @Test
+    fun `an installed resolver overrules what a classloader claims about itself`() {
+        // Attribution now selects which plugin gets disabled and written out of
+        // installed.json, so "whatever this loader says its id is" is too weak. A
+        // plugin defining classes through a nested loader of its own - a scripting
+        // engine, an embedded framework - controls that answer and could name a
+        // rival. With the host's resolver installed, only what the host recognises
+        // counts, and this loader is not it.
+        val spoofing = FakePluginClassLoader(OTHER_PLUGIN, javaClass.classLoader)
+        val action = spoofing.loadThrowingAction()
+        PluginExecutionBoundary.pluginIdResolver = { loader ->
+            // Stands in for `(loader as? PluginClassLoader)?.pluginId`: a type check
+            // against something only the host constructs.
+            if (loader is TrustedLoader) loader.trustedPluginId else null
+        }
+
+        assertNull(
+            PluginExecutionBoundary.pluginIdOfOwner(action),
+            "a loader the host does not recognise attributes to nobody, whatever it claims",
+        )
+        assertSame(action, PluginExecutionBoundary.wrapPluginCallback(action), "and so it is not wrapped")
+    }
+
+    @Test
+    fun `an installed resolver is what identifies a recognised loader`() {
+        val trusted = TrustedLoader(PLUGIN, javaClass.classLoader)
+        val action = trusted.loadThrowingAction()
+        PluginExecutionBoundary.pluginIdResolver = { loader ->
+            if (loader is TrustedLoader) loader.trustedPluginId else null
+        }
+
+        assertEquals(PLUGIN, PluginExecutionBoundary.pluginIdOfOwner(action))
+    }
+
+    @Test
     fun `the first tag wins`() {
         val error = IllegalStateException("boom")
         PluginExecutionBoundary.tag(error, PLUGIN)
@@ -220,8 +254,16 @@ class PluginExecutionBoundaryTest {
      * it back. `CrashHandlerAttributionTest` pins the same thing against the real
      * loader, which is the assertion that cannot be faked.
      */
-    private class FakePluginClassLoader(
-        val pluginId: String,
+
+    /**
+     * Defines [ThrowingAction] in itself, so the action's class - and therefore its
+     * classloader - is this loader rather than the test's.
+     *
+     * `defineClass` is protected, so a subclass can call it directly; going through
+     * reflection instead fails under the module system ("java.base does not opens
+     * java.lang"), which is worth stating because it looks like the obvious route.
+     */
+    private abstract class DefiningLoader(
         parent: ClassLoader,
     ) : ClassLoader(parent) {
         fun loadThrowingAction(): () -> Unit {
@@ -236,6 +278,28 @@ class PluginExecutionBoundaryTest {
             return defined.getDeclaredConstructor().newInstance()
         }
     }
+
+    /**
+     * Stands in for `PluginClassLoader` when NO resolver is installed.
+     *
+     * `pluginId` is a plain Kotlin `val`, **not** `@JvmField`, because that is what
+     * `PluginClassLoader` declares: a constructor property, i.e. a private backing
+     * field plus a public `getPluginId()`. The `@JvmField` this fixture used at
+     * first was the only form a `getField` lookup can see, so it made the test pass
+     * against a production shape the code could not actually read. Do not add it
+     * back. `CrashHandlerAttributionTest` pins the same thing against the real
+     * loader, which is the assertion that cannot be faked.
+     */
+    private class FakePluginClassLoader(
+        val pluginId: String,
+        parent: ClassLoader,
+    ) : DefiningLoader(parent)
+
+    /** A loader the fake resolver recognises, standing in for `PluginClassLoader`. */
+    private class TrustedLoader(
+        val trustedPluginId: String,
+        parent: ClassLoader,
+    ) : DefiningLoader(parent)
 
     /** A plugin-authored callback: public, no-arg constructor, throws when invoked. */
     class ThrowingAction : () -> Unit {

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundaryTest.kt
@@ -228,6 +228,23 @@ class PluginExecutionBoundaryTest {
     }
 
     @Test
+    fun `the first resolver install wins`() {
+        // The setter was public once, and this object is reachable from plugin code
+        // (plugin.sandbox is not a shared package, so a child-first miss delegates
+        // to the parent). A second install must not be able to reroute every
+        // attribution in the process.
+        val trusted = TrustedLoader(PLUGIN, javaClass.classLoader)
+        val action = trusted.loadThrowingAction()
+        PluginExecutionBoundary.installPluginIdResolver { loader ->
+            if (loader is TrustedLoader) loader.trustedPluginId else null
+        }
+
+        PluginExecutionBoundary.installPluginIdResolver { OTHER_PLUGIN }
+
+        assertEquals(PLUGIN, PluginExecutionBoundary.pluginIdOfOwner(action), "the first install stands")
+    }
+
+    @Test
     fun `the first tag wins`() {
         val error = IllegalStateException("boom")
         PluginExecutionBoundary.tag(error, PLUGIN)

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundaryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginExecutionBoundaryTest.kt
@@ -203,9 +203,9 @@ class PluginExecutionBoundaryTest {
         // counts, and this loader is not it.
         val spoofing = FakePluginClassLoader(OTHER_PLUGIN, javaClass.classLoader)
         val action = spoofing.loadThrowingAction()
-        PluginExecutionBoundary.pluginIdResolver = { loader ->
-            // Stands in for `(loader as? PluginClassLoader)?.pluginId`: a type check
-            // against something only the host constructs.
+        // Stands in for `(loader as? PluginClassLoader)?.pluginId`: a type check
+        // against something only the host constructs.
+        PluginExecutionBoundary.resetForTest { loader ->
             if (loader is TrustedLoader) loader.trustedPluginId else null
         }
 
@@ -220,7 +220,7 @@ class PluginExecutionBoundaryTest {
     fun `an installed resolver is what identifies a recognised loader`() {
         val trusted = TrustedLoader(PLUGIN, javaClass.classLoader)
         val action = trusted.loadThrowingAction()
-        PluginExecutionBoundary.pluginIdResolver = { loader ->
+        PluginExecutionBoundary.resetForTest { loader ->
             if (loader is TrustedLoader) loader.trustedPluginId else null
         }
 


### PR DESCRIPTION
Follow-ups from #139, in priority order from that PR's review thread.

## 1. Attribution moved to the invocation site

`wrapPluginCallback` was applied while *mapping* `ContextMenuItemData` to `ContextMenuItem`, which returns a fresh closure for every plugin-owned item on every recomposition. The items then compare unequal and Compose cannot skip the menu subtree - and `SubMenuContent` / `ContextMenuContent` are already on the `LongMethod` and `CyclomaticComplexMethod` baselines, so that is not a cheap subtree to rebuild.

Attribution now happens where the host actually invokes the callback, via a new `PluginExecutionBoundary.invokeAttributed`. That costs one cached `ClassValue` lookup and no allocation, keeps item identity stable, and covers every callback that reaches the call site rather than only those built through a wrapping factory.

## 2. The wiring is now pinned

This was the gap worth closing most: `PluginExecutionBoundaryTest` proves the attribution machinery works, but nothing proved it was *called*. Deleting the call site left every test green while every plugin callback silently became unattributed - and the next plugin crash takes the app down, which is the bug #139 exists to fix. Same shape as the `noteRecoveryOutcome` wiring bug `WindowExceptionRoute` documents.

`ContextMenuAttributionTest` drives the real `contextMenu` modifier, right-clicks, clicks the item, and asserts the attribution scope observed *from inside the action*. The action is a genuinely plugin-defined lambda - real jar, real `PluginClassLoader` - because a host-owned lambda attributes to nobody whether or not the wiring exists, which would make the assertion vacuous.

Verified it bites: deleting `invokeAttributed` from `ContextMenu.kt` fails both cases.

## Not done, deliberately

The review suggested wrapping at `SandboxedPluginContext` registration time to cover shortcut providers, status-bar items and deep-link handlers. Checked each: `PluginShortcutRegistryImpl:150` and `DeepLinkActionRegistryImpl:81` both `catch (t: Throwable)`, and status-bar content renders inside `PluginExtensionBoundary`. None of them can reach the uncaught handler, so wrapping them changes no behaviour. The context menu was the uncovered surface, because it invokes `onClick` bare from a Compose click handler.

## Also from the review

- **Disposition threaded into `showCrashDialogWindow`** instead of recomputed. Both computations call `canRecover`, which asks the live managers, so a concurrent unload between them could build the dialog with a different disposition than the one the slot decision used.
- **Plugin ids capped and stripped of control characters** at the three display sites. They come from a plugin-supplied manifest, and the status bar holds one message at a time - a long id pushed "where to undo this" out of view.
- **`PluginCrashRecovery.installIfAbsent`** replaces a check-then-set two windows could both pass.
- **`originalHandler` deleted** - assigned at install, never read, and #139 removed the KDoc that used to explain it.
- **`pendingCrashReport` KDoc corrected** - it said to observe it in BossApp; nothing does, and its single-valued semantics are load-bearing for the submit path.
- **`tag()` documents the reused-throwable caveat** - a cached, stackless singleton keeps its first attribution.
- **Renamed a test that asserted the opposite of its name.** `a crash arriving during recovery does not re-enter it` asserts the marker is *not* set when `isKnown` runs; what protects that instant is the dialog slot, which `finish()` releases only after `resolve` returns.

## Tests

1674 pass across `:composeApp:desktopTest` and `:plugin-platform:plugin-sandbox:desktopTest`; ktlint and detekt clean. The probe-jar fixture is now shared (`PluginProbeJar`) between the attribution tests rather than duplicated.

## Still open from #139's thread

Gating persistence on tag-derived attribution (heuristic attribution as session-only quarantine); a typed `PluginIdentified` interface instead of duck-typed `getPluginId()`; consolidating `PluginCrashInterceptor.attributeToPlugin` onto `PluginExecutionBoundary`; moving `causeChain` into plugin-sandbox so its last duplicate goes; direct tests for `disableEverywhere` / `isPluginKnown` / `jarPathOf`.