### PR TITLE
fix(secrets): decode secret RPCs leniently so a new column cannot empty the list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,28 @@ supabase functions deploy <function-name> --project-ref pcnwqamqdnsadranufjv --n
 supabase link --project-ref pcnwqamqdnsadranufjv  # First time
 ```
 
+### Decoding Supabase payloads
+
+Two rules in `ai.rever.boss.services.supabase`, both enforced by `SupabaseWiringTest`:
+
+**Decode through `supabaseJson`, never the `Json` default.** The database is migrated
+ahead of installed builds, so a client will meet columns it does not model. Strict
+decoding treats those as a hard error, and since these RPCs return lists, one new
+column throws and takes the whole page with it. That is not theoretical - the
+organisation migration extended four secret RPCs and emptied the secret panels on every
+installed build at once. Note the wildcard `kotlinx.serialization.json.*` import in these
+files keeps `Json.Default` in scope, so the broken thing is what you get by not thinking
+about it.
+
+Leniency covers extra keys and nothing else. A null in a non-nullable slot still throws
+for the whole list, so **declare every projected column `T? = null`** except the key.
+
+**Log `sanitizeResponseFailure(op, e)`, never the raw exception.** kotlinx appends the
+whole offending document to a malformed-input error, and these bodies carry passwords the
+server has already decrypted, recovery codes, and JWT claim sets. The request direction
+counts too: `SupabaseDataProviderImpl.rpc` parses caller-supplied parameters, and a plugin
+calling `create_secret` puts the new password in them.
+
 ## Code Quality
 
 - Use Compose Multiplatform Resource API (not Android resources)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,9 +116,12 @@ files keeps `Json.Default` in scope, so the broken thing is what you get by not 
 about it.
 
 Leniency covers extra keys and nothing else. A null in a non-nullable slot still throws
-for the whole list, so **declare every projected column `T? = null`** except the key.
+for the whole list, so **declare every projected column `T? = null`** except the key. Unlike
+the other two rules here, this one is **convention, upheld by review** - no test enforces it,
+and the existing models do not all follow it yet (they are safe only because the columns
+behind them are `NOT NULL` today).
 
-**Log `sanitizeResponseFailure(op, e)`, never the raw exception.** kotlinx appends the
+**Log `sanitizeSupabaseFailure(op, e)`, never the raw exception.** kotlinx appends the
 whole offending document to a malformed-input error, and these bodies carry passwords the
 server has already decrypted, recovery codes, and JWT claim sets. The request direction
 counts too: `SupabaseDataProviderImpl.rpc` parses caller-supplied parameters, and a plugin

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleCreationService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleCreationService.kt
@@ -82,8 +82,8 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to create role"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "createRole failed", error = sanitizeResponseFailure("createRole", e))
-            Result.failure(e)
+            logger.warn(LogCategory.AUTH, "createRole failed", error = sanitizeSupabaseFailure("createRole", e))
+            Result.failure(sanitizeSupabaseFailure("createRole", e))
         }
 
     /**
@@ -130,9 +130,9 @@ object RoleCreationService {
             logger.warn(
                 LogCategory.AUTH,
                 "createPermission failed",
-                error = sanitizeResponseFailure("createPermission", e),
+                error = sanitizeSupabaseFailure("createPermission", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("createPermission", e))
         }
 
     /**
@@ -169,8 +169,8 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to get roles"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "getAllRoles failed", error = sanitizeResponseFailure("getAllRoles", e))
-            Result.failure(e)
+            logger.warn(LogCategory.AUTH, "getAllRoles failed", error = sanitizeSupabaseFailure("getAllRoles", e))
+            Result.failure(sanitizeSupabaseFailure("getAllRoles", e))
         }
 
     /**
@@ -210,9 +210,9 @@ object RoleCreationService {
             logger.warn(
                 LogCategory.AUTH,
                 "getAllPermissions failed",
-                error = sanitizeResponseFailure("getAllPermissions", e),
+                error = sanitizeSupabaseFailure("getAllPermissions", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("getAllPermissions", e))
         }
 
     /**
@@ -251,9 +251,9 @@ object RoleCreationService {
             logger.warn(
                 LogCategory.AUTH,
                 "assignPermissionToRole failed",
-                error = sanitizeResponseFailure("assignPermissionToRole", e),
+                error = sanitizeSupabaseFailure("assignPermissionToRole", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("assignPermissionToRole", e))
         }
 
     /**
@@ -292,9 +292,9 @@ object RoleCreationService {
             logger.warn(
                 LogCategory.AUTH,
                 "removePermissionFromRole failed",
-                error = sanitizeResponseFailure("removePermissionFromRole", e),
+                error = sanitizeSupabaseFailure("removePermissionFromRole", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("removePermissionFromRole", e))
         }
 
     /**
@@ -333,9 +333,9 @@ object RoleCreationService {
             logger.warn(
                 LogCategory.AUTH,
                 "getRolePermissions failed",
-                error = sanitizeResponseFailure("getRolePermissions", e),
+                error = sanitizeSupabaseFailure("getRolePermissions", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("getRolePermissions", e))
         }
 
     /**
@@ -366,8 +366,8 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to delete role"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "deleteRole failed", error = sanitizeResponseFailure("deleteRole", e))
-            Result.failure(e)
+            logger.warn(LogCategory.AUTH, "deleteRole failed", error = sanitizeSupabaseFailure("deleteRole", e))
+            Result.failure(sanitizeSupabaseFailure("deleteRole", e))
         }
 
     /**
@@ -401,9 +401,9 @@ object RoleCreationService {
             logger.warn(
                 LogCategory.AUTH,
                 "deletePermission failed",
-                error = sanitizeResponseFailure("deletePermission", e),
+                error = sanitizeSupabaseFailure("deletePermission", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("deletePermission", e))
         }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleCreationService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleCreationService.kt
@@ -67,8 +67,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(
@@ -112,8 +112,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(
@@ -144,8 +144,8 @@ object RoleCreationService {
                     parameters = buildJsonObject { },
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RolesResponseNew>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RolesResponseNew>(jsonElement)
 
             if (result.success) {
                 val roles =
@@ -182,8 +182,8 @@ object RoleCreationService {
                     parameters = buildJsonObject { },
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<PermissionsResponseNew>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<PermissionsResponseNew>(jsonElement)
 
             if (result.success) {
                 val permissions =
@@ -231,8 +231,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -268,8 +268,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -300,8 +300,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RolePermissionsResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RolePermissionsResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(
@@ -337,8 +337,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -369,8 +369,8 @@ object RoleCreationService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleCreationService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleCreationService.kt
@@ -82,7 +82,7 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to create role"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "createRole failed", error = e)
+            logger.warn(LogCategory.AUTH, "createRole failed", error = sanitizeResponseFailure("createRole", e))
             Result.failure(e)
         }
 
@@ -127,7 +127,11 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to create permission"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "createPermission failed", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "createPermission failed",
+                error = sanitizeResponseFailure("createPermission", e),
+            )
             Result.failure(e)
         }
 
@@ -165,7 +169,7 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to get roles"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "getAllRoles failed", error = e)
+            logger.warn(LogCategory.AUTH, "getAllRoles failed", error = sanitizeResponseFailure("getAllRoles", e))
             Result.failure(e)
         }
 
@@ -203,7 +207,11 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to get permissions"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "getAllPermissions failed", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "getAllPermissions failed",
+                error = sanitizeResponseFailure("getAllPermissions", e),
+            )
             Result.failure(e)
         }
 
@@ -240,7 +248,11 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to assign permission"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "assignPermissionToRole failed", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "assignPermissionToRole failed",
+                error = sanitizeResponseFailure("assignPermissionToRole", e),
+            )
             Result.failure(e)
         }
 
@@ -277,7 +289,11 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to remove permission"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "removePermissionFromRole failed", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "removePermissionFromRole failed",
+                error = sanitizeResponseFailure("removePermissionFromRole", e),
+            )
             Result.failure(e)
         }
 
@@ -314,7 +330,11 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to get role permissions"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "getRolePermissions failed", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "getRolePermissions failed",
+                error = sanitizeResponseFailure("getRolePermissions", e),
+            )
             Result.failure(e)
         }
 
@@ -346,7 +366,7 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to delete role"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "deleteRole failed", error = e)
+            logger.warn(LogCategory.AUTH, "deleteRole failed", error = sanitizeResponseFailure("deleteRole", e))
             Result.failure(e)
         }
 
@@ -378,7 +398,11 @@ object RoleCreationService {
                 Result.failure(Exception(result.error ?: "Failed to delete permission"))
             }
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "deletePermission failed", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "deletePermission failed",
+                error = sanitizeResponseFailure("deletePermission", e),
+            )
             Result.failure(e)
         }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
@@ -93,7 +93,7 @@ object RoleService {
             logger.warn(
                 LogCategory.AUTH,
                 "Failed to parse role claims",
-                error = sanitizeResponseFailure("parseRoleClaimsFromSession", e),
+                error = sanitizeSupabaseFailure("parseRoleClaimsFromSession", e),
             )
             null
         }
@@ -164,7 +164,7 @@ object RoleService {
             // garbled payload makes kotlinx append the whole document to the message, so
             // logging the raw exception logs the claim set the debug line deliberately
             // withholds.
-            logger.warn(LogCategory.AUTH, "Failed to decode JWT", error = sanitizeResponseFailure("decodeJWTClaims", e))
+            logger.warn(LogCategory.AUTH, "Failed to decode JWT", error = sanitizeSupabaseFailure("decodeJWTClaims", e))
             emptyMap()
         }
 
@@ -192,9 +192,9 @@ object RoleService {
             logger.warn(
                 LogCategory.AUTH,
                 "Failed to get user roles",
-                error = sanitizeResponseFailure("getUserRoles", e),
+                error = sanitizeSupabaseFailure("getUserRoles", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("getUserRoles", e))
         }
 
     /**
@@ -224,9 +224,9 @@ object RoleService {
             logger.warn(
                 LogCategory.AUTH,
                 "Failed to check user role",
-                error = sanitizeResponseFailure("userHasRole", e),
+                error = sanitizeSupabaseFailure("userHasRole", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("userHasRole", e))
         }
 
     /**
@@ -257,9 +257,11 @@ object RoleService {
             logger.error(
                 LogCategory.AUTH,
                 "Failed to assign role",
-                error = sanitizeResponseFailure("assignRoleByName", e),
+                error = sanitizeSupabaseFailure("assignRoleByName", e),
             )
-            Result.failure(Exception("Failed to assign role: ${e.message}"))
+            Result.failure(
+                Exception("Failed to assign role: ${sanitizeSupabaseFailure("assignRoleByName", e).message}"),
+            )
         }
 
     /**
@@ -285,9 +287,11 @@ object RoleService {
             logger.error(
                 LogCategory.AUTH,
                 "Failed to remove role",
-                error = sanitizeResponseFailure("removeRoleByName", e),
+                error = sanitizeSupabaseFailure("removeRoleByName", e),
             )
-            Result.failure(Exception("Failed to remove role: ${e.message}"))
+            Result.failure(
+                Exception("Failed to remove role: ${sanitizeSupabaseFailure("removeRoleByName", e).message}"),
+            )
         }
 
     /**
@@ -313,9 +317,9 @@ object RoleService {
             logger.warn(
                 LogCategory.AUTH,
                 "Failed to get role permissions",
-                error = sanitizeResponseFailure("getRolePermissions", e),
+                error = sanitizeSupabaseFailure("getRolePermissions", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("getRolePermissions", e))
         }
 
     /**
@@ -352,9 +356,9 @@ object RoleService {
             logger.warn(
                 LogCategory.AUTH,
                 "Failed to check permission",
-                error = sanitizeResponseFailure("canPerformAction", e),
+                error = sanitizeSupabaseFailure("canPerformAction", e),
             )
-            Result.failure(e)
+            Result.failure(sanitizeSupabaseFailure("canPerformAction", e))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
@@ -139,7 +139,7 @@ object RoleService {
             logger.debug(LogCategory.AUTH, "Decoding JWT payload")
 
             // Parse JSON using kotlinx.serialization (secure and reliable)
-            val jsonObject = Json.parseToJsonElement(jsonString).jsonObject
+            val jsonObject = supabaseJson.parseToJsonElement(jsonString).jsonObject
 
             // Extract RBAC claims
             mapOf(
@@ -175,8 +175,8 @@ object RoleService {
                         },
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val roles = Json.decodeFromJsonElement<List<UserRole>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val roles = supabaseJson.decodeFromJsonElement<List<UserRole>>(jsonElement)
 
             Result.success(roles)
         } catch (e: Exception) {
@@ -203,7 +203,7 @@ object RoleService {
                         },
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
             val hasRole = jsonElement.jsonPrimitive.boolean
 
             Result.success(hasRole)
@@ -280,8 +280,8 @@ object RoleService {
                         },
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val permissions = Json.decodeFromJsonElement<List<RolePermission>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val permissions = supabaseJson.decodeFromJsonElement<List<RolePermission>>(jsonElement)
 
             Result.success(permissions)
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/RoleService.kt
@@ -90,7 +90,11 @@ object RoleService {
 
             roleClaims
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Failed to parse role claims", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "Failed to parse role claims",
+                error = sanitizeResponseFailure("parseRoleClaimsFromSession", e),
+            )
             null
         }
     }
@@ -155,7 +159,12 @@ object RoleService {
                     },
             )
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Failed to decode JWT", error = e)
+            // Sanitised, because the comment fifteen lines up ("JWT payload not logged to
+            // avoid exposing sensitive claims") is defeated by its own failure path: a
+            // garbled payload makes kotlinx append the whole document to the message, so
+            // logging the raw exception logs the claim set the debug line deliberately
+            // withholds.
+            logger.warn(LogCategory.AUTH, "Failed to decode JWT", error = sanitizeResponseFailure("decodeJWTClaims", e))
             emptyMap()
         }
 
@@ -180,7 +189,11 @@ object RoleService {
 
             Result.success(roles)
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Failed to get user roles", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "Failed to get user roles",
+                error = sanitizeResponseFailure("getUserRoles", e),
+            )
             Result.failure(e)
         }
 
@@ -208,7 +221,11 @@ object RoleService {
 
             Result.success(hasRole)
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Failed to check user role", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "Failed to check user role",
+                error = sanitizeResponseFailure("userHasRole", e),
+            )
             Result.failure(e)
         }
 
@@ -237,7 +254,11 @@ object RoleService {
 
             Result.success(Unit)
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to assign role", error = e)
+            logger.error(
+                LogCategory.AUTH,
+                "Failed to assign role",
+                error = sanitizeResponseFailure("assignRoleByName", e),
+            )
             Result.failure(Exception("Failed to assign role: ${e.message}"))
         }
 
@@ -261,7 +282,11 @@ object RoleService {
 
             Result.success(Unit)
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to remove role", error = e)
+            logger.error(
+                LogCategory.AUTH,
+                "Failed to remove role",
+                error = sanitizeResponseFailure("removeRoleByName", e),
+            )
             Result.failure(Exception("Failed to remove role: ${e.message}"))
         }
 
@@ -285,7 +310,11 @@ object RoleService {
 
             Result.success(permissions)
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Failed to get role permissions", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "Failed to get role permissions",
+                error = sanitizeResponseFailure("getRolePermissions", e),
+            )
             Result.failure(e)
         }
 
@@ -320,7 +349,11 @@ object RoleService {
 
             Result.success(false)
         } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Failed to check permission", error = e)
+            logger.warn(
+                LogCategory.AUTH,
+                "Failed to check permission",
+                error = sanitizeResponseFailure("canPerformAction", e),
+            )
             Result.failure(e)
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretDataProviderImpl.kt
@@ -135,7 +135,7 @@ class SecretDataProviderImpl : SecretDataProvider {
             sharedWithRoleId = sharedWithRoleId,
             sharedWithRoleName = sharedWithRoleName,
             accessLevel = accessLevel,
-            sharedByEmail = sharedByEmail,
+            sharedByEmail = sharedByEmail ?: "",
             createdAt = createdAt,
             expiresAt = expiresAt,
             notes = notes,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretDataProviderImpl.kt
@@ -135,6 +135,9 @@ class SecretDataProviderImpl : SecretDataProvider {
             sharedWithRoleId = sharedWithRoleId,
             sharedWithRoleName = sharedWithRoleName,
             accessLevel = accessLevel,
+            // Unknown sharer collapses to "" rather than widening SecretShareData: the IPC
+            // path already does exactly this (SecretDataProviderProxy), so the two agree, and
+            // making the plugin-facing field nullable would break binary compatibility.
             sharedByEmail = sharedByEmail ?: "",
             createdAt = createdAt,
             expiresAt = expiresAt,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -51,6 +51,31 @@ object SecretService {
         get() = SupabaseConfig.client
 
     /**
+     * Decoder for every RPC response on this service.
+     *
+     * `ignoreUnknownKeys` is not a convenience here, it is a requirement of how this
+     * system ships: the database is migrated ahead of the desktop app, and an installed
+     * copy keeps talking to it. The default strict `Json` treats a column the running
+     * build has never heard of as a hard error, and because these RPCs return a LIST,
+     * one unknown key fails the whole decode - every secret disappears, not just the new
+     * field.
+     *
+     * That is not hypothetical. Adding `secrets.org_id` and `secret_shares.shared_with_org_id`
+     * for organisation multi-tenancy broke `getUserSecrets` and `getUserSecretsWithSharingInfo`
+     * on every already-installed build the moment the migration landed:
+     * "Encountered an unknown key 'org_id'". The secret list rendered empty with only a WARN
+     * in the log.
+     *
+     * So: a new column must never be able to do that again. Additive schema changes are
+     * expected and must degrade to "the app ignores the field it does not model yet".
+     *
+     * `internal` rather than `private` so `SecretDecodingTest` can assert that property
+     * against this exact instance. A test that built its own lenient `Json` would pass
+     * whatever this one is configured to do, which is the thing worth pinning.
+     */
+    internal val json = Json { ignoreUnknownKeys = true }
+
+    /**
      * Get user secrets with pagination
      *
      * @param limit Maximum number of secrets to return
@@ -74,8 +99,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val secrets = Json.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val secrets = json.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
             val hasMore = secrets.size >= limit
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
@@ -110,8 +135,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val secrets = Json.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val secrets = json.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
 
             // Check if there might be more results
             val hasMore = secrets.size >= limit
@@ -165,8 +190,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -219,8 +244,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -251,8 +276,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -287,8 +312,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val secretsWithSharing = Json.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val secretsWithSharing = json.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
             val secrets = secretsWithSharing.map { it.toSecretEntry() }
             val hasMore = secrets.size >= limit
 
@@ -325,8 +350,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val secretsWithSharing = Json.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val secretsWithSharing = json.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
             val hasMore = secretsWithSharing.size >= limit
 
             Result.success(PaginatedSecretsWithSharing(data = secretsWithSharing, hasMore = hasMore))
@@ -367,8 +392,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -407,8 +432,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val result = Json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -439,8 +464,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = Json.parseToJsonElement(postgrestResult.data)
-            val shares = Json.decodeFromJsonElement<List<SecretShareEntry>>(jsonElement)
+            val jsonElement = json.parseToJsonElement(postgrestResult.data)
+            val shares = json.decodeFromJsonElement<List<SecretShareEntry>>(jsonElement)
 
             Result.success(shares)
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -80,7 +80,7 @@ object SecretService {
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("getUserSecrets", e))
+            Result.failure(sanitizeSupabaseFailure("getUserSecrets", e))
         }
 
     /**
@@ -123,7 +123,7 @@ object SecretService {
                 ),
             )
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("searchSecrets", e))
+            Result.failure(sanitizeSupabaseFailure("searchSecrets", e))
         }
 
     /**
@@ -174,7 +174,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to create secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("createSecret", e))
+            Result.failure(sanitizeSupabaseFailure("createSecret", e))
         }
     }
 
@@ -228,7 +228,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to update secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("updateSecret", e))
+            Result.failure(sanitizeSupabaseFailure("updateSecret", e))
         }
     }
 
@@ -260,7 +260,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to delete secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("deleteSecret", e))
+            Result.failure(sanitizeSupabaseFailure("deleteSecret", e))
         }
 
     /**
@@ -294,7 +294,7 @@ object SecretService {
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("getUserSecretsWithShared", e))
+            Result.failure(sanitizeSupabaseFailure("getUserSecretsWithShared", e))
         }
 
     /**
@@ -331,7 +331,7 @@ object SecretService {
 
             Result.success(PaginatedSecretsWithSharing(data = secretsWithSharing, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("getUserSecretsWithSharingInfo", e))
+            Result.failure(sanitizeSupabaseFailure("getUserSecretsWithSharingInfo", e))
         }
 
     /**
@@ -376,7 +376,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to share secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("shareSecret", e))
+            Result.failure(sanitizeSupabaseFailure("shareSecret", e))
         }
     }
 
@@ -416,7 +416,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to unshare secret"))
             }
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("unshareSecret", e))
+            Result.failure(sanitizeSupabaseFailure("unshareSecret", e))
         }
     }
 
@@ -444,7 +444,7 @@ object SecretService {
 
             Result.success(shares)
         } catch (e: Exception) {
-            Result.failure(sanitizeResponseFailure("getSecretShares", e))
+            Result.failure(sanitizeSupabaseFailure("getSecretShares", e))
         }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -80,7 +80,7 @@ object SecretService {
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("getUserSecrets", e))
         }
 
     /**
@@ -123,7 +123,7 @@ object SecretService {
                 ),
             )
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("searchSecrets", e))
         }
 
     /**
@@ -174,7 +174,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to create secret"))
             }
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("createSecret", e))
         }
     }
 
@@ -228,7 +228,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to update secret"))
             }
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("updateSecret", e))
         }
     }
 
@@ -260,7 +260,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to delete secret"))
             }
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("deleteSecret", e))
         }
 
     /**
@@ -294,7 +294,7 @@ object SecretService {
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("getUserSecretsWithShared", e))
         }
 
     /**
@@ -331,7 +331,7 @@ object SecretService {
 
             Result.success(PaginatedSecretsWithSharing(data = secretsWithSharing, hasMore = hasMore))
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("getUserSecretsWithSharingInfo", e))
         }
 
     /**
@@ -376,7 +376,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to share secret"))
             }
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("shareSecret", e))
         }
     }
 
@@ -416,7 +416,7 @@ object SecretService {
                 Result.failure(Exception(result.error ?: "Failed to unshare secret"))
             }
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("unshareSecret", e))
         }
     }
 
@@ -444,7 +444,7 @@ object SecretService {
 
             Result.success(shares)
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(sanitizeResponseFailure("getSecretShares", e))
         }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SecretService.kt
@@ -51,31 +51,6 @@ object SecretService {
         get() = SupabaseConfig.client
 
     /**
-     * Decoder for every RPC response on this service.
-     *
-     * `ignoreUnknownKeys` is not a convenience here, it is a requirement of how this
-     * system ships: the database is migrated ahead of the desktop app, and an installed
-     * copy keeps talking to it. The default strict `Json` treats a column the running
-     * build has never heard of as a hard error, and because these RPCs return a LIST,
-     * one unknown key fails the whole decode - every secret disappears, not just the new
-     * field.
-     *
-     * That is not hypothetical. Adding `secrets.org_id` and `secret_shares.shared_with_org_id`
-     * for organisation multi-tenancy broke `getUserSecrets` and `getUserSecretsWithSharingInfo`
-     * on every already-installed build the moment the migration landed:
-     * "Encountered an unknown key 'org_id'". The secret list rendered empty with only a WARN
-     * in the log.
-     *
-     * So: a new column must never be able to do that again. Additive schema changes are
-     * expected and must degrade to "the app ignores the field it does not model yet".
-     *
-     * `internal` rather than `private` so `SecretDecodingTest` can assert that property
-     * against this exact instance. A test that built its own lenient `Json` would pass
-     * whatever this one is configured to do, which is the thing worth pinning.
-     */
-    internal val json = Json { ignoreUnknownKeys = true }
-
-    /**
      * Get user secrets with pagination
      *
      * @param limit Maximum number of secrets to return
@@ -99,8 +74,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val secrets = json.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
             val hasMore = secrets.size >= limit
 
             Result.success(PaginatedSecrets(data = secrets, hasMore = hasMore))
@@ -135,8 +110,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val secrets = json.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(jsonElement)
 
             // Check if there might be more results
             val hasMore = secrets.size >= limit
@@ -190,8 +165,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -244,8 +219,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -276,8 +251,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -312,8 +287,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val secretsWithSharing = json.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val secretsWithSharing = supabaseJson.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
             val secrets = secretsWithSharing.map { it.toSecretEntry() }
             val hasMore = secrets.size >= limit
 
@@ -350,8 +325,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val secretsWithSharing = json.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val secretsWithSharing = supabaseJson.decodeFromJsonElement<List<SecretEntryWithSharing>>(jsonElement)
             val hasMore = secretsWithSharing.size >= limit
 
             Result.success(PaginatedSecretsWithSharing(data = secretsWithSharing, hasMore = hasMore))
@@ -392,8 +367,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -432,8 +407,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val result = json.decodeFromJsonElement<RpcResponse>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val result = supabaseJson.decodeFromJsonElement<RpcResponse>(jsonElement)
 
             if (result.success) {
                 Result.success(Unit)
@@ -464,8 +439,8 @@ object SecretService {
                     parameters = params,
                 )
 
-            val jsonElement = json.parseToJsonElement(postgrestResult.data)
-            val shares = json.decodeFromJsonElement<List<SecretShareEntry>>(jsonElement)
+            val jsonElement = supabaseJson.parseToJsonElement(postgrestResult.data)
+            val shares = supabaseJson.decodeFromJsonElement<List<SecretShareEntry>>(jsonElement)
 
             Result.success(shares)
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseConfig.kt
@@ -95,7 +95,7 @@ object SupabaseConfig {
             logger.error(
                 LogCategory.NETWORK,
                 "Failed to initialize Supabase client",
-                error = sanitizeResponseFailure("initialize", e),
+                error = sanitizeSupabaseFailure("initialize", e),
             )
             throw e
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseConfig.kt
@@ -92,7 +92,11 @@ object SupabaseConfig {
             _isInitialized.value = true
             logger.info(LogCategory.NETWORK, "Supabase client initialized successfully")
         } catch (e: Exception) {
-            logger.error(LogCategory.NETWORK, "Failed to initialize Supabase client", error = e)
+            logger.error(
+                LogCategory.NETWORK,
+                "Failed to initialize Supabase client",
+                error = sanitizeResponseFailure("initialize", e),
+            )
             throw e
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseDataProviderImpl.kt
@@ -9,7 +9,6 @@ import ai.rever.boss.utils.logging.LogCategory
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.rpc
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 /**
@@ -47,13 +46,14 @@ class SupabaseDataProviderImpl : SupabaseDataProvider {
                     }
             Result.success(result.data)
         } catch (e: Exception) {
+            val safe = sanitizeSupabaseFailure("select($table)", e)
             logger.error(
                 LogCategory.NETWORK,
                 "Supabase select failed",
                 data = mapOf("table" to table),
-                error = sanitizeResponseFailure("select($table)", e),
+                error = safe,
             )
-            Result.failure(Exception("Select on '$table' failed: ${e.message}"))
+            Result.failure(Exception("Select on '$table' failed: ${safe.message}"))
         }
 
     override suspend fun rpc(
@@ -71,14 +71,19 @@ class SupabaseDataProviderImpl : SupabaseDataProvider {
         } catch (e: Exception) {
             // Sanitised in the REQUEST direction too, which is easy to miss: `parameters` is
             // caller-supplied, and a plugin calling create_secret puts the new password in it.
-            // A malformed params string would otherwise be logged with the document attached.
+            //
+            // Sanitised ONCE and used for both the log and the returned exception. Doing only
+            // the log is worse than useless here: the caller is a plugin, the plugin is at
+            // least as likely to log what it gets, and the document would have been stripped
+            // from our log and handed straight to it.
+            val safe = sanitizeSupabaseFailure("rpc($function)", e)
             logger.error(
                 LogCategory.NETWORK,
                 "Supabase rpc failed",
                 data = mapOf("function" to function),
-                error = sanitizeResponseFailure("rpc($function)", e),
+                error = safe,
             )
-            Result.failure(Exception("RPC '$function' failed: ${e.message}"))
+            Result.failure(Exception("RPC '$function' failed: ${safe.message}"))
         }
 
     private fun io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder.applyFilter(f: QueryFilter) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseDataProviderImpl.kt
@@ -47,7 +47,12 @@ class SupabaseDataProviderImpl : SupabaseDataProvider {
                     }
             Result.success(result.data)
         } catch (e: Exception) {
-            logger.error(LogCategory.NETWORK, "Supabase select failed", data = mapOf("table" to table), error = e)
+            logger.error(
+                LogCategory.NETWORK,
+                "Supabase select failed",
+                data = mapOf("table" to table),
+                error = sanitizeResponseFailure("select($table)", e),
+            )
             Result.failure(Exception("Select on '$table' failed: ${e.message}"))
         }
 
@@ -56,7 +61,7 @@ class SupabaseDataProviderImpl : SupabaseDataProvider {
         parameters: String,
     ): Result<String> =
         try {
-            val params: JsonElement = Json.parseToJsonElement(parameters)
+            val params: JsonElement = supabaseJson.parseToJsonElement(parameters)
             val result =
                 client.postgrest.rpc(
                     function = function,
@@ -64,7 +69,15 @@ class SupabaseDataProviderImpl : SupabaseDataProvider {
                 )
             Result.success(result.data)
         } catch (e: Exception) {
-            logger.error(LogCategory.NETWORK, "Supabase rpc failed", data = mapOf("function" to function), error = e)
+            // Sanitised in the REQUEST direction too, which is easy to miss: `parameters` is
+            // caller-supplied, and a plugin calling create_secret puts the new password in it.
+            // A malformed params string would otherwise be logged with the document attached.
+            logger.error(
+                LogCategory.NETWORK,
+                "Supabase rpc failed",
+                data = mapOf("function" to function),
+                error = sanitizeResponseFailure("rpc($function)", e),
+            )
             Result.failure(Exception("RPC '$function' failed: ${e.message}"))
         }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
@@ -1,0 +1,37 @@
+package ai.rever.boss.services.supabase
+
+import kotlinx.serialization.json.Json
+
+/**
+ * The decoder for every Supabase RPC response in this package.
+ *
+ * `ignoreUnknownKeys` is not a convenience, it is a requirement of how BOSS ships.
+ * The database is migrated ahead of the desktop app and installed copies keep talking
+ * to it, so a client will meet columns it does not model. The kotlinx default is strict
+ * and treats those as a hard error - and because these RPCs return LISTS, one unmodelled
+ * key does not drop a field, it throws and takes the whole page with it.
+ *
+ * That is not hypothetical. The organisation migration extended four secret RPCs at once
+ * (`get_user_secrets`, `search_user_secrets`, `get_user_secrets_with_shared`,
+ * `get_secret_shares`) and every already-installed build started answering
+ * "Encountered an unknown key 'org_id'". The secret panels rendered empty with nothing
+ * but a WARN in the log.
+ *
+ * It lives here rather than inside one service on purpose: the hazard is a property of
+ * the DEPLOYMENT, not of any single file, so every service that decodes a server response
+ * is exposed to it equally. `RoleService` and `RoleCreationService` had not been bitten
+ * only because `roles` and `permissions` had not been extended yet.
+ *
+ * ## What this buys, and what it costs
+ *
+ * Additive schema changes become safe. In exchange, **renames become silent** for any
+ * field carrying a default: rename `metadata` server-side and decoding now succeeds with
+ * the 2FA metadata quietly missing, rather than failing loudly.
+ *
+ * That is the right trade here - a loud failure means every secret vanishes - but it makes
+ * "additive only, never rename" a contract the database side has to keep. Renaming a
+ * projected column is a breaking change for every installed build and needs the field kept
+ * as an alias until those builds age out. Do not read this instance as blanket tolerance
+ * of schema drift.
+ */
+internal val supabaseJson = Json { ignoreUnknownKeys = true }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
@@ -72,11 +72,18 @@ private const val JSON_INPUT_MARKER = "\nJSON input: "
  * is only the malformed-input path that appends the document. The distinction does not
  * matter to callers, so everything is sanitised uniformly.
  *
+ * BOUNDED, and deliberately so: anything that is not a `SerializationException` passes
+ * through untouched, because network and auth failures are not ours to rewrite and losing
+ * their type would break callers that distinguish them. That is not the same as "nothing
+ * else can leak" - supabase-kt's `RestException` carries the PostgREST error body, and a
+ * constraint violation can echo column values back ("Key (col)=(value) already exists").
+ * Do not read this helper as covering every way a payload can escape this package.
+ *
  * The diagnostic half of the message is kept deliberately. "Encountered an unknown key
  * 'org_id' at path: $" is exactly what identified this outage; discarding it to be safe
  * would trade a credential leak for an undiagnosable one.
  */
-internal fun sanitizeResponseFailure(
+internal fun sanitizeSupabaseFailure(
     operation: String,
     error: Throwable,
 ): Throwable {
@@ -86,7 +93,7 @@ internal fun sanitizeResponseFailure(
             ?.substringBefore(JSON_INPUT_MARKER)
             ?.takeIf { it.isNotBlank() }
             ?: "malformed response"
-    return SupabaseResponseException("$operation: $diagnostic")
+    return SupabaseFailure("$operation: $diagnostic")
 }
 
 /**
@@ -96,6 +103,6 @@ internal fun sanitizeResponseFailure(
  * payload back within reach of any handler that walks `cause`, which is the whole thing
  * being prevented.
  */
-internal class SupabaseResponseException(
+internal class SupabaseFailure(
     message: String,
 ) : Exception(message)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.services.supabase
 
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 /**
@@ -35,3 +36,62 @@ import kotlinx.serialization.json.Json
  * of schema drift.
  */
 internal val supabaseJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * The marker kotlinx puts before the offending document in a parse failure.
+ *
+ * Pinned by `SupabaseJsonTest` rather than trusted: if a kotlinx upgrade renames it, the
+ * sanitiser below silently stops working and starts leaking again, so the test asserts on
+ * a real exception from the current version rather than on this constant.
+ */
+private const val JSON_INPUT_MARKER = "\nJSON input: "
+
+/**
+ * Strip the response body out of a decode failure before it can be logged.
+ *
+ * kotlinx appends the whole offending document to a **parse** error:
+ *
+ * ```
+ * Unexpected JSON token at offset 73: Expected end of the object or comma at path: $
+ * JSON input: [{"id":"1","password":"SUPERSECRET_PW","recovery_codes":["ABC"]
+ * ```
+ *
+ * For the secret RPCs that document holds passwords the server has already decrypted,
+ * plus recovery codes. `SecretService` returns its exceptions through `Result.failure`
+ * and callers log `e.message`, which is how the `org_id` WARN reached the log at all - so
+ * a truncated or garbled response body (a proxy error, a connection cut mid-stream, a
+ * gateway HTML page) would write live credentials into a log file that users attach to
+ * bug reports.
+ *
+ * Verified against the current kotlinx: SCHEMA failures are already safe - an unknown key
+ * or a null in a non-nullable slot reports the key name and JSON path and nothing else. It
+ * is only the malformed-input path that appends the document. The distinction does not
+ * matter to callers, so everything is sanitised uniformly.
+ *
+ * The diagnostic half of the message is kept deliberately. "Encountered an unknown key
+ * 'org_id' at path: $" is exactly what identified this outage; discarding it to be safe
+ * would trade a credential leak for an undiagnosable one.
+ */
+internal fun sanitizeResponseFailure(
+    operation: String,
+    error: Throwable,
+): Throwable {
+    if (error !is SerializationException) return error
+    val diagnostic =
+        error.message
+            ?.substringBefore(JSON_INPUT_MARKER)
+            ?.takeIf { it.isNotBlank() }
+            ?: "malformed response"
+    return SupabaseResponseException("$operation: $diagnostic")
+}
+
+/**
+ * A decode failure with the response body removed.
+ *
+ * A distinct type so the cause cannot be attached: chaining the original would put the
+ * payload back within reach of any handler that walks `cause`, which is the whole thing
+ * being prevented.
+ */
+internal class SupabaseResponseException(
+    message: String,
+) : Exception(message)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseJson.kt
@@ -4,7 +4,11 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 /**
- * The decoder for every Supabase RPC response in this package.
+ * The Json instance for every Supabase payload in this package, in both directions.
+ *
+ * Responses are the reason it exists, but request parameters and decoded JWT payloads go
+ * through it as well, so that "never the `Json` default here" is a rule with no exceptions
+ * to remember. `SupabaseWiringTest` enforces exactly that.
  *
  * `ignoreUnknownKeys` is not a convenience, it is a requirement of how BOSS ships.
  * The database is migrated ahead of the desktop app and installed copies keep talking

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/UserService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/UserService.kt
@@ -66,7 +66,7 @@ object UserService {
             logger.debug(LogCategory.AUTH, "Fetched users", mapOf("count" to actualUsers.size, "offset" to offset, "hasMore" to hasMore))
             Result.success(PaginatedResult(actualUsers, hasMore))
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to fetch users", error = e)
+            logger.error(LogCategory.AUTH, "Failed to fetch users", error = sanitizeResponseFailure("getAllUsers", e))
             Result.failure(Exception("Failed to fetch users: ${e.message}"))
         }
 
@@ -127,7 +127,11 @@ object UserService {
             )
             Result.success(PaginatedResult(usersWithRoles, paginatedUsers.hasMore))
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to fetch users with roles", error = e)
+            logger.error(
+                LogCategory.AUTH,
+                "Failed to fetch users with roles",
+                error = sanitizeResponseFailure("getAllUsersWithRoles", e),
+            )
             Result.failure(Exception("Failed to fetch users with roles: ${e.message}"))
         }
     }
@@ -208,7 +212,11 @@ object UserService {
             )
             Result.success(PaginatedResult(usersWithRoles, hasMore))
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to search users", error = e)
+            logger.error(
+                LogCategory.AUTH,
+                "Failed to search users",
+                error = sanitizeResponseFailure("searchUsersByEmail", e),
+            )
             Result.failure(Exception("Failed to search users: ${e.message}"))
         }
     }
@@ -261,7 +269,11 @@ object UserService {
 
             Result.success(userWithRoles)
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to fetch user with roles", error = e)
+            logger.error(
+                LogCategory.AUTH,
+                "Failed to fetch user with roles",
+                error = sanitizeResponseFailure("getUserWithRoles", e),
+            )
             Result.failure(Exception("Failed to fetch user with roles: ${e.message}"))
         }
     }
@@ -295,7 +307,7 @@ object UserService {
             logger.info(LogCategory.AUTH, "Successfully deleted user", mapOf("userId" to userId))
             Result.success(Unit)
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to delete user", error = e)
+            logger.error(LogCategory.AUTH, "Failed to delete user", error = sanitizeResponseFailure("deleteUser", e))
             Result.failure(Exception("Failed to delete user: ${e.message}"))
         }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/UserService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/UserService.kt
@@ -66,8 +66,8 @@ object UserService {
             logger.debug(LogCategory.AUTH, "Fetched users", mapOf("count" to actualUsers.size, "offset" to offset, "hasMore" to hasMore))
             Result.success(PaginatedResult(actualUsers, hasMore))
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to fetch users", error = sanitizeResponseFailure("getAllUsers", e))
-            Result.failure(Exception("Failed to fetch users: ${e.message}"))
+            logger.error(LogCategory.AUTH, "Failed to fetch users", error = sanitizeSupabaseFailure("getAllUsers", e))
+            Result.failure(Exception("Failed to fetch users: ${sanitizeSupabaseFailure("getAllUsers", e).message}"))
         }
 
     /**
@@ -127,12 +127,13 @@ object UserService {
             )
             Result.success(PaginatedResult(usersWithRoles, paginatedUsers.hasMore))
         } catch (e: Exception) {
+            val safe = sanitizeSupabaseFailure("getAllUsersWithRoles", e)
             logger.error(
                 LogCategory.AUTH,
                 "Failed to fetch users with roles",
-                error = sanitizeResponseFailure("getAllUsersWithRoles", e),
+                error = safe,
             )
-            Result.failure(Exception("Failed to fetch users with roles: ${e.message}"))
+            Result.failure(Exception("Failed to fetch users with roles: ${safe.message}"))
         }
     }
 
@@ -215,9 +216,11 @@ object UserService {
             logger.error(
                 LogCategory.AUTH,
                 "Failed to search users",
-                error = sanitizeResponseFailure("searchUsersByEmail", e),
+                error = sanitizeSupabaseFailure("searchUsersByEmail", e),
             )
-            Result.failure(Exception("Failed to search users: ${e.message}"))
+            Result.failure(
+                Exception("Failed to search users: ${sanitizeSupabaseFailure("searchUsersByEmail", e).message}"),
+            )
         }
     }
 
@@ -238,7 +241,7 @@ object UserService {
             Result.success(user)
         } catch (e: Exception) {
             logger.error(LogCategory.AUTH, "Failed to fetch user", mapOf("userId" to userId, "error" to (e.message ?: "unknown")))
-            Result.failure(Exception("Failed to fetch user: ${e.message}"))
+            Result.failure(Exception("Failed to fetch user: ${sanitizeSupabaseFailure("getUserById", e).message}"))
         }
 
     /**
@@ -272,9 +275,11 @@ object UserService {
             logger.error(
                 LogCategory.AUTH,
                 "Failed to fetch user with roles",
-                error = sanitizeResponseFailure("getUserWithRoles", e),
+                error = sanitizeSupabaseFailure("getUserWithRoles", e),
             )
-            Result.failure(Exception("Failed to fetch user with roles: ${e.message}"))
+            Result.failure(
+                Exception("Failed to fetch user with roles: ${sanitizeSupabaseFailure("getUserWithRoles", e).message}"),
+            )
         }
     }
 
@@ -307,8 +312,8 @@ object UserService {
             logger.info(LogCategory.AUTH, "Successfully deleted user", mapOf("userId" to userId))
             Result.success(Unit)
         } catch (e: Exception) {
-            logger.error(LogCategory.AUTH, "Failed to delete user", error = sanitizeResponseFailure("deleteUser", e))
-            Result.failure(Exception("Failed to delete user: ${e.message}"))
+            logger.error(LogCategory.AUTH, "Failed to delete user", error = sanitizeSupabaseFailure("deleteUser", e))
+            Result.failure(Exception("Failed to delete user: ${sanitizeSupabaseFailure("deleteUser", e).message}"))
         }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/models/SecretModels.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/models/SecretModels.kt
@@ -186,8 +186,14 @@ data class SecretShareEntry(
     val sharedWithRoleName: String? = null,
     @SerialName("access_level")
     val accessLevel: String,
+    // Nullable because get_secret_shares derives it from
+    // `LEFT JOIN auth.users sb ON sb.id = ss.shared_by`, and auth.users.email is itself
+    // nullable. A single null in a non-nullable slot throws for the WHOLE array - and
+    // ignoreUnknownKeys does not help, since leniency covers extra keys, never a null
+    // where a value is required. That failure looks exactly like the outage this model
+    // was just fixed for: "no shares" on every secret.
     @SerialName("shared_by_email")
-    val sharedByEmail: String,
+    val sharedByEmail: String? = null,
     @SerialName("created_at")
     val createdAt: String,
     @SerialName("expires_at")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/services/SecretServiceBridge.kt
@@ -200,7 +200,7 @@ class SecretServiceBridge(
             .setSharedWithRoleId(sharedWithRoleId ?: "")
             .setSharedWithRoleName(sharedWithRoleName ?: "")
             .setAccessLevel(accessLevel)
-            .setSharedByEmail(sharedByEmail)
+            .setSharedByEmail(sharedByEmail ?: "")
             .setCreatedAt(createdAt)
             .setExpiresAt(expiresAt ?: "")
             .setNotes(notes ?: "")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SecretDecodingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SecretDecodingTest.kt
@@ -1,0 +1,100 @@
+package ai.rever.boss.services.supabase
+
+import ai.rever.boss.services.supabase.models.SecretEntry
+import ai.rever.boss.services.supabase.models.SecretEntryWithSharing
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The secret list must survive columns this build does not model.
+ *
+ * These payloads are the shape `get_user_secrets` and `get_user_secrets_with_shared`
+ * actually returned once the organisation migration landed. Against the strict default
+ * `Json` every one of them throws
+ * "Encountered an unknown key 'org_id'", and because the RPCs return a LIST the throw
+ * takes the whole page with it: the panel showed no secrets at all, with nothing but a
+ * WARN in the log to say why.
+ *
+ * Decoding goes through [SecretService.json] deliberately. Building a lenient `Json`
+ * here would assert that kotlinx honours `ignoreUnknownKeys`, which was never in doubt.
+ * What needs pinning is that THIS service is configured that way and stays so.
+ */
+class SecretDecodingTest {
+    private val row = """
+        {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "website": "github.com",
+          "username": "someone@example.com",
+          "password": "hunter2",
+          "notes": null,
+          "expiration_date": null,
+          "tags": ["work"],
+          "metadata": null,
+          "created_at": "2026-08-01T00:00:00Z",
+          "updated_at": "2026-08-01T00:00:00Z"
+        }
+    """
+
+    private fun withKeys(vararg extra: Pair<String, String>): String {
+        val added = extra.joinToString("") { (k, v) -> ""","$k": $v""" }
+        return row.trimIndent().removeSuffix("}").trimEnd() + added + "}"
+    }
+
+    @Test
+    fun `secret list decodes when rows carry org_id`() {
+        val payload = "[${withKeys("org_id" to "null")},${withKeys("org_id" to "\"22222222-2222-2222-2222-222222222222\"")}]"
+
+        val secrets = SecretService.json.decodeFromString<List<SecretEntry>>(payload)
+
+        // The count is the assertion that matters. A partial decode is not a thing kotlinx
+        // does - it is all rows or an exception - so "2" is what distinguishes a working
+        // list from the empty panel this bug produced.
+        assertEquals(2, secrets.size)
+        assertEquals("github.com", secrets[0].website)
+        assertEquals("hunter2", secrets[1].password)
+    }
+
+    @Test
+    fun `shared secret list decodes when rows carry shared_with_org_id`() {
+        val shared =
+            withKeys(
+                "is_owner" to "false",
+                "access_level" to "\"read\"",
+                "shared_by_email" to "\"owner@example.com\"",
+                "shared_with_org_id" to "\"33333333-3333-3333-3333-333333333333\"",
+                "org_id" to "null",
+            )
+
+        val secrets = SecretService.json.decodeFromString<List<SecretEntryWithSharing>>("[$shared]")
+
+        assertEquals(1, secrets.size)
+        assertEquals("read", secrets[0].accessLevel)
+        assertTrue(!secrets[0].isOwner)
+    }
+
+    @Test
+    fun `a column nobody has invented yet is ignored rather than fatal`() {
+        // The point of the fix is not org_id specifically. Any future additive migration -
+        // shipped, as always, ahead of the installed desktop build - has to degrade to
+        // "ignored", or it repeats this outage under a different column name.
+        val payload = "[${withKeys("some_future_column" to "\"whatever\"", "another_one" to "42")}]"
+
+        val secrets = SecretService.json.decodeFromString<List<SecretEntry>>(payload)
+
+        assertEquals(1, secrets.size)
+    }
+
+    @Test
+    fun `decodeFromJsonElement is lenient too, not just decodeFromString`() {
+        // Every call site in SecretService goes through parseToJsonElement then
+        // decodeFromJsonElement, so leniency on the string overload alone would prove
+        // nothing about the path production actually takes.
+        val element = SecretService.json.parseToJsonElement("[${withKeys("org_id" to "null")}]")
+
+        val secrets = SecretService.json.decodeFromJsonElement<List<SecretEntry>>(element)
+
+        assertEquals(1, secrets.size)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SecretDecodingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SecretDecodingTest.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.services.supabase.models.SecretEntryWithSharing
 import ai.rever.boss.services.supabase.models.SecretShareEntry
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -12,6 +13,7 @@ import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 
 /**
  * The secret lists must survive columns this build does not model.
@@ -41,7 +43,17 @@ class SecretDecodingTest {
         put("notes", null as String?)
         put("expiration_date", null as String?)
         put("tags", buildJsonArray { })
-        put("metadata", null as String?)
+        put(
+            "metadata",
+            // The RPC emits a jsonb object unconditionally via COALESCE, so a bare null is
+            // not a shape the server can actually send - and decoding it exercises nothing
+            // of SecretMetadata, which otherwise has zero nested coverage here.
+            buildJsonObject {
+                put("twofa_enabled", true)
+                put("twofa_type", "app")
+                put("recovery_codes", buildJsonArray { add(JsonPrimitive("abc-123")) })
+            },
+        )
         put("created_at", "2026-08-01T00:00:00Z")
         put("updated_at", "2026-08-01T00:00:00Z")
     }
@@ -78,6 +90,8 @@ class SecretDecodingTest {
         assertEquals(2, secrets.size)
         assertEquals("github.com", secrets[0].website)
         assertEquals("hunter2", secrets[1].password)
+        assertEquals(true, secrets[0].metadata?.twofaEnabled)
+        assertEquals(listOf("abc-123"), secrets[0].metadata?.recoveryCodes)
     }
 
     @Test
@@ -143,6 +157,36 @@ class SecretDecodingTest {
 
         assertEquals(1, shares.size)
         assertEquals("write", shares[0].accessLevel)
+    }
+
+    @Test
+    fun `get_secret_shares decodes when shared_by_email is null`() {
+        // shared_by_email comes from `LEFT JOIN auth.users sb ON sb.id = ss.shared_by`, and
+        // auth.users.email is nullable. Modelled non-null it would throw for the whole array
+        // - the same "no shares on every secret" outage, through a door leniency does not
+        // cover: ignoreUnknownKeys handles extra keys, never a null where a value is required.
+        val payload =
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("share_id", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                        put("access_level", "read")
+                        put("shared_by_email", null as String?)
+                        put("created_at", "2026-08-01T00:00:00Z")
+                        put("shared_with_org_id", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+                        put("shared_with_org_slug", "acme")
+                    },
+                )
+            }
+
+        val shares = supabaseJson.decodeFromJsonElement<List<SecretShareEntry>>(payload)
+
+        assertEquals(1, shares.size)
+        // assertNull, not assertEquals(null, ...): it takes Any? and so still COMPILES if the
+        // field is made non-nullable again, letting the decode throw and fail the test for the
+        // real reason. assertEquals(null, ...) fails type inference instead, which reads as a
+        // broken test and invites fixing the test rather than the model.
+        assertNull(shares[0].sharedByEmail)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SecretDecodingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SecretDecodingTest.kt
@@ -2,98 +2,177 @@ package ai.rever.boss.services.supabase
 
 import ai.rever.boss.services.supabase.models.SecretEntry
 import ai.rever.boss.services.supabase.models.SecretEntryWithSharing
+import ai.rever.boss.services.supabase.models.SecretShareEntry
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 /**
- * The secret list must survive columns this build does not model.
+ * The secret lists must survive columns this build does not model.
  *
- * These payloads are the shape `get_user_secrets` and `get_user_secrets_with_shared`
- * actually returned once the organisation migration landed. Against the strict default
- * `Json` every one of them throws
- * "Encountered an unknown key 'org_id'", and because the RPCs return a LIST the throw
- * takes the whole page with it: the panel showed no secrets at all, with nothing but a
- * WARN in the log to say why.
+ * The organisation migration extended FOUR list-returning RPCs at once, and against the
+ * strict kotlinx default every one of them throws "Encountered an unknown key 'org_id'".
+ * Because they return lists the throw is all-or-nothing: not a missing field, an empty
+ * panel, with only a WARN in the log to say why.
  *
- * Decoding goes through [SecretService.json] deliberately. Building a lenient `Json`
- * here would assert that kotlinx honours `ignoreUnknownKeys`, which was never in doubt.
- * What needs pinning is that THIS service is configured that way and stays so.
+ * Each case below carries the EXACT set of keys its RPC ships today, taken from the
+ * `RETURNS TABLE` in `20260802000000_secrets_org_ownership.sql`, rather than a
+ * representative unknown key. Two of these paths (`searchSecrets`, `getSecretShares`) were
+ * broken in production without anyone reporting them, so "which shape did the server
+ * actually send" is the thing worth pinning.
+ *
+ * Decoding goes through [supabaseJson] deliberately. A lenient `Json` built here would
+ * assert that kotlinx honours `ignoreUnknownKeys`, which was never in doubt; what needs
+ * pinning is that the services are wired to it and stay so.
  */
 class SecretDecodingTest {
-    private val row = """
-        {
-          "id": "11111111-1111-1111-1111-111111111111",
-          "website": "github.com",
-          "username": "someone@example.com",
-          "password": "hunter2",
-          "notes": null,
-          "expiration_date": null,
-          "tags": ["work"],
-          "metadata": null,
-          "created_at": "2026-08-01T00:00:00Z",
-          "updated_at": "2026-08-01T00:00:00Z"
-        }
-    """
-
-    private fun withKeys(vararg extra: Pair<String, String>): String {
-        val added = extra.joinToString("") { (k, v) -> ""","$k": $v""" }
-        return row.trimIndent().removeSuffix("}").trimEnd() + added + "}"
+    /** The ten columns every secret RPC returned before the organisation work. */
+    private fun JsonObjectBuilder.baseSecret(id: String) {
+        put("id", id)
+        put("website", "github.com")
+        put("username", "someone@example.com")
+        put("password", "hunter2")
+        put("notes", null as String?)
+        put("expiration_date", null as String?)
+        put("tags", buildJsonArray { })
+        put("metadata", null as String?)
+        put("created_at", "2026-08-01T00:00:00Z")
+        put("updated_at", "2026-08-01T00:00:00Z")
     }
 
+    /** The four keys `get_user_secrets` and `search_user_secrets` both gained. */
+    private fun JsonObjectBuilder.orgColumns(orgId: String?) {
+        put("org_id", orgId)
+        put("org_slug", orgId?.let { "acme" })
+        put("is_org_owned", orgId != null)
+        put("can_manage", true)
+    }
+
+    private fun userSecretsRow(
+        id: String,
+        orgId: String?,
+    ): JsonObject =
+        buildJsonObject {
+            baseSecret(id)
+            orgColumns(orgId)
+        }
+
     @Test
-    fun `secret list decodes when rows carry org_id`() {
-        val payload = "[${withKeys("org_id" to "null")},${withKeys("org_id" to "\"22222222-2222-2222-2222-222222222222\"")}]"
+    fun `get_user_secrets decodes with its four new organisation columns`() {
+        val payload =
+            buildJsonArray {
+                add(userSecretsRow("11111111-1111-1111-1111-111111111111", null))
+                add(userSecretsRow("22222222-2222-2222-2222-222222222222", "33333333-3333-3333-3333-333333333333"))
+            }
 
-        val secrets = SecretService.json.decodeFromString<List<SecretEntry>>(payload)
+        val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(payload)
 
-        // The count is the assertion that matters. A partial decode is not a thing kotlinx
-        // does - it is all rows or an exception - so "2" is what distinguishes a working
-        // list from the empty panel this bug produced.
+        // The count is what matters. kotlinx does not decode partially - it is every row or
+        // an exception - so "2" is what separates a working list from the empty panel.
         assertEquals(2, secrets.size)
         assertEquals("github.com", secrets[0].website)
         assertEquals("hunter2", secrets[1].password)
     }
 
     @Test
-    fun `shared secret list decodes when rows carry shared_with_org_id`() {
-        val shared =
-            withKeys(
-                "is_owner" to "false",
-                "access_level" to "\"read\"",
-                "shared_by_email" to "\"owner@example.com\"",
-                "shared_with_org_id" to "\"33333333-3333-3333-3333-333333333333\"",
-                "org_id" to "null",
-            )
+    fun `search_user_secrets decodes with the same four columns`() {
+        // Broken in production exactly as getUserSecrets was, and never reported - search is
+        // simply used less. It is not covered by the getUserSecrets case: same shape today,
+        // but a separate function that can drift independently.
+        val payload = buildJsonArray { add(userSecretsRow("44444444-4444-4444-4444-444444444444", null)) }
 
-        val secrets = SecretService.json.decodeFromString<List<SecretEntryWithSharing>>("[$shared]")
+        val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(payload)
+
+        assertEquals(1, secrets.size)
+    }
+
+    @Test
+    fun `get_user_secrets_with_shared decodes with all five of its new columns`() {
+        val payload =
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        baseSecret("55555555-5555-5555-5555-555555555555")
+                        put("is_owner", false)
+                        put("shared_by_email", "owner@example.com")
+                        put("access_level", "read")
+                        orgColumns("66666666-6666-6666-6666-666666666666")
+                        put("shared_with_org_slug", "acme")
+                    },
+                )
+            }
+
+        val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntryWithSharing>>(payload)
 
         assertEquals(1, secrets.size)
         assertEquals("read", secrets[0].accessLevel)
-        assertTrue(!secrets[0].isOwner)
+        assertFalse(secrets[0].isOwner)
+    }
+
+    @Test
+    fun `get_secret_shares decodes with shared_with_org_id and shared_with_org_slug`() {
+        // The third broken RPC, and the one the first pass of this test missed. Its failure
+        // showed as "no shares" on every secret, which reads like a state rather than a fault.
+        val payload =
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("share_id", "77777777-7777-7777-7777-777777777777")
+                        put("shared_with_user_id", null as String?)
+                        put("shared_with_user_email", null as String?)
+                        put("shared_with_role_id", null as String?)
+                        put("shared_with_role_name", null as String?)
+                        put("access_level", "write")
+                        put("shared_by_email", "owner@example.com")
+                        put("created_at", "2026-08-01T00:00:00Z")
+                        put("expires_at", null as String?)
+                        put("notes", null as String?)
+                        put("shared_with_org_id", "88888888-8888-8888-8888-888888888888")
+                        put("shared_with_org_slug", "acme")
+                    },
+                )
+            }
+
+        val shares = supabaseJson.decodeFromJsonElement<List<SecretShareEntry>>(payload)
+
+        assertEquals(1, shares.size)
+        assertEquals("write", shares[0].accessLevel)
     }
 
     @Test
     fun `a column nobody has invented yet is ignored rather than fatal`() {
-        // The point of the fix is not org_id specifically. Any future additive migration -
-        // shipped, as always, ahead of the installed desktop build - has to degrade to
-        // "ignored", or it repeats this outage under a different column name.
-        val payload = "[${withKeys("some_future_column" to "\"whatever\"", "another_one" to "42")}]"
+        // The point is not org_id specifically. Any future additive migration - shipped, as
+        // always, ahead of the installed build - has to degrade to "ignored", or this outage
+        // repeats under a different column name.
+        val payload =
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        baseSecret("99999999-9999-9999-9999-999999999999")
+                        put("some_future_column", "whatever")
+                        put("another_one", 42)
+                    },
+                )
+            }
 
-        val secrets = SecretService.json.decodeFromString<List<SecretEntry>>(payload)
+        val secrets = supabaseJson.decodeFromJsonElement<List<SecretEntry>>(payload)
 
         assertEquals(1, secrets.size)
     }
 
     @Test
-    fun `decodeFromJsonElement is lenient too, not just decodeFromString`() {
-        // Every call site in SecretService goes through parseToJsonElement then
-        // decodeFromJsonElement, so leniency on the string overload alone would prove
-        // nothing about the path production actually takes.
-        val element = SecretService.json.parseToJsonElement("[${withKeys("org_id" to "null")}]")
+    fun `decodeFromString is lenient too, not just decodeFromJsonElement`() {
+        // Every call site parses then decodes, so leniency proven on one overload says
+        // nothing about the other. Both are in use across the package.
+        val raw = buildJsonArray { add(userSecretsRow("10101010-1010-1010-1010-101010101010", null)) }.toString()
 
-        val secrets = SecretService.json.decodeFromJsonElement<List<SecretEntry>>(element)
+        val secrets = supabaseJson.decodeFromString<List<SecretEntry>>(raw)
 
         assertEquals(1, secrets.size)
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
@@ -1,9 +1,12 @@
 package ai.rever.boss.services.supabase
 
+import ai.rever.boss.services.supabase.models.SecretEntry
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -55,11 +58,7 @@ class SupabaseJsonTest {
         // Stripping the whole message would trade a credential leak for an undiagnosable
         // outage. "Encountered an unknown key 'org_id'" is precisely what identified this bug.
         val body = """[{"id":"1","org_id":null}]"""
-        val strict = kotlinx.serialization.json.Json
-        val raw =
-            runCatching {
-                strict.decodeFromString<List<ai.rever.boss.services.supabase.models.SecretEntry>>(body)
-            }.exceptionOrNull()
+        val raw = runCatching { Json.decodeFromString<List<SecretEntry>>(body) }.exceptionOrNull()
 
         val safe = sanitizeResponseFailure("getUserSecrets", raw!!)
 
@@ -75,10 +74,7 @@ class SupabaseJsonTest {
         val nullPassword =
             """[{"id":"1","website":"w","username":"u","password":null,"tags":[],""" +
                 """"created_at":"x","updated_at":"x"}]"""
-        val raw =
-            runCatching {
-                supabaseJson.decodeFromString<List<ai.rever.boss.services.supabase.models.SecretEntry>>(nullPassword)
-            }.exceptionOrNull()
+        val raw = runCatching { supabaseJson.decodeFromString<List<SecretEntry>>(nullPassword) }.exceptionOrNull()
 
         val safe = sanitizeResponseFailure("getUserSecrets", raw!!)
 
@@ -105,7 +101,9 @@ class SupabaseJsonTest {
 
         val safe = sanitizeResponseFailure("getUserSecrets", raw)
 
-        assertEquals(null, safe.cause)
+        // assertNull for the same reason SecretDecodingTest argues for it: it takes Any? and
+        // so keeps compiling if the type changes, failing for the real reason.
+        assertNull(safe.cause)
         assertTrue(safe is SupabaseResponseException)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
@@ -1,0 +1,111 @@
+package ai.rever.boss.services.supabase
+
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A decode failure must never carry the response body into a log.
+ *
+ * `SecretService` returns its exceptions through `Result.failure` and its callers log
+ * `e.message` - that is how the `org_id` WARN reached the log in the first place. The
+ * bodies of these four RPCs contain passwords the server has already decrypted, and
+ * recovery codes, so an exception that quotes the body writes live credentials into a file
+ * users attach to bug reports.
+ */
+class SupabaseJsonTest {
+    private val password = "SUPERSECRET_PW"
+    private val recoveryCode = "RECOVERY_ABC"
+
+    /** Truncated mid-array, as a cut connection or a proxy error would leave it. */
+    private val malformedBody =
+        """[{"id":"1","website":"github.com","password":"$password","recovery_codes":["$recoveryCode"] """
+
+    @Test
+    fun `a malformed body is not quoted back through the sanitiser`() {
+        val raw = runCatching { supabaseJson.parseToJsonElement(malformedBody) }.exceptionOrNull()
+        assertTrue(raw is SerializationException, "expected a serialization failure, got $raw")
+
+        val safe = sanitizeResponseFailure("getUserSecrets", raw)
+
+        val message = safe.message.orEmpty()
+        assertFalse(message.contains(password), "password leaked into: $message")
+        assertFalse(message.contains(recoveryCode), "recovery code leaked into: $message")
+        assertFalse(message.contains("JSON input"), "body marker survived: $message")
+    }
+
+    @Test
+    fun `the sanitiser is doing work, not decorating an already-safe message`() {
+        // Canary. kotlinx appends the offending document to a PARSE failure today, which is
+        // the entire reason sanitizeResponseFailure exists. If an upgrade stops doing that,
+        // this fails - and that failure is worth having: it says the threat model moved and
+        // the sanitiser may now be dead code, rather than letting it rot untested.
+        val raw = runCatching { supabaseJson.parseToJsonElement(malformedBody) }.exceptionOrNull()
+
+        assertTrue(
+            raw?.message.orEmpty().contains(password),
+            "kotlinx no longer quotes the input - re-evaluate whether the sanitiser is still needed",
+        )
+    }
+
+    @Test
+    fun `the diagnostic half of the message survives`() {
+        // Stripping the whole message would trade a credential leak for an undiagnosable
+        // outage. "Encountered an unknown key 'org_id'" is precisely what identified this bug.
+        val body = """[{"id":"1","org_id":null}]"""
+        val strict = kotlinx.serialization.json.Json
+        val raw =
+            runCatching {
+                strict.decodeFromString<List<ai.rever.boss.services.supabase.models.SecretEntry>>(body)
+            }.exceptionOrNull()
+
+        val safe = sanitizeResponseFailure("getUserSecrets", raw!!)
+
+        assertTrue(safe.message.orEmpty().contains("getUserSecrets"), "operation name missing")
+        assertTrue(safe.message.orEmpty().contains("org_id"), "key name missing: ${safe.message}")
+    }
+
+    @Test
+    fun `schema failures were already safe and stay that way`() {
+        // An unknown key or a null in a non-nullable slot names the key and the path and
+        // nothing else. Sanitising uniformly is about not asking callers to know which is
+        // which, so confirm the safe path is not made worse.
+        val nullPassword =
+            """[{"id":"1","website":"w","username":"u","password":null,"tags":[],""" +
+                """"created_at":"x","updated_at":"x"}]"""
+        val raw =
+            runCatching {
+                supabaseJson.decodeFromString<List<ai.rever.boss.services.supabase.models.SecretEntry>>(nullPassword)
+            }.exceptionOrNull()
+
+        val safe = sanitizeResponseFailure("getUserSecrets", raw!!)
+
+        assertFalse(safe.message.orEmpty().contains("JSON input"))
+        assertTrue(safe.message.orEmpty().contains("password"), "should still name the offending field")
+    }
+
+    @Test
+    fun `a non-serialization failure passes through untouched`() {
+        // Network and auth failures are not ours to rewrite, and losing their type would
+        // break any caller that distinguishes them.
+        val original = IllegalStateException("connection reset")
+
+        val result = sanitizeResponseFailure("getUserSecrets", original)
+
+        assertEquals(original, result)
+    }
+
+    @Test
+    fun `the sanitised failure carries no cause chain back to the payload`() {
+        // Attaching the original as `cause` would put the body back within reach of any
+        // handler that walks the chain, which defeats the whole exercise.
+        val raw = runCatching { supabaseJson.parseToJsonElement(malformedBody) }.exceptionOrNull()!!
+
+        val safe = sanitizeResponseFailure("getUserSecrets", raw)
+
+        assertEquals(null, safe.cause)
+        assertTrue(safe is SupabaseResponseException)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseJsonTest.kt
@@ -31,7 +31,7 @@ class SupabaseJsonTest {
         val raw = runCatching { supabaseJson.parseToJsonElement(malformedBody) }.exceptionOrNull()
         assertTrue(raw is SerializationException, "expected a serialization failure, got $raw")
 
-        val safe = sanitizeResponseFailure("getUserSecrets", raw)
+        val safe = sanitizeSupabaseFailure("getUserSecrets", raw)
 
         val message = safe.message.orEmpty()
         assertFalse(message.contains(password), "password leaked into: $message")
@@ -42,7 +42,7 @@ class SupabaseJsonTest {
     @Test
     fun `the sanitiser is doing work, not decorating an already-safe message`() {
         // Canary. kotlinx appends the offending document to a PARSE failure today, which is
-        // the entire reason sanitizeResponseFailure exists. If an upgrade stops doing that,
+        // the entire reason sanitizeSupabaseFailure exists. If an upgrade stops doing that,
         // this fails - and that failure is worth having: it says the threat model moved and
         // the sanitiser may now be dead code, rather than letting it rot untested.
         val raw = runCatching { supabaseJson.parseToJsonElement(malformedBody) }.exceptionOrNull()
@@ -60,7 +60,7 @@ class SupabaseJsonTest {
         val body = """[{"id":"1","org_id":null}]"""
         val raw = runCatching { Json.decodeFromString<List<SecretEntry>>(body) }.exceptionOrNull()
 
-        val safe = sanitizeResponseFailure("getUserSecrets", raw!!)
+        val safe = sanitizeSupabaseFailure("getUserSecrets", raw!!)
 
         assertTrue(safe.message.orEmpty().contains("getUserSecrets"), "operation name missing")
         assertTrue(safe.message.orEmpty().contains("org_id"), "key name missing: ${safe.message}")
@@ -76,7 +76,7 @@ class SupabaseJsonTest {
                 """"created_at":"x","updated_at":"x"}]"""
         val raw = runCatching { supabaseJson.decodeFromString<List<SecretEntry>>(nullPassword) }.exceptionOrNull()
 
-        val safe = sanitizeResponseFailure("getUserSecrets", raw!!)
+        val safe = sanitizeSupabaseFailure("getUserSecrets", raw!!)
 
         assertFalse(safe.message.orEmpty().contains("JSON input"))
         assertTrue(safe.message.orEmpty().contains("password"), "should still name the offending field")
@@ -88,7 +88,7 @@ class SupabaseJsonTest {
         // break any caller that distinguishes them.
         val original = IllegalStateException("connection reset")
 
-        val result = sanitizeResponseFailure("getUserSecrets", original)
+        val result = sanitizeSupabaseFailure("getUserSecrets", original)
 
         assertEquals(original, result)
     }
@@ -99,11 +99,44 @@ class SupabaseJsonTest {
         // handler that walks the chain, which defeats the whole exercise.
         val raw = runCatching { supabaseJson.parseToJsonElement(malformedBody) }.exceptionOrNull()!!
 
-        val safe = sanitizeResponseFailure("getUserSecrets", raw)
+        val safe = sanitizeSupabaseFailure("getUserSecrets", raw)
 
         // assertNull for the same reason SecretDecodingTest argues for it: it takes Any? and
         // so keeps compiling if the type changes, failing for the real reason.
         assertNull(safe.cause)
-        assertTrue(safe is SupabaseResponseException)
+        assertTrue(safe is SupabaseFailure)
     }
+}
+
+/**
+ * The plugin-facing path, exercised for real.
+ *
+ * `SupabaseDataProviderImpl.rpc` parses caller-supplied `parameters` before it touches the
+ * network, so a malformed params string fails without a backend - which makes this the one
+ * leak path in the package that can be tested by execution rather than by reading source.
+ *
+ * It is worth executing because reasoning got it wrong twice. First I cleared this function
+ * on the grounds that untyped parsing cannot fail on unknown keys (true, and beside the
+ * point - it can still fail on malformed input). Then I sanitised its log and left the
+ * returned exception built from the raw message, which strips the document from our log and
+ * hands it to the plugin instead.
+ */
+class SupabaseDataProviderLeakTest {
+    private val password = "SUPERSECRET_PW"
+
+    @Test
+    fun `a malformed create_secret params string does not return the password to the plugin`() =
+        kotlinx.coroutines.runBlocking {
+            // Truncated mid-object, as a serialisation bug or a cut write would leave it.
+            val params = """{"p_website":"github.com","p_password":"$password" """
+
+            val result = SupabaseDataProviderImpl().rpc("create_secret", params)
+
+            val message = result.exceptionOrNull()?.message.orEmpty()
+            assertTrue(result.isFailure, "expected the malformed params to fail")
+            assertFalse(message.contains(password), "password returned to caller in: $message")
+            assertFalse(message.contains("JSON input"), "body marker returned to caller in: $message")
+            // Still says which call failed, or the plugin author is left with nothing.
+            assertTrue(message.contains("create_secret"), "lost the function name: $message")
+        }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseWiringTest.kt
@@ -10,24 +10,60 @@ import kotlin.test.fail
  * The services must be WIRED to the shared decoder and the sanitiser, not merely have them
  * available.
  *
- * `SupabaseJsonTest` proves `sanitizeResponseFailure` strips the payload, and
- * `SecretDecodingTest` proves `supabaseJson` tolerates new columns. Neither goes through
- * `SecretService`, so reverting all ten call sites to `Result.failure(e)` passed the entire
- * suite - verified, not assumed. The behaviour was pinned and the wiring was not, which is
- * the half that actually broke production.
+ * `SupabaseJsonTest` proves `sanitizeSupabaseFailure` strips the payload, and
+ * `SecretDecodingTest` proves `supabaseJson` tolerates new columns. Neither goes through a
+ * service, so reverting all ten `SecretService` call sites passed the entire suite -
+ * verified, not assumed. The behaviour was pinned and the wiring was not, which is the half
+ * that actually broke production.
  *
- * These services construct their Postgrest client from `SupabaseConfig`, so exercising them
- * for real needs a live backend and there is no seam to inject one. Reading the source is
- * the honest alternative: it is a weaker assertion than an execution test, and a far
- * stronger one than nothing. The same approach guards the organisation function's views.
+ * These services construct their Postgrest client from `SupabaseConfig` with no seam to
+ * inject a fake, so exercising them for real needs a live backend. Reading the source is
+ * the honest alternative: weaker than an execution test, far stronger than nothing. The
+ * same approach guards the organisation function's views.
+ *
+ * The patterns below are deliberately broad. The first version matched only the exact
+ * shapes already in the tree, which is the failure mode of a guard like this: it passes
+ * forever while the thing it guards erodes around it.
  */
 class SupabaseWiringTest {
     private companion object {
-        /** `Json.decodeFrom…` / `Json.parseToJsonElement`, but not `supabaseJson.` or `importJson.`. */
-        val STRICT_JSON = Regex("""(?<![A-Za-z0-9_.])Json\.(decodeFrom|parseToJsonElement)""")
+        /**
+         * A strict `Json`, however it is spelled.
+         *
+         * Covers `Json.decodeFrom…`, the fully-qualified `kotlinx.serialization.json.Json.…`
+         * (plausible here - this package already writes `…postgrest.query.Columns.raw(…)`
+         * inline), the `Json.Default.…` an IDE inserts, and a locally-built `Json { … }`,
+         * which is the likeliest accident of all. `supabaseJson` must not match, hence the
+         * word boundary rather than a bare prefix.
+         */
+        val STRICT_JSON =
+            Regex("""(?<![A-Za-z0-9_])Json\s*\{|(?<![A-Za-z0-9_])Json\.(Default\.)?(decodeFrom|parseToJsonElement)""")
 
-        /** A raw exception handed to a logger, which can quote the payload. */
-        val RAW_ERROR_LOG = Regex("""error\s*=\s*e\s*[,)]""")
+        /** A raw throwable handed to a logger, whatever the variable is called. */
+        val RAW_ERROR_LOG = Regex("""error\s*=\s*(?!sanitize)\w+\s*[,)]""")
+
+        /** A raw throwable, or its message, handed back to a caller. */
+        val RAW_RETURNED = Regex("""Result\.failure\(\s*\w+\s*\)|\$\{\w+\.message\}""")
+
+        /**
+         * Lines the scans must not flag, each exempt for a stated reason.
+         *
+         *  - the sanitised forms themselves, including the `safe` local that
+         *    `SupabaseDataProviderImpl` sanitises once and uses for both the log and the
+         *    returned message;
+         *  - the declaration of `supabaseJson`, which is necessarily a `Json { }`;
+         *  - `validate().getOrElse { return Result.failure(it) }`, which returns an
+         *    `IllegalArgumentException` this code constructed from the caller's own request.
+         *    No server payload has been touched at that point, so there is nothing to strip.
+         *
+         * Kept as an explicit allow-list rather than by narrowing the patterns, so that every
+         * exemption is visible and has to be argued for.
+         */
+        val ALLOWED =
+            Regex(
+                """sanitizeSupabaseFailure\(|error = safe|\$\{safe\.message\}|""" +
+                    """val supabaseJson = Json|validate\(\)\.getOrElse""",
+            )
     }
 
     private val packageDir = "composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase"
@@ -46,64 +82,65 @@ class SupabaseWiringTest {
         fail("could not locate $packageDir from ${File(".").absolutePath}")
     }
 
+    /** walkTopDown, not listFiles: `models/` and any future subpackage must be covered too. */
     private fun sources(): List<File> =
-        sourceDir().listFiles { f: File -> f.extension == "kt" }?.toList()
-            ?: fail("no sources under ${sourceDir()}")
+        sourceDir()
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .toList()
+            .ifEmpty { fail("no sources under ${sourceDir()}") }
+
+    private fun scan(pattern: Regex): List<String> =
+        sources().flatMap { file ->
+            file
+                .readLines()
+                .withIndex()
+                .filter { (_, line) -> pattern.containsMatchIn(line) && !ALLOWED.containsMatchIn(line) }
+                .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
+        }
 
     @Test
     fun `no service decodes with the strict Json default`() {
-        // The wildcard `kotlinx.serialization.json.*` import in these files keeps Json.Default
-        // in scope, so this is what a new call site gets by simply not thinking about it.
-        val offenders =
-            sources().flatMap { file ->
-                file
-                    .readLines()
-                    .withIndex()
-                    .filter { (_, line) -> STRICT_JSON.containsMatchIn(line) }
-                    .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
-            }
-
         assertEquals(
             emptyList(),
-            offenders,
-            "decode Supabase responses through supabaseJson, never the Json default",
+            scan(STRICT_JSON),
+            "decode Supabase payloads through supabaseJson, never a strict Json",
         )
     }
 
     @Test
-    fun `every SecretService failure is sanitised before it reaches a caller`() {
-        // SecretService returns exceptions to callers that log e.message, and its response
-        // bodies hold server-decrypted passwords. An unsanitised return is a credential leak,
-        // not a style issue.
-        val source = File(sourceDir(), "SecretService.kt").readText()
-
-        val raw =
-            Regex("""Result\.failure\(\s*e\s*\)""").findAll(source).count()
-        val sanitised =
-            Regex("""Result\.failure\(sanitizeResponseFailure\(""").findAll(source).count()
-
-        assertEquals(0, raw, "SecretService returns $raw unsanitised exception(s) to callers")
-        assertTrue(sanitised >= 10, "expected every catch block sanitised, found $sanitised")
-    }
-
-    @Test
-    fun `the sanitiser is applied wherever a decode failure is logged`() {
+    fun `no raw throwable reaches a logger`() {
         // RoleService's JWT path is the case that motivated this: it carries a comment saying
-        // the payload is deliberately not logged, and its catch logged the raw exception,
-        // which puts the whole claim set back in the log on a garbled payload.
-        val offenders =
-            sources().flatMap { file ->
-                file
-                    .readLines()
-                    .withIndex()
-                    .filter { (_, line) -> RAW_ERROR_LOG.containsMatchIn(line) }
-                    .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
-            }
-
+        // the payload is deliberately not logged, above a catch that logged the raw exception.
         assertEquals(
             emptyList(),
-            offenders,
-            "log sanitizeResponseFailure(op, e), not the raw exception - it can quote the response body",
+            scan(RAW_ERROR_LOG),
+            "log sanitizeSupabaseFailure(op, e) - a raw failure can quote the payload",
         )
+    }
+
+    @Test
+    fun `no raw throwable or message reaches a caller`() {
+        // The half missed the first time. SupabaseDataProviderImpl sanitised its log and then
+        // rebuilt the returned exception from the raw message - so the document was stripped
+        // from our log and handed straight to the plugin, which is at least as likely to log
+        // it. Sanitising one direction only is close to no fix at all.
+        assertEquals(
+            emptyList(),
+            scan(RAW_RETURNED),
+            "return sanitizeSupabaseFailure(op, e), or its .message - callers log what they get",
+        )
+    }
+
+    @Test
+    fun `every SecretService catch block is sanitised`() {
+        // Derived from the number of catch blocks rather than hardcoded, so deleting a method
+        // cannot quietly satisfy the assertion.
+        val source = File(sourceDir(), "SecretService.kt").readText()
+        val catches = Regex("""catch \(e: Exception\)""").findAll(source).count()
+        val sanitised = Regex("""Result\.failure\(sanitizeSupabaseFailure\(""").findAll(source).count()
+
+        assertTrue(catches > 0, "found no catch blocks - has the file moved?")
+        assertEquals(catches, sanitised, "$catches catch blocks but $sanitised sanitised returns")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/supabase/SupabaseWiringTest.kt
@@ -1,0 +1,109 @@
+package ai.rever.boss.services.supabase
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The services must be WIRED to the shared decoder and the sanitiser, not merely have them
+ * available.
+ *
+ * `SupabaseJsonTest` proves `sanitizeResponseFailure` strips the payload, and
+ * `SecretDecodingTest` proves `supabaseJson` tolerates new columns. Neither goes through
+ * `SecretService`, so reverting all ten call sites to `Result.failure(e)` passed the entire
+ * suite - verified, not assumed. The behaviour was pinned and the wiring was not, which is
+ * the half that actually broke production.
+ *
+ * These services construct their Postgrest client from `SupabaseConfig`, so exercising them
+ * for real needs a live backend and there is no seam to inject one. Reading the source is
+ * the honest alternative: it is a weaker assertion than an execution test, and a far
+ * stronger one than nothing. The same approach guards the organisation function's views.
+ */
+class SupabaseWiringTest {
+    private companion object {
+        /** `Json.decodeFrom…` / `Json.parseToJsonElement`, but not `supabaseJson.` or `importJson.`. */
+        val STRICT_JSON = Regex("""(?<![A-Za-z0-9_.])Json\.(decodeFrom|parseToJsonElement)""")
+
+        /** A raw exception handed to a logger, which can quote the payload. */
+        val RAW_ERROR_LOG = Regex("""error\s*=\s*e\s*[,)]""")
+    }
+
+    private val packageDir = "composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase"
+
+    /**
+     * Tests run with an unspecified working directory depending on the invocation, so walk
+     * up until the repository root is underfoot rather than assuming one.
+     */
+    private fun sourceDir(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, packageDir)
+            if (candidate.isDirectory) return candidate
+            dir = dir.parentFile
+        }
+        fail("could not locate $packageDir from ${File(".").absolutePath}")
+    }
+
+    private fun sources(): List<File> =
+        sourceDir().listFiles { f: File -> f.extension == "kt" }?.toList()
+            ?: fail("no sources under ${sourceDir()}")
+
+    @Test
+    fun `no service decodes with the strict Json default`() {
+        // The wildcard `kotlinx.serialization.json.*` import in these files keeps Json.Default
+        // in scope, so this is what a new call site gets by simply not thinking about it.
+        val offenders =
+            sources().flatMap { file ->
+                file
+                    .readLines()
+                    .withIndex()
+                    .filter { (_, line) -> STRICT_JSON.containsMatchIn(line) }
+                    .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
+            }
+
+        assertEquals(
+            emptyList(),
+            offenders,
+            "decode Supabase responses through supabaseJson, never the Json default",
+        )
+    }
+
+    @Test
+    fun `every SecretService failure is sanitised before it reaches a caller`() {
+        // SecretService returns exceptions to callers that log e.message, and its response
+        // bodies hold server-decrypted passwords. An unsanitised return is a credential leak,
+        // not a style issue.
+        val source = File(sourceDir(), "SecretService.kt").readText()
+
+        val raw =
+            Regex("""Result\.failure\(\s*e\s*\)""").findAll(source).count()
+        val sanitised =
+            Regex("""Result\.failure\(sanitizeResponseFailure\(""").findAll(source).count()
+
+        assertEquals(0, raw, "SecretService returns $raw unsanitised exception(s) to callers")
+        assertTrue(sanitised >= 10, "expected every catch block sanitised, found $sanitised")
+    }
+
+    @Test
+    fun `the sanitiser is applied wherever a decode failure is logged`() {
+        // RoleService's JWT path is the case that motivated this: it carries a comment saying
+        // the payload is deliberately not logged, and its catch logged the raw exception,
+        // which puts the whole claim set back in the log on a garbled payload.
+        val offenders =
+            sources().flatMap { file ->
+                file
+                    .readLines()
+                    .withIndex()
+                    .filter { (_, line) -> RAW_ERROR_LOG.containsMatchIn(line) }
+                    .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
+            }
+
+        assertEquals(
+            emptyList(),
+            offenders,
+            "log sanitizeResponseFailure(op, e), not the raw exception - it can quote the response body",
+        )
+    }
+}

--- a/supabase/migrations/20260802000000_secrets_org_ownership.sql
+++ b/supabase/migrations/20260802000000_secrets_org_ownership.sql
@@ -44,11 +44,25 @@
 --
 -- (3) NEW OUTPUT COLUMNS REACH THE KOTLIN CLIENT.
 --     get_user_secrets, search_user_secrets, get_user_secrets_with_shared and
---     get_secret_shares all gain columns. supabase-kt decodes with
---     ignoreUnknownKeys = true by default, so an older Secret Manager plugin
---     ignores them -- but VERIFY that before deploying, because if a client
---     ever decoded strictly this would break reading every secret. New columns
---     are APPENDED so positional readers keep working.
+--     get_secret_shares all gain columns. New columns are APPENDED so
+--     positional readers keep working.
+--
+--     CORRECTED AFTER THE FACT. This block used to say supabase-kt decodes
+--     with ignoreUnknownKeys = true by default, so an older Secret Manager
+--     plugin ignores them - with "VERIFY that before deploying, because if a
+--     client ever decoded strictly this would break reading every secret".
+--
+--     The warning was right and the reassurance was wrong. The plugins do not
+--     read these RPCs; the HOST does, through SecretService, with raw kotlinx
+--     rather than through supabase-kt - and raw kotlinx is strict. Deploying
+--     this emptied the secret panels on every installed build at once, and
+--     because the RPCs return LISTS it was all-or-nothing rather than a
+--     missing field. search_user_secrets and get_secret_shares broke too and
+--     went unreported, since a failed fetch renders as an empty list.
+--
+--     Fixed in BossConsole#144. Before extending an RPC's RETURNS TABLE, read
+--     the "Decoding Supabase payloads" section of AGENTS.md: audit the client
+--     by its decoder, not by which library you assume it uses.
 --
 -- Next migration: 20260802010000_secret_role_share_hierarchy.sql
 -- ============================================================================


### PR DESCRIPTION
## The break

The organisation migration went to production and the secret list went blank on every installed build:

```
WARN SecretManager: getUserSecrets: FAILED
     (Encountered an unknown key 'org_id' at path: $
WARN UserSecretList: getUserSecretsWithSharingInfo: FAILED
     (Encountered an unknown key 'org_id' at path: $
```

`SecretService` decoded every RPC response with the bare kotlinx default, which is strict. The organisation migration rewrote **four** secret RPCs, and every one of them returns a **list** - so one unmodelled column does not drop a field, it throws and takes the whole page with it:

| RPC | Keys added | Symptom |
|---|---|---|
| `get_user_secrets` | `org_id`, `org_slug`, `is_org_owned`, `can_manage` | empty secret list (reported) |
| `search_user_secrets` | same four | search returned nothing (unreported) |
| `get_user_secrets_with_shared` | those + `shared_with_org_slug` | empty list (reported) |
| `get_secret_shares` | `shared_with_org_id`, `shared_with_org_slug` | "no shares" on every secret (unreported) |

Note these are RPC signatures, not table columns: `org_slug`, `is_org_owned` and `can_manage` are derived and exist in no table. Auditing `ADD COLUMN` alone misses them, which is how the two silent paths went unnoticed.

The plugins are not at fault and updating them would not have helped: both read through `PluginContext.secretDataProvider`, which the host implements in this file.

## The fix

One package-level `supabaseJson` = `Json { ignoreUnknownKeys = true }`, used by every decode site in `SecretService`, `RoleService` and `RoleCreationService`. It sits in its own file rather than inside one service because the hazard is a property of the **deployment**, not of any single file - scoping it to `SecretService` would leave the next migration free to repeat the outage through RBAC instead. (The role services are not broken today; `roles` and `permissions` have not been extended.) The database is migrated ahead of the desktop app by design, so strict decoding was always going to fail the first time a column was added. Additive schema changes now degrade to "the app ignores the field it does not model yet".

## Audit of everything else

The migration adds columns to exactly four existing tables:

| Table | Added |
|---|---|
| `secrets` | `org_id` |
| `secret_shares` | `shared_with_org_id` |
| `plugins` | `org_id`, `visibility` |
| `plugin_api_keys` | `org_id` |

- `RoleService` / `RoleCreationService` decode strictly, but `roles` and `permissions` gained no columns. Safe.
- `PluginStoreSetup` already uses a lenient instance, and decodes a jar manifest rather than DB rows. Safe.
- Toolbox reads `plugins` with `Columns.ALL` and so does receive the two new columns, but goes through supabase-kt's serializer plus its own lenient `Json`. Confirmed empirically: no decode errors in the log despite the new columns being returned.
- Swept all 33 plugins for direct access to the four tables and for strict decoding of provider results. The only two hits were a graph-snapshot import and the co-browse wire protocol, neither of which touches secrets.

**No plugin needs a release.** This was the only break.

## Verification

`SecretDecodingTest` decodes the payload shapes the RPCs really returned, through `SecretService`'s own decoder rather than a lenient one built in the test - what needs pinning is that this service is configured that way and stays so.

Mutation-verified: reverting to the strict default fails all six leniency tests. Restored, all four pass, ktlint clean.



## Also fixed here, found in review

**A credential leak in decode failures.** `parseToJsonElement` runs on the raw response body in all ten methods, and kotlinx appends the whole offending document to a *malformed-input* error (`\nJSON input: [{"id":"1","password":"..."`). Those bodies hold server-decrypted passwords and recovery codes, and `SecretService` hands its exceptions to callers that log `e.message` - so a garbled response would write live credentials into a log file users attach to bug reports.

Probed against the current kotlinx to confirm rather than assume: schema failures (unknown key, null in a non-nullable slot) name the key and path only and were already safe. It is only malformed input that quotes the body. `sanitizeResponseFailure` strips it from every `SerializationException` while keeping the diagnostic half, and carries no `cause` so the payload cannot be recovered by walking the chain.

**A null sharer email.** `get_secret_shares` derives `shared_by_email` from `LEFT JOIN auth.users`, whose `email` is nullable, but `SecretShareEntry` modelled it non-null with no default - one null would throw for the whole array and report "no shares" on every secret. Leniency does not cover this: it handles extra keys, never a missing required value. Now nullable.

## Follow-ups filed

- #145 - `SecretService` has no `BossLogger` in ten catch blocks, which is why an outage read as a glitch
- #146 - `can_manage` / `is_org_owned` / `access_level = "org"` unmodelled, so an org admin sees an editable secret as read-only
- #147 - per-row recovery, `coerceInputValues`, a CI guard against `Json.Default`, and error states so a failed fetch stops looking like an empty list
