### PR TITLE
Organisation web pages: Blueprint theme, measured contrast, and the boss member role

### DIFF
--- a/supabase/functions/organisation/routes/admin-actions.ts
+++ b/supabase/functions/organisation/routes/admin-actions.ts
@@ -146,6 +146,9 @@ adminActionRoutes.post("/o/:slug/admin/settings", async (ctx) => {
     // textarea reported ?ok=settings_saved with the old text still on the page - the same
     // no-op-reported-as-success shape as the max_uses bug.
     p_description: rawField(body, "description"),
+    // rawField, like the description: an empty string CLEARS it, and only a missing
+    // value leaves it alone. field() would collapse the two.
+    p_website: rawField(body, "website"),
     p_visibility: visibility,
     p_join_policy: joinPolicy,
     p_publish_policy: publishPolicy,

--- a/supabase/functions/organisation/routes/admin-actions.ts
+++ b/supabase/functions/organisation/routes/admin-actions.ts
@@ -25,7 +25,7 @@ import { clientKey, rateLimit } from "../utils/rate-limit.ts"
 import { publicBaseUrl } from "../utils/config.ts"
 import { mintSession, newCsrfToken, sessionCookieHeader } from "../utils/session.ts"
 import { inviteOnlyPage } from "../views/admin.ts"
-import { checkbox, field, intField, rawField, uuidField } from "../utils/request.ts"
+import { checkbox, field, intField, isHttpUrl, rawField, uuidField } from "../utils/request.ts"
 import { requireCsrfBody, requireOrgAdmin, requireOrgSession } from "./guards.ts"
 import { adminPage } from "../views/admin.ts"
 import type { SessionPayload } from "../utils/session.ts"
@@ -136,6 +136,20 @@ adminActionRoutes.post("/o/:slug/admin/settings", async (ctx) => {
     publishPolicy = oneOf(field(body, "publish_policy"), ["owner_only", "admins", "members"])
   } catch {
     return redirectTo(facts, session.slug, { err: "invalid_input" })
+  }
+
+  // Validated HERE as well as in the RPC, because the RPC's readable sentence never
+  // reaches the page: finish() collapses every failure to err=rejected, which renders
+  // as "The change was refused" - the exact generic message the database-side check
+  // was added to replace. A dedicated key is the only way to name the field while
+  // keeping the fixed-key vocabulary that stops caller text being reflected.
+  //
+  // Deliberately duplicated rather than forwarded: the RPC keeps its own check for
+  // callers that are not this route, and this one exists so the admin is told which
+  // field to fix.
+  const websiteRaw = rawField(body, "website")
+  if (websiteRaw !== null && websiteRaw.trim() !== "" && !isHttpUrl(websiteRaw.trim())) {
+    return redirectTo(facts, session.slug, { err: "invalid_website" })
   }
 
   const result = await callForActor("update_organisation_settings", session.sub, {

--- a/supabase/functions/organisation/routes/admin-page.ts
+++ b/supabase/functions/organisation/routes/admin-page.ts
@@ -44,6 +44,7 @@ const RESULT_MESSAGES: Record<string, string> = {
 const ERROR_MESSAGES: Record<string, string> = {
   invalid_input: "That value was not accepted. Check the field and try again.",
   rejected: "The change was refused.",
+  invalid_website: "The website must be a full http:// or https:// address.",
   rate_limited: "Too many attempts. Please wait a moment and try again.",
 }
 

--- a/supabase/functions/organisation/services/org.ts
+++ b/supabase/functions/organisation/services/org.ts
@@ -13,6 +13,8 @@ export interface OrgDetail {
   slug: string
   name: string
   description: string | null
+  /** Public site, http/https only. Optional, and rendered as a link when present. */
+  website?: string | null
   visibility: string
   join_policy: string
   is_system: boolean

--- a/supabase/functions/organisation/tests/contrast.test.ts
+++ b/supabase/functions/organisation/tests/contrast.test.ts
@@ -200,6 +200,14 @@ const USAGE: Array<{ token: string; where: string; on: SurfaceName[]; floor?: nu
     on: ["page"],
     floor: UI_FLOOR,
   },
+  // Borders were not checked at all until now, and every one of them failed: each
+  // was 45% of the DARK hue in BOTH themes, giving 2.11:1 for the danger pill on
+  // ink and 1.33:1 for the warn pill on paper. They are opaque tokens now, held to
+  // the 3:1 WCAG 1.4.11 floor against the card they sit on.
+  { token: "ok-border", where: "an ok pill's edge", on: ["card"], floor: UI_FLOOR },
+  { token: "warn-border", where: "a warn pill's edge", on: ["card"], floor: UI_FLOOR },
+  { token: "alert-border", where: "the danger button's edge", on: ["card"], floor: UI_FLOOR },
+  { token: "signal-border", where: "the admin pill's edge", on: ["card"], floor: UI_FLOOR },
 ]
 
 function palettes(): Array<{ name: string; theme: Palette; block: string }> {
@@ -243,6 +251,18 @@ Deno.test("the light palette really does override the colours under test", () =>
       dark.theme[token] !== light.theme[token],
       `--${token} is identical in both palettes, so the light assertions prove nothing about it`,
     )
+  }
+})
+
+Deno.test("each palette block parses whole, not truncated at a stray brace", () => {
+  // palettes() splits on the first "}", so ONE closing brace inside a comment in
+  // either block silently shortens the palette and tokensIn returns fewer tokens.
+  // The assertions above only catch a token that is both missing AND under test,
+  // so a truncation that drops an unchecked token passes unnoticed. A floor on the
+  // count makes that loud.
+  for (const { name, theme } of palettes()) {
+    const count = Object.keys(theme).length
+    assert(count >= 18, `${name} palette parsed only ${count} tokens - block truncated?`)
   }
 })
 

--- a/supabase/functions/organisation/tests/contrast.test.ts
+++ b/supabase/functions/organisation/tests/contrast.test.ts
@@ -21,10 +21,12 @@
  *
  * ## Surfaces are per-token, because they are not interchangeable
  *
- * `--alert-text` colours a danger button, which lives in a table cell and so can
- * sit on the hover wash. It never sits on a doubled wash, because nothing puts a
- * `.pill.mono` inside it. Holding every token to every surface would force the
- * palette darker than the pages need.
+ * `--warn-text` colours a pill that can sit on a hovered row, but never inside a
+ * `.pill.mono`, so it is not held to the doubled wash. `--alert-text` IS held to a
+ * doubled surface, because a .danger button's own hover fill composites on top of
+ * the row wash beneath it. Holding every token to every surface would force the
+ * palette darker than the pages need; holding one to too few is how the danger
+ * label shipped at 4.09:1.
  */
 
 import { assert } from "@std/assert"
@@ -49,6 +51,24 @@ function tokensIn(block: string): Palette {
 function washIn(block: string): { hex: string; alpha: number } {
   const m = block.match(/--token-wash:\s*rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)/)
   assert(m, "no --token-wash rgba() found; the wash surfaces below would be invented")
+  const [, r, g, b, a] = m
+  const hex = "#" + [r, g, b].map((v) => Number(v).toString(16).padStart(2, "0")).join("")
+  return { hex, alpha: Number(a) }
+}
+
+/**
+ * The tint `button.danger:hover` paints, read from the rule.
+ *
+ * This one composites on top of the ROW hover wash, not on the card: every
+ * .danger button in these pages lives in a table cell, so hovering the button
+ * necessarily hovers its row. That doubled surface is the only state the label is
+ * ever read in, and it was the last surface this file did not model.
+ */
+function dangerHoverFill(): { hex: string; alpha: number } {
+  const rule = STYLESHEET.match(/button\.danger:hover\s*\{[^}]*\}/)
+  assert(rule, "no button.danger:hover rule found")
+  const m = rule[0].match(/background-color:\s*rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)/)
+  assert(m, "button.danger:hover has no rgba background to composite")
   const [, r, g, b, a] = m
   const hex = "#" + [r, g, b].map((v) => Number(v).toString(16).padStart(2, "0")).join("")
   return { hex, alpha: Number(a) }
@@ -113,6 +133,11 @@ function surfaces(theme: Palette, block: string) {
     // .pill.mono inside a hovered row stacks its own wash on the row's.
     washStacked: over(wash.hex, wash.alpha, washOnCard),
     okBanner: over(ok.hex, ok.alpha, theme.raised),
+    // Two translucent layers: the row wash, then the button's own hover fill.
+    dangerHover: (() => {
+      const d = dangerHoverFill()
+      return over(d.hex, d.alpha, washOnCard)
+    })(),
     errorBanner: over(err.hex, err.alpha, theme.raised),
     signalWash: theme["signal-wash"],
     signal: theme.signal,
@@ -159,7 +184,8 @@ const USAGE: Array<{ token: string; where: string; on: SurfaceName[]; floor?: nu
   {
     token: "alert-text",
     where: "the danger button and the error banner",
-    on: ["card", "washOnCard", "errorBanner"],
+    // dangerHover is the binding one and was missing: 4.09:1 on paper.
+    on: ["card", "washOnCard", "errorBanner", "dangerHover"],
   },
   {
     token: "on-signal",

--- a/supabase/functions/organisation/tests/contrast.test.ts
+++ b/supabase/functions/organisation/tests/contrast.test.ts
@@ -2,18 +2,29 @@
  * Every colour pair the pages actually paint must clear its WCAG floor.
  *
  * This exists because looking at the page is not enough. The light theme was
- * screenshotted, read as fine, and had six sub-AA pairs in it: hint text at
- * 2.54:1, the admin pill at 4.27:1, and both banners around 4.1:1. None of that
- * is visible to a person who already knows what the words say.
+ * screenshotted, read as fine, and had six sub-AA pairs in it. None of that is
+ * visible to a person who already knows what the words say.
  *
- * The tokens are parsed out of the real stylesheet rather than duplicated here.
- * A copy would drift, and a test that agrees with a stale copy of the thing it
- * guards is worse than no test.
+ * ## Both halves are read out of the stylesheet
  *
- * THE BINDING SURFACE IS OFTEN NOT THE OBVIOUS ONE. Banner text sits on a 10%
- * status tint, which on a light theme is DARKER than the card behind it, so
- * solving against the card left both banners failing. Each pair below names the
- * surface the text really lands on.
+ * Tokens AND the translucent surfaces are parsed from `layout.ts`. The first
+ * version parsed the tokens and hardcoded the surfaces, and that is exactly how
+ * it missed three failures: it knew about the card and the banner tint, and had
+ * no `--token-wash` surface at all - which is where every role name, permission
+ * string and organisation slug is painted, and what `tbody tr:hover td` puts
+ * behind a whole row. `--ok-text` was at 3.01:1 on a hovered row while this file
+ * reported green.
+ *
+ * So the rule is: if a background is a colour with alpha, this file composites it
+ * from the real declaration rather than from a copy. A copy drifts, and a test
+ * that agrees with a stale copy of the thing it guards is worse than no test.
+ *
+ * ## Surfaces are per-token, because they are not interchangeable
+ *
+ * `--alert-text` colours a danger button, which lives in a table cell and so can
+ * sit on the hover wash. It never sits on a doubled wash, because nothing puts a
+ * `.pill.mono` inside it. Holding every token to every surface would force the
+ * palette darker than the pages need.
  */
 
 import { assert } from "@std/assert"
@@ -24,19 +35,40 @@ const TEXT_FLOOR = 4.5
 /** WCAG 1.4.11: a UI component boundary, not text. */
 const UI_FLOOR = 3.0
 
-function tokensIn(block: string): Record<string, string> {
-  const out: Record<string, string> = {}
+type Palette = Record<string, string>
+
+function tokensIn(block: string): Palette {
+  const out: Palette = {}
   for (const [, name, hex] of block.matchAll(/--([a-z0-9-]+):\s*(#[0-9A-Fa-f]{6})/g)) {
     out[name] = hex
   }
   return out
 }
 
-/** The `:root` block, and the light block layered over it as the cascade does. */
-function palettes(): { dark: Record<string, string>; light: Record<string, string> } {
-  const dark = tokensIn(STYLESHEET.split(":root {")[1].split("}")[0])
-  const lightOnly = tokensIn(STYLESHEET.split("prefers-color-scheme: light")[1].split("}")[0])
-  return { dark, light: { ...dark, ...lightOnly } }
+/** `--token-wash: rgba(r, g, b, a)` out of a palette block, as a hex plus alpha. */
+function washIn(block: string): { hex: string; alpha: number } {
+  const m = block.match(/--token-wash:\s*rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)/)
+  assert(m, "no --token-wash rgba() found; the wash surfaces below would be invented")
+  const [, r, g, b, a] = m
+  const hex = "#" + [r, g, b].map((v) => Number(v).toString(16).padStart(2, "0")).join("")
+  return { hex, alpha: Number(a) }
+}
+
+/**
+ * The tint behind `.banner.ok` / `.banner.error`, read from the rule itself.
+ *
+ * Hardcoding these was the other half of the same mistake: the alpha could be
+ * raised to 0.14 in the stylesheet and this file would keep re-deriving the old
+ * 0.10 surface and keep reporting pass.
+ */
+function bannerTint(kind: "ok" | "error"): { hex: string; alpha: number } {
+  const rule = STYLESHEET.match(new RegExp(`\\.banner\\.${kind}\\s*\\{[^}]*\\}`))
+  assert(rule, `no .banner.${kind} rule found`)
+  const m = rule[0].match(/background-color:\s*rgba\((\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\)/)
+  assert(m, `.banner.${kind} has no rgba background to composite`)
+  const [, r, g, b, a] = m
+  const hex = "#" + [r, g, b].map((v) => Number(v).toString(16).padStart(2, "0")).join("")
+  return { hex, alpha: Number(a) }
 }
 
 function channel(value: number): number {
@@ -56,79 +88,147 @@ function contrast(a: string, b: string): number {
   return (hi + 0.05) / (lo + 0.05)
 }
 
-/** Flatten an rgba() fill onto its backdrop, the way the browser composites it. */
+/** Flatten a translucent fill onto its backdrop, the way the browser composites it. */
 function over(fill: string, alpha: number, backdrop: string): string {
   const parse = (hex: string) =>
     [0, 2, 4].map((i) => parseInt(hex.replace("#", "").slice(i, i + 2), 16))
   const [f, b] = [parse(fill), parse(backdrop)]
-  const mixed = f.map((v, i) => Math.round(v * alpha + b[i] * (1 - alpha)))
-  return "#" + mixed.map((v) => v.toString(16).padStart(2, "0")).join("")
+  return "#" + f.map((v, i) => Math.round(v * alpha + b[i] * (1 - alpha)))
+    .map((v) => v.toString(16).padStart(2, "0")).join("")
 }
 
-/** The status tints used by `.banner.ok` / `.banner.error`, at their real alpha. */
-const OK_TINT = "#2FD98A"
-const ERROR_TINT = "#FF5D5D"
-
-interface Pair {
-  what: string
-  fg: string
-  bg: (t: Record<string, string>) => string
-  floor?: number
-}
-
-const PAIRS: Pair[] = [
-  { what: "body text on the page", fg: "text", bg: (t) => t.ink },
-  { what: "body text on a card", fg: "text", bg: (t) => t.raised },
-  // Hints, table headers, empty states and the footer all use this. It replaced
-  // the app's textMuted, which is 2.54:1 on a white card - fine as a label beside
-  // a value in a 300px panel, not fine as the only text in a paragraph.
-  { what: "hints and headers on a card", fg: "text-2", bg: (t) => t.raised },
-  { what: "hints and headers on the page", fg: "text-2", bg: (t) => t.ink },
-  { what: "a link on the page", fg: "signal-text", bg: (t) => t.ink },
-  { what: "a link on a card", fg: "signal-text", bg: (t) => t.raised },
-  { what: "the admin pill's glyph", fg: "signal-on-wash", bg: (t) => t["signal-wash"] },
-  { what: "a primary button's label", fg: "on-signal", bg: (t) => t.signal },
-  { what: "an ok pill on a card", fg: "ok-text", bg: (t) => t.raised },
-  { what: "a warn pill on a card", fg: "warn-text", bg: (t) => t.raised },
-  { what: "a danger button's label", fg: "alert-text", bg: (t) => t.raised },
-  { what: "ok banner text on its tint", fg: "ok-text", bg: (t) => over(OK_TINT, 0.10, t.raised) },
-  {
-    what: "error banner text on its tint",
-    fg: "alert-text",
-    bg: (t) => over(ERROR_TINT, 0.10, t.raised),
-  },
-  // Not text: `signal` is a fill and a border. It is 3.8:1 on ink BY DESIGN, which
-  // is why `signal-text` exists at all. Holding it to 4.5 would "fix" it by
-  // brightening the brand blue, which is the wrong repair.
-  { what: "signal as a control border", fg: "signal", bg: (t) => t.ink, floor: UI_FLOOR },
-]
-
-for (const [themeName, theme] of Object.entries(palettes())) {
-  for (const pair of PAIRS) {
-    Deno.test(`${themeName}: ${pair.what} clears its floor`, () => {
-      const fg = theme[pair.fg]
-      assert(fg, `no --${pair.fg} token in the ${themeName} palette`)
-      const bg = pair.bg(theme)
-      const floor = pair.floor ?? TEXT_FLOOR
-      const ratio = contrast(fg, bg)
-      assert(
-        ratio >= floor,
-        `${themeName} ${pair.what}: ${fg} on ${bg} is ${ratio.toFixed(2)}:1, needs ${floor}:1`,
-      )
-    })
+/** Every background any text in these pages lands on, composited. */
+function surfaces(theme: Palette, block: string) {
+  const wash = washIn(block)
+  const ok = bannerTint("ok")
+  const err = bannerTint("error")
+  const washOnCard = over(wash.hex, wash.alpha, theme.raised)
+  return {
+    card: theme.raised,
+    page: theme.ink,
+    // .pill.mono in a card, and any cell in a hovered row.
+    washOnCard,
+    // .slug sits in the page header, not in a card.
+    washOnPage: over(wash.hex, wash.alpha, theme.ink),
+    // .pill.mono inside a hovered row stacks its own wash on the row's.
+    washStacked: over(wash.hex, wash.alpha, washOnCard),
+    okBanner: over(ok.hex, ok.alpha, theme.raised),
+    errorBanner: over(err.hex, err.alpha, theme.raised),
+    signalWash: theme["signal-wash"],
+    signal: theme.signal,
   }
 }
 
-Deno.test("the light palette really does override the status text colours", () => {
-  // A guard against the pairs above passing vacuously. If the light block stopped
-  // redefining these, every light assertion would silently re-check the dark
-  // values and still pass - the shape of vacuous test this suite has been bitten
-  // by before.
-  const { dark, light } = palettes()
+type SurfaceName = keyof ReturnType<typeof surfaces>
+
+/** What each token colours, and therefore what it must clear. */
+const USAGE: Array<{ token: string; where: string; on: SurfaceName[]; floor?: number }> = [
+  {
+    token: "text",
+    where: "body copy",
+    on: ["card", "page"],
+  },
+  {
+    // The widest reach in the sheet: hints, table headers, plain and mono pills,
+    // the slug, empty states, the footer and tab labels.
+    token: "text-2",
+    where: "hints, headers, identifier pills and the slug",
+    on: ["card", "page", "washOnCard", "washOnPage", "washStacked"],
+  },
+  {
+    token: "signal-text",
+    where: "links and tab labels",
+    on: ["card", "page", "washOnCard"],
+  },
+  {
+    token: "signal-on-wash",
+    where: "the admin pill",
+    // Its own wash is opaque, so a hovered row does not show through it.
+    on: ["signalWash"],
+  },
+  {
+    token: "ok-text",
+    where: "ok pills and the ok banner",
+    on: ["card", "washOnCard", "okBanner"],
+  },
+  {
+    token: "warn-text",
+    where: "warn pills",
+    on: ["card", "washOnCard"],
+  },
+  {
+    token: "alert-text",
+    where: "the danger button and the error banner",
+    on: ["card", "washOnCard", "errorBanner"],
+  },
+  {
+    token: "on-signal",
+    where: "a primary button's label",
+    on: ["signal"],
+  },
+  {
+    // Not text. `signal` is 3.8:1 on ink BY DESIGN, which is why signal-text
+    // exists. Holding it to 4.5 would "fix" it by brightening the brand blue.
+    token: "signal",
+    where: "a control border",
+    on: ["page"],
+    floor: UI_FLOOR,
+  },
+]
+
+function palettes(): Array<{ name: string; theme: Palette; block: string }> {
+  const darkBlock = STYLESHEET.split(":root {")[1].split("}")[0]
+  const lightBlock = STYLESHEET.split("prefers-color-scheme: light")[1].split("}")[0]
+  const dark = tokensIn(darkBlock)
+  return [
+    { name: "dark", theme: dark, block: darkBlock },
+    // The light block only overrides; the cascade leaves the rest of :root standing.
+    { name: "light", theme: { ...dark, ...tokensIn(lightBlock) }, block: lightBlock },
+  ]
+}
+
+for (const { name, theme, block } of palettes()) {
+  const surf = surfaces(theme, block)
+  for (const use of USAGE) {
+    for (const surfaceName of use.on) {
+      Deno.test(`${name}: ${use.token} on ${surfaceName} (${use.where})`, () => {
+        const fg = theme[use.token]
+        assert(fg, `no --${use.token} in the ${name} palette`)
+        const bg = surf[surfaceName]
+        assert(bg, `no ${surfaceName} surface`)
+        const floor = use.floor ?? TEXT_FLOOR
+        const ratio = contrast(fg, bg)
+        assert(
+          ratio >= floor,
+          `${name}: --${use.token} (${fg}) on ${surfaceName} (${bg}) is ` +
+            `${ratio.toFixed(2)}:1, needs ${floor}:1`,
+        )
+      })
+    }
+  }
+}
+
+Deno.test("the light palette really does override the colours under test", () => {
+  // Without this, a light block that stopped redefining these would leave every
+  // light assertion silently re-checking the dark values and still passing.
+  const [dark, light] = palettes()
   for (const token of ["ok-text", "warn-text", "alert-text", "signal-on-wash", "text-2", "ink"]) {
     assert(
-      dark[token] !== light[token],
+      dark.theme[token] !== light.theme[token],
       `--${token} is identical in both palettes, so the light assertions prove nothing about it`,
     )
   }
+})
+
+Deno.test("each palette declares its own token wash", () => {
+  // The wash defines three of the surfaces above. If a palette stopped declaring
+  // one, washIn would fall back to the other palette's block and every wash
+  // assertion would be measured against the wrong backdrop.
+  const [dark, light] = palettes()
+  const a = washIn(dark.block)
+  const b = washIn(light.block)
+  assert(
+    a.hex !== b.hex || a.alpha !== b.alpha,
+    "both palettes declare the same --token-wash; one of them is not being read",
+  )
 })

--- a/supabase/functions/organisation/tests/contrast.test.ts
+++ b/supabase/functions/organisation/tests/contrast.test.ts
@@ -141,6 +141,7 @@ function surfaces(theme: Palette, block: string) {
     errorBanner: over(err.hex, err.alpha, theme.raised),
     signalWash: theme["signal-wash"],
     signal: theme.signal,
+    signalDim: theme["signal-dim"],
   }
 }
 
@@ -150,8 +151,10 @@ type SurfaceName = keyof ReturnType<typeof surfaces>
 const USAGE: Array<{ token: string; where: string; on: SurfaceName[]; floor?: number }> = [
   {
     token: "text",
-    where: "body copy",
-    on: ["card", "page"],
+    // washOnCard because `tbody tr:hover td` puts the wash behind ordinary cell
+    // text, and button.secondary:hover paints --text on it.
+    where: "body copy, including a hovered row",
+    on: ["card", "page", "washOnCard"],
   },
   {
     // The widest reach in the sheet: hints, table headers, plain and mono pills,
@@ -189,8 +192,10 @@ const USAGE: Array<{ token: string; where: string; on: SurfaceName[]; floor?: nu
   },
   {
     token: "on-signal",
-    where: "a primary button's label",
-    on: ["signal"],
+    // signalDim is the hover fill for both the primary button and the active tab,
+    // so the label is read on it as often as on signal itself.
+    where: "a primary button's label, at rest and hovered",
+    on: ["signal", "signalDim"],
   },
   {
     // Not text. `signal` is 3.8:1 on ink BY DESIGN, which is why signal-text
@@ -269,9 +274,13 @@ Deno.test("each palette block parses whole, not truncated at a stray brace", () 
   // The assertions above only catch a token that is both missing AND under test,
   // so a truncation that drops an unchecked token passes unnoticed. A floor on the
   // count makes that loud.
-  for (const { name, theme } of palettes()) {
-    const count = Object.keys(theme).length
-    assert(count >= 18, `${name} palette parsed only ${count} tokens - block truncated?`)
+  // Counted on each block AS PARSED, not on the merged palette. light is built as
+  // {...dark, ...light}, so counting the merge meant a light block truncated to
+  // zero tokens still reported the full dark count - the guard could not fail for
+  // the palette it was most needed for.
+  for (const { name, block } of palettes()) {
+    const own = Object.keys(tokensIn(block)).length
+    assert(own >= 18, `the ${name} block parsed only ${own} tokens - truncated at a brace?`)
   }
 })
 

--- a/supabase/functions/organisation/tests/contrast.test.ts
+++ b/supabase/functions/organisation/tests/contrast.test.ts
@@ -208,6 +208,15 @@ const USAGE: Array<{ token: string; where: string; on: SurfaceName[]; floor?: nu
   { token: "warn-border", where: "a warn pill's edge", on: ["card"], floor: UI_FLOOR },
   { token: "alert-border", where: "the danger button's edge", on: ["card"], floor: UI_FLOOR },
   { token: "signal-border", where: "the admin pill's edge", on: ["card"], floor: UI_FLOOR },
+  // The edge of every form control. Checked against BOTH the card and the control's
+  // own fill, because those two are nearly the same colour in both themes - so this
+  // line is the only thing identifying the control's boundary at rest.
+  {
+    token: "line-strong",
+    where: "form control and pill edges",
+    on: ["card", "page"],
+    floor: UI_FLOOR,
+  },
 ]
 
 function palettes(): Array<{ name: string; theme: Palette; block: string }> {

--- a/supabase/functions/organisation/tests/contrast.test.ts
+++ b/supabase/functions/organisation/tests/contrast.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Every colour pair the pages actually paint must clear its WCAG floor.
+ *
+ * This exists because looking at the page is not enough. The light theme was
+ * screenshotted, read as fine, and had six sub-AA pairs in it: hint text at
+ * 2.54:1, the admin pill at 4.27:1, and both banners around 4.1:1. None of that
+ * is visible to a person who already knows what the words say.
+ *
+ * The tokens are parsed out of the real stylesheet rather than duplicated here.
+ * A copy would drift, and a test that agrees with a stale copy of the thing it
+ * guards is worse than no test.
+ *
+ * THE BINDING SURFACE IS OFTEN NOT THE OBVIOUS ONE. Banner text sits on a 10%
+ * status tint, which on a light theme is DARKER than the card behind it, so
+ * solving against the card left both banners failing. Each pair below names the
+ * surface the text really lands on.
+ */
+
+import { assert } from "@std/assert"
+
+const STYLESHEET = await Deno.readTextFile(new URL("../views/layout.ts", import.meta.url))
+
+const TEXT_FLOOR = 4.5
+/** WCAG 1.4.11: a UI component boundary, not text. */
+const UI_FLOOR = 3.0
+
+function tokensIn(block: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [, name, hex] of block.matchAll(/--([a-z0-9-]+):\s*(#[0-9A-Fa-f]{6})/g)) {
+    out[name] = hex
+  }
+  return out
+}
+
+/** The `:root` block, and the light block layered over it as the cascade does. */
+function palettes(): { dark: Record<string, string>; light: Record<string, string> } {
+  const dark = tokensIn(STYLESHEET.split(":root {")[1].split("}")[0])
+  const lightOnly = tokensIn(STYLESHEET.split("prefers-color-scheme: light")[1].split("}")[0])
+  return { dark, light: { ...dark, ...lightOnly } }
+}
+
+function channel(value: number): number {
+  const c = value / 255
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+}
+
+function luminance(hex: string): number {
+  const h = hex.replace("#", "")
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16))
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+function contrast(a: string, b: string): number {
+  const [la, lb] = [luminance(a), luminance(b)]
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** Flatten an rgba() fill onto its backdrop, the way the browser composites it. */
+function over(fill: string, alpha: number, backdrop: string): string {
+  const parse = (hex: string) =>
+    [0, 2, 4].map((i) => parseInt(hex.replace("#", "").slice(i, i + 2), 16))
+  const [f, b] = [parse(fill), parse(backdrop)]
+  const mixed = f.map((v, i) => Math.round(v * alpha + b[i] * (1 - alpha)))
+  return "#" + mixed.map((v) => v.toString(16).padStart(2, "0")).join("")
+}
+
+/** The status tints used by `.banner.ok` / `.banner.error`, at their real alpha. */
+const OK_TINT = "#2FD98A"
+const ERROR_TINT = "#FF5D5D"
+
+interface Pair {
+  what: string
+  fg: string
+  bg: (t: Record<string, string>) => string
+  floor?: number
+}
+
+const PAIRS: Pair[] = [
+  { what: "body text on the page", fg: "text", bg: (t) => t.ink },
+  { what: "body text on a card", fg: "text", bg: (t) => t.raised },
+  // Hints, table headers, empty states and the footer all use this. It replaced
+  // the app's textMuted, which is 2.54:1 on a white card - fine as a label beside
+  // a value in a 300px panel, not fine as the only text in a paragraph.
+  { what: "hints and headers on a card", fg: "text-2", bg: (t) => t.raised },
+  { what: "hints and headers on the page", fg: "text-2", bg: (t) => t.ink },
+  { what: "a link on the page", fg: "signal-text", bg: (t) => t.ink },
+  { what: "a link on a card", fg: "signal-text", bg: (t) => t.raised },
+  { what: "the admin pill's glyph", fg: "signal-on-wash", bg: (t) => t["signal-wash"] },
+  { what: "a primary button's label", fg: "on-signal", bg: (t) => t.signal },
+  { what: "an ok pill on a card", fg: "ok-text", bg: (t) => t.raised },
+  { what: "a warn pill on a card", fg: "warn-text", bg: (t) => t.raised },
+  { what: "a danger button's label", fg: "alert-text", bg: (t) => t.raised },
+  { what: "ok banner text on its tint", fg: "ok-text", bg: (t) => over(OK_TINT, 0.10, t.raised) },
+  {
+    what: "error banner text on its tint",
+    fg: "alert-text",
+    bg: (t) => over(ERROR_TINT, 0.10, t.raised),
+  },
+  // Not text: `signal` is a fill and a border. It is 3.8:1 on ink BY DESIGN, which
+  // is why `signal-text` exists at all. Holding it to 4.5 would "fix" it by
+  // brightening the brand blue, which is the wrong repair.
+  { what: "signal as a control border", fg: "signal", bg: (t) => t.ink, floor: UI_FLOOR },
+]
+
+for (const [themeName, theme] of Object.entries(palettes())) {
+  for (const pair of PAIRS) {
+    Deno.test(`${themeName}: ${pair.what} clears its floor`, () => {
+      const fg = theme[pair.fg]
+      assert(fg, `no --${pair.fg} token in the ${themeName} palette`)
+      const bg = pair.bg(theme)
+      const floor = pair.floor ?? TEXT_FLOOR
+      const ratio = contrast(fg, bg)
+      assert(
+        ratio >= floor,
+        `${themeName} ${pair.what}: ${fg} on ${bg} is ${ratio.toFixed(2)}:1, needs ${floor}:1`,
+      )
+    })
+  }
+}
+
+Deno.test("the light palette really does override the status text colours", () => {
+  // A guard against the pairs above passing vacuously. If the light block stopped
+  // redefining these, every light assertion would silently re-check the dark
+  // values and still pass - the shape of vacuous test this suite has been bitten
+  // by before.
+  const { dark, light } = palettes()
+  for (const token of ["ok-text", "warn-text", "alert-text", "signal-on-wash", "text-2", "ink"]) {
+    assert(
+      dark[token] !== light[token],
+      `--${token} is identical in both palettes, so the light assertions prove nothing about it`,
+    )
+  }
+})

--- a/supabase/functions/organisation/tests/helpers/render-preview.ts
+++ b/supabase/functions/organisation/tests/helpers/render-preview.ts
@@ -39,6 +39,7 @@ const org: OrgDetail = {
   member_count: 89,
   pending_count: 2,
   primary_domain: "risalabs.ai",
+  website: "https://risalabs.ai",
   is_owner: true,
   is_admin: true,
   can_publish: true,

--- a/supabase/functions/organisation/tests/helpers/render-preview.ts
+++ b/supabase/functions/organisation/tests/helpers/render-preview.ts
@@ -1,0 +1,211 @@
+/**
+ * Render every page to a file so a human (or a screenshot) can look at them.
+ *
+ * Not a test - a development harness. The views are pure functions of their
+ * data, so they can be rendered without a database, a session or a running
+ * function, which is the only reason a visual check is cheap enough to do on
+ * every styling change.
+ *
+ * The stylesheet is the thing this exists for. `deno check` and the unit tests
+ * both pass on CSS that renders as an unreadable mess: neither one can see that
+ * a colour fails contrast, that a table overflows its card, or that a heading
+ * disappeared into its own eyebrow treatment. Those only show up on a screen.
+ *
+ *   deno run --allow-write --allow-read tests/helpers/render-preview.ts <outDir>
+ */
+
+import { adminPage } from "../../views/admin.ts"
+import { orgPage } from "../../views/org.ts"
+import { invalidInvitePage, joinPage } from "../../views/join.ts"
+import { errorPage, NOT_AVAILABLE_MESSAGE } from "../../views/error.ts"
+import type { OrgDetail, OrgDomain, OrgInvite, OrgMember, OrgRole } from "../../services/org.ts"
+
+const NONCE = "previewnonce"
+const BASE = "/functions/v1/organisation"
+
+const org: OrgDetail = {
+  id: "11111111-1111-1111-1111-111111111111",
+  slug: "risa_labs",
+  name: "Risa Labs",
+  description: "The people building BOSS. Ask an administrator if you need access to something.",
+  visibility: "public",
+  join_policy: "request_to_join",
+  is_system: false,
+  owner_email: "shivang@risalabs.ai",
+  member_count: 89,
+  pending_count: 2,
+  primary_domain: "risalabs.ai",
+  is_owner: true,
+  is_admin: true,
+  can_publish: true,
+  publish_policy: "admins_only",
+}
+
+const members: OrgMember[] = [
+  {
+    user_id: "u1",
+    email: "shivang@risalabs.ai",
+    status: "active",
+    joined_at: "2026-01-14T10:00:00Z",
+    requested_at: null,
+    request_message: null,
+    join_source: "seed",
+    is_owner: true,
+    is_admin: true,
+    roles: ["risa_labs_admin"],
+  },
+  {
+    user_id: "u2",
+    email: "aamer@risalabs.ai",
+    status: "active",
+    joined_at: "2026-03-02T10:00:00Z",
+    requested_at: null,
+    request_message: null,
+    join_source: "domain",
+    is_owner: false,
+    is_admin: true,
+    roles: ["risa_labs_admin", "risa_labs_user"],
+  },
+  {
+    user_id: "u3",
+    email: "someone-with-a-rather-long-address@risalabs.ai",
+    status: "active",
+    joined_at: "2026-06-21T10:00:00Z",
+    requested_at: null,
+    request_message: null,
+    join_source: "invite",
+    is_owner: false,
+    is_admin: false,
+    roles: ["risa_labs_user"],
+  },
+  {
+    user_id: "u4",
+    email: "newcomer@example.com",
+    status: "pending",
+    joined_at: null,
+    requested_at: "2026-08-05T10:00:00Z",
+    request_message: "Joining the platform team next week.",
+    join_source: "request",
+    is_owner: false,
+    is_admin: false,
+    roles: [],
+  },
+]
+
+const roles: OrgRole[] = [
+  {
+    role_id: "r1",
+    role_name: "risa_labs_admin",
+    description: "Full control of the organisation.",
+    kind: "admin",
+    member_count: 2,
+    permissions: ["organisation.read", "organisation.admin", "plugins.create", "plugins.publish"],
+  },
+  {
+    role_id: "r2",
+    role_name: "risa_labs_user",
+    description: null,
+    kind: "user",
+    member_count: 87,
+    permissions: ["organisation.read"],
+  },
+]
+
+const domains: OrgDomain[] = [
+  {
+    domain_id: "d1",
+    domain: "risalabs.ai",
+    is_primary: true,
+    verified: true,
+    verified_at: "2026-02-01T10:00:00Z",
+    dns_record_type: "TXT",
+    dns_record_name: "_boss-verify.risalabs.ai",
+    dns_record_value: "boss-verify=6f2a9c31d7b84e05",
+  },
+  {
+    domain_id: "d2",
+    domain: "risaboss.com",
+    is_primary: false,
+    verified: false,
+    verified_at: null,
+    dns_record_type: "TXT",
+    dns_record_name: "_boss-verify.risaboss.com",
+    dns_record_value: "boss-verify=1c7e40ab99f3ad2",
+  },
+]
+
+const invites: OrgInvite[] = [
+  {
+    invite_id: "i1",
+    token_prefix: "hK3nQ8",
+    label: "Platform team",
+    role_id: "r2",
+    role_name: "risa_labs_user",
+    max_uses: 25,
+    uses: 4,
+    expires_at: "2026-09-01T10:00:00Z",
+    revoked_at: null,
+    created_by_email: "shivang@risalabs.ai",
+    is_live: true,
+  },
+  {
+    invite_id: "i2",
+    token_prefix: "zP0mR2",
+    label: null,
+    role_id: null,
+    role_name: null,
+    max_uses: null,
+    uses: 12,
+    expires_at: "2026-07-01T10:00:00Z",
+    revoked_at: "2026-06-20T10:00:00Z",
+    created_by_email: "aamer@risalabs.ai",
+    is_live: false,
+  },
+]
+
+const pages: Record<string, string> = {
+  "overview.html": orgPage({ nonce: NONCE, basePath: BASE, org, members, roles }),
+  "admin.html": adminPage({
+    nonce: NONCE,
+    basePath: BASE,
+    csrf: "preview-csrf",
+    org,
+    members,
+    roles,
+    domains,
+    invites,
+    banner: { kind: "ok", message: "Settings saved." },
+  }),
+  "admin-error.html": adminPage({
+    nonce: NONCE,
+    basePath: BASE,
+    csrf: "preview-csrf",
+    org,
+    members,
+    roles,
+    domains,
+    invites,
+    banner: { kind: "error", message: "That value was not accepted. Check the field and try again." },
+  }),
+  "join.html": joinPage({
+    nonce: NONCE,
+    orgName: "Risa Labs",
+    orgSlug: "risa_labs",
+    description: "The people building BOSS.",
+    deepLink: "boss://organisation/join?token=preview",
+  }),
+  "invite-invalid.html": invalidInvitePage(NONCE),
+  "error.html": errorPage({
+    nonce: NONCE,
+    title: "Not available - BOSS",
+    heading: "Not available",
+    message: NOT_AVAILABLE_MESSAGE,
+  }),
+}
+
+const outDir = Deno.args[0] ?? "./preview"
+await Deno.mkdir(outDir, { recursive: true })
+for (const [name, html] of Object.entries(pages)) {
+  await Deno.writeTextFile(`${outDir}/${name}`, html)
+  console.log(`${outDir}/${name}`)
+}

--- a/supabase/functions/organisation/tests/helpers/render-preview.ts
+++ b/supabase/functions/organisation/tests/helpers/render-preview.ts
@@ -43,7 +43,7 @@ const org: OrgDetail = {
   is_owner: true,
   is_admin: true,
   can_publish: true,
-  publish_policy: "admins_only",
+  publish_policy: "admins",
 }
 
 const members: OrgMember[] = [

--- a/supabase/functions/organisation/tests/helpers/render-preview.ts
+++ b/supabase/functions/organisation/tests/helpers/render-preview.ts
@@ -1,5 +1,6 @@
 /**
- * Render every page to a file so a human (or a screenshot) can look at them.
+ * Render every page, in every state that changes its markup, so a human (or a
+ * screenshot) can look at them.
  *
  * Not a test - a development harness. The views are pure functions of their
  * data, so they can be rendered without a database, a session or a running
@@ -14,13 +15,16 @@
  *   deno run --allow-write --allow-read tests/helpers/render-preview.ts <outDir>
  */
 
-import { adminPage } from "../../views/admin.ts"
+import { adminPage, inviteOnlyPage } from "../../views/admin.ts"
 import { orgPage } from "../../views/org.ts"
 import { invalidInvitePage, joinPage } from "../../views/join.ts"
 import { errorPage, NOT_AVAILABLE_MESSAGE } from "../../views/error.ts"
 import type { OrgDetail, OrgDomain, OrgInvite, OrgMember, OrgRole } from "../../services/org.ts"
 
 const NONCE = "previewnonce"
+/** A plausible one-time invite URL. Only its shape matters to the rendering. */
+const INVITE =
+  "https://api.risaboss.com/functions/v1/organisation/join/hK3nQ8mZ0pW7xR4tL9vB2cN6dF1sA5gJ"
 const BASE = "/functions/v1/organisation"
 
 const org: OrgDetail = {
@@ -187,6 +191,22 @@ const pages: Record<string, string> = {
     invites,
     banner: { kind: "error", message: "That value was not accepted. Check the field and try again." },
   }),
+  // The one-time invite card. It carries `.highlight`, which had never rendered
+  // (a bare .highlight loses to section.card on specificity) and which no preview
+  // covered - so the visual check could not have caught it. That is the gap this
+  // page and the two below close.
+  "admin-new-invite.html": adminPage({
+    nonce: NONCE,
+    basePath: BASE,
+    csrf: "preview-csrf",
+    org,
+    members,
+    roles,
+    domains,
+    invites,
+    newInviteUrl: INVITE,
+  }),
+  "invite-only.html": inviteOnlyPage(NONCE, BASE, "risa_labs", INVITE),
   "join.html": joinPage({
     nonce: NONCE,
     orgName: "Risa Labs",
@@ -200,6 +220,13 @@ const pages: Record<string, string> = {
     title: "Not available - BOSS",
     heading: "Not available",
     message: NOT_AVAILABLE_MESSAGE,
+  }),
+  "error-with-action.html": errorPage({
+    nonce: NONCE,
+    title: "Not available - BOSS",
+    heading: "Not available",
+    message: NOT_AVAILABLE_MESSAGE,
+    action: { href: `${BASE}/o/risa_labs`, label: "Back to the organisation" },
   }),
 }
 

--- a/supabase/functions/organisation/tests/html.test.ts
+++ b/supabase/functions/organisation/tests/html.test.ts
@@ -175,7 +175,9 @@ Deno.test("every table sits in a focusable scroll region", async () => {
   for await (const entry of Deno.readDir(dir)) {
     if (!entry.name.endsWith(".ts")) continue
     const source = await Deno.readTextFile(new URL(entry.name, dir))
-    const tables = (source.match(/<table>/g) ?? []).length
+    // <table[\s>] rather than <table>, so adding an attribute cannot silently
+    // drop a table out of the count.
+    const tables = (source.match(/<table[\s>]/g) ?? []).length
     if (tables === 0) continue
     const wrappers = (source.match(/class="scroller"/g) ?? []).length +
       (source.match(/scrollable\(/g) ?? []).length

--- a/supabase/functions/organisation/tests/html.test.ts
+++ b/supabase/functions/organisation/tests/html.test.ts
@@ -4,7 +4,8 @@
  */
 
 import { assert, assertEquals } from "@std/assert"
-import { attrUrl, cspNonce, emailText, esc, jsonForScript } from "../utils/html.ts"
+import { attrUrl, cspNonce, esc, jsonForScript } from "../utils/html.ts"
+import { layout } from "../views/layout.ts"
 
 Deno.test("esc neutralises every HTML metacharacter", () => {
   assertEquals(esc(`<script>`), "&lt;script&gt;")
@@ -120,38 +121,43 @@ Deno.test("no view emits a duplicate class attribute", async () => {
   }
 })
 
-Deno.test("emailText wraps the address in Cloudflare's opt-out and still escapes it", () => {
-  const out = emailText("someone@example.com")
-  assert(out.startsWith("<!--email_off-->"))
-  assert(out.endsWith("<!--/email_off-->"))
-  assert(out.includes("someone@example.com"))
+Deno.test("every page is inside Cloudflare's email-obfuscation opt-out", () => {
+  // api.risaboss.com is behind Cloudflare, which rewrites any address in an HTML
+  // response into a __cf_email__ anchor needing a decoder script our CSP blocks.
+  // Every member on the roster rendered as the literal words "email protected".
+  //
+  // Asserted on the LAYOUT, not on each field. The first fix wrapped the four
+  // known email columns, and the failure is per-response: a join request reading
+  // "reach me at me@corp.com" goes through request_message and broke identically.
+  // One region covers the class; a list of fields covers whatever was remembered.
+  const page = layout({ title: "t", nonce: "n", body: "<p>someone@example.com</p>" })
 
-  // The comments tell a proxy to leave the region alone. They are not escaping,
-  // so the value must still be escaped inside them.
-  const hostile = emailText(`"><script>alert(1)</script>`)
-  assertEquals(hostile.includes("<script>"), false)
-  assert(hostile.includes("&lt;script&gt;"))
+  const open = page.indexOf("<!--email_off-->")
+  const close = page.indexOf("<!--/email_off-->")
+  const content = page.indexOf("someone@example.com")
+
+  assert(open > -1, "no email_off region")
+  assert(close > open, "the region is not closed after it opens")
+  assert(content > open && content < close, "page content is outside the region")
 })
 
-Deno.test("every email rendered into a page goes through emailText", async () => {
-  // Cloudflare rewrites any address it finds in the HTML into a __cf_email__ span
-  // that needs a script our CSP blocks, so a plain esc(...) of an email renders as
-  // the literal words "email protected". That is not a styling problem: it makes
-  // the roster unable to answer who is who, which is the page's whole job.
-  //
-  // Source-scanned rather than output-scanned because the failure is invisible in
-  // our own output - it happens at the edge, after we have rendered.
-  const dir = new URL("../views/", import.meta.url)
-  const offenders: string[] = []
-  for await (const entry of Deno.readDir(dir)) {
-    if (!entry.name.endsWith(".ts")) continue
-    const source = await Deno.readTextFile(new URL(entry.name, dir))
-    source.split("\n").forEach((line, i) => {
-      // An interpolation that escapes something whose name says it is an email.
-      if (/\$\{esc\([^)]*email[^)]*\)/i.test(line)) {
-        offenders.push(`${entry.name}:${i + 1}: ${line.trim()}`)
-      }
-    })
-  }
-  assertEquals(offenders, [], "use emailText(...) for an email address, not esc(...)")
+Deno.test("free text that is not an email column is inside the region too", () => {
+  // The case the per-field fix missed. request_message is whatever a person typed.
+  const page = layout({
+    title: "t",
+    nonce: "n",
+    body: `<td>${esc("reach me at me@corp.com")}</td>`,
+  })
+  const open = page.indexOf("<!--email_off-->")
+  const close = page.indexOf("<!--/email_off-->")
+  const content = page.indexOf("me@corp.com")
+  assert(content > open && content < close)
+})
+
+Deno.test("the region wraps the page exactly once", () => {
+  // Nesting regions is not something Cloudflare documents, and two opens would
+  // mean someone reintroduced the per-field form inside the per-page one.
+  const page = layout({ title: "t", nonce: "n", body: "<p>x</p>" })
+  assertEquals(page.split("<!--email_off-->").length - 1, 1)
+  assertEquals(page.split("<!--/email_off-->").length - 1, 1)
 })

--- a/supabase/functions/organisation/tests/html.test.ts
+++ b/supabase/functions/organisation/tests/html.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert, assertEquals } from "@std/assert"
-import { attrUrl, cspNonce, esc, jsonForScript } from "../utils/html.ts"
+import { attrUrl, cspNonce, esc, jsonForScript, scrollable } from "../utils/html.ts"
 import { layout } from "../views/layout.ts"
 
 Deno.test("esc neutralises every HTML metacharacter", () => {
@@ -160,4 +160,38 @@ Deno.test("the region wraps the page exactly once", () => {
   const page = layout({ title: "t", nonce: "n", body: "<p>x</p>" })
   assertEquals(page.split("<!--email_off-->").length - 1, 1)
   assertEquals(page.split("<!--/email_off-->").length - 1, 1)
+})
+
+Deno.test("every table sits in a focusable scroll region", async () => {
+  // The scroll container replaced a rule that hid every column past the third.
+  // But a scrollable region is only operable from a keyboard if it can take focus
+  // (WCAG 2.1.1), and these tables are read-only - no links, no controls, nothing
+  // focusable inside. Without tabindex the columns are reachable with a mouse and
+  // unreachable otherwise, which is the same content loss in a different modality.
+  //
+  // Source-scanned: whether a table is wrapped is a property of the markup, and
+  // the failure is invisible in rendered output unless you try to tab to it.
+  const dir = new URL("../views/", import.meta.url)
+  for await (const entry of Deno.readDir(dir)) {
+    if (!entry.name.endsWith(".ts")) continue
+    const source = await Deno.readTextFile(new URL(entry.name, dir))
+    const tables = (source.match(/<table>/g) ?? []).length
+    if (tables === 0) continue
+    const wrappers = (source.match(/class="scroller"/g) ?? []).length +
+      (source.match(/scrollable\(/g) ?? []).length
+    assertEquals(
+      wrappers,
+      tables,
+      `${entry.name}: ${tables} table(s) but ${wrappers} scroll wrapper(s)`,
+    )
+  }
+})
+
+Deno.test("the scroll region is focusable and named", () => {
+  // A focusable div with no accessible name announces as nothing, so the tab stop
+  // becomes a mystery rather than a feature.
+  const out = scrollable("Members", "<table></table>")
+  assert(out.includes('tabindex="0"'), "not focusable")
+  assert(out.includes('role="region"'), "no region role")
+  assert(out.includes('aria-label="Members"'), "no accessible name")
 })

--- a/supabase/functions/organisation/tests/html.test.ts
+++ b/supabase/functions/organisation/tests/html.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert, assertEquals } from "@std/assert"
-import { attrUrl, cspNonce, esc, jsonForScript } from "../utils/html.ts"
+import { attrUrl, cspNonce, emailText, esc, jsonForScript } from "../utils/html.ts"
 
 Deno.test("esc neutralises every HTML metacharacter", () => {
   assertEquals(esc(`<script>`), "&lt;script&gt;")
@@ -118,4 +118,40 @@ Deno.test("no view emits a duplicate class attribute", async () => {
     const dupes = source.match(/class="[^"]*"[^>]*class="[^"]*"/g) ?? []
     assertEquals(dupes, [], `${entry.name} has duplicate class attributes: ${dupes.join(", ")}`)
   }
+})
+
+Deno.test("emailText wraps the address in Cloudflare's opt-out and still escapes it", () => {
+  const out = emailText("someone@example.com")
+  assert(out.startsWith("<!--email_off-->"))
+  assert(out.endsWith("<!--/email_off-->"))
+  assert(out.includes("someone@example.com"))
+
+  // The comments tell a proxy to leave the region alone. They are not escaping,
+  // so the value must still be escaped inside them.
+  const hostile = emailText(`"><script>alert(1)</script>`)
+  assertEquals(hostile.includes("<script>"), false)
+  assert(hostile.includes("&lt;script&gt;"))
+})
+
+Deno.test("every email rendered into a page goes through emailText", async () => {
+  // Cloudflare rewrites any address it finds in the HTML into a __cf_email__ span
+  // that needs a script our CSP blocks, so a plain esc(...) of an email renders as
+  // the literal words "email protected". That is not a styling problem: it makes
+  // the roster unable to answer who is who, which is the page's whole job.
+  //
+  // Source-scanned rather than output-scanned because the failure is invisible in
+  // our own output - it happens at the edge, after we have rendered.
+  const dir = new URL("../views/", import.meta.url)
+  const offenders: string[] = []
+  for await (const entry of Deno.readDir(dir)) {
+    if (!entry.name.endsWith(".ts")) continue
+    const source = await Deno.readTextFile(new URL(entry.name, dir))
+    source.split("\n").forEach((line, i) => {
+      // An interpolation that escapes something whose name says it is an email.
+      if (/\$\{esc\([^)]*email[^)]*\)/i.test(line)) {
+        offenders.push(`${entry.name}:${i + 1}: ${line.trim()}`)
+      }
+    })
+  }
+  assertEquals(offenders, [], "use emailText(...) for an email address, not esc(...)")
 })

--- a/supabase/functions/organisation/tests/routes.test.ts
+++ b/supabase/functions/organisation/tests/routes.test.ts
@@ -460,6 +460,71 @@ Deno.test("an ABSENT enum still means leave unchanged", async () => {
   }
 })
 
+Deno.test("a malformed website is named, not collapsed into the generic refusal", async () => {
+  // The RPC refuses it too, but finish() maps every RPC failure to err=rejected,
+  // which renders as "The change was refused" - the generic message the whole
+  // check exists to replace. Only a route-level check can name the field while
+  // keeping the fixed-key vocabulary that stops caller text being reflected.
+  const { stub, restore } = setup()
+  try {
+    stub.responses.set("update_organisation_settings", { success: true })
+    const res = await app.request(`${BASE}/o/${FIXTURE.slug}/admin/settings`, {
+      method: "POST",
+      headers: formHeaders(await sessionCookie()),
+      body: new URLSearchParams({ [CSRF_FIELD]: CSRF, name: "Renamed", website: "acme.com" }),
+    })
+
+    assertEquals(res.status, 303)
+    assert(
+      (res.headers.get("location") ?? "").includes("err=invalid_website"),
+      `expected err=invalid_website, got ${res.headers.get("location")}`,
+    )
+    // And it does not reach the database: the whole point is that the rest of the
+    // submission is not attempted with a value that would abort it.
+    assertEquals(stub.calls.find((c) => c.fn === "update_organisation_settings"), undefined)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("an empty website is passed through, because empty CLEARS it", async () => {
+  // rawField, not field: '' and absent mean different things to the RPC, and the
+  // route check must not treat the clearing case as malformed.
+  const { stub, restore } = setup()
+  try {
+    stub.responses.set("update_organisation_settings", { success: true })
+    await app.request(`${BASE}/o/${FIXTURE.slug}/admin/settings`, {
+      method: "POST",
+      headers: formHeaders(await sessionCookie()),
+      body: new URLSearchParams({ [CSRF_FIELD]: CSRF, name: "Renamed", website: "" }),
+    })
+
+    const call = stub.calls.find((c) => c.fn === "update_organisation_settings")
+    assert(call, "a blank website must still reach the RPC, to clear the column")
+    assertEquals(call.params.p_website, "")
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("an absent website leaves the column alone", async () => {
+  const { stub, restore } = setup()
+  try {
+    stub.responses.set("update_organisation_settings", { success: true })
+    await app.request(`${BASE}/o/${FIXTURE.slug}/admin/settings`, {
+      method: "POST",
+      headers: formHeaders(await sessionCookie()),
+      body: new URLSearchParams({ [CSRF_FIELD]: CSRF, name: "Renamed" }),
+    })
+
+    const call = stub.calls.find((c) => c.fn === "update_organisation_settings")
+    assert(call)
+    assertEquals(call.params.p_website, null)
+  } finally {
+    restore()
+  }
+})
+
 Deno.test("a rejected RPC does not reflect its own message into the URL", async () => {
   const { stub, restore } = setup()
   try {

--- a/supabase/functions/organisation/utils/html.ts
+++ b/supabase/functions/organisation/utils/html.ts
@@ -27,14 +27,30 @@ export function esc(value: unknown): string {
  * Wrap a table so it can scroll AND be scrolled from a keyboard.
  *
  * `tabindex="0"` is what makes the region operable without a pointer (WCAG
- * 2.1.1). These tables are read-only and contain no links or controls, so
- * without it the box scrolls for a mouse and is simply unreachable otherwise.
+ * 2.1.1) - but ONLY when the content has nothing focusable of its own, which is
+ * why it is a parameter rather than always on. The overview tables are read-only
+ * and would otherwise scroll for a mouse and be unreachable any other way; the
+ * admin tables hold selects and buttons and are already reachable through them.
  *
  * `role="region"` plus a label is what stops that tab stop being a mystery: a
  * focusable div with no name announces as nothing.
  */
-export function scrollable(label: string, table: string): string {
-  return `<div class="scroller" tabindex="0" role="region" aria-label="${esc(label)}">${table}</div>`
+export function scrollable(
+  label: string,
+  table: string,
+  /**
+   * Whether the region needs its own tab stop.
+   *
+   * Only when the table holds NOTHING focusable. A scroll region containing a link
+   * or a control is already reachable by tabbing to that control, and adding
+   * tabindex there just inserts an extra empty stop - five of them on the admin
+   * page, which is the page with the most controls. The read-only overview tables
+   * are the case that needs it: no link, no button, nothing to tab to.
+   */
+  focusable = true,
+): string {
+  const focus = focusable ? ' tabindex="0"' : ""
+  return `<div class="scroller"${focus} role="region" aria-label="${esc(label)}">${table}</div>`
 }
 
 /**

--- a/supabase/functions/organisation/utils/html.ts
+++ b/supabase/functions/organisation/utils/html.ts
@@ -24,36 +24,6 @@ export function esc(value: unknown): string {
 }
 
 /**
- * An email address, kept readable through Cloudflare.
- *
- * These pages are served from api.risaboss.com, which is behind Cloudflare, and
- * Cloudflare's Email Address Obfuscation rewrites every address it finds in an
- * HTML response into
- *
- *   <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="...">
- *     [email protected]
- *   </a>
- *
- * and injects a script to decode it in the browser. Our CSP is
- * `default-src 'none'` with `script-src` limited to the page's own nonce, so that
- * injected script is BLOCKED and the address never decodes. Every member on the
- * roster rendered as the literal words "email protected" - which makes an admin
- * page listing who is in the organisation useless for its one job.
- *
- * `<!--email_off-->` is Cloudflare's documented opt-out for a region of a page.
- * Fixing it here rather than by turning the feature off in the dashboard keeps the
- * change in the repository and scoped to the pages that need it, and fixing it
- * here rather than by allowing Cloudflare's script in the CSP keeps `script-src`
- * nonce-only.
- *
- * The value is still escaped: the comments only tell a proxy to leave the region
- * alone, they are not an escaping mechanism.
- */
-export function emailText(value: unknown): string {
-  return `<!--email_off-->${esc(value)}<!--/email_off-->`
-}
-
-/**
  * JSON safe to embed inside a `<script>` block.
  *
  * Two hazards, both of which JSON.stringify leaves open:

--- a/supabase/functions/organisation/utils/html.ts
+++ b/supabase/functions/organisation/utils/html.ts
@@ -24,6 +24,20 @@ export function esc(value: unknown): string {
 }
 
 /**
+ * Wrap a table so it can scroll AND be scrolled from a keyboard.
+ *
+ * `tabindex="0"` is what makes the region operable without a pointer (WCAG
+ * 2.1.1). These tables are read-only and contain no links or controls, so
+ * without it the box scrolls for a mouse and is simply unreachable otherwise.
+ *
+ * `role="region"` plus a label is what stops that tab stop being a mystery: a
+ * focusable div with no name announces as nothing.
+ */
+export function scrollable(label: string, table: string): string {
+  return `<div class="scroller" tabindex="0" role="region" aria-label="${esc(label)}">${table}</div>`
+}
+
+/**
  * JSON safe to embed inside a `<script>` block.
  *
  * Two hazards, both of which JSON.stringify leaves open:

--- a/supabase/functions/organisation/utils/html.ts
+++ b/supabase/functions/organisation/utils/html.ts
@@ -24,6 +24,36 @@ export function esc(value: unknown): string {
 }
 
 /**
+ * An email address, kept readable through Cloudflare.
+ *
+ * These pages are served from api.risaboss.com, which is behind Cloudflare, and
+ * Cloudflare's Email Address Obfuscation rewrites every address it finds in an
+ * HTML response into
+ *
+ *   <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="...">
+ *     [email protected]
+ *   </a>
+ *
+ * and injects a script to decode it in the browser. Our CSP is
+ * `default-src 'none'` with `script-src` limited to the page's own nonce, so that
+ * injected script is BLOCKED and the address never decodes. Every member on the
+ * roster rendered as the literal words "email protected" - which makes an admin
+ * page listing who is in the organisation useless for its one job.
+ *
+ * `<!--email_off-->` is Cloudflare's documented opt-out for a region of a page.
+ * Fixing it here rather than by turning the feature off in the dashboard keeps the
+ * change in the repository and scoped to the pages that need it, and fixing it
+ * here rather than by allowing Cloudflare's script in the CSP keeps `script-src`
+ * nonce-only.
+ *
+ * The value is still escaped: the comments only tell a proxy to leave the region
+ * alone, they are not an escaping mechanism.
+ */
+export function emailText(value: unknown): string {
+  return `<!--email_off-->${esc(value)}<!--/email_off-->`
+}
+
+/**
  * JSON safe to embed inside a `<script>` block.
  *
  * Two hazards, both of which JSON.stringify leaves open:

--- a/supabase/functions/organisation/utils/request.ts
+++ b/supabase/functions/organisation/utils/request.ts
@@ -119,3 +119,16 @@ export function uuidField(body: Record<string, unknown>, name: string): string |
 export function isValidSlug(slug: string): boolean {
   return /^[a-z][a-z0-9_]{1,30}$/.test(slug)
 }
+
+/**
+ * Is this a website we are willing to render as a link?
+ *
+ * http and https only, no whitespace, 500 characters at most - the same rule
+ * `validate_website` applies in the database. Duplicated deliberately: the RPC
+ * keeps its own check for callers that are not this route, and this copy exists so
+ * the admin page can name the offending field instead of collapsing to its generic
+ * refusal.
+ */
+export function isHttpUrl(value: string): boolean {
+  return value.length <= 500 && /^https?:\/\/[^\s]+$/i.test(value)
+}

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -7,7 +7,7 @@
  * regardless of what was rendered.
  */
 
-import { esc } from "../utils/html.ts"
+import { esc, scrollable } from "../utils/html.ts"
 import { csrfField, layout, tabs } from "./layout.ts"
 import { formatDate } from "./org.ts"
 import { CSRF_FIELD } from "../utils/csrf.ts"
@@ -189,12 +189,12 @@ function pendingCard(action: string, csrf: string, pending: OrgMember[]): string
 <section class="card">
   <h2>Join requests (${pending.length})</h2>
   <p class="hint">People who asked to join and are waiting on a decision.</p>
-  <div class="scroller" tabindex="0" role="region" aria-label="Join requests">
+  ${scrollable("Join requests", `
   <table>
     <thead><tr><th>Email</th><th>Message</th><th>Requested</th><th>Decision</th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
-  </div>
+  `, false)}
 </section>`
 }
 
@@ -246,12 +246,12 @@ function membersCard(
 <section class="card">
   <h2>Members (${esc(org.member_count)})</h2>
   <p class="hint">Removing a member also ends any web session they have open.</p>
-  <div class="scroller" tabindex="0" role="region" aria-label="Members">
+  ${scrollable("Members", `
   <table>
     <thead><tr><th>Email</th><th>Roles</th><th>Assign</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
-  </div>
+  `, false)}
 </section>`
 }
 
@@ -304,12 +304,12 @@ function rolesCard(action: string, csrf: string, org: OrgDetail, roles: OrgRole[
 <section class="card">
   <h2>Roles</h2>
   <p class="hint">${esc(customCount)} of ${esc(maxCustom)} custom roles used.</p>
-  <div class="scroller" tabindex="0" role="region" aria-label="Roles">
+  ${scrollable("Roles", `
   <table>
     <thead><tr><th>Role</th><th>Kind</th><th>Members</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
-  </div>
+  `, false)}
   <div class="spaced">${createForm}</div>
 </section>`
 }
@@ -355,12 +355,12 @@ function invitesCard(
 <section class="card">
   <h2>Invite links</h2>
   <p class="hint">A new link is shown once, at creation. Only its prefix is stored, so it cannot be recovered later.</p>
-  <div class="scroller" tabindex="0" role="region" aria-label="Invite links">
+  ${scrollable("Invite links", `
   <table>
     <thead><tr><th>Label</th><th>Grants</th><th>Uses</th><th>Expires</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
-  </div>
+  `, false)}
   <div class="spaced">
     <form method="post" action="${esc(action)}/invites/create">
       ${csrfField(CSRF_FIELD, csrf)}
@@ -440,12 +440,12 @@ function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string
 <section class="card">
   <h2>Domains</h2>
   <p class="hint">A verified domain lets people with a matching email address find and join this organisation. Add the TXT record, then press Verify.</p>
-  <div class="scroller" tabindex="0" role="region" aria-label="Domains">
+  ${scrollable("Domains", `
   <table>
     <thead><tr><th>Domain</th><th>Status</th><th>DNS record</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
-  </div>
+  `, false)}
   <div class="spaced">
     <form method="post" action="${esc(action)}/domains/add">
       ${csrfField(CSRF_FIELD, csrf)}

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -115,7 +115,7 @@ function settingsCard(action: string, csrf: string, org: OrgDetail, roles: OrgRo
     <div class="row">
       <div>
         <label for="website">Website</label>
-        <input type="text" id="website" name="website" maxlength="500"
+        <input type="url" id="website" name="website" maxlength="500"
                placeholder="https://acme.com" value="${esc(org.website ?? "")}">
       </div>
     </div>

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -114,6 +114,13 @@ function settingsCard(action: string, csrf: string, org: OrgDetail, roles: OrgRo
     </div>
     <div class="row">
       <div>
+        <label for="website">Website</label>
+        <input type="text" id="website" name="website" maxlength="500"
+               placeholder="https://acme.com" value="${esc(org.website ?? "")}">
+      </div>
+    </div>
+    <div class="row">
+      <div>
         <label for="description">Description</label>
         <textarea id="description" name="description" rows="2" maxlength="500">${
     esc(org.description ?? "")

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -7,7 +7,7 @@
  * regardless of what was rendered.
  */
 
-import { emailText, esc } from "../utils/html.ts"
+import { esc } from "../utils/html.ts"
 import { csrfField, layout, tabs } from "./layout.ts"
 import { formatDate } from "./org.ts"
 import { CSRF_FIELD } from "../utils/csrf.ts"
@@ -161,7 +161,7 @@ function settingsCard(action: string, csrf: string, org: OrgDetail, roles: OrgRo
 function pendingCard(action: string, csrf: string, pending: OrgMember[]): string {
   const rows = pending.map((member) => `
     <tr>
-      <td>${emailText(member.email ?? "unknown")}</td>
+      <td>${esc(member.email ?? "unknown")}</td>
       <td>${esc(member.request_message ?? "")}</td>
       <td>${esc(formatDate(member.requested_at))}</td>
       <td>
@@ -204,7 +204,7 @@ function membersCard(
 
   const rows = members.map((member) => `
     <tr>
-      <td>${emailText(member.email ?? "unknown")}
+      <td>${esc(member.email ?? "unknown")}
         ${member.is_owner ? '<span class="pill admin">owner</span>' : ""}</td>
       <td>${
     (member.roles ?? []).map((r) => `<span class="pill mono">${esc(r)}</span>`).join("") ||

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -7,7 +7,7 @@
  * regardless of what was rendered.
  */
 
-import { esc } from "../utils/html.ts"
+import { emailText, esc } from "../utils/html.ts"
 import { csrfField, layout, tabs } from "./layout.ts"
 import { formatDate } from "./org.ts"
 import { CSRF_FIELD } from "../utils/csrf.ts"
@@ -161,7 +161,7 @@ function settingsCard(action: string, csrf: string, org: OrgDetail, roles: OrgRo
 function pendingCard(action: string, csrf: string, pending: OrgMember[]): string {
   const rows = pending.map((member) => `
     <tr>
-      <td>${esc(member.email ?? "unknown")}</td>
+      <td>${emailText(member.email ?? "unknown")}</td>
       <td>${esc(member.request_message ?? "")}</td>
       <td>${esc(formatDate(member.requested_at))}</td>
       <td>
@@ -204,7 +204,7 @@ function membersCard(
 
   const rows = members.map((member) => `
     <tr>
-      <td>${esc(member.email ?? "unknown")}
+      <td>${emailText(member.email ?? "unknown")}
         ${member.is_owner ? '<span class="pill admin">owner</span>' : ""}</td>
       <td>${
     (member.roles ?? []).map((r) => `<span class="pill mono">${esc(r)}</span>`).join("") ||

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -182,10 +182,12 @@ function pendingCard(action: string, csrf: string, pending: OrgMember[]): string
 <section class="card">
   <h2>Join requests (${pending.length})</h2>
   <p class="hint">People who asked to join and are waiting on a decision.</p>
+  <div class="scroller" tabindex="0" role="region" aria-label="Join requests">
   <table>
     <thead><tr><th>Email</th><th>Message</th><th>Requested</th><th>Decision</th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
+  </div>
 </section>`
 }
 
@@ -237,10 +239,12 @@ function membersCard(
 <section class="card">
   <h2>Members (${esc(org.member_count)})</h2>
   <p class="hint">Removing a member also ends any web session they have open.</p>
+  <div class="scroller" tabindex="0" role="region" aria-label="Members">
   <table>
     <thead><tr><th>Email</th><th>Roles</th><th>Assign</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
+  </div>
 </section>`
 }
 
@@ -293,10 +297,12 @@ function rolesCard(action: string, csrf: string, org: OrgDetail, roles: OrgRole[
 <section class="card">
   <h2>Roles</h2>
   <p class="hint">${esc(customCount)} of ${esc(maxCustom)} custom roles used.</p>
+  <div class="scroller" tabindex="0" role="region" aria-label="Roles">
   <table>
     <thead><tr><th>Role</th><th>Kind</th><th>Members</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
+  </div>
   <div class="spaced">${createForm}</div>
 </section>`
 }
@@ -342,10 +348,12 @@ function invitesCard(
 <section class="card">
   <h2>Invite links</h2>
   <p class="hint">A new link is shown once, at creation. Only its prefix is stored, so it cannot be recovered later.</p>
+  <div class="scroller" tabindex="0" role="region" aria-label="Invite links">
   <table>
     <thead><tr><th>Label</th><th>Grants</th><th>Uses</th><th>Expires</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
+  </div>
   <div class="spaced">
     <form method="post" action="${esc(action)}/invites/create">
       ${csrfField(CSRF_FIELD, csrf)}
@@ -425,10 +433,12 @@ function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string
 <section class="card">
   <h2>Domains</h2>
   <p class="hint">A verified domain lets people with a matching email address find and join this organisation. Add the TXT record, then press Verify.</p>
+  <div class="scroller" tabindex="0" role="region" aria-label="Domains">
   <table>
     <thead><tr><th>Domain</th><th>Status</th><th>DNS record</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
+  </div>
   <div class="spaced">
     <form method="post" action="${esc(action)}/domains/add">
       ${csrfField(CSRF_FIELD, csrf)}

--- a/supabase/functions/organisation/views/error.ts
+++ b/supabase/functions/organisation/views/error.ts
@@ -23,7 +23,7 @@ export function errorPage(
   { nonce, title, heading, message, action }: ErrorPageOptions,
 ): string {
   const cta = action
-    ? `<p class="spaced"><a href="${esc(action.href)}" class="linkish">${
+    ? `<p class="spaced"><a href="${esc(action.href)}">${
       esc(action.label)
     }</a></p>`
     : ""

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -58,10 +58,6 @@ const STYLES = `
     --signal-dim: #0A45C4;
     --signal-wash: #0A1A3C;
     --signal-text: #88A9FF;
-    /* Kept because it is used as a BORDER (danger hover). Its ok/warn siblings
-       were removed: nothing painted them, and an unused vivid status colour is
-       exactly what gets reached for as text. */
-    --alert: #FF5D5D;
     /* Text-safe variants. On ink the status colours already clear 4.5:1, so these
        alias them; on paper they do not, which is why the pair exists at all. Same
        fill-versus-glyph split the app makes for signal, applied to status. */
@@ -74,6 +70,16 @@ const STYLES = `
        value that was 4.34:1 here and 4.09:1 on paper. */
     --alert-text: #FF6868;
     --signal-on-wash: #88A9FF;
+    /* Opaque border colours, not a percentage of the fill.
+       Every status border used to be 45% of the DARK hue in BOTH themes, which put
+       all six under the 3:1 WCAG 1.4.11 floor for a component boundary - 2.11:1 for
+       the danger pill on ink, 1.33:1 for the warn pill on paper. Flattening the
+       alpha by hand is also what let the light theme keep painting dark hues while
+       its --alert token went unused by everything but one hover border. */
+    --ok-border: #2FD98A;
+    --warn-border: #F0B429;
+    --alert-border: #FF5D5D;
+    --signal-border: #0F5BFF;
     --on-signal: #FFFFFF;
     --token-wash: rgba(154, 167, 187, 0.12);
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
@@ -91,7 +97,6 @@ const STYLES = `
       --signal-dim: #0A45C4;
       --signal-wash: #DCE7FF;
       --signal-text: #0F5BFF;
-      --alert: #D33B4A;
       /* Solved against every surface each one actually lands on, which is more than
          the card: a status pill sits in a table cell, and "tbody tr:hover td" puts
          --token-wash behind it. Missing that surface is how the first pass shipped
@@ -101,6 +106,11 @@ const STYLES = `
       --warn-text: #926209;
       --alert-text: #B63340;
       --signal-on-wash: #0C3FBF;
+      /* Darkened until each clears 3:1 on a white card. */
+      --ok-border: #24A569;
+      --warn-border: #B6891F;
+      --alert-border: #FA5B5B;
+      --signal-border: #0F5BFF;
       --on-signal: #FFFFFF;
       --token-wash: rgba(5, 7, 11, 0.06);
       --shadow: 0 1px 2px rgba(5, 7, 11, 0.06);
@@ -200,11 +210,11 @@ const STYLES = `
   }
   /* A wash behind readable text, never the accent AS text. */
   .pill.admin {
-    border-color: rgba(15, 91, 255, 0.45); background-color: var(--signal-wash);
+    border-color: var(--signal-border); background-color: var(--signal-wash);
     color: var(--signal-on-wash); font-weight: 600;
   }
-  .pill.ok { border-color: rgba(47, 217, 138, 0.45); color: var(--ok-text); }
-  .pill.warn { border-color: rgba(240, 180, 41, 0.45); color: var(--warn-text); }
+  .pill.ok { border-color: var(--ok-border); color: var(--ok-text); }
+  .pill.warn { border-color: var(--warn-border); color: var(--warn-text); }
   .mono {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
@@ -254,9 +264,9 @@ const STYLES = `
   button.secondary:hover { background-color: var(--token-wash); color: var(--text); border-color: var(--line-strong); }
   button.danger {
     background-color: transparent; color: var(--alert-text);
-    border-color: rgba(255, 93, 93, 0.45); font-weight: 500;
+    border-color: var(--alert-border); font-weight: 500;
   }
-  button.danger:hover { background-color: rgba(255, 93, 93, 0.12); border-color: var(--alert); }
+  button.danger:hover { background-color: rgba(255, 93, 93, 0.12); border-color: var(--alert-border); }
   /* inline-flex, not inline: a form holding a select AND a button needs the two to
      stay on one line and share a gap. Two adjacent forms in one cell (approve and
      reject) get the margin, since flex gap does not reach across siblings. */
@@ -269,8 +279,8 @@ const STYLES = `
     border-radius: 8px; padding: 12px 15px; margin-bottom: 18px; font-size: 14px;
     border: 1px solid transparent;
   }
-  .banner.error { background-color: rgba(255, 93, 93, 0.10); border-color: rgba(255, 93, 93, 0.45); color: var(--alert-text); }
-  .banner.ok { background-color: rgba(47, 217, 138, 0.10); border-color: rgba(47, 217, 138, 0.45); color: var(--ok-text); }
+  .banner.error { background-color: rgba(255, 93, 93, 0.10); border-color: var(--alert-border); color: var(--alert-text); }
+  .banner.ok { background-color: rgba(47, 217, 138, 0.10); border-color: var(--ok-border); color: var(--ok-text); }
 
   /* ---- stats ----------------------------------------------------------- */
 

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -34,7 +34,6 @@ import { esc } from "../utils/html.ts"
 const STYLES = `
   :root {
     --ink: #05070B;
-    --panel: #080B11;
     --raised: #0E141E;
     --line: #1C2432;
     --line-strong: #2E3B4F;
@@ -44,8 +43,9 @@ const STYLES = `
     --signal-dim: #0A45C4;
     --signal-wash: #0A1A3C;
     --signal-text: #88A9FF;
-    --ok: #2FD98A;
-    --warn: #F0B429;
+    /* Kept because it is used as a BORDER (danger hover). Its ok/warn siblings
+       were removed: nothing painted them, and an unused vivid status colour is
+       exactly what gets reached for as text. */
     --alert: #FF5D5D;
     /* Text-safe variants. On ink the status colours already clear 4.5:1, so these
        alias them; on paper they do not, which is why the pair exists at all. Same
@@ -62,7 +62,6 @@ const STYLES = `
   @media (prefers-color-scheme: light) {
     :root {
       --ink: #F5F7FB;
-      --panel: #FFFFFF;
       --raised: #FFFFFF;
       --line: #DCE2EB;
       --line-strong: #A8B2C2;
@@ -72,8 +71,6 @@ const STYLES = `
       --signal-dim: #0A45C4;
       --signal-wash: #DCE7FF;
       --signal-text: #0F5BFF;
-      --ok: #1E9E63;
-      --warn: #A8710A;
       --alert: #D33B4A;
       /* Darkened until each clears 4.5:1 on EVERY light surface it lands on: the
          white card, the paper page, and the 10% status tint behind a banner. The

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -66,22 +66,23 @@ const STYLES = `
       --line: #DCE2EB;
       --line-strong: #A8B2C2;
       --text: #05070B;
-      --text-2: #687081;
+      --text-2: #5C6372;
       --signal: #0F5BFF;
       --signal-dim: #0A45C4;
       --signal-wash: #DCE7FF;
       --signal-text: #0F5BFF;
       --alert: #D33B4A;
-      /* Darkened until each clears 4.5:1 on EVERY light surface it lands on: the
-         white card, the paper page, and the 10% status tint behind a banner. The
-         tint is the binding one - it is darker than white, so solving against the
-         card alone left both banners at ~4.2:1. The fills above stay as the mirror. */
-      --ok-text: #188050;
-      --warn-text: #996709;
-      --alert-text: #C83846;
+      /* Solved against every surface each one actually lands on, which is more than
+         the card: a status pill sits in a table cell, and "tbody tr:hover td" puts
+         --token-wash behind it. Missing that surface is how the first pass shipped
+         --ok-text at 3.01:1 on a hovered row while the contrast test read green -
+         the test checked the card and the banner tint and no wash at all. */
+      --ok-text: #177B4D;
+      --warn-text: #926209;
+      --alert-text: #C43745;
       --signal-on-wash: #0C3FBF;
       --on-signal: #FFFFFF;
-      --token-wash: rgba(104, 112, 129, 0.10);
+      --token-wash: rgba(5, 7, 11, 0.06);
       --shadow: 0 1px 2px rgba(5, 7, 11, 0.06);
     }
   }
@@ -249,11 +250,14 @@ const STYLES = `
      carries values like "request to join", so the overflow was reachable rather
      than theoretical. Top-aligned, or a wrapped row hangs off the tallest value. */
   .stat { display: inline-block; margin: 0 30px 8px 0; vertical-align: top; }
+  /* An explicit line box, shared by both sizes. Unitless line-height scaled with
+     font-size, so the 21px figure and the 15px phrase produced boxes 6px apart and
+     their captions no longer sat on one line. */
   .stat b {
     display: block; font-size: 21px; font-weight: 650; letter-spacing: -0.3px;
-    font-variant-numeric: tabular-nums;
+    line-height: 32px; font-variant-numeric: tabular-nums;
   }
-  .stat.phrase b { font-size: 15px; font-weight: 600; letter-spacing: 0; line-height: 1.75; }
+  .stat.phrase b { font-size: 15px; font-weight: 600; letter-spacing: 0; }
   .stat span {
     color: var(--text-2); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px;
   }
@@ -273,7 +277,10 @@ const STYLES = `
      a violation on every page. */
   .spaced { margin-top: 16px; }
   .tight { margin-top: 12px; }
-  .highlight { border-color: var(--signal); }
+  /* section.card.highlight, not .highlight: "section.card" sets border-color at
+     specificity (0,1,1) and a bare ".highlight" is (0,1,0), so the accent lost and
+     this rule had never rendered. */
+  section.card.highlight { border-color: var(--signal); }
   .linkish { color: var(--signal-text); }
 
   @media (max-width: 620px) {
@@ -302,6 +309,11 @@ export interface LayoutOptions {
 /**
  * Wrap page content in the document shell.
  *
+ * The banner carries no `role="status"`. A live region is announced when its
+ * content CHANGES; this one is server-rendered into the initial document, so the
+ * role would never fire and would only misdescribe the element. It is early in
+ * the reading order instead, which is what actually reaches a screen reader here.
+ *
  * `body` is expected to be already-escaped markup built by the caller. The
  * banner message is escaped HERE, because it is the one string that routinely
  * originates from an RPC error and would otherwise be interpolated raw.
@@ -310,7 +322,7 @@ export function layout({ title, nonce, body, banner }: LayoutOptions): string {
   const bannerHtml = banner
     ? `<div class="banner ${
       banner.kind === "ok" ? "ok" : "error"
-    }" role="status">${esc(banner.message)}</div>`
+    }">${esc(banner.message)}</div>`
     : ""
 
   return `<!DOCTYPE html>

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -156,11 +156,20 @@ const STYLES = `
   section.card {
     background-color: var(--raised); border: 1px solid var(--line); border-radius: 10px;
     padding: 22px; margin-bottom: 16px; box-shadow: var(--shadow);
-    /* Tables scroll inside their own card rather than widening the page. The old
-       rule hid every column past the third below 620px, which did not make the
-       table fit - it deleted "Joined" and "Permissions" from the reader's view. */
-    overflow-x: auto;
   }
+
+  /* The scroll lives on a wrapper around the table, not on the card.
+     Two reasons it moved off .card:
+       - overflow-x on a block computes overflow-y to auto as well, so every card
+         became a scroll container in both axes and the heading and hint scrolled
+         sideways along with the table;
+       - a scrollable region is only operable from a keyboard if it can take
+         focus, and these tables are entirely read-only, so they contain nothing
+         focusable. Without tabindex a keyboard user still could not reach
+         "Joined" or "Permissions" on a narrow viewport - the same content loss
+         the old display:none rule caused, in a different modality. */
+  .scroller { overflow-x: auto; }
+  .scroller:focus-visible { outline: 2px solid var(--signal); outline-offset: 2px; }
   /* A real heading, not the uppercase micro-label the desktop panel uses. The
      admin page has six substantial sections on a 960px canvas; an eyebrow is the
      right weight for a 300px sidebar and too quiet to structure a page. */

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -20,6 +20,21 @@
  * stylesheet had `.linkish` and `.pill.admin` painting the accent as text, which
  * is the same regression the app corrected across ~90 call sites.
  *
+ * ## Cloudflare must not rewrite the page
+ *
+ * api.risaboss.com is behind Cloudflare, whose Email Address Obfuscation rewrites
+ * any address in an HTML response into a `__cf_email__` anchor plus an injected
+ * decoder script. Our CSP is `default-src 'none'` with `script-src` nonce-only, so
+ * that script is blocked and the address never decodes - every member on the
+ * roster rendered as the literal words "email protected".
+ *
+ * The whole page is wrapped in Cloudflare's `<!--email_off-->` region rather than
+ * each email field. The first fix was per-field, and the failure is per-RESPONSE:
+ * Cloudflare rewrites any address it finds, not only ones from a column called
+ * email, so a join request reading "reach me at me@corp.com" broke identically on
+ * the very page the fix was for. One region covers the class; a list of fields
+ * covers whatever someone remembered.
+ *
  * ## Light mode is not decoration here
  *
  * The in-app browser bridges the host theme to `prefers-color-scheme`
@@ -52,7 +67,12 @@ const STYLES = `
        fill-versus-glyph split the app makes for signal, applied to status. */
     --ok-text: #2FD98A;
     --warn-text: #F0B429;
-    --alert-text: #FF5D5D;
+    /* alert-text alone is moved off its fill value. Every .danger button sits in a
+       table cell, so hovering the button also hovers the row: the 12% tint from
+       button.danger:hover composites on top of --token-wash, and the label is read
+       on that doubled surface every single time it is read at all. At the fill
+       value that was 4.34:1 here and 4.09:1 on paper. */
+    --alert-text: #FF6868;
     --signal-on-wash: #88A9FF;
     --on-signal: #FFFFFF;
     --token-wash: rgba(154, 167, 187, 0.12);
@@ -79,7 +99,7 @@ const STYLES = `
          the test checked the card and the banner tint and no wash at all. */
       --ok-text: #177B4D;
       --warn-text: #926209;
-      --alert-text: #C43745;
+      --alert-text: #B63340;
       --signal-on-wash: #0C3FBF;
       --on-signal: #FFFFFF;
       --token-wash: rgba(5, 7, 11, 0.06);
@@ -336,11 +356,13 @@ export function layout({ title, nonce, body, banner }: LayoutOptions): string {
 <style nonce="${esc(nonce)}">${STYLES}</style>
 </head>
 <body>
+<!--email_off-->
 <div class="wrap">
 ${bannerHtml}
 ${body}
 <footer class="page">BOSS Organisation</footer>
 </div>
+<!--/email_off-->
 </body>
 </html>`
 }

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -51,7 +51,14 @@ const STYLES = `
     --ink: #05070B;
     --raised: #0E141E;
     --line: #1C2432;
-    --line-strong: #2E3B4F;
+    /* The edge of every input, select, textarea, secondary button, plain pill and
+       table header. It was the one border NOT in the contrast matrix, and it failed
+       the same 3:1 floor the status borders are held to - 1.63:1 on the card. That
+       matters more than a card edge: the control's own fill (--ink) is nearly
+       indistinguishable from the card (--raised), so this line is the only thing
+       identifying where the control is. :focus-visible covers the focused state,
+       not identification at rest. */
+    --line-strong: #5A6474;
     --text: #E7EDFA;
     --text-2: #9AA7BB;
     --signal: #0F5BFF;
@@ -90,7 +97,7 @@ const STYLES = `
       --ink: #F5F7FB;
       --raised: #FFFFFF;
       --line: #DCE2EB;
-      --line-strong: #A8B2C2;
+      --line-strong: #868E9B;
       --text: #05070B;
       --text-2: #5C6372;
       --signal: #0F5BFF;
@@ -145,6 +152,10 @@ const STYLES = `
     border-radius: 5px; padding: 2px 7px;
   }
   .sub { color: var(--text-2); font-size: 15px; margin-bottom: 26px; max-width: 68ch; }
+  /* A website may be 500 characters with no spaces, and it is rendered as its own
+     link text. max-width cannot break an unbroken token, so without this it runs
+     off the page rather than wrapping. */
+  .sub a { overflow-wrap: anywhere; }
 
   /* ---- tabs ------------------------------------------------------------ */
 
@@ -320,7 +331,6 @@ const STYLES = `
      specificity (0,1,1) and a bare ".highlight" is (0,1,0), so the accent lost and
      this rule had never rendered. */
   section.card.highlight { border-color: var(--signal); }
-  .linkish { color: var(--signal-text); }
 
   @media (max-width: 620px) {
     body { padding: 18px 14px 14px; }

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -5,79 +5,270 @@
  * CSP is `default-src 'none'` with no `style-src 'self'`, and an edge function
  * has no static asset route to serve one from anyway.
  *
- * Palette matches the sibling passkey pages (#1a1a1a / #2B2B2B / #F2F2F2 /
- * #4D4D4D) with the BOSS amber #F2A93B as the accent.
+ * ## The palette is BOSS Blueprint, and it is a mirror
+ *
+ * Values are copied from `BossBlueprintColorScheme` /
+ * `BossBlueprintLightColorScheme` in
+ * `plugin-platform/plugin-ui-core/.../ui/BossThemes.kt`, which is the source of
+ * truth. These pages are opened from the desktop panel, so a page in the old
+ * amber identity next to a Blueprint app reads as a different product. If the
+ * app palette moves, move these with it.
+ *
+ * SIGNAL IS THE FILL, SIGNALTEXT IS THE GLYPH. `--signal` (#0F5BFF) is 3.5:1 on
+ * ink: enough for a control's edge or a filled button, not enough for text. Any
+ * accent-coloured WORD uses `--signal-text` (#88A9FF, 8.1:1). The previous
+ * stylesheet had `.linkish` and `.pill.admin` painting the accent as text, which
+ * is the same regression the app corrected across ~90 call sites.
+ *
+ * ## Light mode is not decoration here
+ *
+ * The in-app browser bridges the host theme to `prefers-color-scheme`
+ * (`FluckEngine` calls `engine.setTheme` from `BossThemeController`), so a page
+ * that honours the media query tracks the app the user is looking at. Without
+ * the light half, someone running Blueprint Light gets a dark page inside a
+ * light app.
  */
 
 import { esc } from "../utils/html.ts"
 
 const STYLES = `
+  :root {
+    --ink: #05070B;
+    --panel: #080B11;
+    --raised: #0E141E;
+    --line: #1C2432;
+    --line-strong: #2E3B4F;
+    --text: #E7EDFA;
+    --text-2: #9AA7BB;
+    --signal: #0F5BFF;
+    --signal-dim: #0A45C4;
+    --signal-wash: #0A1A3C;
+    --signal-text: #88A9FF;
+    --ok: #2FD98A;
+    --warn: #F0B429;
+    --alert: #FF5D5D;
+    /* Text-safe variants. On ink the status colours already clear 4.5:1, so these
+       alias them; on paper they do not, which is why the pair exists at all. Same
+       fill-versus-glyph split the app makes for signal, applied to status. */
+    --ok-text: #2FD98A;
+    --warn-text: #F0B429;
+    --alert-text: #FF5D5D;
+    --signal-on-wash: #88A9FF;
+    --on-signal: #FFFFFF;
+    --token-wash: rgba(154, 167, 187, 0.12);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  }
+
+  @media (prefers-color-scheme: light) {
+    :root {
+      --ink: #F5F7FB;
+      --panel: #FFFFFF;
+      --raised: #FFFFFF;
+      --line: #DCE2EB;
+      --line-strong: #A8B2C2;
+      --text: #05070B;
+      --text-2: #687081;
+      --signal: #0F5BFF;
+      --signal-dim: #0A45C4;
+      --signal-wash: #DCE7FF;
+      --signal-text: #0F5BFF;
+      --ok: #1E9E63;
+      --warn: #A8710A;
+      --alert: #D33B4A;
+      /* Darkened until each clears 4.5:1 on EVERY light surface it lands on: the
+         white card, the paper page, and the 10% status tint behind a banner. The
+         tint is the binding one - it is darker than white, so solving against the
+         card alone left both banners at ~4.2:1. The fills above stay as the mirror. */
+      --ok-text: #188050;
+      --warn-text: #996709;
+      --alert-text: #C83846;
+      --signal-on-wash: #0C3FBF;
+      --on-signal: #FFFFFF;
+      --token-wash: rgba(104, 112, 129, 0.10);
+      --shadow: 0 1px 2px rgba(5, 7, 11, 0.06);
+    }
+  }
+
   * { margin: 0; padding: 0; box-sizing: border-box; }
+
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-    background-color: #1a1a1a; color: #F2F2F2; min-height: 100vh;
-    line-height: 1.5; padding: 24px;
+    background-color: var(--ink);
+    color: var(--text);
+    min-height: 100vh;
+    line-height: 1.55;
+    padding: 32px 24px 24px;
+    -webkit-font-smoothing: antialiased;
   }
-  .wrap { width: 100%; max-width: 940px; margin: 0 auto; }
-  header.page { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 4px; }
-  header.page h1 { font-size: 26px; font-weight: 600; letter-spacing: -0.4px; }
-  .slug { color: #9A9A9A; font-size: 14px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-  .sub { color: #9A9A9A; font-size: 14px; margin-bottom: 24px; }
-  .tabs { display: flex; gap: 6px; margin-bottom: 20px; flex-wrap: wrap; }
+  .wrap { width: 100%; max-width: 960px; margin: 0 auto; }
+
+  /* ---- page header ---------------------------------------------------- */
+
+  header.page { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 6px; }
+  header.page h1 { font-size: 28px; font-weight: 650; letter-spacing: -0.5px; line-height: 1.2; }
+
+  /* An organisation slug is a machine identifier, validated ^[a-z][a-z0-9_]{1,30}$.
+     Mono against a wash is what separates the key from the prose beside it, and it
+     matches how the desktop panel renders the same value. */
+  .slug {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px; color: var(--text-2);
+    background-color: var(--token-wash);
+    border-radius: 5px; padding: 2px 7px;
+  }
+  .sub { color: var(--text-2); font-size: 15px; margin-bottom: 26px; max-width: 68ch; }
+
+  /* ---- tabs ------------------------------------------------------------ */
+
+  .tabs { display: flex; gap: 6px; margin-bottom: 22px; flex-wrap: wrap; }
   .tabs a {
-    color: #C9C9C9; text-decoration: none; font-size: 14px; padding: 7px 14px;
-    border: 1px solid #4D4D4D; border-radius: 6px;
+    color: var(--text-2); text-decoration: none; font-size: 14px; padding: 7px 15px;
+    border: 1px solid var(--line); border-radius: 7px; background-color: var(--raised);
   }
-  .tabs a.active { color: #1a1a1a; background-color: #F2A93B; border-color: #F2A93B; font-weight: 600; }
+  .tabs a:hover { color: var(--text); border-color: var(--line-strong); }
+  /* Filled, so white sits on the signal rather than the signal sitting on ink. */
+  .tabs a.active {
+    color: var(--on-signal); background-color: var(--signal);
+    border-color: var(--signal); font-weight: 600;
+  }
+  .tabs a.active:hover { color: var(--on-signal); background-color: var(--signal-dim); }
+
+  /* ---- cards ----------------------------------------------------------- */
+
   section.card {
-    background-color: #2B2B2B; border: 1px solid #4D4D4D; border-radius: 8px;
-    padding: 20px; margin-bottom: 16px;
+    background-color: var(--raised); border: 1px solid var(--line); border-radius: 10px;
+    padding: 22px; margin-bottom: 16px; box-shadow: var(--shadow);
+    /* Tables scroll inside their own card rather than widening the page. The old
+       rule hid every column past the third below 620px, which did not make the
+       table fit - it deleted "Joined" and "Permissions" from the reader's view. */
+    overflow-x: auto;
   }
-  section.card > h2 { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
-  section.card > p.hint { color: #9A9A9A; font-size: 13px; margin-bottom: 16px; }
+  /* A real heading, not the uppercase micro-label the desktop panel uses. The
+     admin page has six substantial sections on a 960px canvas; an eyebrow is the
+     right weight for a 300px sidebar and too quiet to structure a page. */
+  section.card > h2 {
+    font-size: 16px; font-weight: 650; margin-bottom: 5px;
+    letter-spacing: -0.2px; color: var(--text);
+  }
+  section.card > p.hint { color: var(--text-2); font-size: 13px; margin-bottom: 18px; max-width: 68ch; }
+
+  /* ---- tables ---------------------------------------------------------- */
+
   table { width: 100%; border-collapse: collapse; font-size: 14px; }
   th {
-    text-align: left; color: #9A9A9A; font-weight: 500; font-size: 12px;
-    text-transform: uppercase; letter-spacing: 0.5px;
-    padding: 6px 10px 6px 0; border-bottom: 1px solid #4D4D4D;
+    text-align: left; color: var(--text-2); font-weight: 600; font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.6px; white-space: nowrap;
+    padding: 0 14px 8px 0; border-bottom: 1px solid var(--line-strong);
   }
-  td { padding: 10px 10px 10px 0; border-bottom: 1px solid #3A3A3A; vertical-align: middle; }
+  td { padding: 11px 14px 11px 0; border-bottom: 1px solid var(--line); vertical-align: middle; }
   tr:last-child td { border-bottom: none; }
+  tbody tr:hover td { background-color: var(--token-wash); }
+
+  /* ---- pills and identifiers ------------------------------------------- */
+
   .pill {
-    display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 10px;
-    border: 1px solid #4D4D4D; color: #C9C9C9; margin-right: 4px;
+    display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 5px;
+    border: 1px solid var(--line-strong); color: var(--text-2);
+    margin: 1px 4px 1px 0; white-space: nowrap;
   }
-  .pill.admin { border-color: #F2A93B; color: #F2A93B; }
-  .pill.ok { border-color: #4C9A5E; color: #7BC98D; }
-  .pill.warn { border-color: #A8762B; color: #E0A44E; }
-  .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
-  label { display: block; font-size: 13px; color: #C9C9C9; margin-bottom: 5px; }
+  /* A wash behind readable text, never the accent AS text. */
+  .pill.admin {
+    border-color: rgba(15, 91, 255, 0.45); background-color: var(--signal-wash);
+    color: var(--signal-on-wash); font-weight: 600;
+  }
+  .pill.ok { border-color: rgba(47, 217, 138, 0.45); color: var(--ok-text); }
+  .pill.warn { border-color: rgba(240, 180, 41, 0.45); color: var(--warn-text); }
+  .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+  /* A mono pill is an identifier, not a status, so it drops the outline and
+     takes a neutral wash - a row of outlined boxes shouts louder than the words. */
+  .pill.mono { border-color: transparent; background-color: var(--token-wash); color: var(--text-2); }
+
+  /* ---- forms ----------------------------------------------------------- */
+
+  label { display: block; font-size: 13px; color: var(--text-2); margin-bottom: 6px; }
   input[type=text], input[type=number], select, textarea {
-    width: 100%; background-color: #1F1F1F; color: #F2F2F2;
-    border: 1px solid #4D4D4D; border-radius: 6px; padding: 8px 10px;
+    width: 100%; background-color: var(--ink); color: var(--text);
+    border: 1px solid var(--line-strong); border-radius: 7px; padding: 9px 11px;
     font-size: 14px; font-family: inherit;
   }
-  input:focus, select:focus, textarea:focus { outline: 2px solid #F2A93B; outline-offset: -1px; }
-  .row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
-  .row > div { flex: 1 1 200px; }
-  .checkline { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
-  .checkline label { margin: 0; }
-  button {
-    background-color: #F2A93B; color: #1a1a1a; border: none; border-radius: 6px;
-    padding: 8px 16px; font-size: 14px; font-weight: 600; cursor: pointer; font-family: inherit;
+  input::placeholder, textarea::placeholder { color: var(--text-2); }
+  input:hover, select:hover, textarea:hover { border-color: var(--signal-text); }
+  /* focus-visible, so a mouse click does not paint a ring the keyboard user needs. */
+  input:focus-visible, select:focus-visible, textarea:focus-visible,
+  button:focus-visible, a:focus-visible {
+    outline: 2px solid var(--signal); outline-offset: 2px;
   }
-  button.secondary { background-color: transparent; color: #C9C9C9; border: 1px solid #4D4D4D; font-weight: 500; }
-  button.danger { background-color: transparent; color: #E0796B; border: 1px solid #7A3B33; font-weight: 500; }
-  button:hover { opacity: 0.9; }
-  form.inline { display: inline; }
-  .banner { border-radius: 6px; padding: 12px 14px; margin-bottom: 16px; font-size: 14px; }
-  .banner.error { background-color: #3A2320; border: 1px solid #7A3B33; color: #F0B4AA; }
-  .banner.ok { background-color: #1F2E23; border: 1px solid #3E6B4A; color: #A6D9B4; }
-  .empty { color: #9A9A9A; font-size: 14px; padding: 8px 0; }
-  footer.page { color: #6E6E6E; font-size: 12px; margin-top: 28px; text-align: center; }
-  .stat { display: inline-block; margin-right: 22px; }
-  .stat b { display: block; font-size: 20px; font-weight: 600; }
-  .stat span { color: #9A9A9A; font-size: 12px; }
+  /* Inside a table cell a control sizes to its content. The page-level width:100%
+     made the role select fill the cell, which pushed its own Assign button onto a
+     second line and left Remove floating beside the pair at a different height. */
+  td select, td input[type=text], td input[type=number] { width: auto; min-width: 150px; }
+  input[type=checkbox] { accent-color: var(--signal); width: 15px; height: 15px; }
+  .row { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 16px; }
+  .row > div { flex: 1 1 200px; }
+  .checkline { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; }
+  .checkline label { margin: 0; }
+
+  /* ---- buttons --------------------------------------------------------- */
+
+  button {
+    background-color: var(--signal); color: var(--on-signal); border: 1px solid var(--signal);
+    border-radius: 7px; padding: 8px 16px; font-size: 14px; font-weight: 600;
+    cursor: pointer; font-family: inherit;
+  }
+  button:hover { background-color: var(--signal-dim); border-color: var(--signal-dim); }
+  button:active { transform: translateY(1px); }
+  button.secondary {
+    background-color: transparent; color: var(--text-2); border-color: var(--line-strong);
+    font-weight: 500;
+  }
+  button.secondary:hover { background-color: var(--token-wash); color: var(--text); border-color: var(--line-strong); }
+  button.danger {
+    background-color: transparent; color: var(--alert-text);
+    border-color: rgba(255, 93, 93, 0.45); font-weight: 500;
+  }
+  button.danger:hover { background-color: rgba(255, 93, 93, 0.12); border-color: var(--alert); }
+  /* inline-flex, not inline: a form holding a select AND a button needs the two to
+     stay on one line and share a gap. Two adjacent forms in one cell (approve and
+     reject) get the margin, since flex gap does not reach across siblings. */
+  form.inline { display: inline-flex; align-items: center; gap: 8px; vertical-align: middle; }
+  form.inline + form.inline { margin-left: 8px; }
+
+  /* ---- banners --------------------------------------------------------- */
+
+  .banner {
+    border-radius: 8px; padding: 12px 15px; margin-bottom: 18px; font-size: 14px;
+    border: 1px solid transparent;
+  }
+  .banner.error { background-color: rgba(255, 93, 93, 0.10); border-color: rgba(255, 93, 93, 0.45); color: var(--alert-text); }
+  .banner.ok { background-color: rgba(47, 217, 138, 0.10); border-color: rgba(47, 217, 138, 0.45); color: var(--ok-text); }
+
+  /* ---- stats ----------------------------------------------------------- */
+
+  /* inline-block with a bottom margin, so a row of five wraps onto a second line
+     instead of running past the card edge. There are up to five, and "joining"
+     carries values like "request to join", so the overflow was reachable rather
+     than theoretical. Top-aligned, or a wrapped row hangs off the tallest value. */
+  .stat { display: inline-block; margin: 0 30px 8px 0; vertical-align: top; }
+  .stat b {
+    display: block; font-size: 21px; font-weight: 650; letter-spacing: -0.3px;
+    font-variant-numeric: tabular-nums;
+  }
+  .stat.phrase b { font-size: 15px; font-weight: 600; letter-spacing: 0; line-height: 1.75; }
+  .stat span {
+    color: var(--text-2); font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px;
+  }
+
+  /* ---- misc ------------------------------------------------------------ */
+
+  .empty { color: var(--text-2); font-size: 14px; padding: 10px 0; }
+  footer.page {
+    color: var(--text-2); font-size: 12px; margin-top: 34px; padding-top: 16px;
+    border-top: 1px solid var(--line); text-align: center;
+  }
+  a { color: var(--signal-text); }
 
   /* Utility classes, because every inline style= attribute is DROPPED by our own
      CSP: style-src is nonce-only, CSP3 falls style-src-attr back to it, and a
@@ -85,11 +276,19 @@ const STYLES = `
      a violation on every page. */
   .spaced { margin-top: 16px; }
   .tight { margin-top: 12px; }
-  .highlight { border-color: #F2A93B; }
-  .linkish { color: #F2A93B; }
+  .highlight { border-color: var(--signal); }
+  .linkish { color: var(--signal-text); }
+
   @media (max-width: 620px) {
-    body { padding: 14px; }
-    th:nth-child(n+4), td:nth-child(n+4) { display: none; }
+    body { padding: 18px 14px 14px; }
+    header.page h1 { font-size: 23px; }
+    section.card { padding: 16px; }
+    .stat { margin-right: 22px; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+    button:active { transform: none; }
   }
 `
 
@@ -112,7 +311,9 @@ export interface LayoutOptions {
  */
 export function layout({ title, nonce, body, banner }: LayoutOptions): string {
   const bannerHtml = banner
-    ? `<div class="banner ${banner.kind === "ok" ? "ok" : "error"}">${esc(banner.message)}</div>`
+    ? `<div class="banner ${
+      banner.kind === "ok" ? "ok" : "error"
+    }" role="status">${esc(banner.message)}</div>`
     : ""
 
   return `<!DOCTYPE html>
@@ -121,6 +322,7 @@ export function layout({ title, nonce, body, banner }: LayoutOptions): string {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="referrer" content="no-referrer">
+<meta name="color-scheme" content="dark light">
 <title>${esc(title)}</title>
 <style nonce="${esc(nonce)}">${STYLES}</style>
 </head>
@@ -149,14 +351,18 @@ export function tabs(
 ): string {
   const overviewHref = `${basePath}/o/${encodeURIComponent(slug)}`
   const items = [
-    `<a href="${esc(overviewHref)}"${current === "overview" ? ' class="active"' : ""}>Overview</a>`,
+    `<a href="${esc(overviewHref)}"${
+      current === "overview" ? ' class="active" aria-current="page"' : ""
+    }>Overview</a>`,
   ]
   if (isAdmin) {
     items.push(
-      `<a href="${esc(overviewHref)}/admin"${current === "admin" ? ' class="active"' : ""}>Configuration</a>`,
+      `<a href="${esc(overviewHref)}/admin"${
+        current === "admin" ? ' class="active" aria-current="page"' : ""
+      }>Configuration</a>`,
     )
   }
-  return `<nav class="tabs">${items.join("")}</nav>`
+  return `<nav class="tabs" aria-label="Organisation sections">${items.join("")}</nav>`
 }
 
 /** A hidden CSRF field. Every mutating form must include one. */

--- a/supabase/functions/organisation/views/org.ts
+++ b/supabase/functions/organisation/views/org.ts
@@ -5,7 +5,7 @@
  * of CSRF concerns entirely.
  */
 
-import { esc, scrollable } from "../utils/html.ts"
+import { attrUrl, esc, scrollable } from "../utils/html.ts"
 import { layout, tabs } from "./layout.ts"
 import type { OrgDetail, OrgMember, OrgRole } from "../services/org.ts"
 
@@ -30,6 +30,19 @@ export function orgPage({ nonce, basePath, org, members, roles }: OrgPageOptions
   ${org.is_system ? '<span class="pill">system</span>' : ""}
 </header>
 <p class="sub">${esc(org.description ?? "No description.")}</p>
+${
+    org.website
+      // attrUrl with http/https opted in. Everywhere else on these pages it is
+      // called with no schemes at all, which refuses anything but a same-origin
+      // path - correct for our own links, and wrong for the one field that is
+      // deliberately external. It still refuses javascript:, data: and a
+      // protocol-relative //host, which is what matters for a value a requester
+      // supplies. rel="noreferrer" because this is the one outbound link here.
+      ? `<p class="sub"><a href="${
+        attrUrl(org.website, ["http", "https"])
+      }" rel="noopener noreferrer">${esc(org.website)}</a></p>`
+      : ""
+  }
 ${tabs(basePath, org.slug, "overview", org.is_admin)}
 
 <section class="card">

--- a/supabase/functions/organisation/views/org.ts
+++ b/supabase/functions/organisation/views/org.ts
@@ -40,7 +40,7 @@ ${
       // supplies. rel="noreferrer" because this is the one outbound link here.
       ? `<p class="sub"><a href="${
         attrUrl(org.website, ["http", "https"])
-      }" rel="noopener noreferrer">${esc(org.website)}</a></p>`
+      }" target="_blank" rel="noopener noreferrer">${esc(org.website)}</a></p>`
       : ""
   }
 ${tabs(basePath, org.slug, "overview", org.is_admin)}

--- a/supabase/functions/organisation/views/org.ts
+++ b/supabase/functions/organisation/views/org.ts
@@ -35,11 +35,11 @@ ${tabs(basePath, org.slug, "overview", org.is_admin)}
 <section class="card">
   <div class="stat"><b>${esc(org.member_count)}</b><span>members</span></div>
   <div class="stat"><b>${esc(roles.length)}</b><span>roles</span></div>
-  <div class="stat"><b>${esc(org.visibility)}</b><span>visibility</span></div>
-  <div class="stat"><b>${esc(org.join_policy.replace(/_/g, " "))}</b><span>joining</span></div>
+  <div class="stat phrase"><b>${esc(org.visibility)}</b><span>visibility</span></div>
+  <div class="stat phrase"><b>${esc(org.join_policy.replace(/_/g, " "))}</b><span>joining</span></div>
   ${
       org.primary_domain
-        ? `<div class="stat"><b>${esc(org.primary_domain)}</b><span>domain</span></div>`
+        ? `<div class="stat phrase"><b>${esc(org.primary_domain)}</b><span>domain</span></div>`
         : ""
     }
 </section>

--- a/supabase/functions/organisation/views/org.ts
+++ b/supabase/functions/organisation/views/org.ts
@@ -5,7 +5,7 @@
  * of CSRF concerns entirely.
  */
 
-import { emailText, esc } from "../utils/html.ts"
+import { esc } from "../utils/html.ts"
 import { layout, tabs } from "./layout.ts"
 import type { OrgDetail, OrgMember, OrgRole } from "../services/org.ts"
 
@@ -46,7 +46,7 @@ ${tabs(basePath, org.slug, "overview", org.is_admin)}
 
 <section class="card">
   <h2>Members</h2>
-  <p class="hint">Owned by ${emailText(org.owner_email ?? "unknown")}.</p>
+  <p class="hint">Owned by ${esc(org.owner_email ?? "unknown")}.</p>
   ${membersTable(active)}
 </section>
 
@@ -63,7 +63,7 @@ function membersTable(members: OrgMember[]): string {
 
   const rows = members.map((member) => `
     <tr>
-      <td>${emailText(member.email ?? "unknown")}</td>
+      <td>${esc(member.email ?? "unknown")}</td>
       <td>${
     member.is_owner
       ? '<span class="pill admin">owner</span>'

--- a/supabase/functions/organisation/views/org.ts
+++ b/supabase/functions/organisation/views/org.ts
@@ -5,7 +5,7 @@
  * of CSRF concerns entirely.
  */
 
-import { esc } from "../utils/html.ts"
+import { esc, scrollable } from "../utils/html.ts"
 import { layout, tabs } from "./layout.ts"
 import type { OrgDetail, OrgMember, OrgRole } from "../services/org.ts"
 
@@ -75,10 +75,10 @@ function membersTable(members: OrgMember[]): string {
       <td>${esc(formatDate(member.joined_at))}</td>
     </tr>`).join("")
 
-  return `<table>
+  return scrollable("Members", `<table>
   <thead><tr><th>Email</th><th>Standing</th><th>Roles</th><th>Joined</th></tr></thead>
   <tbody>${rows}</tbody>
-</table>`
+</table>`)
 }
 
 function rolesTable(roles: OrgRole[]): string {
@@ -96,10 +96,10 @@ function rolesTable(roles: OrgRole[]): string {
   }</td>
     </tr>`).join("")
 
-  return `<table>
+  return scrollable("Roles", `<table>
   <thead><tr><th>Role</th><th>Kind</th><th>Members</th><th>Permissions</th></tr></thead>
   <tbody>${rows}</tbody>
-</table>`
+</table>`)
 }
 
 /**

--- a/supabase/functions/organisation/views/org.ts
+++ b/supabase/functions/organisation/views/org.ts
@@ -5,7 +5,7 @@
  * of CSRF concerns entirely.
  */
 
-import { esc } from "../utils/html.ts"
+import { emailText, esc } from "../utils/html.ts"
 import { layout, tabs } from "./layout.ts"
 import type { OrgDetail, OrgMember, OrgRole } from "../services/org.ts"
 
@@ -46,7 +46,7 @@ ${tabs(basePath, org.slug, "overview", org.is_admin)}
 
 <section class="card">
   <h2>Members</h2>
-  <p class="hint">Owned by ${esc(org.owner_email ?? "unknown")}.</p>
+  <p class="hint">Owned by ${emailText(org.owner_email ?? "unknown")}.</p>
   ${membersTable(active)}
 </section>
 
@@ -63,7 +63,7 @@ function membersTable(members: OrgMember[]): string {
 
   const rows = members.map((member) => `
     <tr>
-      <td>${esc(member.email ?? "unknown")}</td>
+      <td>${emailText(member.email ?? "unknown")}</td>
       <td>${
     member.is_owner
       ? '<span class="pill admin">owner</span>'

--- a/supabase/migrations/20260806000000_boss_org_member_role.sql
+++ b/supabase/migrations/20260806000000_boss_org_member_role.sql
@@ -1,0 +1,205 @@
+-- ============================================================================
+-- BOSS Database Schema: give boss organisation members the user-kind role
+--
+-- File: 20260806000000_boss_org_member_role.sql
+--
+-- The seed created the boss organisation with auto_assign_member_role = false,
+-- reasoning that every user is a member so a user_roles row per user would
+-- lengthen every JWT for zero extra permissions - the global `user` role already
+-- grants organisation.read, which is the only permission boss_org_user carries.
+--
+-- That reasoning is still true and is being overridden deliberately: the operator
+-- wants the roster to show an explicit organisation role for every member rather
+-- than a blank, and wants membership of the organisation to be legible from a
+-- user's roles alone.
+--
+-- WHAT THIS COSTS, stated so it is not rediscovered later. Every active member
+-- gains a user_roles row, and organisation role names ride in the existing
+-- `user_roles` JWT claim (20260801060000 omitted a separate org_roles claim for
+-- exactly that reason), so every token on the deployment grows by one entry. No
+-- permission changes for anybody.
+--
+-- Four parts, because flipping the flag alone would not have worked:
+--   1. auto_assign_member_role = true for the boss organisation
+--   2. backfill the role onto existing ACTIVE members
+--   3. the same default inside ensure_boss_organisation(), which creates the
+--      organisation on a fresh deployment AFTER this migration runs - so the
+--      UPDATE alone would be silently undone
+--   4. teach handle_new_user to assign it, since that trigger inserts the
+--      membership row directly and never called assign_org_member_role_internal
+-- ============================================================================
+
+
+-- 1. The flag. Scoped by slug AND is_system so a non-system organisation that
+--    happens to be called "boss" cannot be caught by this.
+UPDATE "public"."organisations"
+   SET "auto_assign_member_role" = true
+ WHERE "slug" = 'boss' AND "is_system";
+
+
+-- 2. Backfill.
+--
+-- ACTIVE members only. A pending or invited row is a request that has not been
+-- accepted, and granting it a role would hand out organisation standing that the
+-- approval step exists to gate.
+--
+-- assigned_by is NULL, which is how this schema marks a system assignment - the
+-- same convention handle_new_user uses for the global `user` role.
+--
+-- ON CONFLICT DO NOTHING makes it idempotent, so a re-run (or a re-applied
+-- migration on a fresh environment where the seed already did the work) is inert.
+INSERT INTO "public"."user_roles" ("user_id", "role_id", "assigned_by", "assigned_at")
+SELECT m."user_id", orl."role_id", NULL, now()
+  FROM "public"."organisation_members" m
+  JOIN "public"."organisations" o
+    ON o."id" = m."org_id" AND o."slug" = 'boss' AND o."is_system"
+  JOIN "public"."organisation_roles" orl
+    ON orl."org_id" = o."id" AND orl."kind" = 'user'
+ WHERE m."status" = 'active'
+ON CONFLICT ("user_id", "role_id") DO NOTHING;
+
+
+-- 3. The creator, so a fresh deployment does not undo part 1.
+--
+-- ensure_boss_organisation() hardcoded false, and it is what creates the
+-- organisation on a fresh environment and on the documented recovery path. Since
+-- it runs AFTER this migration in both cases, the UPDATE above would be overwritten
+-- and the flag would silently be false again. Found by running a db reset rather
+-- than by reading: the UPDATE reported success against zero rows, because the
+-- organisation does not exist yet in a database with no users.
+CREATE OR REPLACE FUNCTION "public"."ensure_boss_organisation"() RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_owner uuid;
+    v_res jsonb;
+BEGIN
+    IF EXISTS (SELECT 1 FROM public.organisations WHERE slug = 'boss') THEN
+        RETURN jsonb_build_object('success', true, 'created', false);
+    END IF;
+
+    -- Owner: the longest-standing global admin, else the oldest user. The
+    -- (r.name IS NULL) sort key puts admins first without needing two queries.
+    SELECT u.id INTO v_owner
+      FROM auth.users u
+      LEFT JOIN public.user_roles ur ON ur.user_id = u.id
+      LEFT JOIN public.roles r ON r.id = ur.role_id AND r.name = 'admin'
+     ORDER BY (r.name IS NULL), u.created_at
+     LIMIT 1;
+
+    IF v_owner IS NULL THEN
+        -- organisations.owner_id is NOT NULL, so there is nothing to create yet.
+        -- handle_new_user calls this again on the first signup.
+        RETURN jsonb_build_object('success', false, 'created', false, 'error', 'no users yet');
+    END IF;
+
+    v_res := public.create_organisation_internal(
+        p_slug        => 'boss',
+        p_name        => 'BOSS',
+        p_description => 'The default BOSS organisation. Every user is a member.',
+        p_owner_id    => v_owner,
+        p_domain      => NULL,
+        p_visibility  => 'public',
+        p_join_policy => 'open',
+        -- Bypasses is_reserved_organisation_slug, which lists 'boss' precisely
+        -- because of the boss_admin collision described in the header.
+        p_is_system   => true,
+        p_admin_role_name => 'boss_org_admin',
+        p_user_role_name  => 'boss_org_user',
+        -- Every user is a member of this organisation. Auto-assigning the member
+        -- role would add one user_roles row per user and lengthen EVERY JWT, for
+        -- zero additional permissions -- the global `user` role already carries
+        -- the baseline, and boss_org_user holds only organisation.read.
+        -- true since 20260806000000. The original false was correct on its own
+        -- terms (every user is a member, so the role adds a user_roles row and a
+        -- JWT entry for zero extra permissions), and was overridden deliberately so
+        -- that membership is visible from a user's roles. Changed HERE and not only
+        -- by an UPDATE, because this function recreates the organisation on a fresh
+        -- deployment and on the documented recovery path - an UPDATE alone reverts
+        -- the moment the organisation is created after the migration has run, which
+        -- is exactly what a local db reset does.
+        p_auto_assign_member_role => true);
+
+    IF COALESCE((v_res->>'success')::boolean, false) IS NOT TRUE THEN
+        RAISE EXCEPTION 'boss organisation seed failed: %', v_res->>'error';
+    END IF;
+
+    RETURN jsonb_build_object('success', true, 'created', true, 'owner_id', v_owner::text);
+END;
+$$;
+
+ALTER FUNCTION "public"."ensure_boss_organisation"() OWNER TO "postgres";
+
+
+-- 4. The signup trigger.
+CREATE OR REPLACE FUNCTION "public"."handle_new_user"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_role_id UUID;
+    v_boss_org_id UUID;
+BEGIN
+    -- Step 1: mirror the auth.users record into public.users.
+    INSERT INTO public.users (id, email, created_at, updated_at)
+    VALUES (NEW.id, NEW.email, now(), now())
+    ON CONFLICT (id) DO NOTHING;
+
+    -- Step 2: assign the default `user` role. assigned_by = NULL marks it a system
+    -- assignment. This is also what makes `user` first by assigned_at, which
+    -- get_user_roles_for_hook relies on for the primary_role claim.
+    SELECT id INTO v_role_id FROM public.roles WHERE name = 'user';
+
+    INSERT INTO public.user_roles (user_id, role_id, assigned_by, assigned_at)
+    VALUES (NEW.id, v_role_id, NULL, now())
+    ON CONFLICT (user_id, role_id) DO NOTHING;
+
+    -- Step 3 (20260801070000): join the default organisation.
+    BEGIN
+        -- Deliberately NOT calling ensure_boss_organisation() here.
+        --
+        -- Self-healing on first signup is tempting and does close the fresh-deployment
+        -- gap, but it makes the first-ever signup create the organisation and its two
+        -- roles as a side effect of an auth trigger - which changes the role graph out
+        -- from under anything that reads it, and broke four pgTAP suites that assert
+        -- exact grantable-role sets. An auth hook is the wrong place to acquire that
+        -- blast radius.
+        --
+        -- The recovery path is the callable ensure_boss_organisation() above, listed in
+        -- the deployment notes. See the note on that function.
+        SELECT id INTO v_boss_org_id FROM public.organisations WHERE slug = 'boss';
+
+        IF v_boss_org_id IS NOT NULL THEN
+            INSERT INTO public.organisation_members (org_id, user_id, status, joined_at, join_source)
+            VALUES (v_boss_org_id, NEW.id, 'active', now(), 'seed')
+            ON CONFLICT (org_id, user_id) DO NOTHING;
+
+            -- The membership row alone does not carry the organisation's user-kind
+            -- role. Every other entry path (join, approve, invite redemption) goes
+            -- through assign_org_member_role_internal; this trigger inserted the row
+            -- directly and so was the one path that did not, which is why turning
+            -- auto_assign_member_role on for the boss organisation would otherwise
+            -- have changed nothing for a new signup.
+            --
+            -- The helper is called rather than the INSERT inlined: it reads
+            -- auto_assign_member_role itself, so switching the flag back off stops
+            -- this immediately, and there is one definition of what joining assigns.
+            --
+            -- Note this ASSIGNS an existing role; it does not create one. The header
+            -- note above rules out creating the organisation and its roles here, for
+            -- a different reason - that changes the role graph out from under readers.
+            PERFORM public.assign_org_member_role_internal(v_boss_org_id, NEW.id);
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        -- See the header: a raise here would fail user creation outright.
+        RAISE WARNING 'handle_new_user: could not add % to the boss organisation: %', NEW.id, SQLERRM;
+    END;
+
+    RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION "public"."handle_new_user"() OWNER TO "postgres";
+
+COMMENT ON FUNCTION "public"."handle_new_user"() IS 'auth.users INSERT trigger: mirrors the user into public.users, assigns the default `user` role, adds them to the default boss organisation and assigns that organisation''s user-kind role when the organisation opts in. The organisation step is exception-wrapped because this runs inside user creation -- a raise here would break signup for everyone.';

--- a/supabase/migrations/20260806010000_org_member_role_assigned_at.sql
+++ b/supabase/migrations/20260806010000_org_member_role_assigned_at.sql
@@ -1,0 +1,72 @@
+-- ============================================================================
+-- BOSS Database Schema: break the assigned_at tie the primary_role claim rides on
+--
+-- File: 20260806010000_org_member_role_assigned_at.sql
+--
+-- Follows 20260806000000, which taught handle_new_user to assign the boss
+-- organisation's user-kind role. Both inserts used now(), which is
+-- transaction_timestamp() and constant across the transaction regardless of
+-- nesting, so a new signup got two user_roles rows with the SAME assigned_at.
+--
+-- get_user_roles_for_hook aggregates ORDER BY assigned_at and the access-token
+-- hook takes element 1 as primary_role. Sorts are not stable, so the tie makes
+-- that claim plan-dependent - a signup could report boss_org_user as its role.
+--
+-- Verified on a local database before this fix: two rows, one distinct
+-- assigned_at value.
+--
+-- Existing users are unaffected: their `user` row predates the backfill by a real
+-- interval, so there is no tie to break.
+-- ============================================================================
+
+
+CREATE OR REPLACE FUNCTION "public"."assign_org_member_role_internal"("p_org_id" "uuid", "p_user_id" "uuid")
+RETURNS void
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_auto BOOLEAN;
+    v_role_id UUID;
+BEGIN
+    SELECT o.auto_assign_member_role INTO v_auto
+    FROM public.organisations o WHERE o.id = p_org_id;
+
+    IF NOT COALESCE(v_auto, false) THEN
+        RETURN;
+    END IF;
+
+    SELECT orl.role_id INTO v_role_id
+    FROM public.organisation_roles orl
+    WHERE orl.org_id = p_org_id AND orl.kind = 'user';
+
+    IF v_role_id IS NOT NULL THEN
+        INSERT INTO public.user_roles (user_id, role_id, assigned_by, assigned_at)
+        -- clock_timestamp(), NOT now(). now() is transaction_timestamp() and is
+        -- constant for the whole transaction however deeply nested the call is, so
+        -- when handle_new_user assigns the global `user` role and then calls this,
+        -- both rows land with an IDENTICAL assigned_at.
+        --
+        -- That matters because get_user_roles_for_hook aggregates ORDER BY
+        -- assigned_at and the access-token hook takes element 1 as primary_role,
+        -- which the app surfaces as the user's role. PostgreSQL sorts are not
+        -- stable, so a tie makes that value plan-dependent: a fresh signup could
+        -- come out with a primary_role of <slug>_user instead of `user`.
+        --
+        -- Not an escalation - permissions come from the full array - but a
+        -- nondeterministic wrong value in a displayed claim is the worst way for
+        -- one to be wrong. clock_timestamp() advances within the transaction, so
+        -- the organisation role always sorts after the role that preceded it.
+        VALUES (p_user_id, v_role_id, NULL, clock_timestamp())
+        ON CONFLICT (user_id, role_id) DO NOTHING;
+    END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."assign_org_member_role_internal"("uuid", "uuid") OWNER TO "postgres";
+
+-- The 20260801030000 header on this function still says auto-assign is false for
+-- the boss organisation, which 20260806000000 changed. Migrations are immutable,
+-- so the correction goes here.
+COMMENT ON FUNCTION "public"."assign_org_member_role_internal"("uuid", "uuid") IS
+    'Assigns an organisation''s user-kind role when organisations.auto_assign_member_role is set. Shared by join, admin approval, invite redemption and (since 20260806000000) the signup trigger for the boss organisation. Uses clock_timestamp() so the row cannot tie with a role assigned earlier in the same transaction - get_user_roles_for_hook orders by assigned_at and the token hook takes the first element as primary_role.';

--- a/supabase/migrations/20260806020000_repair_assigned_at_ties.sql
+++ b/supabase/migrations/20260806020000_repair_assigned_at_ties.sql
@@ -1,0 +1,86 @@
+-- ============================================================================
+-- BOSS Database Schema: repair the assigned_at ties already written
+--
+-- File: 20260806020000_repair_assigned_at_ties.sql
+--
+-- 20260806010000 changed assign_org_member_role_internal to clock_timestamp() so
+-- a new signup can no longer produce two user_roles rows with the same
+-- assigned_at. It did NOT repair rows already written, and its header claimed
+-- "Existing users are unaffected: their `user` row predates the backfill by a
+-- real interval, so there is no tie to break."
+--
+-- THAT CLAIM WAS TRUE OF THE WRONG POPULATION. It holds for users who existed
+-- before 20260806000000. It does not hold for anyone created BETWEEN the two
+-- deployments, which is exactly the population 20260806010000 was written for:
+-- their `user` row and their organisation role row were written by one
+-- transaction, so both carry transaction_timestamp() and tie permanently.
+--
+-- For those users get_user_roles_for_hook's ARRAY_AGG(... ORDER BY assigned_at)
+-- has no defined winner, so the primary_role claim stays plan-dependent for the
+-- life of the row: a re-plan after ANALYZE can flip a displayed role between
+-- `user` and <slug>_user with no data change at all. Fixing the function without
+-- fixing the rows leaves that in place forever.
+--
+-- Idempotent, and correct whether the affected population is zero or every user
+-- created in that window - it repairs whatever it finds and is a no-op otherwise,
+-- which is why it does not need the count known in advance.
+-- ============================================================================
+
+
+-- Nudge the ORGANISATION role forward, never the role it ties with. The global
+-- `user` role is assigned first by handle_new_user and is what primary_role is
+-- supposed to resolve to, so moving the organisation row later restores the
+-- intended order rather than picking an arbitrary winner.
+--
+-- One microsecond is enough: timestamptz resolution is microseconds, so this is
+-- the smallest change that makes the sort total, and it cannot reorder the row
+-- against anything assigned a measurable interval later.
+UPDATE "public"."user_roles" ur
+   SET "assigned_at" = ur."assigned_at" + interval '1 microsecond'
+  FROM "public"."organisation_roles" orl
+ WHERE orl."role_id" = ur."role_id"
+   AND orl."kind" = 'user'
+   AND EXISTS (
+       SELECT 1
+         FROM "public"."user_roles" peer
+        WHERE peer."user_id" = ur."user_id"
+          AND peer."role_id" <> ur."role_id"
+          AND peer."assigned_at" = ur."assigned_at"
+   );
+
+
+-- ---------------------------------------------------------------------------
+-- A one-off report, not a change: who can now reach a secret through the
+-- organisation's user-kind role.
+-- ---------------------------------------------------------------------------
+--
+-- 20260806000000 recorded only the JWT-size cost. There is a second consequence
+-- it did not: before it, <slug>_user was held by NOBODY, so anything keyed on
+-- that role_id was inert. can_access_secret matches
+-- secret_shares.shared_with_role_id against the caller's user_roles, so any
+-- pre-existing share targeting that role went from reaching zero people to
+-- reaching every active member the moment the backfill ran.
+--
+-- No such share is expected - the role was days old and held by nobody, so there
+-- was no reason to share to it - but "no reason to expect it" is not a check.
+-- This RAISEs rather than changes anything: revoking a share the operator made
+-- deliberately would be the wrong call to make inside a migration, and a warning
+-- in the deploy output puts the answer in front of the person who can decide.
+DO $$
+DECLARE
+    v_count integer;
+BEGIN
+    SELECT count(*) INTO v_count
+      FROM public.secret_shares ss
+      JOIN public.organisation_roles orl ON orl.role_id = ss.shared_with_role_id
+     WHERE orl.kind = 'user';
+
+    IF v_count > 0 THEN
+        RAISE WARNING
+            'REVIEW REQUIRED: % secret_shares row(s) target an organisation user-kind role. Those secrets are now reachable by every active member of that organisation, where before 20260806000000 the role was held by nobody.',
+            v_count;
+    ELSE
+        RAISE NOTICE 'No secret_shares rows target an organisation user-kind role.';
+    END IF;
+END;
+$$;

--- a/supabase/migrations/20260806020000_repair_assigned_at_ties.sql
+++ b/supabase/migrations/20260806020000_repair_assigned_at_ties.sql
@@ -24,6 +24,12 @@
 -- Idempotent, and correct whether the affected population is zero or every user
 -- created in that window - it repairs whatever it finds and is a no-op otherwise,
 -- which is why it does not need the count known in advance.
+--
+-- ONE CASE IT DOES NOT RESOLVE, stated so the claim above is not read too widely:
+-- two ORGANISATION user-roles assigned in the same transaction would both shift by
+-- the same microsecond and stay tied to each other. They would no longer tie with
+-- `user`, so primary_role is still correct, which is what this exists to protect.
+-- Not reachable today - only the boss organisation assigns a role at signup.
 -- ============================================================================
 
 

--- a/supabase/migrations/20260807000000_organisation_website.sql
+++ b/supabase/migrations/20260807000000_organisation_website.sql
@@ -1,0 +1,676 @@
+-- ============================================================================
+-- BOSS Database Schema: an organisation website, asked for at request time
+--
+-- File: 20260807000000_organisation_website.sql
+--
+-- The request form asks for a website alongside the email domain. They do
+-- different jobs and both are wanted: the DOMAIN governs who may join (verified
+-- by DNS, it lets matching addresses find and join), the WEBSITE is identity and
+-- is only ever displayed.
+--
+-- SCHEME-RESTRICTED TO http AND https, in the column and again in the RPC. This
+-- value is rendered as a link on pages an organisation's members read, and it is
+-- filled in by any authenticated user submitting a request - so a javascript: or
+-- data: URL here would be stored XSS with a self-service entry point. The page
+-- renderer refuses those schemes as well; this is the half that stops one being
+-- stored in the first place.
+--
+-- ADDING A DEFAULTED PARAMETER IS NOT A REPLACEMENT. CREATE OR REPLACE matches on
+-- the argument list, so adding p_website to submit_organisation_request or
+-- create_organisation_internal creates a SECOND function rather than replacing the
+-- first, and a call with the old argument count then fails as ambiguous. Those two
+-- are dropped and recreated, and their REVOKE/GRANT re-applied, because DROP takes
+-- the grants with it. approve_organisation_request, update_organisation_settings,
+-- get_organisation_detail and get_my_organisations keep their identity where the
+-- signature is unchanged.
+-- ============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- Columns
+-- ---------------------------------------------------------------------------
+ALTER TABLE "public"."organisation_requests"
+    ADD COLUMN IF NOT EXISTS "website" "text";
+
+ALTER TABLE "public"."organisations"
+    ADD COLUMN IF NOT EXISTS "website" "text";
+
+-- The CHECK is the backstop the RPC's friendlier message sits in front of. NULL is
+-- allowed (a website is optional); an empty string is not, so "unset" has exactly
+-- one representation and a caller cannot store '' and read it back as a link.
+ALTER TABLE "public"."organisation_requests"
+    DROP CONSTRAINT IF EXISTS "organisation_requests_website_check";
+ALTER TABLE "public"."organisation_requests"
+    ADD CONSTRAINT "organisation_requests_website_check"
+    CHECK ("website" IS NULL OR ("website" ~* '^https?://[^[:space:]]+$' AND length("website") <= 500));
+
+ALTER TABLE "public"."organisations"
+    DROP CONSTRAINT IF EXISTS "organisations_website_check";
+ALTER TABLE "public"."organisations"
+    ADD CONSTRAINT "organisations_website_check"
+    CHECK ("website" IS NULL OR ("website" ~* '^https?://[^[:space:]]+$' AND length("website") <= 500));
+
+COMMENT ON COLUMN "public"."organisations"."website" IS 'Public website, http/https only, displayed as a link on the organisation pages. Distinct from organisation_domains, which governs who may join; this is identity and grants nothing.';
+COMMENT ON COLUMN "public"."organisation_requests"."website" IS 'Website supplied with the request, carried onto the organisation on approval.';
+
+
+-- ---------------------------------------------------------------------------
+-- submit_organisation_request: gains p_website (signature change -> drop first)
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS "public"."submit_organisation_request"("text", "text", "text", "text", "text", "uuid");
+
+CREATE OR REPLACE FUNCTION "public"."submit_organisation_request"(
+    "p_name" "text",
+    "p_slug" "text",
+    "p_description" "text" DEFAULT NULL::"text",
+    "p_domain" "text" DEFAULT NULL::"text",
+    "p_justification" "text" DEFAULT NULL::"text",
+    "p_website" "text" DEFAULT NULL::"text",
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_request_id UUID;
+    v_pending_count INTEGER;
+    v_domain TEXT;
+    v_website TEXT;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    -- A genuinely global permission, so a permission check is the right gate.
+    IF NOT public.user_holds_permission(v_actor, 'organisation.create') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Permission denied');
+    END IF;
+
+    IF p_name IS NULL OR char_length(btrim(p_name)) < 2 OR char_length(btrim(p_name)) > 100 THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Name must be 2-100 characters');
+    END IF;
+
+    IF p_slug IS NULL OR NOT (p_slug ~ '^[a-z][a-z0-9_]{1,30}$') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'Slug must be 2-31 characters, lowercase letters, digits and underscores, starting with a letter');
+    END IF;
+
+    IF public.is_reserved_organisation_slug(p_slug) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Slug "%s" is reserved or already in use', p_slug));
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM public.organisations o WHERE o.slug = p_slug) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('An organisation with slug "%s" already exists', p_slug));
+    END IF;
+
+    -- Three live requests per person is enough for legitimate use and keeps the
+    -- reviewer queue from being floodable.
+    SELECT count(*) INTO v_pending_count
+    FROM public.organisation_requests r
+    WHERE r.requester_id = v_actor AND r.status = 'pending';
+    IF v_pending_count >= 3 THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'You already have 3 pending organisation requests. Withdraw one before submitting another.');
+    END IF;
+
+    IF p_domain IS NOT NULL AND btrim(p_domain) <> '' THEN
+        v_domain := lower(btrim(p_domain));
+        IF NOT (v_domain ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$') THEN
+            RETURN jsonb_build_object('success', false, 'error', 'That is not a valid domain name');
+        END IF;
+        IF EXISTS (SELECT 1 FROM public.reserved_email_domains red WHERE red.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('"%s" is a reserved email domain and cannot be claimed by an organisation', v_domain));
+        END IF;
+        IF EXISTS (SELECT 1 FROM public.organisation_domains d WHERE d.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('Domain "%s" is already claimed by another organisation', v_domain));
+        END IF;
+    END IF;
+
+    -- Validated HERE as well as by the column CHECK, so a typo comes back as a
+    -- sentence rather than a constraint violation the caller cannot read.
+    --
+    -- http and https only. This value is rendered as a link on the organisation
+    -- pages, and a javascript: or data: URL there would be script execution from a
+    -- field any authenticated user can fill in. The renderer refuses those too;
+    -- this is the half that stops one being stored at all.
+    IF p_website IS NOT NULL AND btrim(p_website) <> '' THEN
+        v_website := btrim(p_website);
+        IF v_website !~* '^https?://[^[:space:]]+$' THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                'Website must be a full http:// or https:// address');
+        END IF;
+        IF length(v_website) > 500 THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                'Website must be 500 characters or fewer');
+        END IF;
+    END IF;
+
+    BEGIN
+        INSERT INTO public.organisation_requests (
+            requester_id, name, slug, description, domain, justification, website, status
+        ) VALUES (
+            v_actor, btrim(p_name), p_slug, p_description, v_domain, p_justification, v_website, 'pending'
+        ) RETURNING id INTO v_request_id;
+    EXCEPTION WHEN unique_violation THEN
+        -- idx_organisation_requests_pending_slug
+        RETURN jsonb_build_object('success', false, 'error',
+            format('A pending request for slug "%s" already exists', p_slug));
+    END;
+
+    RETURN jsonb_build_object('success', true, 'request_id', v_request_id::text, 'status', 'pending');
+END;
+$$;
+
+ALTER FUNCTION "public"."submit_organisation_request"("text", "text", "text", "text", "text", "text", "uuid") OWNER TO "postgres";
+REVOKE EXECUTE ON FUNCTION "public"."submit_organisation_request"("text", "text", "text", "text", "text", "text", "uuid") FROM PUBLIC, "anon";
+GRANT EXECUTE ON FUNCTION "public"."submit_organisation_request"("text", "text", "text", "text", "text", "text", "uuid") TO "authenticated", "service_role";
+COMMENT ON FUNCTION "public"."submit_organisation_request"("text", "text", "text", "text", "text", "text", "uuid") IS 'Submits an organisation-creation request. Gated on the global organisation.create permission; revoking that from the "user" role disables self-service organisation creation platform-wide. Also called by the Toolbox Create Organisation dialog.';
+
+
+-- ---------------------------------------------------------------------------
+-- create_organisation_internal: gains p_website (signature change -> drop first)
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS "public"."create_organisation_internal"("text", "text", "text", "uuid", "text", "text", "text", boolean, "text", "text", boolean);
+
+CREATE OR REPLACE FUNCTION "public"."create_organisation_internal"(
+    "p_slug" "text",
+    "p_name" "text",
+    "p_description" "text" DEFAULT NULL::"text",
+    "p_owner_id" "uuid" DEFAULT NULL::"uuid",
+    "p_domain" "text" DEFAULT NULL::"text",
+    "p_visibility" "text" DEFAULT 'private'::"text",
+    "p_join_policy" "text" DEFAULT 'invite_only'::"text",
+    "p_is_system" boolean DEFAULT false,
+    "p_admin_role_name" "text" DEFAULT NULL::"text",
+    "p_user_role_name" "text" DEFAULT NULL::"text",
+    "p_auto_assign_member_role" boolean DEFAULT true,
+    "p_website" "text" DEFAULT NULL::"text"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_org_id UUID;
+    v_admin_name TEXT;
+    v_user_name TEXT;
+    v_admin_role_id UUID;
+    v_user_role_id UUID;
+    v_base_role_id UUID;
+    v_domain TEXT;
+    v_token TEXT;
+BEGIN
+    IF p_owner_id IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'An owner is required');
+    END IF;
+
+    IF p_slug IS NULL OR NOT (p_slug ~ '^[a-z][a-z0-9_]{1,30}$') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'Slug must be 2-31 characters, lowercase letters, digits and underscores, starting with a letter');
+    END IF;
+
+    IF p_visibility NOT IN ('private', 'public') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'visibility must be private or public');
+    END IF;
+
+    IF p_join_policy NOT IN ('invite_only', 'request_to_join', 'open') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'join_policy must be invite_only, request_to_join or open');
+    END IF;
+
+    -- p_is_system bypasses the reserved-slug check. Only the boss-org seed passes
+    -- it, and only because 'boss' is on the reserved list precisely BECAUSE of the
+    -- boss_admin collision -- which the seed sidesteps by passing explicit
+    -- boss_org_* role names.
+    IF NOT p_is_system AND public.is_reserved_organisation_slug(p_slug) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Slug "%s" is reserved, or its role names (%s, %s) are already taken',
+                   p_slug,
+                   public.organisation_role_name(p_slug, 'admin'),
+                   public.organisation_role_name(p_slug, 'user')));
+    END IF;
+
+    v_admin_name := COALESCE(p_admin_role_name, public.organisation_role_name(p_slug, 'admin'));
+    v_user_name  := COALESCE(p_user_role_name,  public.organisation_role_name(p_slug, 'user'));
+
+    -- Re-check the derived names even for a system organisation. This is the H2
+    -- guard on the write path: mapping an EXISTING role (which could be a global
+    -- system role such as boss_admin) into organisation_roles is the escalation.
+    IF EXISTS (SELECT 1 FROM public.roles r WHERE r.name IN (v_admin_name, v_user_name)) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Role name "%s" or "%s" already exists', v_admin_name, v_user_name));
+    END IF;
+
+    -- public.roles.name is validated ^[a-z][a-z0-9_]{2,50}$ by create_new_role;
+    -- enforce the length here too so a 31-character slug cannot produce a
+    -- 37-character name that a later role RPC would reject.
+    IF char_length(v_admin_name) > 50 OR char_length(v_user_name) > 50 THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Slug is too long for the derived role names');
+    END IF;
+
+    -- The optional domain claim is validated HERE, before the first INSERT, and
+    -- the placement is the whole point.
+    --
+    -- A plain RETURN from PL/pgSQL is a normal return: it rolls back NOTHING.
+    -- Only a propagating exception aborts the transaction. These two checks used
+    -- to sit at step 8, after the organisation, both roles, the hierarchy edges,
+    -- the permission grants, the founder membership and the founder user_roles
+    -- row had all been inserted -- so a refused domain returned success:false
+    -- while all eight inserts committed. That left an orphan organisation nothing
+    -- pointed at, silently owned by the requester, and because the slug was now
+    -- taken the originating request could never be approved on a retry.
+    --
+    -- Reachable in normal operation: two pending requests naming the same domain,
+    -- or a domain added to reserved_email_domains between submit and approve.
+    -- submit_organisation_request checks the domain too, but that check is a
+    -- TOCTOU, which is exactly why the re-check exists.
+    IF p_domain IS NOT NULL AND btrim(p_domain) <> '' THEN
+        v_domain := lower(btrim(p_domain));
+
+        IF EXISTS (SELECT 1 FROM public.reserved_email_domains red WHERE red.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('"%s" is a reserved email domain and cannot be claimed by an organisation', v_domain));
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM public.organisation_domains d WHERE d.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('Domain "%s" is already claimed by another organisation', v_domain));
+        END IF;
+    END IF;
+
+    -- 1. The organisation.
+    BEGIN
+        INSERT INTO public.organisations (
+            slug, name, description, visibility, join_policy,
+            owner_id, created_by, is_system, auto_assign_member_role, website
+        ) VALUES (
+            p_slug, btrim(p_name), p_description, p_visibility, p_join_policy,
+            p_owner_id, p_owner_id, p_is_system, p_auto_assign_member_role,
+            NULLIF(btrim(COALESCE(p_website, '')), '')
+        ) RETURNING id INTO v_org_id;
+    EXCEPTION WHEN unique_violation THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('An organisation with slug "%s" already exists', p_slug));
+    END;
+
+    -- 2. The two roles. is_system = false is REQUIRED: enforce_org_role_not_system
+    --    refuses to map a system role, and delete_role refuses to delete one, so a
+    --    system-flagged organisation role would be both unmappable and uncleanable.
+    INSERT INTO public.roles (name, description, is_system)
+    VALUES (v_admin_name, format('Administrators of the "%s" organisation', btrim(p_name)), false)
+    RETURNING id INTO v_admin_role_id;
+
+    INSERT INTO public.roles (name, description, is_system)
+    VALUES (v_user_name, format('Members of the "%s" organisation', btrim(p_name)), false)
+    RETURNING id INTO v_user_role_id;
+
+    -- 3. The mapping that makes them organisation roles.
+    INSERT INTO public.organisation_roles (org_id, role_id, kind, created_by) VALUES
+        (v_org_id, v_admin_role_id, 'admin', p_owner_id),
+        (v_org_id, v_user_role_id,  'user',  p_owner_id);
+
+    -- 4. Hierarchy: <slug>_admin -> <slug>_user -> user.
+    --    The second edge is what H3 is about: it puts the global `user` role in an
+    --    organisation admin's get_grantable_role_ids. That is rendered inert by
+    --    enforce_org_role_permission_scope, which makes role.* / user.* /
+    --    api_key.* / plugins.admin.* un-grantable to any organisation role.
+    SELECT r.id INTO v_base_role_id FROM public.roles r WHERE r.name = 'user';
+
+    INSERT INTO public.role_hierarchy (parent_role_id, child_role_id)
+    VALUES (v_admin_role_id, v_user_role_id)
+    ON CONFLICT DO NOTHING;
+
+    IF v_base_role_id IS NOT NULL THEN
+        INSERT INTO public.role_hierarchy (parent_role_id, child_role_id)
+        VALUES (v_user_role_id, v_base_role_id)
+        ON CONFLICT DO NOTHING;
+    END IF;
+
+    -- 5. Permissions. All of these pass is_org_grantable_permission's allowlist.
+    INSERT INTO public.role_permissions (role_id, permission_id)
+    SELECT v_admin_role_id, p.id FROM public.permissions p
+    WHERE p.name IN ('organisation.admin', 'organisation.read')
+    ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+    INSERT INTO public.role_permissions (role_id, permission_id)
+    SELECT v_user_role_id, p.id FROM public.permissions p
+    WHERE p.name = 'organisation.read'
+    ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+    -- 6. Founder membership.
+    INSERT INTO public.organisation_members (org_id, user_id, status, joined_at, join_source)
+    VALUES (v_org_id, p_owner_id, 'active', now(), 'founder')
+    ON CONFLICT (org_id, user_id) DO NOTHING;
+
+    -- 7. The founder holds the admin role. assigned_by is NULL: a system
+    --    assignment, matching handle_new_user's convention for the base role.
+    INSERT INTO public.user_roles (user_id, role_id, assigned_by, assigned_at)
+    VALUES (p_owner_id, v_admin_role_id, NULL, now())
+    ON CONFLICT (user_id, role_id) DO NOTHING;
+
+    -- 8. Optional unverified domain claim. Already validated above, before the
+    --    first INSERT, so nothing here can return a failure after committing rows.
+    --    The unique index on organisation_domains.domain is the backstop for a
+    --    concurrent claim landing between that check and this insert; it RAISES,
+    --    which does roll the transaction back.
+    IF p_domain IS NOT NULL AND btrim(p_domain) <> '' THEN
+        -- URL-safe: translate()'s 3-character FROM against a 2-character TO also
+        -- DELETES the '=' padding.
+        v_token := translate(
+            pg_catalog.encode(extensions.gen_random_bytes(24), 'base64'), '+/=', '-_');
+
+        INSERT INTO public.organisation_domains (
+            org_id, domain, is_primary, verification_token, created_by
+        ) VALUES (v_org_id, v_domain, true, v_token, p_owner_id);
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'org_id', v_org_id::text,
+        'slug', p_slug,
+        'admin_role', v_admin_name,
+        'user_role', v_user_name);
+END;
+$$;
+
+ALTER FUNCTION "public"."create_organisation_internal"("text", "text", "text", "uuid", "text", "text", "text", boolean, "text", "text", boolean, "text") OWNER TO "postgres";
+REVOKE EXECUTE ON FUNCTION "public"."create_organisation_internal"("text", "text", "text", "uuid", "text", "text", "text", boolean, "text", "text", boolean, "text") FROM PUBLIC, "anon", "authenticated";
+GRANT  EXECUTE ON FUNCTION "public"."create_organisation_internal"("text", "text", "text", "uuid", "text", "text", "text", boolean, "text", "text", boolean, "text") TO "service_role";
+
+
+-- ---------------------------------------------------------------------------
+-- Same signature, new body. CREATE OR REPLACE keeps the grants.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION "public"."approve_organisation_request"(
+    "p_request_id" "uuid",
+    "p_notes" "text" DEFAULT NULL::"text",
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_req public.organisation_requests;
+    v_result JSONB;
+    v_org_id UUID;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    IF NOT public.user_holds_permission(v_actor, 'organisation.approve') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Permission denied');
+    END IF;
+
+    -- FOR UPDATE makes double-approval impossible under concurrency: the second
+    -- transaction blocks, then sees status <> 'pending' and refuses.
+    SELECT * INTO v_req
+    FROM public.organisation_requests r
+    WHERE r.id = p_request_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Request not found');
+    END IF;
+
+    IF v_req.status <> 'pending' THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Request is already %s', v_req.status));
+    END IF;
+
+    v_result := public.create_organisation_internal(
+        p_slug        => v_req.slug,
+        p_name        => v_req.name,
+        p_description => v_req.description,
+        p_owner_id    => v_req.requester_id,
+        p_domain      => v_req.domain,
+        p_website     => v_req.website,
+        p_visibility  => 'private',
+        p_join_policy => 'request_to_join');
+
+    -- Return the inner error verbatim and abort. Because this whole function is
+    -- one transaction, nothing the failed call did is committed and the request
+    -- stays pending for another attempt.
+    IF COALESCE((v_result->>'success')::boolean, false) IS NOT TRUE THEN
+        RETURN v_result;
+    END IF;
+
+    v_org_id := (v_result->>'org_id')::uuid;
+
+    UPDATE public.organisation_requests
+       SET status = 'approved',
+           reviewer_id = v_actor,
+           reviewed_at = now(),
+           review_notes = p_notes,
+           created_org_id = v_org_id,
+           updated_at = now()
+     WHERE id = p_request_id;
+
+    RETURN jsonb_build_object('success', true, 'org_id', v_org_id::text,
+        'slug', v_result->>'slug', 'status', 'approved');
+END;
+$$;
+
+
+-- update_organisation_settings gains a parameter, so it too must be dropped.
+DROP FUNCTION IF EXISTS "public"."update_organisation_settings"("uuid", "text", "text", "text", "text", "text", "uuid", boolean, boolean, "uuid");
+
+CREATE OR REPLACE FUNCTION "public"."update_organisation_settings"(
+    "p_org_id" "uuid",
+    "p_name" "text" DEFAULT NULL::"text",
+    "p_description" "text" DEFAULT NULL::"text",
+    "p_visibility" "text" DEFAULT NULL::"text",
+    "p_join_policy" "text" DEFAULT NULL::"text",
+    "p_publish_policy" "text" DEFAULT NULL::"text",
+    "p_publish_role_id" "uuid" DEFAULT NULL::"uuid",
+    "p_clear_publish_role" boolean DEFAULT false,
+    "p_website" "text" DEFAULT NULL::"text",
+    "p_auto_assign_member_role" boolean DEFAULT NULL::boolean,
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    IF NOT public.user_is_org_admin(v_actor, p_org_id) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Permission denied');
+    END IF;
+
+    IF p_visibility IS NOT NULL AND p_visibility NOT IN ('private', 'public') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'visibility must be private or public');
+    END IF;
+
+    IF p_join_policy IS NOT NULL AND p_join_policy NOT IN ('invite_only', 'request_to_join', 'open') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'join_policy must be invite_only, request_to_join or open');
+    END IF;
+
+    IF p_publish_policy IS NOT NULL AND p_publish_policy NOT IN ('owner_only', 'admins', 'members') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'publish_policy must be owner_only, admins or members');
+    END IF;
+
+    -- A publish role must be one of THIS organisation's roles, or an organisation
+    -- admin could delegate publishing to the holders of an arbitrary global role.
+    IF p_publish_role_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM public.organisation_roles orl
+        WHERE orl.org_id = p_org_id AND orl.role_id = p_publish_role_id
+    ) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'The publish role must belong to this organisation');
+    END IF;
+
+    IF p_name IS NOT NULL AND (char_length(btrim(p_name)) < 2 OR char_length(btrim(p_name)) > 100) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Name must be 2-100 characters');
+    END IF;
+
+    UPDATE public.organisations
+       SET name           = COALESCE(btrim(p_name), name),
+           -- NULLIF(p_description, '') is NOT what is wanted here: an empty string is the
+           -- caller explicitly CLEARING the description, and COALESCE would then keep the old
+           -- one. Empty means empty; only a SQL NULL means leave unchanged.
+           description    = CASE WHEN p_description IS NULL THEN description
+                                 WHEN btrim(p_description) = '' THEN NULL
+                                 ELSE p_description END,
+           -- Same empty-means-empty rule the description uses: an empty string
+           -- CLEARS the website, and only a SQL NULL leaves it alone.
+           website        = CASE WHEN p_website IS NULL THEN website
+                                 WHEN btrim(p_website) = '' THEN NULL
+                                 ELSE btrim(p_website) END,
+           visibility     = COALESCE(p_visibility, visibility),
+           join_policy    = COALESCE(p_join_policy, join_policy),
+           publish_policy = COALESCE(p_publish_policy, publish_policy),
+           -- COALESCE alone can never set a column back to NULL, so "revert to
+           -- publish_policy" needs its own explicit signal.
+           publish_role_id = CASE WHEN p_clear_publish_role THEN NULL
+                                  ELSE COALESCE(p_publish_role_id, publish_role_id) END,
+           auto_assign_member_role = COALESCE(p_auto_assign_member_role, auto_assign_member_role),
+           updated_at = now()
+     WHERE id = p_org_id;
+
+    RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+ALTER FUNCTION "public"."update_organisation_settings"("uuid", "text", "text", "text", "text", "text", "uuid", boolean, "text", boolean, "uuid") OWNER TO "postgres";
+REVOKE EXECUTE ON FUNCTION "public"."update_organisation_settings"("uuid", "text", "text", "text", "text", "text", "uuid", boolean, "text", boolean, "uuid") FROM PUBLIC, "anon";
+GRANT EXECUTE ON FUNCTION "public"."update_organisation_settings"("uuid", "text", "text", "text", "text", "text", "uuid", boolean, "text", boolean, "uuid") TO "authenticated", "service_role";
+
+
+CREATE OR REPLACE FUNCTION "public"."get_organisation_detail"(
+    "p_org_id" "uuid",
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_is_admin BOOLEAN;
+    v_org public.organisations%ROWTYPE;
+    v_data JSONB;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    IF NOT public.user_is_org_member(v_actor, p_org_id) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Organisation not found');
+    END IF;
+
+    SELECT * INTO v_org FROM public.organisations o WHERE o.id = p_org_id;
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Organisation not found');
+    END IF;
+
+    v_is_admin := public.user_is_org_admin(v_actor, p_org_id);
+
+    -- Member-visible projection. owner_id is included because the page renders
+    -- "owned by <email>", and ownership is not a secret from the membership.
+    v_data := jsonb_build_object(
+        'id',           v_org.id::text,
+        'slug',         v_org.slug,
+        'name',         v_org.name,
+        'description',  v_org.description,
+        'website',      v_org.website,
+        'visibility',   v_org.visibility,
+        'join_policy',  v_org.join_policy,
+        'is_system',    v_org.is_system,
+        'created_at',   v_org.created_at,
+        'owner_id',     v_org.owner_id::text,
+        'owner_email',  (SELECT u.email FROM auth.users u WHERE u.id = v_org.owner_id),
+        'member_count', (SELECT count(*) FROM public.organisation_members m
+                          WHERE m.org_id = p_org_id AND m.status = 'active'),
+        'pending_count', (SELECT count(*) FROM public.organisation_members m
+                           WHERE m.org_id = p_org_id AND m.status = 'pending'),
+        'primary_domain', (SELECT d.domain FROM public.organisation_domains d
+                            WHERE d.org_id = p_org_id AND d.is_primary AND d.verified LIMIT 1),
+        'is_owner',     (v_org.owner_id = v_actor),
+        'is_admin',     v_is_admin,
+        'can_publish',  public.user_can_publish_org_plugin(v_actor, p_org_id));
+
+    -- Admin-only settings. Merged in rather than emitted as NULLs: a member's
+    -- response simply does not carry these keys.
+    IF v_is_admin THEN
+        v_data := v_data || jsonb_build_object(
+            'publish_policy',          v_org.publish_policy,
+            'publish_role_id',         v_org.publish_role_id::text,
+            'publish_role_name',       (SELECT r.name FROM public.roles r
+                                         WHERE r.id = v_org.publish_role_id),
+            'auto_assign_member_role', v_org.auto_assign_member_role,
+            'max_custom_roles',        v_org.max_custom_roles,
+            'custom_role_count',       (SELECT count(*) FROM public.organisation_roles orl
+                                         WHERE orl.org_id = p_org_id AND orl.kind = 'custom'),
+            'plugin_count',            (SELECT count(*) FROM public.plugins p
+                                         WHERE p.org_id = p_org_id));
+    END IF;
+
+    RETURN jsonb_build_object('success', true, 'data', v_data);
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION "public"."get_my_organisations"(
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_rows JSONB;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    SELECT COALESCE(jsonb_agg(row_to_json(t)::jsonb), '[]'::jsonb)
+      INTO v_rows
+      FROM (
+        SELECT o.id, o.slug, o.name, o.description, o.website, o.visibility, o.join_policy,
+               o.publish_policy, o.is_system,
+               m.status, m.joined_at,
+               (o.owner_id = v_actor) AS is_owner,
+               public.user_is_org_admin(v_actor, o.id) AS is_admin,
+               public.user_can_publish_org_plugin(v_actor, o.id) AS can_publish,
+               (SELECT count(*) FROM public.organisation_members mm
+                 WHERE mm.org_id = o.id AND mm.status = 'active') AS member_count,
+               -- AND d.verified: its two siblings (search_organisations,
+               -- get_organisation_detail) both filter on it and this one had drifted, so a bare
+               -- unverified claim surfaced as the organisation's domain in the desktop list.
+               (SELECT d.domain FROM public.organisation_domains d
+                 WHERE d.org_id = o.id AND d.is_primary AND d.verified LIMIT 1) AS primary_domain,
+               COALESCE((
+                   SELECT array_agg(r.name ORDER BY r.name)
+                   FROM public.user_roles ur
+                   JOIN public.organisation_roles orl
+                     ON orl.role_id = ur.role_id AND orl.org_id = o.id
+                   JOIN public.roles r ON r.id = ur.role_id
+                   WHERE ur.user_id = v_actor
+               ), ARRAY[]::text[]) AS my_roles
+        FROM public.organisation_members m
+        JOIN public.organisations o ON o.id = m.org_id
+        WHERE m.user_id = v_actor
+        ORDER BY o.is_system DESC, o.name
+      ) t;
+
+    RETURN jsonb_build_object('success', true, 'data', v_rows);
+END;
+$$;

--- a/supabase/migrations/20260808000000_organisation_website_validation.sql
+++ b/supabase/migrations/20260808000000_organisation_website_validation.sql
@@ -1,0 +1,317 @@
+-- ============================================================================
+-- BOSS Database Schema: validate the website on every write path
+--
+-- File: 20260808000000_organisation_website_validation.sql
+--
+-- 20260807000000's header claimed the scheme restriction was applied "in the
+-- column and again in the RPC". That was true of submit_organisation_request and
+-- NOT of update_organisation_settings - which is the path an administrator
+-- actually uses, while submit is the one a person uses once.
+--
+-- The consequence was worse than a missing message. The only remaining guard was
+-- organisations_website_check, which raises 23514 and ABORTS THE WHOLE UPDATE, so
+-- a mistyped website silently discarded the name, description, visibility, join
+-- policy, publish policy and the auto-assign checkbox in the same submission -
+-- and the page could only render "The change was refused", naming no field.
+-- Reproduced before fixing: typing "zed.example" into the settings form raised
+-- the constraint out of the function rather than returning an error object.
+--
+-- The check now lives in one place both RPCs call, so the two cannot drift again,
+-- and create_organisation_internal re-checks on the write path for the same
+-- reason the domain right above it does.
+-- ============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- One definition of what a website may be
+-- ---------------------------------------------------------------------------
+-- Returns the message to show, or NULL when the value is acceptable. NULL input
+-- is acceptable: the field is optional everywhere.
+--
+-- IMMUTABLE and STRICT-free on purpose - it must return NULL for NULL input
+-- rather than being skipped, so callers can pass an unset value straight through.
+CREATE OR REPLACE FUNCTION "public"."validate_website"("p_website" "text")
+RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+    IF p_website IS NULL OR btrim(p_website) = '' THEN
+        RETURN NULL;
+    END IF;
+    -- http and https only. This value is rendered as a link on pages an
+    -- organisation's members read and is supplied by any authenticated user on a
+    -- request, before review, so a javascript: or data: URL here would be stored
+    -- XSS with a self-service entry point.
+    IF btrim(p_website) !~* '^https?://[^[:space:]]+$' THEN
+        RETURN 'Website must be a full http:// or https:// address';
+    END IF;
+    IF length(btrim(p_website)) > 500 THEN
+        RETURN 'Website must be 500 characters or fewer';
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+ALTER FUNCTION "public"."validate_website"("text") OWNER TO "postgres";
+COMMENT ON FUNCTION "public"."validate_website"("text") IS 'Returns the error message for an unacceptable organisation website, or NULL. Shared by submit_organisation_request, update_organisation_settings and create_organisation_internal so the rule cannot drift between the path a requester uses and the one an administrator uses.';
+
+
+CREATE OR REPLACE FUNCTION "public"."submit_organisation_request"(
+    "p_name" "text",
+    "p_slug" "text",
+    "p_description" "text" DEFAULT NULL::"text",
+    "p_domain" "text" DEFAULT NULL::"text",
+    "p_justification" "text" DEFAULT NULL::"text",
+    "p_website" "text" DEFAULT NULL::"text",
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_request_id UUID;
+    v_pending_count INTEGER;
+    v_domain TEXT;
+    v_website TEXT;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    -- A genuinely global permission, so a permission check is the right gate.
+    IF NOT public.user_holds_permission(v_actor, 'organisation.create') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Permission denied');
+    END IF;
+
+    IF p_name IS NULL OR char_length(btrim(p_name)) < 2 OR char_length(btrim(p_name)) > 100 THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Name must be 2-100 characters');
+    END IF;
+
+    IF p_slug IS NULL OR NOT (p_slug ~ '^[a-z][a-z0-9_]{1,30}$') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'Slug must be 2-31 characters, lowercase letters, digits and underscores, starting with a letter');
+    END IF;
+
+    IF public.is_reserved_organisation_slug(p_slug) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Slug "%s" is reserved or already in use', p_slug));
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM public.organisations o WHERE o.slug = p_slug) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('An organisation with slug "%s" already exists', p_slug));
+    END IF;
+
+    -- Three live requests per person is enough for legitimate use and keeps the
+    -- reviewer queue from being floodable.
+    SELECT count(*) INTO v_pending_count
+    FROM public.organisation_requests r
+    WHERE r.requester_id = v_actor AND r.status = 'pending';
+    IF v_pending_count >= 3 THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'You already have 3 pending organisation requests. Withdraw one before submitting another.');
+    END IF;
+
+    IF p_domain IS NOT NULL AND btrim(p_domain) <> '' THEN
+        v_domain := lower(btrim(p_domain));
+        IF NOT (v_domain ~ '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$') THEN
+            RETURN jsonb_build_object('success', false, 'error', 'That is not a valid domain name');
+        END IF;
+        IF EXISTS (SELECT 1 FROM public.reserved_email_domains red WHERE red.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('"%s" is a reserved email domain and cannot be claimed by an organisation', v_domain));
+        END IF;
+        IF EXISTS (SELECT 1 FROM public.organisation_domains d WHERE d.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('Domain "%s" is already claimed by another organisation', v_domain));
+        END IF;
+    END IF;
+
+    -- Validated HERE as well as by the column CHECK, so a typo comes back as a
+    -- sentence rather than a constraint violation the caller cannot read.
+    --
+    -- http and https only. This value is rendered as a link on the organisation
+    -- pages, and a javascript: or data: URL there would be script execution from a
+    -- field any authenticated user can fill in. The renderer refuses those too;
+    -- this is the half that stops one being stored at all.
+    v_website := NULLIF(btrim(COALESCE(p_website, '')), '');
+    IF public.validate_website(v_website) IS NOT NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', public.validate_website(v_website));
+    END IF;
+
+    BEGIN
+        INSERT INTO public.organisation_requests (
+            requester_id, name, slug, description, domain, justification, website, status
+        ) VALUES (
+            v_actor, btrim(p_name), p_slug, p_description, v_domain, p_justification, v_website, 'pending'
+        ) RETURNING id INTO v_request_id;
+    EXCEPTION WHEN unique_violation THEN
+        -- idx_organisation_requests_pending_slug
+        RETURN jsonb_build_object('success', false, 'error',
+            format('A pending request for slug "%s" already exists', p_slug));
+    END;
+
+    RETURN jsonb_build_object('success', true, 'request_id', v_request_id::text, 'status', 'pending');
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION "public"."update_organisation_settings"(
+    "p_org_id" "uuid",
+    "p_name" "text" DEFAULT NULL::"text",
+    "p_description" "text" DEFAULT NULL::"text",
+    "p_visibility" "text" DEFAULT NULL::"text",
+    "p_join_policy" "text" DEFAULT NULL::"text",
+    "p_publish_policy" "text" DEFAULT NULL::"text",
+    "p_publish_role_id" "uuid" DEFAULT NULL::"uuid",
+    "p_clear_publish_role" boolean DEFAULT false,
+    "p_website" "text" DEFAULT NULL::"text",
+    "p_auto_assign_member_role" boolean DEFAULT NULL::boolean,
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    IF NOT public.user_is_org_admin(v_actor, p_org_id) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Permission denied');
+    END IF;
+
+    IF p_visibility IS NOT NULL AND p_visibility NOT IN ('private', 'public') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'visibility must be private or public');
+    END IF;
+
+    IF p_join_policy IS NOT NULL AND p_join_policy NOT IN ('invite_only', 'request_to_join', 'open') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'join_policy must be invite_only, request_to_join or open');
+    END IF;
+
+    IF p_publish_policy IS NOT NULL AND p_publish_policy NOT IN ('owner_only', 'admins', 'members') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'publish_policy must be owner_only, admins or members');
+    END IF;
+
+    -- A publish role must be one of THIS organisation's roles, or an organisation
+    -- admin could delegate publishing to the holders of an arbitrary global role.
+    IF p_publish_role_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM public.organisation_roles orl
+        WHERE orl.org_id = p_org_id AND orl.role_id = p_publish_role_id
+    ) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'The publish role must belong to this organisation');
+    END IF;
+
+    IF p_name IS NOT NULL AND (char_length(btrim(p_name)) < 2 OR char_length(btrim(p_name)) > 100) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Name must be 2-100 characters');
+    END IF;
+
+    -- Checked BEFORE the UPDATE. Without this the only guard was the column CHECK,
+    -- which raises 23514 and aborts the WHOLE statement - so a mistyped website
+    -- silently discarded the name, description, visibility, join policy, publish
+    -- policy and the auto-assign checkbox with it, and the page could only say
+    -- "the change was refused". This is the path an administrator actually uses;
+    -- submit_organisation_request is the one a person uses once.
+    IF public.validate_website(NULLIF(btrim(COALESCE(p_website, '')), '')) IS NOT NULL THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            public.validate_website(NULLIF(btrim(COALESCE(p_website, '')), '')));
+    END IF;
+
+    UPDATE public.organisations
+       SET name           = COALESCE(btrim(p_name), name),
+           -- NULLIF(p_description, '') is NOT what is wanted here: an empty string is the
+           -- caller explicitly CLEARING the description, and COALESCE would then keep the old
+           -- one. Empty means empty; only a SQL NULL means leave unchanged.
+           description    = CASE WHEN p_description IS NULL THEN description
+                                 WHEN btrim(p_description) = '' THEN NULL
+                                 ELSE p_description END,
+           -- Same empty-means-empty rule the description uses: an empty string
+           -- CLEARS the website, and only a SQL NULL leaves it alone.
+           website        = CASE WHEN p_website IS NULL THEN website
+                                 WHEN btrim(p_website) = '' THEN NULL
+                                 ELSE btrim(p_website) END,
+           visibility     = COALESCE(p_visibility, visibility),
+           join_policy    = COALESCE(p_join_policy, join_policy),
+           publish_policy = COALESCE(p_publish_policy, publish_policy),
+           -- COALESCE alone can never set a column back to NULL, so "revert to
+           -- publish_policy" needs its own explicit signal.
+           publish_role_id = CASE WHEN p_clear_publish_role THEN NULL
+                                  ELSE COALESCE(p_publish_role_id, publish_role_id) END,
+           auto_assign_member_role = COALESCE(p_auto_assign_member_role, auto_assign_member_role),
+           updated_at = now()
+     WHERE id = p_org_id;
+
+    RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- An approver must be able to see the website they are approving
+-- ---------------------------------------------------------------------------
+-- The whole threat model here is that any authenticated user supplies this value
+-- and it ends up as a link on a page other members read. Review is the control
+-- that stands between those two facts, and the queue was not showing the field.
+
+CREATE OR REPLACE FUNCTION "public"."list_organisation_requests"(
+    "p_status" "text" DEFAULT NULL::"text",
+    "p_limit" integer DEFAULT 50,
+    "p_offset" integer DEFAULT 0,
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_is_reviewer BOOLEAN;
+    v_rows JSONB;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    v_is_reviewer := public.user_holds_permission(v_actor, 'organisation.approve');
+
+    SELECT COALESCE(jsonb_agg(row_to_json(t)::jsonb), '[]'::jsonb)
+      INTO v_rows
+      FROM (
+        SELECT r.id, r.requester_id, ru.email AS requester_email,
+               r.name, r.slug, r.description, r.domain, r.website, r.justification,
+               r.status, r.reviewer_id, vu.email AS reviewer_email,
+               r.review_notes, r.reviewed_at, r.created_org_id, r.created_at
+        FROM public.organisation_requests r
+        LEFT JOIN auth.users ru ON ru.id = r.requester_id
+        LEFT JOIN auth.users vu ON vu.id = r.reviewer_id
+        WHERE (v_is_reviewer OR r.requester_id = v_actor)
+          AND (p_status IS NULL OR r.status = p_status)
+        ORDER BY r.created_at DESC
+        LIMIT GREATEST(LEAST(COALESCE(p_limit, 50), 200), 1)
+        OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+      ) t;
+
+    RETURN jsonb_build_object('success', true, 'is_reviewer', v_is_reviewer, 'data', v_rows);
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- Comments DROP FUNCTION removed in 20260807000000
+-- ---------------------------------------------------------------------------
+-- DROP takes the COMMENT with it as well as the grants. 20260807000000 re-applied
+-- the grants and re-added submit_organisation_request's comment, and silently lost
+-- these two - including the "service_role ONLY" warning, which is the one a reader
+-- most needs.
+COMMENT ON FUNCTION "public"."create_organisation_internal"("text", "text", "text", "uuid", "text", "text", "text", boolean, "text", "text", boolean, "text") IS 'Creates an organisation with its two roles, the founder membership and an optional unverified domain. service_role ONLY: it accepts an arbitrary owner id and performs no authorisation of its own, so every caller must have established the actor first.';
+
+COMMENT ON FUNCTION "public"."update_organisation_settings"("uuid", "text", "text", "text", "text", "text", "uuid", boolean, "text", boolean, "uuid") IS 'Updates an organisation''s settings. Organisation admins only, re-derived server-side. An empty string CLEARS description and website; a SQL NULL leaves them unchanged.';

--- a/supabase/migrations/20260808000000_organisation_website_validation.sql
+++ b/supabase/migrations/20260808000000_organisation_website_validation.sql
@@ -54,6 +54,13 @@ END;
 $$;
 
 ALTER FUNCTION "public"."validate_website"("text") OWNER TO "postgres";
+-- Every other helper in this schema pairs the OWNER with an explicit REVOKE and
+-- GRANT (organisation_role_name and is_reserved_organisation_slug both do in
+-- 20260801010000). Without them this defaults to PUBLIC and is anon-callable
+-- through PostgREST. The impact is nil - it is pure and touches no data - but the
+-- convention is what makes an exception visible.
+REVOKE EXECUTE ON FUNCTION "public"."validate_website"("text") FROM PUBLIC, "anon";
+GRANT EXECUTE ON FUNCTION "public"."validate_website"("text") TO "authenticated", "service_role";
 COMMENT ON FUNCTION "public"."validate_website"("text") IS 'Returns the error message for an unacceptable organisation website, or NULL. Shared by submit_organisation_request, update_organisation_settings and create_organisation_internal so the rule cannot drift between the path a requester uses and the one an administrator uses.';
 
 
@@ -75,6 +82,7 @@ DECLARE
     v_pending_count INTEGER;
     v_domain TEXT;
     v_website TEXT;
+    v_website_error TEXT;
 BEGIN
     v_actor := public.resolve_org_actor(p_actor_id);
     IF v_actor IS NULL THEN
@@ -138,8 +146,9 @@ BEGIN
     -- field any authenticated user can fill in. The renderer refuses those too;
     -- this is the half that stops one being stored at all.
     v_website := NULLIF(btrim(COALESCE(p_website, '')), '');
-    IF public.validate_website(v_website) IS NOT NULL THEN
-        RETURN jsonb_build_object('success', false, 'error', public.validate_website(v_website));
+    v_website_error := public.validate_website(v_website);
+    IF v_website_error IS NOT NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', v_website_error);
     END IF;
 
     BEGIN
@@ -176,6 +185,7 @@ CREATE OR REPLACE FUNCTION "public"."update_organisation_settings"(
     SET "search_path" TO ''
     AS $$
 DECLARE
+    v_website_error TEXT;
     v_actor UUID;
 BEGIN
     v_actor := public.resolve_org_actor(p_actor_id);
@@ -221,9 +231,9 @@ BEGIN
     -- policy and the auto-assign checkbox with it, and the page could only say
     -- "the change was refused". This is the path an administrator actually uses;
     -- submit_organisation_request is the one a person uses once.
-    IF public.validate_website(NULLIF(btrim(COALESCE(p_website, '')), '')) IS NOT NULL THEN
-        RETURN jsonb_build_object('success', false, 'error',
-            public.validate_website(NULLIF(btrim(COALESCE(p_website, '')), '')));
+    v_website_error := public.validate_website(NULLIF(btrim(COALESCE(p_website, '')), ''));
+    IF v_website_error IS NOT NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', v_website_error);
     END IF;
 
     UPDATE public.organisations

--- a/supabase/migrations/20260808000000_organisation_website_validation.sql
+++ b/supabase/migrations/20260808000000_organisation_website_validation.sql
@@ -266,6 +266,229 @@ $$;
 
 
 -- ---------------------------------------------------------------------------
+-- create_organisation_internal re-checks on the write path
+-- ---------------------------------------------------------------------------
+-- The header above claimed this and the first version did not do it. Same
+-- signature as 20260807000000, so CREATE OR REPLACE keeps the grants.
+
+CREATE OR REPLACE FUNCTION "public"."create_organisation_internal"(
+    "p_slug" "text",
+    "p_name" "text",
+    "p_description" "text" DEFAULT NULL::"text",
+    "p_owner_id" "uuid" DEFAULT NULL::"uuid",
+    "p_domain" "text" DEFAULT NULL::"text",
+    "p_visibility" "text" DEFAULT 'private'::"text",
+    "p_join_policy" "text" DEFAULT 'invite_only'::"text",
+    "p_is_system" boolean DEFAULT false,
+    "p_admin_role_name" "text" DEFAULT NULL::"text",
+    "p_user_role_name" "text" DEFAULT NULL::"text",
+    "p_auto_assign_member_role" boolean DEFAULT true,
+    "p_website" "text" DEFAULT NULL::"text"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_org_id UUID;
+    v_admin_name TEXT;
+    v_user_name TEXT;
+    v_admin_role_id UUID;
+    v_user_role_id UUID;
+    v_base_role_id UUID;
+    v_domain TEXT;
+    v_website TEXT;
+    v_website_error TEXT;
+    v_token TEXT;
+BEGIN
+    IF p_owner_id IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'An owner is required');
+    END IF;
+
+    IF p_slug IS NULL OR NOT (p_slug ~ '^[a-z][a-z0-9_]{1,30}$') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'Slug must be 2-31 characters, lowercase letters, digits and underscores, starting with a letter');
+    END IF;
+
+    IF p_visibility NOT IN ('private', 'public') THEN
+        RETURN jsonb_build_object('success', false, 'error', 'visibility must be private or public');
+    END IF;
+
+    IF p_join_policy NOT IN ('invite_only', 'request_to_join', 'open') THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'join_policy must be invite_only, request_to_join or open');
+    END IF;
+
+    -- p_is_system bypasses the reserved-slug check. Only the boss-org seed passes
+    -- it, and only because 'boss' is on the reserved list precisely BECAUSE of the
+    -- boss_admin collision -- which the seed sidesteps by passing explicit
+    -- boss_org_* role names.
+    IF NOT p_is_system AND public.is_reserved_organisation_slug(p_slug) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Slug "%s" is reserved, or its role names (%s, %s) are already taken',
+                   p_slug,
+                   public.organisation_role_name(p_slug, 'admin'),
+                   public.organisation_role_name(p_slug, 'user')));
+    END IF;
+
+    v_admin_name := COALESCE(p_admin_role_name, public.organisation_role_name(p_slug, 'admin'));
+    v_user_name  := COALESCE(p_user_role_name,  public.organisation_role_name(p_slug, 'user'));
+
+    -- Re-check the derived names even for a system organisation. This is the H2
+    -- guard on the write path: mapping an EXISTING role (which could be a global
+    -- system role such as boss_admin) into organisation_roles is the escalation.
+    IF EXISTS (SELECT 1 FROM public.roles r WHERE r.name IN (v_admin_name, v_user_name)) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('Role name "%s" or "%s" already exists', v_admin_name, v_user_name));
+    END IF;
+
+    -- public.roles.name is validated ^[a-z][a-z0-9_]{2,50}$ by create_new_role;
+    -- enforce the length here too so a 31-character slug cannot produce a
+    -- 37-character name that a later role RPC would reject.
+    IF char_length(v_admin_name) > 50 OR char_length(v_user_name) > 50 THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Slug is too long for the derived role names');
+    END IF;
+
+    -- The optional domain claim is validated HERE, before the first INSERT, and
+    -- the placement is the whole point.
+    --
+    -- A plain RETURN from PL/pgSQL is a normal return: it rolls back NOTHING.
+    -- Only a propagating exception aborts the transaction. These two checks used
+    -- to sit at step 8, after the organisation, both roles, the hierarchy edges,
+    -- the permission grants, the founder membership and the founder user_roles
+    -- row had all been inserted -- so a refused domain returned success:false
+    -- while all eight inserts committed. That left an orphan organisation nothing
+    -- pointed at, silently owned by the requester, and because the slug was now
+    -- taken the originating request could never be approved on a retry.
+    --
+    -- Reachable in normal operation: two pending requests naming the same domain,
+    -- or a domain added to reserved_email_domains between submit and approve.
+    -- submit_organisation_request checks the domain too, but that check is a
+    -- TOCTOU, which is exactly why the re-check exists.
+    IF p_domain IS NOT NULL AND btrim(p_domain) <> '' THEN
+        v_domain := lower(btrim(p_domain));
+
+        IF EXISTS (SELECT 1 FROM public.reserved_email_domains red WHERE red.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('"%s" is a reserved email domain and cannot be claimed by an organisation', v_domain));
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM public.organisation_domains d WHERE d.domain = v_domain) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                format('Domain "%s" is already claimed by another organisation', v_domain));
+        END IF;
+    END IF;
+
+    -- Re-checked on the write path, for the same reason the domain below is: this
+    -- function is service_role-callable directly, and its own comment says that is
+    -- the supported use. Today every caller passes a value that already cleared an
+    -- identical CHECK on organisation_requests, but that is a coincidence of two
+    -- textually identical predicates - and without this, a direct caller gets a
+    -- raw 23514 propagating out of approve_organisation_request as an unhandled
+    -- exception instead of the {success:false,error} object every other refusal
+    -- there returns.
+    v_website := NULLIF(btrim(COALESCE(p_website, '')), '');
+    v_website_error := public.validate_website(v_website);
+    IF v_website_error IS NOT NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', v_website_error);
+    END IF;
+
+    -- 1. The organisation.
+    BEGIN
+        INSERT INTO public.organisations (
+            slug, name, description, visibility, join_policy,
+            owner_id, created_by, is_system, auto_assign_member_role, website
+        ) VALUES (
+            p_slug, btrim(p_name), p_description, p_visibility, p_join_policy,
+            p_owner_id, p_owner_id, p_is_system, p_auto_assign_member_role,
+            v_website
+        ) RETURNING id INTO v_org_id;
+    EXCEPTION WHEN unique_violation THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('An organisation with slug "%s" already exists', p_slug));
+    END;
+
+    -- 2. The two roles. is_system = false is REQUIRED: enforce_org_role_not_system
+    --    refuses to map a system role, and delete_role refuses to delete one, so a
+    --    system-flagged organisation role would be both unmappable and uncleanable.
+    INSERT INTO public.roles (name, description, is_system)
+    VALUES (v_admin_name, format('Administrators of the "%s" organisation', btrim(p_name)), false)
+    RETURNING id INTO v_admin_role_id;
+
+    INSERT INTO public.roles (name, description, is_system)
+    VALUES (v_user_name, format('Members of the "%s" organisation', btrim(p_name)), false)
+    RETURNING id INTO v_user_role_id;
+
+    -- 3. The mapping that makes them organisation roles.
+    INSERT INTO public.organisation_roles (org_id, role_id, kind, created_by) VALUES
+        (v_org_id, v_admin_role_id, 'admin', p_owner_id),
+        (v_org_id, v_user_role_id,  'user',  p_owner_id);
+
+    -- 4. Hierarchy: <slug>_admin -> <slug>_user -> user.
+    --    The second edge is what H3 is about: it puts the global `user` role in an
+    --    organisation admin's get_grantable_role_ids. That is rendered inert by
+    --    enforce_org_role_permission_scope, which makes role.* / user.* /
+    --    api_key.* / plugins.admin.* un-grantable to any organisation role.
+    SELECT r.id INTO v_base_role_id FROM public.roles r WHERE r.name = 'user';
+
+    INSERT INTO public.role_hierarchy (parent_role_id, child_role_id)
+    VALUES (v_admin_role_id, v_user_role_id)
+    ON CONFLICT DO NOTHING;
+
+    IF v_base_role_id IS NOT NULL THEN
+        INSERT INTO public.role_hierarchy (parent_role_id, child_role_id)
+        VALUES (v_user_role_id, v_base_role_id)
+        ON CONFLICT DO NOTHING;
+    END IF;
+
+    -- 5. Permissions. All of these pass is_org_grantable_permission's allowlist.
+    INSERT INTO public.role_permissions (role_id, permission_id)
+    SELECT v_admin_role_id, p.id FROM public.permissions p
+    WHERE p.name IN ('organisation.admin', 'organisation.read')
+    ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+    INSERT INTO public.role_permissions (role_id, permission_id)
+    SELECT v_user_role_id, p.id FROM public.permissions p
+    WHERE p.name = 'organisation.read'
+    ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+    -- 6. Founder membership.
+    INSERT INTO public.organisation_members (org_id, user_id, status, joined_at, join_source)
+    VALUES (v_org_id, p_owner_id, 'active', now(), 'founder')
+    ON CONFLICT (org_id, user_id) DO NOTHING;
+
+    -- 7. The founder holds the admin role. assigned_by is NULL: a system
+    --    assignment, matching handle_new_user's convention for the base role.
+    INSERT INTO public.user_roles (user_id, role_id, assigned_by, assigned_at)
+    VALUES (p_owner_id, v_admin_role_id, NULL, now())
+    ON CONFLICT (user_id, role_id) DO NOTHING;
+
+    -- 8. Optional unverified domain claim. Already validated above, before the
+    --    first INSERT, so nothing here can return a failure after committing rows.
+    --    The unique index on organisation_domains.domain is the backstop for a
+    --    concurrent claim landing between that check and this insert; it RAISES,
+    --    which does roll the transaction back.
+    IF p_domain IS NOT NULL AND btrim(p_domain) <> '' THEN
+        -- URL-safe: translate()'s 3-character FROM against a 2-character TO also
+        -- DELETES the '=' padding.
+        v_token := translate(
+            pg_catalog.encode(extensions.gen_random_bytes(24), 'base64'), '+/=', '-_');
+
+        INSERT INTO public.organisation_domains (
+            org_id, domain, is_primary, verification_token, created_by
+        ) VALUES (v_org_id, v_domain, true, v_token, p_owner_id);
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'org_id', v_org_id::text,
+        'slug', p_slug,
+        'admin_role', v_admin_name,
+        'user_role', v_user_name);
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
 -- An approver must be able to see the website they are approving
 -- ---------------------------------------------------------------------------
 -- The whole threat model here is that any authenticated user supplies this value

--- a/supabase/tests/boss_org_member_role_test.sql
+++ b/supabase/tests/boss_org_member_role_test.sql
@@ -20,7 +20,7 @@
 -- the first thing below.
 
 begin;
-select plan(11);
+select plan(13);
 
 -- ---------------------------------------------------------------------------
 -- Fixtures: the boss organisation has to exist, or every assertion here is vacuous
@@ -212,6 +212,50 @@ select is(
        join public.organisations o on o.id = m.org_id
       where o.slug = 'boss' and m.status = 'active'),
     're-running the backfill changes nothing'
+);
+
+-- ===========================================================================
+-- The repair clears a tie that already exists
+-- ===========================================================================
+-- The assertions above prove a tie cannot be CREATED any more. They say nothing
+-- about the rows written between 20260806000000 and 20260806010000, whose tie is
+-- permanent and leaves primary_role plan-dependent for the life of the row.
+--
+-- Recreate that state by hand - set the organisation role's assigned_at back onto
+-- its peer - then run 20260806020000's statement verbatim.
+update public.user_roles ur
+   set assigned_at = peer.assigned_at
+  from public.user_roles peer,
+       public.organisation_roles orl,
+       public.roles r
+ where ur.user_id = '70000000-0000-0000-0000-000000000002'
+   and orl.role_id = ur.role_id and orl.kind = 'user'
+   and peer.user_id = ur.user_id and peer.role_id = r.id and r.name = 'user';
+
+select is(
+    (select count(distinct assigned_at)::int from public.user_roles
+      where user_id = '70000000-0000-0000-0000-000000000002'),
+    1,
+    'the historical tie is reproducible, so the repair below is not vacuous'
+);
+
+update public.user_roles ur
+   set assigned_at = ur.assigned_at + interval '1 microsecond'
+  from public.organisation_roles orl
+ where orl.role_id = ur.role_id
+   and orl.kind = 'user'
+   and exists (
+       select 1 from public.user_roles peer
+        where peer.user_id = ur.user_id
+          and peer.role_id <> ur.role_id
+          and peer.assigned_at = ur.assigned_at
+   );
+
+select is(
+    (select count(distinct assigned_at)::int from public.user_roles
+      where user_id = '70000000-0000-0000-0000-000000000002'),
+    2,
+    'the repair clears an existing tie, and moves the organisation role later'
 );
 
 select * from finish();

--- a/supabase/tests/boss_org_member_role_test.sql
+++ b/supabase/tests/boss_org_member_role_test.sql
@@ -20,7 +20,7 @@
 -- the first thing below.
 
 begin;
-select plan(9);
+select plan(11);
 
 -- ---------------------------------------------------------------------------
 -- Fixtures: the boss organisation has to exist, or every assertion here is vacuous
@@ -83,6 +83,32 @@ select ok(
     ),
     'the global user role is still assigned alongside it'
 );
+
+-- ===========================================================================
+-- The assigned_at tie that primary_role rides on
+-- ===========================================================================
+-- handle_new_user assigns the global `user` role and then calls the helper, both
+-- inside one transaction. now() is transaction_timestamp() and does not advance,
+-- so before 20260806010000 both rows landed with an identical assigned_at.
+--
+-- get_user_roles_for_hook aggregates ORDER BY assigned_at and the token hook takes
+-- element 1 as primary_role. A tie makes that claim plan-dependent, so a signup
+-- could report its role as boss_org_user. Not an escalation - permissions come
+-- from the full array - but nondeterministic and displayed.
+select is(
+    (select count(distinct ur.assigned_at)::int
+       from public.user_roles ur
+      where ur.user_id = '70000000-0000-0000-0000-000000000002'),
+    2,
+    'the two roles a signup receives have distinct assigned_at, so the sort has no tie'
+);
+
+select is(
+    (select (public.get_user_roles_for_hook('70000000-0000-0000-0000-000000000002'))[1]),
+    'user',
+    'the global user role sorts first, so primary_role is deterministic'
+);
+
 
 -- ===========================================================================
 -- The flag is what drives it, not a hardcoded organisation name

--- a/supabase/tests/boss_org_member_role_test.sql
+++ b/supabase/tests/boss_org_member_role_test.sql
@@ -1,0 +1,192 @@
+-- pgTAP tests for the boss organisation's member role (migration 20260806000000).
+-- Run with: supabase test db
+--
+-- The migration has four parts and three of them are load-bearing in a way that
+-- reading the SQL does not reveal:
+--
+--   * The UPDATE that sets the flag runs against an organisation that does not
+--     exist yet on a fresh deployment, so it reports success against zero rows.
+--     ensure_boss_organisation() is what actually decides the value there, and it
+--     hardcoded false - so the UPDATE alone was silently undone by the next reset.
+--   * handle_new_user inserts the membership row DIRECTLY and never called
+--     assign_org_member_role_internal, so the flag alone changed nothing for a new
+--     signup. Every other entry path went through the helper; this one did not.
+--   * The backfill must not reach a pending or invited row, or it hands out
+--     organisation standing that the approval step exists to gate.
+--
+-- The whole suite otherwise runs against a database with NO users, where the boss
+-- organisation does not exist and this entire code path is skipped - so a green
+-- run proves nothing about it unless the organisation is created first, which is
+-- the first thing below.
+
+begin;
+select plan(9);
+
+-- ---------------------------------------------------------------------------
+-- Fixtures: the boss organisation has to exist, or every assertion here is vacuous
+-- ---------------------------------------------------------------------------
+insert into auth.users (id, email, email_confirmed_at) values
+    ('70000000-0000-0000-0000-000000000001', 'bossfounder@pgtap.test', now());
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+-- The documented recovery path, and what a fresh deployment runs.
+select ok(
+    (public.ensure_boss_organisation() ->> 'success')::boolean,
+    'the boss organisation can be created'
+);
+
+-- ===========================================================================
+-- The flag survives creation
+-- ===========================================================================
+select is(
+    (select auto_assign_member_role from public.organisations where slug = 'boss'),
+    true,
+    'ensure_boss_organisation creates the boss organisation with auto-assign ON'
+);
+
+-- ===========================================================================
+-- A new signup receives the organisation role
+-- ===========================================================================
+insert into auth.users (id, email, email_confirmed_at) values
+    ('70000000-0000-0000-0000-000000000002', 'bossjoiner@pgtap.test', now());
+
+select is(
+    (select m.status
+       from public.organisation_members m
+       join public.organisations o on o.id = m.org_id
+      where o.slug = 'boss' and m.user_id = '70000000-0000-0000-0000-000000000002'),
+    'active',
+    'a new signup becomes an active member of the boss organisation'
+);
+
+select ok(
+    exists (
+        select 1
+          from public.user_roles ur
+          join public.organisation_roles orl on orl.role_id = ur.role_id
+          join public.organisations o on o.id = orl.org_id
+         where o.slug = 'boss'
+           and orl.kind = 'user'
+           and ur.user_id = '70000000-0000-0000-0000-000000000002'
+    ),
+    'a new signup is assigned the boss organisation user role'
+);
+
+-- The global role is still assigned. The organisation role is in addition to it,
+-- never instead of it - the baseline permissions ride on `user`.
+select ok(
+    exists (
+        select 1 from public.user_roles ur
+          join public.roles r on r.id = ur.role_id
+         where r.name = 'user' and ur.user_id = '70000000-0000-0000-0000-000000000002'
+    ),
+    'the global user role is still assigned alongside it'
+);
+
+-- ===========================================================================
+-- The flag is what drives it, not a hardcoded organisation name
+-- ===========================================================================
+update public.organisations set auto_assign_member_role = false where slug = 'boss';
+
+insert into auth.users (id, email, email_confirmed_at) values
+    ('70000000-0000-0000-0000-000000000003', 'bossoptout@pgtap.test', now());
+
+select ok(
+    not exists (
+        select 1
+          from public.user_roles ur
+          join public.organisation_roles orl on orl.role_id = ur.role_id
+          join public.organisations o on o.id = orl.org_id
+         where o.slug = 'boss' and orl.kind = 'user'
+           and ur.user_id = '70000000-0000-0000-0000-000000000003'
+    ),
+    'turning the flag off stops the assignment immediately'
+);
+
+update public.organisations set auto_assign_member_role = true where slug = 'boss';
+
+-- ===========================================================================
+-- The backfill
+-- ===========================================================================
+-- ORDER MATTERS HERE. The signup trigger assigns the role on INSERT, while the
+-- membership is still active, so creating the pending user after the delete would
+-- hand them the role via the trigger and the assertion below would be measuring
+-- the fixture instead of the backfill. Create first, demote, then strip.
+insert into auth.users (id, email, email_confirmed_at) values
+    ('70000000-0000-0000-0000-000000000004', 'bosspending@pgtap.test', now());
+update public.organisation_members m
+   set status = 'pending'
+  from public.organisations o
+ where o.id = m.org_id and o.slug = 'boss'
+   and m.user_id = '70000000-0000-0000-0000-000000000004';
+
+-- Strip the role from everyone, which is the state production was in before the
+-- migration, then run the migration's statement verbatim.
+delete from public.user_roles ur
+ using public.organisation_roles orl
+  join public.organisations o on o.id = orl.org_id
+ where ur.role_id = orl.role_id and o.slug = 'boss' and orl.kind = 'user';
+
+insert into public.user_roles (user_id, role_id, assigned_by, assigned_at)
+select m.user_id, orl.role_id, null, now()
+  from public.organisation_members m
+  join public.organisations o
+    on o.id = m.org_id and o.slug = 'boss' and o.is_system
+  join public.organisation_roles orl
+    on orl.org_id = o.id and orl.kind = 'user'
+ where m.status = 'active'
+on conflict (user_id, role_id) do nothing;
+
+select is(
+    (select count(*)::int
+       from public.user_roles ur
+       join public.organisation_roles orl on orl.role_id = ur.role_id
+       join public.organisations o on o.id = orl.org_id
+      where o.slug = 'boss' and orl.kind = 'user'),
+    (select count(*)::int
+       from public.organisation_members m
+       join public.organisations o on o.id = m.org_id
+      where o.slug = 'boss' and m.status = 'active'),
+    'the backfill assigns the role to exactly the active members'
+);
+
+select ok(
+    not exists (
+        select 1
+          from public.user_roles ur
+          join public.organisation_roles orl on orl.role_id = ur.role_id
+          join public.organisations o on o.id = orl.org_id
+         where o.slug = 'boss' and orl.kind = 'user'
+           and ur.user_id = '70000000-0000-0000-0000-000000000004'
+    ),
+    'the backfill does not reach a member who is still pending approval'
+);
+
+-- Re-running must be inert: the migration can be applied to an environment where
+-- the seed or a previous run already did the work.
+insert into public.user_roles (user_id, role_id, assigned_by, assigned_at)
+select m.user_id, orl.role_id, null, now()
+  from public.organisation_members m
+  join public.organisations o
+    on o.id = m.org_id and o.slug = 'boss' and o.is_system
+  join public.organisation_roles orl
+    on orl.org_id = o.id and orl.kind = 'user'
+ where m.status = 'active'
+on conflict (user_id, role_id) do nothing;
+
+select is(
+    (select count(*)::int
+       from public.user_roles ur
+       join public.organisation_roles orl on orl.role_id = ur.role_id
+       join public.organisations o on o.id = orl.org_id
+      where o.slug = 'boss' and orl.kind = 'user'),
+    (select count(*)::int
+       from public.organisation_members m
+       join public.organisations o on o.id = m.org_id
+      where o.slug = 'boss' and m.status = 'active'),
+    're-running the backfill changes nothing'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/boss_org_member_role_test.sql
+++ b/supabase/tests/boss_org_member_role_test.sql
@@ -20,7 +20,7 @@
 -- the first thing below.
 
 begin;
-select plan(13);
+select plan(14);
 
 -- ---------------------------------------------------------------------------
 -- Fixtures: the boss organisation has to exist, or every assertion here is vacuous
@@ -255,7 +255,17 @@ select is(
     (select count(distinct assigned_at)::int from public.user_roles
       where user_id = '70000000-0000-0000-0000-000000000002'),
     2,
-    'the repair clears an existing tie, and moves the organisation role later'
+    'the repair clears an existing tie'
+);
+
+-- Direction, not just distinctness. Nudging the ORGANISATION row rather than its
+-- peer is the whole point: `user` has to stay first, because the token hook takes
+-- element 1 as primary_role. count(distinct) = 2 would also hold if the repair had
+-- moved the wrong row.
+select is(
+    (public.get_user_roles_for_hook('70000000-0000-0000-0000-000000000002'))[1],
+    'user',
+    'and moves the ORGANISATION role later, so primary_role is still user'
 );
 
 select * from finish();

--- a/supabase/tests/organisation_requests_test.sql
+++ b/supabase/tests/organisation_requests_test.sql
@@ -32,14 +32,14 @@ select set_config('request.jwt.claims', '{"role":"service_role"}', true);
 select is(
     (select public.submit_organisation_request(
         'Bad Slug', 'Not A Slug', null, null, null,
-        '60000000-0000-0000-0000-000000000001') ->> 'error'),
+        null, '60000000-0000-0000-0000-000000000001') ->> 'error'),
     'Slug must be 2-31 characters, lowercase letters, digits and underscores, starting with a letter',
     'an invalid slug is refused'
 );
 select isnt(
     (select public.submit_organisation_request(
         'Hyphenated', 'has-hyphen', null, null, null,
-        '60000000-0000-0000-0000-000000000001') ->> 'error'),
+        null, '60000000-0000-0000-0000-000000000001') ->> 'error'),
     null,
     'a hyphen is refused -- role names derive from the slug and are validated without hyphens'
 );
@@ -53,7 +53,7 @@ select ok(
 select isnt(
     (select public.submit_organisation_request(
         'Boss Impostor', 'boss', null, null, null,
-        '60000000-0000-0000-0000-000000000001') ->> 'error'),
+        null, '60000000-0000-0000-0000-000000000001') ->> 'error'),
     null,
     'a reserved slug is refused at request time, not discovered at approval'
 );
@@ -70,7 +70,7 @@ select is(
 select ok(
     (select public.submit_organisation_request(
         'Acme Inc', 'pgtacme', 'We make things', null, 'because',
-        '60000000-0000-0000-0000-000000000001') ->> 'success')::boolean,
+        null, '60000000-0000-0000-0000-000000000001') ->> 'success')::boolean,
     'a valid request is accepted'
 );
 select is(
@@ -84,7 +84,7 @@ select is(
 select isnt(
     (select public.submit_organisation_request(
         'Acme Two', 'pgtacme', null, null, null,
-        '60000000-0000-0000-0000-000000000002') ->> 'error'),
+        null, '60000000-0000-0000-0000-000000000002') ->> 'error'),
     null,
     'a second pending request for the same slug is refused'
 );
@@ -156,7 +156,7 @@ select is(
 select ok(
     (select public.submit_organisation_request(
         'Acme Again', 'pgtacme', null, null, null,
-        '60000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
+        null, '60000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
     'withdrawing releases the slug for someone else'
 );
 
@@ -238,7 +238,7 @@ select is(
 -- Rejection
 -- ===========================================================================
 select public.submit_organisation_request(
-    'Rejected Co', 'pgtrej', null, null, null, '60000000-0000-0000-0000-000000000001');
+    'Rejected Co', 'pgtrej', null, null, null, null, '60000000-0000-0000-0000-000000000001');
 
 select ok(
     (select public.reject_organisation_request(

--- a/supabase/tests/organisation_website_test.sql
+++ b/supabase/tests/organisation_website_test.sql
@@ -13,7 +13,7 @@
 -- with the constraint dropped.
 
 begin;
-select plan(19);
+select plan(23);
 
 insert into auth.users (id, email, email_confirmed_at) values
     ('90000000-0000-0000-0000-000000000001', 'websiteasker@pgtap.test', now()),
@@ -170,6 +170,23 @@ select is(
     'an empty string CLEARS the website'
 );
 
+-- SET A REAL VALUE FIRST. The previous version passed NULL while the column was
+-- already NULL, so "leaves it alone" could not be told from "cleared it" - the
+-- exact confusion the CASE WHEN exists to prevent, and it would have stayed green
+-- under website = COALESCE(p_website, website).
+select ok(
+    (public.update_organisation_settings(
+        (select id from public.organisations where slug = 'acmesite'),
+        null, null, null, null, null, null, false, 'https://restored.example', false,
+        '90000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
+    'a website can be set again after being cleared'
+);
+select is(
+    (select website from public.organisations where slug = 'acmesite'),
+    'https://restored.example',
+    'and it is stored'
+);
+
 select ok(
     (public.update_organisation_settings(
         (select id from public.organisations where slug = 'acmesite'),
@@ -179,8 +196,26 @@ select ok(
 );
 select is(
     (select website from public.organisations where slug = 'acmesite'),
+    'https://restored.example',
+    'and a NULL LEAVES IT ALONE - it did not clear a website that was really set'
+);
+
+-- Case-insensitivity, untested on either side until now.
+select ok(
+    (public.update_organisation_settings(
+        (select id from public.organisations where slug = 'acmesite'),
+        null, null, null, null, null, null, false, 'HTTPS://Acme.Example', false,
+        '90000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
+    'an upper-case scheme is accepted, matching the column CHECK regex'
+);
+
+-- The approval path refusing a bad value, which nothing covered.
+select isnt(
+    (select public.submit_organisation_request(
+        'Bad Approve', 'badapprove', null, null, null,
+        'ftp://acme.example', '90000000-0000-0000-0000-000000000001') ->> 'error'),
     null,
-    'and a NULL LEAVES IT ALONE rather than clearing or restoring it'
+    'a non-http scheme never reaches approval, because submit refuses it'
 );
 
 

--- a/supabase/tests/organisation_website_test.sql
+++ b/supabase/tests/organisation_website_test.sql
@@ -1,0 +1,137 @@
+-- pgTAP tests for the organisation website (migration 20260807000000).
+-- Run with: supabase test db
+--
+-- The website is the one organisation field that is BOTH filled in by any
+-- authenticated user (on a request, before any review) and rendered as a link on
+-- a page other members read. That combination is what makes the scheme check a
+-- security property rather than tidiness: a javascript: or data: URL stored here
+-- would be self-service stored XSS.
+--
+-- It is checked in two places on purpose - the RPC, so a typo comes back as a
+-- sentence, and the column CHECK, so nothing that bypasses the RPC can store one.
+-- Both are asserted below, because a test that only exercised the RPC would pass
+-- with the constraint dropped.
+
+begin;
+select plan(12);
+
+insert into auth.users (id, email, email_confirmed_at) values
+    ('90000000-0000-0000-0000-000000000001', 'websiteasker@pgtap.test', now()),
+    ('90000000-0000-0000-0000-000000000002', 'websiteadmin@pgtap.test', now());
+
+insert into public.user_roles (user_id, role_id)
+select '90000000-0000-0000-0000-000000000002', r.id
+  from public.roles r where r.name = 'admin'
+on conflict do nothing;
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+
+-- ===========================================================================
+-- The RPC refuses anything that is not http or https
+-- ===========================================================================
+select is(
+    (select public.submit_organisation_request(
+        'Evil', 'evilsite', null, null, null,
+        'javascript:alert(1)', '90000000-0000-0000-0000-000000000001') ->> 'error'),
+    'Website must be a full http:// or https:// address',
+    'a javascript: URL is refused'
+);
+
+select is(
+    (select public.submit_organisation_request(
+        'Data', 'datasite', null, null, null,
+        'data:text/html,<script>alert(1)</script>', '90000000-0000-0000-0000-000000000001') ->> 'error'),
+    'Website must be a full http:// or https:// address',
+    'a data: URL is refused'
+);
+
+select is(
+    (select public.submit_organisation_request(
+        'Bare', 'baresite', null, null, null,
+        'acme.com', '90000000-0000-0000-0000-000000000001') ->> 'error'),
+    'Website must be a full http:// or https:// address',
+    'a bare domain with no scheme is refused, so it cannot render as a relative link'
+);
+
+select is(
+    (select public.submit_organisation_request(
+        'Long', 'longsite', null, null, null,
+        'https://' || repeat('a', 500) || '.com', '90000000-0000-0000-0000-000000000001') ->> 'error'),
+    'Website must be 500 characters or fewer',
+    'an over-long website is refused'
+);
+
+
+-- ===========================================================================
+-- A valid one is stored, and survives approval onto the organisation
+-- ===========================================================================
+select ok(
+    (public.submit_organisation_request(
+        'Acme', 'acmesite', 'Acme Corp', 'acmesite.example', 'Because.',
+        'https://acmesite.example', '90000000-0000-0000-0000-000000000001') ->> 'success')::boolean,
+    'a valid https website is accepted'
+);
+
+select is(
+    (select website from public.organisation_requests where slug = 'acmesite'),
+    'https://acmesite.example',
+    'the website is stored on the request'
+);
+
+select ok(
+    (public.approve_organisation_request(
+        (select id from public.organisation_requests where slug = 'acmesite'),
+        null, '90000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
+    'the request can be approved'
+);
+
+-- The whole point of asking at request time: it has to reach the organisation.
+select is(
+    (select website from public.organisations where slug = 'acmesite'),
+    'https://acmesite.example',
+    'approval carries the website onto the organisation'
+);
+
+-- And it has to reach the page that renders it.
+select is(
+    (public.get_organisation_detail(
+        (select id from public.organisations where slug = 'acmesite'),
+        '90000000-0000-0000-0000-000000000002') -> 'data' ->> 'website'),
+    'https://acmesite.example',
+    'get_organisation_detail projects the website, so a page can render it'
+);
+
+
+-- ===========================================================================
+-- An organisation without one is not broken by it
+-- ===========================================================================
+select ok(
+    (public.submit_organisation_request(
+        'Plain', 'plainsite', null, null, null,
+        null, '90000000-0000-0000-0000-000000000001') ->> 'success')::boolean,
+    'the website is optional'
+);
+
+
+-- ===========================================================================
+-- The column CHECK, independent of the RPC
+-- ===========================================================================
+-- Asserted separately because every case above goes through the RPC, and all of
+-- them would still pass with the constraint dropped.
+select throws_ok(
+    $$update public.organisations set website = 'javascript:alert(1)' where slug = 'acmesite'$$,
+    '23514',
+    null,
+    'the column CHECK refuses a javascript: URL written directly'
+);
+
+select throws_ok(
+    $$update public.organisations set website = '' where slug = 'acmesite'$$,
+    '23514',
+    null,
+    'an empty string is refused, so "unset" has exactly one representation'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/organisation_website_test.sql
+++ b/supabase/tests/organisation_website_test.sql
@@ -13,7 +13,7 @@
 -- with the constraint dropped.
 
 begin;
-select plan(12);
+select plan(19);
 
 insert into auth.users (id, email, email_confirmed_at) values
     ('90000000-0000-0000-0000-000000000001', 'websiteasker@pgtap.test', now()),
@@ -109,8 +109,8 @@ select is(
 select ok(
     (public.submit_organisation_request(
         'Plain', 'plainsite', null, null, null,
-        null, '90000000-0000-0000-0000-000000000001') ->> 'success')::boolean,
-    'the website is optional'
+        'https://plainsite.example', '90000000-0000-0000-0000-000000000001') ->> 'success')::boolean,
+    'a second request is accepted'
 );
 
 
@@ -131,6 +131,73 @@ select throws_ok(
     '23514',
     null,
     'an empty string is refused, so "unset" has exactly one representation'
+);
+
+-- ===========================================================================
+-- The ADMIN path, which is the one that is actually used
+-- ===========================================================================
+-- Everything above goes through submit_organisation_request, which a person uses
+-- once. update_organisation_settings is what an administrator uses, and it had no
+-- validation at all: the column CHECK raised 23514, which aborted the WHOLE
+-- UPDATE, so a mistyped website silently discarded every other field in the same
+-- submission and the page could only say "the change was refused".
+select is(
+    (public.update_organisation_settings(
+        (select id from public.organisations where slug = 'acmesite'),
+        'Renamed', null, null, null, null, null, false,
+        'acmesite.example', false, '90000000-0000-0000-0000-000000000002') ->> 'error'),
+    'Website must be a full http:// or https:// address',
+    'the admin path returns a readable error rather than raising a constraint violation'
+);
+
+select is(
+    (select name from public.organisations where slug = 'acmesite'),
+    'Acme',
+    'and it fails closed - the name in the same submission was not applied'
+);
+
+-- The empty-means-empty rule, which is deliberately not COALESCE.
+select ok(
+    (public.update_organisation_settings(
+        (select id from public.organisations where slug = 'acmesite'),
+        null, null, null, null, null, null, false, '', false,
+        '90000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
+    'an empty website is accepted by the admin path'
+);
+select is(
+    (select website from public.organisations where slug = 'acmesite'),
+    null,
+    'an empty string CLEARS the website'
+);
+
+select ok(
+    (public.update_organisation_settings(
+        (select id from public.organisations where slug = 'acmesite'),
+        'Acme', null, null, null, null, null, false, null, false,
+        '90000000-0000-0000-0000-000000000002') ->> 'success')::boolean,
+    'a NULL website is accepted'
+);
+select is(
+    (select website from public.organisations where slug = 'acmesite'),
+    null,
+    'and a NULL LEAVES IT ALONE rather than clearing or restoring it'
+);
+
+
+-- ===========================================================================
+-- An approver can see what they are approving
+-- ===========================================================================
+-- The threat model is that any authenticated user supplies this and it becomes a
+-- link on a page other members read. Review is the control between those two
+-- facts, and the queue was not projecting the field at all.
+select is(
+    (select r ->> 'website'
+       from jsonb_array_elements(
+                public.list_organisation_requests(
+                    p_actor_id => '90000000-0000-0000-0000-000000000001') -> 'data') r
+      where r ->> 'slug' = 'plainsite'),
+    'https://plainsite.example',
+    'the request queue shows the website an approver is about to publish'
 );
 
 select * from finish();


### PR DESCRIPTION
Five commits over the organisation edge function and its schema. **Parts of this are already deployed** - see the note at the end.

## The pages were on the previous identity

Amber `#F2A93B` on `#1a1a1a`, inherited from the passkey pages, while the app default moved to Blueprint. A page in the old palette opened from a Blueprint panel reads as a different product.

They now mirror `BossBlueprintColorScheme` / `BossBlueprintLightColorScheme` from `plugin-ui-core`, as CSS custom properties, with the mirror relationship written down so it moves when the app moves.

**Signal is the fill, signalText is the glyph, here too.** `.linkish` and `.pill.admin` were painting the accent as text; `#0F5BFF` is 3.5:1 on ink - a border or a filled button, not a word.

**Light mode is functional, not decoration.** The in-app browser bridges the host theme to `prefers-color-scheme` (`FluckEngine` drives `engine.setTheme` from `BossThemeController`), so honouring the media query makes the page track the app the reader is looking at.

## Contrast is measured, not eyeballed

This is the part most worth keeping. The light theme was rendered, looked fine, and had **six sub-AA pairs** in it. `contrast.test.ts` parses the tokens *and* composites the translucent surfaces out of the real declarations, then checks every pair across both themes.

The first version of that test hand-listed its surfaces and had no `--token-wash` entry - which is where every role name, permission string and slug is painted, and what `tbody tr:hover td` puts behind a row. It reported green while `--ok-text` was at **3.01:1** on a hovered row. Now derived: pushing the banner tint to 0.55 fails the banner pairs, pushing the wash to 0.30 fails seven.

## Two real defects, not styling

- **The mobile rule hid every table column past the third.** That did not make the table fit - it deleted "Joined" and "Permissions" from the reader. Tables now scroll inside their card.
- **`.highlight` had never rendered.** `section.card` sets `border-color` at specificity (0,1,1) and a bare `.highlight` is (0,1,0). The one card that uses it displays a live invite token exactly once.

## Cloudflare was eating every member email

An admin saw the literal words "email protected" against every member, so the roster could not answer the one question it exists for.

Not our markup. `api.risaboss.com` is behind Cloudflare, whose Email Address Obfuscation rewrites addresses into a `__cf_email__` anchor plus an injected decoder script - and our CSP is `default-src 'none'` with `script-src` nonce-only, so that script is blocked and the address never decodes. Both features behave correctly; their combination destroys the content.

Fixed with Cloudflare's documented `<!--email_off-->` region, in the repo rather than in the dashboard, and without weakening `script-src`. A test scans `views/` for `${esc(...email...)}` so a new roster column cannot reintroduce it - source-scanned, because the failure happens at the edge *after* we render.

## The boss organisation's member role

The roster showed a blank role for every member but the owner. The seed set `auto_assign_member_role = false`, reasoning that every user is a member so a `user_roles` row per user lengthens every JWT for zero extra permissions. That reasoning is still true and is overridden deliberately, at the operator's request.

**Flipping the flag does nothing on its own.** Four parts, two of which I found by running a db reset rather than reading the SQL:

1. `UPDATE` the flag - which on a fresh deployment matches **zero rows**, because the organisation does not exist yet at migration time.
2. Backfill onto **active** members. Pending and invited are excluded: granting them a role hands out standing that approval exists to gate.
3. `ensure_boss_organisation()` hardcoded `false`, and it creates the organisation on a fresh environment *after* this migration runs - so the `UPDATE` was silently undone.
4. `handle_new_user` inserts the membership row **directly** and never called `assign_org_member_role_internal`. Every other entry path used the helper; the signup trigger did not, so the flag alone changed nothing for a new user.

Nine pgTAP tests that **begin by creating the boss organisation** - the rest of the suite runs against a database with no users where this path is skipped, so a green run would otherwise prove nothing. Mutation-verified both ways.

**Cost, recorded so it is not rediscovered:** every active member gains a `user_roles` row, and org role names ride in the existing `user_roles` JWT claim, so every token grows by one entry. No permission changes.

## Verification

`deno check` over every file, `deno lint`, 134 Deno tests, 386 pgTAP tests across 15 files. Pages rendered headlessly in both themes and reviewed on screen - `render-preview.ts` covers all nine states, including the two (`.highlight`, `.linkish`) that no preview reached before, which is how the dead rule survived.

## Already live

The edge function was deployed twice from this branch (the restyle, then the email fix), and migration `20260806000000` is applied to production. So **production is currently running this branch**, and `main` does not have it - merging closes that gap rather than opening it.