### PR TITLE
Route the last window dialogs and plugin toasts above the browser surface

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -27,6 +27,7 @@ import ai.rever.boss.plugin.api.LocalWindowIdProvider
 import ai.rever.boss.plugin.api.LocalWindowProjectStateProvider
 import ai.rever.boss.plugin.api.LocalWorkspaceDataProvider
 import ai.rever.boss.plugin.sandbox.notification.PluginToastHost
+import ai.rever.boss.plugin.sandbox.notification.PluginToastState
 import ai.rever.boss.services.bookmarks.BookmarkAPIAccess
 import ai.rever.boss.updater.UpdateAvailableDialog
 import ai.rever.boss.updater.UpdateBanner
@@ -45,6 +46,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -62,14 +64,44 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 /**
- * Size of the toast overlay window before its content has been measured.
+ * Hard upper bound on the toast overlay: its size before measurement, and the ceiling every later
+ * measurement is taken against.
  *
- * An upper bound, deliberately, not an estimate: the heavyweight overlay measures its content
- * inside a window of this size, so anything smaller measures CLIPPED content and the overlay then
- * settles at the clipped size. Width is `PluginToastHost`'s own `widthIn(max = 400.dp)` plus its
- * 16.dp padding on each side; the height is just roomy enough for a tall stack of toasts.
+ * A bound, not an estimate. The overlay measures its content against this rather than against its
+ * own current size, so content that would exceed it is CLIPPED rather than merely starting small.
+ * Width is `PluginToastHost`'s own `widthIn(max = 400.dp)` plus its 16.dp padding on each side;
+ * height comfortably clears `PluginToastState`'s three-toast maximum. It is also the region the
+ * overlay swallows clicks in until measurement lands, so it is kept no larger than it needs to be.
  */
-private val TOAST_OVERLAY_INITIAL_SIZE = DpSize(432.dp, 900.dp)
+private val TOAST_OVERLAY_INITIAL_SIZE = DpSize(432.dp, 600.dp)
+
+/**
+ * Plugin toasts, layered above the heavyweight browser surface.
+ *
+ * Drawn in the scaffold they land BEHIND that surface, so a toast raised while a browser tab is
+ * showing is invisible. `OverlayCorner` rather than `OverlayHud` because a toast stays up for
+ * seconds: a parent-sized HUD swallows every click beneath it, which is fine for a switcher held
+ * for a moment and not for this.
+ *
+ * **The empty check is the load-bearing line.** `PluginToastHost` composes its padded `Column`
+ * unconditionally, and `DefaultPlugin.pluginToastState` is never null, so without it every loaded
+ * plugin would hold an always-on-top, click-eating overlay window open for the whole session -
+ * over other applications too, since it is always-on-top. Guarding on the content matches what
+ * `TabCycleOverlayHost` and both drag ghosts already do.
+ *
+ * Extracted from the scaffold so this guard can be tested directly; see `ToastOverlayTest`.
+ */
+@Composable
+internal fun BoxScope.ToastOverlay(toastState: PluginToastState) {
+    val toasts by toastState.toasts.collectAsState()
+    if (toasts.isEmpty()) return
+    OverlayCorner(
+        alignment = Alignment.TopEnd,
+        initialSize = TOAST_OVERLAY_INITIAL_SIZE,
+    ) {
+        PluginToastHost(toastState = toastState)
+    }
+}
 
 /**
  * Provides every CompositionLocal that plugins and host UI below BossApp read:
@@ -368,18 +400,8 @@ internal fun BossAppScaffold(
 
             // Plugin notification toasts — the render surface for every plugin's
             // PluginContext.notificationProvider.showToast().
-            //
-            // OverlayCorner rather than a plain aligned Box: drawn in this scaffold they land
-            // BEHIND the heavyweight browser surface, so a toast raised while a browser tab is
-            // showing is invisible. Corner and not OverlayHud because a toast stays up for
-            // seconds — a parent-sized HUD would make the window unclickable for that whole time.
             state.currentDefaultPlugin?.pluginToastState?.let { toastState ->
-                OverlayCorner(
-                    alignment = Alignment.TopEnd,
-                    initialSize = TOAST_OVERLAY_INITIAL_SIZE,
-                ) {
-                    PluginToastHost(toastState = toastState)
-                }
+                ToastOverlay(toastState = toastState)
             }
 
             // MRU tab-switcher overlay (Ctrl+Tab in most-recently-used mode)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -83,18 +84,34 @@ private val TOAST_OVERLAY_INITIAL_SIZE = DpSize(432.dp, 600.dp)
  * seconds: a parent-sized HUD swallows every click beneath it, which is fine for a switcher held
  * for a moment and not for this.
  *
- * **The empty check is the load-bearing line.** `PluginToastHost` composes its padded `Column`
- * unconditionally, and `DefaultPlugin.pluginToastState` is never null, so without it every loaded
- * plugin would hold an always-on-top, click-eating overlay window open for the whole session -
- * over other applications too, since it is always-on-top. Guarding on the content matches what
- * `TabCycleOverlayHost` and both drag ghosts already do.
+ * **Two guards, and both are load-bearing**, because the overlay window is always-on-top and a
+ * non-focusable AWT window still eats mouse events (the JVM has no portable click-through). So
+ * wherever it sits is a dead region, of this app and of whatever is in front of it.
  *
- * Extracted from the scaffold so this guard can be tested directly; see `ToastOverlayTest`.
+ *  - **Empty.** `PluginToastHost` composes its padded `Column` unconditionally and
+ *    `DefaultPlugin.pluginToastState` is never null, so without this every loaded plugin would
+ *    hold a window open for the whole session.
+ *  - **Window focus.** Toast lifetime is NOT bounded by a timer: `ToastDuration.INDEFINITE` skips
+ *    auto-dismissal entirely, it is part of the plugin IPC surface, and the host itself raises one
+ *    (`BossPluginNotificationService.notifyPluginDisabled`, an ERROR toast with a "Re-enable"
+ *    action - precisely the kind a user leaves sitting while they go elsewhere). Escaping the
+ *    scene is only worth anything while the user is looking at this window, so an unfocused window
+ *    draws toasts in place, exactly as before this overlay existed. That also stops
+ *    `HeavyweightCorner`'s frame-clock loop, which would otherwise run for as long as the toast.
+ *
+ * Guarding on content matches what `TabCycleOverlayHost` and both drag ghosts already do.
+ *
+ * Extracted from the scaffold so both guards can be tested directly; see `ToastOverlayTest`.
  */
 @Composable
 internal fun BoxScope.ToastOverlay(toastState: PluginToastState) {
     val toasts by toastState.toasts.collectAsState()
     if (toasts.isEmpty()) return
+
+    if (!LocalWindowInfo.current.isWindowFocused) {
+        PluginToastHost(toastState = toastState, modifier = Modifier.align(Alignment.TopEnd))
+        return
+    }
     OverlayCorner(
         alignment = Alignment.TopEnd,
         initialSize = TOAST_OVERLAY_INITIAL_SIZE,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -6,6 +6,7 @@ import ai.rever.boss.components.bars.horizontal.BossTopBar
 import ai.rever.boss.components.bars.vertical.BossLeftSideBar
 import ai.rever.boss.components.bars.vertical.BossRightSideBar
 import ai.rever.boss.components.overlays.DraggingItemOverlay
+import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.components.overlays.TabDraggingOverlay
 import ai.rever.boss.components.plugin.LocalPanelPluginIdResolver
 import ai.rever.boss.components.plugin.panels.left_bottom.TopOfMind.LocalSplitViewState
@@ -56,7 +57,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+
+/**
+ * Size of the toast overlay window before its content has been measured.
+ *
+ * An upper bound, deliberately, not an estimate: the heavyweight overlay measures its content
+ * inside a window of this size, so anything smaller measures CLIPPED content and the overlay then
+ * settles at the clipped size. Width is `PluginToastHost`'s own `widthIn(max = 400.dp)` plus its
+ * 16.dp padding on each side; the height is just roomy enough for a tall stack of toasts.
+ */
+private val TOAST_OVERLAY_INITIAL_SIZE = DpSize(432.dp, 900.dp)
 
 /**
  * Provides every CompositionLocal that plugins and host UI below BossApp read:
@@ -355,11 +368,18 @@ internal fun BossAppScaffold(
 
             // Plugin notification toasts — the render surface for every plugin's
             // PluginContext.notificationProvider.showToast().
+            //
+            // OverlayCorner rather than a plain aligned Box: drawn in this scaffold they land
+            // BEHIND the heavyweight browser surface, so a toast raised while a browser tab is
+            // showing is invisible. Corner and not OverlayHud because a toast stays up for
+            // seconds — a parent-sized HUD would make the window unclickable for that whole time.
             state.currentDefaultPlugin?.pluginToastState?.let { toastState ->
-                PluginToastHost(
-                    toastState = toastState,
-                    modifier = Modifier.align(Alignment.TopEnd),
-                )
+                OverlayCorner(
+                    alignment = Alignment.TopEnd,
+                    initialSize = TOAST_OVERLAY_INITIAL_SIZE,
+                ) {
+                    PluginToastHost(toastState = toastState)
+                }
             }
 
             // MRU tab-switcher overlay (Ctrl+Tab in most-recently-used mode)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -136,6 +136,24 @@ object OverlayConfig {
     )? = null
 
     /**
+     * Platform-injected heavyweight CORNER renderer - a **content-sized**, non-focusable window
+     * placed at [alignment] inside the parent, opening at `initialSize` until its content measures.
+     *
+     * Distinct from [heavyweightHud] purely by sizing, and that distinction is the point: a HUD is
+     * parent-sized, which swallows every click beneath it, and that is only acceptable for something
+     * up for as long as a key is held. Toasts linger for seconds while the user keeps working, so
+     * their overlay must cover no more than itself. Null until injected; callers fall back to
+     * drawing in place.
+     */
+    var heavyweightCorner: (
+        @Composable (
+            alignment: Alignment,
+            initialSize: DpSize,
+            content: @Composable () -> Unit,
+        ) -> Unit
+    )? = null
+
+    /**
      * How many heavyweight POPUP windows are currently open.
      *
      * Exists so a heavyweight MODAL can tell "the user clicked away" from "a child overlay of mine
@@ -189,6 +207,32 @@ fun BoxScope.OverlayHud(
     val hw = OverlayConfig.heavyweightHud
     if (routeOverlayHeavyweight(hw != null) && hw != null) {
         hw(alignment) { content() }
+    } else {
+        Box(modifier = Modifier.align(alignment)) { content() }
+    }
+}
+
+/**
+ * A long-lived corner overlay (toast notifications) at [alignment], layered above the browser.
+ *
+ * Distinct from [OverlayHud] because it must not swallow clicks: a HUD covers the whole parent
+ * window, which is fine for a keypress-length switcher and not for a toast that stays up for
+ * seconds while the user keeps working. This one is sized to its content, so only the toast itself
+ * is covered.
+ *
+ * [initialSize] is the size of the window before its content has been measured, so it must be a
+ * generous UPPER bound - too small and the content measures clipped, then the overlay settles at
+ * the clipped size. On the lightweight path it is unused, as the content sizes itself normally.
+ */
+@Composable
+fun BoxScope.OverlayCorner(
+    alignment: Alignment,
+    initialSize: DpSize,
+    content: @Composable () -> Unit,
+) {
+    val hw = OverlayConfig.heavyweightCorner
+    if (routeOverlayHeavyweight(hw != null) && hw != null) {
+        hw(alignment, initialSize) { content() }
     } else {
         Box(modifier = Modifier.align(alignment)) { content() }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -1,0 +1,136 @@
+package ai.rever.boss.components.overlays
+
+import ai.rever.boss.plugin.browser.LocalAwtWindow
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.rememberWindowState
+
+/**
+ * Heavyweight host for a long-lived corner overlay - toast notifications.
+ *
+ * **Content-sized, and that is the whole reason this exists instead of reusing a sibling.** Both
+ * existing renderers are wrong here, for opposite reasons:
+ *
+ *  - [HeavyweightHud] is parent-sized. A non-focusable AWT window still receives mouse events and
+ *    the JVM has no portable click-through, so it swallows every click underneath it. That is
+ *    tolerable for the Ctrl+Tab switcher, which is up only while a key is held, and not tolerable
+ *    for a toast that lingers for seconds while the user keeps working - it would make the whole
+ *    window unclickable for the duration.
+ *  - `HeavyweightPopup`'s scrim calls `onDismissRequest` on any click, so clicking anywhere in the
+ *    app would dismiss the toast instead of reaching what was clicked.
+ *
+ * A window sized to its content covers only the toast itself: its own buttons still work, and every
+ * click outside it reaches the app untouched. Same trade as [HeavyweightGhost], which is
+ * content-sized for the same reason.
+ *
+ * Sizing is necessarily two-pass, because a window's size must be chosen before its content can be
+ * measured: it opens at [initialSize], then follows the measured content. Make [initialSize] a
+ * generous upper bound rather than a guess at the real size - measuring inside a window that is too
+ * small measures CLIPPED content, and the overlay would then settle at the clipped size and stay
+ * there.
+ */
+@Composable
+fun HeavyweightCorner(
+    alignment: Alignment,
+    initialSize: DpSize,
+    content: @Composable () -> Unit,
+) {
+    val parent = LocalAwtWindow.current
+    val bounds = rememberOverlayParentBounds(parent)
+    val density = LocalDensity.current.density
+    var measured by remember { mutableStateOf<DpSize?>(null) }
+    val size = measured ?: initialSize
+
+    val state =
+        rememberWindowState(
+            size = size,
+            position =
+                cornerPosition(bounds, size, alignment).let { WindowPosition(it.first.dp, it.second.dp) },
+        )
+
+    // Assign from an effect, never during composition. Both values change while the overlay is up
+    // (the content grows as toasts stack, and the parent moves), and writing window state inline
+    // during composition is what made the cursor overlay jitter.
+    LaunchedEffect(size, bounds, alignment) {
+        state.size = size
+        val at = cornerPosition(bounds, size, alignment)
+        state.position = WindowPosition(at.first.dp, at.second.dp)
+    }
+
+    Window(
+        onCloseRequest = {},
+        state = state,
+        undecorated = true,
+        transparent = true,
+        alwaysOnTop = true,
+        focusable = false,
+        resizable = false,
+    ) {
+        EnsureOverlayWindowTransparent(window)
+        Box(
+            modifier =
+                Modifier.onGloballyPositioned { coordinates ->
+                    val next =
+                        DpSize(
+                            (coordinates.size.width / density).dp,
+                            (coordinates.size.height / density).dp,
+                        )
+                    // Ignore a zero measurement. It happens while the window is being torn down, and
+                    // acting on it would collapse the overlay and hide a toast that is still showing.
+                    if (next.width.value > 0f && next.height.value > 0f && next != measured) {
+                        measured = next
+                    }
+                },
+        ) {
+            content()
+        }
+    }
+}
+
+/**
+ * Top-left corner, in AWT logical units, for an overlay of [size] placed at [alignment] inside
+ * [bounds] - or the origin when the parent could not be measured.
+ *
+ * Pure so the arithmetic is pinned by a test; composing a `Window` needs a display, so this is the
+ * only reachable part. Offsets are floored at zero so content larger than the parent overhangs the
+ * bottom-right rather than being pushed off the top-left, where it would be unreachable.
+ */
+internal fun cornerPosition(
+    bounds: IntArray?,
+    size: DpSize,
+    alignment: Alignment,
+): Pair<Int, Int> {
+    if (bounds == null) return 0 to 0
+    val width = size.width.value.toInt()
+    val height = size.height.value.toInt()
+    val slackX = (bounds[2] - width).coerceAtLeast(0)
+    val slackY = (bounds[3] - height).coerceAtLeast(0)
+    val x =
+        bounds[0] +
+            when (alignment) {
+                Alignment.TopStart, Alignment.CenterStart, Alignment.BottomStart -> 0
+                Alignment.TopEnd, Alignment.CenterEnd, Alignment.BottomEnd -> slackX
+                else -> slackX / 2
+            }
+    val y =
+        bounds[1] +
+            when (alignment) {
+                Alignment.TopStart, Alignment.TopCenter, Alignment.TopEnd -> 0
+                Alignment.BottomStart, Alignment.BottomCenter, Alignment.BottomEnd -> slackY
+                else -> slackY / 2
+            }
+    return x to y
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -8,18 +8,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
+import javax.swing.RootPaneContainer
+import java.awt.Window as AwtWindow
 
 /**
- * Heavyweight host for a long-lived corner overlay - toast notifications.
+ * Heavyweight host for a corner overlay that outlives a keypress - toast notifications.
  *
  * **Content-sized, and that is the whole reason this exists instead of reusing a sibling.** Both
  * existing renderers are wrong here, for opposite reasons:
@@ -33,14 +38,22 @@ import androidx.compose.ui.window.rememberWindowState
  *    app would dismiss the toast instead of reaching what was clicked.
  *
  * A window sized to its content covers only the toast itself: its own buttons still work, and every
- * click outside it reaches the app untouched. Same trade as [HeavyweightGhost], which is
- * content-sized for the same reason.
+ * click outside it reaches the app. Same trade as [HeavyweightGhost], which is content-sized for
+ * the same reason.
  *
- * Sizing is necessarily two-pass, because a window's size must be chosen before its content can be
- * measured: it opens at [initialSize], then follows the measured content. Make [initialSize] a
- * generous upper bound rather than a guess at the real size - measuring inside a window that is too
- * small measures CLIPPED content, and the overlay would then settle at the clipped size and stay
- * there.
+ * **Callers must compose this only while there is something to show.** Because the window eats
+ * clicks wherever it sits, one composed unconditionally is a permanently dead region of the app -
+ * and, being always-on-top, of whatever other application is in front.
+ *
+ * Two things here are deliberately not the obvious implementation, both because the obvious one
+ * fails silently:
+ *
+ *  - Content is measured against [initialSize], **never against the window's current size** (see
+ *    [measuredAgainst]). Measuring against the window makes the size a one-way ratchet: the window
+ *    shrinks to fit what is showing, the next toast is then measured inside that smaller window,
+ *    measures clipped, and the overlay can never grow back.
+ *  - Parent bounds come from the CONTENT PANE, not the window (see [contentPaneBounds]), and are
+ *    re-read on the frame clock rather than remembered once.
  */
 @Composable
 fun HeavyweightCorner(
@@ -49,21 +62,32 @@ fun HeavyweightCorner(
     content: @Composable () -> Unit,
 ) {
     val parent = LocalAwtWindow.current
-    val bounds = rememberOverlayParentBounds(parent)
     val density = LocalDensity.current.density
     var measured by remember { mutableStateOf<DpSize?>(null) }
     val size = measured ?: initialSize
+    var bounds by remember(parent) { mutableStateOf(contentPaneBounds(parent)) }
 
     val state =
         rememberWindowState(
             size = size,
-            position =
-                cornerPosition(bounds, size, alignment).let { WindowPosition(it.first.dp, it.second.dp) },
+            position = cornerPosition(bounds, size, alignment).let { WindowPosition(it.first.dp, it.second.dp) },
         )
 
-    // Assign from an effect, never during composition. Both values change while the overlay is up
-    // (the content grows as toasts stack, and the parent moves), and writing window state inline
-    // during composition is what made the cursor overlay jitter.
+    // Track the parent on the frame clock. `rememberOverlayParentBounds` is keyed on the window
+    // INSTANCE, which never changes, so it captures the bounds once - fine for the sub-second
+    // overlays that came before, wrong for one that is up while the user can drag or resize the
+    // window out from under it. Only assign on an actual change: each one is a native setLocation.
+    LaunchedEffect(parent) {
+        while (true) {
+            withFrameNanos { }
+            val next = contentPaneBounds(parent) ?: continue
+            val current = bounds
+            if (current == null || !next.contentEquals(current)) bounds = next
+        }
+    }
+
+    // Assign window state from an effect, never during composition - writing it inline during
+    // composition is what made the cursor overlay jitter.
     LaunchedEffect(size, bounds, alignment) {
         state.size = size
         val at = cornerPosition(bounds, size, alignment)
@@ -82,22 +106,75 @@ fun HeavyweightCorner(
         EnsureOverlayWindowTransparent(window)
         Box(
             modifier =
-                Modifier.onGloballyPositioned { coordinates ->
-                    val next =
-                        DpSize(
-                            (coordinates.size.width / density).dp,
-                            (coordinates.size.height / density).dp,
-                        )
-                    // Ignore a zero measurement. It happens while the window is being torn down, and
-                    // acting on it would collapse the overlay and hide a toast that is still showing.
-                    if (next.width.value > 0f && next.height.value > 0f && next != measured) {
-                        measured = next
-                    }
-                },
+                Modifier
+                    // Order matters: the constraint override is OUTSIDE, so the observer inside it
+                    // reports a size measured against the ceiling rather than against the window.
+                    .measuredAgainst(initialSize)
+                    .onGloballyPositioned { coordinates ->
+                        val next =
+                            DpSize(
+                                (coordinates.size.width / density).dp,
+                                (coordinates.size.height / density).dp,
+                            )
+                        // Ignore a zero measurement: it happens while the overlay is torn down, and
+                        // acting on it would collapse the window and hide content still showing.
+                        if (next.width.value > 0f && next.height.value > 0f && next != measured) {
+                            measured = next
+                        }
+                    },
         ) {
             content()
         }
     }
+}
+
+/**
+ * Measures content against [ceiling] rather than against the incoming constraints.
+ *
+ * Callers observe the result with an `onGloballyPositioned` placed INSIDE this modifier, so what it
+ * reports is the ceiling-constrained size rather than whatever the window currently is.
+ *
+ * This is what stops the overlay's size from becoming a one-way ratchet. The natural implementation
+ * - measure normally and report `onGloballyPositioned`'s size - feeds the window's own size back
+ * into the measurement: once the window has shrunk to fit one toast, the next is measured inside
+ * that smaller window, so it measures CLIPPED, the reported size never grows, and every later toast
+ * renders squashed. Nothing warns; the window is still transparent, still correctly placed, and
+ * still passes every gate.
+ *
+ * Measuring against a constant ceiling instead makes the answer independent of the current size, so
+ * it converges rather than ratcheting. [ceiling] is therefore a hard upper bound on the overlay, not
+ * merely a first guess.
+ */
+internal fun Modifier.measuredAgainst(ceiling: DpSize): Modifier =
+    layout { measurable, _ ->
+        val placeable =
+            measurable.measure(
+                Constraints(
+                    maxWidth = ceiling.width.roundToPx(),
+                    maxHeight = ceiling.height.roundToPx(),
+                ),
+            )
+        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+    }
+
+/**
+ * The parent's CONTENT PANE bounds on screen as `[x, y, width, height]`, or null if unreadable.
+ *
+ * Not the window's own bounds, which is what [rememberOverlayParentBounds] returns. `BossWindow` is
+ * decorated, so its frame bounds include the native title bar and borders - and for an overlay
+ * anchored to a CORNER that difference is the bug, not a rounding error: anchored to the frame, a
+ * top-aligned overlay sits over the title bar, and since it eats clicks, over the window controls
+ * with it. The parent-sized renderers cannot see this because they cover a superset either way.
+ *
+ * [HeavyweightGhost] documents the same trap from the other side and avoids it by reading the cursor
+ * instead of converting at all; a corner anchor has no equivalent escape, so it converts correctly.
+ */
+internal fun contentPaneBounds(parent: AwtWindow?): IntArray? {
+    val pane = (parent as? RootPaneContainer)?.contentPane?.takeIf { it.isShowing } ?: return null
+    return runCatching {
+        val at = pane.locationOnScreen
+        intArrayOf(at.x, at.y, pane.width, pane.height)
+    }.getOrNull()
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,10 +50,11 @@ import java.awt.Window as AwtWindow
  * Two things here are deliberately not the obvious implementation, both because the obvious one
  * fails silently:
  *
- *  - Content is measured against [initialSize], **never against the window's current size** (see
- *    [measuredAgainst]). Measuring against the window makes the size a one-way ratchet: the window
- *    shrinks to fit what is showing, the next toast is then measured inside that smaller window,
- *    measures clipped, and the overlay can never grow back.
+ *  - Content is measured against a ceiling ([initialSize], clamped to the parent by
+ *    [clampCeiling]), **never against the window's current size** (see [measuredAgainst]).
+ *    Measuring against the window makes the size a one-way ratchet: the window shrinks to fit what
+ *    is showing, the next toast is then measured inside that smaller window, measures clipped, and
+ *    the overlay can never grow back.
  *  - Parent bounds come from the CONTENT PANE, not the window (see [contentPaneBounds]), and are
  *    re-read on the frame clock rather than remembered once.
  */
@@ -66,6 +69,13 @@ fun HeavyweightCorner(
     var measured by remember { mutableStateOf<DpSize?>(null) }
     val size = measured ?: initialSize
     var bounds by remember(parent) { mutableStateOf(contentPaneBounds(parent)) }
+    // Clamp the ceiling to the parent. The ceiling is a hard clip, not a soft start, and toast text
+    // is arbitrary plugin content: three wordy toasts can exceed a fixed height, and because the
+    // window is CONTENT-sized the overflow is not cosmetic - the bottom toast's dismiss button ends
+    // up outside the window, unclickable, on the INDEFINITE path where dismissing is the only way
+    // out. Clamping to the parent keeps the overlay inside the window without reintroducing any
+    // dependency on the overlay's OWN size, which is what the ratchet was.
+    val ceiling = clampCeiling(initialSize, bounds)
 
     val state =
         rememberWindowState(
@@ -109,7 +119,7 @@ fun HeavyweightCorner(
                 Modifier
                     // Order matters: the constraint override is OUTSIDE, so the observer inside it
                     // reports a size measured against the ceiling rather than against the window.
-                    .measuredAgainst(initialSize)
+                    .measuredAgainst(ceiling)
                     .onGloballyPositioned { coordinates ->
                         val next =
                             DpSize(
@@ -170,12 +180,33 @@ internal fun Modifier.measuredAgainst(ceiling: DpSize): Modifier =
  * instead of converting at all; a corner anchor has no equivalent escape, so it converts correctly.
  */
 internal fun contentPaneBounds(parent: AwtWindow?): IntArray? {
-    val pane = (parent as? RootPaneContainer)?.contentPane?.takeIf { it.isShowing } ?: return null
-    return runCatching {
-        val at = pane.locationOnScreen
-        intArrayOf(at.x, at.y, pane.width, pane.height)
-    }.getOrNull()
+    val pane = (parent as? RootPaneContainer)?.contentPane?.takeIf { it.isShowing }
+    val bounds =
+        pane?.let {
+            runCatching { it.locationOnScreen }.getOrNull()?.let { at ->
+                intArrayOf(at.x, at.y, it.width, it.height)
+            }
+        }
+    // Loud, once. A null here does not degrade gracefully: cornerPosition falls back to 0,0, which
+    // is the top-left of the PRIMARY display, so the overlay detaches from the window entirely.
+    // OverlayWindowBounds makes the same condition loud for the same reason - it was silent once,
+    // and an intermittent report of exactly this had nothing to correlate against.
+    if (bounds == null && unmeasurableParentReported.compareAndSet(false, true)) {
+        logger.warn(
+            LogCategory.UI,
+            "Corner overlay could not measure its parent content pane - placing at the screen origin",
+            mapOf("reason" to if (pane == null) "no showing content pane" else "locationOnScreen failed"),
+        )
+    }
+    return bounds
 }
+
+/** One warning per session for [contentPaneBounds]; it is consulted on the frame clock. */
+private val unmeasurableParentReported =
+    java.util.concurrent.atomic
+        .AtomicBoolean(false)
+
+private val logger = BossLogger.forComponent("HeavyweightCorner")
 
 /**
  * Top-left corner, in AWT logical units, for an overlay of [size] placed at [alignment] inside
@@ -210,4 +241,22 @@ internal fun cornerPosition(
                 else -> slackY / 2
             }
     return x to y
+}
+
+/**
+ * [initialSize], reduced to fit inside [bounds] when the parent is smaller.
+ *
+ * Only ever shrinks, and never consults the overlay's own current size - that dependency is exactly
+ * the ratchet [measuredAgainst] exists to break. A null [bounds] leaves the ceiling alone, since an
+ * unmeasurable parent says nothing about how big the content may be.
+ */
+internal fun clampCeiling(
+    initialSize: DpSize,
+    bounds: IntArray?,
+): DpSize {
+    if (bounds == null) return initialSize
+    return DpSize(
+        minOf(initialSize.width.value, bounds[2].toFloat()).dp,
+        minOf(initialSize.height.value, bounds[3].toFloat()).dp,
+    )
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -460,6 +460,14 @@ fun main(args: Array<String>) {
         ai.rever.boss.components.overlays
             .HeavyweightGhost(size, ghostContent)
     }
+    ai.rever.boss.components.overlays.OverlayConfig.heavyweightCorner = {
+        alignment,
+        initialSize,
+        cornerContent,
+        ->
+        ai.rever.boss.components.overlays
+            .HeavyweightCorner(alignment, initialSize, cornerContent)
+    }
     // plugin-ui-core owns the modal registry (plugins draw dialogs too) and depends on nothing but
     // Compose, so it cannot log. Give it this logger instead: the condition it reports is a dialog
     // that silently fell back to lightweight and is now hidden behind the page, which is invisible

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/MemoryPressureNoticeDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/MemoryPressureNoticeDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.performance
 
+import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -22,7 +23,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 
 /**
  * Tells the user when the memory-pressure watchdog has tightened the resource tier under them.
@@ -44,7 +44,7 @@ fun MemoryPressureNoticeDialog(onRestartRequested: () -> Unit) {
 
     val colors = BossTheme.colors
 
-    Dialog(onDismissRequest = { MemoryPressureWatchdog.acknowledge() }) {
+    BossDialog(onDismissRequest = { MemoryPressureWatchdog.acknowledge() }) {
         Column(
             modifier =
                 Modifier

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -931,338 +931,338 @@ fun ApplicationScope.BossWindow(
                     },
                 )
             }
-        }
 
-        // CLI Installation Dialog
-        if (showCLIInstallDialog) {
-            CLIInstallationDialog(
-                onDismiss = {
-                    showCLIInstallDialog = false
-                    // Refresh CLI installation status after dialog closes
-                    isCliInstalled = CLIInstaller.isInstalled()
-                },
-            )
-        }
+            // CLI Installation Dialog
+            if (showCLIInstallDialog) {
+                CLIInstallationDialog(
+                    onDismiss = {
+                        showCLIInstallDialog = false
+                        // Refresh CLI installation status after dialog closes
+                        isCliInstalled = CLIInstaller.isInstalled()
+                    },
+                )
+            }
 
-        // Password / bookmark import dialog
-        if (showImportDialog) {
-            ImportDataDialog(onDismiss = { showImportDialog = false })
-        }
+            // Password / bookmark import dialog
+            if (showImportDialog) {
+                ImportDataDialog(onDismiss = { showImportDialog = false })
+            }
 
-        // Exactly one window mounts this: the watchdog is process-wide, so mounting it per window
-        // would show the same notice once per open window.
-        //
-        // Identity, not a count. `windowCount <= 1` looks equivalent but is the opposite bug: with
-        // two windows open it is false in BOTH, so nobody mounts the dialog and the notice is
-        // never seen at all. Reading `windows` also registers a snapshot read, so this re-evaluates
-        // when the first window closes and the role passes to the next one.
-        if (WindowManager.windows.firstOrNull()?.id == windowState.id) {
-            ai.rever.boss.performance.MemoryPressureNoticeDialog(
-                onRestartRequested = {
-                    ai.rever.boss.config.ResourceModeConfig
-                        .requestUltraLiteOnNextLaunch()
-                    // A real relaunch, via the path the updater and Browser Engine settings
-                    // already use. Closing this window instead only removed one entry from
-                    // WindowManager, so with a second window open a button labelled "Restart"
-                    // made the user's tabs vanish and left the app running in the old tier.
-                    ai.rever.boss.utils.ApplicationRestarter
-                        .restartApplication()
-                },
-            )
-        }
+            // Exactly one window mounts this: the watchdog is process-wide, so mounting it per window
+            // would show the same notice once per open window.
+            //
+            // Identity, not a count. `windowCount <= 1` looks equivalent but is the opposite bug: with
+            // two windows open it is false in BOTH, so nobody mounts the dialog and the notice is
+            // never seen at all. Reading `windows` also registers a snapshot read, so this re-evaluates
+            // when the first window closes and the role passes to the next one.
+            if (WindowManager.windows.firstOrNull()?.id == windowState.id) {
+                ai.rever.boss.performance.MemoryPressureNoticeDialog(
+                    onRestartRequested = {
+                        ai.rever.boss.config.ResourceModeConfig
+                            .requestUltraLiteOnNextLaunch()
+                        // A real relaunch, via the path the updater and Browser Engine settings
+                        // already use. Closing this window instead only removed one entry from
+                        // WindowManager, so with a second window open a button labelled "Restart"
+                        // made the user's tabs vanish and left the app running in the old tier.
+                        ai.rever.boss.utils.ApplicationRestarter
+                            .restartApplication()
+                    },
+                )
+            }
 
-        // Reset Browser Confirmation Dialog
-        if (showResetBrowserDialog) {
-            var isResetting by remember { mutableStateOf(false) }
+            // Reset Browser Confirmation Dialog
+            if (showResetBrowserDialog) {
+                var isResetting by remember { mutableStateOf(false) }
 
-            BossAlertDialog(
-                onDismissRequest = {
-                    if (!isResetting) {
-                        showResetBrowserDialog = false
-                        resetBrowserResult = null
-                    }
-                },
-                title = {
-                    Text("Reset Browser")
-                },
-                text = {
-                    Column {
+                BossAlertDialog(
+                    onDismissRequest = {
+                        if (!isResetting) {
+                            showResetBrowserDialog = false
+                            resetBrowserResult = null
+                        }
+                    },
+                    title = {
+                        Text("Reset Browser")
+                    },
+                    text = {
+                        Column {
+                            when {
+                                isResetting -> {
+                                    Text("Resetting browser profile...")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("Please wait, this may take a moment.")
+                                }
+
+                                resetBrowserResult == null -> {
+                                    Text("This will reset the browser to fix persistent issues.")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("The following will be cleared:")
+                                    Text("• Browser cache and cookies")
+                                    Text("• Saved login sessions")
+                                    Text("• Browser history")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("All browser tabs will be closed. Continue?")
+                                }
+
+                                resetBrowserResult == true -> {
+                                    Text("✅ Browser reset successful!")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("Please close any browser tabs and reopen them.")
+                                }
+
+                                else -> {
+                                    Text("❌ Browser reset failed.")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("Please try restarting BOSS manually.")
+                                }
+                            }
+                        }
+                    },
+                    confirmButton = {
                         when {
                             isResetting -> {
-                                Text("Resetting browser profile...")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("Please wait, this may take a moment.")
+                                // No button while resetting
                             }
 
                             resetBrowserResult == null -> {
-                                Text("This will reset the browser to fix persistent issues.")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("The following will be cleared:")
-                                Text("• Browser cache and cookies")
-                                Text("• Saved login sessions")
-                                Text("• Browser history")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("All browser tabs will be closed. Continue?")
-                            }
-
-                            resetBrowserResult == true -> {
-                                Text("✅ Browser reset successful!")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("Please close any browser tabs and reopen them.")
+                                Button(
+                                    onClick = {
+                                        isResetting = true
+                                        menuScope.launch {
+                                            val result = FluckEngine.resetBrowserProfile()
+                                            resetBrowserResult = result.success
+                                            isResetting = false
+                                        }
+                                    },
+                                    colors =
+                                        ButtonDefaults.buttonColors(
+                                            backgroundColor = BossTheme.colors.alert,
+                                        ),
+                                ) {
+                                    Text("Reset Browser", color = BossTheme.colors.onSignal)
+                                }
                             }
 
                             else -> {
-                                Text("❌ Browser reset failed.")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("Please try restarting BOSS manually.")
+                                Button(
+                                    onClick = {
+                                        showResetBrowserDialog = false
+                                        resetBrowserResult = null
+                                    },
+                                ) {
+                                    Text("Close")
+                                }
                             }
                         }
-                    }
-                },
-                confirmButton = {
-                    when {
-                        isResetting -> {
-                            // No button while resetting
-                        }
-
-                        resetBrowserResult == null -> {
-                            Button(
-                                onClick = {
-                                    isResetting = true
-                                    menuScope.launch {
-                                        val result = FluckEngine.resetBrowserProfile()
-                                        resetBrowserResult = result.success
-                                        isResetting = false
-                                    }
-                                },
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        backgroundColor = BossTheme.colors.alert,
-                                    ),
-                            ) {
-                                Text("Reset Browser", color = BossTheme.colors.onSignal)
-                            }
-                        }
-
-                        else -> {
-                            Button(
+                    },
+                    dismissButton = {
+                        if (resetBrowserResult == null && !isResetting) {
+                            TextButton(
                                 onClick = {
                                     showResetBrowserDialog = false
-                                    resetBrowserResult = null
                                 },
                             ) {
-                                Text("Close")
+                                Text("Cancel")
                             }
                         }
-                    }
-                },
-                dismissButton = {
-                    if (resetBrowserResult == null && !isResetting) {
-                        TextButton(
-                            onClick = {
-                                showResetBrowserDialog = false
-                            },
-                        ) {
-                            Text("Cancel")
+                    },
+                )
+            }
+
+            // Reset Terminal Confirmation Dialog
+            if (showResetTerminalDialog) {
+                var isResetting by remember { mutableStateOf(false) }
+
+                BossAlertDialog(
+                    onDismissRequest = {
+                        if (!isResetting) {
+                            showResetTerminalDialog = false
+                            resetTerminalResult = null
                         }
-                    }
-                },
-            )
-        }
+                    },
+                    title = {
+                        Text("Reset Terminal")
+                    },
+                    text = {
+                        Column {
+                            when {
+                                isResetting -> {
+                                    Text("Resetting terminal sessions...")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("Please wait, this may take a moment.")
+                                }
 
-        // Reset Terminal Confirmation Dialog
-        if (showResetTerminalDialog) {
-            var isResetting by remember { mutableStateOf(false) }
+                                resetTerminalResult == null -> {
+                                    Text("This will reset all terminals to fix persistent issues.")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("The following will be cleared:")
+                                    Text("• All terminal sessions")
+                                    Text("• Terminal history in current session")
+                                    Text("• Running processes")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("All terminals will be reset with fresh sessions. Continue?")
+                                }
 
-            BossAlertDialog(
-                onDismissRequest = {
-                    if (!isResetting) {
-                        showResetTerminalDialog = false
-                        resetTerminalResult = null
-                    }
-                },
-                title = {
-                    Text("Reset Terminal")
-                },
-                text = {
-                    Column {
+                                resetTerminalResult == true -> {
+                                    Text("✅ Terminal reset successful!")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("Terminal tabs will refresh with new sessions automatically.")
+                                }
+
+                                else -> {
+                                    Text("❌ Terminal reset failed.")
+                                    Spacer(
+                                        modifier =
+                                            androidx.compose.ui.Modifier
+                                                .height(8.dp),
+                                    )
+                                    Text("Please try restarting BOSS manually.")
+                                }
+                            }
+                        }
+                    },
+                    confirmButton = {
                         when {
                             isResetting -> {
-                                Text("Resetting terminal sessions...")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("Please wait, this may take a moment.")
+                                // No button while resetting
                             }
 
                             resetTerminalResult == null -> {
-                                Text("This will reset all terminals to fix persistent issues.")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("The following will be cleared:")
-                                Text("• All terminal sessions")
-                                Text("• Terminal history in current session")
-                                Text("• Running processes")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("All terminals will be reset with fresh sessions. Continue?")
-                            }
-
-                            resetTerminalResult == true -> {
-                                Text("✅ Terminal reset successful!")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("Terminal tabs will refresh with new sessions automatically.")
+                                Button(
+                                    onClick = {
+                                        isResetting = true
+                                        menuScope.launch {
+                                            try {
+                                                // Use IO dispatcher for resource disposal per CLAUDE.md threading guidelines
+                                                withContext(Dispatchers.IO) {
+                                                    TerminalAPIAccess.resetAllTerminals()
+                                                }
+                                                resetTerminalResult = true
+                                            } catch (e: Exception) {
+                                                bossWindowLogger.warn(
+                                                    LogCategory.TERMINAL,
+                                                    "Terminal reset failed - dialog shows failure state",
+                                                    error = e,
+                                                )
+                                                resetTerminalResult = false
+                                            }
+                                            isResetting = false
+                                        }
+                                    },
+                                    colors =
+                                        ButtonDefaults.buttonColors(
+                                            backgroundColor = BossTheme.colors.alert,
+                                        ),
+                                ) {
+                                    Text("Reset Terminal", color = BossTheme.colors.onSignal)
+                                }
                             }
 
                             else -> {
-                                Text("❌ Terminal reset failed.")
-                                Spacer(
-                                    modifier =
-                                        androidx.compose.ui.Modifier
-                                            .height(8.dp),
-                                )
-                                Text("Please try restarting BOSS manually.")
+                                Button(
+                                    onClick = {
+                                        showResetTerminalDialog = false
+                                        resetTerminalResult = null
+                                    },
+                                ) {
+                                    Text("Close")
+                                }
                             }
                         }
-                    }
-                },
-                confirmButton = {
-                    when {
-                        isResetting -> {
-                            // No button while resetting
-                        }
-
-                        resetTerminalResult == null -> {
-                            Button(
-                                onClick = {
-                                    isResetting = true
-                                    menuScope.launch {
-                                        try {
-                                            // Use IO dispatcher for resource disposal per CLAUDE.md threading guidelines
-                                            withContext(Dispatchers.IO) {
-                                                TerminalAPIAccess.resetAllTerminals()
-                                            }
-                                            resetTerminalResult = true
-                                        } catch (e: Exception) {
-                                            bossWindowLogger.warn(
-                                                LogCategory.TERMINAL,
-                                                "Terminal reset failed - dialog shows failure state",
-                                                error = e,
-                                            )
-                                            resetTerminalResult = false
-                                        }
-                                        isResetting = false
-                                    }
-                                },
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        backgroundColor = BossTheme.colors.alert,
-                                    ),
-                            ) {
-                                Text("Reset Terminal", color = BossTheme.colors.onSignal)
-                            }
-                        }
-
-                        else -> {
-                            Button(
+                    },
+                    dismissButton = {
+                        if (resetTerminalResult == null && !isResetting) {
+                            TextButton(
                                 onClick = {
                                     showResetTerminalDialog = false
-                                    resetTerminalResult = null
                                 },
                             ) {
-                                Text("Close")
+                                Text("Cancel")
                             }
                         }
-                    }
-                },
-                dismissButton = {
-                    if (resetTerminalResult == null && !isResetting) {
-                        TextButton(
-                            onClick = {
-                                showResetTerminalDialog = false
-                            },
-                        ) {
-                            Text("Cancel")
-                        }
-                    }
-                },
-            )
-        }
+                    },
+                )
+            }
 
-        // Welcome Wizard Dialog
-        if (showWelcomeWizard) {
-            TerminalAPIAccess.TerminalOnboardingWizard(
-                onDismiss = { showWelcomeWizard = false },
-                onComplete = { showWelcomeWizard = false },
-            )
-        }
+            // Welcome Wizard Dialog
+            if (showWelcomeWizard) {
+                TerminalAPIAccess.TerminalOnboardingWizard(
+                    onDismiss = { showWelcomeWizard = false },
+                    onComplete = { showWelcomeWizard = false },
+                )
+            }
 
-        // Screen Capture Picker Dialog
-        val captureRequest by ScreenCaptureNotifier.captureRequest.collectAsState()
-        captureRequest?.let { request ->
-            ScreenCapturePickerDialog(
-                screens = request.screens,
-                windows = request.windows,
-                browsers = request.browsers,
-                onDismiss = { ScreenCaptureNotifier.cancel(request.requestId) },
-                onSelect = { source, audioMode ->
-                    ScreenCaptureNotifier.selectSource(request.requestId, source, audioMode)
-                },
-            )
-        }
+            // Screen Capture Picker Dialog
+            val captureRequest by ScreenCaptureNotifier.captureRequest.collectAsState()
+            captureRequest?.let { request ->
+                ScreenCapturePickerDialog(
+                    screens = request.screens,
+                    windows = request.windows,
+                    browsers = request.browsers,
+                    onDismiss = { ScreenCaptureNotifier.cancel(request.requestId) },
+                    onSelect = { source, audioMode ->
+                        ScreenCaptureNotifier.selectSource(request.requestId, source, audioMode)
+                    },
+                )
+            }
 
-        // Screen Recording permission rationale — explains why, before the macOS prompt.
-        val permissionRationale by ScreenCaptureNotifier.permissionRationale.collectAsState()
-        if (permissionRationale != null) {
-            BossAlertDialog(
-                onDismissRequest = { ScreenCaptureNotifier.resolvePermissionRationale(false) },
-                title = { Text("Allow screen sharing?") },
-                text = {
-                    Text(
-                        "To share a screen, window, or browser tab, BOSS needs macOS " +
-                            "Screen Recording permission. macOS will now ask you to allow \u201CBOSS\u201D. " +
-                            "You can change this anytime in System Settings \u203A Privacy & Security \u203A Screen Recording.",
-                    )
-                },
-                confirmButton = {
-                    TextButton(onClick = { ScreenCaptureNotifier.resolvePermissionRationale(true) }) { Text("Continue") }
-                },
-                dismissButton = {
-                    TextButton(onClick = { ScreenCaptureNotifier.resolvePermissionRationale(false) }) { Text("Not now") }
-                },
-            )
+            // Screen Recording permission rationale — explains why, before the macOS prompt.
+            val permissionRationale by ScreenCaptureNotifier.permissionRationale.collectAsState()
+            if (permissionRationale != null) {
+                BossAlertDialog(
+                    onDismissRequest = { ScreenCaptureNotifier.resolvePermissionRationale(false) },
+                    title = { Text("Allow screen sharing?") },
+                    text = {
+                        Text(
+                            "To share a screen, window, or browser tab, BOSS needs macOS " +
+                                "Screen Recording permission. macOS will now ask you to allow \u201CBOSS\u201D. " +
+                                "You can change this anytime in System Settings \u203A Privacy & Security \u203A Screen Recording.",
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { ScreenCaptureNotifier.resolvePermissionRationale(true) }) { Text("Continue") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { ScreenCaptureNotifier.resolvePermissionRationale(false) }) { Text("Not now") }
+                    },
+                )
+            }
         }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
@@ -1,0 +1,92 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.overlays.OverlayConfig
+import ai.rever.boss.plugin.sandbox.notification.PluginToastState
+import ai.rever.boss.plugin.sandbox.notification.ToastDuration
+import ai.rever.boss.plugin.sandbox.notification.ToastMessage
+import ai.rever.boss.plugin.sandbox.notification.ToastType
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the empty check in [ToastOverlay].
+ *
+ * Without it the overlay is composed for every loaded plugin for the entire session, because
+ * `PluginToastHost` composes its padded `Column` unconditionally and `DefaultPlugin.pluginToastState`
+ * is never null. Since a non-focusable AWT window still receives mouse events and there is no
+ * portable click-through, that is a permanently dead region of the app - and, being always-on-top, of
+ * whatever other application is in front. The guard is one line, and nothing else in the build would
+ * notice it going missing.
+ */
+class ToastOverlayTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val previousRenderer = OverlayConfig.heavyweightCorner
+    private val previousUseHeavyweight = OverlayConfig.useHeavyweightPopups
+
+    @After
+    fun restore() {
+        // OverlayConfig is a process-global registry; leaving a fake in it would leak into any
+        // other test that routes an overlay.
+        OverlayConfig.heavyweightCorner = previousRenderer
+        OverlayConfig.useHeavyweightPopups = previousUseHeavyweight
+    }
+
+    /** How many times the heavyweight renderer is asked for a window, for the given toasts. */
+    private fun windowsOpenedFor(messages: List<String>): Int {
+        var opened = 0
+        OverlayConfig.useHeavyweightPopups = true
+        OverlayConfig.heavyweightCorner = { _, _, _ ->
+            // Counted, not composed: composing a real Window needs a display.
+            opened++
+        }
+        val state = PluginToastState(CoroutineScope(Job()))
+        messages.forEach { title ->
+            // INDEFINITE so no auto-dismiss timer can race the assertion.
+            state.show(
+                ToastMessage(
+                    type = ToastType.INFO,
+                    title = title,
+                    message = title,
+                    duration = ToastDuration.INDEFINITE,
+                ),
+            )
+        }
+
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    ToastOverlay(toastState = state)
+                }
+            }
+        }
+        rule.waitForIdle()
+        return opened
+    }
+
+    @Test
+    fun `no overlay window is opened when there are no toasts`() {
+        assertEquals(
+            0,
+            windowsOpenedFor(emptyList()),
+            "an empty toast host still measures 32x32 from its own padding, so an unguarded " +
+                "overlay holds a click-eating always-on-top window open for the whole session",
+        )
+    }
+
+    @Test
+    fun `an overlay window is opened once there is a toast`() {
+        assertEquals(1, windowsOpenedFor(listOf("Something happened")))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
@@ -10,13 +10,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.test.junit4.createComposeRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
-import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Pins the empty check in [ToastOverlay].
@@ -35,23 +39,38 @@ class ToastOverlayTest {
     private val previousRenderer = OverlayConfig.heavyweightCorner
     private val previousUseHeavyweight = OverlayConfig.useHeavyweightPopups
 
+    private val scopes = mutableListOf<CoroutineScope>()
+
     @After
     fun restore() {
+        // Each harness run built a scope with live auto-dismiss timers; leaving them running leaks
+        // into the rest of the module.
+        scopes.forEach { it.cancel() }
         // OverlayConfig is a process-global registry; leaving a fake in it would leak into any
         // other test that routes an overlay.
         OverlayConfig.heavyweightCorner = previousRenderer
         OverlayConfig.useHeavyweightPopups = previousUseHeavyweight
     }
 
-    /** How many times the heavyweight renderer is asked for a window, for the given toasts. */
-    private fun windowsOpenedFor(messages: List<String>): Int {
-        var opened = 0
+    /**
+     * Whether the heavyweight renderer is asked for a window at all, for the given toasts and
+     * window-focus state.
+     *
+     * Presence, not a count: `opened++` would tally COMPOSITIONS, so any extra recomposition of
+     * ToastOverlay would break an equality assertion without anything being wrong.
+     */
+    private fun windowRequestedFor(
+        messages: List<String>,
+        focused: Boolean = true,
+    ): Boolean {
+        var requested = false
         OverlayConfig.useHeavyweightPopups = true
         OverlayConfig.heavyweightCorner = { _, _, _ ->
-            // Counted, not composed: composing a real Window needs a display.
-            opened++
+            // Recorded, not composed: composing a real Window needs a display.
+            requested = true
         }
-        val state = PluginToastState(CoroutineScope(Job()))
+        val scope = CoroutineScope(Job()).also { scopes += it }
+        val state = PluginToastState(scope)
         messages.forEach { title ->
             // INDEFINITE so no auto-dismiss timer can race the assertion.
             state.show(
@@ -65,21 +84,27 @@ class ToastOverlayTest {
         }
 
         rule.setContent {
-            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+            CompositionLocalProvider(
+                LocalHeavyweightOverlays provides true,
+                LocalWindowInfo provides FakeWindowInfo(focused),
+            ) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     ToastOverlay(toastState = state)
                 }
             }
         }
         rule.waitForIdle()
-        return opened
+        return requested
     }
+
+    private class FakeWindowInfo(
+        override val isWindowFocused: Boolean,
+    ) : WindowInfo
 
     @Test
     fun `no overlay window is opened when there are no toasts`() {
-        assertEquals(
-            0,
-            windowsOpenedFor(emptyList()),
+        assertFalse(
+            windowRequestedFor(emptyList()),
             "an empty toast host still measures 32x32 from its own padding, so an unguarded " +
                 "overlay holds a click-eating always-on-top window open for the whole session",
         )
@@ -87,6 +112,16 @@ class ToastOverlayTest {
 
     @Test
     fun `an overlay window is opened once there is a toast`() {
-        assertEquals(1, windowsOpenedFor(listOf("Something happened")))
+        assertTrue(windowRequestedFor(listOf("Something happened")))
+    }
+
+    @Test
+    fun `no overlay window is opened while the parent window is unfocused`() {
+        assertFalse(
+            windowRequestedFor(listOf("Plugin Disabled"), focused = false),
+            "toast lifetime is unbounded (ToastDuration.INDEFINITE, which the host itself raises), " +
+                "so an always-on-top click-eating window over ANOTHER application must not outlive " +
+                "the user looking at this one",
+        )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerSizingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerSizingTest.kt
@@ -1,0 +1,127 @@
+package ai.rever.boss.components.overlays
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the sizing half of [HeavyweightCorner], which the placement tests cannot reach.
+ *
+ * The bug this exists for is a one-way ratchet, and it is invisible to every other gate: measuring
+ * content against the overlay's own current size means the window shrinks to fit what is showing,
+ * the next toast is measured inside that smaller window and so measures CLIPPED, and the overlay can
+ * never grow back. Nothing warns, placement stays correct, and the toast simply renders squashed.
+ *
+ * These assert on the REAL modifier chain rather than on reasoning about it, because that is the
+ * only thing that distinguishes the two implementations.
+ */
+class HeavyweightCornerSizingTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val ceiling = DpSize(432.dp, 600.dp)
+    private val toast = DpSize(400.dp, 120.dp)
+
+    /**
+     * Lays [contentSize] out inside a window of [available], recording every size the observer
+     * inside the constraint override reports. [available] is a state, so a test can shrink or grow
+     * "the window" and watch what measurement does in response.
+     */
+    private fun harness(
+        initialAvailable: DpSize,
+        contentSize: DpSize,
+    ): Harness {
+        val seen = mutableListOf<IntSize>()
+        var available by mutableStateOf(initialAvailable)
+        var density = 1f
+        rule.setContent {
+            density = LocalDensity.current.density
+            // The outer Box stands in for the overlay WINDOW: content is laid out inside whatever
+            // size the window currently has, which is exactly the feedback path being tested.
+            Box(modifier = Modifier.size(available.width, available.height)) {
+                Box(
+                    modifier =
+                        Modifier
+                            .measuredAgainst(ceiling)
+                            .onGloballyPositioned { seen += it.size },
+                ) {
+                    Box(modifier = Modifier.size(contentSize.width, contentSize.height))
+                }
+            }
+        }
+        rule.waitForIdle()
+        return Harness(
+            seen = seen,
+            resize = { next ->
+                available = next
+                rule.waitForIdle()
+            },
+            density = density,
+        )
+    }
+
+    private class Harness(
+        val seen: List<IntSize>,
+        val resize: (DpSize) -> Unit,
+        val density: Float,
+    )
+
+    @Test
+    fun `content is measured against the ceiling, not the window's current size`() {
+        // The ratchet state: the window has already shrunk to 32x32, which is exactly what an empty
+        // toast host measures - a Column with nothing in it, plus 16.dp padding on each side. A
+        // toast then arrives.
+        val h = harness(initialAvailable = DpSize(32.dp, 32.dp), contentSize = toast)
+
+        assertTrue(h.seen.isNotEmpty(), "expected at least one measurement")
+        // Assert on EVERY measurement, not only the last: a wrong first frame IS the bug, because
+        // the window is resized from it.
+        h.seen.forEach { size ->
+            assertTrue(
+                size.width > 32 && size.height > 32,
+                "measured $size - clipped to the window instead of the ceiling, so the overlay " +
+                    "would resize to the clipped size and never grow back",
+            )
+        }
+    }
+
+    @Test
+    fun `measurement does not change when the window shrinks under it`() {
+        val h = harness(initialAvailable = ceiling, contentSize = toast)
+        val whenLarge = h.seen.last()
+
+        // Shrink the window the way the real one shrinks after fitting itself to a toast.
+        h.resize(DpSize(32.dp, 32.dp))
+
+        // Independence from the current size is the whole property: it is what makes the two-pass
+        // sizing converge instead of ratchet.
+        assertEquals(whenLarge, h.seen.last())
+    }
+
+    @Test
+    fun `content is still capped by the ceiling`() {
+        // The flip side: the ceiling is a real bound, so the overlay never opens a window larger
+        // than the region it is allowed to swallow clicks in.
+        val h = harness(initialAvailable = ceiling, contentSize = DpSize(2000.dp, 2000.dp))
+
+        val expected =
+            IntSize(
+                (ceiling.width.value * h.density).toInt(),
+                (ceiling.height.value * h.density).toInt(),
+            )
+        assertEquals(expected, h.seen.last())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerTest.kt
@@ -1,0 +1,55 @@
+package ai.rever.boss.components.overlays
+
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins [cornerPosition], the only part of the toast overlay reachable without a display.
+ *
+ * Placement is the part of this that has actually gone wrong before: an overlay measured against
+ * the wrong origin, or in the wrong units, compiles and passes every other gate while sitting
+ * visibly off-target on screen.
+ */
+class HeavyweightCornerTest {
+    private val parent = intArrayOf(100, 50, 1000, 800)
+    private val size = DpSize(432.dp, 200.dp)
+
+    @Test
+    fun `top end sits at the parent's right edge, not the screen's`() {
+        // 100 + (1000 - 432) = 668, i.e. offset from the PARENT origin. Using the screen origin
+        // instead is the classic version of this bug and lands the toast on the wrong monitor.
+        assertEquals(668 to 50, cornerPosition(parent, size, Alignment.TopEnd))
+    }
+
+    @Test
+    fun `top start sits at the parent origin`() {
+        assertEquals(100 to 50, cornerPosition(parent, size, Alignment.TopStart))
+    }
+
+    @Test
+    fun `bottom end offsets by both slacks`() {
+        assertEquals(668 to 650, cornerPosition(parent, size, Alignment.BottomEnd))
+    }
+
+    @Test
+    fun `center centres on both axes`() {
+        assertEquals(384 to 350, cornerPosition(parent, size, Alignment.Center))
+    }
+
+    @Test
+    fun `content larger than the parent overhangs bottom-right rather than escaping top-left`() {
+        // A negative slack would put the toast above and left of the window, where it is off screen
+        // and its dismiss button is unreachable. Floor at the parent origin instead.
+        val huge = DpSize(2000.dp, 2000.dp)
+        assertEquals(100 to 50, cornerPosition(parent, huge, Alignment.TopEnd))
+        assertEquals(100 to 50, cornerPosition(parent, huge, Alignment.BottomEnd))
+    }
+
+    @Test
+    fun `unmeasured parent falls back to the origin`() {
+        assertEquals(0 to 0, cornerPosition(null, size, Alignment.TopEnd))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightOverlayTest.kt
@@ -277,6 +277,7 @@ class HeavyweightOverlayTest {
         OverlayConfig.hideHeavyweightTooltip = null
         OverlayConfig.heavyweightHud = null
         OverlayConfig.heavyweightGhost = null
+        OverlayConfig.heavyweightCorner = null
         OverlayConfig.openHeavyweightPopups = 0
     }
 
@@ -290,6 +291,7 @@ class HeavyweightOverlayTest {
         assertNull(OverlayConfig.heavyweightPopup)
         assertNull(OverlayConfig.heavyweightModal)
         assertNull(OverlayConfig.heavyweightTooltip)
+        assertNull(OverlayConfig.heavyweightCorner)
         assertNull(OverlayConfig.hideHeavyweightTooltip)
         assertNull(OverlayConfig.heavyweightHud)
         assertNull(OverlayConfig.heavyweightGhost)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NoRawDialogConventionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NoRawDialogConventionTest.kt
@@ -1,0 +1,66 @@
+package ai.rever.boss.components.overlays
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Asserts no host source imports `androidx.compose.ui.window.Dialog` directly.
+ *
+ * Under HARDWARE_ACCELERATED the JxBrowser view is a native child window composited ABOVE the
+ * Compose scene, so a plain `Dialog` opened over a browser tab renders behind the page. `BossDialog`
+ * routes into its own always-on-top window instead.
+ *
+ * A convention test rather than review vigilance because the failure is invisible in the diff and on
+ * any machine that is not looking at a browser tab at the time: the dialog composes, lays out and
+ * logs exactly as it should, and is simply not on screen. The same PR that added this test found
+ * `MemoryPressureNoticeDialog` still calling `Dialog` directly and a whole span of dialogs that
+ * *looked* converted but sat outside the CompositionLocal that routes them - two different ways for
+ * "it uses the right API" and "it actually routes" to come apart.
+ *
+ * Deliberately an import check. It cannot catch a fully-qualified call, but it catches the shape
+ * every real call site takes, and it costs nothing.
+ */
+class NoRawDialogConventionTest {
+    private val allowed =
+        setOf(
+            // The routing primitive itself: its lightweight branch IS the plain Dialog.
+            "BossDialog.kt",
+        )
+
+    @Test
+    fun `no host source imports the raw Compose Dialog`() {
+        val root = repoRoot()
+        val roots =
+            listOf(File(root, "composeApp/src"), File(root, "plugin-platform"))
+                .filter { it.isDirectory }
+        check(roots.isNotEmpty()) { "no source roots found under $root" }
+
+        val offenders =
+            roots
+                .flatMap { it.walkTopDown().filter { f -> f.isFile && f.extension == "kt" } }
+                .filter { it.name !in allowed }
+                .filter { file ->
+                    file.readLines().any { it.trim() == "import androidx.compose.ui.window.Dialog" }
+                }.map { it.relativeTo(root).path }
+                .sorted()
+
+        if (offenders.isNotEmpty()) {
+            fail(
+                "These files import androidx.compose.ui.window.Dialog directly, so their dialogs " +
+                    "render BEHIND the browser surface under HARDWARE_ACCELERATED. Use BossDialog " +
+                    "(ai.rever.boss.plugin.ui.BossDialog) instead:\n  " + offenders.joinToString("\n  "),
+            )
+        }
+    }
+
+    /** Walks up from the test's working directory to the checkout root. */
+    private fun repoRoot(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            if (File(dir, "composeApp").isDirectory && File(dir, "version.properties").isFile) return dir
+            dir = dir.parentFile
+        }
+        fail("could not locate the repository root from ${File(".").absolutePath}")
+    }
+}


### PR DESCRIPTION
Two overlays were still rendering behind the heavyweight JxBrowser surface: the screen-capture picker used for screen sharing in the fluck browser plugin, and plugin toast notifications.

## Window dialogs: a scope bug, not a missing call

`ScreenCapturePickerDialog` already called `BossDialog`, so it looked converted. It was not reached: `LocalHeavyweightOverlays` was provided around `BossAppWithAuth` only, a 20-line span at `BossWindow.kt:914..934`, while the dialog composes at line 1234. The local read its `false` default and the dialog routed lightweight anyway.

Extending the provider to the end of the window content covers six dialogs at once:

| Dialog | Line |
|---|---|
| `CLIInstallationDialog` | 937 |
| `ImportDataDialog` | 948 |
| Reset Terminal (`BossAlertDialog`) | 977 |
| Reset Browser (`BossAlertDialog`) | 1096 |
| `ScreenCapturePickerDialog` | 1234 |
| Screen-recording rationale (`BossAlertDialog`) | 1248 |

That file's diff is large but `git diff -w` reduces it to a single moved brace; the rest is reindentation.

### On the JxBrowser API question

There is no native picker API to defer to. JxBrowser 9.3.0's capture package exposes only `CaptureSources` (browsers / screens / applicationWindows), `CaptureSession` (stop / source / isActive), `CaptureSource`, `CaptureSourceType`, `AudioCaptureMode` and `NotificationVisibility` - source enumeration and session control. The picker UI is ours, so overlay routing is the only available fix.

## Toasts need a third renderer

Neither existing renderer works here, for opposite reasons:

- **`HeavyweightHud` is parent-sized.** A non-focusable AWT window still receives mouse events and the JVM has no portable click-through, so it swallows every click beneath it. Acceptable for the Ctrl+Tab switcher, which is up only while a key is held; not acceptable for a toast that lingers for seconds while the user keeps working - the window would be unclickable for that whole time.
- **`HeavyweightPopup`'s scrim dismisses on any click**, so clicking anywhere in the app would eat the click and kill the toast.

`HeavyweightCorner` is content-sized, like `HeavyweightGhost` and for the same reason: it covers only the toast, so its dismiss button works and every click outside it reaches the app.

Two details worth review attention:

- **Sizing is two-pass** because a window's size must be chosen before its content can be measured. `initialSize` is deliberately a generous upper bound (432x900 dp, from `PluginToastHost`'s own `widthIn(max = 400.dp)` plus its 16.dp padding): measuring inside too small a window measures *clipped* content, and the overlay would then settle at the clipped size and stay there.
- **Window state is assigned from a `LaunchedEffect`, never during composition.** Writing it inline is what made the cursor overlay jitter previously.

`cornerPosition` is pure and pinned by six tests. Placement is the part of this that has gone wrong before, and it passes every other gate while sitting visibly off-target on screen.

## Known trade-off

The toast window is `alwaysOnTop`, so a toast raised just before switching apps floats above the other app for its remaining lifetime. The HUD and drag ghost share this property, but they last a keypress rather than seconds. Left as-is for now; suppressing the overlay while the parent window is inactive is the fix if it reads wrong in practice.

## Verification

- `ktlintFormat`, `:composeApp:compileKotlinDesktop`, `detekt`, `ktlintCheck` all green, with no warnings on any touched file
- `:composeApp:desktopTest`: 1710 tests, 0 failures, 0 errors (counted from the XML reports, not from the build's exit code)
- 6 new `HeavyweightCornerTest` cases, confirmed executed via the test XML rather than inferred from a green filtered run
- Ran the app from this worktree: `mode=HARDWARE_ACCELERATED` confirmed in the log, and zero occurrences of either degradation warning ("could not measure its parent window", "came up opaque")

On-screen confirmation of the two user-visible surfaces is still outstanding.
