### PR TITLE
feat(llm): serve credential brokers to plugins, by id rather than by URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,37 @@ MACOS_DEVELOPER_ID=Developer ID Application: ...  # Optional, signs local packag
 
 **Priority**: Environment variables > System properties > local.properties > Embedded build config
 
+### Credential brokers
+
+A provider whose credential nobody types in: the user is signed in to BOSS and an
+organisation gateway mints a short-lived scoped key for that identity. RISA Codex GLM works
+this way.
+
+The exchange is **host-side and stays that way**. Nothing on `PluginContext` exposes the
+Supabase access token - `AuthDataProvider` gives identity only, `SupabaseDataProvider` proxies
+queries with the host attaching auth - so `CredentialBrokerClient` hands a plugin the
+*downstream* credential and never the session that bought it.
+
+**A broker is named by id, never by URL.** `CredentialBrokers` owns the id to endpoint map. An
+`exchange(url)` shape would have handed every installed plugin a way to post the user's session
+token to a host of its choosing; as it is, the worst a plugin can do is name a broker this
+build does not have. `CredentialBrokersTest` pins that, plus that every broker declares an
+https endpoint and a `scopedTo` prefix (published so a careful plugin can check where it is
+about to send a bearer token).
+
+`RisaLlmTokenCommand` is a thin adapter over the same registry, so the `BOSS llm-token` helper
+Codex invokes and the plugin-facing `BrokeredCredentialProvider` cannot drift apart or hold two
+copies of the endpoint.
+
+Adding one means an entry in `CredentialBrokers.all()`. The plugin-facing side needs no change.
+
+**The three-wrapper rule applies.** `brokeredCredentialProvider` is overridden in
+`DefaultPlugin`, `TrackingPluginContext` **and**
+`plugin-platform/plugin-sandbox/.../SandboxedPluginContext`. Missing the sandbox one returns
+null for every plugin, silently - that has happened before with `mcpToolRegistry`. The
+implementation lives in `desktopMain` (it speaks HTTP), so `DefaultPlugin` reads it through
+`BrokeredCredentialAccess`, a commonMain holder that `main.kt` populates at startup.
+
 ### AI credentials are not configured here
 
 `OPENAI_API_KEY` used to be listed above as a `local.properties` key that enabled AI

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -643,6 +643,18 @@ class DefaultPlugin(
     override val llmProvider: ai.rever.boss.plugin.api.LlmProvider?
         get() = getPluginAPI(ai.rever.boss.plugin.api.LlmProviderSettingsAPI::class.java)
 
+    /**
+     * Credential brokers, for a provider whose credential nobody types in.
+     *
+     * Read through a holder because the implementation exchanges a Supabase session over
+     * HTTP and so lives in desktopMain, while this class is commonMain. Null until desktop
+     * startup registers one.
+     */
+    override val brokeredCredentialProvider: ai.rever.boss.plugin.api.BrokeredCredentialProvider?
+        get() =
+            ai.rever.boss.services.llm.BrokeredCredentialAccess
+                .current()
+
     // Panel event provider for plugins that need to trigger panel events
     override val panelEventProvider: ai.rever.boss.plugin.api.PanelEventProvider by lazy {
         ai.rever.boss.components.plugin.providers

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.api.ApplicationEventBus
 import ai.rever.boss.plugin.api.AuthDataProvider
 import ai.rever.boss.plugin.api.BackgroundTaskProvider
 import ai.rever.boss.plugin.api.BookmarkDataProvider
+import ai.rever.boss.plugin.api.BrokeredCredentialProvider
 import ai.rever.boss.plugin.api.CacheProvider
 import ai.rever.boss.plugin.api.ClipboardProvider
 import ai.rever.boss.plugin.api.ContextMenuProvider
@@ -318,6 +319,8 @@ class TrackingPluginContext(
     override val fileSystemDataProvider: FileSystemDataProvider? get() = delegate.fileSystemDataProvider
     override val secretDataProvider: SecretDataProvider? get() = delegate.secretDataProvider
     override val llmProvider: LlmProvider? get() = delegate.llmProvider
+    override val brokeredCredentialProvider: BrokeredCredentialProvider?
+        get() = delegate.brokeredCredentialProvider
     override val runConfigurationDataProvider: RunConfigurationDataProvider? get() = delegate.runConfigurationDataProvider
     override val activeTabsProvider: ActiveTabsProvider? get() = delegate.activeTabsProvider
     override val windowId: String? get() = delegate.windowId

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/llm/BrokeredCredentialAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/llm/BrokeredCredentialAccess.kt
@@ -1,0 +1,30 @@
+package ai.rever.boss.services.llm
+
+import ai.rever.boss.plugin.api.BrokeredCredentialProvider
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+private val logger = BossLogger.forComponent("BrokeredCredentialAccess")
+
+/**
+ * Holds the host's credential-broker implementation so `DefaultPlugin` can serve it.
+ *
+ * A holder rather than a direct reference because the implementation exchanges a Supabase
+ * session over HTTP and so lives in `desktopMain`, while `DefaultPlugin` - the class that
+ * has to expose it on `PluginContext` - is in `commonMain`. Desktop startup registers it.
+ *
+ * Null until then, and null on any build that does not register one, which is the same
+ * "provider may be absent" contract every other member of `PluginContext` has.
+ */
+object BrokeredCredentialAccess {
+    @Volatile
+    private var provider: BrokeredCredentialProvider? = null
+
+    /** Called once from desktop startup. */
+    fun initialize(implementation: BrokeredCredentialProvider) {
+        provider = implementation
+        logger.debug(LogCategory.SYSTEM, "BrokeredCredentialAccess initialized")
+    }
+
+    fun current(): BrokeredCredentialProvider? = provider
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/BrokeredCredentialProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/BrokeredCredentialProviderImpl.kt
@@ -1,0 +1,49 @@
+package ai.rever.boss.llm
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+/**
+ * Serves credential brokers to plugins.
+ *
+ * The host half of `BrokeredCredentialProvider`. A plugin names a broker by id and gets back
+ * the downstream credential; the Supabase session stays in this process, which is the point -
+ * nothing on `PluginContext` exposes it, and this keeps that boundary rather than widening it.
+ */
+internal object BrokeredCredentialProviderImpl : ai.rever.boss.plugin.api.BrokeredCredentialProvider {
+    private val logger = BossLogger.forComponent("BrokeredCredentials")
+
+    override fun availableBrokers(): List<ai.rever.boss.plugin.api.BrokerInfo> {
+        val signedIn = CredentialBrokerClient.isSignedIn()
+        return CredentialBrokers.all().map { broker ->
+            ai.rever.boss.plugin.api.BrokerInfo(
+                id = broker.id,
+                displayName = broker.displayName,
+                // Availability is "could this work right now", which for every broker here
+                // means a signed-in session. A plugin can then explain rather than offering
+                // an action that can only fail.
+                available = signedIn,
+                scopedTo = broker.scopedTo,
+            )
+        }
+    }
+
+    override suspend fun exchange(brokerId: String): Result<ai.rever.boss.plugin.api.BrokeredCredential> =
+        CredentialBrokerClient
+            .exchange(brokerId)
+            .map { issued ->
+                ai.rever.boss.plugin.api.BrokeredCredential(
+                    token = issued.token,
+                    refreshAfterSeconds = issued.refreshAfterSeconds,
+                    expiresAt = issued.expiresAt,
+                )
+            }.onFailure { error ->
+                // The token is never logged; the reason is, because "the provider says not
+                // configured" is otherwise unexplainable from the outside.
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "Broker exchange failed",
+                    mapOf("broker" to brokerId, "reason" to (error.message ?: "unknown")),
+                )
+            }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/CredentialBrokers.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/CredentialBrokers.kt
@@ -1,0 +1,243 @@
+package ai.rever.boss.llm
+
+import ai.rever.boss.services.auth.CoreAuthService
+import ai.rever.boss.services.supabase.SupabaseConfig
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.user.UserSession
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * A credential broker: an endpoint that exchanges the signed-in BOSS session for a
+ * short-lived credential scoped to something downstream.
+ *
+ * [tokenUrl] lives here, in the host, and is **never** supplied by a caller. A plugin asks
+ * for a broker by [id], so the worst it can do is name one this host does not have. An
+ * `exchange(url)` shape would instead hand every installed plugin a way to post the user's
+ * session token to a host of its choosing.
+ */
+internal data class CredentialBroker(
+    val id: String,
+    val displayName: String,
+    val tokenUrl: String,
+    /**
+     * The endpoint prefix the issued credential is meant for, published to plugins so a
+     * careful one can check before it posts a bearer token somewhere.
+     */
+    val scopedTo: String?,
+)
+
+/**
+ * Every broker this build knows about.
+ *
+ * A registry rather than a constant so a second one costs an entry, and so
+ * [RisaLlmTokenCommand] and the plugin-facing provider resolve the same way instead of
+ * each carrying its own copy of the URL.
+ */
+internal object CredentialBrokers {
+    const val RISA_GLM: String = "risa-glm"
+
+    private const val RISA_TOKEN_URL = "https://llm.risa.inc/auth/token"
+    private const val RISA_API_BASE = "https://llm.risa.inc/v1"
+
+    /** Overrides RISA's token endpoint, for pointing a dev build at a staging gateway. */
+    private const val RISA_TOKEN_URL_ENV = "RISA_LLM_TOKEN_URL"
+
+    fun all(): List<CredentialBroker> =
+        listOf(
+            CredentialBroker(
+                id = RISA_GLM,
+                displayName = "RISA Codex GLM",
+                tokenUrl =
+                    System
+                        .getenv(RISA_TOKEN_URL_ENV)
+                        ?.takeIf { it.isNotBlank() }
+                        ?: RISA_TOKEN_URL,
+                scopedTo = RISA_API_BASE,
+            ),
+        )
+
+    fun find(id: String): CredentialBroker? = all().firstOrNull { it.id == id }
+}
+
+/** What a broker returned. Mirrors the api's `BrokeredCredential` without depending on it. */
+internal data class BrokeredToken(
+    val token: String,
+    val refreshAfterSeconds: Long,
+    val expiresAt: String?,
+)
+
+/**
+ * Exchanges the current session for a broker credential.
+ *
+ * The session never leaves this process: callers get the downstream credential and nothing
+ * else. That is the whole reason the exchange is host-side - nothing on `PluginContext`
+ * exposes the Supabase access token, and this keeps it that way.
+ */
+@OptIn(ExperimentalTime::class)
+internal object CredentialBrokerClient {
+    private val logger = BossLogger.forComponent("CredentialBroker")
+    private val responseJson = Json { ignoreUnknownKeys = true }
+
+    private const val REQUEST_TIMEOUT_MS = 90_000L
+    private const val CONNECT_TIMEOUT_MS = 30_000L
+    private const val SESSION_WAIT_ATTEMPTS = 100
+    private const val SESSION_WAIT_DELAY_MS = 100L
+
+    /** Whether a broker could be used right now, i.e. somebody is signed in. */
+    fun isSignedIn(): Boolean =
+        runCatching {
+            SupabaseConfig.isInitialized.value &&
+                SupabaseConfig.client.auth
+                    .currentSessionOrNull() != null
+        }.getOrDefault(false)
+
+    suspend fun exchange(brokerId: String): Result<BrokeredToken> {
+        val broker =
+            CredentialBrokers.find(brokerId)
+                ?: return Result.failure(
+                    IllegalStateException("This BOSS build does not know a credential broker called '$brokerId'."),
+                )
+        return runCatching { exchangeOrThrow(broker) }
+    }
+
+    private suspend fun exchangeOrThrow(broker: CredentialBroker): BrokeredToken {
+        if (!SupabaseConfig.isInitialized.value) {
+            SupabaseConfig.initializeFromEnvironment()
+        }
+
+        var session =
+            waitForSession()
+                ?: error("Open BOSS and sign in with your RISA account, then retry.")
+
+        val client =
+            HttpClient(CIO) {
+                install(HttpTimeout) {
+                    requestTimeoutMillis = REQUEST_TIMEOUT_MS
+                    connectTimeoutMillis = CONNECT_TIMEOUT_MS
+                    socketTimeoutMillis = REQUEST_TIMEOUT_MS
+                }
+            }
+        return try {
+            var response = post(client, broker, session)
+            var body = response.second
+
+            // A locally unexpired access token can still be rejected after a server-side
+            // revocation or session migration. Refresh once and retry; never loop, and never
+            // mask an authorization or entitlement failure as something retryable.
+            if (response.first == HTTP_UNAUTHORIZED) {
+                session = refreshedSession()
+                response = post(client, broker, session)
+                body = response.second
+            }
+
+            if (response.first != HTTP_OK) {
+                error(parseBrokerError(body))
+            }
+            parseToken(body)
+        } finally {
+            client.close()
+        }
+    }
+
+    private suspend fun post(
+        client: HttpClient,
+        broker: CredentialBroker,
+        session: UserSession,
+    ): Pair<Int, String> {
+        val response =
+            client.post(broker.tokenUrl) {
+                header(HttpHeaders.Authorization, "Bearer ${session.accessToken}")
+                header(HttpHeaders.Accept, "application/json")
+            }
+        return response.status.value to response.bodyAsText()
+    }
+
+    /**
+     * Refreshes through [CoreAuthService], which owns the single-flight lock.
+     *
+     * Supabase rotates the refresh token, so a second refresh overlapping the app's own
+     * presents an already-used one, and a rejected refresh token is what drops the user to
+     * the login screen.
+     */
+    private suspend fun refreshedSession(): UserSession {
+        try {
+            CoreAuthService.refreshSession()
+        } catch (_: Exception) {
+            error("Your BOSS session expired. Open BOSS, sign in again, and retry.")
+        }
+        return SupabaseConfig.client.auth
+            .currentSessionOrNull()
+            ?: error("Your BOSS session expired. Open BOSS, sign in again, and retry.")
+    }
+
+    private suspend fun waitForSession(): UserSession? {
+        var attempts = 0
+        while (attempts < SESSION_WAIT_ATTEMPTS) {
+            val session = SupabaseConfig.client.auth.currentSessionOrNull()
+            if (session != null) {
+                return if (session.expiresAt > Clock.System.now()) session else refreshedSession()
+            }
+            delay(SESSION_WAIT_DELAY_MS)
+            attempts += 1
+        }
+        return null
+    }
+
+    private fun parseToken(body: String): BrokeredToken {
+        val root = responseJson.parseToJsonElement(body).jsonObject
+        val token =
+            root["access_token"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                ?: error("The credential broker returned an empty token.")
+        return BrokeredToken(
+            token = token,
+            // Absent means "do not reuse": a broker that did not say is not promising a
+            // window, and inventing one risks holding a credential past its life.
+            refreshAfterSeconds = root["refresh_after_seconds"]?.jsonPrimitive?.longOrNull ?: 0L,
+            expiresAt = root["expires_at"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+
+    /**
+     * The broker's own `error.message` when it sent one, never the raw body.
+     *
+     * A broker's error body is written for a person; anything else it contains is not, and
+     * this string is shown in a panel and returned over the single-instance channel.
+     */
+    internal fun parseBrokerError(body: String): String =
+        try {
+            Json
+                .parseToJsonElement(body)
+                .jsonObject["error"]
+                ?.jsonObject
+                ?.get("message")
+                ?.jsonPrimitive
+                ?.contentOrNull
+                ?: DEFAULT_BROKER_ERROR
+        } catch (_: Exception) {
+            DEFAULT_BROKER_ERROR
+        }
+
+    private const val DEFAULT_BROKER_ERROR = "The credential broker rejected the token request."
+    private const val HTTP_OK = 200
+    private const val HTTP_UNAUTHORIZED = 401
+
+    init {
+        logger.trace(LogCategory.SYSTEM, "Credential brokers available", mapOf("count" to CredentialBrokers.all().size))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/RisaLlmTokenCommand.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/llm/RisaLlmTokenCommand.kt
@@ -1,45 +1,19 @@
 package ai.rever.boss.llm
 
-import ai.rever.boss.services.auth.CoreAuthService
-import ai.rever.boss.services.supabase.SupabaseConfig
 import ai.rever.boss.utils.SingleInstanceManager
-import io.github.jan.supabase.auth.auth
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.HttpHeaders
-import kotlinx.coroutines.delay
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 /**
  * Headless credential-helper entrypoint invoked by Codex.
  *
- * stdout contains only the short-lived LiteLLM virtual key. The BOSS/Supabase
- * session and the CoreWeave credential are never printed or returned.
+ * stdout contains only the short-lived credential. The BOSS/Supabase session and the
+ * CoreWeave credential are never printed or returned.
+ *
+ * The exchange itself is not here: it lives in [CredentialBrokerClient], shared with the
+ * plugin-facing `BrokeredCredentialProvider`, so the endpoint and the session handling
+ * exist once rather than twice.
  */
-@OptIn(ExperimentalTime::class)
 object RisaLlmTokenCommand {
     private const val COMMAND = "llm-token"
-    private const val DEFAULT_TOKEN_URL = "https://llm.risa.inc/auth/token"
-    private const val TOKEN_REQUEST_TIMEOUT_MS = 90_000L
-    private const val SESSION_WAIT_ATTEMPTS = 100
-    private const val SESSION_WAIT_DELAY_MS = 100L
-    private val responseJson = Json { ignoreUnknownKeys = true }
-
-    @Serializable
-    private data class TokenResponse(
-        @SerialName("access_token")
-        val accessToken: String,
-    )
 
     fun isRequested(args: Array<String>): Boolean = args.size == 1 && args[0] == COMMAND
 
@@ -67,121 +41,23 @@ object RisaLlmTokenCommand {
         }
     }
 
-    internal suspend fun fetchTokenForRunningBoss(): String {
-        if (!SupabaseConfig.isInitialized.value) {
-            SupabaseConfig.initializeFromEnvironment()
-        }
-
-        var session =
-            waitForSession()
-                ?: error("Open BOSS and sign in with your risalabs.ai account, then retry.")
-
-        val tokenUrl =
-            System
-                .getenv("RISA_LLM_TOKEN_URL")
-                ?.takeIf { it.isNotBlank() }
-                ?: DEFAULT_TOKEN_URL
-
-        val client =
-            HttpClient(CIO) {
-                install(HttpTimeout) {
-                    requestTimeoutMillis = TOKEN_REQUEST_TIMEOUT_MS
-                    connectTimeoutMillis = 30_000L
-                    socketTimeoutMillis = TOKEN_REQUEST_TIMEOUT_MS
-                }
-            }
-        return try {
-            var response =
-                client.post(tokenUrl) {
-                    header(HttpHeaders.Authorization, "Bearer ${session.accessToken}")
-                    header(HttpHeaders.Accept, "application/json")
-                }
-            var body = response.bodyAsText()
-
-            // A locally unexpired access token can still be rejected after a
-            // server-side revocation or session migration. Refresh once and
-            // retry; never loop or mask authorization/entitlement failures.
-            if (response.status.value == 401) {
-                session = refreshSession()
-                response =
-                    client.post(tokenUrl) {
-                        header(HttpHeaders.Authorization, "Bearer ${session.accessToken}")
-                        header(HttpHeaders.Accept, "application/json")
-                    }
-                body = response.bodyAsText()
-            }
-
-            if (response.status.value != 200) {
-                val message = parseGatewayError(body)
-                error(message)
-            }
-
-            val parsed: TokenResponse = responseJson.decodeFromString(body)
-            parsed.accessToken.takeIf { it.isNotBlank() }
-                ?: error("RISA LLM gateway returned an empty token.")
-        } finally {
-            client.close()
-        }
-    }
+    /**
+     * The RISA GLM credential, from the shared broker registry.
+     *
+     * A thin adapter now: the exchange, the session handling and the endpoint all live in
+     * [CredentialBrokerClient], so this path and the plugin-facing
+     * `BrokeredCredentialProvider` cannot drift apart or hold two copies of the URL. Called
+     * in the **running** BOSS process, over the single-instance channel, never in the helper.
+     */
+    internal suspend fun fetchTokenForRunningBoss(): String =
+        CredentialBrokerClient
+            .exchange(CredentialBrokers.RISA_GLM)
+            .getOrElse { error -> error(error.message ?: "Could not obtain a RISA LLM token.") }
+            .token
 
     /**
-     * Refreshes through [CoreAuthService] rather than calling supabase-kt
-     * directly. Supabase rotates the refresh token, so a second refresh
-     * overlapping the app's own presents an already-used token, and a rejected
-     * refresh token is what drops the user to the login screen. That service
-     * owns the single-flight lock the recovery loop also holds.
+     * Kept as the tested entry point for the broker's error shape, delegating so there is
+     * one parser rather than two that can disagree about what a gateway error looks like.
      */
-    private suspend fun refreshSession(): io.github.jan.supabase.auth.user.UserSession {
-        try {
-            CoreAuthService.refreshSession()
-        } catch (_: Exception) {
-            error(
-                "Your BOSS session expired. Open BOSS, sign in again, and retry.",
-            )
-        }
-
-        return SupabaseConfig.client.auth
-            .currentSessionOrNull()
-            ?: error(
-                "Your BOSS session expired. Open BOSS, sign in again, and retry.",
-            )
-    }
-
-    private suspend fun waitForSession(): io.github.jan.supabase.auth.user.UserSession? {
-        var attempts = 0
-        while (attempts < SESSION_WAIT_ATTEMPTS) {
-            val auth = SupabaseConfig.client.auth
-            val session = auth.currentSessionOrNull()
-            if (session != null) {
-                return ensureFreshSession(session)
-            }
-            delay(SESSION_WAIT_DELAY_MS)
-            attempts += 1
-        }
-        return null
-    }
-
-    private suspend fun ensureFreshSession(
-        session: io.github.jan.supabase.auth.user.UserSession,
-    ): io.github.jan.supabase.auth.user.UserSession {
-        if (session.expiresAt > Clock.System.now()) {
-            return session
-        }
-
-        val refreshed = refreshSession()
-        check(refreshed.expiresAt > Clock.System.now()) {
-            "Your BOSS session expired. Open BOSS, sign in again, and retry."
-        }
-        return refreshed
-    }
-
-    internal fun parseGatewayError(body: String): String =
-        try {
-            val root = Json.parseToJsonElement(body).jsonObject
-            val error = root["error"]?.jsonObject
-            error?.get("message")?.jsonPrimitive?.content
-                ?: "RISA LLM gateway rejected the token request."
-        } catch (_: Exception) {
-            "RISA LLM gateway rejected the token request."
-        }
+    internal fun parseGatewayError(body: String): String = CredentialBrokerClient.parseBrokerError(body)
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -155,6 +155,14 @@ fun main(args: Array<String>) {
     BossLogger.configureFromEnvironment()
     BossLogger.initialize() // Register shutdown hook for log flushing
 
+    // Serve credential brokers to plugins. Registered from here rather than from
+    // BossAppStartupEffects because the implementation exchanges a Supabase session over
+    // HTTP and so lives in desktopMain, while the PluginContext that exposes it is
+    // commonMain. Safe this early: the object holds no state and touches nothing until a
+    // plugin actually asks for a broker.
+    ai.rever.boss.services.llm.BrokeredCredentialAccess
+        .initialize(ai.rever.boss.llm.BrokeredCredentialProviderImpl)
+
     // Set WM_CLASS for Linux desktop integration (must be before any AWT init)
     setLinuxWMClass()
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/llm/CredentialBrokersTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/llm/CredentialBrokersTest.kt
@@ -1,0 +1,79 @@
+package ai.rever.boss.llm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The broker registry is the security boundary for this feature: a plugin names a broker by
+ * id, and the host decides what that means. These pin the properties that make that true.
+ */
+class CredentialBrokersTest {
+    @Test
+    fun `a plugin can only reach a broker this build declares`() {
+        // The whole point of id-not-URL. An unknown id is a refusal, not an attempt.
+        assertNull(CredentialBrokers.find("not-a-broker"))
+        assertNull(CredentialBrokers.find("https://attacker.example/collect"))
+        assertNotNull(CredentialBrokers.find(CredentialBrokers.RISA_GLM))
+    }
+
+    @Test
+    fun `an unknown broker id fails without touching the network`() {
+        val result = kotlinx.coroutines.runBlocking { CredentialBrokerClient.exchange("nope") }
+
+        assertTrue(result.isFailure)
+        assertTrue(
+            result
+                .exceptionOrNull()
+                ?.message
+                .orEmpty()
+                .contains("does not know"),
+        )
+    }
+
+    @Test
+    fun `every broker declares an https endpoint and what it is scoped to`() {
+        // scopedTo is published to plugins so a careful one can check where it is about to
+        // post a bearer token. A broker without it gives them nothing to check against.
+        CredentialBrokers.all().forEach { broker ->
+            assertTrue(broker.tokenUrl.startsWith("https://"), "${broker.id} token URL is not https")
+            val scope = assertNotNull(broker.scopedTo, "${broker.id} declares no scope")
+            assertTrue(scope.startsWith("https://"), "${broker.id} scope is not https")
+        }
+    }
+
+    @Test
+    fun `broker ids are unique`() {
+        // find() takes the first match, so a duplicate would silently shadow one.
+        val ids = CredentialBrokers.all().map { it.id }
+
+        assertEquals(ids.distinct(), ids)
+    }
+
+    @Test
+    fun `a broker error message never carries the raw body`() {
+        val leaky = "sk-live-secret and api_base=https://internal.gateway.example/v1"
+
+        val message = CredentialBrokerClient.parseBrokerError(leaky)
+
+        assertFalse(message.contains("sk-live-secret"), message)
+        assertFalse(message.contains("internal.gateway.example"), message)
+    }
+
+    @Test
+    fun `the RISA endpoint is overridable for a staging build but defaults to production`() {
+        // The override exists so a dev build can point at staging. It comes from the
+        // environment, which is the host's, not from anything a plugin supplies.
+        val broker = assertNotNull(CredentialBrokers.find(CredentialBrokers.RISA_GLM))
+        val fromEnv = System.getenv("RISA_LLM_TOKEN_URL")
+
+        if (fromEnv.isNullOrBlank()) {
+            assertEquals("https://llm.risa.inc/auth/token", broker.tokenUrl)
+        } else {
+            assertEquals(fromEnv, broker.tokenUrl)
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/llm/RisaLlmTokenCommandTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/llm/RisaLlmTokenCommandTest.kt
@@ -2,10 +2,12 @@ package ai.rever.boss.llm
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class RisaLlmTokenCommandTest {
     @Test
     fun extractsSafeGatewayError() {
+        // A broker's own error.message is written for a person, so it is shown as-is.
         val message =
             RisaLlmTokenCommand.parseGatewayError(
                 """{"error":{"message":"RISA LLM access has been disabled for this account"}}""",
@@ -16,8 +18,30 @@ class RisaLlmTokenCommandTest {
 
     @Test
     fun doesNotEchoUnknownProviderPayload() {
-        val message = RisaLlmTokenCommand.parseGatewayError("upstream secret-like failure")
+        // Anything that is not that field is not written for a person, and this string is
+        // shown in a panel and returned over the single-instance channel. Asserting the
+        // property rather than the exact sentence: the wording became broker-generic when
+        // the parser moved, and the thing that matters is that the body does not leak.
+        val body = "upstream secret-like failure sk-abc123 api_base=https://internal.example"
 
-        assertEquals("RISA LLM gateway rejected the token request.", message)
+        val message = RisaLlmTokenCommand.parseGatewayError(body)
+
+        assertFalse(message.contains("sk-abc123"), message)
+        assertFalse(message.contains("internal.example"), message)
+        assertEquals("The credential broker rejected the token request.", message)
+    }
+
+    @Test
+    fun aMalformedBodyStillYieldsAMessage() {
+        // Not-JSON and JSON-without-an-error both have to produce something showable, or a
+        // failing exchange surfaces as an empty toast.
+        assertEquals(
+            "The credential broker rejected the token request.",
+            RisaLlmTokenCommand.parseGatewayError("{ this is not json"),
+        )
+        assertEquals(
+            "The credential broker rejected the token request.",
+            RisaLlmTokenCommand.parseGatewayError("""{"status":"nope"}"""),
+        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,12 @@ intellij-platform = "243.21565.199"
 # bump it when consuming a new SDK release. Distribution is store/GitHub-
 # releases ONLY: plugin-platform/plugin-api-core downloads this release's jar and
 # filters the api package locally (no Maven registry involved).
-boss-plugin-api = "1.0.71"
+# NOTE: 1.0.74 is not released yet. It is cut by merging
+# risa-labs-inc/boss-plugin-api#31, and this pin must not land before that release
+# exists - fetchApiPluginJar has no Maven fallback, so CI fails with a 404 on the
+# release asset. For local work, build the jar into a sibling
+# boss_plugins/boss-plugin-api checkout at exactly this version.
+boss-plugin-api = "1.0.74"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.api.ApplicationEventBus
 import ai.rever.boss.plugin.api.AuthDataProvider
 import ai.rever.boss.plugin.api.BackgroundTaskProvider
 import ai.rever.boss.plugin.api.BookmarkDataProvider
+import ai.rever.boss.plugin.api.BrokeredCredentialProvider
 import ai.rever.boss.plugin.api.CacheProvider
 import ai.rever.boss.plugin.api.ClipboardProvider
 import ai.rever.boss.plugin.api.ContextMenuProvider
@@ -121,6 +122,9 @@ class SandboxedPluginContext(
 
     override val llmProvider: LlmProvider?
         get() = delegate.llmProvider
+
+    override val brokeredCredentialProvider: BrokeredCredentialProvider?
+        get() = delegate.brokeredCredentialProvider
 
     override val runConfigurationDataProvider: RunConfigurationDataProvider?
         get() = delegate.runConfigurationDataProvider


### PR DESCRIPTION
> **Stacked on #136.** Base is `feat/coreweave-glm-rollout`, not `main`.
>
> **Do not merge before boss-plugin-api v1.0.74 exists** (cut by merging
> risa-labs-inc/boss-plugin-api#31). The pin in this PR names it, `fetchApiPluginJar` has no
> Maven fallback, and CI fails with a 404 on the release asset until then. This is exactly why
> it is a separate PR: #136 stays green and mergeable on its own.

## Summary

Generalises #136's RISA-shaped host bridge into the plugin-facing `BrokeredCredentialProvider`,
so a provider whose credential nobody types in can be an ordinary entry in
`Settings -> AI Providers` instead of a host special case.

- `CredentialBrokers` - the id to endpoint registry, host-owned
- `CredentialBrokerClient` - the exchange, shared by the `llm-token` helper and plugins
- `BrokeredCredentialProviderImpl` - the plugin-facing half
- `brokeredCredentialProvider` overridden in all three `PluginContext` wrappers
- `RisaLlmTokenCommand` shrinks from 179 lines to 40

## Why the exchange stays host-side

Nothing on `PluginContext` exposes the Supabase access token, deliberately: `AuthDataProvider`
gives identity only, and `SupabaseDataProvider` proxies queries with the host attaching auth.
This keeps that boundary rather than widening it - a plugin gets the *downstream* credential and
never the session that bought it.

## A broker is named by id, never by URL

`CredentialBrokers` owns the map. An `exchange(url)` signature would have handed every installed
plugin a way to post the user's session token to a host of its choosing; as it is, the worst a
plugin can do is name a broker this build does not have, which is a refusal that touches no
network.

`CredentialBrokersTest` pins that, plus:

- **ids are unique** - `find()` takes the first match, so a duplicate would silently shadow one;
- every broker declares an **https** endpoint and a `scopedTo` prefix, published so a careful
  plugin can check where it is about to send a bearer token;
- a broker error message never carries the raw response body.

## The three-wrapper rule

`brokeredCredentialProvider` is overridden in `DefaultPlugin`, `TrackingPluginContext` **and**
`SandboxedPluginContext`. Missing the sandbox one returns null for every plugin, silently - that
has happened before with `mcpToolRegistry`.

The implementation speaks HTTP so it lives in `desktopMain`, while the `PluginContext` that has
to expose it is `commonMain`; `DefaultPlugin` reads it through a holder that `main.kt` populates
at startup.

## One test changed rather than being kept

`doesNotEchoUnknownProviderPayload` asserted an exact sentence. The wording became
broker-generic when the parser moved, so it now asserts the property that actually matters -
the raw body never reaches the message - plus a case for a malformed body.

## Verification

- `./gradlew :composeApp:desktopTest` (1625), `detekt`, `ktlintCheck` - all green locally
  against a sibling api jar built at 1.0.74
- CI will be red on `fetchApiPluginJar` until the api release exists
