### PR TITLE
Offer to install a plugin dependency the user is missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,12 +84,38 @@ feature that silently did nothing. The AI Gateway made that concrete: three plug
 - **The event bus is a `Channel`, not a `SharedFlow`.** A broadcast would put the same dialog in
   front of every open window and let each of them start the same install. The collector applies
   back-pressure (`snapshotFlow { … }.first { it == null }`) so a second missing dependency is
-  asked about after the first rather than replacing it.
+  asked about after the first rather than replacing it, and re-checks `isInstalled` before
+  showing - two dependents of one missing plugin each raise a prompt, so installing for the
+  first satisfies the second.
 - **Installing is the host's to do.** `PluginRepository.getPlugin(id)` plus `downloadPlugin`
   resolve an id to a jar, which no plugin can do - a plugin holding a null API can only send
-  the user to the Toolbox to search by name. `StoreMissingDependencyInstaller` deletes the jar
-  again if it fails to load, so a scan on the next launch cannot pick up something that just
-  failed its checks.
+  the user to the Toolbox to search by name.
+
+Four things `StoreMissingDependencyInstaller` gets right that are easy to get wrong, all found
+in review:
+
+- **A failed download deletes its jar.** `RemotePluginRepository.downloadPlugin` writes straight
+  into the target path and only deletes on a hash or signature rejection, so a connection that
+  dies mid-stream leaves a truncated jar at the *final* filename - which `PluginJarReconciler`
+  then finds and retries on every launch.
+- **Cleanup removes the `.sig` sidecar with the jar.** Reinstalling the same version reuses the
+  filename, so a surviving sidecar meets fresh bytes and hard-fails the load, which is worse
+  than being unsigned.
+- **It downloads straight to the final name**, not through a `-downloading.jar` rename. The
+  sidecar is written next to whatever path `downloadPlugin` was given, so a rename afterwards
+  orphans it. (`PluginInstallService` does rename, and does leave the sidecar behind.)
+- **It writes the `installed.json` entry.** `setPluginEnabled` updates an existing entry and
+  does nothing when there is none, so a plugin known only by its presence on disk cannot be
+  disabled persistently.
+
+Installs are detached and coalesced per plugin id (`KeyedDetachedJobs`, as reloads are): the
+prompt is driven from a window's scope, so closing that window mid-download would otherwise
+abort the install and leave the partial jar.
+
+Reporting is gated to the install entry point. `doReloadPlugin` finishes by calling
+`loadPlugin` too, and reload is reached by `resetPluginInstances`, the Toolbox's update flow and
+the evolver's hot reload - none of which is a user asking to install anything, and re-offering a
+dependency someone declined on every reload would be worse than silence.
 
 Transitive dependencies are deliberately not chased: the dependency loads through the manager
 directly, so answering one question never produces a second dialog.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,39 @@ For a bottom split use `panel: horizontal_split`. Reuse a pane across calls by p
 - Supabase + Edge Functions
 - BossTerm for terminal integration (bundled in the `terminal-tab` plugin)
 
+## Plugin dependencies are resolved at install time
+
+`plugin.json` `dependencies` used to be read in exactly one place -
+`DynamicPluginManager.checkCanUnload`, which refuses to uninstall a plugin something else
+depends on. Nothing looked at them when a plugin was *installed*, so installing a plugin whose
+dependency was absent produced no signal at all and the user met the consequence later, as a
+feature that silently did nothing. The AI Gateway made that concrete: three plugins declare it
+`optional: true` and each falls back to an unconfigured state.
+
+`PluginDependencyResolution.missingFor(manifest, installedIds)` now answers what is absent, and
+`MissingDependencyDialog` offers to install it. Four things about the placement:
+
+- **The hook is in `PluginLoaderDelegateImpl.loadPlugin`, not `installPlugin`.** That manager
+  method also serves startup restore, the bundled-plugin load and the api hot-swap's
+  reload-all, so a prompt there would be one dialog per plugin on every launch. The delegate is
+  the path plugin-manager install and update flows take, which is the only place a *user* asked
+  for something.
+- **Optional dependencies are reported, flagged, not dropped.** An optional dependency is how a
+  plugin says "this feature needs that plugin". Dropping them would leave this reporting
+  nothing for the case it was built for.
+- **The event bus is a `Channel`, not a `SharedFlow`.** A broadcast would put the same dialog in
+  front of every open window and let each of them start the same install. The collector applies
+  back-pressure (`snapshotFlow { … }.first { it == null }`) so a second missing dependency is
+  asked about after the first rather than replacing it.
+- **Installing is the host's to do.** `PluginRepository.getPlugin(id)` plus `downloadPlugin`
+  resolve an id to a jar, which no plugin can do - a plugin holding a null API can only send
+  the user to the Toolbox to search by name. `StoreMissingDependencyInstaller` deletes the jar
+  again if it fails to load, so a scan on the next launch cannot pick up something that just
+  failed its checks.
+
+Transitive dependencies are deliberately not chased: the dependency loads through the manager
+directly, so answering one question never produces a second dialog.
+
 ## Configuration
 
 Create `local.properties`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,6 @@ in review:
 - **Cleanup removes the `.sig` sidecar with the jar.** Reinstalling the same version reuses the
   filename, so a surviving sidecar meets fresh bytes and hard-fails the load, which is worse
   than being unsigned.
-- **It downloads straight to the final name**, not through a `-downloading.jar` rename. The
-  sidecar is written next to whatever path `downloadPlugin` was given, so a rename afterwards
-  orphans it. (`PluginInstallService` does rename, and does leave the sidecar behind.)
 - **It writes the `installed.json` entry.** `setPluginEnabled` updates an existing entry and
   does nothing when there is none, so a plugin known only by its presence on disk cannot be
   disabled persistently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,17 @@ feature that silently did nothing. The AI Gateway made that concrete: three plug
   resolve an id to a jar, which no plugin can do - a plugin holding a null API can only send
   the user to the Toolbox to search by name.
 
-Four things `StoreMissingDependencyInstaller` gets right that are easy to get wrong, all found
+**The downloaded jar is vetted before it is loaded.** Nothing binds a store row to the plugin id
+its jar declares: `enforceStoreSignature` binds the hash to the row and the row to the store's
+key, not the identity, so an admin uploading the wrong jar is enough. Loading first and checking
+after is too late twice over - `installPlugin` inspects the *incoming* manifest and starts a full
+api hot swap for a newer `ai.rever.boss.plugin.api` jar, which is exactly what
+`NOT_USER_INSTALLABLE` exists to keep out of a two-button dialog, and a jar declaring some other
+installed plugin would be registered against a path that is about to be deleted. So the manifest
+is read first and a mismatch is refused; the post-load check stays as belt and braces. The
+recorded version comes from that manifest too, since update checking compares against it.
+
+Five things `StoreMissingDependencyInstaller` gets right that are easy to get wrong, all found
 in review:
 
 - **A failed download deletes its jar.** `RemotePluginRepository.downloadPlugin` writes straight
@@ -107,6 +117,9 @@ in review:
 - **It writes the `installed.json` entry.** `setPluginEnabled` updates an existing entry and
   does nothing when there is none, so a plugin known only by its presence on disk cannot be
   disabled persistently.
+- **It only deletes a jar it created.** A plugin can sit on disk with no manager entry (a load
+  that failed transiently at startup), so cleanup checks whether the path was already occupied
+  before the download.
 
 Installs are detached and coalesced per plugin id (`KeyedDetachedJobs`, as reloads are): the
 prompt is driven from a window's scope, so closing that window mid-download would otherwise

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,15 @@ feature that silently did nothing. The AI Gateway made that concrete: three plug
 `PluginDependencyResolution.missingFor(manifest, installedIds)` now answers what is absent, and
 `MissingDependencyDialog` offers to install it. Four things about the placement:
 
-- **The hook is in `PluginLoaderDelegateImpl.loadPlugin`, not `installPlugin`.** That manager
-  method also serves startup restore, the bundled-plugin load and the api hot-swap's
-  reload-all, so a prompt there would be one dialog per plugin on every launch. The delegate is
-  the path plugin-manager install and update flows take, which is the only place a *user* asked
-  for something.
+- **`MissingDependencyReporter` is called from the three paths that install for a user**, and
+  never from `DynamicPluginManager.installPlugin`. That manager method also serves startup
+  restore, the bundled-plugin load and the api hot-swap's reload-all, so reporting there would be
+  one dialog per plugin on every launch. The three are `PluginLoaderDelegateImpl.loadPlugin`
+  (what plugin-manager's install and update flows reach), `PluginInstallService` (the first-run
+  wizard, where several plugins are chosen at once and so the likeliest place for an unmet
+  dependency) and `PluginUpdateBridge` (an update can add a dependency the installed version
+  never declared). A **reload** must not report: `resetPluginInstances`, the Toolbox reload and
+  the evolver's hot reload all end in a load, and none is a user asking for anything.
 - **Optional dependencies are reported, flagged, not dropped.** An optional dependency is how a
   plugin says "this feature needs that plugin". Dropping them would leave this reporting
   nothing for the case it was built for.
@@ -144,6 +148,10 @@ Deliberately out of scope, so nobody assumes more than exists:
 - **With two windows open, the window that asks may not be the one that reported.** The install
   is still correct; the answering window may just not show the change until relaunch. See
   `MissingDependencyPrompt`.
+- **A declined prompt is remembered for the session, not persisted.** All three gateway
+  consumers declare it optional, so without that, declining for one means being asked again for
+  the next. "Not now" is an answer about now, and a decision that outlived the session would
+  leave no way to be asked again short of editing a file.
 - **The dependent is not reloaded after its dependency installs.** It has already loaded and
   already resolved its handle to the dependency, typically to null. This is survivable because
   the consumers resolve the API *lazily, per call* - which their own AGENTS.md files require,
@@ -157,6 +165,14 @@ those disagreed - reporter on the raw `pluginStates` keys, installer on keys-plu
 install left a dangling entry that made every *later* dependent of that plugin report nothing at
 all, silently re-creating the problem this feature exists to remove. There is now one
 `installedAndOnDisk` predicate in `PluginLoaderDelegateImpl`, passed to both.
+
+**"Installed" is `state == LOADED || the jar exists`.** Both halves are load-bearing and each
+was a bug on its own. Requiring only an entry meant a binary-incompatible load - which registers
+a DISABLED entry while the installer deletes the jar it rejected - looked installed, so Retry
+reported success with nothing installed and every later dependent went silent. Requiring only the
+jar meant a *running* plugin whose file had moved looked absent: `PluginJarReconciler` and the
+updater both rewrite paths without repointing the manager's in-memory `jarPath`, so the prompt
+would fire for something already loaded and Install would fail with "Plugin already loaded".
 
 One trap worth knowing: `isInstalled` has to mean *usable*, not "the manager has an entry".
 `installPlugin` registers a DISABLED entry for a binary-incompatible plugin, and this installer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,12 @@ feature that silently did nothing. The AI Gateway made that concrete: three plug
 `PluginDependencyResolution.missingFor(manifest, installedIds)` now answers what is absent, and
 `MissingDependencyDialog` offers to install it. Four things about the placement:
 
+- **The wizard reports once after its whole batch, never per iteration.** A first-run selection
+  of `[jupyter-notebook, ai-gateway]` - the pick this feature exists for - otherwise prompted for
+  the gateway while the loop was two iterations from installing it, and taking Install raced the
+  wizard's own download (the two paths write different filenames for one plugin id, so neither
+  the path nor the coalescing key collides). After the loop, `installedAndOnDisk` already holds
+  everything the batch installed, so nothing intra-batch is reported at all.
 - **`MissingDependencyReporter` is called from the three paths that install for a user**, and
   never from `DynamicPluginManager.installPlugin`. That manager method also serves startup
   restore, the bundled-plugin load and the api hot-swap's reload-all, so reporting there would be
@@ -148,6 +154,10 @@ Deliberately out of scope, so nobody assumes more than exists:
 - **With two windows open, the window that asks may not be the one that reported.** The install
   is still correct; the answering window may just not show the change until relaunch. See
   `MissingDependencyPrompt`.
+- **The bus filters at report time, not only in the collector.** A prompt the collector is
+  certain to discard - declined, or a duplicate of one already waiting - still costs one of four
+  buffer slots on the way through, and that can be what refuses a different dependency which
+  could have been shown.
 - **A declined prompt is remembered for the session, not persisted.** All three gateway
   consumers declare it optional, so without that, declining for one means being asked again for
   the next. "Not now" is an answer about now, and a decision that outlived the session would

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,10 +114,14 @@ recorded version comes from that manifest too, since update checking compares ag
 Five things `StoreMissingDependencyInstaller` gets right that are easy to get wrong, all found
 in review:
 
-- **A failed download deletes its jar.** `RemotePluginRepository.downloadPlugin` writes straight
-  into the target path and only deletes on a hash or signature rejection, so a connection that
-  dies mid-stream leaves a truncated jar at the *final* filename - which `PluginJarReconciler`
-  then finds and retries on every launch.
+- **The download goes to a `<name>.jar.part` sibling and is moved into place, with its
+  sidecar.** `downloadPlugin` streams into whatever path it is given and `outputStream()`
+  truncates on open, so downloading onto the final name destroys any jar already there the
+  instant the connection opens - and a stream that then dies leaves a truncated file at a name
+  every later launch tries to load. A "was a file already here" guard does not help: by then its
+  contents are gone either way. The suffix deliberately does not end in `.jar`, so a part file
+  left by a kill is ignored by the directory scan. Both files move together, because the
+  signature is written next to the path `downloadPlugin` was given.
 - **Cleanup removes the `.sig` sidecar with the jar.** Reinstalling the same version reuses the
   filename, so a surviving sidecar meets fresh bytes and hard-fails the load, which is worse
   than being unsigned.
@@ -127,9 +131,10 @@ in review:
 - **It writes the `installed.json` entry.** `setPluginEnabled` updates an existing entry and
   does nothing when there is none, so a plugin known only by its presence on disk cannot be
   disabled persistently.
-- **It only deletes a jar it created.** A plugin can sit on disk with no manager entry (a load
-  that failed transiently at startup), so cleanup checks whether the path was already occupied
-  before the download.
+- **Nothing is reported for a plugin that did not actually register.** `installPlugin` returns
+  success with `state = DISABLED` when registration failed as binary-incompatible or the plugin
+  is hidden for lack of access; reporting then offers to install a second plugin to support a
+  dead one.
 
 Installs are detached and coalesced per plugin id (`KeyedDetachedJobs`, as reloads are): the
 prompt is driven from a window's scope, so closing that window mid-download would otherwise
@@ -158,10 +163,13 @@ Deliberately out of scope, so nobody assumes more than exists:
   certain to discard - declined, or a duplicate of one already waiting - still costs one of four
   buffer slots on the way through, and that can be what refuses a different dependency which
   could have been shown.
-- **A declined prompt is remembered for the session, not persisted.** All three gateway
-  consumers declare it optional, so without that, declining for one means being asked again for
-  the next. "Not now" is an answer about now, and a decision that outlived the session would
-  leave no way to be asked again short of editing a file.
+- **A declined prompt is remembered for the session, not persisted, and keyed by kind.** "Not
+  now" on an *optional* dependency is one answer about that plugin - three consumers declare the
+  gateway optional, and being asked three times for one answer is what this prevents. "Skip" on a
+  *required* one is keyed by `(dependent, missing)`, because another plugin that hard-requires the
+  same thing is a different question and silencing it would be worse, not better. Neither
+  persists: an answer that outlived the session would leave no way to be asked again short of
+  editing a file.
 - **The dependent is not reloaded after its dependency installs.** It has already loaded and
   already resolved its handle to the dependency, typically to null. This is survivable because
   the consumers resolve the API *lazily, per call* - which their own AGENTS.md files require,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,10 @@ in review:
 - **Nothing is reported for a plugin that did not actually register.** `installPlugin` returns
   success with `state = DISABLED` when registration failed as binary-incompatible or the plugin
   is hidden for lack of access; reporting then offers to install a second plugin to support a
-  dead one.
+  dead one. All **three** report paths check `state == LOADED`, not just the delegate.
+- **A promotion that half-succeeds cleans up both paths.** If the jar moves and the sidecar step
+  then throws, deleting only the part file would leave an unvetted, never-loaded jar at a
+  scannable name for the next launch to load.
 
 Installs are detached and coalesced per plugin id (`KeyedDetachedJobs`, as reloads are): the
 prompt is driven from a window's scope, so closing that window mid-download would otherwise
@@ -184,13 +187,19 @@ install left a dangling entry that made every *later* dependent of that plugin r
 all, silently re-creating the problem this feature exists to remove. There is now one
 `installedAndOnDisk` predicate in `PluginLoaderDelegateImpl`, passed to both.
 
-**"Installed" is `state == LOADED || the jar exists`.** Both halves are load-bearing and each
+**"Installed" is `state == LOADED || (the jar exists && not recorded incompatible)`.** Both halves are load-bearing and each
 was a bug on its own. Requiring only an entry meant a binary-incompatible load - which registers
 a DISABLED entry while the installer deletes the jar it rejected - looked installed, so Retry
 reported success with nothing installed and every later dependent went silent. Requiring only the
 jar meant a *running* plugin whose file had moved looked absent: `PluginJarReconciler` and the
 updater both rewrite paths without repointing the manager's in-memory `jarPath`, so the prompt
 would fire for something already loaded and Install would fail with "Plugin already loaded".
+The incompatibility clause exists because there are **two** binary-incompatibility paths in
+`installPlugin` and only one of them fails: the load-time one returns `Result.failure`, but the
+*registration-time* one force-unloads the plugin and returns `Result.success` with `state =
+DISABLED` and the jar still on disk. Without it, that jar made a plugin which was unloaded and
+will not run count as installed - so Install reported success and wrote an `installed.json` entry
+for it, and every other dependent of it went unprompted.
 
 One trap worth knowing: `isInstalled` has to mean *usable*, not "the manager has an entry".
 `installPlugin` registers a DISABLED entry for a binary-incompatible plugin, and this installer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,19 @@ Deliberately out of scope, so nobody assumes more than exists:
 - **With two windows open, the window that asks may not be the one that reported.** The install
   is still correct; the answering window may just not show the change until relaunch. See
   `MissingDependencyPrompt`.
+- **The dependent is not reloaded after its dependency installs.** It has already loaded and
+  already resolved its handle to the dependency, typically to null. This is survivable because
+  the consumers resolve the API *lazily, per call* - which their own AGENTS.md files require,
+  precisely because plugin load order is not guaranteed - so they pick it up without a reload. A
+  consumer that cached the handle at `register()` would stay broken until relaunch, and would be
+  wrong for the same reason on a normal cold start.
+
+**Both halves must share one definition of "installed".** The reporter filters the manifest's
+dependencies against what is present; the installer's Install guard asks the same question. When
+those disagreed - reporter on the raw `pluginStates` keys, installer on keys-plus-jar - a failed
+install left a dangling entry that made every *later* dependent of that plugin report nothing at
+all, silently re-creating the problem this feature exists to remove. There is now one
+`installedAndOnDisk` predicate in `PluginLoaderDelegateImpl`, passed to both.
 
 One trap worth knowing: `isInstalled` has to mean *usable*, not "the manager has an entry".
 `installPlugin` registers a DISABLED entry for a binary-incompatible plugin, and this installer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,26 @@ Reporting is gated to the install entry point. `doReloadPlugin` finishes by call
 the evolver's hot reload - none of which is a user asking to install anything, and re-offering a
 dependency someone declined on every reload would be worse than silence.
 
-Transitive dependencies are deliberately not chased: the dependency loads through the manager
-directly, so answering one question never produces a second dialog.
+Deliberately out of scope, so nobody assumes more than exists:
+
+- **Transitive dependencies are not chased.** The dependency loads through the manager directly,
+  so answering one question never produces a second dialog.
+- **`PluginDependency.version` is ignored.** Presence is by id, matching `checkCanUnload`. A
+  plugin needing 2.x is satisfied by 1.x, and a prompt could not usefully fix a wrong-version
+  install anyway.
+- **`NOT_USER_INSTALLABLE` ids are never offered**: the microkernel runtime (which
+  `loadPlugin` refuses outright and `DefaultPlugin` skips on scan, so it looks missing to every
+  manifest naming it) and the api plugin (whose install is an unload-all / swap / reload-all hot
+  swap, not something to start from a dialog about something else).
+- **With two windows open, the window that asks may not be the one that reported.** The install
+  is still correct; the answering window may just not show the change until relaunch. See
+  `MissingDependencyPrompt`.
+
+One trap worth knowing: `isInstalled` has to mean *usable*, not "the manager has an entry".
+`installPlugin` registers a DISABLED entry for a binary-incompatible plugin, and this installer
+deletes the jar it rejected - so an entry-only check made Retry close the dialog reporting
+success with nothing installed, and silenced the prompt for every other dependent of that
+plugin. The check is an entry whose `jarPath` still exists.
 
 ## Configuration
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -13,6 +13,7 @@ import ai.rever.boss.components.dialogs.TabType
 import ai.rever.boss.components.dialogs.TerminalLinkOpenDialog
 import ai.rever.boss.components.dialogs.TopOfMindDialog
 import ai.rever.boss.components.events.FileEventBus
+import ai.rever.boss.components.plugin.MissingDependencyDialog
 import ai.rever.boss.components.plugin.PluginUpdateBridge
 import ai.rever.boss.components.plugin.providers.GenericDialogHostContent
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
@@ -481,7 +482,7 @@ internal fun BossAppDialogs(state: BossAppState) {
     // A plugin the user just installed needs another plugin that is not there. Offer to
     // install it rather than leaving the feature to fail silently later.
     state.pendingMissingPluginDependency?.let { prompt ->
-        ai.rever.boss.components.plugin.MissingDependencyDialog(
+        MissingDependencyDialog(
             prompt = prompt,
             installing = state.installingMissingDependency,
             error = state.missingDependencyError,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -494,18 +494,24 @@ internal fun BossAppDialogs(state: BossAppState) {
                 state.installingMissingDependency = true
                 state.missingDependencyError = null
                 coroutineScope.launch {
-                    val result = prompt.installer.install(prompt.missing.missingPluginId)
-                    state.installingMissingDependency = false
-                    result
-                        .onSuccess {
-                            state.pendingMissingPluginDependency = null
-                            state.missingDependencyError = null
-                        }.onFailure { error ->
-                            // Keep the dialog up with the reason and a Retry: dismissing on
-                            // failure would look like it worked.
-                            state.missingDependencyError =
-                                error.message ?: "Could not install the plugin."
-                        }
+                    try {
+                        prompt.installer
+                            .install(prompt.missing.missingPluginId)
+                            .onSuccess {
+                                state.pendingMissingPluginDependency = null
+                                state.missingDependencyError = null
+                            }.onFailure { error ->
+                                // Keep the dialog up with the reason and a Retry: dismissing on
+                                // failure would look like it worked.
+                                state.missingDependencyError =
+                                    error.message ?: "Could not install the plugin."
+                            }
+                    } finally {
+                        // Always, because "installing" disables every button and blocks
+                        // dismissal: a throw here rather than a failed Result would leave a
+                        // modal that can only be escaped by closing the window.
+                        state.installingMissingDependency = false
+                    }
                 }
             },
         )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -478,6 +478,38 @@ internal fun BossAppDialogs(state: BossAppState) {
         )
     }
 
+    // A plugin the user just installed needs another plugin that is not there. Offer to
+    // install it rather than leaving the feature to fail silently later.
+    state.pendingMissingPluginDependency?.let { prompt ->
+        ai.rever.boss.components.plugin.MissingDependencyDialog(
+            prompt = prompt,
+            installing = state.installingMissingDependency,
+            error = state.missingDependencyError,
+            onDismiss = {
+                state.pendingMissingPluginDependency = null
+                state.missingDependencyError = null
+            },
+            onInstall = {
+                state.installingMissingDependency = true
+                state.missingDependencyError = null
+                coroutineScope.launch {
+                    val result = prompt.installer.install(prompt.missing.missingPluginId)
+                    state.installingMissingDependency = false
+                    result
+                        .onSuccess {
+                            state.pendingMissingPluginDependency = null
+                            state.missingDependencyError = null
+                        }.onFailure { error ->
+                            // Keep the dialog up with the reason and a Retry: dismissing on
+                            // failure would look like it worked.
+                            state.missingDependencyError =
+                                error.message ?: "Could not install the plugin."
+                        }
+                }
+            },
+        )
+    }
+
     // Directory picker for project selection (must be outside conditional for Compose)
     val directoryPicker =
         rememberDirectoryPicker { path ->

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -31,6 +31,8 @@ import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.platform.rememberDirectoryPicker
 import ai.rever.boss.plugin.api.Panel.Companion.left
 import ai.rever.boss.plugin.api.Panel.Companion.top
+import ai.rever.boss.plugin.sandbox.notification.ToastMessage
+import ai.rever.boss.plugin.sandbox.notification.ToastType
 import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
@@ -500,6 +502,18 @@ internal fun BossAppDialogs(state: BossAppState) {
                             .onSuccess {
                                 state.pendingMissingPluginDependency = null
                                 state.missingDependencyError = null
+                                // The dialog closing is otherwise the only signal, and since the
+                                // dependent is deliberately not reloaded, the user needs telling
+                                // that a feature may not light up until they relaunch.
+                                state.currentDefaultPlugin?.pluginToastState?.show(
+                                    ToastMessage(
+                                        type = ToastType.SUCCESS,
+                                        title = "Plugin installed",
+                                        message =
+                                            "${prompt.missing.dependentDisplayName} can use it now. " +
+                                                "Relaunch BOSS if a feature still reports it missing.",
+                                    ),
+                                )
                             }.onFailure { error ->
                                 // Keep the dialog up with the reason and a Retry: dismissing on
                                 // failure would look like it worked.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -494,7 +494,7 @@ internal fun BossAppDialogs(state: BossAppState) {
                 // "Not now" is an answer for the session: three plugins declare the gateway
                 // optional, so without this, declining once means being asked again for the
                 // next one that needs it.
-                PluginDependencyEventBus.decline(prompt.missing.missingPluginId)
+                PluginDependencyEventBus.decline(prompt.missing)
                 state.pendingMissingPluginDependency = null
                 state.missingDependencyError = null
             },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.components.dialogs.TerminalLinkOpenDialog
 import ai.rever.boss.components.dialogs.TopOfMindDialog
 import ai.rever.boss.components.events.FileEventBus
 import ai.rever.boss.components.plugin.MissingDependencyDialog
+import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.PluginUpdateBridge
 import ai.rever.boss.components.plugin.providers.GenericDialogHostContent
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
@@ -51,6 +52,7 @@ import ai.rever.boss.window.selectProjectInWindow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -489,6 +491,10 @@ internal fun BossAppDialogs(state: BossAppState) {
             installing = state.installingMissingDependency,
             error = state.missingDependencyError,
             onDismiss = {
+                // "Not now" is an answer for the session: three plugins declare the gateway
+                // optional, so without this, declining once means being asked again for the
+                // next one that needs it.
+                PluginDependencyEventBus.decline(prompt.missing.missingPluginId)
                 state.pendingMissingPluginDependency = null
                 state.missingDependencyError = null
             },
@@ -497,9 +503,16 @@ internal fun BossAppDialogs(state: BossAppState) {
                 state.missingDependencyError = null
                 coroutineScope.launch {
                     try {
-                        prompt.installer
-                            .install(prompt.missing.missingPluginId)
-                            .onSuccess {
+                        // runCatching rather than a catch block: a throw instead of a failed
+                        // Result would otherwise leave the dialog open with no message and an
+                        // "Install" button, looking like the click did nothing. Cancellation is
+                        // rethrown - the install is detached and continues, so nothing went wrong
+                        // and there is no longer anywhere to report it to.
+                        runCatching { prompt.installer.install(prompt.missing.missingPluginId) }
+                            .getOrElse { error ->
+                                if (error is CancellationException) throw error
+                                Result.failure(error)
+                            }.onSuccess {
                                 state.pendingMissingPluginDependency = null
                                 state.missingDependencyError = null
                                 // The dialog closing is otherwise the only signal, and since the

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -176,6 +177,21 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                     operationName = event.operationName,
                 )
             }.launchIn(this)
+    }
+
+    // A plugin the user just installed declares a dependency that is not present. Only
+    // user-initiated installs report here (see PluginLoaderDelegateImpl), so this cannot
+    // fire during startup restore or the api hot-swap's reload-all.
+    LaunchedEffect(windowId) {
+        ai.rever.boss.components.plugin.PluginDependencyEventBus.missingDependencies
+            .collect { prompt ->
+                state.pendingMissingPluginDependency = prompt
+                // Back-pressure instead of a queue: the next prompt stays in the channel
+                // until this one is answered, so a second missing dependency is asked about
+                // after the first rather than replacing it or being dropped. Cancelling this
+                // effect (the window closing) leaves the rest for another window.
+                snapshotFlow { state.pendingMissingPluginDependency }.first { it == null }
+            }
     }
 
     // Listen for terminal link click events (Issue #346)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -196,7 +196,14 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                     withContext(Dispatchers.IO) {
                         prompt.installer.isInstalled(prompt.missing.missingPluginId)
                     }
-                if (present) return@collect
+                if (present || PluginDependencyEventBus.wasDeclined(prompt.missing.missingPluginId)) {
+                    return@collect
+                }
+                // Reset here rather than relying on the previous dialog's exit path having
+                // cleared them: the three fields are reused for every prompt, and ordering
+                // between that clear and this assignment should not be load-bearing.
+                state.installingMissingDependency = false
+                state.missingDependencyError = null
                 state.pendingMissingPluginDependency = prompt
                 // Back-pressure instead of a queue: the next prompt stays in the channel until
                 // this one is answered, so a second missing dependency is asked about after the

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -196,7 +196,7 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                     withContext(Dispatchers.IO) {
                         prompt.installer.isInstalled(prompt.missing.missingPluginId)
                     }
-                if (present || PluginDependencyEventBus.wasDeclined(prompt.missing.missingPluginId)) {
+                if (present || PluginDependencyEventBus.wasDeclined(prompt.missing)) {
                     return@collect
                 }
                 // Reset here rather than relying on the previous dialog's exit path having

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -41,12 +41,14 @@ import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.withContext
 
 /**
  * Event-bus listeners for one BossApp window. Every bus is window-filtered by
@@ -189,13 +191,18 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                 // Re-check rather than trusting the report: two dependents of one missing
                 // plugin each raise a prompt, so installing for the first satisfies the
                 // second, whose dialog would otherwise claim something untrue and reinstall
-                // what is already loaded.
-                if (prompt.installer.isInstalled(prompt.missing.missingPluginId)) return@collect
+                // what is already loaded. Off the UI thread because the check stats the jar.
+                val present =
+                    withContext(Dispatchers.IO) {
+                        prompt.installer.isInstalled(prompt.missing.missingPluginId)
+                    }
+                if (present) return@collect
                 state.pendingMissingPluginDependency = prompt
-                // Back-pressure instead of a queue: the next prompt stays in the channel
-                // until this one is answered, so a second missing dependency is asked about
-                // after the first rather than replacing it or being dropped. Cancelling this
-                // effect (the window closing) leaves the rest for another window.
+                // Back-pressure instead of a queue: the next prompt stays in the channel until
+                // this one is answered, so a second missing dependency is asked about after the
+                // first rather than replacing it or being dropped. Cancelling this effect (the
+                // window closing) leaves whatever is still in the channel for another window -
+                // though a prompt already received here and not yet shown does go with it.
                 snapshotFlow { state.pendingMissingPluginDependency }.first { it == null }
             }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.components.events.TerminalLinkEventBus
 import ai.rever.boss.components.events.URLEventBus
 import ai.rever.boss.components.events.WorkspaceEventBus
 import ai.rever.boss.components.plugin.PanelIds
+import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.window_panel.SplitOrientation
 import ai.rever.boss.components.workspaces.WorkspaceSerializer
 import ai.rever.boss.components.workspaces.applyWorkspace
@@ -183,8 +184,13 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
     // user-initiated installs report here (see PluginLoaderDelegateImpl), so this cannot
     // fire during startup restore or the api hot-swap's reload-all.
     LaunchedEffect(windowId) {
-        ai.rever.boss.components.plugin.PluginDependencyEventBus.missingDependencies
+        PluginDependencyEventBus.missingDependencies
             .collect { prompt ->
+                // Re-check rather than trusting the report: two dependents of one missing
+                // plugin each raise a prompt, so installing for the first satisfies the
+                // second, whose dialog would otherwise claim something untrue and reinstall
+                // what is already loaded.
+                if (prompt.installer.isInstalled(prompt.missing.missingPluginId)) return@collect
                 state.pendingMissingPluginDependency = prompt
                 // Back-pressure instead of a queue: the next prompt stays in the channel
                 // until this one is answered, so a second missing dependency is asked about

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -86,6 +86,19 @@ internal class BossAppState(
     var showShortcutHelpDialog by mutableStateOf(false)
 
     // Terminal link open dialog (Issue #346)
+
+    /**
+     * A dependency a just-installed plugin declares but which is absent.
+     *
+     * One at a time rather than a queue: installs are user-initiated and one at a time, so
+     * a second is a rare case not worth the state, and a stack of modal dialogs would be
+     * worse than showing the newest.
+     */
+    var pendingMissingPluginDependency by
+        mutableStateOf<ai.rever.boss.components.plugin.MissingDependencyPrompt?>(null)
+    var installingMissingDependency by mutableStateOf(false)
+    var missingDependencyError by mutableStateOf<String?>(null)
+
     var showTerminalLinkDialog by mutableStateOf(false)
     var pendingTerminalLinkUrl by mutableStateOf("")
     var pendingTerminalSourceId by mutableStateOf<String?>(null)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.model.TabDraggableComponent
 import ai.rever.boss.components.plugin.AvailablePluginUpdate
 import ai.rever.boss.components.plugin.DefaultPlugin
+import ai.rever.boss.components.plugin.MissingDependencyPrompt
 import ai.rever.boss.components.plugin.providers.SplitViewOperationsImpl
 import ai.rever.boss.components.plugin.providers.WorkspaceDataProviderImpl
 import ai.rever.boss.components.registery.PanelComponentStore
@@ -86,22 +87,21 @@ internal class BossAppState(
     var showShortcutHelpDialog by mutableStateOf(false)
 
     // Terminal link open dialog (Issue #346)
+    var showTerminalLinkDialog by mutableStateOf(false)
+    var pendingTerminalLinkUrl by mutableStateOf("")
+    var pendingTerminalSourceId by mutableStateOf<String?>(null)
 
     /**
      * A dependency a just-installed plugin declares but which is absent.
      *
-     * One at a time rather than a queue: installs are user-initiated and one at a time, so
-     * a second is a rare case not worth the state, and a stack of modal dialogs would be
-     * worse than showing the newest.
+     * One at a time rather than a queue, and the one being shown is the *oldest* unanswered
+     * prompt: the collector holds the rest in the bus until this is answered, so a second
+     * missing dependency never replaces a dialog the user is part-way through.
      */
     var pendingMissingPluginDependency by
-        mutableStateOf<ai.rever.boss.components.plugin.MissingDependencyPrompt?>(null)
+        mutableStateOf<MissingDependencyPrompt?>(null)
     var installingMissingDependency by mutableStateOf(false)
     var missingDependencyError by mutableStateOf<String?>(null)
-
-    var showTerminalLinkDialog by mutableStateOf(false)
-    var pendingTerminalLinkUrl by mutableStateOf("")
-    var pendingTerminalSourceId by mutableStateOf<String?>(null)
 
     // A terminal command that arrived from outside this BOSS invocation and is
     // waiting for the operator to confirm it. Null whenever nothing is pending.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
@@ -1,0 +1,212 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.components.plugin.PluginDependencyResolution.description
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * Offers to install a dependency a just-installed plugin declares but which is absent.
+ *
+ * The point is that it *installs*, rather than telling someone where to go and look. The host
+ * can: `PluginRepository.downloadPlugin(pluginId, …)` resolves a plugin by id and
+ * `DynamicPluginManager.installPlugin` loads the result. A plugin cannot do either, which is
+ * why the equivalent prompt inside a plugin can only open the Toolbox.
+ *
+ * @param prompt the unmet dependency plus the installer that can fix it
+ * @param installing true while the install is in flight, so the dialog stays put and shows why
+ * @param error a failure from the last attempt, kept on screen with Retry rather than vanishing
+ */
+@Composable
+fun MissingDependencyDialog(
+    prompt: MissingDependencyPrompt,
+    installing: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onInstall: () -> Unit,
+) {
+    val missing = prompt.missing
+
+    // Show the id straight away and replace it with the store's display name if that
+    // resolves. The alternative - waiting - means a dialog that appears late or not at all
+    // when the store is unreachable, which is exactly when the user most needs telling.
+    val resolvedName by
+        produceState(initialValue = missing.missingPluginId, missing.missingPluginId) {
+            runCatching { prompt.installer.displayNameFor(missing.missingPluginId) }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() }
+                ?.let { value = it }
+        }
+
+    BossDialog(
+        // Not dismissable while installing: the install continues regardless, and a dialog
+        // that vanishes mid-download reads as "nothing happened".
+        onDismissRequest = { if (!installing) onDismiss() },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = !installing,
+                dismissOnClickOutside = !installing,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .width(400.dp)
+                    .onKeyEvent { event ->
+                        val escape = event.type == KeyEventType.KeyDown && event.key == Key.Escape
+                        if (!installing && escape) {
+                            onDismiss()
+                            true
+                        } else {
+                            false
+                        }
+                    },
+            shape = RoundedCornerShape(8.dp),
+            backgroundColor = BossTheme.colors.panel,
+            elevation = 8.dp,
+        ) {
+            MissingDependencyBody(
+                missing = missing,
+                resolvedName = resolvedName,
+                installing = installing,
+                error = error,
+                onDismiss = onDismiss,
+                onInstall = onInstall,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MissingDependencyBody(
+    missing: MissingPluginDependency,
+    resolvedName: String,
+    installing: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onInstall: () -> Unit,
+) {
+    Column(modifier = Modifier.padding(20.dp)) {
+        Text(
+            text = if (missing.optional) "Recommended plugin" else "Required plugin missing",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = BossTheme.colors.textPrimary,
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text = missing.description(resolvedName),
+            fontSize = 13.sp,
+            color = BossTheme.colors.textSecondary,
+        )
+
+        if (error != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = error,
+                fontSize = 12.sp,
+                color = BossTheme.colors.alert,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        MissingDependencyActions(
+            optional = missing.optional,
+            resolvedName = resolvedName,
+            installing = installing,
+            hasError = error != null,
+            onDismiss = onDismiss,
+            onInstall = onInstall,
+        )
+    }
+}
+
+@Composable
+private fun MissingDependencyActions(
+    optional: Boolean,
+    resolvedName: String,
+    installing: Boolean,
+    hasError: Boolean,
+    onDismiss: () -> Unit,
+    onInstall: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (installing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(14.dp),
+                strokeWidth = 2.dp,
+                color = BossTheme.colors.signalText,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Installing $resolvedName",
+                fontSize = 12.sp,
+                color = BossTheme.colors.textSecondary,
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        TextButton(
+            onClick = onDismiss,
+            enabled = !installing,
+            colors =
+                ButtonDefaults.textButtonColors(
+                    contentColor = BossTheme.colors.textSecondary,
+                ),
+        ) {
+            // An optional dependency is a suggestion, so declining it is not "skipping" a
+            // step the plugin needed.
+            Text(if (optional) "Not now" else "Skip")
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Button(
+            onClick = onInstall,
+            enabled = !installing,
+            colors =
+                ButtonDefaults.buttonColors(
+                    backgroundColor = BossTheme.colors.signal,
+                    contentColor = BossTheme.colors.onSignal,
+                ),
+        ) {
+            Text(if (hasError) "Retry" else "Install")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
@@ -136,6 +136,21 @@ private fun MissingDependencyBody(
             overflow = TextOverflow.Ellipsis,
         )
 
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // The plugin id, always, even once the store name resolves. This is a consent dialog
+        // for downloading and running code, and the display name is the one string the least
+        // trustworthy party controls - so the identity the host will actually install by is
+        // shown alongside it. The clamps stop a crafted name breaking the dialog; they do not
+        // stop it misleading inside it.
+        Text(
+            text = missing.missingPluginId,
+            fontSize = 11.sp,
+            color = BossTheme.colors.textMuted,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
         if (error != null) {
             Spacer(modifier = Modifier.height(12.dp))
             Text(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
@@ -1,6 +1,5 @@
 package ai.rever.boss.components.plugin
 
-import ai.rever.boss.components.plugin.PluginDependencyResolution.description
 import ai.rever.boss.plugin.ui.BossDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingDependencyDialog.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
@@ -126,9 +127,14 @@ private fun MissingDependencyBody(
         Spacer(modifier = Modifier.height(10.dp))
 
         Text(
+            // Both names in this sentence are attacker-influenced - the id comes from a
+            // plugin manifest, the resolved name from a store listing - so neither is allowed
+            // to grow the dialog or run on into something that reads like our own copy.
             text = missing.description(resolvedName),
             fontSize = 13.sp,
             color = BossTheme.colors.textSecondary,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis,
         )
 
         if (error != null) {
@@ -137,6 +143,8 @@ private fun MissingDependencyBody(
                 text = error,
                 fontSize = 12.sp,
                 color = BossTheme.colors.alert,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
             )
         }
 
@@ -177,6 +185,9 @@ private fun MissingDependencyActions(
                 text = "Installing $resolvedName",
                 fontSize = 12.sp,
                 color = BossTheme.colors.textSecondary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -66,6 +66,27 @@ object PluginDependencyResolution {
     val NOT_USER_INSTALLABLE = setOf(MicrokernelRuntime.PLUGIN_ID, "ai.rever.boss.plugin.api")
 
     /**
+     * The plugins that count as installed: an entry whose jar is still on disk.
+     *
+     * One function for both halves of the prompt - the reporter's "what is missing" set and the
+     * Install button's guard - because when they disagreed the feature broke in a way no test
+     * saw. `installPlugin` registers a DISABLED entry for a binary-incompatible plugin, and the
+     * installer deletes the jar it just rejected; a definition of "installed" that looked only
+     * at entries then treated that plugin as present, so every *later* dependent of it reported
+     * nothing at all, silently re-creating the problem this feature exists to remove.
+     *
+     * @param exists injected so this is testable without a filesystem; the host passes
+     *   `File(it).isFile`.
+     */
+    fun installedAndOnDisk(
+        states: Map<String, DynamicPluginInfo>,
+        exists: (jarPath: String) -> Boolean,
+    ): Set<String> =
+        states
+            .filterValues { info -> exists(info.jarPath) }
+            .keys
+
+    /**
      * Dependencies of [manifest] that are not in [installedPluginIds].
      *
      * Returns optional dependencies too. They are worth telling someone about - an optional

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -78,6 +78,13 @@ object PluginDependencyResolution {
      * at entries then treated that plugin as present, so every *later* dependent of it reported
      * nothing at all, silently re-creating the problem this feature exists to remove.
      *
+     * [isIncompatible] qualifies the **jar** clause only, and must not override LOADED.
+     * `PluginCrashRegistry` keeps the flag until something clears it, and the only caller of
+     * `clearIncompatible` is the re-enable path - not install or update. So a plugin that failed
+     * registration, was updated from the Toolbox's own "Plugin Incompatible" prompt and is now
+     * running still carries the flag; excluding it would report a *running* plugin as missing,
+     * and taking Install would then discard the download and claim it "did not start".
+     *
      * The jar clause needs [isIncompatible] to stay honest. There are **two** binary
      * incompatibility paths in `installPlugin` and only one of them fails: the load-time one
      * returns `Result.failure`, but the *registration-time* one force-unloads the plugin and
@@ -107,9 +114,10 @@ object PluginDependencyResolution {
             // would look absent, the prompt would fire, and Install would fail with "Plugin
             // already loaded", which is both wrong and unactionable. The case this predicate
             // exists for is unaffected: a binary-incompatible entry is DISABLED, never LOADED.
-            .filterKeys { pluginId -> !isIncompatible(pluginId) }
-            .filterValues { info -> info.state == PluginState.LOADED || exists(info.jarPath) }
-            .keys
+            .filterValues { info ->
+                info.state == PluginState.LOADED ||
+                    (exists(info.jarPath) && !isIncompatible(info.manifest.pluginId))
+            }.keys
 
     /**
      * Dependencies of [manifest] that are not in [installedPluginIds].

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.api.PluginDependency
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.channels.Channel
@@ -83,7 +84,14 @@ object PluginDependencyResolution {
         exists: (jarPath: String) -> Boolean,
     ): Set<String> =
         states
-            .filterValues { info -> exists(info.jarPath) }
+            // A plugin that is LOADED counts however its jar path reads. The manager's
+            // `jarPath` is not repointed when a file moves - `PluginJarReconciler` rewrites
+            // `installed.json` and the updater writes a version-named file and deletes the old
+            // one - so a running plugin can hold a path that no longer exists. Without this it
+            // would look absent, the prompt would fire, and Install would fail with "Plugin
+            // already loaded", which is both wrong and unactionable. The case this predicate
+            // exists for is unaffected: a binary-incompatible entry is DISABLED, never LOADED.
+            .filterValues { info -> info.state == PluginState.LOADED || exists(info.jarPath) }
             .keys
 
     /**
@@ -110,6 +118,9 @@ object PluginDependencyResolution {
             // install: the prompt would ask the user to install what they just installed.
             .filterNot { dependency -> dependency.pluginId == manifest.pluginId }
             .filterNot { dependency -> dependency.pluginId in NOT_USER_INSTALLABLE }
+            // A blank id is a manifest typo, and it reads as one: "Flow works without , but
+            // some of its features need it", then " was not found in the plugin store."
+            .filterNot { dependency -> dependency.pluginId.isBlank() }
             .groupBy { dependency -> dependency.pluginId }
             // One prompt per plugin, and when a manifest declares the same dependency twice
             // with different flags the stricter one wins: calling something "Recommended"
@@ -201,6 +212,28 @@ data class MissingDependencyPrompt(
  */
 open class PluginDependencyBus {
     private val logger = BossLogger.forComponent("PluginDependencyBus")
+
+    /**
+     * Missing plugins the user has already declined, for this process only.
+     *
+     * All three gateway consumers declare it optional, so without this, declining for
+     * jupyter-notebook means being asked again for llmrpa and again for flow-tab. The
+     * `isInstalled` re-check only covers the case where it was installed in between.
+     *
+     * Not persisted, deliberately: "Not now" is an answer about now, and a decision that
+     * outlived the session would leave no way to be asked again short of editing a file.
+     */
+    private val declined =
+        java.util.concurrent.ConcurrentHashMap
+            .newKeySet<String>()
+
+    /** Records a "Not now" so this missing plugin stops asking for the rest of the session. */
+    fun decline(missingPluginId: String) {
+        declined.add(missingPluginId)
+    }
+
+    /** Whether the user already declined this missing plugin in this session. */
+    fun wasDeclined(missingPluginId: String): Boolean = missingPluginId in declined
 
     /**
      * A channel, not a `SharedFlow`, because exactly one window must ask.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -237,13 +237,29 @@ open class PluginDependencyBus {
      */
     private val queued = ConcurrentHashMap.newKeySet<String>()
 
-    /** Records a "Not now" so this missing plugin stops asking for the rest of the session. */
-    fun decline(missingPluginId: String) {
-        declined.add(missingPluginId)
+    /**
+     * Records a dismissal so the same question stops being asked this session.
+     *
+     * Keyed differently by kind, because the two buttons ask different things. "Not now" on an
+     * *optional* dependency is an answer about that plugin - three consumers declare the gateway
+     * optional, and being asked three times for one answer is the thing this prevents. "Skip" on
+     * a *required* one is an answer about this dependent only: another plugin that hard-requires
+     * the same thing is a different question, and silencing it would be strictly worse than the
+     * optional case.
+     */
+    fun decline(missing: MissingPluginDependency) {
+        declined.add(declineKey(missing))
     }
 
-    /** Whether the user already declined this missing plugin in this session. */
-    fun wasDeclined(missingPluginId: String): Boolean = missingPluginId in declined
+    /** Whether this exact question was already declined this session. */
+    fun wasDeclined(missing: MissingPluginDependency): Boolean = declineKey(missing) in declined
+
+    private fun declineKey(missing: MissingPluginDependency) =
+        if (missing.optional) {
+            missing.missingPluginId
+        } else {
+            "${missing.dependentPluginId}->${missing.missingPluginId}"
+        }
 
     /**
      * A channel, not a `SharedFlow`, because exactly one window must ask.
@@ -280,7 +296,7 @@ open class PluginDependencyBus {
      */
     fun report(prompt: MissingDependencyPrompt) {
         val missingPluginId = prompt.missing.missingPluginId
-        if (wasDeclined(missingPluginId) || !queued.add(missingPluginId)) return
+        if (wasDeclined(prompt.missing) || !queued.add(missingPluginId)) return
         if (prompts.trySend(prompt).isFailure) {
             queued.remove(missingPluginId)
             // DROP_OLDEST is silent, and a prompt that never appears is indistinguishable

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -6,7 +6,9 @@ import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A dependency a just-installed plugin declares but which is not present.
@@ -227,6 +229,14 @@ open class PluginDependencyBus {
         java.util.concurrent.ConcurrentHashMap
             .newKeySet<String>()
 
+    /**
+     * Missing plugins with a prompt already waiting, so the buffer is not spent on duplicates.
+     *
+     * Three consumers of one gateway report three prompts and the collector discards two on
+     * arrival - but they occupy slots first.
+     */
+    private val queued = ConcurrentHashMap.newKeySet<String>()
+
     /** Records a "Not now" so this missing plugin stops asking for the rest of the session. */
     fun decline(missingPluginId: String) {
         declined.add(missingPluginId)
@@ -253,11 +263,26 @@ open class PluginDependencyBus {
      */
     private val prompts = Channel<MissingDependencyPrompt>(capacity = 4)
 
-    val missingDependencies = prompts.receiveAsFlow()
+    val missingDependencies =
+        prompts
+            .receiveAsFlow()
+            // Freed on the way out, not when the dialog is answered: the collector may decline to
+            // show this one (already installed, or declined since), and a slot held for a prompt
+            // nobody will ever show is what `queued` exists to avoid.
+            .onEach { prompt -> queued.remove(prompt.missing.missingPluginId) }
 
-    /** Non-suspending on purpose, so the install path never waits on a UI. */
+    /**
+     * Non-suspending on purpose, so the install path never waits on a UI.
+     *
+     * Filters here and not only in the collector, because a prompt the collector is certain to
+     * discard still costs a buffer slot on the way through - and with four slots, that can be
+     * what refuses a different dependency which could have been shown.
+     */
     fun report(prompt: MissingDependencyPrompt) {
+        val missingPluginId = prompt.missing.missingPluginId
+        if (wasDeclined(missingPluginId) || !queued.add(missingPluginId)) return
         if (prompts.trySend(prompt).isFailure) {
+            queued.remove(missingPluginId)
             // DROP_OLDEST is silent, and a prompt that never appears is indistinguishable
             // from a feature that does not exist. Say so somewhere.
             logger.warn(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -32,12 +32,38 @@ data class MissingPluginDependency(
  */
 object PluginDependencyResolution {
     /**
+     * Plugin ids a manifest can name but which must never be offered for install.
+     *
+     * Both are system components that happen to live in the store under a plugin id, and both
+     * have a guard somewhere else that this path would route around:
+     *
+     * - the **microkernel runtime** is a classpath dependency for out-of-process child JVMs.
+     *   `PluginLoaderDelegateImpl.loadPlugin` refuses it outright, and `DefaultPlugin` skips it
+     *   on directory scan - so it is never in `pluginStates`, which would make it look missing
+     *   to every manifest that names it. Pushing it through `installPlugin` trips the
+     *   binary-compatibility validator on core JDK classes.
+     * - the **api plugin** is the shared `ApiClassLoader` layer. Installing a newer one is an
+     *   unload-everything / swap / reload-everything hot swap, which is not a thing to start
+     *   from a two-button dialog about something else.
+     *
+     * The api id is a literal because `ApiClassLoader.API_PLUGIN_ID` lives in `desktopMain`
+     * while this resolver is common; `PluginDependencyResolutionTest` pins the pair.
+     */
+    val NOT_USER_INSTALLABLE = setOf(MicrokernelRuntime.PLUGIN_ID, "ai.rever.boss.plugin.api")
+
+    /**
      * Dependencies of [manifest] that are not in [installedPluginIds].
      *
      * Returns optional dependencies too. They are worth telling someone about - an optional
      * dependency is how a plugin says "this feature needs that plugin", which is exactly
      * the thing a user would want to know at install time - but they are flagged so the
      * prompt can be a suggestion rather than a warning.
+     *
+     * **Presence is by id only.** `PluginDependency.version` is ignored, so a plugin needing
+     * 2.x is satisfied by 1.x being installed. That matches the one other reader of these
+     * declarations (`DynamicPluginManager.checkCanUnload`); resolving version ranges would be a
+     * different feature, and a prompt that offered to "install" something already present at
+     * the wrong version could not do anything useful about it anyway.
      */
     fun missingFor(
         manifest: PluginManifest,
@@ -48,6 +74,7 @@ object PluginDependencyResolution {
             // A plugin depending on itself is a manifest mistake, not something to offer to
             // install: the prompt would ask the user to install what they just installed.
             .filterNot { dependency -> dependency.pluginId == manifest.pluginId }
+            .filterNot { dependency -> dependency.pluginId in NOT_USER_INSTALLABLE }
             .groupBy { dependency -> dependency.pluginId }
             // One prompt per plugin, and when a manifest declares the same dependency twice
             // with different flags the stricter one wins: calling something "Recommended"
@@ -87,12 +114,18 @@ object PluginDependencyResolution {
  */
 interface MissingDependencyInstaller {
     /**
-     * Whether the plugin is installed *now*.
+     * Whether the plugin is present and usable *now*.
      *
      * A prompt can be raised and answered later, so what was missing at report time may not
      * be by the time it reaches a window - two dependents of one missing plugin each raise a
      * prompt, and installing for the first satisfies the second. Without this the second
      * dialog would state something untrue and reinstall what is already there.
+     *
+     * "Usable" and not merely "the manager has an entry": a load that fails as binary
+     * incompatible *registers* a disabled entry, and this installer deletes the jar it just
+     * rejected. Answering only "is there an entry" would then make Retry close the dialog
+     * reporting success with nothing installed, and silence the prompt for every other
+     * dependent of the same plugin.
      */
     fun isInstalled(pluginId: String): Boolean
 
@@ -112,8 +145,17 @@ interface MissingDependencyInstaller {
  * A missing dependency plus the means to fix it.
  *
  * The installer travels with the event rather than sitting in a global holder because it is
- * bound to the `DynamicPluginManager` that reported - one per window - and installing through
- * a different window's manager would load the plugin into the wrong one.
+ * bound to the `DynamicPluginManager` that reported - one per window - so Install always loads
+ * the dependency into the manager that was actually missing it, whichever window asks.
+ *
+ * **Known limitation, with more than one window open.** Delivery is to whichever window
+ * collects first, which is not necessarily the one that reported. The install is still correct
+ * (the jar lands on disk and loads into the reporting window's manager), but the person who
+ * answered may see nothing change in the window they were looking at until the next launch.
+ * Routing back to the reporting window would need the prompt to carry a window id and the
+ * collector to be able to decline one without consuming it - a claim registry rather than a
+ * channel. Not built, because a single window is the overwhelmingly common case and the
+ * consequence is cosmetic.
  */
 data class MissingDependencyPrompt(
     val missing: MissingPluginDependency,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -1,0 +1,151 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginDependency
+import ai.rever.boss.plugin.api.PluginManifest
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * A dependency a just-installed plugin declares but which is not present.
+ *
+ * Carries the dependent's display name so the prompt can say "Flow needs the AI Gateway"
+ * rather than naming two plugin ids at a user.
+ */
+data class MissingPluginDependency(
+    val dependentPluginId: String,
+    val dependentDisplayName: String,
+    val missingPluginId: String,
+    /** True when the dependent declared it `optional`, i.e. it works without it. */
+    val optional: Boolean,
+)
+
+/**
+ * Works out which of a plugin's declared dependencies are absent.
+ *
+ * Pure, so the interesting rules are testable without a plugin loader: manifest
+ * `dependencies` were previously read in exactly one place -
+ * `DynamicPluginManager.checkCanUnload` - which meant installing a plugin whose dependency
+ * was missing produced no signal at all. The user found out when a feature silently did
+ * nothing.
+ */
+object PluginDependencyResolution {
+    /**
+     * Dependencies of [manifest] that are not in [installedPluginIds].
+     *
+     * Returns optional dependencies too. They are worth telling someone about - an optional
+     * dependency is how a plugin says "this feature needs that plugin", which is exactly
+     * the thing a user would want to know at install time - but they are flagged so the
+     * prompt can be a suggestion rather than a warning.
+     */
+    fun missingFor(
+        manifest: PluginManifest,
+        installedPluginIds: Set<String>,
+    ): List<MissingPluginDependency> =
+        manifest.dependencies
+            .filterNot { dependency -> dependency.pluginId in installedPluginIds }
+            // A plugin depending on itself is a manifest mistake, not something to offer to
+            // install: the prompt would ask the user to install what they just installed.
+            .filterNot { dependency -> dependency.pluginId == manifest.pluginId }
+            .distinctBy { dependency -> dependency.pluginId }
+            .map { dependency -> manifest.toMissing(dependency) }
+
+    /**
+     * What to tell the user, given whatever name we managed to resolve for the dependency.
+     *
+     * [resolvedName] is the dependency's store display name when the lookup succeeded and its
+     * plugin id when it did not - a raw id is poor but honest, and better than a prompt that
+     * waits on the network before it can say anything.
+     */
+    fun MissingPluginDependency.description(resolvedName: String): String =
+        if (optional) {
+            "$dependentDisplayName works without $resolvedName, but some of its features need it."
+        } else {
+            "$dependentDisplayName needs $resolvedName, which is not installed."
+        }
+
+    private fun PluginManifest.toMissing(dependency: PluginDependency) =
+        MissingPluginDependency(
+            dependentPluginId = pluginId,
+            dependentDisplayName = displayName,
+            missingPluginId = dependency.pluginId,
+            optional = dependency.optional,
+        )
+}
+
+/**
+ * Installs a plugin the host knows only by id, for the prompt's Install button.
+ *
+ * An interface so the prompt can be built and tested without a store, a network or a plugin
+ * loader; the real one lives in `desktopMain` because resolving a version and downloading a
+ * jar is desktop-side work.
+ */
+interface MissingDependencyInstaller {
+    /**
+     * The dependency's display name in the store, or null when it cannot be resolved.
+     *
+     * Separate from [install] so the prompt can appear immediately with the id and improve
+     * itself when the lookup lands, rather than blocking on the network to say anything.
+     */
+    suspend fun displayNameFor(pluginId: String): String?
+
+    /** Downloads and loads the plugin. The message on failure is shown to the user. */
+    suspend fun install(pluginId: String): Result<Unit>
+}
+
+/**
+ * A missing dependency plus the means to fix it.
+ *
+ * The installer travels with the event rather than sitting in a global holder because it is
+ * bound to the `DynamicPluginManager` that reported - one per window - and installing through
+ * a different window's manager would load the plugin into the wrong one.
+ */
+data class MissingDependencyPrompt(
+    val missing: MissingPluginDependency,
+    val installer: MissingDependencyInstaller,
+)
+
+/**
+ * Carries a missing dependency from the install path to whichever window can ask about it.
+ *
+ * An event bus rather than a direct call because the install runs in
+ * `PluginLoaderDelegateImpl`, which has no window, no Compose scope and no idea whether a
+ * UI exists at all - the same reason `TerminalLinkEventBus` exists, though not the same
+ * delivery (see [prompts]).
+ *
+ * **Only user-initiated installs emit here.** Startup restore and the api hot-swap's
+ * reload-all both go through `DynamicPluginManager.installPlugin` directly, and a prompt on
+ * those paths would be a dialog per plugin on every launch.
+ *
+ * A class with a singleton subclass rather than a bare object, so a test can hold its own bus.
+ * The shared buffer otherwise carries prompts between tests, which is the same coupling two
+ * windows would have.
+ */
+open class PluginDependencyBus {
+    /**
+     * A channel, not a `SharedFlow`, because exactly one window must ask.
+     *
+     * A broadcast would put an identical dialog in front of every open window, and each of
+     * them could start the same install - so this is not a smaller version of the right
+     * thing, it is the wrong delivery semantics. Channel receive hands each prompt to a
+     * single collector.
+     *
+     * Buffered and dropping, so reporting never suspends the installer and a prompt raised
+     * before any window exists is asked as soon as one appears rather than lost.
+     */
+    private val prompts =
+        Channel<MissingDependencyPrompt>(
+            capacity = 4,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    val missingDependencies = prompts.receiveAsFlow()
+
+    /** Non-suspending on purpose, so the install path never waits on a UI. */
+    fun report(prompt: MissingDependencyPrompt) {
+        prompts.trySend(prompt)
+    }
+}
+
+/** The bus the host actually uses. */
+object PluginDependencyEventBus : PluginDependencyBus()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -19,7 +19,21 @@ data class MissingPluginDependency(
     val missingPluginId: String,
     /** True when the dependent declared it `optional`, i.e. it works without it. */
     val optional: Boolean,
-)
+) {
+    /**
+     * What to tell the user, given whatever name we managed to resolve for the dependency.
+     *
+     * [resolvedName] is the dependency's store display name when the lookup succeeded and its
+     * plugin id when it did not - a raw id is poor but honest, and better than a prompt that
+     * waits on the network before it can say anything.
+     */
+    fun description(resolvedName: String): String =
+        if (optional) {
+            "$dependentDisplayName works without $resolvedName, but some of its features need it."
+        } else {
+            "$dependentDisplayName needs $resolvedName, which is not installed."
+        }
+}
 
 /**
  * Works out which of a plugin's declared dependencies are absent.
@@ -81,20 +95,6 @@ object PluginDependencyResolution {
             // that the plugin actually requires is the worse way to be wrong.
             .map { (_, declarations) -> declarations.minBy { it.optional } }
             .map { dependency -> manifest.toMissing(dependency) }
-
-    /**
-     * What to tell the user, given whatever name we managed to resolve for the dependency.
-     *
-     * [resolvedName] is the dependency's store display name when the lookup succeeded and its
-     * plugin id when it did not - a raw id is poor but honest, and better than a prompt that
-     * waits on the network before it can say anything.
-     */
-    fun MissingPluginDependency.description(resolvedName: String): String =
-        if (optional) {
-            "$dependentDisplayName works without $resolvedName, but some of its features need it."
-        } else {
-            "$dependentDisplayName needs $resolvedName, which is not installed."
-        }
 
     private fun PluginManifest.toMissing(dependency: PluginDependency) =
         MissingPluginDependency(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -78,12 +78,26 @@ object PluginDependencyResolution {
      * at entries then treated that plugin as present, so every *later* dependent of it reported
      * nothing at all, silently re-creating the problem this feature exists to remove.
      *
+     * The jar clause needs [isIncompatible] to stay honest. There are **two** binary
+     * incompatibility paths in `installPlugin` and only one of them fails: the load-time one
+     * returns `Result.failure`, but the *registration-time* one force-unloads the plugin and
+     * returns `Result.success` with `state = DISABLED` and the jar still on disk. Without this
+     * filter that jar makes a plugin which was unloaded and will not run count as installed - so
+     * the Install button would report success for it, and every other dependent of it would go
+     * unprompted.
+     *
      * @param exists injected so this is testable without a filesystem; the host passes
-     *   `File(it).isFile`.
+     *   `File(it).isFile`
+     * @param isIncompatible whether the host has recorded this plugin as binary-incompatible;
+     *   the host passes `PluginCrashRegistry.isIncompatible`. Being last, it captures a trailing
+     *   lambda, so pass both by name - [exists] deliberately has no default, which turns a call
+     *   that meant to write `exists` as a trailing lambda into a compile error rather than a
+     *   silent swap of the two.
      */
     fun installedAndOnDisk(
         states: Map<String, DynamicPluginInfo>,
         exists: (jarPath: String) -> Boolean,
+        isIncompatible: (pluginId: String) -> Boolean = { false },
     ): Set<String> =
         states
             // A plugin that is LOADED counts however its jar path reads. The manager's
@@ -93,6 +107,7 @@ object PluginDependencyResolution {
             // would look absent, the prompt would fire, and Install would fail with "Plugin
             // already loaded", which is both wrong and unactionable. The case this predicate
             // exists for is unaffected: a binary-incompatible entry is DISABLED, never LOADED.
+            .filterKeys { pluginId -> !isIncompatible(pluginId) }
             .filterValues { info -> info.state == PluginState.LOADED || exists(info.jarPath) }
             .keys
 
@@ -285,7 +300,7 @@ open class PluginDependencyBus {
             // Freed on the way out, not when the dialog is answered: the collector may decline to
             // show this one (already installed, or declined since), and a slot held for a prompt
             // nobody will ever show is what `queued` exists to avoid.
-            .onEach { prompt -> queued.remove(prompt.missing.missingPluginId) }
+            .onEach { prompt -> queued.remove(declineKey(prompt.missing)) }
 
     /**
      * Non-suspending on purpose, so the install path never waits on a UI.
@@ -296,9 +311,12 @@ open class PluginDependencyBus {
      */
     fun report(prompt: MissingDependencyPrompt) {
         val missingPluginId = prompt.missing.missingPluginId
-        if (wasDeclined(prompt.missing) || !queued.add(missingPluginId)) return
+        // Keyed like a decline, not by bare id: an optional prompt already waiting would
+        // otherwise swallow a *required* one for the same plugin, and declining the optional
+        // dialog would then silence the plugin that actually requires it.
+        if (wasDeclined(prompt.missing) || !queued.add(declineKey(prompt.missing))) return
         if (prompts.trySend(prompt).isFailure) {
-            queued.remove(missingPluginId)
+            queued.remove(declineKey(prompt.missing))
             // DROP_OLDEST is silent, and a prompt that never appears is indistinguishable
             // from a feature that does not exist. Say so somewhere.
             logger.warn(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -2,7 +2,8 @@ package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.api.PluginDependency
 import ai.rever.boss.plugin.api.PluginManifest
-import kotlinx.coroutines.channels.BufferOverflow
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 
@@ -47,7 +48,11 @@ object PluginDependencyResolution {
             // A plugin depending on itself is a manifest mistake, not something to offer to
             // install: the prompt would ask the user to install what they just installed.
             .filterNot { dependency -> dependency.pluginId == manifest.pluginId }
-            .distinctBy { dependency -> dependency.pluginId }
+            .groupBy { dependency -> dependency.pluginId }
+            // One prompt per plugin, and when a manifest declares the same dependency twice
+            // with different flags the stricter one wins: calling something "Recommended"
+            // that the plugin actually requires is the worse way to be wrong.
+            .map { (_, declarations) -> declarations.minBy { it.optional } }
             .map { dependency -> manifest.toMissing(dependency) }
 
     /**
@@ -81,6 +86,16 @@ object PluginDependencyResolution {
  * jar is desktop-side work.
  */
 interface MissingDependencyInstaller {
+    /**
+     * Whether the plugin is installed *now*.
+     *
+     * A prompt can be raised and answered later, so what was missing at report time may not
+     * be by the time it reaches a window - two dependents of one missing plugin each raise a
+     * prompt, and installing for the first satisfies the second. Without this the second
+     * dialog would state something untrue and reinstall what is already there.
+     */
+    fun isInstalled(pluginId: String): Boolean
+
     /**
      * The dependency's display name in the store, or null when it cannot be resolved.
      *
@@ -122,6 +137,8 @@ data class MissingDependencyPrompt(
  * windows would have.
  */
 open class PluginDependencyBus {
+    private val logger = BossLogger.forComponent("PluginDependencyBus")
+
     /**
      * A channel, not a `SharedFlow`, because exactly one window must ask.
      *
@@ -130,20 +147,32 @@ open class PluginDependencyBus {
      * thing, it is the wrong delivery semantics. Channel receive hands each prompt to a
      * single collector.
      *
-     * Buffered and dropping, so reporting never suspends the installer and a prompt raised
-     * before any window exists is asked as soon as one appears rather than lost.
+     * Buffered, so reporting never suspends the installer and a prompt raised before any
+     * window exists is asked as soon as one appears rather than lost.
+     *
+     * Left on the default suspend-on-overflow policy and only ever written with `trySend`:
+     * a `DROP_OLDEST` channel always accepts, so the overflow would be invisible, and the
+     * oldest prompt is the one the user is most likely part-way through answering. A full
+     * buffer refuses the newest and says so instead.
      */
-    private val prompts =
-        Channel<MissingDependencyPrompt>(
-            capacity = 4,
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        )
+    private val prompts = Channel<MissingDependencyPrompt>(capacity = 4)
 
     val missingDependencies = prompts.receiveAsFlow()
 
     /** Non-suspending on purpose, so the install path never waits on a UI. */
     fun report(prompt: MissingDependencyPrompt) {
-        prompts.trySend(prompt)
+        if (prompts.trySend(prompt).isFailure) {
+            // DROP_OLDEST is silent, and a prompt that never appears is indistinguishable
+            // from a feature that does not exist. Say so somewhere.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Dropped a missing-dependency prompt",
+                mapOf(
+                    "dependent" to prompt.missing.dependentPluginId,
+                    "missing" to prompt.missing.missingPluginId,
+                ),
+            )
+        }
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginStoreSetup
+import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
@@ -109,8 +110,10 @@ actual object PluginUpdateBridge {
                 loadPlugin = { path ->
                     manager.installPlugin(path).map { info ->
                         // An update can add a dependency the installed version never declared,
-                        // and this path does not go through PluginLoaderDelegateImpl.
-                        reporter.report(info.manifest)
+                        // and this path does not go through PluginLoaderDelegateImpl. Only for a
+                        // plugin that actually registered: `installPlugin` returns success with
+                        // `state = DISABLED` when registration failed as binary-incompatible.
+                        if (info.state == PluginState.LOADED) reporter.report(info.manifest)
                     }
                 },
             )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -104,7 +105,13 @@ actual object PluginUpdateBridge {
                 pluginId = pluginId,
                 downloadPath = targetPath,
                 unloadPlugin = { id -> manager.uninstallPlugin(id, force = true).map { } },
-                loadPlugin = { path -> manager.installPlugin(path).map { } },
+                loadPlugin = { path ->
+                    manager.installPlugin(path).map { info ->
+                        // An update can add a dependency the installed version never declared,
+                        // and this path does not go through PluginLoaderDelegateImpl.
+                        MissingDependencyReporter.forManager(manager).report(info.manifest)
+                    }
+                },
             )
         return if (result.isSuccess) {
             PluginUpdateRegistry.clear(pluginId)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -100,6 +100,7 @@ actual object PluginUpdateBridge {
             return Result.failure(Exception("Refusing to download update outside the plugin directory"))
         }
         val targetPath = targetFile.absolutePath
+        val reporter = MissingDependencyReporter.forManager(manager)
         val result =
             mgr.updatePlugin(
                 pluginId = pluginId,
@@ -109,7 +110,7 @@ actual object PluginUpdateBridge {
                     manager.installPlugin(path).map { info ->
                         // An update can add a dependency the installed version never declared,
                         // and this path does not go through PluginLoaderDelegateImpl.
-                        MissingDependencyReporter.forManager(manager).report(info.manifest)
+                        reporter.report(info.manifest)
                     }
                 },
             )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -45,6 +45,9 @@ class PluginInstallService(
     ): Result<PluginInstallResult> =
         withContext(Dispatchers.IO) {
             val installedIds = mutableListOf<String>()
+
+            /** Manifests of everything this batch loaded, for the one dependency report below. */
+            val installedManifests = mutableListOf<PluginManifest>()
             val failedIds = mutableListOf<Pair<String, String>>() // pluginId to error message
 
             if (plugins.isEmpty()) {
@@ -108,8 +111,10 @@ class PluginInstallService(
                     // If plugin has a GitHub URL, install from GitHub
                     if (plugin.githubUrl.isNotEmpty()) {
                         val result = installFromGitHub(plugin, pluginDir, progress, totalPlugins, onProgress)
-                        if (result.isSuccess) {
+                        val installedManifest = result.getOrNull()
+                        if (installedManifest != null) {
                             installedIds.add(plugin.id)
+                            installedManifests.add(installedManifest)
                         } else {
                             failedIds.add(plugin.id to (result.exceptionOrNull()?.message ?: "GitHub install failed"))
                         }
@@ -180,11 +185,7 @@ class PluginInstallService(
                     val installResult = dynamicPluginManager.installPlugin(jarPath, enabled = true)
 
                     if (installResult.isSuccess) {
-                        // The wizard installs several plugins at once, so it is the path where an
-                        // unmet dependency is most likely - and it never goes through
-                        // PluginLoaderDelegateImpl, so without this it was the one user-initiated
-                        // install that stayed silent.
-                        manifest?.let { dependencyReporter.report(it) }
+                        manifest?.let { installedManifests.add(it) }
 
                         // Persist the installation with actual version
                         PluginPersistence.addInstalledPlugin(
@@ -233,6 +234,18 @@ class PluginInstallService(
 
             onProgress(1f, "Installation complete")
 
+            // Report unmet dependencies once the whole batch is in, never per iteration.
+            // Reporting inside the loop meant a selection of [jupyter-notebook, ai-gateway] - the
+            // pick this feature exists for - prompted for the gateway while the wizard was still
+            // two lines from installing it: the loop runs on IO, so the collector on Main showed
+            // the dialog over the wizard, and taking Install raced the wizard's own download.
+            // (The two paths write different filenames for one plugin id, so nothing collides at
+            // the path level and the coalescing guard never sees a shared key.) After the loop,
+            // `installedAndOnDisk` already contains everything the batch installed, so nothing
+            // intra-batch is reported at all. This also covers the GitHub branch, which reports
+            // nowhere else.
+            installedManifests.forEach { installedManifest -> dependencyReporter.report(installedManifest) }
+
             // Log summary
             logger.info(
                 LogCategory.SYSTEM,
@@ -262,13 +275,35 @@ class PluginInstallService(
      * Install a plugin from GitHub.
      * Downloads the release JAR directly from GitHub releases.
      */
+
+    /**
+     * The manifest id is authoritative, so a mismatch with the wizard's expectation is logged and
+     * the install continues.
+     */
+    private fun warnOnIdMismatch(
+        plugin: WizardPluginInfo,
+        manifest: PluginManifest,
+    ) {
+        if (manifest.pluginId == plugin.id) return
+        logger.warn(
+            LogCategory.SYSTEM,
+            "Plugin ID mismatch between expected and manifest",
+            mapOf(
+                "expectedId" to plugin.id,
+                "manifestId" to manifest.pluginId,
+                "githubUrl" to plugin.githubUrl,
+            ),
+        )
+    }
+
+    /** Returns the installed manifest, so the caller's batch dependency report includes it. */
     private suspend fun installFromGitHub(
         plugin: WizardPluginInfo,
         pluginDir: File,
         baseProgress: Float,
         totalPlugins: Int,
         onProgress: (Float, String) -> Unit,
-    ): Result<Unit> =
+    ): Result<PluginManifest> =
         withContext(Dispatchers.IO) {
             try {
                 onProgress(baseProgress + (0.1f / totalPlugins), "Checking GitHub releases for ${plugin.name}...")
@@ -296,19 +331,7 @@ class PluginInstallService(
                     extractManifestFromJar(jarPath)
                         ?: return@withContext Result.failure(Exception("Downloaded JAR does not contain valid plugin manifest"))
 
-                // Verify manifest plugin ID matches expected ID
-                if (manifest.pluginId != plugin.id) {
-                    logger.warn(
-                        LogCategory.SYSTEM,
-                        "Plugin ID mismatch between expected and manifest",
-                        mapOf(
-                            "expectedId" to plugin.id,
-                            "manifestId" to manifest.pluginId,
-                            "githubUrl" to plugin.githubUrl,
-                        ),
-                    )
-                    // Continue with manifest ID as it's the authoritative source
-                }
+                warnOnIdMismatch(plugin, manifest)
 
                 onProgress(baseProgress + (0.7f / totalPlugins), "Installing ${plugin.name}...")
 
@@ -337,7 +360,7 @@ class PluginInstallService(
                     ),
                 )
 
-                Result.success(Unit)
+                Result.success(manifest)
             } catch (e: Exception) {
                 logger.error(
                     LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginPersistence
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.repository.PluginWithSource
 import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
@@ -185,9 +186,13 @@ class PluginInstallService(
                     val installResult = dynamicPluginManager.installPlugin(jarPath, enabled = true)
 
                     if (installResult.isSuccess) {
-                        if (manifest != null) {
+                        // Only a plugin that actually registered: `installPlugin` returns success
+                        // with `state = DISABLED` when registration failed as binary-incompatible,
+                        // and prompting then offers a second plugin to support a dead one.
+                        val registered = installResult.getOrNull()?.state == PluginState.LOADED
+                        if (manifest != null && registered) {
                             installedManifests.add(manifest)
-                        } else {
+                        } else if (manifest == null) {
                             // Installed, but its dependencies were never checked. Say so rather
                             // than leaving the batch quietly incomplete.
                             logger.warn(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.wizard.plugin
 
+import ai.rever.boss.components.plugin.DynamicPluginInfo
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginPersistence
@@ -112,10 +113,14 @@ class PluginInstallService(
                     // If plugin has a GitHub URL, install from GitHub
                     if (plugin.githubUrl.isNotEmpty()) {
                         val result = installFromGitHub(plugin, pluginDir, progress, totalPlugins, onProgress)
-                        val installedManifest = result.getOrNull()
-                        if (installedManifest != null) {
+                        val installedPlugin = result.getOrNull()
+                        if (installedPlugin != null) {
                             installedIds.add(plugin.id)
-                            installedManifests.add(installedManifest)
+                            // Same LOADED gate as the store branch: a plugin that installed but
+                            // did not register must not have its dependencies offered.
+                            if (installedPlugin.state == PluginState.LOADED) {
+                                installedManifests.add(installedPlugin.manifest)
+                            }
                         } else {
                             failedIds.add(plugin.id to (result.exceptionOrNull()?.message ?: "GitHub install failed"))
                         }
@@ -311,14 +316,18 @@ class PluginInstallService(
         )
     }
 
-    /** Returns the installed manifest, so the caller's batch dependency report includes it. */
+    /**
+     * Returns what the manager registered, so the caller's batch dependency report can include it
+     * *and* check that it actually loaded - `installPlugin` returns success with
+     * `state = DISABLED` for a registration-time binary incompatibility.
+     */
     private suspend fun installFromGitHub(
         plugin: WizardPluginInfo,
         pluginDir: File,
         baseProgress: Float,
         totalPlugins: Int,
         onProgress: (Float, String) -> Unit,
-    ): Result<PluginManifest> =
+    ): Result<DynamicPluginInfo> =
         withContext(Dispatchers.IO) {
             try {
                 onProgress(baseProgress + (0.1f / totalPlugins), "Checking GitHub releases for ${plugin.name}...")
@@ -353,9 +362,11 @@ class PluginInstallService(
                 // Install the plugin
                 val installResult = dynamicPluginManager.installPlugin(jarPath, enabled = true)
 
-                if (installResult.isFailure) {
-                    return@withContext Result.failure(installResult.exceptionOrNull() ?: Exception("Install failed"))
-                }
+                val installed =
+                    installResult.getOrNull()
+                        ?: return@withContext Result.failure(
+                            installResult.exceptionOrNull() ?: Exception("Install failed"),
+                        )
 
                 // Persist the installation
                 PluginPersistence.addInstalledPlugin(
@@ -375,7 +386,7 @@ class PluginInstallService(
                     ),
                 )
 
-                Result.success(manifest)
+                Result.success(installed)
             } catch (e: Exception) {
                 logger.error(
                     LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -185,7 +185,17 @@ class PluginInstallService(
                     val installResult = dynamicPluginManager.installPlugin(jarPath, enabled = true)
 
                     if (installResult.isSuccess) {
-                        manifest?.let { installedManifests.add(it) }
+                        if (manifest != null) {
+                            installedManifests.add(manifest)
+                        } else {
+                            // Installed, but its dependencies were never checked. Say so rather
+                            // than leaving the batch quietly incomplete.
+                            logger.warn(
+                                LogCategory.SYSTEM,
+                                "Installed a plugin whose manifest could not be read, so dependencies went unchecked",
+                                mapOf("pluginId" to plugin.id),
+                            )
+                        }
 
                         // Persist the installation with actual version
                         PluginPersistence.addInstalledPlugin(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.wizard.plugin
 
 import ai.rever.boss.components.plugin.DynamicPluginManager
+import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginPersistence
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginManifest
@@ -25,6 +26,9 @@ import java.util.jar.JarFile
  */
 class PluginInstallService(
     private val dynamicPluginManager: DynamicPluginManager,
+    /** Raises the install-time dependency prompt; see [MissingDependencyReporter]. */
+    private val dependencyReporter: MissingDependencyReporter =
+        MissingDependencyReporter.forManager(dynamicPluginManager),
 ) {
     private val logger = BossLogger.forComponent("PluginInstallService")
 
@@ -176,6 +180,12 @@ class PluginInstallService(
                     val installResult = dynamicPluginManager.installPlugin(jarPath, enabled = true)
 
                     if (installResult.isSuccess) {
+                        // The wizard installs several plugins at once, so it is the path where an
+                        // unmet dependency is most likely - and it never goes through
+                        // PluginLoaderDelegateImpl, so without this it was the one user-initiated
+                        // install that stayed silent.
+                        manifest?.let { dependencyReporter.report(it) }
+
                         // Persist the installation with actual version
                         PluginPersistence.addInstalledPlugin(
                             pluginId = plugin.id,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.components.plugin.PluginDependencyBus
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.PluginDependencyResolution
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.loader.ApiClassLoader
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
@@ -87,15 +88,19 @@ class MissingDependencyReporter(
      * Log the dependencies that are missing but cannot be offered.
      *
      * `missingFor` filters system components out, so without this a plugin genuinely lacking the
-     * api plugin or the microkernel runtime produced no prompt *and* no log line - the same
-     * silence this feature exists to remove, in the case where a support log matters most.
+     * api plugin produced no prompt *and* no log line - the same silence this feature exists to
+     * remove, in the case where a support log matters most.
      */
     private fun logUnofferable(
         manifest: PluginManifest,
         installed: Set<String>,
     ) {
         manifest.dependencies
-            .filter { it.pluginId in PluginDependencyResolution.NOT_USER_INSTALLABLE && it.pluginId !in installed }
+            // The api plugin only: the microkernel runtime is skipped on directory scan and
+            // refused by `loadPlugin`, so it is *never* in `pluginStates` and this test is always
+            // true for it - every out-of-process plugin declaring it would warn that a system
+            // component is missing while its child JVMs spawn perfectly well.
+            .filter { it.pluginId == ApiClassLoader.API_PLUGIN_ID && it.pluginId !in installed }
             .forEach { dependency ->
                 logger.warn(
                     LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
@@ -9,6 +9,7 @@ import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.PluginDependencyResolution
 import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.loader.ApiClassLoader
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
@@ -40,6 +41,7 @@ class MissingDependencyReporter(
     private val installer: MissingDependencyInstaller,
     private val bus: PluginDependencyBus = PluginDependencyEventBus,
     private val jarExists: (String) -> Boolean = { File(it).isFile },
+    private val isIncompatible: (String) -> Boolean = { PluginCrashRegistry.isIncompatible(it) },
 ) {
     private val logger = BossLogger.forComponent("MissingDependencyReporter")
 
@@ -48,7 +50,12 @@ class MissingDependencyReporter(
      *
      * See `PluginDependencyResolution.installedAndOnDisk` for why one definition matters.
      */
-    private fun installedPluginIds() = PluginDependencyResolution.installedAndOnDisk(states(), jarExists)
+    private fun installedPluginIds() =
+        PluginDependencyResolution.installedAndOnDisk(
+            states = states(),
+            exists = jarExists,
+            isIncompatible = isIncompatible,
+        )
 
     /**
      * Report whatever [manifest] declares and does not have.
@@ -121,7 +128,11 @@ class MissingDependencyReporter(
         fun forManager(manager: DynamicPluginManager): MissingDependencyReporter {
             val installedNow: (String) -> Boolean = { pluginId ->
                 pluginId in
-                    PluginDependencyResolution.installedAndOnDisk(manager.pluginStates.value) { File(it).isFile }
+                    PluginDependencyResolution.installedAndOnDisk(
+                        states = manager.pluginStates.value,
+                        exists = { File(it).isFile },
+                        isIncompatible = { PluginCrashRegistry.isIncompatible(it) },
+                    )
             }
             return MissingDependencyReporter(
                 states = { manager.pluginStates.value },
@@ -129,8 +140,11 @@ class MissingDependencyReporter(
                     StoreMissingDependencyInstaller(
                         repository = { PluginStoreSetup.remoteRepository },
                         pluginDir = { PluginStoreSetup.getPluginDir() },
-                        installedNow = installedNow,
-                        load = { jarPath -> manager.installPlugin(jarPath) },
+                        hooks =
+                            InstallerHooks(
+                                installedNow = installedNow,
+                                load = { jarPath -> manager.installPlugin(jarPath) },
+                            ),
                     ),
             )
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
@@ -1,0 +1,133 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.components.plugin.DynamicPluginInfo
+import ai.rever.boss.components.plugin.DynamicPluginManager
+import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.components.plugin.MissingDependencyPrompt
+import ai.rever.boss.components.plugin.PluginDependencyBus
+import ai.rever.boss.components.plugin.PluginDependencyEventBus
+import ai.rever.boss.components.plugin.PluginDependencyResolution
+import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+
+/**
+ * Raises the install-time prompt for dependencies a plugin declares but which are absent.
+ *
+ * A class, and not the private method it started as, because more than one host path installs
+ * on a user's behalf and each of them should report:
+ *
+ * - `PluginLoaderDelegateImpl.loadPlugin`, which the plugin-manager's install and update flows
+ *   reach directly;
+ * - `PluginInstallService`, the first-run wizard - the path where several plugins are chosen at
+ *   once, so the one where an unmet dependency is *most* likely;
+ * - `PluginUpdateBridge`, where an update can add a dependency the installed version never had.
+ *
+ * What must not report is a **reload**: `resetPluginInstances`, the Toolbox's reload and the
+ * evolver's hot reload all end in a load, and none of them is a user asking to install
+ * anything. Startup restore, the bundled-plugin load and the api hot-swap's reload-all go
+ * through `DynamicPluginManager.installPlugin` directly and so never reach here at all - which
+ * is the point, since a prompt on those paths would be one dialog per plugin on every launch.
+ *
+ * Takes the two things it needs rather than a `DynamicPluginManager`, so what it decides is
+ * testable without standing up a loader, a sandbox and two registries. [forManager] is the
+ * shape every real call site wants.
+ */
+class MissingDependencyReporter(
+    private val states: () -> Map<String, DynamicPluginInfo>,
+    private val installer: MissingDependencyInstaller,
+    private val bus: PluginDependencyBus = PluginDependencyEventBus,
+    private val jarExists: (String) -> Boolean = { File(it).isFile },
+) {
+    private val logger = BossLogger.forComponent("MissingDependencyReporter")
+
+    /**
+     * The plugins that count as installed, shared by the report set and the Install guard.
+     *
+     * See `PluginDependencyResolution.installedAndOnDisk` for why one definition matters.
+     */
+    private fun installedPluginIds() = PluginDependencyResolution.installedAndOnDisk(states(), jarExists)
+
+    /**
+     * Report whatever [manifest] declares and does not have.
+     *
+     * Fire-and-forget. A missing dependency is worth mentioning but never worth failing an
+     * install the user asked for, or making them wait on a window that may not exist yet.
+     */
+    fun report(manifest: PluginManifest) {
+        runCatching {
+            val installed = installedPluginIds()
+            logUnofferable(manifest, installed)
+
+            PluginDependencyResolution
+                .missingFor(manifest, installed)
+                .forEach { missing ->
+                    logger.info(
+                        LogCategory.SYSTEM,
+                        "Installed plugin declares a dependency that is not present",
+                        mapOf(
+                            "plugin" to missing.dependentPluginId,
+                            "missing" to missing.missingPluginId,
+                            "optional" to missing.optional,
+                        ),
+                    )
+                    bus.report(MissingDependencyPrompt(missing, installer))
+                }
+        }.onFailure { error ->
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Could not check a plugin's dependencies",
+                mapOf("plugin" to manifest.pluginId, "error" to (error.message ?: "unknown")),
+            )
+        }
+    }
+
+    /**
+     * Log the dependencies that are missing but cannot be offered.
+     *
+     * `missingFor` filters system components out, so without this a plugin genuinely lacking the
+     * api plugin or the microkernel runtime produced no prompt *and* no log line - the same
+     * silence this feature exists to remove, in the case where a support log matters most.
+     */
+    private fun logUnofferable(
+        manifest: PluginManifest,
+        installed: Set<String>,
+    ) {
+        manifest.dependencies
+            .filter { it.pluginId in PluginDependencyResolution.NOT_USER_INSTALLABLE && it.pluginId !in installed }
+            .forEach { dependency ->
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Plugin declares a missing system component, which cannot be offered for install",
+                    mapOf("plugin" to manifest.pluginId, "missing" to dependency.pluginId),
+                )
+            }
+    }
+
+    companion object {
+        /**
+         * The reporter every real install path wants: bound to one window's manager.
+         *
+         * Bound so the dependency loads into the same manager that was missing it, and reaching
+         * the store lazily because `PluginStoreSetup` initialises during startup while a
+         * reporter can outlive a store that never came up at all.
+         */
+        fun forManager(manager: DynamicPluginManager): MissingDependencyReporter {
+            val installedNow: (String) -> Boolean = { pluginId ->
+                pluginId in
+                    PluginDependencyResolution.installedAndOnDisk(manager.pluginStates.value) { File(it).isFile }
+            }
+            return MissingDependencyReporter(
+                states = { manager.pluginStates.value },
+                installer =
+                    StoreMissingDependencyInstaller(
+                        repository = { PluginStoreSetup.remoteRepository },
+                        pluginDir = { PluginStoreSetup.getPluginDir() },
+                        installedNow = installedNow,
+                        load = { jarPath -> manager.installPlugin(jarPath) },
+                    ),
+            )
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -2,6 +2,9 @@ package ai.rever.boss.plugin
 
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MicrokernelRuntime
+import ai.rever.boss.components.plugin.MissingDependencyPrompt
+import ai.rever.boss.components.plugin.PluginDependencyEventBus
+import ai.rever.boss.components.plugin.PluginDependencyResolution
 import ai.rever.boss.components.plugin.findRelocatedPluginJar
 import ai.rever.boss.components.plugin.resolveReloadJarPath
 import ai.rever.boss.components.registery.PanelComponentStoreRegistry
@@ -55,6 +58,56 @@ class PluginLoaderDelegateImpl(
      */
     private val detachedReloads = KeyedDetachedJobs<String, LoadedPluginInfo?>(reloadScope)
 
+    /**
+     * Fixes a missing dependency, for the prompt's Install button.
+     *
+     * Bound to this delegate's manager so the dependency loads into the same window that
+     * asked, and holds the store lazily because `PluginStoreSetup` initialises during startup
+     * while this delegate can outlive a store that never came up at all.
+     */
+    private val dependencyInstaller =
+        StoreMissingDependencyInstaller(
+            dynamicPluginManager = dynamicPluginManager,
+            repository = { PluginStoreSetup.remoteRepository },
+            pluginDir = { PluginStoreSetup.getPluginDir() },
+        )
+
+    /**
+     * Tell the user about dependencies this plugin declares but which are absent.
+     *
+     * Deliberately here and not in `DynamicPluginManager.installPlugin`: that method also
+     * serves startup restore, the bundled-plugin load and the api hot-swap's reload-all, so
+     * a prompt there would be one dialog per plugin on every launch. This delegate is the
+     * path plugin-manager install and update flows take, which is the only place a *user*
+     * asked for something.
+     *
+     * Reporting is fire-and-forget. A missing dependency is worth mentioning but never
+     * worth failing an install the user asked for, or making them wait on a window that may
+     * not exist yet.
+     */
+    private fun reportMissingDependencies(manifest: ai.rever.boss.plugin.api.PluginManifest) {
+        runCatching {
+            // Every plugin the host knows about, not only the enabled ones: a disabled
+            // dependency is installed, so offering to install it again would be the wrong
+            // fix and the wrong sentence.
+            val installed = dynamicPluginManager.pluginStates.value.keys
+            PluginDependencyResolution
+                .missingFor(manifest, installed)
+                .forEach { missing ->
+                    logger.info(
+                        LogCategory.SYSTEM,
+                        "Installed plugin declares a dependency that is not present",
+                        mapOf(
+                            "plugin" to missing.dependentPluginId,
+                            "missing" to missing.missingPluginId,
+                            "optional" to missing.optional,
+                        ),
+                    )
+                    PluginDependencyEventBus.report(MissingDependencyPrompt(missing, dependencyInstaller))
+                }
+        }
+    }
+
     override suspend fun loadPlugin(jarPath: String): LoadedPluginInfo? {
         // Never try to load the microkernel runtime via the plugin-install
         // path — it's a classpath dependency for OOP child JVMs, not a
@@ -95,6 +148,7 @@ class PluginLoaderDelegateImpl(
             if (result.isSuccess) {
                 val loadedPlugin = result.getOrNull()
                 loadedPlugin?.let { info ->
+                    reportMissingDependencies(info.manifest)
                     LoadedPluginInfo(
                         pluginId = info.manifest.pluginId,
                         displayName = info.manifest.displayName,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -66,18 +66,28 @@ class PluginLoaderDelegateImpl(
      * asked, and holds the store lazily because `PluginStoreSetup` initialises during startup
      * while this delegate can outlive a store that never came up at all.
      */
+
+    /**
+     * The single definition of "this plugin is installed", for both halves of the prompt.
+     *
+     * A jar on disk as well as an entry, because `installPlugin` registers a DISABLED entry for
+     * a binary-incompatible plugin and the installer deletes the jar it just rejected. The two
+     * halves *must* agree: when the reporter used the raw `pluginStates` keys and the installer
+     * used this, a failed install left a dangling entry that made every later dependent of that
+     * plugin report nothing at all - silently re-creating the problem this feature exists to
+     * remove.
+     */
+    private val installedAndOnDisk: (String) -> Boolean = { pluginId ->
+        dynamicPluginManager.pluginStates.value[pluginId]
+            ?.jarPath
+            ?.let { File(it).exists() } == true
+    }
+
     private val dependencyInstaller =
         StoreMissingDependencyInstaller(
             repository = { PluginStoreSetup.remoteRepository },
             pluginDir = { PluginStoreSetup.getPluginDir() },
-            // A jar on disk as well as an entry: `installPlugin` registers a DISABLED entry
-            // for a binary-incompatible plugin, and the installer deletes the jar it rejected,
-            // so an entry alone would report a failed install as an install.
-            installedNow = { pluginId ->
-                dynamicPluginManager.pluginStates.value[pluginId]
-                    ?.jarPath
-                    ?.let { File(it).exists() } == true
-            },
+            installedNow = installedAndOnDisk,
             load = { jarPath -> dynamicPluginManager.installPlugin(jarPath) },
         )
 
@@ -100,10 +110,14 @@ class PluginLoaderDelegateImpl(
     ) {
         if (!report) return
         runCatching {
-            // Every plugin the host knows about, not only the enabled ones: a disabled
-            // dependency is installed, so offering to install it again would be the wrong
-            // fix and the wrong sentence.
-            val installed = dynamicPluginManager.pluginStates.value.keys
+            // Every plugin present on disk, not only the enabled ones: a disabled dependency
+            // is installed, so offering to install it again would be the wrong fix and the
+            // wrong sentence. Filtered through the same predicate the installer uses - see
+            // [installedAndOnDisk] for what a mismatch cost.
+            val installed =
+                dynamicPluginManager.pluginStates.value.keys
+                    .filter(installedAndOnDisk)
+                    .toSet()
             PluginDependencyResolution
                 .missingFor(manifest, installed)
                 .forEach { missing ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.plugin.api.InaccessiblePluginInfo
 import ai.rever.boss.plugin.api.LoadedPluginInfo
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.api.PluginLoaderDelegate
+import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
@@ -67,9 +68,10 @@ class PluginLoaderDelegateImpl(
      */
     private val dependencyInstaller =
         StoreMissingDependencyInstaller(
-            dynamicPluginManager = dynamicPluginManager,
             repository = { PluginStoreSetup.remoteRepository },
             pluginDir = { PluginStoreSetup.getPluginDir() },
+            installedNow = { pluginId -> dynamicPluginManager.isInstalled(pluginId) },
+            load = { jarPath -> dynamicPluginManager.installPlugin(jarPath) },
         )
 
     /**
@@ -85,7 +87,11 @@ class PluginLoaderDelegateImpl(
      * worth failing an install the user asked for, or making them wait on a window that may
      * not exist yet.
      */
-    private fun reportMissingDependencies(manifest: ai.rever.boss.plugin.api.PluginManifest) {
+    private fun reportMissingDependencies(
+        manifest: PluginManifest,
+        report: Boolean,
+    ) {
+        if (!report) return
         runCatching {
             // Every plugin the host knows about, not only the enabled ones: a disabled
             // dependency is installed, so offering to install it again would be the wrong
@@ -105,10 +111,29 @@ class PluginLoaderDelegateImpl(
                     )
                     PluginDependencyEventBus.report(MissingDependencyPrompt(missing, dependencyInstaller))
                 }
+        }.onFailure { error ->
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Could not check a plugin's dependencies",
+                mapOf("plugin" to manifest.pluginId, "error" to (error.message ?: "unknown")),
+            )
         }
     }
 
-    override suspend fun loadPlugin(jarPath: String): LoadedPluginInfo? {
+    override suspend fun loadPlugin(jarPath: String): LoadedPluginInfo? = loadPlugin(jarPath, reportDependencies = true)
+
+    /**
+     * @param reportDependencies whether an unmet dependency should prompt.
+     *
+     * False for reloads. `doReloadPlugin` finishes by calling this, and reload is reached by
+     * `resetPluginInstances`, the Toolbox's update flow and the evolver's hot reload - none of
+     * which is a user asking to install anything. Without the distinction, an optional
+     * dependency someone declined with "Not now" would be re-offered on every reload.
+     */
+    private suspend fun loadPlugin(
+        jarPath: String,
+        reportDependencies: Boolean,
+    ): LoadedPluginInfo? {
         // Never try to load the microkernel runtime via the plugin-install
         // path — it's a classpath dependency for OOP child JVMs, not a
         // loadable plugin. DefaultPlugin.loadExternalPlugins already skips
@@ -148,7 +173,7 @@ class PluginLoaderDelegateImpl(
             if (result.isSuccess) {
                 val loadedPlugin = result.getOrNull()
                 loadedPlugin?.let { info ->
-                    reportMissingDependencies(info.manifest)
+                    reportMissingDependencies(info.manifest, reportDependencies)
                     LoadedPluginInfo(
                         pluginId = info.manifest.pluginId,
                         displayName = info.manifest.displayName,
@@ -267,7 +292,7 @@ class PluginLoaderDelegateImpl(
             }
 
             // Reload
-            loadPlugin(jarPath)
+            loadPlugin(jarPath, reportDependencies = false)
         } catch (e: Exception) {
             logger.error(LogCategory.SYSTEM, "Exception reloading plugin", error = e)
             null

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin
 
+import ai.rever.boss.components.plugin.DynamicPluginInfo
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MicrokernelRuntime
 import ai.rever.boss.components.plugin.findRelocatedPluginJar
@@ -11,7 +12,6 @@ import ai.rever.boss.plugin.api.InaccessiblePluginInfo
 import ai.rever.boss.plugin.api.LoadedPluginInfo
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.api.PluginLoaderDelegate
-import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
@@ -70,7 +70,7 @@ class PluginLoaderDelegateImpl(
      * inside [loadPlugin]'s try / isSuccess / let.
      */
     private fun describe(
-        info: ai.rever.boss.components.plugin.DynamicPluginInfo,
+        info: DynamicPluginInfo,
         reportDependencies: Boolean,
     ): LoadedPluginInfo {
         if (reportDependencies) dependencyReporter.report(info.manifest)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -73,7 +73,14 @@ class PluginLoaderDelegateImpl(
         info: DynamicPluginInfo,
         reportDependencies: Boolean,
     ): LoadedPluginInfo {
-        if (reportDependencies) dependencyReporter.report(info.manifest)
+        // Only for a plugin that actually registered. `installPlugin` returns success with
+        // `state = DISABLED` when registration failed as binary-incompatible or the plugin is
+        // hidden for lack of access - reporting there would say "Flow needs the AI Gateway" for
+        // something that is not running and will not run, and taking Install would download a
+        // second plugin to support a dead one.
+        if (reportDependencies && info.state == PluginState.LOADED) {
+            dependencyReporter.report(info.manifest)
+        }
         return LoadedPluginInfo(
             pluginId = info.manifest.pluginId,
             displayName = info.manifest.displayName,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -59,6 +59,12 @@ class PluginLoaderDelegateImpl(
      */
     private val detachedReloads = KeyedDetachedJobs<String, LoadedPluginInfo?>(reloadScope)
 
+    /** See `PluginDependencyResolution.installedAndOnDisk` for why both halves share this. */
+    private fun installedPluginIds(): Set<String> =
+        PluginDependencyResolution.installedAndOnDisk(dynamicPluginManager.pluginStates.value) { jarPath ->
+            File(jarPath).isFile
+        }
+
     /**
      * Fixes a missing dependency, for the prompt's Install button.
      *
@@ -66,28 +72,11 @@ class PluginLoaderDelegateImpl(
      * asked, and holds the store lazily because `PluginStoreSetup` initialises during startup
      * while this delegate can outlive a store that never came up at all.
      */
-
-    /**
-     * The single definition of "this plugin is installed", for both halves of the prompt.
-     *
-     * A jar on disk as well as an entry, because `installPlugin` registers a DISABLED entry for
-     * a binary-incompatible plugin and the installer deletes the jar it just rejected. The two
-     * halves *must* agree: when the reporter used the raw `pluginStates` keys and the installer
-     * used this, a failed install left a dangling entry that made every later dependent of that
-     * plugin report nothing at all - silently re-creating the problem this feature exists to
-     * remove.
-     */
-    private val installedAndOnDisk: (String) -> Boolean = { pluginId ->
-        dynamicPluginManager.pluginStates.value[pluginId]
-            ?.jarPath
-            ?.let { File(it).exists() } == true
-    }
-
     private val dependencyInstaller =
         StoreMissingDependencyInstaller(
             repository = { PluginStoreSetup.remoteRepository },
             pluginDir = { PluginStoreSetup.getPluginDir() },
-            installedNow = installedAndOnDisk,
+            installedNow = { pluginId -> pluginId in installedPluginIds() },
             load = { jarPath -> dynamicPluginManager.installPlugin(jarPath) },
         )
 
@@ -111,13 +100,9 @@ class PluginLoaderDelegateImpl(
         if (!report) return
         runCatching {
             // Every plugin present on disk, not only the enabled ones: a disabled dependency
-            // is installed, so offering to install it again would be the wrong fix and the
-            // wrong sentence. Filtered through the same predicate the installer uses - see
-            // [installedAndOnDisk] for what a mismatch cost.
-            val installed =
-                dynamicPluginManager.pluginStates.value.keys
-                    .filter(installedAndOnDisk)
-                    .toSet()
+            // is installed, so offering to install it again would be the wrong fix and the wrong
+            // sentence. The same set the Install guard uses, by construction.
+            val installed = installedPluginIds()
             PluginDependencyResolution
                 .missingFor(manifest, installed)
                 .forEach { missing ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -2,9 +2,6 @@ package ai.rever.boss.plugin
 
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MicrokernelRuntime
-import ai.rever.boss.components.plugin.MissingDependencyPrompt
-import ai.rever.boss.components.plugin.PluginDependencyEventBus
-import ai.rever.boss.components.plugin.PluginDependencyResolution
 import ai.rever.boss.components.plugin.findRelocatedPluginJar
 import ai.rever.boss.components.plugin.resolveReloadJarPath
 import ai.rever.boss.components.registery.PanelComponentStoreRegistry
@@ -59,71 +56,45 @@ class PluginLoaderDelegateImpl(
      */
     private val detachedReloads = KeyedDetachedJobs<String, LoadedPluginInfo?>(reloadScope)
 
-    /** See `PluginDependencyResolution.installedAndOnDisk` for why both halves share this. */
-    private fun installedPluginIds(): Set<String> =
-        PluginDependencyResolution.installedAndOnDisk(dynamicPluginManager.pluginStates.value) { jarPath ->
-            File(jarPath).isFile
-        }
+    /**
+     * Raises the install-time dependency prompt. See [MissingDependencyReporter] for which
+     * paths report and, more importantly, which must not.
+     */
+    private val dependencyReporter = MissingDependencyReporter.forManager(dynamicPluginManager)
 
     /**
-     * Fixes a missing dependency, for the prompt's Install button.
+     * Report the plugin's unmet dependencies (unless this is a reload) and describe it for the
+     * caller.
      *
-     * Bound to this delegate's manager so the dependency loads into the same window that
-     * asked, and holds the store lazily because `PluginStoreSetup` initialises during startup
-     * while this delegate can outlive a store that never came up at all.
+     * A function rather than an inline block only because the two together sit four levels deep
+     * inside [loadPlugin]'s try / isSuccess / let.
      */
-    private val dependencyInstaller =
-        StoreMissingDependencyInstaller(
-            repository = { PluginStoreSetup.remoteRepository },
-            pluginDir = { PluginStoreSetup.getPluginDir() },
-            installedNow = { pluginId -> pluginId in installedPluginIds() },
-            load = { jarPath -> dynamicPluginManager.installPlugin(jarPath) },
+    private fun describe(
+        info: ai.rever.boss.components.plugin.DynamicPluginInfo,
+        reportDependencies: Boolean,
+    ): LoadedPluginInfo {
+        if (reportDependencies) dependencyReporter.report(info.manifest)
+        return LoadedPluginInfo(
+            pluginId = info.manifest.pluginId,
+            displayName = info.manifest.displayName,
+            version = info.manifest.version,
+            description = info.manifest.description,
+            author = info.manifest.author,
+            url = info.manifest.url,
+            type =
+                info.manifest.type.name
+                    .lowercase(),
+            apiVersion = info.manifest.apiVersion,
+            minBossVersion = info.manifest.minBossVersion,
+            isSystemPlugin = info.manifest.systemPlugin,
+            canUnload = info.manifest.canUnload,
+            loadPriority = info.manifest.loadPriority,
+            isEnabled = info.enabled,
+            healthy = info.state == PluginState.LOADED,
+            jarPath = info.jarPath,
+            installedAt = System.currentTimeMillis(),
+            requiresAdmin = info.manifest.requiresAdmin,
         )
-
-    /**
-     * Tell the user about dependencies this plugin declares but which are absent.
-     *
-     * Deliberately here and not in `DynamicPluginManager.installPlugin`: that method also
-     * serves startup restore, the bundled-plugin load and the api hot-swap's reload-all, so
-     * a prompt there would be one dialog per plugin on every launch. This delegate is the
-     * path plugin-manager install and update flows take, which is the only place a *user*
-     * asked for something.
-     *
-     * Reporting is fire-and-forget. A missing dependency is worth mentioning but never
-     * worth failing an install the user asked for, or making them wait on a window that may
-     * not exist yet.
-     */
-    private fun reportMissingDependencies(
-        manifest: PluginManifest,
-        report: Boolean,
-    ) {
-        if (!report) return
-        runCatching {
-            // Every plugin present on disk, not only the enabled ones: a disabled dependency
-            // is installed, so offering to install it again would be the wrong fix and the wrong
-            // sentence. The same set the Install guard uses, by construction.
-            val installed = installedPluginIds()
-            PluginDependencyResolution
-                .missingFor(manifest, installed)
-                .forEach { missing ->
-                    logger.info(
-                        LogCategory.SYSTEM,
-                        "Installed plugin declares a dependency that is not present",
-                        mapOf(
-                            "plugin" to missing.dependentPluginId,
-                            "missing" to missing.missingPluginId,
-                            "optional" to missing.optional,
-                        ),
-                    )
-                    PluginDependencyEventBus.report(MissingDependencyPrompt(missing, dependencyInstaller))
-                }
-        }.onFailure { error ->
-            logger.warn(
-                LogCategory.SYSTEM,
-                "Could not check a plugin's dependencies",
-                mapOf("plugin" to manifest.pluginId, "error" to (error.message ?: "unknown")),
-            )
-        }
     }
 
     override suspend fun loadPlugin(jarPath: String): LoadedPluginInfo? = loadPlugin(jarPath, reportDependencies = true)
@@ -178,30 +149,7 @@ class PluginLoaderDelegateImpl(
             val result = dynamicPluginManager.installPlugin(jarPath, enabled = true)
             if (result.isSuccess) {
                 val loadedPlugin = result.getOrNull()
-                loadedPlugin?.let { info ->
-                    reportMissingDependencies(info.manifest, reportDependencies)
-                    LoadedPluginInfo(
-                        pluginId = info.manifest.pluginId,
-                        displayName = info.manifest.displayName,
-                        version = info.manifest.version,
-                        description = info.manifest.description,
-                        author = info.manifest.author,
-                        url = info.manifest.url,
-                        type =
-                            info.manifest.type.name
-                                .lowercase(),
-                        apiVersion = info.manifest.apiVersion,
-                        minBossVersion = info.manifest.minBossVersion,
-                        isSystemPlugin = info.manifest.systemPlugin,
-                        canUnload = info.manifest.canUnload,
-                        loadPriority = info.manifest.loadPriority,
-                        isEnabled = info.enabled,
-                        healthy = info.state == PluginState.LOADED,
-                        jarPath = info.jarPath,
-                        installedAt = System.currentTimeMillis(),
-                        requiresAdmin = info.manifest.requiresAdmin,
-                    )
-                }
+                loadedPlugin?.let { info -> describe(info, reportDependencies) }
             } else {
                 logger.error(LogCategory.SYSTEM, "Failed to load plugin", error = result.exceptionOrNull())
                 null

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -70,7 +70,14 @@ class PluginLoaderDelegateImpl(
         StoreMissingDependencyInstaller(
             repository = { PluginStoreSetup.remoteRepository },
             pluginDir = { PluginStoreSetup.getPluginDir() },
-            installedNow = { pluginId -> dynamicPluginManager.isInstalled(pluginId) },
+            // A jar on disk as well as an entry: `installPlugin` registers a DISABLED entry
+            // for a binary-incompatible plugin, and the installer deletes the jar it rejected,
+            // so an entry alone would report a failed install as an install.
+            installedNow = { pluginId ->
+                dynamicPluginManager.pluginStates.value[pluginId]
+                    ?.jarPath
+                    ?.let { File(it).exists() } == true
+            },
             load = { jarPath -> dynamicPluginManager.installPlugin(jarPath) },
         )
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.plugin.loader.PluginManifestReader
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepository
+import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
@@ -98,22 +99,29 @@ class StoreMissingDependencyInstaller(
             runCatching { store.getPlugin(pluginId).getOrNull() }.getOrNull()
                 ?: return failure("$pluginId was not found in the plugin store.")
 
-        val target = targetJar(pluginId, info)
-        // A jar already at this exact path is not ours to delete: a plugin can be on disk
-        // without the manager having registered it (a load that failed transiently at
-        // startup), and a failed download must not take the user's file with it.
-        val preexisting = target.exists()
+        // `<id_with_underscores>_<version>.jar` in the plugins directory, so a later directory
+        // scan picks it up like any other install. Both parts are sanitised because both come
+        // from a store row. Note `PluginInstallService` writes `<id>-<version>.jar` and
+        // `PluginUpdateBridge` a third shape; `PluginJarReconciler` knows all three and dedupes
+        // by manifest id, so this is untidy rather than broken.
+        val target = File(pluginDir(), "${safe(pluginId.replace('.', '_'))}_${safe(info.version)}.jar")
+        // Download beside the target, never onto it. `downloadPlugin` streams into whatever path
+        // it is given and `outputStream()` truncates on open, so downloading straight to the
+        // final name destroys any jar already there the moment the connection opens - and a
+        // download that then dies mid-stream leaves a truncated file at a name every subsequent
+        // launch will try to load. Guarding with "was a file already here" does not help: by
+        // then its contents are gone either way.
+        //
+        // The suffix deliberately does not end in `.jar`, so a part file left behind by a kill
+        // is ignored by the directory scan rather than loaded. (`PluginInstallService` uses
+        // `-downloading.jar`, which is scannable, and moves the jar without its sidecar.)
+        val part = File("${target.absolutePath}.part")
         return store
-            .downloadPlugin(pluginId, info.version, target.absolutePath)
+            .downloadPlugin(pluginId, info.version, part.absolutePath)
             .fold(
-                onSuccess = { jarPath -> vetAndLoad(pluginId, jarPath, info) },
+                onSuccess = { downloaded -> promoteAndLoad(pluginId, downloaded, target, info) },
                 onFailure = { error ->
-                    // A download that dies mid-stream leaves a truncated jar at the final
-                    // name, and nothing upstream removes it: `downloadPlugin` writes straight
-                    // into the target and only deletes on a hash or signature rejection. Left
-                    // there, every launch would find it, fail to read it and log the failure
-                    // again.
-                    if (!preexisting) discard(target.absolutePath)
+                    discard(part.absolutePath)
                     logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
                     failure("Could not download ${info.displayName}: ${error.message ?: "unknown error"}")
                 },
@@ -121,32 +129,35 @@ class StoreMissingDependencyInstaller(
     }
 
     /**
-     * Where the downloaded jar goes: `<id_with_underscores>_<version>.jar` in the plugins
-     * directory, so a later directory scan picks it up like any other install.
+     * Move the completed download onto its final name, sidecar included, then load it.
      *
-     * Downloaded straight to its final name rather than through a `-downloading.jar` rename:
-     * `downloadPlugin` writes the signature sidecar next to whatever path it was given, and a
-     * rename afterwards would leave the `.sig` behind under the temporary name - so the jar
-     * would load as unsigned. Partial files are handled by deleting on failure instead.
-     *
-     * Both parts are sanitised because both come from a store row, and a `version` of `../x`
-     * would otherwise write outside the plugins directory. Note this scheme differs from
-     * `PluginInstallService`'s `<id>-<version>.jar`; neither is canonical, and the loader finds
-     * either, but a shared helper would stop them drifting further.
+     * Both files move together: `downloadPlugin` writes the signature next to the path it was
+     * given, so promoting the jar alone would leave the `.sig` under the part name and the jar
+     * would load as unsigned.
      */
-    private fun targetJar(
+    private suspend fun promoteAndLoad(
         pluginId: String,
+        downloaded: String,
+        target: File,
         info: PluginInfo,
-    ) = File(pluginDir(), "${safe(pluginId.replace('.', '_'))}_${safe(info.version)}.jar")
-
-    /**
-     * Keeps only what a plugin jar name needs, so no store value can name a path.
-     *
-     * Path separators go, which is what stops a `version` of `../x` escaping the directory;
-     * dots survive because versions are full of them and, with separators gone, cannot
-     * traverse.
-     */
-    private fun safe(part: String) = part.replace(Regex("[^A-Za-z0-9.-]"), "_")
+    ): Result<Unit> {
+        val moved =
+            runCatching {
+                target.atomicMoveFrom(File(downloaded))
+                val signature = PluginSignatureSidecar.read(downloaded)
+                if (signature != null) {
+                    PluginSignatureSidecar.write(target.absolutePath, signature)
+                    PluginSignatureSidecar.delete(downloaded)
+                }
+            }
+        val error = moved.exceptionOrNull()
+        if (error != null) {
+            discard(downloaded)
+            logger.error(LogCategory.SYSTEM, "Could not move a downloaded dependency into place", error = error)
+            return failure("Downloaded ${info.displayName} but could not put it in place.")
+        }
+        return vetAndLoad(pluginId, target.absolutePath, info)
+    }
 
     /**
      * Loads the downloaded jar and records it.
@@ -248,6 +259,14 @@ class StoreMissingDependencyInstaller(
     }
 
     private fun failure(message: String): Result<Unit> = Result.failure(IllegalStateException(message))
+
+    /**
+     * Keeps only what a plugin jar name needs, so no store value can name a path.
+     *
+     * Path separators go, which is what stops a `version` of `../x` escaping the directory; dots
+     * survive because versions are full of them and, with separators gone, cannot traverse.
+     */
+    private fun safe(part: String) = part.replace(Regex("[^A-Za-z0-9.-]"), "_")
 
     private companion object {
         /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -1,0 +1,102 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.components.plugin.DynamicPluginManager
+import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.plugin.repository.PluginInfo
+import ai.rever.boss.plugin.repository.PluginRepository
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+
+/**
+ * Installs a missing plugin dependency from the plugin store.
+ *
+ * This is the part a plugin cannot do for itself, and the reason the prompt belongs in the
+ * host at all: a plugin that finds `AiGatewayAPI == null` can only send the user to the
+ * Toolbox to search for something by name. The host resolves an id against the store,
+ * downloads the jar and loads it.
+ *
+ * Every failure message here is shown to the user, so each says what happened and what it
+ * means for them rather than surfacing a transport error.
+ *
+ * @param repository the store repository, null when it never initialised (offline first run,
+ *   or absent store credentials) - the prompt then says so instead of hanging
+ * @param pluginDir where installed jars live, so a downloaded dependency is picked up by a
+ *   later directory scan exactly like any other install
+ */
+class StoreMissingDependencyInstaller(
+    private val dynamicPluginManager: DynamicPluginManager,
+    private val repository: () -> PluginRepository?,
+    private val pluginDir: () -> File,
+) : MissingDependencyInstaller {
+    private val logger = BossLogger.forComponent("MissingDependencyInstaller")
+
+    override suspend fun displayNameFor(pluginId: String): String? =
+        runCatching { repository()?.getPlugin(pluginId)?.getOrNull()?.displayName }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+
+    override suspend fun install(pluginId: String): Result<Unit> {
+        val store =
+            repository() ?: return failure(
+                "The plugin store is not available. Check your connection and try again.",
+            )
+        return installFromStore(store, pluginId)
+    }
+
+    private suspend fun installFromStore(
+        store: PluginRepository,
+        pluginId: String,
+    ): Result<Unit> {
+        val info =
+            runCatching { store.getPlugin(pluginId).getOrNull() }.getOrNull()
+                ?: return failure("$pluginId was not found in the plugin store.")
+
+        return store
+            .downloadPlugin(pluginId, info.version, targetJar(pluginId, info).absolutePath)
+            .fold(
+                onSuccess = { jarPath -> load(jarPath, info) },
+                onFailure = { error ->
+                    logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
+                    failure("Could not download ${info.displayName}: ${reason(error)}")
+                },
+            )
+    }
+
+    /**
+     * The store's own filename shape, so a later update or uninstall recognises this jar as
+     * that plugin instead of leaving a stray copy behind.
+     */
+    private fun targetJar(
+        pluginId: String,
+        info: PluginInfo,
+    ) = File(pluginDir(), "${pluginId.replace('.', '_')}_${info.version}.jar")
+
+    /**
+     * Loads the downloaded jar through the manager directly.
+     *
+     * Deliberately not back through `PluginLoaderDelegateImpl.loadPlugin`, so a dependency
+     * that has dependencies of its own does not chain prompts: the user answered one
+     * question and should not be handed a second dialog as its consequence. Anything still
+     * missing after this shows up the next time that plugin is installed or updated.
+     */
+    private suspend fun load(
+        jarPath: String,
+        info: PluginInfo,
+    ): Result<Unit> {
+        val error = dynamicPluginManager.installPlugin(jarPath).exceptionOrNull()
+        return if (error == null) {
+            Result.success(Unit)
+        } else {
+            // Leave no half-installed jar: a directory scan on the next launch would load it
+            // without it ever having passed the checks it just failed.
+            runCatching { File(jarPath).delete() }
+            logger.error(LogCategory.SYSTEM, "Failed to load a downloaded plugin dependency", error = error)
+            failure("Downloaded ${info.displayName} but could not load it: ${reason(error)}")
+        }
+    }
+
+    private fun reason(error: Throwable) = error.message ?: "unknown error"
+
+    private fun failure(message: String): Result<Unit> = Result.failure(IllegalStateException(message))
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -22,12 +22,12 @@ import java.io.File
  * Every failure message here is shown to the user, so each says what happened and what it
  * means for them rather than surfacing a transport error.
  *
- * @param repository the store repository, null when it never initialised (offline first run,
- *   or absent store credentials) - the prompt then says so instead of hanging
  * The plugin manager is reached through two lambdas rather than held as an object: those are
  * the only two things wanted from it, and passing them makes the download, cleanup and
  * persistence rules testable without standing up a loader.
  *
+ * @param repository the store repository, null when it never initialised (offline first run,
+ *   or absent store credentials) - the prompt then says so instead of hanging
  * @param pluginDir where installed jars live, so a downloaded dependency is picked up by a
  *   later directory scan exactly like any other install
  * @param installedNow whether a plugin id is loaded in the manager that reported
@@ -58,9 +58,6 @@ class StoreMissingDependencyInstaller(
      * window mid-download would otherwise abort the install and leave the partial jar behind.
      */
     private val installScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-
-    /** A property rather than a function purely to stay under detekt's per-class count. */
-    private val reason: (Throwable) -> String = { error -> error.message ?: "unknown error" }
 
     /**
      * Detaches installs from the window that asked and coalesces them per plugin id.
@@ -121,24 +118,38 @@ class StoreMissingDependencyInstaller(
                     // again.
                     discard(target.absolutePath)
                     logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
-                    failure("Could not download ${info.displayName}: ${reason(error)}")
+                    failure("Could not download ${info.displayName}: ${error.message ?: "unknown error"}")
                 },
             )
     }
 
     /**
-     * The name a store download already uses (`ai_rever_boss_x_1.2.3.jar`), so a later update
-     * or uninstall recognises this jar as that plugin instead of leaving a stray copy.
+     * Where the downloaded jar goes: `<id_with_underscores>_<version>.jar` in the plugins
+     * directory, so a later directory scan picks it up like any other install.
      *
      * Downloaded straight to its final name rather than through a `-downloading.jar` rename:
      * `downloadPlugin` writes the signature sidecar next to whatever path it was given, and a
      * rename afterwards would leave the `.sig` behind under the temporary name - so the jar
      * would load as unsigned. Partial files are handled by deleting on failure instead.
+     *
+     * Both parts are sanitised because both come from a store row, and a `version` of `../x`
+     * would otherwise write outside the plugins directory. Note this scheme differs from
+     * `PluginInstallService`'s `<id>-<version>.jar`; neither is canonical, and the loader finds
+     * either, but a shared helper would stop them drifting further.
      */
     private fun targetJar(
         pluginId: String,
         info: PluginInfo,
-    ) = File(pluginDir(), "${pluginId.replace('.', '_')}_${info.version}.jar")
+    ) = File(pluginDir(), "${safe(pluginId.replace('.', '_'))}_${safe(info.version)}.jar")
+
+    /**
+     * Keeps only what a plugin jar name needs, so no store value can name a path.
+     *
+     * Path separators go, which is what stops a `version` of `../x` escaping the directory;
+     * dots survive because versions are full of them and, with separators gone, cannot
+     * traverse.
+     */
+    private fun safe(part: String) = part.replace(Regex("[^A-Za-z0-9.-]"), "_")
 
     /**
      * Loads the downloaded jar and records it.
@@ -159,35 +170,24 @@ class StoreMissingDependencyInstaller(
             // this jar and load it without it ever having passed the checks it just failed.
             discard(jarPath)
             logger.error(LogCategory.SYSTEM, "Failed to load a downloaded plugin dependency", error = error)
-            return failure("Downloaded ${info.displayName} but could not load it: ${reason(error)}")
+            return failure("Downloaded ${info.displayName} but could not load it: ${error.message ?: "unknown error"}")
         }
-        record(pluginId, jarPath, info)
-        return Result.success(Unit)
-    }
-
-    /**
-     * Writes the `installed.json` entry, as every other install path does.
-     *
-     * Not optional bookkeeping: `setPluginEnabled` updates an existing entry and does nothing
-     * at all when there is none, so a dependency known only by its presence on disk cannot be
-     * disabled persistently - it would come back enabled on the next launch. The entry also
-     * carries the version and source that update checking reads.
-     */
-    private fun record(
-        pluginId: String,
-        jarPath: String,
-        info: PluginInfo,
-    ) {
+        // Write the `installed.json` entry, as every other install path does. Not optional
+        // bookkeeping: `setPluginEnabled` updates an existing entry and does nothing when there
+        // is none, so a plugin known only by its presence on disk cannot be disabled
+        // persistently - it would come back enabled on the next launch. The entry also carries
+        // the version and source that update checking reads.
         runCatching { persist(pluginId, jarPath, info) }
             .onFailure { error ->
-                // The plugin is loaded and usable; only the record failed, so this is not
-                // worth turning a successful install into an error the user sees.
+                // The plugin is loaded and usable; only the record failed, so this is not worth
+                // turning a successful install into an error the user sees.
                 logger.warn(
                     LogCategory.SYSTEM,
                     "Installed a dependency but could not record it",
                     mapOf("pluginId" to pluginId, "error" to (error.message ?: "unknown")),
                 )
             }
+        return Result.success(Unit)
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -52,21 +52,6 @@ class StoreMissingDependencyInstaller(
 ) : MissingDependencyInstaller {
     private val logger = BossLogger.forComponent("MissingDependencyInstaller")
 
-    /**
-     * Owner of detached installs - deliberately never cancelled, like the delegate's
-     * `reloadScope`. The prompt is driven from a window's coroutine scope, and closing that
-     * window mid-download would otherwise abort the install and leave the partial jar behind.
-     */
-    private val installScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-
-    /**
-     * Detaches installs from the window that asked and coalesces them per plugin id.
-     *
-     * Coalescing is not a nicety here: two dependents can each raise a prompt for the same
-     * missing plugin, so without it two Installs could download to the same path at once.
-     */
-    private val detachedInstalls = KeyedDetachedJobs<String, Result<Unit>>(installScope)
-
     override fun isInstalled(pluginId: String): Boolean = installedNow(pluginId)
 
     override suspend fun displayNameFor(pluginId: String): String? =
@@ -75,7 +60,7 @@ class StoreMissingDependencyInstaller(
             ?.takeIf { it.isNotBlank() }
 
     override suspend fun install(pluginId: String): Result<Unit> =
-        detachedInstalls.run(
+        DETACHED_INSTALLS.run(
             key = pluginId,
             onDetachedFailure = { error ->
                 // The window closed while this ran, so nothing is left to show the failure to.
@@ -165,12 +150,26 @@ class StoreMissingDependencyInstaller(
         info: PluginInfo,
     ): Result<Unit> {
         val error = load(jarPath).exceptionOrNull()
-        if (error != null) {
+        val wrongPlugin = error == null && !isInstalled(pluginId)
+        if (error != null || wrongPlugin) {
             // Leave nothing half-installed: a directory scan on the next launch would find
             // this jar and load it without it ever having passed the checks it just failed.
             discard(jarPath)
-            logger.error(LogCategory.SYSTEM, "Failed to load a downloaded plugin dependency", error = error)
-            return failure("Downloaded ${info.displayName} but could not load it: ${error.message ?: "unknown error"}")
+            return if (wrongPlugin) {
+                // The load succeeded but not as the plugin that was missing: a store row for X
+                // can point at a jar whose manifest declares Y. Reporting success would close
+                // the dialog with the dependency still absent, the one outcome every other
+                // branch here is careful to avoid.
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "A dependency jar loaded as a different plugin",
+                    mapOf("expected" to pluginId, "jarPath" to jarPath),
+                )
+                failure("${info.displayName} did not install as $pluginId. The store entry may be wrong.")
+            } else {
+                logger.error(LogCategory.SYSTEM, "Failed to load a downloaded plugin dependency", error = error)
+                failure("Downloaded ${info.displayName} but could not load it: ${error?.message ?: "unknown error"}")
+            }
         }
         // Write the `installed.json` entry, as every other install path does. Not optional
         // bookkeeping: `setPluginEnabled` updates an existing entry and does nothing when there
@@ -202,4 +201,25 @@ class StoreMissingDependencyInstaller(
     }
 
     private fun failure(message: String): Result<Unit> = Result.failure(IllegalStateException(message))
+
+    private companion object {
+        /**
+         * Owner of detached installs - deliberately never cancelled, like the delegate's
+         * `reloadScope`. The prompt runs on a window's coroutine scope, and closing that window
+         * mid-download would otherwise abort the install and leave the partial jar behind.
+         */
+        private val INSTALL_SCOPE = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+        /**
+         * Detaches installs from the window that asked and coalesces them per plugin id.
+         *
+         * **Process-wide, not per instance.** One installer exists per window, so a per-instance
+         * guard would not have covered the case that most needs it: two windows each prompting
+         * for the same missing plugin would run two `downloadPlugin` calls writing the same
+         * `<id>_<version>.jar` at once. Coalescing here means the second Install joins the
+         * first job rather than racing it - and so loads into the manager that started it,
+         * which is the multi-window limitation already documented on `MissingDependencyPrompt`.
+         */
+        private val DETACHED_INSTALLS = KeyedDetachedJobs<String, Result<Unit>>(INSTALL_SCOPE)
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.plugin
 
 import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.components.plugin.PluginDependencyResolution
+import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.loader.PluginManifestReader
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepository
@@ -39,14 +42,17 @@ class StoreMissingDependencyInstaller(
     private val pluginDir: () -> File,
     private val installedNow: (pluginId: String) -> Boolean,
     private val load: suspend (jarPath: String) -> Result<*>,
-    private val persist: (pluginId: String, jarPath: String, info: PluginInfo) -> Unit =
-        { pluginId, jarPath, info ->
+    private val readManifest: (jarPath: String) -> PluginManifest? = { jarPath ->
+        runCatching { PluginManifestReader.readFromJar(jarPath) }.getOrNull()
+    },
+    private val persist: (pluginId: String, jarPath: String, version: String, sourceUrl: String) -> Unit =
+        { pluginId, jarPath, version, sourceUrl ->
             PluginPersistence.addInstalledPlugin(
                 pluginId = pluginId,
                 jarPath = jarPath,
                 enabled = true,
-                sourceUrl = info.downloadUrl,
-                installedVersion = info.version,
+                sourceUrl = sourceUrl,
+                installedVersion = version,
             )
         },
 ) : MissingDependencyInstaller {
@@ -67,20 +73,22 @@ class StoreMissingDependencyInstaller(
                 logger.error(LogCategory.SYSTEM, "Detached dependency install failed", error = error)
             },
         ) {
-            installOnce(pluginId)
-        }
+            // A second prompt for the same dependency can outlive the install that satisfied it.
+            val store = repository()
+            when {
+                isInstalled(pluginId) -> {
+                    Result.success(Unit)
+                }
 
-    private suspend fun installOnce(pluginId: String): Result<Unit> {
-        // A second prompt for the same dependency can outlive the install that satisfied it.
-        if (isInstalled(pluginId)) return Result.success(Unit)
+                store == null -> {
+                    failure("The plugin store is not available. Check your connection and try again.")
+                }
 
-        val store = repository()
-        return if (store == null) {
-            failure("The plugin store is not available. Check your connection and try again.")
-        } else {
-            installFromStore(store, pluginId)
+                else -> {
+                    installFromStore(store, pluginId)
+                }
+            }
         }
-    }
 
     private suspend fun installFromStore(
         store: PluginRepository,
@@ -91,17 +99,21 @@ class StoreMissingDependencyInstaller(
                 ?: return failure("$pluginId was not found in the plugin store.")
 
         val target = targetJar(pluginId, info)
+        // A jar already at this exact path is not ours to delete: a plugin can be on disk
+        // without the manager having registered it (a load that failed transiently at
+        // startup), and a failed download must not take the user's file with it.
+        val preexisting = target.exists()
         return store
             .downloadPlugin(pluginId, info.version, target.absolutePath)
             .fold(
-                onSuccess = { jarPath -> loadAndRecord(pluginId, jarPath, info) },
+                onSuccess = { jarPath -> vetAndLoad(pluginId, jarPath, info) },
                 onFailure = { error ->
                     // A download that dies mid-stream leaves a truncated jar at the final
                     // name, and nothing upstream removes it: `downloadPlugin` writes straight
                     // into the target and only deletes on a hash or signature rejection. Left
                     // there, every launch would find it, fail to read it and log the failure
                     // again.
-                    discard(target.absolutePath)
+                    if (!preexisting) discard(target.absolutePath)
                     logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
                     failure("Could not download ${info.displayName}: ${error.message ?: "unknown error"}")
                 },
@@ -144,22 +156,51 @@ class StoreMissingDependencyInstaller(
      * and should not be handed a second dialog as its consequence. Anything still missing
      * shows up the next time that plugin is installed or updated.
      */
-    private suspend fun loadAndRecord(
+    private suspend fun vetAndLoad(
         pluginId: String,
         jarPath: String,
         info: PluginInfo,
     ): Result<Unit> {
+        // Vet the bytes BEFORE loading them. The id filter in `missingFor` only covers the id a
+        // manifest *names*; nothing binds a store row to the id its jar *declares* (the
+        // signature binds the hash to the row and the row to the store's key, not the plugin
+        // identity), so an admin uploading the wrong jar is enough. Loading first and noticing
+        // after is too late twice over: `installPlugin` inspects the incoming manifest and
+        // starts a full api hot swap for a newer `ai.rever.boss.plugin.api` jar - the exact
+        // thing NOT_USER_INSTALLABLE exists to keep out of a two-button dialog - and a jar that
+        // declares some *other* installed plugin would be loaded, re-pointed at this path, and
+        // then have that path deleted underneath it.
+        val declared = readManifest(jarPath)
+        val declaredId = declared?.pluginId
+        if (declaredId != pluginId || declaredId in PluginDependencyResolution.NOT_USER_INSTALLABLE) {
+            discard(jarPath)
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Refusing a dependency jar that declares a different plugin",
+                mapOf("expected" to pluginId, "declared" to (declaredId ?: "unreadable")),
+            )
+            return failure(
+                "${info.displayName} did not install as $pluginId. The store entry may be wrong.",
+            )
+        }
+        return loadAndRecord(pluginId, jarPath, info, declared.version)
+    }
+
+    private suspend fun loadAndRecord(
+        pluginId: String,
+        jarPath: String,
+        info: PluginInfo,
+        version: String,
+    ): Result<Unit> {
         val error = load(jarPath).exceptionOrNull()
+        // Belt and braces after the pre-load check: the manager registers what the jar declares,
+        // so if the requested id still is not present the load did not do what it claimed.
         val wrongPlugin = error == null && !isInstalled(pluginId)
         if (error != null || wrongPlugin) {
             // Leave nothing half-installed: a directory scan on the next launch would find
             // this jar and load it without it ever having passed the checks it just failed.
             discard(jarPath)
             return if (wrongPlugin) {
-                // The load succeeded but not as the plugin that was missing: a store row for X
-                // can point at a jar whose manifest declares Y. Reporting success would close
-                // the dialog with the dependency still absent, the one outcome every other
-                // branch here is careful to avoid.
                 logger.warn(
                     LogCategory.SYSTEM,
                     "A dependency jar loaded as a different plugin",
@@ -174,9 +215,12 @@ class StoreMissingDependencyInstaller(
         // Write the `installed.json` entry, as every other install path does. Not optional
         // bookkeeping: `setPluginEnabled` updates an existing entry and does nothing when there
         // is none, so a plugin known only by its presence on disk cannot be disabled
-        // persistently - it would come back enabled on the next launch. The entry also carries
-        // the version and source that update checking reads.
-        runCatching { persist(pluginId, jarPath, info) }
+        // persistently - it would come back enabled on the next launch.
+        //
+        // The version comes from the jar's own manifest, not the store row: update checking
+        // compares against it, and a row whose version string disagrees with its jar would make
+        // every future comparison wrong. Same reason `PluginInstallService` reads the manifest.
+        runCatching { persist(pluginId, jarPath, version, info.downloadUrl) }
             .onFailure { error ->
                 // The plugin is loaded and usable; only the record failed, so this is not worth
                 // turning a successful install into an error the user sees.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -45,7 +45,7 @@ class StoreMissingDependencyInstaller(
     private val readManifest: (jarPath: String) -> PluginManifest? = { jarPath ->
         runCatching { PluginManifestReader.readFromJar(jarPath) }.getOrNull()
     },
-    private val persist: (pluginId: String, jarPath: String, version: String, sourceUrl: String) -> Unit =
+    private val persist: (pluginId: String, jarPath: String, version: String, sourceUrl: String?) -> Unit =
         { pluginId, jarPath, version, sourceUrl ->
             PluginPersistence.addInstalledPlugin(
                 pluginId = pluginId,
@@ -220,7 +220,10 @@ class StoreMissingDependencyInstaller(
         // The version comes from the jar's own manifest, not the store row: update checking
         // compares against it, and a row whose version string disagrees with its jar would make
         // every future comparison wrong. Same reason `PluginInstallService` reads the manifest.
-        runCatching { persist(pluginId, jarPath, version, info.downloadUrl) }
+        // Null rather than the empty string: the store's detail response never populates
+        // `downloadUrl`, and recording "" would look like a known-empty source instead of an
+        // absent one - and would fight the preserve-existing-sourceUrl logic later.
+        runCatching { persist(pluginId, jarPath, version, info.downloadUrl.ifBlank { null }) }
             .onFailure { error ->
                 // The plugin is loaded and usable; only the record failed, so this is not worth
                 // turning a successful install into an error the user sees.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -1,11 +1,14 @@
 package ai.rever.boss.plugin
 
-import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import java.io.File
 
 /**
@@ -21,27 +24,80 @@ import java.io.File
  *
  * @param repository the store repository, null when it never initialised (offline first run,
  *   or absent store credentials) - the prompt then says so instead of hanging
+ * The plugin manager is reached through two lambdas rather than held as an object: those are
+ * the only two things wanted from it, and passing them makes the download, cleanup and
+ * persistence rules testable without standing up a loader.
+ *
  * @param pluginDir where installed jars live, so a downloaded dependency is picked up by a
  *   later directory scan exactly like any other install
+ * @param installedNow whether a plugin id is loaded in the manager that reported
+ * @param load the load leg, i.e. `DynamicPluginManager.installPlugin`
+ * @param persist records the install the way every other install path does; see [record]
  */
 class StoreMissingDependencyInstaller(
-    private val dynamicPluginManager: DynamicPluginManager,
     private val repository: () -> PluginRepository?,
     private val pluginDir: () -> File,
+    private val installedNow: (pluginId: String) -> Boolean,
+    private val load: suspend (jarPath: String) -> Result<*>,
+    private val persist: (pluginId: String, jarPath: String, info: PluginInfo) -> Unit =
+        { pluginId, jarPath, info ->
+            PluginPersistence.addInstalledPlugin(
+                pluginId = pluginId,
+                jarPath = jarPath,
+                enabled = true,
+                sourceUrl = info.downloadUrl,
+                installedVersion = info.version,
+            )
+        },
 ) : MissingDependencyInstaller {
     private val logger = BossLogger.forComponent("MissingDependencyInstaller")
+
+    /**
+     * Owner of detached installs - deliberately never cancelled, like the delegate's
+     * `reloadScope`. The prompt is driven from a window's coroutine scope, and closing that
+     * window mid-download would otherwise abort the install and leave the partial jar behind.
+     */
+    private val installScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    /** A property rather than a function purely to stay under detekt's per-class count. */
+    private val reason: (Throwable) -> String = { error -> error.message ?: "unknown error" }
+
+    /**
+     * Detaches installs from the window that asked and coalesces them per plugin id.
+     *
+     * Coalescing is not a nicety here: two dependents can each raise a prompt for the same
+     * missing plugin, so without it two Installs could download to the same path at once.
+     */
+    private val detachedInstalls = KeyedDetachedJobs<String, Result<Unit>>(installScope)
+
+    override fun isInstalled(pluginId: String): Boolean = installedNow(pluginId)
 
     override suspend fun displayNameFor(pluginId: String): String? =
         runCatching { repository()?.getPlugin(pluginId)?.getOrNull()?.displayName }
             .getOrNull()
             ?.takeIf { it.isNotBlank() }
 
-    override suspend fun install(pluginId: String): Result<Unit> {
-        val store =
-            repository() ?: return failure(
-                "The plugin store is not available. Check your connection and try again.",
-            )
-        return installFromStore(store, pluginId)
+    override suspend fun install(pluginId: String): Result<Unit> =
+        detachedInstalls.run(
+            key = pluginId,
+            onDetachedFailure = { error ->
+                // The window closed while this ran, so nothing is left to show the failure to.
+                logger.error(LogCategory.SYSTEM, "Detached dependency install failed", error = error)
+            },
+        ) {
+            installOnce(pluginId)
+        }
+
+    private suspend fun installOnce(pluginId: String): Result<Unit> {
+        // A second prompt for the same dependency can outlive the install that satisfied it.
+        if (isInstalled(pluginId)) return Result.success(Unit)
+
+        val store = repository()
+        return if (store == null) {
+            failure("The plugin store is not available. Check your connection and try again.")
+        } else {
+            installFromStore(store, pluginId)
+        }
     }
 
     private suspend fun installFromStore(
@@ -52,11 +108,18 @@ class StoreMissingDependencyInstaller(
             runCatching { store.getPlugin(pluginId).getOrNull() }.getOrNull()
                 ?: return failure("$pluginId was not found in the plugin store.")
 
+        val target = targetJar(pluginId, info)
         return store
-            .downloadPlugin(pluginId, info.version, targetJar(pluginId, info).absolutePath)
+            .downloadPlugin(pluginId, info.version, target.absolutePath)
             .fold(
-                onSuccess = { jarPath -> load(jarPath, info) },
+                onSuccess = { jarPath -> loadAndRecord(pluginId, jarPath, info) },
                 onFailure = { error ->
+                    // A download that dies mid-stream leaves a truncated jar at the final
+                    // name, and nothing upstream removes it: `downloadPlugin` writes straight
+                    // into the target and only deletes on a hash or signature rejection. Left
+                    // there, every launch would find it, fail to read it and log the failure
+                    // again.
+                    discard(target.absolutePath)
                     logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
                     failure("Could not download ${info.displayName}: ${reason(error)}")
                 },
@@ -64,8 +127,13 @@ class StoreMissingDependencyInstaller(
     }
 
     /**
-     * The store's own filename shape, so a later update or uninstall recognises this jar as
-     * that plugin instead of leaving a stray copy behind.
+     * The name a store download already uses (`ai_rever_boss_x_1.2.3.jar`), so a later update
+     * or uninstall recognises this jar as that plugin instead of leaving a stray copy.
+     *
+     * Downloaded straight to its final name rather than through a `-downloading.jar` rename:
+     * `downloadPlugin` writes the signature sidecar next to whatever path it was given, and a
+     * rename afterwards would leave the `.sig` behind under the temporary name - so the jar
+     * would load as unsigned. Partial files are handled by deleting on failure instead.
      */
     private fun targetJar(
         pluginId: String,
@@ -73,30 +141,65 @@ class StoreMissingDependencyInstaller(
     ) = File(pluginDir(), "${pluginId.replace('.', '_')}_${info.version}.jar")
 
     /**
-     * Loads the downloaded jar through the manager directly.
+     * Loads the downloaded jar and records it.
      *
-     * Deliberately not back through `PluginLoaderDelegateImpl.loadPlugin`, so a dependency
-     * that has dependencies of its own does not chain prompts: the user answered one
-     * question and should not be handed a second dialog as its consequence. Anything still
-     * missing after this shows up the next time that plugin is installed or updated.
+     * Deliberately not back through [PluginLoaderDelegateImpl.loadPlugin], so a dependency
+     * that has dependencies of its own does not chain prompts: the user answered one question
+     * and should not be handed a second dialog as its consequence. Anything still missing
+     * shows up the next time that plugin is installed or updated.
      */
-    private suspend fun load(
+    private suspend fun loadAndRecord(
+        pluginId: String,
         jarPath: String,
         info: PluginInfo,
     ): Result<Unit> {
-        val error = dynamicPluginManager.installPlugin(jarPath).exceptionOrNull()
-        return if (error == null) {
-            Result.success(Unit)
-        } else {
-            // Leave no half-installed jar: a directory scan on the next launch would load it
-            // without it ever having passed the checks it just failed.
-            runCatching { File(jarPath).delete() }
+        val error = load(jarPath).exceptionOrNull()
+        if (error != null) {
+            // Leave nothing half-installed: a directory scan on the next launch would find
+            // this jar and load it without it ever having passed the checks it just failed.
+            discard(jarPath)
             logger.error(LogCategory.SYSTEM, "Failed to load a downloaded plugin dependency", error = error)
-            failure("Downloaded ${info.displayName} but could not load it: ${reason(error)}")
+            return failure("Downloaded ${info.displayName} but could not load it: ${reason(error)}")
         }
+        record(pluginId, jarPath, info)
+        return Result.success(Unit)
     }
 
-    private fun reason(error: Throwable) = error.message ?: "unknown error"
+    /**
+     * Writes the `installed.json` entry, as every other install path does.
+     *
+     * Not optional bookkeeping: `setPluginEnabled` updates an existing entry and does nothing
+     * at all when there is none, so a dependency known only by its presence on disk cannot be
+     * disabled persistently - it would come back enabled on the next launch. The entry also
+     * carries the version and source that update checking reads.
+     */
+    private fun record(
+        pluginId: String,
+        jarPath: String,
+        info: PluginInfo,
+    ) {
+        runCatching { persist(pluginId, jarPath, info) }
+            .onFailure { error ->
+                // The plugin is loaded and usable; only the record failed, so this is not
+                // worth turning a successful install into an error the user sees.
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Installed a dependency but could not record it",
+                    mapOf("pluginId" to pluginId, "error" to (error.message ?: "unknown")),
+                )
+            }
+    }
+
+    /**
+     * Removes a jar and its signature sidecar together.
+     *
+     * The pair matters: reinstalling the same version reuses the filename, so a surviving
+     * `.sig` would meet fresh bytes and hard-fail at load - worse than being unsigned.
+     */
+    private fun discard(jarPath: String) {
+        runCatching { File(jarPath).delete() }
+        runCatching { PluginSignatureSidecar.delete(jarPath) }
+    }
 
     private fun failure(message: String): Result<Unit> = Result.failure(IllegalStateException(message))
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -26,40 +26,24 @@ import java.io.File
  * Every failure message here is shown to the user, so each says what happened and what it
  * means for them rather than surfacing a transport error.
  *
- * The plugin manager is reached through two lambdas rather than held as an object: those are
- * the only two things wanted from it, and passing them makes the download, cleanup and
- * persistence rules testable without standing up a loader.
+ * The plugin manager is reached through lambdas rather than held as an object: they are the only
+ * things wanted from it, and passing them makes the download, cleanup and persistence rules
+ * testable without standing up a loader, a sandbox and two registries.
  *
  * @param repository the store repository, null when it never initialised (offline first run,
  *   or absent store credentials) - the prompt then says so instead of hanging
  * @param pluginDir where installed jars live, so a downloaded dependency is picked up by a
  *   later directory scan exactly like any other install
- * @param installedNow whether a plugin id is loaded in the manager that reported
- * @param load the load leg, i.e. `DynamicPluginManager.installPlugin`
- * @param persist records the install the way every other install path does; see [record]
+ * @param hooks everything this needs from outside itself; see [InstallerHooks]
  */
 class StoreMissingDependencyInstaller(
     private val repository: () -> PluginRepository?,
     private val pluginDir: () -> File,
-    private val installedNow: (pluginId: String) -> Boolean,
-    private val load: suspend (jarPath: String) -> Result<*>,
-    private val readManifest: (jarPath: String) -> PluginManifest? = { jarPath ->
-        runCatching { PluginManifestReader.readFromJar(jarPath) }.getOrNull()
-    },
-    private val persist: (pluginId: String, jarPath: String, version: String, sourceUrl: String?) -> Unit =
-        { pluginId, jarPath, version, sourceUrl ->
-            PluginPersistence.addInstalledPlugin(
-                pluginId = pluginId,
-                jarPath = jarPath,
-                enabled = true,
-                sourceUrl = sourceUrl,
-                installedVersion = version,
-            )
-        },
+    private val hooks: InstallerHooks,
 ) : MissingDependencyInstaller {
     private val logger = BossLogger.forComponent("MissingDependencyInstaller")
 
-    override fun isInstalled(pluginId: String): Boolean = installedNow(pluginId)
+    override fun isInstalled(pluginId: String): Boolean = hooks.installedNow(pluginId)
 
     override suspend fun displayNameFor(pluginId: String): String? =
         runCatching { repository()?.getPlugin(pluginId)?.getOrNull()?.displayName }
@@ -141,18 +125,13 @@ class StoreMissingDependencyInstaller(
         target: File,
         info: PluginInfo,
     ): Result<Unit> {
-        val moved =
-            runCatching {
-                target.atomicMoveFrom(File(downloaded))
-                val signature = PluginSignatureSidecar.read(downloaded)
-                if (signature != null) {
-                    PluginSignatureSidecar.write(target.absolutePath, signature)
-                    PluginSignatureSidecar.delete(downloaded)
-                }
-            }
-        val error = moved.exceptionOrNull()
+        val error = promote(downloaded, target).exceptionOrNull()
         if (error != null) {
+            // Both paths, because the move may already have succeeded: a sidecar step that then
+            // throws would otherwise leave an unvetted, never-loaded jar at a scannable name for
+            // the next launch to pick up - the thing the `.part` suffix exists to prevent.
             discard(downloaded)
+            discard(target.absolutePath)
             logger.error(LogCategory.SYSTEM, "Could not move a downloaded dependency into place", error = error)
             return failure("Downloaded ${info.displayName} but could not put it in place.")
         }
@@ -181,7 +160,7 @@ class StoreMissingDependencyInstaller(
         // thing NOT_USER_INSTALLABLE exists to keep out of a two-button dialog - and a jar that
         // declares some *other* installed plugin would be loaded, re-pointed at this path, and
         // then have that path deleted underneath it.
-        val declared = readManifest(jarPath)
+        val declared = hooks.readManifest(jarPath)
         val declaredId = declared?.pluginId
         if (declaredId != pluginId || declaredId in PluginDependencyResolution.NOT_USER_INSTALLABLE) {
             discard(jarPath)
@@ -203,7 +182,7 @@ class StoreMissingDependencyInstaller(
         info: PluginInfo,
         version: String,
     ): Result<Unit> {
-        val error = load(jarPath).exceptionOrNull()
+        val error = hooks.load(jarPath).exceptionOrNull()
         // Belt and braces after the pre-load check: the manager registers what the jar declares,
         // so if the requested id still is not present the load did not do what it claimed.
         val wrongPlugin = error == null && !isInstalled(pluginId)
@@ -217,7 +196,13 @@ class StoreMissingDependencyInstaller(
                     "A dependency jar loaded as a different plugin",
                     mapOf("expected" to pluginId, "jarPath" to jarPath),
                 )
-                failure("${info.displayName} did not install as $pluginId. The store entry may be wrong.")
+                // Not "the store entry may be wrong": the manifest was vetted before the load,
+                // so by far the likeliest cause here is a plugin that loaded and then failed to
+                // register - binary-incompatible against this host.
+                failure(
+                    "${info.displayName} downloaded but did not start. It may not be compatible with this " +
+                        "version of BOSS.",
+                )
             } else {
                 logger.error(LogCategory.SYSTEM, "Failed to load a downloaded plugin dependency", error = error)
                 failure("Downloaded ${info.displayName} but could not load it: ${error?.message ?: "unknown error"}")
@@ -234,7 +219,7 @@ class StoreMissingDependencyInstaller(
         // Null rather than the empty string: the store's detail response never populates
         // `downloadUrl`, and recording "" would look like a known-empty source instead of an
         // absent one - and would fight the preserve-existing-sourceUrl logic later.
-        runCatching { persist(pluginId, jarPath, version, info.downloadUrl.ifBlank { null }) }
+        runCatching { hooks.persist(pluginId, jarPath, version, info.downloadUrl.ifBlank { null }) }
             .onFailure { error ->
                 // The plugin is loaded and usable; only the record failed, so this is not worth
                 // turning a successful install into an error the user sees.
@@ -261,12 +246,19 @@ class StoreMissingDependencyInstaller(
     private fun failure(message: String): Result<Unit> = Result.failure(IllegalStateException(message))
 
     /**
-     * Keeps only what a plugin jar name needs, so no store value can name a path.
+     * Move the downloaded jar and its signature onto the final name.
      *
-     * Path separators go, which is what stops a `version` of `../x` escaping the directory; dots
-     * survive because versions are full of them and, with separators gone, cannot traverse.
+     * `persist` rather than `write`, because `target` can already exist - reinstalling the same
+     * version reuses the filename - and `persist` is the one that clears a stale sidecar when the
+     * new download is unsigned. A leftover `.sig` beside fresh bytes is a hard load failure,
+     * which is worse than being unsigned.
      */
-    private fun safe(part: String) = part.replace(Regex("[^A-Za-z0-9.-]"), "_")
+    private fun promote(
+        downloaded: String,
+        target: File,
+    ) = runCatching {
+        hooks.promoteFiles(downloaded, target)
+    }
 
     private companion object {
         /**
@@ -289,3 +281,50 @@ class StoreMissingDependencyInstaller(
         private val DETACHED_INSTALLS = KeyedDetachedJobs<String, Result<Unit>>(INSTALL_SCOPE)
     }
 }
+
+/**
+ * Everything [StoreMissingDependencyInstaller] needs from outside itself.
+ *
+ * Grouped rather than seven constructor parameters, which detekt was right to flag: these are one
+ * concept - "how this talks to the plugin manager and the filesystem" - and the three with
+ * defaults exist purely so tests can drive the paths that would otherwise need a real loader, a
+ * real jar and a real `installed.json`.
+ *
+ * @param installedNow whether a plugin id is present and usable in the manager that reported
+ * @param load the load leg, i.e. `DynamicPluginManager.installPlugin`
+ * @param readManifest reads the downloaded jar's own manifest, so a store row that points at the
+ *   wrong plugin is refused before `installPlugin` can act on the bytes
+ * @param promoteFiles moves the completed download and its signature onto the final name;
+ *   injected so a promotion that half-succeeds (jar moved, sidecar failed) is testable
+ * @param persist records the install the way every other install path does
+ */
+class InstallerHooks(
+    val installedNow: (pluginId: String) -> Boolean,
+    val load: suspend (jarPath: String) -> Result<*>,
+    val readManifest: (jarPath: String) -> PluginManifest? = { jarPath ->
+        runCatching { PluginManifestReader.readFromJar(jarPath) }.getOrNull()
+    },
+    val promoteFiles: (downloaded: String, target: File) -> Unit = { downloaded, target ->
+        target.atomicMoveFrom(File(downloaded))
+        PluginSignatureSidecar.persist(target.absolutePath, PluginSignatureSidecar.read(downloaded))
+        PluginSignatureSidecar.delete(downloaded)
+    },
+    val persist: (pluginId: String, jarPath: String, version: String, sourceUrl: String?) -> Unit =
+        { pluginId, jarPath, version, sourceUrl ->
+            PluginPersistence.addInstalledPlugin(
+                pluginId = pluginId,
+                jarPath = jarPath,
+                enabled = true,
+                sourceUrl = sourceUrl,
+                installedVersion = version,
+            )
+        },
+)
+
+/**
+ * Keeps only what a plugin jar name needs, so no store value can name a path.
+ *
+ * Path separators go, which is what stops a `version` of `../x` escaping the directory; dots
+ * survive because versions are full of them and, with separators gone, cannot traverse.
+ */
+private fun safe(part: String) = part.replace(Regex("[^A-Za-z0-9.-]"), "_")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -163,6 +163,8 @@ class PluginDependencyResolutionTest {
 class PluginDependencyBusTest {
     private val noopInstaller =
         object : MissingDependencyInstaller {
+            override fun isInstalled(pluginId: String): Boolean = false
+
             override suspend fun displayNameFor(pluginId: String): String? = null
 
             override suspend fun install(pluginId: String): Result<Unit> = Result.success(Unit)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -325,6 +325,80 @@ class PluginDependencyBusTest {
         }
 
     @Test
+    fun `a declined plugin stops being reported for the rest of the session`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            bus.decline("com.example.gateway")
+
+            bus.report(prompt("com.example.gateway"))
+            bus.report(prompt("com.example.other"))
+
+            // All three gateway consumers declare it optional, so without this, declining once
+            // means being asked again for the next plugin that needs it.
+            assertEquals(
+                "com.example.other",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+
+    @Test
+    fun `declining one plugin does not silence another`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            bus.decline("com.example.gateway")
+
+            assertTrue(bus.wasDeclined("com.example.gateway"))
+            assertFalse(bus.wasDeclined("com.example.other"))
+        }
+
+    @Test
+    fun `two dependents of one missing plugin occupy a single slot`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            bus.report(prompt("com.example.gateway"))
+            bus.report(prompt("com.example.gateway"))
+            bus.report(prompt("com.example.other"))
+
+            // The collector would discard the duplicate on arrival, but it costs a slot first -
+            // and with four slots that can be what refuses a different, still-relevant prompt.
+            assertEquals(
+                listOf("com.example.gateway", "com.example.other"),
+                (1..2).map {
+                    bus.missingDependencies
+                        .first()
+                        .missing.missingPluginId
+                },
+            )
+        }
+
+    @Test
+    fun `a plugin can be reported again once its prompt has been taken`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            bus.report(prompt("com.example.gateway"))
+            assertEquals(
+                "com.example.gateway",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+
+            // Consuming frees the slot: a second dependent installed later must still be able to
+            // raise it, otherwise the dedup would become a permanent mute.
+            bus.report(prompt("com.example.gateway"))
+            assertEquals(
+                "com.example.gateway",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+
+    @Test
     fun `a prompt reported before anyone collects is delivered when a collector appears`() =
         runTest {
             val bus = PluginDependencyBus()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -269,6 +269,14 @@ class PluginDependencyBusTest {
             override suspend fun install(pluginId: String): Result<Unit> = Result.success(Unit)
         }
 
+    private fun missing(
+        dependentPluginId: String,
+        missingPluginId: String,
+        optional: Boolean,
+    ) = MissingPluginDependency(dependentPluginId, "Dependent", missingPluginId, optional)
+
+    private fun promptFor(missing: MissingPluginDependency) = MissingDependencyPrompt(missing, noopInstaller)
+
     private fun prompt(missingPluginId: String) =
         MissingDependencyPrompt(
             MissingPluginDependency("com.example.d", "Dependent", missingPluginId, optional = false),
@@ -325,18 +333,39 @@ class PluginDependencyBusTest {
         }
 
     @Test
-    fun `a declined plugin stops being reported for the rest of the session`() =
+    fun `declining an optional dependency silences it for every dependent`() =
         runTest {
             val bus = PluginDependencyBus()
-            bus.decline("com.example.gateway")
+            bus.decline(missing("com.example.first", "com.example.gateway", optional = true))
 
-            bus.report(prompt("com.example.gateway"))
-            bus.report(prompt("com.example.other"))
+            // All three gateway consumers declare it optional, so "Not now" is one answer about
+            // the gateway - not something to be asked again for the next plugin that needs it.
+            bus.report(promptFor(missing("com.example.second", "com.example.gateway", optional = true)))
+            bus.report(promptFor(missing("com.example.second", "com.example.other", optional = true)))
 
-            // All three gateway consumers declare it optional, so without this, declining once
-            // means being asked again for the next plugin that needs it.
             assertEquals(
                 "com.example.other",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+
+    @Test
+    fun `skipping a required dependency does not silence another plugin that requires it`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            bus.decline(missing("com.example.first", "com.example.gateway", optional = false))
+
+            // "Skip" answers for this dependent only: another plugin that hard-requires the same
+            // thing is a different question, and silencing that would be worse than the optional
+            // case rather than better.
+            val other = missing("com.example.second", "com.example.gateway", optional = false)
+            assertFalse(bus.wasDeclined(other))
+            bus.report(promptFor(other))
+
+            assertEquals(
+                "com.example.gateway",
                 bus.missingDependencies
                     .first()
                     .missing.missingPluginId,
@@ -347,10 +376,11 @@ class PluginDependencyBusTest {
     fun `declining one plugin does not silence another`() =
         runTest {
             val bus = PluginDependencyBus()
-            bus.decline("com.example.gateway")
+            val gateway = missing("com.example.first", "com.example.gateway", optional = true)
+            bus.decline(gateway)
 
-            assertTrue(bus.wasDeclined("com.example.gateway"))
-            assertFalse(bus.wasDeclined("com.example.other"))
+            assertTrue(bus.wasDeclined(gateway))
+            assertFalse(bus.wasDeclined(missing("com.example.first", "com.example.other", optional = true)))
         }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.plugin
 import ai.rever.boss.components.plugin.PluginDependencyResolution.description
 import ai.rever.boss.plugin.api.PluginDependency
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.loader.ApiClassLoader
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -10,6 +11,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -98,20 +100,64 @@ class PluginDependencyResolutionTest {
     }
 
     @Test
-    fun `a dependency declared twice prompts once`() {
+    fun `a dependency declared twice prompts once, as the stricter declaration`() {
+        // Both orders, because asserting only the count passes whichever declaration wins -
+        // and calling something "Recommended" that the plugin requires is the worse mistake.
+        listOf(
+            listOf(dependency("com.example.gateway"), dependency("com.example.gateway", optional = true)),
+            listOf(dependency("com.example.gateway", optional = true), dependency("com.example.gateway")),
+        ).forEach { declarations ->
+            val missing =
+                PluginDependencyResolution.missingFor(
+                    manifest(dependencies = declarations),
+                    installedPluginIds = emptySet(),
+                )
+
+            assertEquals(1, missing.size, "declared twice, prompted ${missing.size} times")
+            assertFalse(missing.single().optional, "the optional declaration won")
+        }
+    }
+
+    @Test
+    fun `system components are never offered for install`() {
+        PluginDependencyResolution.NOT_USER_INSTALLABLE.forEach { systemId ->
+            val missing =
+                PluginDependencyResolution.missingFor(
+                    manifest(dependencies = listOf(dependency(systemId))),
+                    installedPluginIds = emptySet(),
+                )
+
+            // The microkernel runtime is never in `pluginStates` (DefaultPlugin skips it on
+            // scan), so without this filter it looks missing to every manifest naming it - and
+            // installing it trips the binary-compat validator on core JDK classes. The api
+            // plugin's install is an unload-all/swap/reload-all hot swap.
+            assertTrue(missing.isEmpty(), "offered to install $systemId")
+        }
+    }
+
+    @Test
+    fun `the guarded system ids are the real ones`() {
+        // Literals in the resolver because ApiClassLoader.API_PLUGIN_ID is desktop-only; if
+        // either id is renamed, this fails rather than the filter quietly ceasing to match.
+        assertEquals(
+            setOf("ai.rever.boss.microkernel.runtime", "ai.rever.boss.plugin.api"),
+            PluginDependencyResolution.NOT_USER_INSTALLABLE,
+        )
+        assertEquals(MicrokernelRuntime.PLUGIN_ID, "ai.rever.boss.microkernel.runtime")
+        assertEquals(ApiClassLoader.API_PLUGIN_ID, "ai.rever.boss.plugin.api")
+    }
+
+    @Test
+    fun `a version constraint does not make an installed plugin missing`() {
         val missing =
             PluginDependencyResolution.missingFor(
-                manifest(
-                    dependencies =
-                        listOf(
-                            dependency("com.example.gateway"),
-                            dependency("com.example.gateway", optional = true),
-                        ),
-                ),
-                installedPluginIds = emptySet(),
+                manifest(dependencies = listOf(dependency("com.example.gateway"))),
+                installedPluginIds = setOf("com.example.gateway"),
             )
 
-        assertEquals(1, missing.size)
+        // Presence is by id: documented scope, pinned so a future version check is a
+        // deliberate change rather than a surprise.
+        assertTrue(missing.isEmpty())
     }
 
     @Test
@@ -204,6 +250,25 @@ class PluginDependencyBusTest {
             collectors.forEach { it.cancel() }
 
             assertEquals(listOf("com.example.once"), received)
+        }
+
+    @Test
+    fun `a full buffer refuses the newest and keeps the ones already waiting`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            // Capacity is 4. The fifth has nowhere to go.
+            for (n in 1..5) bus.report(prompt("com.example.p$n"))
+
+            val delivered =
+                (1..4).map {
+                    bus.missingDependencies
+                        .first()
+                        .missing.missingPluginId
+                }
+
+            // Not DROP_OLDEST: the oldest prompt is the one a user is most likely part-way
+            // through answering, and a channel that always accepts makes the drop invisible.
+            assertEquals(listOf("com.example.p1", "com.example.p2", "com.example.p3", "com.example.p4"), delivered)
         }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.api.PluginDependency
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.loader.ApiClassLoader
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -33,6 +34,24 @@ class PluginDependencyResolutionTest {
         apiVersion = "1.0.0",
         mainClass = "com.example.Main",
         dependencies = dependencies,
+    )
+
+    private fun info(
+        pluginId: String,
+        jarPath: String,
+    ) = DynamicPluginInfo(
+        manifest =
+            PluginManifest(
+                pluginId = pluginId,
+                displayName = pluginId,
+                version = "1.0.0",
+                apiVersion = "1.0.0",
+                mainClass = "com.example.Main",
+            ),
+        jarPath = jarPath,
+        state = PluginState.DISABLED,
+        loadedAt = 0L,
+        enabled = false,
     )
 
     private fun dependency(
@@ -174,6 +193,41 @@ class PluginDependencyResolutionTest {
             )
 
         assertEquals(listOf("com.example.gone"), missing.map { it.missingPluginId })
+    }
+
+    @Test
+    fun `an entry whose jar is gone does not count as installed`() {
+        val states =
+            mapOf(
+                "com.example.present" to info("com.example.present", "/plugins/present.jar"),
+                // What `installPlugin` leaves behind for a binary-incompatible plugin, after the
+                // installer has deleted the jar it rejected.
+                "com.example.dangling" to info("com.example.dangling", "/plugins/gone.jar"),
+            )
+
+        val installed =
+            PluginDependencyResolution.installedAndOnDisk(states) { jarPath ->
+                jarPath == "/plugins/present.jar"
+            }
+
+        // The bug this replaces a source-level regex with a real assertion: counting the
+        // dangling entry as installed made every LATER dependent of that plugin report nothing,
+        // with no prompt and no log line.
+        assertEquals(setOf("com.example.present"), installed)
+    }
+
+    @Test
+    fun `a dangling entry means its dependents are still reported as missing`() {
+        val states = mapOf("com.example.gateway" to info("com.example.gateway", "/plugins/gone.jar"))
+
+        val installed = PluginDependencyResolution.installedAndOnDisk(states) { false }
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(dependencies = listOf(dependency("com.example.gateway"))),
+                installedPluginIds = installed,
+            )
+
+        assertEquals(listOf("com.example.gateway"), missing.map { it.missingPluginId })
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -206,9 +206,10 @@ class PluginDependencyResolutionTest {
             )
 
         val installed =
-            PluginDependencyResolution.installedAndOnDisk(states) { jarPath ->
-                jarPath == "/plugins/present.jar"
-            }
+            PluginDependencyResolution.installedAndOnDisk(
+                states = states,
+                exists = { jarPath -> jarPath == "/plugins/present.jar" },
+            )
 
         // The bug this replaces a source-level regex with a real assertion: counting the
         // dangling entry as installed made every LATER dependent of that plugin report nothing,
@@ -217,10 +218,43 @@ class PluginDependencyResolutionTest {
     }
 
     @Test
+    fun `a plugin that failed to register does not count as installed`() {
+        // There are two binary-incompatibility paths in `installPlugin` and only one fails: the
+        // registration-time one force-unloads the plugin and returns SUCCESS with state DISABLED
+        // and the jar still on disk. Counting that jar would have made the Install button report
+        // success for a plugin that was unloaded, and silenced every other dependent of it.
+        val states = mapOf("com.example.gateway" to info("com.example.gateway", "/plugins/gateway.jar"))
+
+        val installed =
+            PluginDependencyResolution.installedAndOnDisk(
+                states = states,
+                exists = { true },
+                isIncompatible = { it == "com.example.gateway" },
+            )
+
+        assertEquals(emptySet(), installed)
+    }
+
+    @Test
+    fun `an incompatible plugin is still reported as missing to its dependents`() {
+        val states = mapOf("com.example.gateway" to info("com.example.gateway", "/plugins/gateway.jar"))
+
+        val installed =
+            PluginDependencyResolution.installedAndOnDisk(states, exists = { true }, isIncompatible = { true })
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(dependencies = listOf(dependency("com.example.gateway"))),
+                installedPluginIds = installed,
+            )
+
+        assertEquals(listOf("com.example.gateway"), missing.map { it.missingPluginId })
+    }
+
+    @Test
     fun `a dangling entry means its dependents are still reported as missing`() {
         val states = mapOf("com.example.gateway" to info("com.example.gateway", "/plugins/gone.jar"))
 
-        val installed = PluginDependencyResolution.installedAndOnDisk(states) { false }
+        val installed = PluginDependencyResolution.installedAndOnDisk(states, exists = { false })
         val missing =
             PluginDependencyResolution.missingFor(
                 manifest(dependencies = listOf(dependency("com.example.gateway"))),
@@ -402,6 +436,26 @@ class PluginDependencyBusTest {
                         .missing.missingPluginId
                 },
             )
+        }
+
+    @Test
+    fun `a required prompt is not swallowed by a pending optional one`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            // jupyter declares the gateway optional; a plugin that hard-requires it installs next.
+            bus.report(promptFor(missing("com.example.jupyter", "com.example.gateway", optional = true)))
+            bus.report(promptFor(missing("com.example.strict", "com.example.gateway", optional = false)))
+
+            // Both must survive: keyed by bare id, the required one was dropped, the user saw only
+            // "Recommended / Not now", and declining that silenced the plugin that required it.
+            val delivered =
+                (1..2).map {
+                    bus.missingDependencies
+                        .first()
+                        .missing.optional
+                }
+            assertEquals(listOf(true, false), delivered)
         }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -39,6 +39,7 @@ class PluginDependencyResolutionTest {
     private fun info(
         pluginId: String,
         jarPath: String,
+        state: PluginState = PluginState.DISABLED,
     ) = DynamicPluginInfo(
         manifest =
             PluginManifest(
@@ -49,9 +50,9 @@ class PluginDependencyResolutionTest {
                 mainClass = "com.example.Main",
             ),
         jarPath = jarPath,
-        state = PluginState.DISABLED,
+        state = state,
         loadedAt = 0L,
-        enabled = false,
+        enabled = state == PluginState.LOADED,
     )
 
     private fun dependency(
@@ -215,6 +216,46 @@ class PluginDependencyResolutionTest {
         // dangling entry as installed made every LATER dependent of that plugin report nothing,
         // with no prompt and no log line.
         assertEquals(setOf("com.example.present"), installed)
+    }
+
+    @Test
+    fun `a loaded plugin counts as installed even when its jar is gone`() {
+        // The LOADED clause exists for this: `PluginJarReconciler` and the updater rewrite paths
+        // without repointing the manager's in-memory `jarPath`, so a running plugin can hold a
+        // path that no longer exists. Every other test in this file uses a DISABLED entry, so
+        // without this the clause was never exercised at all.
+        val states =
+            mapOf(
+                "com.example.gateway" to
+                    info("com.example.gateway", "/plugins/moved.jar", PluginState.LOADED),
+            )
+
+        val installed = PluginDependencyResolution.installedAndOnDisk(states, exists = { false })
+
+        assertEquals(setOf("com.example.gateway"), installed)
+    }
+
+    @Test
+    fun `a loaded plugin still flagged incompatible counts as installed`() {
+        // `PluginCrashRegistry` keeps the flag until the re-enable path clears it, and neither
+        // install nor update does. So a plugin that failed registration, was updated from the
+        // Toolbox's own incompatibility prompt and is now running still carries it - and
+        // excluding it would report a *running* plugin as missing, then claim the download "did
+        // not start".
+        val states =
+            mapOf(
+                "com.example.gateway" to
+                    info("com.example.gateway", "/plugins/gateway.jar", PluginState.LOADED),
+            )
+
+        val installed =
+            PluginDependencyResolution.installedAndOnDisk(
+                states = states,
+                exists = { true },
+                isIncompatible = { true },
+            )
+
+        assertEquals(setOf("com.example.gateway"), installed)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -1,0 +1,221 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.components.plugin.PluginDependencyResolution.description
+import ai.rever.boss.plugin.api.PluginDependency
+import ai.rever.boss.plugin.api.PluginManifest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the install-time dependency prompt decides, without a plugin loader.
+ *
+ * Until this feature, `PluginManifest.dependencies` was read in exactly one place
+ * (`DynamicPluginManager.checkCanUnload`), so installing a plugin whose dependency was absent
+ * produced no signal at all - the user met the consequence later, as a feature that did
+ * nothing. These pin the rules of the resolver that closes that.
+ */
+class PluginDependencyResolutionTest {
+    private fun manifest(
+        pluginId: String = "com.example.dependent",
+        displayName: String = "Dependent",
+        dependencies: List<PluginDependency> = emptyList(),
+    ) = PluginManifest(
+        pluginId = pluginId,
+        displayName = displayName,
+        version = "1.0.0",
+        apiVersion = "1.0.0",
+        mainClass = "com.example.Main",
+        dependencies = dependencies,
+    )
+
+    private fun dependency(
+        pluginId: String,
+        optional: Boolean = false,
+    ) = PluginDependency(pluginId = pluginId, version = "1.0.0", optional = optional)
+
+    @Test
+    fun `an installed dependency is not reported`() {
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(dependencies = listOf(dependency("com.example.gateway"))),
+                installedPluginIds = setOf("com.example.gateway"),
+            )
+
+        assertTrue(missing.isEmpty(), "expected nothing missing, got $missing")
+    }
+
+    @Test
+    fun `an absent dependency is reported with the dependent's display name`() {
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(displayName = "Flow", dependencies = listOf(dependency("com.example.gateway"))),
+                installedPluginIds = emptySet(),
+            )
+
+        assertEquals(1, missing.size)
+        assertEquals("com.example.gateway", missing.single().missingPluginId)
+        // The dialog says "Flow needs ...", so the name has to survive resolution.
+        assertEquals("Flow", missing.single().dependentDisplayName)
+    }
+
+    /**
+     * The gateway is declared `optional: true` by all three of its consumers, so dropping
+     * optional dependencies here would leave this feature reporting nothing at all for the
+     * case it was built for.
+     */
+    @Test
+    fun `an optional dependency is reported and flagged, not dropped`() {
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(dependencies = listOf(dependency("com.example.gateway", optional = true))),
+                installedPluginIds = emptySet(),
+            )
+
+        assertEquals(1, missing.size)
+        assertTrue(missing.single().optional)
+    }
+
+    @Test
+    fun `a self-dependency is not offered for install`() {
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(
+                    pluginId = "com.example.dependent",
+                    dependencies = listOf(dependency("com.example.dependent")),
+                ),
+                // Deliberately empty: mid-install the plugin is not in the installed set yet,
+                // so without the filter it would offer to install what was just installed.
+                installedPluginIds = emptySet(),
+            )
+
+        assertTrue(missing.isEmpty(), "expected no self-dependency, got $missing")
+    }
+
+    @Test
+    fun `a dependency declared twice prompts once`() {
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(
+                    dependencies =
+                        listOf(
+                            dependency("com.example.gateway"),
+                            dependency("com.example.gateway", optional = true),
+                        ),
+                ),
+                installedPluginIds = emptySet(),
+            )
+
+        assertEquals(1, missing.size)
+    }
+
+    @Test
+    fun `only the absent dependencies of several are reported`() {
+        val missing =
+            PluginDependencyResolution.missingFor(
+                manifest(
+                    dependencies =
+                        listOf(
+                            dependency("com.example.here"),
+                            dependency("com.example.gone"),
+                        ),
+                ),
+                installedPluginIds = setOf("com.example.here"),
+            )
+
+        assertEquals(listOf("com.example.gone"), missing.map { it.missingPluginId })
+    }
+
+    @Test
+    fun `a required dependency reads as needed and an optional one as a feature`() {
+        val required =
+            MissingPluginDependency("com.example.d", "Flow", "com.example.gateway", optional = false)
+        val optional = required.copy(optional = true)
+
+        assertEquals("Flow needs AI Gateway, which is not installed.", required.description("AI Gateway"))
+        assertTrue(optional.description("AI Gateway").startsWith("Flow works without AI Gateway"))
+    }
+
+    @Test
+    fun `the description falls back to whatever name it is given`() {
+        val required =
+            MissingPluginDependency("com.example.d", "Flow", "com.example.gateway", optional = false)
+
+        // The dialog passes the plugin id when the store lookup fails, so the sentence still
+        // has to name something rather than reading "Flow needs null".
+        assertTrue(required.description("com.example.gateway").contains("com.example.gateway"))
+    }
+}
+
+/**
+ * The delivery guarantee the prompt depends on.
+ *
+ * A broadcast would put the same dialog in front of every open window and let each of them
+ * start the same install, so "exactly one collector receives it" is the property, not an
+ * implementation detail. Each test builds its own bus - a shared one carries leftover prompts
+ * between tests.
+ */
+class PluginDependencyBusTest {
+    private val noopInstaller =
+        object : MissingDependencyInstaller {
+            override suspend fun displayNameFor(pluginId: String): String? = null
+
+            override suspend fun install(pluginId: String): Result<Unit> = Result.success(Unit)
+        }
+
+    private fun prompt(missingPluginId: String) =
+        MissingDependencyPrompt(
+            MissingPluginDependency("com.example.d", "Dependent", missingPluginId, optional = false),
+            noopInstaller,
+        )
+
+    @Test
+    fun `reporting with nobody collecting neither suspends nor throws`() {
+        // The installer calls this from a plugin-install path: it must never block on a UI
+        // that may not exist yet, and must not fail the install the user asked for.
+        PluginDependencyBus().report(prompt("com.example.dropped"))
+    }
+
+    @Test
+    fun `one prompt reaches exactly one of two collectors`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            val received = mutableListOf<String>()
+            val collectors =
+                List(2) {
+                    launch {
+                        received +=
+                            bus.missingDependencies
+                                .first()
+                                .missing.missingPluginId
+                    }
+                }
+            runCurrent()
+
+            bus.report(prompt("com.example.once"))
+            advanceUntilIdle()
+            collectors.forEach { it.cancel() }
+
+            assertEquals(listOf("com.example.once"), received)
+        }
+
+    @Test
+    fun `a prompt reported before anyone collects is delivered when a collector appears`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            bus.report(prompt("com.example.early"))
+
+            // The install that raised it can finish long before a window exists.
+            assertEquals(
+                "com.example.early",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -1,6 +1,5 @@
 package ai.rever.boss.components.plugin
 
-import ai.rever.boss.components.plugin.PluginDependencyResolution.description
 import ai.rever.boss.plugin.api.PluginDependency
 import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.loader.ApiClassLoader

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/wizard/plugin/WizardDependencyReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/wizard/plugin/WizardDependencyReportTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.wizard.plugin
 
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -59,6 +60,21 @@ class WizardDependencyReportTest {
     }
 
     @Test
+    fun `both branches check the plugin actually registered before reporting it`() {
+        val text = source()
+
+        // `installPlugin` returns success with `state = DISABLED` for a registration-time binary
+        // incompatibility, so reporting on success alone offers to download a second plugin to
+        // support a dead one. Both branches add to the batch, so both need the gate - the store
+        // branch had it and the GitHub branch did not.
+        assertEquals(
+            2,
+            Regex("""PluginState\.LOADED""").findAll(text).count(),
+            "each branch that feeds the dependency batch must check state == LOADED",
+        )
+    }
+
+    @Test
     fun `both install branches feed the batch`() {
         val text = source()
 
@@ -69,9 +85,11 @@ class WizardDependencyReportTest {
             "both the store and GitHub branches must add their manifest to the batch",
         )
         assertTrue(
-            Regex("""installFromGitHub\([\s\S]{0,400}?\): Result<PluginManifest>""").containsMatchIn(text) ||
-                Regex("""\): Result<PluginManifest>""").containsMatchIn(text),
-            "installFromGitHub must return its manifest so the batch can include it",
+            // No `||` fallback: an alternative matching any function with that return type would
+            // always decide the assertion, so the scoped pattern could never fail.
+            Regex("""fun\s+installFromGitHub[\s\S]{0,400}?\): Result<DynamicPluginInfo>""")
+                .containsMatchIn(text),
+            "installFromGitHub must return what registered, so the batch can check it loaded",
         )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/wizard/plugin/WizardDependencyReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/wizard/plugin/WizardDependencyReportTest.kt
@@ -50,8 +50,11 @@ class WizardDependencyReportTest {
             "the wizard must report the collected batch, not one manifest per iteration",
         )
         assertTrue(
-            Regex("""\.report\(""").findAll(text).count() == 1,
-            "expected exactly one dependency report in the wizard, after the loop",
+            // Scoped to the dependency reporter: counting every `.report(` in the file would
+            // fail on an unrelated progress or metrics call, with a message about dependency
+            // ordering that would send the next person the wrong way.
+            Regex("""dependencyReporter\.report\(""").findAll(text).count() == 1,
+            "expected exactly one dependencyReporter.report call in the wizard, after the loop",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/wizard/plugin/WizardDependencyReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/wizard/plugin/WizardDependencyReportTest.kt
@@ -1,0 +1,74 @@
+package ai.rever.boss.components.wizard.plugin
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The wizard must report unmet dependencies **after** its batch, not inside the loop.
+ *
+ * This is the bug the placement fixes: a first-run selection of `[jupyter-notebook, ai-gateway]`,
+ * which is the pick this whole feature exists for, reported the gateway as missing while the loop
+ * was still two iterations from installing it. `installPlugins` runs on `Dispatchers.IO`, so the
+ * collector on Main showed the dialog over the wizard, and taking Install raced the wizard's own
+ * download - the two paths write different filenames for one plugin id, so nothing collides at
+ * the path level and the process-wide coalescing guard never sees a shared key. Reporting after
+ * the loop means `installedAndOnDisk` already contains everything the batch installed, so nothing
+ * intra-batch is reported at all.
+ *
+ * A source-level assertion for the same reason as `DependencyPromptOnInstallOnlyTest`:
+ * `PluginInstallService.installPlugins` needs a live `DynamicPluginManager`, a store and a
+ * network to reach, so the ordering cannot be observed from a unit test. It is asserted here
+ * because ordering is exactly what went wrong.
+ */
+class WizardDependencyReportTest {
+    private fun source(): String {
+        val root =
+            assertNotNull(
+                generateSequence(File("").absoluteFile) { it.parentFile }
+                    .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+                "could not locate the repository root",
+            )
+        val file =
+            File(
+                root,
+                "composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallService.kt",
+            )
+        assertTrue(file.isFile, "PluginInstallService.kt not found at ${file.absolutePath}")
+        return file.readText()
+    }
+
+    @Test
+    fun `the batch collects manifests and reports once, outside the install loop`() {
+        val text = source()
+
+        // Exactly one report call, and it iterates the collected batch rather than a single
+        // manifest - which is only possible after the loop has finished.
+        assertTrue(
+            Regex("""installedManifests\.forEach\s*\{[^}]*\.report\(""").containsMatchIn(text),
+            "the wizard must report the collected batch, not one manifest per iteration",
+        )
+        assertTrue(
+            Regex("""\.report\(""").findAll(text).count() == 1,
+            "expected exactly one dependency report in the wizard, after the loop",
+        )
+    }
+
+    @Test
+    fun `both install branches feed the batch`() {
+        val text = source()
+
+        // The GitHub branch reports nowhere else, so if it does not contribute its manifest here
+        // it is silent - which it was.
+        assertTrue(
+            Regex("""installedManifests\.add\(""").findAll(text).count() >= 2,
+            "both the store and GitHub branches must add their manifest to the batch",
+        )
+        assertTrue(
+            Regex("""installFromGitHub\([\s\S]{0,400}?\): Result<PluginManifest>""").containsMatchIn(text) ||
+                Regex("""\): Result<PluginManifest>""").containsMatchIn(text),
+            "installFromGitHub must return its manifest so the batch can include it",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
@@ -49,11 +49,26 @@ class DependencyPromptOnInstallOnlyTest {
     }
 
     @Test
+    fun `a plugin that did not actually register is not reported for`() {
+        // `installPlugin` returns success with `state = DISABLED` when registration failed as
+        // binary-incompatible, or the plugin is hidden for lack of access. Reporting then says
+        // "Flow needs the AI Gateway" for something that is not running and will not run, and
+        // taking Install downloads a second plugin to support a dead one.
+        assertTrue(
+            Regex(
+                """if\s*\(\s*reportDependencies\s*&&\s*info\.state\s*==\s*""" +
+                    """PluginState\.LOADED\s*\)[\s\S]{0,300}?\.report\(""",
+            ).containsMatchIn(source()),
+            "reporting must be gated on the plugin having actually loaded",
+        )
+    }
+
+    @Test
     fun `the load path consults the flag before reporting`() {
         // Matches the guard wherever it sits, so adding a log line or rewrapping the expression
         // does not fail a test about behaviour.
         assertTrue(
-            Regex("""if\s*\(\s*reportDependencies\s*\)[\s\S]{0,200}?\.report\(""").containsMatchIn(source()),
+            Regex("""if\s*\(\s*reportDependencies\b[\s\S]{0,400}?\.report\(""").containsMatchIn(source()),
             "the load path must consult reportDependencies before reporting",
         )
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
@@ -36,55 +36,39 @@ class DependencyPromptOnInstallOnlyTest {
 
     @Test
     fun `the reload path does not report missing dependencies`() {
-        val text = source()
-
-        assertEquals(
-            1,
-            Regex("""reportDependencies\s*=\s*false""").findAll(text).count(),
-            "expected exactly one non-reporting load, at the reload call site",
-        )
-        // Anchored to the comment marking the reload leg of doReloadPlugin, so moving the flag
-        // onto some other call fails rather than passing on the count alone.
-        assertTrue(
-            Regex("""//\s*Reload\s*\n\s*loadPlugin\(\s*jarPath\s*,\s*reportDependencies\s*=\s*false\s*\)""")
-                .containsMatchIn(text),
-            "doReloadPlugin's load must be the one that does not report",
-        )
-    }
-
-    @Test
-    fun `the public entry point is the one that reports`() {
-        // Whitespace-tolerant: a signature change or a ktlint rewrap must not fail this for a
-        // non-reason, or the next person deletes the test instead of reading it.
+        // Asserts the property, not the formatting: doReloadPlugin's own load must be a
+        // non-reporting one. Deliberately not a count of `reportDependencies = false` - a second
+        // legitimate non-reporting caller is allowed, and a test that forbade one would be
+        // deleted rather than understood.
         assertTrue(
             Regex(
-                """override\s+suspend\s+fun\s+loadPlugin\(\s*jarPath:\s*String\s*\)""" +
-                    """[^\n]*=\s*loadPlugin\(\s*jarPath\s*,\s*reportDependencies\s*=\s*true\s*\)""",
+                """fun\s+doReloadPlugin[\s\S]{0,4000}?loadPlugin\(\s*jarPath\s*,""" +
+                    """\s*reportDependencies\s*=\s*false\s*\)""",
             ).containsMatchIn(source()),
-            "the delegate's public loadPlugin must be the reporting one",
+            "doReloadPlugin must load without reporting missing dependencies",
         )
     }
 
     @Test
-    fun `the report set and the install guard share one definition of installed`() {
+    fun `the report set and the install guard come from one function`() {
         val text = source()
 
-        // The bug this pins: the reporter used the raw `pluginStates` keys while the installer
-        // required keys-plus-jar. A binary-incompatible load leaves a DISABLED entry whose jar
-        // the installer has deleted, so the reporter then saw that plugin as present and every
-        // LATER dependent of it reported nothing - the silence this feature exists to remove.
-        assertTrue(
-            Regex("""\.keys\s*\n?\s*\.filter\(\s*installedAndOnDisk\s*\)""").containsMatchIn(text),
-            "the report set must be filtered through installedAndOnDisk, not the raw keys",
-        )
-        assertTrue(
-            Regex("""installedNow\s*=\s*installedAndOnDisk""").containsMatchIn(text),
-            "the installer's guard must be the same predicate, not a second copy",
-        )
+        // What the definition *is* now has real tests (`installedAndOnDisk` in
+        // PluginDependencyResolutionTest). This only pins that both halves still read it from
+        // one place: when they diverged, a failed install left a dangling entry that silenced
+        // the prompt for every later dependent of that plugin.
         assertEquals(
             1,
-            Regex("""val\s+installedAndOnDisk""").findAll(text).count(),
-            "there must be exactly one definition of installed",
+            Regex("""fun\s+installedPluginIds\(""").findAll(text).count(),
+            "there must be exactly one definition of the installed set",
+        )
+        assertTrue(
+            Regex("""installedNow\s*=\s*\{[^}]*installedPluginIds\(\)""").containsMatchIn(text),
+            "the Install guard must read the same set as the reporter",
+        )
+        assertTrue(
+            Regex("""val\s+installed\s*=\s*installedPluginIds\(\)""").containsMatchIn(text),
+            "the report set must read the same set as the Install guard",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
@@ -2,7 +2,6 @@ package ai.rever.boss.plugin
 
 import java.io.File
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -12,14 +11,14 @@ import kotlin.test.assertTrue
  * `doReloadPlugin` finishes by calling `loadPlugin`, and reload is reached by
  * `resetPluginInstances`, the Toolbox's update flow and the evolver's hot reload - none of which
  * is a user asking to install anything, so re-offering a dependency someone already declined on
- * every reload would be worse than saying nothing. The whole distinction is one boolean at two
- * call sites, and collapsing the private overload back into the public one would silently lose
- * it while every behavioural test still passed.
+ * every reload would be worse than saying nothing.
  *
- * A source-level assertion because the seam is unreachable from a unit test:
+ * A source-level assertion because this one seam is unreachable from a unit test:
  * `PluginLoaderDelegateImpl` takes a concrete `DynamicPluginManager`, which cannot be faked.
- * Same approach as `WindowsArm64SourceIsolationTest`, for the same reason - a mistake that no
- * behavioural test can see should still fail a PR.
+ * Same approach as `WindowsArm64SourceIsolationTest`, for the same reason - a mistake no
+ * behavioural test can see should still fail a PR. Everything else about the prompt now has real
+ * tests (`MissingDependencyReporterTest`, `PluginDependencyResolutionTest`), so this file is
+ * deliberately down to the one property that cannot have one.
  */
 class DependencyPromptOnInstallOnlyTest {
     private fun source(): String {
@@ -50,36 +49,12 @@ class DependencyPromptOnInstallOnlyTest {
     }
 
     @Test
-    fun `the report set and the install guard come from one function`() {
-        val text = source()
-
-        // What the definition *is* now has real tests (`installedAndOnDisk` in
-        // PluginDependencyResolutionTest). This only pins that both halves still read it from
-        // one place: when they diverged, a failed install left a dangling entry that silenced
-        // the prompt for every later dependent of that plugin.
-        assertEquals(
-            1,
-            Regex("""fun\s+installedPluginIds\(""").findAll(text).count(),
-            "there must be exactly one definition of the installed set",
-        )
+    fun `the load path consults the flag before reporting`() {
+        // Matches the guard wherever it sits, so adding a log line or rewrapping the expression
+        // does not fail a test about behaviour.
         assertTrue(
-            Regex("""installedNow\s*=\s*\{[^}]*installedPluginIds\(\)""").containsMatchIn(text),
-            "the Install guard must read the same set as the reporter",
-        )
-        assertTrue(
-            Regex("""val\s+installed\s*=\s*installedPluginIds\(\)""").containsMatchIn(text),
-            "the report set must read the same set as the Install guard",
-        )
-    }
-
-    @Test
-    fun `reporting is gated on the flag rather than always running`() {
-        // The flag has to be consulted, not merely accepted: an early-return in the reporter
-        // is what makes the reload path silent.
-        assertTrue(
-            Regex("""fun\s+reportMissingDependencies\([^)]*\)\s*\{\s*\n\s*if\s*\(!\s*\w+\s*\)\s*return""")
-                .containsMatchIn(source()),
-            "reportMissingDependencies must return early when reporting is off",
+            Regex("""if\s*\(\s*reportDependencies\s*\)[\s\S]{0,200}?\.report\(""").containsMatchIn(source()),
+            "the load path must consult reportDependencies before reporting",
         )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
@@ -1,0 +1,72 @@
+package ai.rever.boss.plugin
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The dependency prompt must fire on install and not on reload.
+ *
+ * `doReloadPlugin` finishes by calling `loadPlugin`, and reload is reached by
+ * `resetPluginInstances`, the Toolbox's update flow and the evolver's hot reload - none of which
+ * is a user asking to install anything, so re-offering a dependency someone already declined on
+ * every reload would be worse than saying nothing. The whole distinction is one boolean at two
+ * call sites, and collapsing the private overload back into the public one would silently lose
+ * it while every behavioural test still passed.
+ *
+ * A source-level assertion because the seam is unreachable from a unit test:
+ * `PluginLoaderDelegateImpl` takes a concrete `DynamicPluginManager`, which cannot be faked.
+ * Same approach as `WindowsArm64SourceIsolationTest`, for the same reason - a mistake that no
+ * behavioural test can see should still fail a PR.
+ */
+class DependencyPromptOnInstallOnlyTest {
+    private fun source(): String {
+        val root =
+            assertNotNull(
+                generateSequence(File("").absoluteFile) { it.parentFile }
+                    .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+                "could not locate the repository root",
+            )
+        val file = File(root, "composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt")
+        assertTrue(file.isFile, "PluginLoaderDelegateImpl.kt not found at ${file.absolutePath}")
+        return file.readText()
+    }
+
+    @Test
+    fun `the reload path does not report missing dependencies`() {
+        val text = source()
+
+        assertEquals(
+            1,
+            Regex("""reportDependencies = false""").findAll(text).count(),
+            "expected exactly one non-reporting load, at the reload call site",
+        )
+        // Anchored to the comment marking the reload leg of doReloadPlugin, so moving the flag
+        // onto some other call fails rather than passing on the count alone.
+        assertTrue(
+            Regex("""// Reload\s*\n\s*loadPlugin\(jarPath, reportDependencies = false\)""")
+                .containsMatchIn(text),
+            "doReloadPlugin's load must be the one that does not report",
+        )
+    }
+
+    @Test
+    fun `the public entry point is the one that reports`() {
+        assertTrue(
+            source().contains(
+                "override suspend fun loadPlugin(jarPath: String): LoadedPluginInfo? =" +
+                    " loadPlugin(jarPath, reportDependencies = true)",
+            ),
+            "the delegate's public loadPlugin must be the reporting one",
+        )
+    }
+
+    @Test
+    fun `reporting is gated on the flag rather than always running`() {
+        // The flag has to be consulted, not merely accepted: an early-return in the reporter
+        // is what makes the reload path silent.
+        assertTrue(source().contains("if (!report) return"), "reportMissingDependencies must honour its flag")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
@@ -40,13 +40,13 @@ class DependencyPromptOnInstallOnlyTest {
 
         assertEquals(
             1,
-            Regex("""reportDependencies = false""").findAll(text).count(),
+            Regex("""reportDependencies\s*=\s*false""").findAll(text).count(),
             "expected exactly one non-reporting load, at the reload call site",
         )
         // Anchored to the comment marking the reload leg of doReloadPlugin, so moving the flag
         // onto some other call fails rather than passing on the count alone.
         assertTrue(
-            Regex("""// Reload\s*\n\s*loadPlugin\(jarPath, reportDependencies = false\)""")
+            Regex("""//\s*Reload\s*\n\s*loadPlugin\(\s*jarPath\s*,\s*reportDependencies\s*=\s*false\s*\)""")
                 .containsMatchIn(text),
             "doReloadPlugin's load must be the one that does not report",
         )
@@ -54,12 +54,37 @@ class DependencyPromptOnInstallOnlyTest {
 
     @Test
     fun `the public entry point is the one that reports`() {
+        // Whitespace-tolerant: a signature change or a ktlint rewrap must not fail this for a
+        // non-reason, or the next person deletes the test instead of reading it.
         assertTrue(
-            source().contains(
-                "override suspend fun loadPlugin(jarPath: String): LoadedPluginInfo? =" +
-                    " loadPlugin(jarPath, reportDependencies = true)",
-            ),
+            Regex(
+                """override\s+suspend\s+fun\s+loadPlugin\(\s*jarPath:\s*String\s*\)""" +
+                    """[^\n]*=\s*loadPlugin\(\s*jarPath\s*,\s*reportDependencies\s*=\s*true\s*\)""",
+            ).containsMatchIn(source()),
             "the delegate's public loadPlugin must be the reporting one",
+        )
+    }
+
+    @Test
+    fun `the report set and the install guard share one definition of installed`() {
+        val text = source()
+
+        // The bug this pins: the reporter used the raw `pluginStates` keys while the installer
+        // required keys-plus-jar. A binary-incompatible load leaves a DISABLED entry whose jar
+        // the installer has deleted, so the reporter then saw that plugin as present and every
+        // LATER dependent of it reported nothing - the silence this feature exists to remove.
+        assertTrue(
+            Regex("""\.keys\s*\n?\s*\.filter\(\s*installedAndOnDisk\s*\)""").containsMatchIn(text),
+            "the report set must be filtered through installedAndOnDisk, not the raw keys",
+        )
+        assertTrue(
+            Regex("""installedNow\s*=\s*installedAndOnDisk""").containsMatchIn(text),
+            "the installer's guard must be the same predicate, not a second copy",
+        )
+        assertEquals(
+            1,
+            Regex("""val\s+installedAndOnDisk""").findAll(text).count(),
+            "there must be exactly one definition of installed",
         )
     }
 
@@ -67,6 +92,10 @@ class DependencyPromptOnInstallOnlyTest {
     fun `reporting is gated on the flag rather than always running`() {
         // The flag has to be consulted, not merely accepted: an early-return in the reporter
         // is what makes the reload path silent.
-        assertTrue(source().contains("if (!report) return"), "reportMissingDependencies must honour its flag")
+        assertTrue(
+            Regex("""fun\s+reportMissingDependencies\([^)]*\)\s*\{\s*\n\s*if\s*\(!\s*\w+\s*\)\s*return""")
+                .containsMatchIn(source()),
+            "reportMissingDependencies must return early when reporting is off",
+        )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/MissingDependencyReporterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/MissingDependencyReporterTest.kt
@@ -1,0 +1,198 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.components.plugin.DynamicPluginInfo
+import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.components.plugin.MissingDependencyPrompt
+import ai.rever.boss.components.plugin.PluginDependencyBus
+import ai.rever.boss.plugin.api.PluginDependency
+import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * What the reporter puts on the bus, with a real bus and no plugin loader.
+ *
+ * The reporter exists as a class rather than a private method because three host paths install
+ * on a user's behalf - the plugin-manager delegate, the first-run wizard and the update bridge -
+ * and for a while only the first of them reported. These tests cover the decisions that were
+ * previously reachable only by reading `PluginLoaderDelegateImpl`'s source.
+ */
+class MissingDependencyReporterTest {
+    private fun manifest(
+        pluginId: String = "com.example.dependent",
+        dependencies: List<PluginDependency> = emptyList(),
+    ) = PluginManifest(
+        pluginId = pluginId,
+        displayName = "Dependent",
+        version = "1.0.0",
+        apiVersion = "1.0.0",
+        mainClass = "com.example.Main",
+        dependencies = dependencies,
+    )
+
+    private fun dependency(
+        pluginId: String,
+        optional: Boolean = false,
+    ) = PluginDependency(pluginId = pluginId, version = "1.0.0", optional = optional)
+
+    private fun loadedInfo(pluginId: String) = stateInfo(pluginId, PluginState.LOADED)
+
+    private fun disabledInfo(pluginId: String) = stateInfo(pluginId, PluginState.DISABLED)
+
+    private fun stateInfo(
+        pluginId: String,
+        state: PluginState,
+    ) = DynamicPluginInfo(
+        manifest = manifest(pluginId),
+        jarPath = "/plugins/$pluginId.jar",
+        state = state,
+        loadedAt = 0L,
+        enabled = state == PluginState.LOADED,
+    )
+
+    /** Nothing is installed and nothing can be installed: only what gets reported matters. */
+    private fun reporter(
+        bus: PluginDependencyBus,
+        states: Map<String, DynamicPluginInfo> = emptyMap(),
+        jarExists: (String) -> Boolean = { true },
+    ) = MissingDependencyReporter(
+        states = { states },
+        installer = NoopInstaller,
+        bus = bus,
+        jarExists = jarExists,
+    )
+
+    private object NoopInstaller : MissingDependencyInstaller {
+        override fun isInstalled(pluginId: String) = false
+
+        override suspend fun displayNameFor(pluginId: String): String? = null
+
+        override suspend fun install(pluginId: String) = Result.success(Unit)
+    }
+
+    @Test
+    fun `an absent dependency reaches the bus`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            reporter(bus).report(manifest(dependencies = listOf(dependency("com.example.gateway"))))
+
+            val prompt: MissingDependencyPrompt = bus.missingDependencies.first()
+            assertEquals("com.example.gateway", prompt.missing.missingPluginId)
+            assertEquals("com.example.dependent", prompt.missing.dependentPluginId)
+        }
+
+    @Test
+    fun `a system component is never put on the bus`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            // Reported alongside one that IS offerable, so the assertion is "the system id was
+            // skipped" rather than "nothing happened".
+            reporter(bus).report(
+                manifest(
+                    dependencies =
+                        listOf(
+                            dependency("ai.rever.boss.plugin.api"),
+                            dependency("ai.rever.boss.microkernel.runtime"),
+                            dependency("com.example.gateway"),
+                        ),
+                ),
+            )
+
+            assertEquals(
+                "com.example.gateway",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+
+    @Test
+    fun `a manifest with nothing missing reports nothing`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            reporter(bus).report(manifest())
+
+            assertNull(withTimeoutOrNull(1_000) { bus.missingDependencies.first() })
+        }
+
+    @Test
+    fun `an installed dependency is not reported`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            val states = mapOf("com.example.gateway" to loadedInfo("com.example.gateway"))
+
+            reporter(bus, states).report(manifest(dependencies = listOf(dependency("com.example.gateway"))))
+
+            assertNull(withTimeoutOrNull(1_000) { bus.missingDependencies.first() })
+        }
+
+    @Test
+    fun `a running plugin whose jar has moved is not reported as missing`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            val states = mapOf("com.example.gateway" to loadedInfo("com.example.gateway"))
+
+            // The manager does not repoint `jarPath` when a file moves, so a LOADED plugin can
+            // hold a path that no longer exists. Reporting it would prompt for something that is
+            // running, and Install would fail with "Plugin already loaded".
+            reporter(bus, states, jarExists = { false })
+                .report(manifest(dependencies = listOf(dependency("com.example.gateway"))))
+
+            assertNull(withTimeoutOrNull(1_000) { bus.missingDependencies.first() })
+        }
+
+    @Test
+    fun `a rejected plugin whose jar was deleted is still reported as missing`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            // What a binary-incompatible load leaves behind, after the installer deleted the jar.
+            val states = mapOf("com.example.gateway" to disabledInfo("com.example.gateway"))
+
+            reporter(bus, states, jarExists = { false })
+                .report(manifest(dependencies = listOf(dependency("com.example.gateway"))))
+
+            assertEquals(
+                "com.example.gateway",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+
+    @Test
+    fun `a blank dependency id is not reported`() =
+        runTest {
+            val bus = PluginDependencyBus()
+
+            reporter(bus).report(
+                manifest(dependencies = listOf(dependency(""), dependency("com.example.gateway"))),
+            )
+
+            // Otherwise the prompt reads "Dependent needs , which is not installed."
+            assertEquals(
+                "com.example.gateway",
+                bus.missingDependencies
+                    .first()
+                    .missing.missingPluginId,
+            )
+        }
+
+    @Test
+    fun `reporting never throws, whatever the manifest holds`() {
+        val bus = PluginDependencyBus()
+
+        // The install that triggered this must not fail because the dependency check did.
+        reporter(bus).report(manifest(dependencies = List(64) { dependency("com.example.d$it") }))
+
+        assertTrue(true)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -196,7 +197,108 @@ class StoreMissingDependencyInstallerTest {
             assertTrue(message.startsWith("Downloaded AI Gateway"), "unhelpful message: $message")
         }
 
-    /** The name a store download uses, so an update or uninstall recognises the jar. */
+    @Test
+    fun `an entry whose jar is gone is not treated as installed`() =
+        runTest {
+            // A binary-incompatible load registers a DISABLED entry and this installer deletes
+            // the jar it rejected. If "installed" meant only "has an entry", Retry would close
+            // the dialog reporting success with nothing installed - so the delegate's check is
+            // an entry whose jar still exists, and this pins the installer half: given a store
+            // and a working load, a retry really does install.
+            val installer = installer(FakeStore(info()))
+
+            assertTrue(installer.install(PLUGIN_ID).isSuccess)
+            assertTrue(jar().exists())
+        }
+
+    @Test
+    fun `a retry after a failed load installs rather than reporting success`() =
+        runTest {
+            var attempt = 0
+            val result =
+                installer(
+                    FakeStore(info()),
+                    load = {
+                        attempt++
+                        if (attempt == 1) {
+                            Result.failure<Unit>(IllegalStateException("incompatible"))
+                        } else {
+                            Result.success(Unit)
+                        }
+                    },
+                ).let { installer ->
+                    assertTrue(installer.install(PLUGIN_ID).isFailure)
+                    installer.install(PLUGIN_ID)
+                }
+
+            assertTrue(result.isSuccess, "retry did not install: ${result.exceptionOrNull()}")
+            assertEquals(2, attempt, "the retry short-circuited instead of loading")
+            assertTrue(jar().exists())
+        }
+
+    @Test
+    fun `displayNameFor returns the store name, and null when there is none`() =
+        runTest {
+            assertEquals("AI Gateway", installer(FakeStore(info())).displayNameFor(PLUGIN_ID))
+            assertNull(installer(FakeStore(plugin = null)).displayNameFor(PLUGIN_ID))
+            assertNull(installer(store = null).displayNameFor(PLUGIN_ID))
+        }
+
+    @Test
+    fun `displayNameFor treats a blank name as no name`() =
+        runTest {
+            // The dialog falls back to the plugin id, which is poor but readable; a blank name
+            // would render the sentence as "Flow needs , which is not installed".
+            val blank = installer(FakeStore(info().copy(displayName = "   ")))
+
+            assertNull(blank.displayNameFor(PLUGIN_ID))
+        }
+
+    @Test
+    fun `displayNameFor survives a store that throws`() =
+        runTest {
+            // Read from `produceState` during composition, so a throw here would take the
+            // dialog down instead of leaving the id on screen.
+            assertNull(installer(ThrowingStore()).displayNameFor(PLUGIN_ID))
+        }
+
+    @Test
+    fun `a version that would escape the plugin directory is sanitised`() =
+        runTest {
+            installer(FakeStore(info(version = "../../evil"))).install(PLUGIN_ID)
+
+            val escaped = File(temp.parentFile, "evil.jar")
+            assertFalse(escaped.exists(), "wrote outside the plugins directory")
+            assertEquals(1, temp.listFiles().orEmpty().count { it.name.endsWith(".jar") })
+        }
+
+    /** A store whose lookup fails outright, as an offline or rate-limited one does. */
+    private class ThrowingStore : PluginRepository {
+        override val id = "store"
+        override val name = "Store"
+        override val isLocal = false
+        override val isAvailable = false
+
+        override suspend fun listPlugins(): Result<List<PluginInfo>> = error("offline")
+
+        override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> = error("offline")
+
+        override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> = error("offline")
+
+        override suspend fun getPluginVersions(pluginId: String) = listPlugins()
+
+        override suspend fun downloadPlugin(
+            pluginId: String,
+            version: String?,
+            targetPath: String,
+        ): Result<String> = error("offline")
+
+        override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+        override suspend fun refresh(): Result<Unit> = error("offline")
+    }
+
+    /** Where a download lands: dots in the id become underscores, the version is sanitised. */
     private fun jar() = File(temp, "${PLUGIN_ID.replace('.', '_')}_1.2.3.jar")
 
     private fun sidecar() = File(PluginSignatureSidecar.pathFor(jar().absolutePath))

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin
 
+import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepository
@@ -100,6 +101,8 @@ class StoreMissingDependencyInstallerTest {
         load: suspend (String) -> Result<*> = { Result.success(Unit) },
         onPersist: (String) -> Unit = {},
         installedAfterLoad: Boolean = true,
+        declaredId: String? = PLUGIN_ID,
+        onPersistVersion: (String) -> Unit = {},
     ): StoreMissingDependencyInstaller {
         temp.mkdirs()
         var loaded = false
@@ -108,9 +111,23 @@ class StoreMissingDependencyInstallerTest {
             pluginDir = { temp },
             installedNow = { id -> id in installed || (loaded && installedAfterLoad) },
             load = { jarPath -> load(jarPath).also { if (it.isSuccess) loaded = true } },
-            persist = { pluginId, _, _ -> onPersist(pluginId) },
+            readManifest = { _ -> declaredId?.let { jarManifest(it) } },
+            persist = { pluginId, _, version, _ ->
+                onPersist(pluginId)
+                onPersistVersion(version)
+            },
         )
     }
+
+    /** What the downloaded jar actually declares, which is not always what the row said. */
+    private fun jarManifest(pluginId: String) =
+        PluginManifest(
+            pluginId = pluginId,
+            displayName = "AI Gateway",
+            version = JAR_VERSION,
+            apiVersion = "1.0.0",
+            mainClass = "com.example.Main",
+        )
 
     @Test
     fun `a successful install records the plugin`() =
@@ -301,6 +318,96 @@ class StoreMissingDependencyInstallerTest {
             assertFalse(jar().exists(), "left a jar that is not the plugin it claims to be")
         }
 
+    @Test
+    fun `a jar declaring a different plugin is refused before it is loaded`() =
+        runTest {
+            var loads = 0
+            val result =
+                installer(
+                    FakeStore(info()),
+                    load = {
+                        loads++
+                        Result.success(Unit)
+                    },
+                    declaredId = "com.example.something.else",
+                ).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure)
+            // Before, not after: `installPlugin` inspects the incoming manifest, so loading
+            // first means a jar that is really a newer api plugin has already started a full
+            // api hot swap, and a jar declaring another installed plugin has already been
+            // registered against a path about to be deleted.
+            assertEquals(0, loads, "loaded a jar that declares the wrong plugin")
+            assertFalse(jar().exists())
+        }
+
+    @Test
+    fun `a jar that declares a system component is refused even if the row asked for it`() =
+        runTest {
+            var loads = 0
+            val result =
+                installer(
+                    FakeStore(info()),
+                    load = {
+                        loads++
+                        Result.success(Unit)
+                    },
+                    declaredId = "ai.rever.boss.plugin.api",
+                ).install(PLUGIN_ID)
+
+            // The id filter in `missingFor` covers the id a manifest *names*; nothing binds a
+            // store row to the id its jar declares, so the bytes have to be checked too - an
+            // api jar reaching `installPlugin` starts an unload-all / swap / reload-all.
+            assertTrue(result.isFailure)
+            assertEquals(0, loads, "started an api hot swap from a dependency prompt")
+        }
+
+    @Test
+    fun `an unreadable manifest is refused rather than loaded hopefully`() =
+        runTest {
+            var loads = 0
+            val result =
+                installer(
+                    FakeStore(info()),
+                    load = {
+                        loads++
+                        Result.success(Unit)
+                    },
+                    declaredId = null,
+                ).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure)
+            assertEquals(0, loads)
+        }
+
+    @Test
+    fun `the recorded version comes from the jar, not the store row`() =
+        runTest {
+            val versions = mutableListOf<String>()
+            installer(FakeStore(info(version = "1.2.3")), onPersistVersion = { versions += it })
+                .install(PLUGIN_ID)
+
+            // Update checking compares against this value, so a row whose version disagrees
+            // with its jar would make every future comparison wrong.
+            assertEquals(listOf(JAR_VERSION), versions)
+        }
+
+    @Test
+    fun `a failed download does not delete a jar that was already there`() =
+        runTest {
+            temp.mkdirs()
+            val existing = jar()
+            existing.writeText("a plugin the manager never registered")
+
+            installer(FakeStore(info(), downloadBytes = null)).install(PLUGIN_ID)
+
+            // A plugin can be on disk without an entry - a load that failed transiently at
+            // startup - and a failed download must not take the user's file with it.
+            assertTrue(existing.exists(), "deleted a pre-existing jar this install did not create")
+        }
+
+    /** A store whose lookup fails outright, as an offline or rate-limited one does. */
+
     /** A store whose lookup fails outright, as an offline or rate-limited one does. */
     private class ThrowingStore : PluginRepository {
         override val id = "store"
@@ -334,5 +441,8 @@ class StoreMissingDependencyInstallerTest {
 
     private companion object {
         const val PLUGIN_ID = "ai.rever.boss.plugin.dynamic.aigateway"
+
+        /** Deliberately different from the store row's 1.2.3, so tests can tell them apart. */
+        const val JAR_VERSION = "1.2.4"
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -1,0 +1,207 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
+import ai.rever.boss.plugin.repository.PluginInfo
+import ai.rever.boss.plugin.repository.PluginRepository
+import ai.rever.boss.plugin.repository.PluginSearchFilter
+import ai.rever.boss.plugin.repository.PluginSearchResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rules of installing a missing dependency, without a store or a plugin loader.
+ *
+ * The three that matter are all about not leaving debris: a download or load that fails must
+ * take its jar *and* its signature sidecar with it, because a truncated jar left at the final
+ * filename is found and retried by every subsequent launch, and a surviving `.sig` meets fresh
+ * bytes on reinstall and hard-fails the load - worse than being unsigned.
+ */
+class StoreMissingDependencyInstallerTest {
+    private val temp = File(System.getProperty("java.io.tmpdir"), "boss-dep-install-${hashCode()}")
+
+    @AfterTest
+    fun cleanup() {
+        temp.deleteRecursively()
+    }
+
+    private fun info(
+        id: String = PLUGIN_ID,
+        version: String = "1.2.3",
+    ) = PluginInfo(
+        pluginId = id,
+        displayName = "AI Gateway",
+        version = version,
+    )
+
+    /**
+     * A store that hands back [plugin] and writes whatever [downloadBytes] says.
+     *
+     * `downloadBytes = null` models a mid-stream failure: `RemotePluginRepository` writes
+     * straight into the target path and only deletes on a hash or signature rejection, so the
+     * partial file is genuinely left behind - the fake reproduces that rather than assuming a
+     * clean failure.
+     */
+    private class FakeStore(
+        private val plugin: PluginInfo?,
+        private val downloadBytes: ByteArray? = ByteArray(8),
+        private val writeSidecar: Boolean = true,
+    ) : PluginRepository {
+        override val id = "store"
+        override val name = "Store"
+        override val isLocal = false
+        override val isAvailable = true
+
+        override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOfNotNull(plugin))
+
+        override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
+            Result.failure(UnsupportedOperationException("unused"))
+
+        override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> = Result.success(plugin)
+
+        override suspend fun getPluginVersions(pluginId: String) = listPlugins()
+
+        override suspend fun downloadPlugin(
+            pluginId: String,
+            version: String?,
+            targetPath: String,
+        ): Result<String> {
+            val target = File(targetPath)
+            target.parentFile?.mkdirs()
+            // Always writes something first, like the real one.
+            target.writeBytes(downloadBytes ?: ByteArray(3))
+            if (writeSidecar) PluginSignatureSidecar.write(targetPath, "signature")
+            return if (downloadBytes == null) {
+                Result.failure(IllegalStateException("connection reset"))
+            } else {
+                Result.success(targetPath)
+            }
+        }
+
+        override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+        override suspend fun refresh(): Result<Unit> = Result.success(Unit)
+    }
+
+    private fun installer(
+        store: PluginRepository?,
+        installed: Set<String> = emptySet(),
+        load: suspend (String) -> Result<*> = { Result.success(Unit) },
+        onPersist: (String) -> Unit = {},
+    ): StoreMissingDependencyInstaller {
+        temp.mkdirs()
+        return StoreMissingDependencyInstaller(
+            repository = { store },
+            pluginDir = { temp },
+            installedNow = { it in installed },
+            load = load,
+            persist = { pluginId, _, _ -> onPersist(pluginId) },
+        )
+    }
+
+    @Test
+    fun `a successful install records the plugin`() =
+        runTest {
+            val recorded = mutableListOf<String>()
+            val result = installer(FakeStore(info()), onPersist = { recorded += it }).install(PLUGIN_ID)
+
+            assertTrue(result.isSuccess, "expected success, got ${result.exceptionOrNull()}")
+            // Without this entry `setPluginEnabled` silently no-ops, so the dependency cannot
+            // be disabled persistently and returns enabled on the next launch.
+            assertEquals(listOf(PLUGIN_ID), recorded)
+            assertTrue(jar().exists())
+        }
+
+    @Test
+    fun `a download that fails mid-stream leaves no jar and no sidecar`() =
+        runTest {
+            val result = installer(FakeStore(info(), downloadBytes = null)).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure)
+            assertFalse(jar().exists(), "a truncated jar would be found and retried every launch")
+            assertFalse(sidecar().exists(), "an orphaned .sig hard-fails the load on reinstall")
+        }
+
+    @Test
+    fun `a jar that fails to load is deleted along with its sidecar`() =
+        runTest {
+            val result =
+                installer(
+                    FakeStore(info()),
+                    load = { Result.failure<Unit>(IllegalStateException("binary incompatible")) },
+                ).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure)
+            assertFalse(jar().exists())
+            assertFalse(sidecar().exists())
+        }
+
+    @Test
+    fun `a failed load is not recorded as installed`() =
+        runTest {
+            val recorded = mutableListOf<String>()
+            installer(
+                FakeStore(info()),
+                load = { Result.failure<Unit>(IllegalStateException("nope")) },
+                onPersist = { recorded += it },
+            ).install(PLUGIN_ID)
+
+            assertTrue(recorded.isEmpty(), "recorded a plugin that never loaded: $recorded")
+        }
+
+    @Test
+    fun `an already-installed dependency is not downloaded again`() =
+        runTest {
+            val result = installer(FakeStore(info()), installed = setOf(PLUGIN_ID)).install(PLUGIN_ID)
+
+            assertTrue(result.isSuccess)
+            // A prompt can outlive the install that satisfied it; re-downloading over a jar the
+            // running manager holds open fails outright on Windows.
+            assertFalse(jar().exists(), "downloaded a dependency that was already installed")
+        }
+
+    @Test
+    fun `no store yields a message about the store, not a transport error`() =
+        runTest {
+            val result = installer(store = null).install(PLUGIN_ID)
+
+            val message = result.exceptionOrNull()?.message.orEmpty()
+            assertTrue(message.contains("plugin store is not available"), "unhelpful message: $message")
+        }
+
+    @Test
+    fun `a plugin the store does not have names the plugin it could not find`() =
+        runTest {
+            val result = installer(FakeStore(plugin = null)).install(PLUGIN_ID)
+
+            val message = result.exceptionOrNull()?.message.orEmpty()
+            assertTrue(message.contains(PLUGIN_ID), "unhelpful message: $message")
+        }
+
+    @Test
+    fun `the failure message names the plugin, never the transport`() =
+        runTest {
+            val result =
+                installer(
+                    FakeStore(info()),
+                    load = { Result.failure<Unit>(IllegalStateException("classloader constraint violation")) },
+                ).install(PLUGIN_ID)
+
+            val message = result.exceptionOrNull()?.message.orEmpty()
+            assertTrue(message.startsWith("Downloaded AI Gateway"), "unhelpful message: $message")
+        }
+
+    /** The name a store download uses, so an update or uninstall recognises the jar. */
+    private fun jar() = File(temp, "${PLUGIN_ID.replace('.', '_')}_1.2.3.jar")
+
+    private fun sidecar() = File(PluginSignatureSidecar.pathFor(jar().absolutePath))
+
+    private companion object {
+        const val PLUGIN_ID = "ai.rever.boss.plugin.dynamic.aigateway"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.plugin.repository.PluginSearchFilter
 import ai.rever.boss.plugin.repository.PluginSearchResult
+import ai.rever.boss.utils.atomicMoveFrom
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
@@ -107,19 +108,32 @@ class StoreMissingDependencyInstallerTest {
         installedAfterLoad: Boolean = true,
         declaredId: String? = PLUGIN_ID,
         onPersistVersion: (String) -> Unit = {},
+        promoteFiles: ((String, File) -> Unit)? = null,
     ): StoreMissingDependencyInstaller {
         temp.mkdirs()
         var loaded = false
         return StoreMissingDependencyInstaller(
             repository = { store },
             pluginDir = { temp },
-            installedNow = { id -> id in installed || (loaded && installedAfterLoad) },
-            load = { jarPath -> load(jarPath).also { if (it.isSuccess) loaded = true } },
-            readManifest = { _ -> declaredId?.let { jarManifest(it) } },
-            persist = { pluginId, _, version, _ ->
-                onPersist(pluginId)
-                onPersistVersion(version)
-            },
+            hooks =
+                InstallerHooks(
+                    installedNow = { id -> id in installed || (loaded && installedAfterLoad) },
+                    load = { jarPath -> load(jarPath).also { if (it.isSuccess) loaded = true } },
+                    readManifest = { _ -> declaredId?.let { jarManifest(it) } },
+                    promoteFiles =
+                        promoteFiles ?: { downloaded, target ->
+                            target.atomicMoveFrom(File(downloaded))
+                            PluginSignatureSidecar.persist(
+                                target.absolutePath,
+                                PluginSignatureSidecar.read(downloaded),
+                            )
+                            PluginSignatureSidecar.delete(downloaded)
+                        },
+                    persist = { pluginId, _, version, _ ->
+                        onPersist(pluginId)
+                        onPersistVersion(version)
+                    },
+                ),
         )
     }
 
@@ -480,6 +494,50 @@ class StoreMissingDependencyInstallerTest {
 
             assertEquals(PLUGIN_ID, manifest.pluginId)
             assertEquals(JAR_VERSION, manifest.version)
+        }
+
+    @Test
+    fun `a promotion that moves the jar and then fails leaves nothing behind`() =
+        runTest {
+            val result =
+                installer(
+                    FakeStore(info()),
+                    promoteFiles = { downloaded, target ->
+                        // The move succeeds, the sidecar step throws - `persist` writes through a
+                        // temp file and both moves propagate IOException, so this is reachable.
+                        target.atomicMoveFrom(File(downloaded))
+                        error("sidecar write failed")
+                    },
+                ).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure)
+            // Cleaning only the part path would leave an unvetted, never-loaded jar at a
+            // scannable name for the next launch's directory scan to load.
+            assertFalse(jar().exists(), "left an unvetted jar at its final name")
+            val leftovers = temp.listFiles().orEmpty().map { it.name }
+            assertTrue(leftovers.none { it.endsWith(".part") }, "left a part file: $leftovers")
+        }
+
+    @Test
+    fun `a plugin that loads but never registers is reported as a failure`() =
+        runTest {
+            val recorded = mutableListOf<String>()
+            val result =
+                installer(
+                    FakeStore(info()),
+                    // `installPlugin` returns SUCCESS with state DISABLED for a registration-time
+                    // binary incompatibility, so the requested id is still not usable afterwards.
+                    load = { Result.success(Unit) },
+                    installedAfterLoad = false,
+                    onPersist = { recorded += it },
+                ).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure, "reported success for a plugin that never registered")
+            assertTrue(recorded.isEmpty(), "recorded a plugin that never registered: $recorded")
+            // The message must not blame the store: the manifest was vetted before the load.
+            val message = result.exceptionOrNull()?.message.orEmpty()
+            assertTrue(message.contains("did not start"), "misleading message: $message")
+            assertFalse(jar().exists())
         }
 
     /** Counts downloads, to prove two concurrent installs collapse into one. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -397,17 +397,43 @@ class StoreMissingDependencyInstallerTest {
         }
 
     @Test
-    fun `a failed download does not delete a jar that was already there`() =
+    fun `a failed download leaves an existing jar byte-identical`() =
         runTest {
             temp.mkdirs()
             val existing = jar()
-            existing.writeText("a plugin the manager never registered")
+            val original = "a plugin the manager never registered"
+            existing.writeText(original)
 
             installer(FakeStore(info(), downloadBytes = null)).install(PLUGIN_ID)
 
-            // A plugin can be on disk without an entry - a load that failed transiently at
-            // startup - and a failed download must not take the user's file with it.
+            // Content, not existence: `downloadPlugin` streams into the path it is given and
+            // `outputStream()` truncates on open, so an earlier version of this asserted
+            // `exists()` and passed on three bytes of junk left by the failed download. The
+            // download goes to a `.part` sibling now, so the real jar is never opened at all.
             assertTrue(existing.exists(), "deleted a pre-existing jar this install did not create")
+            assertEquals(original, existing.readText(), "overwrote a pre-existing jar with a partial download")
+        }
+
+    @Test
+    fun `a failed download leaves no part file behind`() =
+        runTest {
+            installer(FakeStore(info(), downloadBytes = null)).install(PLUGIN_ID)
+
+            val leftovers = temp.listFiles().orEmpty().map { it.name }
+            assertTrue(leftovers.none { it.endsWith(".part") }, "left a part file: $leftovers")
+        }
+
+    @Test
+    fun `a successful download promotes the jar and its sidecar together`() =
+        runTest {
+            assertTrue(installer(FakeStore(info())).install(PLUGIN_ID).isSuccess)
+
+            // Promoting the jar alone would leave the signature under the part name, and the jar
+            // would load as unsigned.
+            assertTrue(jar().exists())
+            assertEquals("signature", PluginSignatureSidecar.read(jar().absolutePath))
+            val leftovers = temp.listFiles().orEmpty().map { it.name }
+            assertTrue(leftovers.none { it.contains(".part") }, "left part files behind: $leftovers")
         }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -89,18 +89,25 @@ class StoreMissingDependencyInstallerTest {
         override suspend fun refresh(): Result<Unit> = Result.success(Unit)
     }
 
+    /**
+     * @param installedAfterLoad what `installedNow` reports once a load has succeeded, which is
+     *   how the real predicate behaves: the manager registers the plugin the *jar* declares, so
+     *   a mismatched store row leaves the requested id still absent.
+     */
     private fun installer(
         store: PluginRepository?,
         installed: Set<String> = emptySet(),
         load: suspend (String) -> Result<*> = { Result.success(Unit) },
         onPersist: (String) -> Unit = {},
+        installedAfterLoad: Boolean = true,
     ): StoreMissingDependencyInstaller {
         temp.mkdirs()
+        var loaded = false
         return StoreMissingDependencyInstaller(
             repository = { store },
             pluginDir = { temp },
-            installedNow = { it in installed },
-            load = load,
+            installedNow = { id -> id in installed || (loaded && installedAfterLoad) },
+            load = { jarPath -> load(jarPath).also { if (it.isSuccess) loaded = true } },
             persist = { pluginId, _, _ -> onPersist(pluginId) },
         )
     }
@@ -270,6 +277,28 @@ class StoreMissingDependencyInstallerTest {
             val escaped = File(temp.parentFile, "evil.jar")
             assertFalse(escaped.exists(), "wrote outside the plugins directory")
             assertEquals(1, temp.listFiles().orEmpty().count { it.name.endsWith(".jar") })
+        }
+
+    @Test
+    fun `a jar that loads as a different plugin is rejected, not reported as installed`() =
+        runTest {
+            // A store row for X can point at a jar whose manifest declares Y. `load` returning
+            // success is not evidence that X arrived, and reporting success here would close the
+            // dialog with the dependency still absent.
+            val recorded = mutableListOf<String>()
+            val result =
+                installer(
+                    FakeStore(info()),
+                    installed = emptySet(),
+                    load = { Result.success(Unit) },
+                    onPersist = { recorded += it },
+                    // Still absent after a "successful" load: the jar was some other plugin.
+                    installedAfterLoad = false,
+                ).install(PLUGIN_ID)
+
+            assertTrue(result.isFailure, "reported success for a plugin that never arrived")
+            assertTrue(recorded.isEmpty(), "recorded a plugin that never arrived: $recorded")
+            assertFalse(jar().exists(), "left a jar that is not the plugin it claims to be")
         }
 
     /** A store whose lookup fails outright, as an offline or rate-limited one does. */

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -1,11 +1,15 @@
 package ai.rever.boss.plugin
 
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.loader.PluginManifestReader
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.plugin.repository.PluginSearchFilter
 import ai.rever.boss.plugin.repository.PluginSearchResult
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import java.io.File
@@ -405,6 +409,88 @@ class StoreMissingDependencyInstallerTest {
             // startup - and a failed download must not take the user's file with it.
             assertTrue(existing.exists(), "deleted a pre-existing jar this install did not create")
         }
+
+    @Test
+    fun `two concurrent installs of one plugin download once`() =
+        runTest {
+            val downloads =
+                java.util.concurrent.atomic
+                    .AtomicInteger()
+            val store = CountingStore(info(), downloads)
+            val subject = installer(store)
+
+            // Coalescing is process-wide precisely for this: two dependents - or two windows -
+            // can each raise a prompt for the same missing plugin, and two downloads writing the
+            // same path at once is the failure it prevents.
+            val both =
+                listOf(
+                    async { subject.install(PLUGIN_ID) },
+                    async { subject.install(PLUGIN_ID) },
+                ).awaitAll()
+
+            assertTrue(both.all { it.isSuccess }, "one of the coalesced installs failed: $both")
+            assertEquals(1, downloads.get(), "downloaded the same plugin twice")
+        }
+
+    @Test
+    fun `the default manifest reader reads a real jar`() =
+        runTest {
+            // Every other test injects `readManifest`, so without this the production default is
+            // never exercised against actual bytes.
+            temp.mkdirs()
+            val jarFile = File(temp, "real-plugin.jar")
+            java.util.zip.ZipOutputStream(jarFile.outputStream()).use { zip ->
+                zip.putNextEntry(java.util.zip.ZipEntry("META-INF/boss-plugin/plugin.json"))
+                zip.write(
+                    (
+                        """{"pluginId":"$PLUGIN_ID","displayName":"AI Gateway","version":"$JAR_VERSION",""" +
+                            """"apiVersion":"1.0.0","mainClass":"com.example.Main"}"""
+                    ).toByteArray(),
+                )
+                zip.closeEntry()
+            }
+
+            val manifest = PluginManifestReader.readFromJar(jarFile.absolutePath)
+
+            assertEquals(PLUGIN_ID, manifest.pluginId)
+            assertEquals(JAR_VERSION, manifest.version)
+        }
+
+    /** Counts downloads, to prove two concurrent installs collapse into one. */
+    private class CountingStore(
+        private val plugin: PluginInfo,
+        private val downloads: java.util.concurrent.atomic.AtomicInteger,
+    ) : PluginRepository {
+        override val id = "store"
+        override val name = "Store"
+        override val isLocal = false
+        override val isAvailable = true
+
+        override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(plugin))
+
+        override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
+            Result.failure(UnsupportedOperationException("unused"))
+
+        override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> = Result.success(plugin)
+
+        override suspend fun getPluginVersions(pluginId: String) = listPlugins()
+
+        override suspend fun downloadPlugin(
+            pluginId: String,
+            version: String?,
+            targetPath: String,
+        ): Result<String> {
+            downloads.incrementAndGet()
+            // Long enough that a second, uncoalesced install would overlap this one.
+            delay(50)
+            File(targetPath).writeBytes(ByteArray(8))
+            return Result.success(targetPath)
+        }
+
+        override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+        override suspend fun refresh(): Result<Unit> = Result.success(Unit)
+    }
 
     /** A store whose lookup fails outright, as an offline or rate-limited one does. */
 


### PR DESCRIPTION
## What

Installing a plugin whose declared dependency is absent now prompts, and the prompt installs it.

`plugin.json` `dependencies` were read in exactly one place - `DynamicPluginManager.checkCanUnload`, which refuses to *uninstall* a plugin something else depends on. Nothing looked at them at install time, so installing a plugin without its dependency produced no signal at all. The user met the consequence later, as a feature that silently did nothing.

The AI Gateway made that concrete: `jupyter-notebook`, `llmrpa` and `flow-tab` each declare `ai.rever.boss.plugin.dynamic.aigateway` and each falls back to an unconfigured panel without it. Those plugins already ask about AI at the point of use (`AiAvailability.promptToFix`), but a plugin can only send the user to the Toolbox to search by name. Resolving an id to a jar needs the host.

## How

| File | Role |
|---|---|
| `PluginDependencyResolution.kt` | pure resolver + `PluginDependencyBus` |
| `MissingDependencyDialog.kt` | the prompt, Install / Skip, error kept on screen with Retry |
| `StoreMissingDependencyInstaller.kt` | store lookup, download, load |
| `PluginLoaderDelegateImpl.kt` | reports after a successful user-initiated load |
| `BossAppState` / `BossAppEventBusEffects` / `BossAppDialogs` | per-window state, collector, dialog |

Four decisions worth review, since each had a live alternative:

- **The hook is `PluginLoaderDelegateImpl.loadPlugin`, not `DynamicPluginManager.installPlugin`.** That manager method also serves startup restore, the bundled-plugin load and the api hot-swap's reload-all, so a prompt there would be one dialog per plugin on every launch. The delegate is the path plugin-manager install and update flows take, which is the only place a *user* asked for something.
- **Optional dependencies are reported and flagged, not dropped.** All three gateway consumers declare it `optional: true`, so dropping them would leave this feature reporting nothing for the case that motivated it. The wording differs instead ("Recommended plugin" / "Not now" versus "Required plugin missing" / "Skip").
- **The bus is a `Channel`, not a `SharedFlow`.** A broadcast would put an identical dialog in front of every open window and let each of them start the same install. The collector back-pressures on the dialog being answered (`snapshotFlow { … }.first { it == null }`), so a second missing dependency is asked about after the first rather than replacing it or being dropped.
- **A jar that downloads but fails to load is deleted again**, so a directory scan on the next launch cannot pick up something that just failed its checks.

Transitive dependencies are deliberately not chased: the dependency loads through the manager directly, so answering one question never produces a second dialog.

## Verification

- `:composeApp:desktopTest` - **1749 tests, 0 failures** (11 new)
- `:composeApp:ktlintCheck` + `:composeApp:detekt` green, no baseline entries added
- **Mutation-checked**, since a resolver that returns nothing passes a naive suite:
  - removing the self-dependency filter fails `a self-dependency is not offered for install`
  - swapping the `Channel` for a broadcast `MutableSharedFlow` fails both `one prompt reaches exactly one of two collectors` and `a prompt reported before anyone collects is delivered when a collector appears`

Not exercised here: the live path needs a store round-trip, so the download and load legs are covered by their own types' tests rather than end to end. Worth a manual pass - install `llmrpa` on a machine without the gateway and take the prompt's Install.