### PR TITLE
feat(menus): real macOS context menus, shared in plugin-ui-core

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -7,6 +7,8 @@ import ai.rever.boss.platform.ContextMenuHandler
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import ai.rever.boss.plugin.ui.BossPopupAnchoring
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.plugin.ui.menu.NATIVE_MENU_ICON_POINTS
+import ai.rever.boss.plugin.ui.menu.NATIVE_MENU_ICON_SCALE
 import ai.rever.boss.plugin.ui.menu.NativeContextMenus
 import ai.rever.boss.plugin.ui.menu.NativeMenuAnchor
 import ai.rever.boss.plugin.ui.menu.NativeMenuNode
@@ -31,9 +33,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
@@ -70,21 +80,69 @@ data class ContextMenuItem(
 )
 
 /**
- * Whether this menu can be rendered by an operating-system menu without losing anything.
+ * Whether this menu can be rendered by an operating-system menu without losing anything the user
+ * can act on.
  *
- * A native menu item is a label, an enabled flag and an optional shortcut. An icon or an inline
- * trailing action button has no native equivalent, and silently dropping one would remove an
- * affordance the user relies on (the sidebar, workspace and run-history menus use trailing
- * buttons for inline edit and delete). Those menus keep the drawn path until they are reshaped
- * to express the same actions as structure.
+ * A native menu item is a label, an enabled flag and an optional shortcut. Two of the app's extras
+ * have no native equivalent, and they are not equally important:
+ *
+ * - A **leading icon is decoration**. macOS menus mostly do not carry one, so dropping it costs
+ *   nothing but appearance. It is deliberately NOT disqualifying: nearly every menu item in the
+ *   app has an icon, so treating icons as blocking would leave essentially every menu on the
+ *   drawn path and make this whole feature invisible.
+ * - An **inline trailing button is a distinct action** - the sidebar, workspace and run-history
+ *   menus use them for edit and delete. Dropping one silently removes something the user relies
+ *   on, so those menus keep the drawn path until they are reshaped to express the same actions as
+ *   structure (a submenu).
  */
 internal fun List<ContextMenuItem>.isNativeRepresentable(): Boolean =
     all { item ->
-        item.icon == null &&
-            item.trailingIcon == null &&
+        item.trailingIcon == null &&
             item.secondaryTrailingIcon == null &&
             item.subMenu?.isNativeRepresentable() != false
     }
+
+/** Icons already rasterised for a native menu, keyed by the vector they came from. */
+internal typealias MenuIcons = Map<ImageVector, ImageBitmap>
+
+/** Every distinct icon in the menu tree, so each is rasterised once rather than once per item. */
+internal fun List<ContextMenuItem>.collectIcons(): List<ImageVector> =
+    flatMap { item ->
+        listOfNotNull(item.icon) + (item.subMenu?.collectIcons() ?: emptyList())
+    }.distinct()
+
+/**
+ * Rasterise an icon for a native menu item.
+ *
+ * The tint is a fixed mid-grey rather than a theme colour: the menu's background is the system's,
+ * not the app's, and macOS offers no way to mark a peer-supplied image as a template - which is
+ * what would let the OS tint it per appearance and while highlighted. This grey approximates the
+ * system secondary label colour and stays legible on both the light and dark menu backgrounds.
+ */
+@Composable
+private fun ImageVector.toNativeMenuIcon(): ImageBitmap {
+    val painter = rememberVectorPainter(this)
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    return remember(this, density, layoutDirection) {
+        // Fixed 2x of the point size, NOT the screen density: the point size is stated by the
+        // multi-resolution image the desktop side builds, so rasterising at the display's scale
+        // would just hand AppKit a bitmap it reads as an oversized icon.
+        val px = NATIVE_MENU_ICON_POINTS * NATIVE_MENU_ICON_SCALE
+        val bitmap = ImageBitmap(px, px)
+        CanvasDrawScope().draw(
+            density = density,
+            layoutDirection = layoutDirection,
+            canvas = Canvas(bitmap),
+            size = Size(px.toFloat(), px.toFloat()),
+        ) {
+            with(painter) { draw(size, colorFilter = ColorFilter.tint(NATIVE_MENU_ICON_TINT)) }
+        }
+        bitmap
+    }
+}
+
+private val NATIVE_MENU_ICON_TINT = Color(0xFF8A8A8E)
 
 /**
  * Convert to the toolkit-neutral model the native engine speaks.
@@ -94,7 +152,7 @@ internal fun List<ContextMenuItem>.isNativeRepresentable(): Boolean =
  * next crash on that thread is blamed on nobody and takes the app down instead of the plugin.
  * This is the one seam plugin crash recovery rests on, and it fails silently.
  */
-internal fun List<ContextMenuItem>.toNativeMenuNodes(): List<NativeMenuNode> =
+internal fun List<ContextMenuItem>.toNativeMenuNodes(icons: MenuIcons = emptyMap()): List<NativeMenuNode> =
     map { item ->
         when {
             item.isDivider -> {
@@ -102,12 +160,13 @@ internal fun List<ContextMenuItem>.toNativeMenuNodes(): List<NativeMenuNode> =
             }
 
             item.subMenu != null -> {
-                NativeMenuNode.Submenu(item.text, item.subMenu.toNativeMenuNodes())
+                NativeMenuNode.Submenu(item.text, item.subMenu.toNativeMenuNodes(icons))
             }
 
             else -> {
                 NativeMenuNode.Item(
                     label = item.text,
+                    icon = item.icon?.let { icons[it] },
                     action = { PluginExecutionBoundary.invokeAttributed(item.onClick) },
                 )
             }
@@ -166,12 +225,14 @@ fun ContextMenu(
     // native menu item cannot render - see [isNativeRepresentable].
     if (useNativeContextMenus() && items.isNativeRepresentable()) {
         val dismiss by rememberUpdatedState(onDismissRequest)
+        // Rasterised here in composition, where density is available; the effect below is not.
+        val icons = items.collectIcons().associateWith { it.toNativeMenuIcon() }
         // Keyed on the menu, not Unit: a second right-click composes a new ContextMenu with new
         // items and must reopen at the new position rather than reuse the first effect.
         DisposableEffect(items) {
             val shown =
                 NativeContextMenus.show(
-                    nodes = items.toNativeMenuNodes(),
+                    nodes = items.toNativeMenuNodes(icons),
                     // The pointer IS the intended position for a right-click menu, and reading it
                     // from the OS avoids converting node-relative Compose pixels into screen
                     // coordinates - a conversion this codebase has nowhere else.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -223,28 +223,38 @@ fun ContextMenu(
     //
     // Falls through whenever the menu carries an icon or an inline trailing button, which a
     // native menu item cannot render - see [isNativeRepresentable].
-    if (useNativeContextMenus() && items.isNativeRepresentable()) {
+    // Tracks a native attempt that could not produce a menu, so this composition falls through to
+    // the drawn paths instead of returning with nothing on screen. Every guard in the engine
+    // exists to make that decline possible; swallowing it here would defeat all of them, and the
+    // reachable causes (no pointer, no showing frame, a throwing `locationOnScreen`) are sticky
+    // rather than transient, so the user would get a right-click that repeatedly does nothing.
+    var nativeUnavailable by remember { mutableStateOf(false) }
+
+    if (useNativeContextMenus() && !nativeUnavailable && items.isNativeRepresentable()) {
         val dismiss by rememberUpdatedState(onDismissRequest)
         // Rasterised here in composition, where density is available; the effect below is not.
         val icons = items.collectIcons().associateWith { it.toNativeMenuIcon() }
-        // Keyed on the menu, not Unit: a second right-click composes a new ContextMenu with new
-        // items and must reopen at the new position rather than reuse the first effect.
-        DisposableEffect(items) {
+        val nodes by rememberUpdatedState(items.toNativeMenuNodes(icons))
+        // Keyed on Unit, NOT on items. This composable exists only while the menu should be up, so
+        // entering composition IS the show and leaving it IS the dismissal. Keying on items would
+        // restart the effect on every recomposition, because the list is rebuilt each time and its
+        // lambdas capture unstable values so equality never holds - and the tab menu is rebuilt on
+        // every tab-bar recomposition, e.g. on each line of terminal output. That would tear down
+        // and reopen the menu under the user's cursor many times a second.
+        DisposableEffect(Unit) {
             val shown =
                 NativeContextMenus.show(
-                    nodes = items.toNativeMenuNodes(icons),
+                    nodes = nodes,
                     // The pointer IS the intended position for a right-click menu, and reading it
                     // from the OS avoids converting node-relative Compose pixels into screen
                     // coordinates - a conversion this codebase has nowhere else.
                     anchor = NativeMenuAnchor.Cursor,
                     onDismiss = { dismiss() },
                 )
-            // Nothing was shown (no invoker, or the plan came out empty), so tell the caller
-            // rather than leaving it believing a menu is up.
-            if (!shown) dismiss()
+            if (!shown) nativeUnavailable = true
             onDispose { NativeContextMenus.hide() }
         }
-        return
+        if (!nativeUnavailable) return
     }
 
     val heavyweight = OverlayConfig.heavyweightPopup

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -159,7 +159,12 @@ internal fun List<ContextMenuItem>.toNativeMenuNodes(icons: MenuIcons = emptyMap
                 NativeMenuNode.Separator
             }
 
-            item.subMenu != null -> {
+            // isNullOrEmpty, matching the drawn renderer. An item with an EMPTY subMenu and a real
+            // onClick is a clickable row there; treating it as a submenu here would make
+            // planNativeMenu drop it as an unopenable dead row, so the item would vanish. Reachable
+            // through the plugin API, which maps `subMenu?.map { ... }` and hands back an empty
+            // non-null list.
+            !item.subMenu.isNullOrEmpty() -> {
                 NativeMenuNode.Submenu(item.text, item.subMenu.toNativeMenuNodes(icons))
             }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -7,6 +7,11 @@ import ai.rever.boss.platform.ContextMenuHandler
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import ai.rever.boss.plugin.ui.BossPopupAnchoring
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.plugin.ui.menu.NativeContextMenus
+import ai.rever.boss.plugin.ui.menu.NativeMenuAnchor
+import ai.rever.boss.plugin.ui.menu.NativeMenuNode
+import ai.rever.boss.plugin.ui.menu.shouldUseNativeMenus
+import ai.rever.boss.window.WindowAppearanceSettingsManager
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -65,6 +70,77 @@ data class ContextMenuItem(
 )
 
 /**
+ * Whether this menu can be rendered by an operating-system menu without losing anything.
+ *
+ * A native menu item is a label, an enabled flag and an optional shortcut. An icon or an inline
+ * trailing action button has no native equivalent, and silently dropping one would remove an
+ * affordance the user relies on (the sidebar, workspace and run-history menus use trailing
+ * buttons for inline edit and delete). Those menus keep the drawn path until they are reshaped
+ * to express the same actions as structure.
+ */
+internal fun List<ContextMenuItem>.isNativeRepresentable(): Boolean =
+    all { item ->
+        item.icon == null &&
+            item.trailingIcon == null &&
+            item.secondaryTrailingIcon == null &&
+            item.subMenu?.isNativeRepresentable() != false
+    }
+
+/**
+ * Convert to the toolkit-neutral model the native engine speaks.
+ *
+ * The action is wrapped in [PluginExecutionBoundary.invokeAttributed] for the same reason the
+ * drawn rows are: a plugin-supplied callback must run inside its own attribution scope, or the
+ * next crash on that thread is blamed on nobody and takes the app down instead of the plugin.
+ * This is the one seam plugin crash recovery rests on, and it fails silently.
+ */
+internal fun List<ContextMenuItem>.toNativeMenuNodes(): List<NativeMenuNode> =
+    map { item ->
+        when {
+            item.isDivider -> {
+                NativeMenuNode.Separator
+            }
+
+            item.subMenu != null -> {
+                NativeMenuNode.Submenu(item.text, item.subMenu.toNativeMenuNodes())
+            }
+
+            else -> {
+                NativeMenuNode.Item(
+                    label = item.text,
+                    action = { PluginExecutionBoundary.invokeAttributed(item.onClick) },
+                )
+            }
+        }
+    }
+
+/**
+ * Forces the menu path in tests.
+ *
+ * The drawn menu is a Compose tree a UI test can find nodes in; a native menu is an OS window
+ * that has none. Without this, every existing menu UI test would pass on CI and fail on a macOS
+ * developer machine purely because of which renderer ran.
+ */
+internal object NativeContextMenuTestOverride {
+    @Volatile
+    internal var enabled: Boolean? = null
+}
+
+/**
+ * Read per show, so toggling the preference takes effect on the next right-click without a
+ * restart. Falls back to enabled if the settings file cannot be read.
+ */
+@Composable
+private fun useNativeContextMenus(): Boolean {
+    NativeContextMenuTestOverride.enabled?.let { return it }
+    val settings by WindowAppearanceSettingsManager.currentSettings.collectAsState()
+    return shouldUseNativeMenus(
+        settingEnabled = settings.useNativeContextMenus,
+        isMacOs = NativeContextMenus.isSupported(),
+    )
+}
+
+/**
  * A custom context menu that can be shown on right-click or long press
  * depending on the platform.
  *
@@ -80,6 +156,36 @@ fun ContextMenu(
     modifier: Modifier = Modifier,
     onDismissRequest: () -> Unit,
 ) {
+    // A real OS menu, where the platform and the menu's shape both allow it.
+    //
+    // This is checked before the heavyweight branch below because it subsumes it: an NSMenu is an
+    // OS-owned window, so it is never occluded by the browser's native surface and needs none of
+    // the heavyweight-window machinery to say so.
+    //
+    // Falls through whenever the menu carries an icon or an inline trailing button, which a
+    // native menu item cannot render - see [isNativeRepresentable].
+    if (useNativeContextMenus() && items.isNativeRepresentable()) {
+        val dismiss by rememberUpdatedState(onDismissRequest)
+        // Keyed on the menu, not Unit: a second right-click composes a new ContextMenu with new
+        // items and must reopen at the new position rather than reuse the first effect.
+        DisposableEffect(items) {
+            val shown =
+                NativeContextMenus.show(
+                    nodes = items.toNativeMenuNodes(),
+                    // The pointer IS the intended position for a right-click menu, and reading it
+                    // from the OS avoids converting node-relative Compose pixels into screen
+                    // coordinates - a conversion this codebase has nowhere else.
+                    anchor = NativeMenuAnchor.Cursor,
+                    onDismiss = { dismiss() },
+                )
+            // Nothing was shown (no invoker, or the plan came out empty), so tell the caller
+            // rather than leaving it believing a menu is up.
+            if (!shown) dismiss()
+            onDispose { NativeContextMenus.hide() }
+        }
+        return
+    }
+
     val heavyweight = OverlayConfig.heavyweightPopup
     if (routeOverlayHeavyweight(heavyweight != null) && heavyweight != null) {
         // HARDWARE_ACCELERATED browser: a lightweight Compose Popup renders BEHIND the

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -512,7 +512,9 @@ fun BossTabsComponent.BossMainTabBar(
                                     add(
                                         ContextMenuItem(
                                             if (isFavorited) "Unfavorite Workspace" else "Favorite Workspace",
-                                            if (isFavorited) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                                            // The icon shows what the action DOES, matching the label: "Unfavorite"
+                                            // empties the star, "Favorite" fills it.
+                                            if (isFavorited) Icons.Outlined.StarBorder else Icons.Filled.Star,
                                             onClick = {
                                                 if (isFavorited) {
                                                     BookmarkAPIAccess.removeFavoriteWorkspace(currentWorkspace.id)
@@ -661,7 +663,9 @@ fun BossTabsComponent.BossMainTabBar(
                                         add(
                                             ContextMenuItem(
                                                 if (isFavorited) "Unfavorite Workspace" else "Favorite Workspace",
-                                                if (isFavorited) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                                                // The icon shows what the action DOES, matching the label: "Unfavorite"
+                                                // empties the star, "Favorite" fills it.
+                                                if (isFavorited) Icons.Outlined.StarBorder else Icons.Filled.Star,
                                                 onClick = {
                                                     if (isFavorited) {
                                                         BookmarkAPIAccess.removeFavoriteWorkspace(currentWorkspace.id)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
@@ -17,6 +17,18 @@ data class WindowAppearanceSettings(
      * Default: SHRINK_TO_FIT (Safari behaviour)
      */
     val tabWidthMode: TabWidthMode = TabWidthMode.SHRINK_TO_FIT,
+    /**
+     * Whether right-click menus are the operating system's own rather than BOSS-drawn.
+     *
+     * On macOS this renders a real NSMenu: system appearance and metrics, native keyboard
+     * navigation and accessibility, and correct behaviour over the browser's native surface,
+     * which a Compose popup is painted behind. Native menus cannot be themed, so turning this
+     * off restores the BOSS-styled menus.
+     *
+     * Currently macOS-only and ignored elsewhere - see `shouldUseNativeMenus` for why Windows
+     * and Linux stay on the drawn menus.
+     */
+    val useNativeContextMenus: Boolean = true,
 )
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/WindowAppearanceSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/WindowAppearanceSettings.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.settings.shared.SettingsDropdown
 import ai.rever.boss.components.settings.shared.SettingsInfoRow
 import ai.rever.boss.components.settings.shared.SettingsSection
 import ai.rever.boss.components.settings.shared.SettingsToggle
+import ai.rever.boss.plugin.ui.menu.NativeContextMenus
 import ai.rever.boss.window.TabWidthMode
 import ai.rever.boss.window.WindowAppearanceSettingsManager
 import androidx.compose.foundation.layout.*
@@ -52,6 +53,8 @@ fun WindowAppearanceSettings() {
             )
         }
 
+        NativeContextMenuSection()
+
         SettingsSection(title = "Tab Bar") {
             SettingsDropdown(
                 label = "Tab Sizing",
@@ -71,6 +74,35 @@ fun WindowAppearanceSettings() {
                         "and the bar scrolls when they overflow.",
             )
         }
+    }
+}
+
+/**
+ * macOS only - see `shouldUseNativeMenus` for why Windows and Linux stay on the drawn menus.
+ * Offering a toggle where it does nothing would just be a lie, so the whole section is hidden.
+ */
+@Composable
+private fun NativeContextMenuSection() {
+    if (!NativeContextMenus.isSupported()) return
+    val settings by WindowAppearanceSettingsManager.currentSettings.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+
+    SettingsSection(title = "Menus") {
+        SettingsToggle(
+            label = "Native Context Menus",
+            checked = settings.useNativeContextMenus,
+            onCheckedChange = { enabled ->
+                coroutineScope.launch {
+                    WindowAppearanceSettingsManager.updateSettings(
+                        settings.copy(useNativeContextMenus = enabled),
+                    )
+                }
+            },
+            description =
+                "Use macOS's own right-click menus. They follow the system appearance rather " +
+                    "than the BOSS theme, and are never hidden behind a web page. Off restores " +
+                    "the BOSS-styled menus.",
+        )
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/ContextMenuAttributionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/ContextMenuAttributionTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.overlays
 
 import ai.rever.boss.crash.pluginprobe.PluginProbeJar
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
+import ai.rever.boss.plugin.ui.menu.NativeMenuNode
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
@@ -14,6 +15,7 @@ import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.unit.dp
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -47,8 +49,22 @@ class ContextMenuAttributionTest {
 
     private val probe = PluginProbeJar.open(javaClass.classLoader)
 
+    /**
+     * These two tests find menu rows as Compose nodes, so they must run against the drawn menu.
+     * A native menu is an OS window with no Compose tree, which would make them fail on macOS and
+     * pass on CI for no reason connected to what they assert. The native path's own attribution is
+     * pinned separately below.
+     */
+    @Before
+    fun useDrawnMenu() {
+        NativeContextMenuTestOverride.enabled = false
+    }
+
     @After
-    fun tearDown() = probe.close()
+    fun tearDown() {
+        NativeContextMenuTestOverride.enabled = null
+        probe.close()
+    }
 
     @Test
     fun `a plugin's context-menu action runs inside that plugin's scope`() {
@@ -132,5 +148,44 @@ class ContextMenuAttributionTest {
         rule.waitForIdle()
         rule.onNodeWithText(label).performClick()
         rule.waitForIdle()
+    }
+
+    @Test
+    fun `the native path attributes a plugin action too`() {
+        // The native renderer builds java.awt.MenuItems, which cannot be constructed headlessly,
+        // so this asserts the conversion rather than the click: the wrapping is the whole of what
+        // attribution depends on, and it is what a port silently drops.
+        var scopeInsideAction: String? = "never invoked"
+        val pluginAction =
+            probe.action(
+                "probeReporter",
+                Runnable { scopeInsideAction = PluginExecutionBoundary.currentPluginId() },
+            )
+
+        val nodes = listOf(ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction)).toNativeMenuNodes()
+        (nodes.single() as NativeMenuNode.Item).action()
+
+        assertEquals(
+            PluginProbeJar.PLUGIN_ID,
+            scopeInsideAction,
+            "a native menu item must invoke a plugin action inside that plugin's attribution scope",
+        )
+    }
+
+    @Test
+    fun `the native path does not leave the plugin scope behind`() {
+        var scopeAfter: String? = "never invoked"
+        val pluginAction = probe.action("probeReporter", Runnable { })
+        val hostAction = { scopeAfter = PluginExecutionBoundary.currentPluginId() }
+
+        val nodes =
+            listOf(
+                ContextMenuItem(text = ITEM_LABEL, onClick = pluginAction),
+                ContextMenuItem(text = HOST_ITEM_LABEL, onClick = hostAction),
+            ).toNativeMenuNodes()
+        (nodes[0] as NativeMenuNode.Item).action()
+        (nodes[1] as NativeMenuNode.Item).action()
+
+        assertEquals(null, scopeAfter, "the plugin's scope must not still be on that thread")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NativeContextMenuRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NativeContextMenuRoutingTest.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.overlays
 import ai.rever.boss.plugin.ui.menu.NativeMenuNode
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.ui.graphics.ImageBitmap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -54,8 +55,39 @@ class NativeContextMenuRoutingTest {
     }
 
     @Test
-    fun `a leading icon disqualifies`() {
-        assertFalse(listOf(ContextMenuItem(text = "Open", icon = Icons.Filled.Delete)).isNativeRepresentable())
+    fun `a leading icon does NOT disqualify`() {
+        // Nearly every menu item in the app has one, so treating icons as blocking would leave
+        // essentially every menu on the drawn path. An icon is decoration; losing it costs
+        // appearance, not function.
+        assertTrue(listOf(ContextMenuItem(text = "Open", icon = Icons.Filled.Delete)).isNativeRepresentable())
+    }
+
+    @Test
+    fun `a realistic tab menu is representable`() {
+        // Mirrors BossMainWindowPanel's tab menu, which is icon-per-item throughout. This is the
+        // menu the feature is most visible on, so pin that it actually qualifies.
+        val items =
+            listOf(
+                ContextMenuItem("Split Right", Icons.Filled.Delete, onClick = {}),
+                ContextMenuItem(isDivider = true),
+                ContextMenuItem("Close Tab", Icons.Filled.Delete, onClick = {}),
+            )
+        assertTrue(items.isNativeRepresentable())
+    }
+
+    @Test
+    fun `a trailing button nested in a submenu still disqualifies`() {
+        val nested =
+            listOf(
+                ContextMenuItem(
+                    text = "Options",
+                    subMenu =
+                        listOf(
+                            ContextMenuItem(text = "Entry", trailingIcon = Icons.Filled.Delete),
+                        ),
+                ),
+            )
+        assertFalse(nested.isNativeRepresentable())
     }
 
     @Test
@@ -68,12 +100,12 @@ class NativeContextMenuRoutingTest {
                         listOf(
                             ContextMenuItem(
                                 text = "More",
-                                subMenu = listOf(ContextMenuItem(text = "Deep", icon = Icons.Filled.Delete)),
+                                subMenu = listOf(ContextMenuItem(text = "Deep", trailingIcon = Icons.Filled.Delete)),
                             ),
                         ),
                 ),
             )
-        assertFalse(nested.isNativeRepresentable(), "a rich item nested two levels down still counts")
+        assertFalse(nested.isNativeRepresentable(), "a trailing button two levels down still counts")
 
         val clean =
             listOf(
@@ -85,6 +117,57 @@ class NativeContextMenuRoutingTest {
     @Test
     fun `an empty menu is trivially representable`() {
         assertTrue(emptyList<ContextMenuItem>().isNativeRepresentable())
+    }
+
+    // ----- icons -----
+
+    @Test
+    fun `distinct icons are collected once, at any depth`() {
+        val a = Icons.Filled.Delete
+        val items =
+            listOf(
+                ContextMenuItem(text = "one", icon = a),
+                ContextMenuItem(text = "two", icon = a),
+                ContextMenuItem(
+                    text = "sub",
+                    subMenu = listOf(ContextMenuItem(text = "deep", icon = a)),
+                ),
+                ContextMenuItem(text = "none"),
+            )
+        // Same ImageVector used three times, rasterised once.
+        assertEquals(listOf(a), items.collectIcons())
+    }
+
+    @Test
+    fun `an item with no icon collects nothing`() {
+        assertTrue(listOf(ContextMenuItem(text = "plain")).collectIcons().isEmpty())
+    }
+
+    @Test
+    fun `a rasterised icon is carried onto the native node, including in submenus`() {
+        val vector = Icons.Filled.Delete
+        val bitmap = ImageBitmap(4, 4)
+        val nodes =
+            listOf(
+                ContextMenuItem(text = "top", icon = vector),
+                ContextMenuItem(
+                    text = "sub",
+                    subMenu = listOf(ContextMenuItem(text = "deep", icon = vector)),
+                ),
+            ).toNativeMenuNodes(mapOf(vector to bitmap))
+
+        assertEquals(bitmap, (nodes[0] as NativeMenuNode.Item).icon)
+        val submenu = nodes[1] as NativeMenuNode.Submenu
+        assertEquals(bitmap, (submenu.children.single() as NativeMenuNode.Item).icon)
+    }
+
+    @Test
+    fun `an unrasterised icon degrades to no icon rather than failing`() {
+        // The map is empty when rasterisation was skipped; the item must still render.
+        val nodes =
+            listOf(ContextMenuItem(text = "top", icon = Icons.Filled.Delete)).toNativeMenuNodes()
+        assertEquals(null, (nodes.single() as NativeMenuNode.Item).icon)
+        assertEquals("top", (nodes.single() as NativeMenuNode.Item).label)
     }
 
     // ----- conversion -----

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NativeContextMenuRoutingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NativeContextMenuRoutingTest.kt
@@ -1,0 +1,136 @@
+package ai.rever.boss.components.overlays
+
+import ai.rever.boss.plugin.ui.menu.NativeMenuNode
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The host-side half of the native menu decision: which menus are eligible, and how the app's
+ * richer [ContextMenuItem] collapses into the native model.
+ *
+ * Rendering itself is not reachable here - `java.awt.MenuComponent` throws `HeadlessException` -
+ * so the engine's own behaviour is covered in plugin-ui-core's `NativeContextMenusTest`.
+ */
+class NativeContextMenuRoutingTest {
+    // ----- eligibility -----
+
+    @Test
+    fun `a plain menu is representable`() {
+        val items =
+            listOf(
+                ContextMenuItem(text = "Split Right"),
+                ContextMenuItem(isDivider = true),
+                ContextMenuItem(text = "Close Tab"),
+            )
+        assertTrue(items.isNativeRepresentable())
+    }
+
+    @Test
+    fun `an inline trailing button makes a menu non-representable`() {
+        // The run-history and sidebar menus use these for inline delete and edit. Dropping them
+        // silently would remove an affordance rather than merely restyle it.
+        val items =
+            listOf(
+                ContextMenuItem(
+                    text = "npm run dev",
+                    trailingIcon = Icons.Filled.Delete,
+                    onTrailingClick = {},
+                ),
+            )
+        assertFalse(items.isNativeRepresentable())
+    }
+
+    @Test
+    fun `a second trailing button also disqualifies`() {
+        val items =
+            listOf(
+                ContextMenuItem(text = "entry", secondaryTrailingIcon = Icons.Filled.Delete),
+            )
+        assertFalse(items.isNativeRepresentable())
+    }
+
+    @Test
+    fun `a leading icon disqualifies`() {
+        assertFalse(listOf(ContextMenuItem(text = "Open", icon = Icons.Filled.Delete)).isNativeRepresentable())
+    }
+
+    @Test
+    fun `a submenu is inspected too, at any depth`() {
+        val nested =
+            listOf(
+                ContextMenuItem(
+                    text = "Options",
+                    subMenu =
+                        listOf(
+                            ContextMenuItem(
+                                text = "More",
+                                subMenu = listOf(ContextMenuItem(text = "Deep", icon = Icons.Filled.Delete)),
+                            ),
+                        ),
+                ),
+            )
+        assertFalse(nested.isNativeRepresentable(), "a rich item nested two levels down still counts")
+
+        val clean =
+            listOf(
+                ContextMenuItem(text = "Options", subMenu = listOf(ContextMenuItem(text = "Save"))),
+            )
+        assertTrue(clean.isNativeRepresentable())
+    }
+
+    @Test
+    fun `an empty menu is trivially representable`() {
+        assertTrue(emptyList<ContextMenuItem>().isNativeRepresentable())
+    }
+
+    // ----- conversion -----
+
+    @Test
+    fun `dividers become separators and items keep their label`() {
+        val nodes =
+            listOf(
+                ContextMenuItem(text = "New Tab"),
+                ContextMenuItem(isDivider = true),
+                ContextMenuItem(text = "Close"),
+            ).toNativeMenuNodes()
+
+        assertEquals(3, nodes.size)
+        assertEquals("New Tab", (nodes[0] as NativeMenuNode.Item).label)
+        assertEquals(NativeMenuNode.Separator, nodes[1])
+        assertEquals("Close", (nodes[2] as NativeMenuNode.Item).label)
+    }
+
+    @Test
+    fun `submenus convert recursively`() {
+        val nodes =
+            listOf(
+                ContextMenuItem(
+                    text = "Share",
+                    subMenu = listOf(ContextMenuItem(text = "Tab"), ContextMenuItem(text = "Window")),
+                ),
+            ).toNativeMenuNodes()
+
+        val submenu = nodes.single() as NativeMenuNode.Submenu
+        assertEquals("Share", submenu.label)
+        assertEquals(listOf("Tab", "Window"), submenu.children.map { (it as NativeMenuNode.Item).label })
+    }
+
+    @Test
+    fun `the click handler is carried across, not dropped`() {
+        var fired = 0
+        val nodes = listOf(ContextMenuItem(text = "Go", onClick = { fired += 1 })).toNativeMenuNodes()
+        (nodes.single() as NativeMenuNode.Item).action()
+        assertEquals(1, fired)
+    }
+
+    @Test
+    fun `a divider that also carries text is still a separator`() {
+        // isDivider wins: the drawn renderer ignores text on a divider row too.
+        val nodes = listOf(ContextMenuItem(text = "ignored", isDivider = true)).toNativeMenuNodes()
+        assertEquals(NativeMenuNode.Separator, nodes.single())
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.kt
@@ -1,0 +1,168 @@
+package ai.rever.boss.plugin.ui.menu
+
+/**
+ * A menu described in terms an operating-system menu can actually render.
+ *
+ * Deliberately narrower than the app's own `ContextMenuItem`: a native menu item is a label, an
+ * enabled flag, an optional shortcut, and nothing else. No icon, no inline trailing buttons, no
+ * per-item colour. Anything richer has to be expressed as structure (a submenu) rather than as
+ * decoration, which is why callers convert into this model instead of it mirroring theirs.
+ */
+sealed interface NativeMenuNode {
+    /**
+     * [shortcut] is display-only. An AWT `MenuShortcut` renders as the platform's menu-key glyph
+     * but does NOT register a live key equivalent, so it cannot double-fire with the app's own
+     * accelerator handling. It must be an uppercase letter or a digit, whose char code IS the
+     * matching `KeyEvent.VK_*` constant; lowercase 'c' is 99, which is not a VK constant at all.
+     */
+    data class Item(
+        val label: String,
+        val enabled: Boolean = true,
+        val shortcut: Char? = null,
+        val action: () -> Unit = {},
+    ) : NativeMenuNode {
+        init {
+            require(shortcut == null || shortcut in 'A'..'Z' || shortcut in '0'..'9') {
+                "shortcut must be an uppercase letter or digit, was '$shortcut'"
+            }
+        }
+    }
+
+    data object Separator : NativeMenuNode
+
+    data class Submenu(
+        val label: String,
+        val children: List<NativeMenuNode>,
+    ) : NativeMenuNode
+}
+
+/** Where the menu should appear. */
+sealed interface NativeMenuAnchor {
+    /**
+     * At the mouse cursor, read from the OS at show time.
+     *
+     * This is the right default for a right-click menu and it sidesteps a real problem: Compose
+     * pointer coordinates are node-relative and in Compose pixels, while a native menu needs
+     * screen coordinates in AWT units. Reading the cursor avoids the conversion entirely.
+     */
+    data object Cursor : NativeMenuAnchor
+
+    /** Absolute screen coordinates, for menus anchored to a widget rather than the pointer. */
+    data class Screen(
+        val x: Int,
+        val y: Int,
+    ) : NativeMenuAnchor
+}
+
+/**
+ * Native menus are enabled on macOS only.
+ *
+ * macOS is the platform whose behaviour was actually measured (`java.awt.PopupMenu` is peered
+ * onto a real `NSMenu` there): `show()` does not block, nothing cancels an open menu, there is no
+ * dismissal event but an open menu holds the input grab, and `MenuShortcut` is display-only. The
+ * other two are excluded for different reasons:
+ *
+ * - **Windows**: unverified and plausibly worse. `WPopupMenuPeer` appears to reach
+ *   `::TrackPopupMenu` through `AwtToolkit::SyncCall`, which would block the EDT for as long as
+ *   the menu is open, freezing the UI. `TrackPopupMenu` also renders the classic Win32 menu,
+ *   which does not follow system dark mode without `uxtheme` work AWT does not do.
+ * - **Linux**: the AWT peer is the Motif-era XAWT menu, which ignores GTK.
+ *
+ * The engine is otherwise platform-neutral. Widening it is this one predicate plus a measurement
+ * on that platform with the same harness.
+ */
+fun shouldUseNativeMenus(
+    settingEnabled: Boolean,
+    isMacOs: Boolean,
+): Boolean = settingEnabled && isMacOs
+
+/**
+ * Normalise a menu for native rendering.
+ *
+ * Two jobs, both of which exist because callers build menus conditionally:
+ *
+ * - **Separator hygiene.** Leading, trailing and consecutive separators are dropped, and an empty
+ *   submenu is removed entirely. A menu assembled with `if` guards routinely produces those, and
+ *   a native menu renders a dangling separator as a stray line rather than ignoring it.
+ * - **Mnemonic escaping.** On Windows, `AppendMenu`/`SetMenuItemInfo` treat `&` in an `MFT_STRING`
+ *   as a mnemonic prefix, so a label like `feat/a&b` would render as `feat/ab` with an underlined
+ *   `b`. Labels here are user data (branch names, file names, workspace names), so this is
+ *   reachable in ordinary use. Unreachable while the gate is macOS-only, but kept and tested so
+ *   widening the gate cannot silently mangle text.
+ */
+fun planNativeMenu(
+    nodes: List<NativeMenuNode>,
+    isWindows: Boolean = false,
+): List<NativeMenuNode> {
+    val planned = ArrayList<NativeMenuNode>(nodes.size)
+    for (node in nodes) {
+        when (node) {
+            is NativeMenuNode.Separator -> {
+                // Drop leading and consecutive separators; a trailing one is trimmed below.
+                if (planned.isNotEmpty() && planned.last() !is NativeMenuNode.Separator) {
+                    planned += NativeMenuNode.Separator
+                }
+            }
+
+            is NativeMenuNode.Item -> {
+                planned +=
+                    node.copy(
+                        label = escapeNativeLabel(node.label, isWindows),
+                    )
+            }
+
+            is NativeMenuNode.Submenu -> {
+                val children = planNativeMenu(node.children, isWindows)
+                // A submenu with nothing in it is an unopenable dead row.
+                if (children.isNotEmpty()) {
+                    planned +=
+                        NativeMenuNode.Submenu(
+                            label = escapeNativeLabel(node.label, isWindows),
+                            children = children,
+                        )
+                }
+            }
+        }
+    }
+    while (planned.lastOrNull() is NativeMenuNode.Separator) planned.removeAt(planned.lastIndex)
+    return planned
+}
+
+/** See the mnemonic note on [planNativeMenu]. */
+fun escapeNativeLabel(
+    label: String,
+    isWindows: Boolean,
+): String = if (isWindows) label.replace("&", "&&") else label
+
+/**
+ * Shows real operating-system context menus.
+ *
+ * Lives here rather than in the app so that plugins, which resolve `ai.rever.boss.plugin.ui.*`
+ * parent-first from the host, get the same menus as host UI does.
+ */
+expect object NativeContextMenus {
+    /** True when this platform is one whose native menu behaviour has been verified. */
+    fun isSupported(): Boolean
+
+    /**
+     * Show [nodes] as a native menu.
+     *
+     * Returns false when nothing was shown, in which case the caller must fall back to its own
+     * menu. [onDismiss] fires exactly once for a menu that was shown, whether it was dismissed by
+     * selecting an item, clicking away, pressing Escape or switching applications.
+     */
+    fun show(
+        nodes: List<NativeMenuNode>,
+        anchor: NativeMenuAnchor = NativeMenuAnchor.Cursor,
+        onDismiss: () -> Unit = {},
+    ): Boolean
+
+    /**
+     * Give up ownership of the menu currently on screen.
+     *
+     * Advisory: an open OS menu cannot be dismissed programmatically. This makes its items inert
+     * and greys them out, so a menu that outlives the UI that opened it cannot act on state that
+     * has already gone away.
+     */
+    fun hide()
+}

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.kt
@@ -101,6 +101,20 @@ fun shouldUseNativeMenus(
 ): Boolean = settingEnabled && isMacOs
 
 /**
+ * Whether a native menu can be produced at all.
+ *
+ * Lifted out of [NativeContextMenus.show] because `isSupported()` short-circuits everything on a
+ * non-macOS machine, so a test that goes through `show()` on CI only ever re-tests the platform
+ * gate - it can never reach the EDT or empty-plan guards it claims to cover. The whole design
+ * leans on this answer being honest, so it gets coverage that actually runs everywhere.
+ */
+fun canShowNatively(
+    isSupported: Boolean,
+    isEventDispatchThread: Boolean,
+    plannedSize: Int,
+): Boolean = isSupported && isEventDispatchThread && plannedSize > 0
+
+/**
  * Normalise a menu for native rendering.
  *
  * Two jobs, both of which exist because callers build menus conditionally:

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.plugin.ui.menu
 
+import androidx.compose.ui.graphics.ImageBitmap
+
 /**
  * A menu described in terms an operating-system menu can actually render.
  *
@@ -19,6 +21,17 @@ sealed interface NativeMenuNode {
         val label: String,
         val enabled: Boolean = true,
         val shortcut: Char? = null,
+        /**
+         * Already rasterised, because only the caller is in a composition and can resolve density.
+         * Applied through the macOS menu peer, which does support images even though the public
+         * `java.awt.MenuItem` API does not - see the desktop implementation.
+         *
+         * Must be square and rasterised at [NATIVE_MENU_ICON_SCALE] times
+         * [NATIVE_MENU_ICON_POINTS]. AppKit reads a plain bitmap's **pixel** dimensions as its
+         * **point** size, so handing it a Retina-sized bitmap renders an icon twice too large;
+         * the desktop side turns this into a multi-resolution image to state the point size.
+         */
+        val icon: ImageBitmap? = null,
         val action: () -> Unit = {},
     ) : NativeMenuNode {
         init {
@@ -35,6 +48,17 @@ sealed interface NativeMenuNode {
         val children: List<NativeMenuNode>,
     ) : NativeMenuNode
 }
+
+/**
+ * The point size a native menu icon should occupy.
+ *
+ * macOS's own menu-item checkmark is 14x13pt, and 16pt is the common convention for custom menu
+ * icons, so this sits at the top of the system's own range rather than inventing a size.
+ */
+const val NATIVE_MENU_ICON_POINTS: Int = 16
+
+/** Rasterise at 2x so the icon stays crisp on Retina; the base variant states the point size. */
+const val NATIVE_MENU_ICON_SCALE: Int = 2
 
 /** Where the menu should appear. */
 sealed interface NativeMenuAnchor {
@@ -105,10 +129,7 @@ fun planNativeMenu(
             }
 
             is NativeMenuNode.Item -> {
-                planned +=
-                    node.copy(
-                        label = escapeNativeLabel(node.label, isWindows),
-                    )
+                planned += node.copy(label = escapeNativeLabel(node.label, isWindows))
             }
 
             is NativeMenuNode.Submenu -> {

--- a/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.ui.menu
 
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toAwtImage
 import java.awt.AWTEvent
 import java.awt.Dialog
 import java.awt.Frame
@@ -418,8 +419,15 @@ private fun NativeMenuNode.Item.toAwtItem(
             isEnabled = node.enabled
             node.shortcut?.let { setShortcut(java.awt.MenuShortcut(it.code)) }
             addActionListener {
-                if (isCurrent()) node.action()
-                onDismiss()
+                // finally, because the action is invokeAttributed, which rethrows by design.
+                // Without this the popup stays attached, the watcher stays installed and the
+                // caller never learns the menu closed - so its state says a menu is up while the
+                // OS menu is already gone, and no further right-click can reopen it.
+                try {
+                    if (isCurrent()) node.action()
+                } finally {
+                    runCatching { onDismiss() }
+                }
             }
         }
     node.icon?.let { pendingIcons += item to it }
@@ -466,20 +474,8 @@ private object MenuItemIcons {
             val (accessor, getPeer) = peerAccessor ?: return
             val peer = getPeer.invoke(accessor, item) ?: return
             val setImage = peer.javaClass.getMethod("setImage", java.awt.Image::class.java)
-            setImage.invoke(peer, icon.toBufferedImage().asMenuIcon())
+            setImage.invoke(peer, icon.toAwtImage().asMenuIcon())
         }
-    }
-
-    /**
-     * Compose 1.11.1 has no `toAwtImage`, so copy the pixels out directly. ImageBitmap hands back
-     * packed ARGB, which is exactly `TYPE_INT_ARGB`'s layout.
-     */
-    private fun ImageBitmap.toBufferedImage(): BufferedImage {
-        val pixels = IntArray(width * height)
-        readPixels(pixels, startX = 0, startY = 0, width = width, height = height)
-        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-        image.setRGB(0, 0, width, height, pixels, 0, width)
-        return image
     }
 
     /**

--- a/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
@@ -75,6 +75,8 @@ internal object OsFamily {
  * safe. Separate from the facade so the AWT mechanics are not mixed into the public surface.
  */
 internal class AwtPopupPresenter {
+    // EDT-only: show() declines off the EDT and hide() posts.
+    @Volatile
     private var attached: Pair<Window, java.awt.PopupMenu>? = null
     private val watcher = DismissWatcher()
 
@@ -83,30 +85,36 @@ internal class AwtPopupPresenter {
      * built for and no-op once ownership has moved on - which is what actually protects against a
      * menu outliving the UI that opened it and then acting on state that has gone away.
      */
+    @Volatile
     private var generation: Long = 0L
 
+    // Guard clauses, each declining for a different reason. Flattening them into one nested
+    // expression would obscure exactly what this function exists to make clear: every path that
+    // cannot produce a menu must say so, so the caller can draw its own.
+    @Suppress("ReturnCount")
     fun show(
         nodes: List<NativeMenuNode>,
         anchor: NativeMenuAnchor,
         onDismiss: () -> Unit,
     ): Boolean {
+        // Decided synchronously, because the caller uses the return value to choose between this
+        // and its own menu. Posting the work would mean reporting success before knowing whether
+        // a menu appears, and a later failure would then leave the right-click doing nothing at
+        // all - the outcome the fallback exists to prevent. Callers are on the EDT (Compose's
+        // main dispatcher); off it, decline.
+        if (!SwingUtilities.isEventDispatchThread()) return false
+
         val planned = planNativeMenu(nodes, OsFamily.isWindows)
         if (planned.isEmpty()) return false
+
+        val at = anchor.resolveScreenPoint()
+        val invoker = resolveInvoker(at) ?: return false
 
         generation += 1
         val shown = generation
         val isCurrent = { generation == shown }
 
-        onEdt {
-            val at = anchor.resolveScreenPoint()
-            val invoker = resolveInvoker(at)
-            if (invoker == null) {
-                // Nothing to hang the popup off. Report dismissal so a caller tracking visibility
-                // cannot stay pinned for a menu that never appeared.
-                onDismiss()
-                return@onEdt
-            }
-
+        run {
             // A PopupMenu must hang off a live Component and AWT keeps it as a child until
             // removed, so detach the previous one rather than accumulating menus on the window.
             detach()
@@ -130,8 +138,17 @@ internal class AwtPopupPresenter {
             // show(), so this is the one window where icons can be applied.
             pendingIcons.forEach { (item, icon) -> MenuItemIcons.apply(item, icon) }
 
-            val local = at.toInvokerCoordinates(invoker)
-            popup.show(invoker, local.x, local.y)
+            val local =
+                at.toInvokerCoordinates(invoker) ?: run {
+                    detach()
+                    return false
+                }
+            // The one call left that can still fail. An escaping exception would leave the caller
+            // believing a menu is up when none is, so decline and let it draw its own.
+            if (runCatching { popup.show(invoker, local.x, local.y) }.isFailure) {
+                detach()
+                return false
+            }
             // Armed after show() (which returns in ~0 ms) so the grace window covers only the gap
             // before the OS takes the input grab, not the invoker resolution before it.
             myWatcher = watcher.install(dismissed)
@@ -143,7 +160,11 @@ internal class AwtPopupPresenter {
     }
 
     fun hide() {
-        generation += 1
+        // Only invalidate while a menu is actually attached. hide() routinely runs from teardown
+        // triggered BY the menu dismissing itself (a DisposableEffect's onDispose), and bumping
+        // unconditionally would fence off the item's own ActionEvent if it is still queued - so
+        // the click the user just made would silently do nothing.
+        if (attached != null) generation += 1
         onEdt {
             watcher.clear()
             // Grey out an orphan before letting go of it. The fence already makes it inert, but
@@ -167,22 +188,28 @@ internal class AwtPopupPresenter {
             }
         }
 
-    /** Falls back to the invoker's own origin when there is no pointer to read. */
-    private fun Point?.toInvokerCoordinates(invoker: Window): Point {
+    /** Null when the origin is unknowable - better to decline than to guess the window corner. */
+    private fun Point?.toInvokerCoordinates(invoker: Window): Point? {
         val origin = runCatching { invoker.locationOnScreen }.getOrNull()
         val screen = this
         return if (origin == null || screen == null) {
-            Point(0, 0)
+            null
         } else {
             Point(screen.x - origin.x, screen.y - origin.y)
         }
     }
 
     private fun resolveInvoker(at: Point?): Window? {
+        // The focused window is only a shortcut if it satisfies what pickInvoker would demand of
+        // it. With several windows open - a main frame, Settings, a detached browser - the
+        // focused one need not contain the click, and using it anyway subtracts the wrong origin
+        // and puts the menu far from the pointer. It must also be a real frame or dialog, since
+        // getWindows() returns the heavyweight windows Swing creates for popups.
         KeyboardFocusManager
             .getCurrentKeyboardFocusManager()
             .focusedWindow
-            ?.takeIf { it.isShowing }
+            ?.takeIf { it is Frame || it is Dialog }
+            ?.takeIf { it.isShowing && (at == null || it.bounds.contains(at)) }
             ?.let { return it }
 
         val candidates =

--- a/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.ui.menu
 
+import androidx.compose.ui.graphics.ImageBitmap
 import java.awt.AWTEvent
 import java.awt.Dialog
 import java.awt.Frame
@@ -11,6 +12,7 @@ import java.awt.Toolkit
 import java.awt.Window
 import java.awt.event.AWTEventListener
 import java.awt.event.MouseEvent
+import java.awt.image.BufferedImage
 import javax.swing.SwingUtilities
 
 /**
@@ -120,9 +122,13 @@ internal class AwtPopupPresenter {
                 watcher.clearIf(myWatcher)
                 onDismiss()
             }
-            materialize(popup, planned, isCurrent, dismissed)
+            val pendingIcons = mutableListOf<Pair<java.awt.MenuItem, ImageBitmap>>()
+            materialize(popup, planned, isCurrent, dismissed, pendingIcons)
             invoker.add(popup)
             attached = invoker to popup
+            // Peers only exist once the menu is realised by add(), and setImage works before
+            // show(), so this is the one window where icons can be applied.
+            pendingIcons.forEach { (item, icon) -> MenuItemIcons.apply(item, icon) }
 
             val local = at.toInvokerCoordinates(invoker)
             popup.show(invoker, local.x, local.y)
@@ -205,6 +211,7 @@ internal class AwtPopupPresenter {
         nodes: List<NativeMenuNode>,
         isCurrent: () -> Boolean,
         onDismiss: () -> Unit,
+        pendingIcons: MutableList<Pair<java.awt.MenuItem, ImageBitmap>>,
     ) {
         nodes.forEach { node ->
             when (node) {
@@ -213,22 +220,13 @@ internal class AwtPopupPresenter {
                 }
 
                 is NativeMenuNode.Item -> {
-                    menu.add(
-                        java.awt.MenuItem(node.label).apply {
-                            isEnabled = node.enabled
-                            node.shortcut?.let { shortcut = java.awt.MenuShortcut(it.code) }
-                            addActionListener {
-                                if (isCurrent()) node.action()
-                                onDismiss()
-                            }
-                        },
-                    )
+                    menu.add(node.toAwtItem(isCurrent, onDismiss, pendingIcons))
                 }
 
                 is NativeMenuNode.Submenu -> {
                     menu.add(
                         java.awt.Menu(node.label).also {
-                            materialize(it, node.children, isCurrent, onDismiss)
+                            materialize(it, node.children, isCurrent, onDismiss, pendingIcons)
                         },
                     )
                 }
@@ -370,3 +368,104 @@ internal fun <T> pickInvoker(
             compareByDescending<InvokerCandidate<T>> { it.isActive }
                 .thenBy { it.bounds.width.toLong() * it.bounds.height.toLong() },
         )
+
+/** Build the AWT item for one node, queueing its icon for after the peer exists. */
+private fun NativeMenuNode.Item.toAwtItem(
+    isCurrent: () -> Boolean,
+    onDismiss: () -> Unit,
+    pendingIcons: MutableList<Pair<java.awt.MenuItem, ImageBitmap>>,
+): java.awt.MenuItem {
+    val node = this
+    val item =
+        java.awt.MenuItem(node.label).apply {
+            isEnabled = node.enabled
+            node.shortcut?.let { setShortcut(java.awt.MenuShortcut(it.code)) }
+            addActionListener {
+                if (isCurrent()) node.action()
+                onDismiss()
+            }
+        }
+    node.icon?.let { pendingIcons += item to it }
+    return item
+}
+
+/**
+ * Puts an icon on a native menu item.
+ *
+ * `java.awt.MenuItem` has no icon API, but its macOS peer does: `sun.lwawt.macosx.CMenuItem`
+ * declares `public void setImage(Image)`, and the JDK's own comment on it says the intended
+ * access is an `instanceof` on the peer, because "we want to support the NSMenuItem image apis".
+ *
+ * The peer is reached through `sun.awt.AWTAccessor$MenuComponentAccessor`, deliberately resolving
+ * the method on the **public interface** rather than on the accessor's implementation class. The
+ * implementation is an anonymous class in `java.awt`, so going through it would need
+ * `--add-opens java.desktop/java.awt`, which this app does not set. Through the interface, the
+ * `sun.awt` and `sun.lwawt.macosx` opens it already has on macOS are enough. Verified both ways.
+ *
+ * Everything is best-effort: this is private JDK API, so a failure drops the icon and keeps the
+ * menu rather than taking the right-click down.
+ */
+private object MenuItemIcons {
+    private val peerAccessor: Pair<Any, java.lang.reflect.Method>? by lazy {
+        runCatching {
+            val accessor =
+                Class
+                    .forName("sun.awt.AWTAccessor")
+                    .getMethod("getMenuComponentAccessor")
+                    .invoke(null)
+            val getPeer =
+                Class
+                    .forName("sun.awt.AWTAccessor\$MenuComponentAccessor")
+                    .getMethod("getPeer", java.awt.MenuComponent::class.java)
+            accessor!! to getPeer
+        }.getOrNull()
+    }
+
+    fun apply(
+        item: java.awt.MenuItem,
+        icon: ImageBitmap,
+    ) {
+        runCatching {
+            val (accessor, getPeer) = peerAccessor ?: return
+            val peer = getPeer.invoke(accessor, item) ?: return
+            val setImage = peer.javaClass.getMethod("setImage", java.awt.Image::class.java)
+            setImage.invoke(peer, icon.toBufferedImage().asMenuIcon())
+        }
+    }
+
+    /**
+     * Compose 1.11.1 has no `toAwtImage`, so copy the pixels out directly. ImageBitmap hands back
+     * packed ARGB, which is exactly `TYPE_INT_ARGB`'s layout.
+     */
+    private fun ImageBitmap.toBufferedImage(): BufferedImage {
+        val pixels = IntArray(width * height)
+        readPixels(pixels, startX = 0, startY = 0, width = width, height = height)
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        image.setRGB(0, 0, width, height, pixels, 0, width)
+        return image
+    }
+
+    /**
+     * State the icon's size in POINTS, not pixels.
+     *
+     * `CImage.createFromImage` branches on `MultiResolutionImage`: given one, it builds an NSImage
+     * from the variants, and the base variant's dimensions become the image's point size. Given a
+     * plain bitmap it instead uses the raw pixel dimensions as the point size, so a 2x bitmap
+     * renders at twice the intended size - which is exactly what a Retina rasterisation produced
+     * before this existed.
+     */
+    private fun BufferedImage.asMenuIcon(): java.awt.Image {
+        val points = NATIVE_MENU_ICON_POINTS
+        if (width == points) return this
+        val base = BufferedImage(points, points, BufferedImage.TYPE_INT_ARGB)
+        base.createGraphics().apply {
+            setRenderingHint(
+                java.awt.RenderingHints.KEY_INTERPOLATION,
+                java.awt.RenderingHints.VALUE_INTERPOLATION_BILINEAR,
+            )
+            drawImage(this@asMenuIcon, 0, 0, points, points, null)
+            dispose()
+        }
+        return java.awt.image.BaseMultiResolutionImage(base, this)
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
@@ -102,10 +102,15 @@ internal class AwtPopupPresenter {
         // a menu appears, and a later failure would then leave the right-click doing nothing at
         // all - the outcome the fallback exists to prevent. Callers are on the EDT (Compose's
         // main dispatcher); off it, decline.
-        if (!SwingUtilities.isEventDispatchThread()) return false
-
         val planned = planNativeMenu(nodes, OsFamily.isWindows)
-        if (planned.isEmpty()) return false
+        if (!canShowNatively(
+                isSupported = true,
+                isEventDispatchThread = SwingUtilities.isEventDispatchThread(),
+                plannedSize = planned.size,
+            )
+        ) {
+            return false
+        }
 
         val at = anchor.resolveScreenPoint()
         val invoker = resolveInvoker(at) ?: return false
@@ -117,6 +122,11 @@ internal class AwtPopupPresenter {
         run {
             // A PopupMenu must hang off a live Component and AWT keeps it as a child until
             // removed, so detach the previous one rather than accumulating menus on the window.
+            // Grey it out first: per measured fact 2 the outgoing NSMenu may still be tracking on
+            // screen, and once detached hide() has no handle left to disable it with. The fence
+            // already makes its items inert, but a menu that looks live and does nothing reads as
+            // a hang. Reachable via the keyboard menu key, which does not consume the grab.
+            attached?.let { (_, menu) -> runCatching { disableAll(menu) } }
             detach()
 
             val popup = java.awt.PopupMenu()

--- a/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopMain/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenus.desktop.kt
@@ -1,0 +1,372 @@
+package ai.rever.boss.plugin.ui.menu
+
+import java.awt.AWTEvent
+import java.awt.Dialog
+import java.awt.Frame
+import java.awt.KeyboardFocusManager
+import java.awt.MouseInfo
+import java.awt.Point
+import java.awt.Rectangle
+import java.awt.Toolkit
+import java.awt.Window
+import java.awt.event.AWTEventListener
+import java.awt.event.MouseEvent
+import javax.swing.SwingUtilities
+
+/**
+ * `java.awt.PopupMenu`, which on macOS is peered by `sun.lwawt.macosx.CPopupMenu` onto a real
+ * `NSMenu` (`CMenu.getNativeMenu()` hands back the `NSMenu*`, and `libawt_lwawt.dylib` carries
+ * `popUpMenuPositioningItem:atLocation:inView:`).
+ *
+ * Four behaviours were **measured** with a throwaway harness rather than read out of the JDK
+ * sources, and each one shapes the code below. Do not re-derive them:
+ *
+ * 1. `show()` does **not** block. It returns in ~0 ms and the EDT stays live, so Compose keeps
+ *    painting while the menu is up. It also means its return is not a dismissal signal.
+ * 2. **Nothing cancels an open menu.** `setVisible(false)`, `remove()` and `dispose()` on the
+ *    invoker all leave it tracking and selectable. So [hide] cannot dismiss; correctness rests on
+ *    the generation fence, which makes a lingering menu's items inert.
+ * 3. **There is no dismissal event on any AWT mask.** But an open menu holds the input grab and
+ *    lets nothing through (dragging the pointer across it, and pressing and releasing a modifier,
+ *    both delivered zero events), while dismissal produces an immediate burst: `MOUSE_EXITED`,
+ *    the Escape key-release, then `MOUSE_ENTERED`. So "clear on the next input event" cannot fire
+ *    early and fires promptly.
+ * 4. `MenuShortcut` is **display-only** - no live key equivalent, so glyphs cannot double-fire
+ *    with the app's own accelerators. Menu items **can** be disabled while the menu is open, and
+ *    a disabled item does not activate; that is what lets [hide] grey an orphan.
+ *
+ * Fact 3 is specifically an NSMenu-tracking property and is the first thing to re-measure if
+ * [shouldUseNativeMenus] ever widens past macOS.
+ */
+actual object NativeContextMenus {
+    private val presenter = AwtPopupPresenter()
+
+    actual fun isSupported(): Boolean = OsFamily.isMac
+
+    actual fun show(
+        nodes: List<NativeMenuNode>,
+        anchor: NativeMenuAnchor,
+        onDismiss: () -> Unit,
+    ): Boolean = if (isSupported()) presenter.show(nodes, anchor, onDismiss) else false
+
+    actual fun hide() = presenter.hide()
+
+    // Re-exported for tests: the dismissal heuristic is the least obvious thing in this file and
+    // the one most likely to need re-measuring if the platform gate ever widens.
+    internal const val DISMISS_GRACE_MS = DismissWatcher.DISMISS_GRACE_MS
+
+    internal fun isDismissalEvent(
+        eventId: Int,
+        elapsedMs: Long,
+    ): Boolean = DismissWatcher.isDismissalEvent(eventId, elapsedMs)
+}
+
+/** Cached once: `os.name` cannot change while the process runs. */
+internal object OsFamily {
+    private val name: String = System.getProperty("os.name")?.lowercase().orEmpty()
+    val isMac: Boolean = name.contains("mac")
+    val isWindows: Boolean = name.contains("windows")
+}
+
+/**
+ * Owns the one popup that can be on screen at a time, plus the state that makes a lingering menu
+ * safe. Separate from the facade so the AWT mechanics are not mixed into the public surface.
+ */
+internal class AwtPopupPresenter {
+    private var attached: Pair<Window, java.awt.PopupMenu>? = null
+    private val watcher = DismissWatcher()
+
+    /**
+     * Bumped on every show and on [hide]. Item actions are fenced on the generation they were
+     * built for and no-op once ownership has moved on - which is what actually protects against a
+     * menu outliving the UI that opened it and then acting on state that has gone away.
+     */
+    private var generation: Long = 0L
+
+    fun show(
+        nodes: List<NativeMenuNode>,
+        anchor: NativeMenuAnchor,
+        onDismiss: () -> Unit,
+    ): Boolean {
+        val planned = planNativeMenu(nodes, OsFamily.isWindows)
+        if (planned.isEmpty()) return false
+
+        generation += 1
+        val shown = generation
+        val isCurrent = { generation == shown }
+
+        onEdt {
+            val at = anchor.resolveScreenPoint()
+            val invoker = resolveInvoker(at)
+            if (invoker == null) {
+                // Nothing to hang the popup off. Report dismissal so a caller tracking visibility
+                // cannot stay pinned for a menu that never appeared.
+                onDismiss()
+                return@onEdt
+            }
+
+            // A PopupMenu must hang off a live Component and AWT keeps it as a child until
+            // removed, so detach the previous one rather than accumulating menus on the window.
+            detach()
+
+            val popup = java.awt.PopupMenu()
+            // Tear down only what THIS menu installed. `materialize` runs an item's action BEFORE
+            // dismissing, so an action that opens another menu would otherwise have its
+            // successor's popup and watcher torn down underneath it, and the generation fence
+            // would then swallow the successor's dismissal.
+            var myWatcher: AWTEventListener? = null
+            val dismissed = {
+                detachIf(popup)
+                watcher.clearIf(myWatcher)
+                onDismiss()
+            }
+            materialize(popup, planned, isCurrent, dismissed)
+            invoker.add(popup)
+            attached = invoker to popup
+
+            val local = at.toInvokerCoordinates(invoker)
+            popup.show(invoker, local.x, local.y)
+            // Armed after show() (which returns in ~0 ms) so the grace window covers only the gap
+            // before the OS takes the input grab, not the invoker resolution before it.
+            myWatcher = watcher.install(dismissed)
+            // No watcher means no dismissal signal will ever arrive. A caller left believing the
+            // menu is still up is the worse direction, so report dismissal now.
+            if (myWatcher == null) dismissed()
+        }
+        return true
+    }
+
+    fun hide() {
+        generation += 1
+        onEdt {
+            watcher.clear()
+            // Grey out an orphan before letting go of it. The fence already makes it inert, but
+            // "clicks and nothing happens" reads as a hang; disabling items on an OPEN menu was
+            // measured to be safe and to stop them activating.
+            attached?.let { (_, menu) -> runCatching { disableAll(menu) } }
+            detach()
+        }
+    }
+
+    // ---- invoker selection -------------------------------------------------------------------
+
+    private fun NativeMenuAnchor.resolveScreenPoint(): Point? =
+        when (this) {
+            is NativeMenuAnchor.Screen -> {
+                Point(x, y)
+            }
+
+            NativeMenuAnchor.Cursor -> {
+                runCatching { MouseInfo.getPointerInfo()?.location }.getOrNull()
+            }
+        }
+
+    /** Falls back to the invoker's own origin when there is no pointer to read. */
+    private fun Point?.toInvokerCoordinates(invoker: Window): Point {
+        val origin = runCatching { invoker.locationOnScreen }.getOrNull()
+        val screen = this
+        return if (origin == null || screen == null) {
+            Point(0, 0)
+        } else {
+            Point(screen.x - origin.x, screen.y - origin.y)
+        }
+    }
+
+    private fun resolveInvoker(at: Point?): Window? {
+        KeyboardFocusManager
+            .getCurrentKeyboardFocusManager()
+            .focusedWindow
+            ?.takeIf { it.isShowing }
+            ?.let { return it }
+
+        val candidates =
+            runCatching { Window.getWindows() }
+                .getOrNull()
+                ?.map {
+                    InvokerCandidate(
+                        window = it,
+                        isFrameOrDialog = it is Frame || it is Dialog,
+                        isShowing = it.isShowing,
+                        isActive = it.isActive,
+                        bounds = it.bounds,
+                    )
+                }.orEmpty()
+
+        // Deliberately no toFront()/requestFocus(): PopupMenu.show does not need an active
+        // invoker, and reordering the window stack from a resolve step would let a right-click
+        // raise a window over whatever the user had in front.
+        return pickInvoker(candidates, at)?.window
+    }
+
+    // ---- rendering ---------------------------------------------------------------------------
+
+    private fun materialize(
+        menu: java.awt.Menu,
+        nodes: List<NativeMenuNode>,
+        isCurrent: () -> Boolean,
+        onDismiss: () -> Unit,
+    ) {
+        nodes.forEach { node ->
+            when (node) {
+                is NativeMenuNode.Separator -> {
+                    menu.addSeparator()
+                }
+
+                is NativeMenuNode.Item -> {
+                    menu.add(
+                        java.awt.MenuItem(node.label).apply {
+                            isEnabled = node.enabled
+                            node.shortcut?.let { shortcut = java.awt.MenuShortcut(it.code) }
+                            addActionListener {
+                                if (isCurrent()) node.action()
+                                onDismiss()
+                            }
+                        },
+                    )
+                }
+
+                is NativeMenuNode.Submenu -> {
+                    menu.add(
+                        java.awt.Menu(node.label).also {
+                            materialize(it, node.children, isCurrent, onDismiss)
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    /** getItem returns the `java.awt.Menu` for a submenu, so recurse to reach its children. */
+    private fun disableAll(menu: java.awt.Menu) {
+        for (i in 0 until menu.itemCount) {
+            val item = menu.getItem(i)
+            item.isEnabled = false
+            if (item is java.awt.Menu) disableAll(item)
+        }
+    }
+
+    private fun detach() {
+        attached?.let { (owner, menu) -> runCatching { owner.remove(menu) } }
+        attached = null
+    }
+
+    private fun detachIf(popup: java.awt.PopupMenu) {
+        if (attached?.second === popup) detach()
+    }
+
+    private fun onEdt(block: () -> Unit) {
+        if (SwingUtilities.isEventDispatchThread()) block() else SwingUtilities.invokeLater(block)
+    }
+}
+
+/**
+ * Knows when a native menu has closed.
+ *
+ * Its own class because inferring dismissal is a wholly separate concern from putting a popup on
+ * screen, and it owns process-wide state (an AWT-wide listener) that must be cleaned up exactly.
+ */
+private class DismissWatcher {
+    private var current: AWTEventListener? = null
+
+    /**
+     * Infer dismissal from the next input event, since AWT reports none (fact 3 above).
+     *
+     * `WINDOW_EVENT_MASK` is included because dismissing by switching applications produces no
+     * input event at all, which would otherwise leave the caller believing the menu is still up.
+     *
+     * Only [AWTEvent.getID] is inspected; no event contents are read. That matters because this
+     * is a process-wide listener installed by a library that runs inside a host application.
+     */
+    fun install(onDismiss: () -> Unit): AWTEventListener? {
+        clear()
+        val armedAt = System.currentTimeMillis()
+        val toolkit = runCatching { Toolkit.getDefaultToolkit() }.getOrNull() ?: return null
+        val listener =
+            object : AWTEventListener {
+                override fun eventDispatched(event: AWTEvent) {
+                    if (!isDismissalEvent(event.id, System.currentTimeMillis() - armedAt)) return
+                    runCatching { toolkit.removeAWTEventListener(this) }
+                    if (current === this) current = null
+                    onDismiss()
+                }
+            }
+        current = listener
+        // Requires AWTPermission("listenToAllAWTEvents"). If a host's policy refuses, lose the
+        // dismissal signal rather than the menu.
+        return runCatching {
+            toolkit.addAWTEventListener(
+                listener,
+                AWTEvent.MOUSE_EVENT_MASK or AWTEvent.MOUSE_MOTION_EVENT_MASK or
+                    AWTEvent.KEY_EVENT_MASK or AWTEvent.WINDOW_EVENT_MASK,
+            )
+            listener
+        }.getOrElse {
+            current = null
+            null
+        }
+    }
+
+    fun clear() {
+        current?.let {
+            runCatching { Toolkit.getDefaultToolkit().removeAWTEventListener(it) }
+        }
+        current = null
+    }
+
+    fun clearIf(listener: AWTEventListener?) {
+        if (listener != null && current === listener) clear()
+    }
+
+    companion object {
+        const val DISMISS_GRACE_MS = 120L
+
+        /**
+         * Whether an AWT input event means the menu has closed.
+         *
+         * Two independent guards, both against mistaking the *opening* right-click's own tail for
+         * a dismissal: nothing inside the grace window counts, since `show()` is posted to the EDT
+         * and the OS grab is not established the instant it returns; and `MOUSE_RELEASED` never
+         * counts, because wall-clock alone is not enough - under a busy EDT that release can be
+         * dispatched well after the window expires. Nothing is lost by filtering it, since the
+         * measured dismissal burst is `MOUSE_EXITED` / key-release / `MOUSE_ENTERED` and a
+         * click-away has its press swallowed by the menu, so a release is never the only signal.
+         */
+        fun isDismissalEvent(
+            eventId: Int,
+            elapsedMs: Long,
+        ): Boolean = elapsedMs >= DISMISS_GRACE_MS && eventId != MouseEvent.MOUSE_RELEASED
+    }
+}
+
+/** The properties [pickInvoker] ranks on, lifted off AWT so the rule can be tested headlessly. */
+internal data class InvokerCandidate<T>(
+    val window: T,
+    val isFrameOrDialog: Boolean,
+    val isShowing: Boolean,
+    val isActive: Boolean,
+    val bounds: Rectangle,
+)
+
+/**
+ * Pick the AWT window to hang a popup off.
+ *
+ * `Window.getWindows()` is not in z-order and also returns the heavyweight windows Swing creates
+ * for popups, so it is filtered to real frames and dialogs. Smallest-area-first is a proxy for
+ * topmost: a popup is owned by its invoker, so choosing the window underneath would place the
+ * menu behind the one on top.
+ */
+internal fun <T> pickInvoker(
+    candidates: List<InvokerCandidate<T>>,
+    at: Point?,
+): InvokerCandidate<T>? =
+    candidates
+        .filter { it.isFrameOrDialog && it.isShowing }
+        // Rectangle.contains is half-open on the right/bottom edges, so a click on the very edge can
+        // match nothing. Falling back to all eligible windows keeps the mild degradation (menu on the
+        // wrong window) rather than introducing a worse one (right-click silently does nothing).
+        .let { eligible ->
+            eligible.filter { at == null || it.bounds.contains(at) }.ifEmpty { eligible }
+        }.minWithOrNull(
+            compareByDescending<InvokerCandidate<T>> { it.isActive }
+                .thenBy { it.bounds.width.toLong() * it.bounds.height.toLong() },
+        )

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenusTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenusTest.kt
@@ -277,4 +277,23 @@ class NativeContextMenusTest {
         // makes this false. Either way it must return, not throw, and not leave a menu behind.
         assertFalse(NativeContextMenus.show(emptyList()))
     }
+
+    // ----- icon sizing -----
+
+    @Test
+    fun `the icon contract is a 2x rasterisation of the point size`() {
+        // AppKit reads a plain bitmap's PIXEL dimensions as its POINT size, so a Retina-scale
+        // rasterisation renders an icon twice too large. The point size is stated separately by
+        // the multi-resolution image, and the bitmap is a fixed 2x of it - never the screen scale.
+        assertEquals(16, NATIVE_MENU_ICON_POINTS)
+        assertEquals(2, NATIVE_MENU_ICON_SCALE)
+        assertEquals(32, NATIVE_MENU_ICON_POINTS * NATIVE_MENU_ICON_SCALE)
+    }
+
+    @Test
+    fun `the point size sits in the range macOS uses for menu items`() {
+        // The system checkmark is 14x13pt and 16pt is the common convention for custom menu
+        // icons; anything materially larger is the bug this range exists to catch.
+        assertTrue(NATIVE_MENU_ICON_POINTS in 14..18)
+    }
 }

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenusTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenusTest.kt
@@ -296,4 +296,29 @@ class NativeContextMenusTest {
         // icons; anything materially larger is the bug this range exists to catch.
         assertTrue(NATIVE_MENU_ICON_POINTS in 14..18)
     }
+
+    // ----- the show() decision, testable off macOS -----
+
+    @Test
+    fun `a native menu needs support, the EDT and a non-empty plan`() {
+        assertTrue(canShowNatively(isSupported = true, isEventDispatchThread = true, plannedSize = 1))
+    }
+
+    @Test
+    fun `each precondition alone is enough to decline`() {
+        // Going through show() on a Linux runner only ever re-tests the platform gate, so these
+        // guards need coverage that actually runs everywhere.
+        assertFalse(canShowNatively(isSupported = false, isEventDispatchThread = true, plannedSize = 1))
+        assertFalse(canShowNatively(isSupported = true, isEventDispatchThread = false, plannedSize = 1))
+        assertFalse(canShowNatively(isSupported = true, isEventDispatchThread = true, plannedSize = 0))
+    }
+
+    @Test
+    fun `an empty plan declines even though the menu had items`() {
+        // A menu of only separators plans to nothing; the caller must draw its own instead.
+        val planned = planNativeMenu(List(3) { NativeMenuNode.Separator })
+        assertFalse(
+            canShowNatively(isSupported = true, isEventDispatchThread = true, plannedSize = planned.size),
+        )
+    }
 }

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenusTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/menu/NativeContextMenusTest.kt
@@ -1,0 +1,280 @@
+package ai.rever.boss.plugin.ui.menu
+
+import java.awt.Point
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the parts a headless CI run can actually see: the menu plan, invoker selection, the
+ * dismissal predicate and the platform gate.
+ *
+ * No AWT menu construction here on purpose - `java.awt.MenuComponent` throws `HeadlessException`,
+ * which is exactly why [planNativeMenu] and [pickInvoker] exist as toolkit-independent steps.
+ */
+class NativeContextMenusTest {
+    private fun item(
+        label: String,
+        enabled: Boolean = true,
+    ) = NativeMenuNode.Item(label = label, enabled = enabled)
+
+    private fun labels(nodes: List<NativeMenuNode>): List<String> =
+        nodes.map {
+            when (it) {
+                is NativeMenuNode.Item -> it.label
+                is NativeMenuNode.Submenu -> "${it.label}>"
+                NativeMenuNode.Separator -> "---"
+            }
+        }
+
+    // ----- the plan -----
+
+    @Test
+    fun `items keep their label and enabled state`() {
+        val plan = planNativeMenu(listOf(item("Copy", enabled = false), item("Paste")))
+        assertEquals(listOf("Copy", "Paste"), labels(plan))
+        assertFalse((plan[0] as NativeMenuNode.Item).enabled)
+        assertTrue((plan[1] as NativeMenuNode.Item).enabled)
+    }
+
+    @Test
+    fun `a separator between items is kept`() {
+        val plan = planNativeMenu(listOf(item("A"), NativeMenuNode.Separator, item("B")))
+        assertEquals(listOf("A", "---", "B"), labels(plan))
+    }
+
+    @Test
+    fun `leading, trailing and consecutive separators are dropped`() {
+        // Menus assembled with `if` guards routinely produce these, and a native menu renders a
+        // dangling separator as a stray line rather than ignoring it.
+        val plan =
+            planNativeMenu(
+                listOf(
+                    NativeMenuNode.Separator,
+                    NativeMenuNode.Separator,
+                    item("A"),
+                    NativeMenuNode.Separator,
+                    NativeMenuNode.Separator,
+                    item("B"),
+                    NativeMenuNode.Separator,
+                ),
+            )
+        assertEquals(listOf("A", "---", "B"), labels(plan))
+    }
+
+    @Test
+    fun `a menu that is only separators plans to nothing`() {
+        assertTrue(planNativeMenu(List(3) { NativeMenuNode.Separator }).isEmpty())
+    }
+
+    @Test
+    fun `submenus are planned recursively`() {
+        val plan =
+            planNativeMenu(
+                listOf(
+                    NativeMenuNode.Submenu(
+                        "Share",
+                        listOf(NativeMenuNode.Separator, item("Tab"), NativeMenuNode.Separator),
+                    ),
+                ),
+            )
+        val submenu = plan.single() as NativeMenuNode.Submenu
+        assertEquals(listOf("Tab"), labels(submenu.children))
+    }
+
+    @Test
+    fun `an empty submenu is removed rather than left unopenable`() {
+        val plan =
+            planNativeMenu(
+                listOf(
+                    item("A"),
+                    NativeMenuNode.Submenu("Empty", emptyList()),
+                    NativeMenuNode.Submenu("AlsoEmpty", listOf(NativeMenuNode.Separator)),
+                ),
+            )
+        assertEquals(listOf("A"), labels(plan))
+    }
+
+    @Test
+    fun `item actions survive planning`() {
+        var fired = 0
+        val plan = planNativeMenu(listOf(NativeMenuNode.Item("Go", action = { fired += 1 })))
+        (plan.single() as NativeMenuNode.Item).action()
+        assertEquals(1, fired)
+    }
+
+    // ----- Windows mnemonic escaping -----
+
+    @Test
+    fun `ampersands are doubled on windows only`() {
+        // A branch named feat/a&b would otherwise render as "feat/ab" with an underlined b.
+        assertEquals(
+            "feat/a&&b",
+            (
+                planNativeMenu(listOf(item("feat/a&b")), isWindows = true)
+                    .single() as NativeMenuNode.Item
+            ).label,
+        )
+        assertEquals(
+            "feat/a&b",
+            (
+                planNativeMenu(listOf(item("feat/a&b")), isWindows = false)
+                    .single() as NativeMenuNode.Item
+            ).label,
+        )
+    }
+
+    @Test
+    fun `escaping reaches submenu labels and their children`() {
+        val plan =
+            planNativeMenu(
+                listOf(NativeMenuNode.Submenu("A&B", listOf(item("C&D")))),
+                isWindows = true,
+            )
+        val submenu = plan.single() as NativeMenuNode.Submenu
+        assertEquals("A&&B", submenu.label)
+        assertEquals("C&&D", (submenu.children.single() as NativeMenuNode.Item).label)
+    }
+
+    // ----- the shortcut contract -----
+
+    @Test
+    fun `a shortcut that is not a VK constant is rejected at construction`() {
+        // 'c'.code is 99, which is not KeyEvent.VK_C and would render as something arbitrary.
+        assertFailsWith<IllegalArgumentException> { NativeMenuNode.Item("Copy", shortcut = 'c') }
+        NativeMenuNode.Item("Copy", shortcut = 'C')
+        NativeMenuNode.Item("One", shortcut = '1')
+        NativeMenuNode.Item("None", shortcut = null)
+    }
+
+    // ----- invoker selection -----
+
+    private fun candidate(
+        name: String,
+        active: Boolean = false,
+        x: Int = 0,
+        y: Int = 0,
+        w: Int = 100,
+        h: Int = 100,
+        frameOrDialog: Boolean = true,
+        showing: Boolean = true,
+    ) = InvokerCandidate(name, frameOrDialog, showing, active, Rectangle(x, y, w, h))
+
+    @Test
+    fun `an active window wins over a larger inactive one`() {
+        val picked =
+            pickInvoker(
+                listOf(candidate("big", w = 2000, h = 2000), candidate("active", active = true)),
+                at = null,
+            )
+        assertEquals("active", picked?.window)
+    }
+
+    @Test
+    fun `among inactive windows the smallest wins, not the largest`() {
+        // Largest is the one most likely to be UNDERNEATH.
+        val picked =
+            pickInvoker(
+                listOf(candidate("fullscreen", w = 3000, h = 2000), candidate("small", w = 400, h = 300)),
+                at = null,
+            )
+        assertEquals("small", picked?.window)
+    }
+
+    @Test
+    fun `popup and hidden windows are not eligible invokers`() {
+        val picked =
+            pickInvoker(
+                listOf(
+                    candidate("popup", frameOrDialog = false, w = 10, h = 10),
+                    candidate("hidden", showing = false, w = 20, h = 20),
+                    candidate("frame", w = 900, h = 900),
+                ),
+                at = null,
+            )
+        assertEquals("frame", picked?.window)
+    }
+
+    @Test
+    fun `only windows containing the point are eligible`() {
+        val picked =
+            pickInvoker(
+                listOf(
+                    candidate("left", x = 0, y = 0, w = 100, h = 100),
+                    candidate("right", x = 500, y = 500, w = 300, h = 300),
+                ),
+                at = Point(600, 600),
+            )
+        assertEquals("right", picked?.window)
+    }
+
+    @Test
+    fun `a click on the half-open right or bottom edge still finds a window`() {
+        // Rectangle.contains is half-open, so (100,100) is NOT inside a 0,0 100x100 frame.
+        // Without the ifEmpty fallback this returns null and no menu appears at all.
+        val picked =
+            pickInvoker(
+                listOf(candidate("frame", x = 0, y = 0, w = 100, h = 100)),
+                at = Point(100, 100),
+            )
+        assertEquals("frame", picked?.window)
+    }
+
+    @Test
+    fun `no eligible window yields null rather than an arbitrary one`() {
+        assertNull(pickInvoker(listOf(candidate("hidden", showing = false)), at = null))
+        assertNull(pickInvoker(emptyList<InvokerCandidate<String>>(), at = null))
+    }
+
+    // ----- the dismissal heuristic -----
+
+    private val grace = NativeContextMenus.DISMISS_GRACE_MS
+    private val moved = java.awt.event.MouseEvent.MOUSE_MOVED
+    private val released = java.awt.event.MouseEvent.MOUSE_RELEASED
+
+    @Test
+    fun `nothing inside the grace window counts as dismissal`() {
+        assertFalse(NativeContextMenus.isDismissalEvent(moved, 0))
+        assertFalse(NativeContextMenus.isDismissalEvent(moved, grace - 1))
+    }
+
+    @Test
+    fun `an ordinary event after the grace window counts as dismissal`() {
+        assertTrue(NativeContextMenus.isDismissalEvent(moved, grace))
+        assertTrue(NativeContextMenus.isDismissalEvent(moved, 5_000))
+    }
+
+    @Test
+    fun `a mouse release never counts, however late it arrives`() {
+        // Wall-clock alone is not enough: under a busy EDT the opening right-click's own release
+        // can be dispatched well after the grace window expires.
+        assertFalse(NativeContextMenus.isDismissalEvent(released, grace + 1))
+        assertFalse(NativeContextMenus.isDismissalEvent(released, 60_000))
+    }
+
+    // ----- the platform gate -----
+
+    @Test
+    fun `only macOS gets native menus, and only when the setting allows`() {
+        assertTrue(shouldUseNativeMenus(settingEnabled = true, isMacOs = true))
+        assertFalse(shouldUseNativeMenus(settingEnabled = false, isMacOs = true))
+    }
+
+    @Test
+    fun `windows and linux stay on the app's own menus even with the setting on`() {
+        // Windows is unverified (TrackPopupMenu may block the EDT); Linux's XAWT peer ignores GTK.
+        assertFalse(shouldUseNativeMenus(settingEnabled = true, isMacOs = false))
+        assertFalse(shouldUseNativeMenus(settingEnabled = false, isMacOs = false))
+    }
+
+    @Test
+    fun `show reports failure rather than throwing when unsupported or empty`() {
+        // On a Linux CI runner isSupported() is false; on a mac dev box the empty plan is what
+        // makes this false. Either way it must return, not throw, and not leave a menu behind.
+        assertFalse(NativeContextMenus.show(emptyList()))
+    }
+}


### PR DESCRIPTION
## What

Right-click menus in the host are now real macOS `NSMenu`s. `java.awt.PopupMenu` is peered by
`sun.lwawt.macosx.CPopupMenu` onto an actual `NSMenu`; the Compose-drawn `Popup` stays as the
fallback.

## Why this is more than cosmetic

Under HARDWARE rendering (the default on every platform since #128) Chromium composites a native
window **over** the Compose scene, so a drawn popup is painted behind the page it belongs to. That
is the reason the heavyweight-window path exists at all. An OS menu is an OS-owned window, so it is
immune by construction rather than worked around, and the native branch is checked before the
heavyweight one because it subsumes it.

## Where it lives

`plugin-ui-core`, behind `expect`/`actual`, as that module's first `desktopMain` file. `commonMain`
cannot import AWT, and putting it here means plugins - which resolve `ai.rever.boss.plugin.ui.*`
parent-first from the host - get the same menus rather than the host owning a private copy.

Routing sits inside the `ContextMenu` composable, the one place both entry points
(`Modifier.contextMenu` and the 9 direct callers) already funnel through. No call site changed, and
`ContextMenuProvider.applyContextMenu` keeps its JVM descriptor, which matters because it is a
published plugin interface used by the `codebase` and `bookmarks` plugins.

Position comes from the cursor rather than the passed `offset`: that offset is node-relative in
Compose pixels and a native menu needs screen coordinates, a conversion this codebase has nowhere
else.

## Four behaviours that were measured, not assumed

None of these can be read out of the JDK's Java sources, and each one shapes the code:

| | |
|---|---|
| `show()` blocks the EDT? | **No.** Returns in ~0 ms, so Compose keeps painting - but its return is not a dismissal signal |
| Anything cancels an open menu? | **No.** Hiding, removing and disposing the invoker all leave it tracking, so `hide()` is advisory and correctness rests on a **generation fence** that makes a lingering menu's items inert |
| Is there a dismissal event? | **No,** on any AWT mask. But an open menu holds the input grab and lets nothing through (a pointer dragged across it, and a modifier pressed and released, both delivered zero events), while dismissal produces an immediate `MOUSE_EXITED` / key-release / `MOUSE_ENTERED` burst. So "clear on the next input event" cannot fire early |
| Is `MenuShortcut` live? | **No,** display-only, so a glyph cannot double-fire with the app's own accelerators |

## Icons

Native menu items **can** carry icons, which is not obvious: `java.awt.MenuItem` has no icon API,
but `sun.lwawt.macosx.CMenuItem.setImage(Image)` is public, and the JDK's own comment says the
intended access is an `instanceof` on the peer "because we want to support the NSMenuItem image
apis".

The peer is reached through the **public** `sun.awt.AWTAccessor$MenuComponentAccessor` interface
rather than its implementation class. The implementation is an anonymous class in `java.awt`, so
going through it would need `--add-opens java.desktop/java.awt`, which this app does not set;
through the interface the `sun.awt` and `sun.lwawt.macosx` opens it already has on macOS suffice.
Verified both ways. Peers exist as soon as `invoker.add(popup)` realises the menu and `setImage`
works before `show()`, so icons are applied during assembly rather than onto a live menu.

Sizing was a bug rather than a tuning value. `CImage.createFromImage` branches on
`MultiResolutionImage`: given one, the base variant's dimensions become the NSImage's **point**
size; given a plain bitmap it uses raw **pixel** dimensions as the point size. Rasterising at the
display density therefore produced a 32pt icon on Retina and a correct one on a 1x screen. The
bitmap is now a fixed 2x of the point size wrapped in a `BaseMultiResolutionImage` whose base
states 16pt.

## What still takes the drawn path

Menus carrying an **inline trailing button** - the sidebar customize, workspace picker and
run-history menus use them for edit and delete. Dropping one silently removes something the user
can act on, unlike an icon, which is decoration. Reshaping those into submenus is a follow-up,
after which the eligibility check becomes dead code.

## A bug this caught

`ContextMenuAttributionTest` failed, which is exactly the silent failure its own KDoc predicts: the
conversion used `item.onClick` raw and dropped `PluginExecutionBoundary.invokeAttributed`, so a
plugin's menu action would have run unattributed and the next plugin crash would have taken the app
down instead of the plugin. Now wrapped, and pinned by two new tests. Those UI tests find menu rows
as Compose nodes, so they force the drawn path through an internal override - otherwise they would
fail on macOS and pass on CI for reasons unconnected to what they assert.

## Scope and settings

macOS only, the same verified gate the BossTerm port uses: Windows `TrackPopupMenu` is unverified
and appears to block the EDT through `AwtToolkit::SyncCall`, and Linux's XAWT peer ignores GTK.
Widening is one predicate plus a measurement.

Settings > Window Appearance > Menus turns it off; the section is hidden where the toggle would do
nothing.

## Tests

44, all headless: the plan (separator hygiene, submenu nesting, Windows mnemonic escaping), invoker
ordering including the half-open `Rectangle` edge click, the dismissal predicate, the platform gate,
icon dedup and carry-through, and the attribution contract on both paths. `java.awt.MenuComponent`
throws `HeadlessException`, which is why `planNativeMenu`/`pickInvoker`/`isDismissalEvent` are
toolkit-independent seams.

`./gradlew build`, `ktlintCheck` and `detekt` green. Exercised by hand in the running app.

## Known limits

- macOS gives no way to mark a peer-supplied image as a **template**, which is what would let it
  tint per appearance and while highlighted. Icons are a fixed mid-grey near the system secondary
  label colour: legible on both backgrounds, but not inverted on highlight.
- Native menus cannot carry the BOSS theme. That is the accepted trade.
- Icon support is private JDK API reached reflectively, so every step is best-effort: a failure
  drops the icon and keeps the menu.
