### PR TITLE
feat(windows): come up as a plain browser on risalabs.ai, with no panel opening by itself

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -102,7 +102,6 @@
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun classifyError(e: Throwable): EngineInitError</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun createEngineInstance( chromiumDir: java.nio.file.Path, profileDirPath: java.nio.file.Path, ): Engine</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses()</ID>
-    <ID>CyclomaticComplexMethod:FocusModeReveal.kt$@Composable internal fun rememberFocusModeReveal( isFocusModeEnabled: Boolean, revealDelayMs: Long, ): FocusModeRevealState</ID>
     <ID>CyclomaticComplexMethod:FormFieldDetector.kt$FormFieldDetector$private fun determineFieldType( inputType: String, fieldName: String, fieldId: String, placeholder: String, autocomplete: String, className: String, ariaLabel: String, ): FieldType</ID>
     <ID>CyclomaticComplexMethod:FormFieldInjector.kt$FormFieldInjector$suspend fun fillCredentials( browser: LockedBrowser, username: String, password: String, mode: FillMode = FillMode.BOTH, ): FillResult</ID>
     <ID>CyclomaticComplexMethod:GlobalSearchDialog.kt$@Composable fun GlobalSearchDialog( projectPath: String, workspaceManager: WorkspaceManager, onDismiss: () -&gt; Unit, onFileSelect: (String) -&gt; Unit, onTabSelect: ((windowId: String, panelId: String, tabId: String) -&gt; Unit)? = null, onBookmarkSelect: ((bookmarkId: String, collectionId: String) -&gt; Unit)? = null, onRunConfigSelect: ((configId: String) -&gt; Unit)? = null, onCommandSelect: ((actionId: String) -&gt; Unit)? = null, )</ID>
@@ -213,7 +212,7 @@
     <ID>LongMethod:BossAppDialogs.kt$@Composable internal fun BossAppDialogs(state: BossAppState)</ID>
     <ID>LongMethod:BossAppEventBusEffects.kt$@Composable internal fun BossAppEventBusEffects(state: BossAppState)</ID>
     <ID>LongMethod:BossAppMenuActionEffects.kt$@Composable internal fun BossAppMenuActionEffects( state: BossAppState, reveal: FocusModeRevealState, )</ID>
-    <ID>LongMethod:BossAppScaffold.kt$@Composable internal fun BossAppScaffold( state: BossAppState, reveal: FocusModeRevealState, isFocusModeEnabled: Boolean, isAutoRevealEnabled: Boolean, revealOffsetDp: Dp, showTitleBar: Boolean, onToggleMaximize: (() -&gt; Unit)?, )</ID>
+    <ID>LongMethod:BossAppScaffold.kt$@Composable internal fun BossAppScaffold( state: BossAppState, reveal: FocusModeRevealState, focusModeSettings: FocusModeSettings, revealOffsetDp: Dp, showTitleBar: Boolean, onToggleMaximize: (() -&gt; Unit)?, )</ID>
     <ID>LongMethod:BossAppStartupEffects.kt$@Composable internal fun BossAppStartupEffects(state: BossAppState)</ID>
     <ID>LongMethod:BossAppWithAuth.kt$@Composable fun ComponentContext.BossAppWithAuth( windowId: String, isFirstWindow: Boolean = false, panelRegistry: ai.rever.boss.components.registery.PanelRegistry, onToggleMaximize: (() -&gt; Unit)? = null, )</ID>
     <ID>LongMethod:BossBottomBar.kt$@Composable fun RowScope.BossLeftBottomBar(tabsComponent: BossTabsComponent? = null)</ID>
@@ -290,7 +289,6 @@
     <ID>LongMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses()</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$suspend fun resetBrowserProfile(): ResetResult</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine.BrowserFindBar$private fun createDialog(owner: java.awt.Window)</ID>
-    <ID>LongMethod:FocusModeReveal.kt$@Composable internal fun rememberFocusModeReveal( isFocusModeEnabled: Boolean, revealDelayMs: Long, ): FocusModeRevealState</ID>
     <ID>LongMethod:FocusModeSettings.kt$@Composable fun FocusModeSettings()</ID>
     <ID>LongMethod:FormFieldDetector.kt$FormFieldDetector$fun injectFormDetectionScript(browser: LockedBrowser)</ID>
     <ID>LongMethod:FormFieldInjector.kt$FormFieldInjector$private suspend fun applyDiscreteMode(browser: LockedBrowser)</ID>
@@ -478,7 +476,6 @@
     <ID>MatchingDeclarationName:DesktopWorkspaceFileManager.kt$WorkspaceFileManager</ID>
     <ID>MatchingDeclarationName:DesktopWorkspaceSettingsManager.kt$WorkspaceSettingsManager</ID>
     <ID>MatchingDeclarationName:FluckPanelProviders.kt$FluckPanelContentProviderImpl : FluckPanelContentProvider</ID>
-    <ID>MatchingDeclarationName:FocusModeReveal.kt$FocusModeRevealState</ID>
     <ID>MatchingDeclarationName:NewTabDialog.desktop.kt$UrlHistoryProvider</ID>
     <ID>MatchingDeclarationName:PluginCrashFallbackUI.kt$PluginProcessState</ID>
     <ID>MatchingDeclarationName:PresetDefinitions.kt$EmacsPresetDefinition</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/BossApp.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/BossApp.kt
@@ -58,11 +58,7 @@ fun ComponentContext.BossApp(
     // Focus mode + window appearance settings drive the chrome.
     val focusModeSettings by FocusModeSettingsManager.currentSettings.collectAsState()
     val windowAppearanceSettings by WindowAppearanceSettingsManager.currentSettings.collectAsState()
-    val reveal =
-        rememberFocusModeReveal(
-            isFocusModeEnabled = focusModeSettings.enabled,
-            revealDelayMs = focusModeSettings.revealDelayMs,
-        )
+    val reveal = rememberFocusModeReveal(focusModeSettings)
 
     // Menu actions can force-reveal sidebars, so they take the reveal state too.
     BossAppMenuActionEffects(state, reveal)
@@ -72,8 +68,7 @@ fun ComponentContext.BossApp(
             BossAppScaffold(
                 state = state,
                 reveal = reveal,
-                isFocusModeEnabled = focusModeSettings.enabled,
-                isAutoRevealEnabled = focusModeSettings.autoRevealEnabled,
+                focusModeSettings = focusModeSettings,
                 revealOffsetDp = with(LocalDensity.current) { focusModeSettings.revealOffsetPx.toDp() },
                 showTitleBar = windowAppearanceSettings.showTitleBar,
                 onToggleMaximize = onToggleMaximize,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -19,6 +19,7 @@ import ai.rever.boss.components.window_panel.components.main_window_panels.TabCy
 import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
+import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.handleTabDropResult
 import ai.rever.boss.plugin.api.LocalBookmarkDataProvider
 import ai.rever.boss.plugin.api.LocalProjectPath
@@ -185,8 +186,7 @@ internal fun BossAppCompositionLocals(
 internal fun BossAppScaffold(
     state: BossAppState,
     reveal: FocusModeRevealState,
-    isFocusModeEnabled: Boolean,
-    isAutoRevealEnabled: Boolean,
+    focusModeSettings: FocusModeSettings,
     revealOffsetDp: Dp,
     showTitleBar: Boolean,
     onToggleMaximize: (() -> Unit)?,
@@ -404,8 +404,7 @@ internal fun BossAppScaffold(
             // Hover reveal strips for focus mode - dynamic sizing to avoid blocking clicks
             FocusModeHoverStrips(
                 state = reveal,
-                isFocusModeEnabled = isFocusModeEnabled,
-                isAutoRevealEnabled = isAutoRevealEnabled,
+                settings = focusModeSettings,
                 revealOffsetDp = revealOffsetDp,
             )
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.components.workspaces.WorkspaceSettingsManager
 import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.asLastSession
 import ai.rever.boss.components.workspaces.extractCurrentWorkspace
+import ai.rever.boss.components.workspaces.requiresProject
 import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.consumePendingInitialProject
 import ai.rever.boss.consumePendingInitialTab
@@ -320,7 +321,17 @@ internal fun BossAppStartupEffects(state: BossAppState) {
     LaunchedEffect(selectedProject.path) {
         if (selectedProject.path.isNotEmpty()) {
             val defaultWorkspace = WorkspaceSettingsManager.getDefaultWorkspace()
-            if (defaultWorkspace != null) {
+            // A workspace that needs no project has nothing to re-derive from a new one, so
+            // re-applying it would only clearAllPanels over whatever the user has open. That
+            // is new since the fresh-start apply: a Windows install now comes up ON the
+            // browser workspace, browses somewhere, and selecting a project would have
+            // discarded the page. Project-shaped workspaces still re-apply, which is the
+            // point of this effect - their tabs are built from {projectPath}.
+            val alreadyApplied =
+                defaultWorkspace != null &&
+                    !defaultWorkspace.requiresProject() &&
+                    workspaceManager.currentWorkspace.value?.id == defaultWorkspace.id
+            if (defaultWorkspace != null && !alreadyApplied) {
                 // Apply the workspace
                 applyWorkspace(defaultWorkspace, splitViewState, windowProjectState)
                 workspaceManager.loadWorkspace(defaultWorkspace)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -1,8 +1,6 @@
 package ai.rever.boss.app
 
-import ai.rever.boss.components.events.PanelEventBus
 import ai.rever.boss.components.plugin.DefaultPlugin
-import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.components.plugin.tab_types.registerPanelHostTab
 import ai.rever.boss.components.registery.PanelComponentStoreRegistry
@@ -175,8 +173,7 @@ internal fun BossAppStartupEffects(state: BossAppState) {
         val pendingProject = consumePendingInitialProject(windowId)
         if (pendingProject != null) {
             windowProjectState.selectProject(pendingProject)
-            PanelEventBus.openPanel(PanelIds.CODEBASE, sourceWindowId = windowId)
-            PanelEventBus.openPanel(PanelIds.RUN_CONFIGURATIONS, sourceWindowId = windowId)
+            openProjectPanels(windowId)
         }
     }
 
@@ -189,8 +186,7 @@ internal fun BossAppStartupEffects(state: BossAppState) {
     LaunchedEffect(windowProjectState) {
         val initialProject = windowProjectState.selectedProject.value
         if (initialProject.path.isNotEmpty()) {
-            PanelEventBus.openPanel(PanelIds.CODEBASE, sourceWindowId = windowId)
-            PanelEventBus.openPanel(PanelIds.RUN_CONFIGURATIONS, sourceWindowId = windowId)
+            openProjectPanels(windowId)
         }
     }
 
@@ -335,8 +331,7 @@ internal fun BossAppStartupEffects(state: BossAppState) {
     // Open CodeBase and RunConfigurations panels when project is selected (reactive architecture)
     LaunchedEffect(selectedProject.path, windowId) {
         if (selectedProject.path.isNotEmpty()) {
-            PanelEventBus.openPanel(PanelIds.CODEBASE, sourceWindowId = windowId)
-            PanelEventBus.openPanel(PanelIds.RUN_CONFIGURATIONS, sourceWindowId = windowId)
+            openProjectPanels(windowId)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -587,6 +587,10 @@ internal fun BossAppStartupEffects(state: BossAppState) {
                             } catch (e: Exception) {
                                 logger.error(LogCategory.WORKSPACE, "Last Session restore failed - continuing startup", error = e)
                             }
+                        } else {
+                            // No Last Session: this is the layout a fresh install opens on.
+                            // Before markHandlersReady, since applyWorkspace clears panels.
+                            applyDefaultWorkspaceOnFreshStart(splitViewState, windowProjectState)
                         }
 
                         // Mark workspace restoration as complete (for auto-show dialog logic)
@@ -616,7 +620,10 @@ internal fun BossAppStartupEffects(state: BossAppState) {
             // plugin tab types) — let it mark handlers ready itself, otherwise
             // handler-created tabs get destroyed by the restore's clearAllPanels.
             if (!state.workspaceRestorationComplete && workspaceManager.currentWorkspace.value == null) {
-                // Still not complete after timeout - assume fresh install
+                // Still not complete after timeout - assume fresh install. Nothing was
+                // restored and there are no workspaces on disk, so this is the very first
+                // launch: apply the default layout before handlers can create tabs.
+                applyDefaultWorkspaceOnFreshStart(splitViewState, windowProjectState)
                 state.workspaceRestorationComplete = true
                 state.markHandlersReady(isSessionResolved)
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeReveal.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeReveal.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.app
 
+import ai.rever.boss.focusmode.FocusModeEdge
+import ai.rever.boss.focusmode.FocusModeSettings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -21,235 +23,190 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.delay
 
 /**
+ * Hover-reveal state for one window edge.
+ *
+ * Three layers, in order:
+ * - [hoveringStrip]: raw cursor presence in the invisible edge strip
+ * - [hoverRevealed]: set after the reveal delay threshold is met
+ * - [shown]: debounced visibility with a grace period, so the bar doesn't flicker
+ *   while the mouse travels from the strip onto the revealed content
+ */
+internal class FocusModeEdgeRevealState {
+    var hoveringStrip by mutableStateOf(false)
+    var hoverRevealed by mutableStateOf(false)
+    var shown by mutableStateOf(false)
+
+    /** Hover on the revealed bar itself, which holds it open. */
+    val interactionSource = MutableInteractionSource()
+}
+
+/**
  * Focus-mode hover-reveal state for the four window edges.
  *
- * Each edge has three layers of state:
- * - `hovering*Strip`: raw cursor presence in the invisible edge strip
- * - `hoverReveal*`: set after the reveal delay threshold is met
- * - `show*`: debounced visibility with a grace period, so the bar doesn't
- *   flicker while the mouse travels from the strip onto the revealed content
+ * The named `show*` / `*InteractionSource` accessors are what the scaffold and the
+ * menu actions bind to; [get] is the per-edge view the effects and strips use.
  */
 internal class FocusModeRevealState {
-    // Hovering states track raw cursor position in hover strips
-    var hoveringTopStrip by mutableStateOf(false)
-    var hoveringLeftStrip by mutableStateOf(false)
-    var hoveringRightStrip by mutableStateOf(false)
-    var hoveringBottomStrip by mutableStateOf(false)
+    private val edges = FocusModeEdge.entries.associateWith { FocusModeEdgeRevealState() }
 
-    // Reveal states are set after delay threshold is met
-    var hoverRevealTop by mutableStateOf(false)
-    var hoverRevealLeft by mutableStateOf(false)
-    var hoverRevealRight by mutableStateOf(false)
-    var hoverRevealBottom by mutableStateOf(false)
+    operator fun get(edge: FocusModeEdge): FocusModeEdgeRevealState = edges.getValue(edge)
 
-    // Debounced visibility states with grace period for smoother transitions
-    var showTopBar by mutableStateOf(false)
-    var showLeftSidebar by mutableStateOf(false)
-    var showRightSidebar by mutableStateOf(false)
-    var showBottomBar by mutableStateOf(false)
+    var showTopBar: Boolean
+        get() = this[FocusModeEdge.TOP].shown
+        set(value) {
+            this[FocusModeEdge.TOP].shown = value
+        }
 
-    // Interaction sources for sidebar hover tracking
-    val topBarInteractionSource = MutableInteractionSource()
-    val leftSidebarInteractionSource = MutableInteractionSource()
-    val rightSidebarInteractionSource = MutableInteractionSource()
-    val bottomBarInteractionSource = MutableInteractionSource()
+    var showLeftSidebar: Boolean
+        get() = this[FocusModeEdge.LEFT].shown
+        set(value) {
+            this[FocusModeEdge.LEFT].shown = value
+        }
+
+    var showRightSidebar: Boolean
+        get() = this[FocusModeEdge.RIGHT].shown
+        set(value) {
+            this[FocusModeEdge.RIGHT].shown = value
+        }
+
+    var showBottomBar: Boolean
+        get() = this[FocusModeEdge.BOTTOM].shown
+        set(value) {
+            this[FocusModeEdge.BOTTOM].shown = value
+        }
+
+    val topBarInteractionSource get() = this[FocusModeEdge.TOP].interactionSource
+    val leftSidebarInteractionSource get() = this[FocusModeEdge.LEFT].interactionSource
+    val rightSidebarInteractionSource get() = this[FocusModeEdge.RIGHT].interactionSource
+    val bottomBarInteractionSource get() = this[FocusModeEdge.BOTTOM].interactionSource
 }
 
 /**
  * Creates the reveal state and runs its per-edge delay and grace-period effects.
- * When focus mode is off, all four bars are simply shown.
+ *
+ * Each edge is gated on [FocusModeSettings.hides] rather than on focus mode as a
+ * whole: an edge focus mode is not set to clear is simply shown, exactly as when
+ * focus mode is off. That is what keeps the sidebars up on Windows, where
+ * hover-reveal cannot fire.
  */
 @Composable
-internal fun rememberFocusModeReveal(
-    isFocusModeEnabled: Boolean,
-    revealDelayMs: Long,
-): FocusModeRevealState {
+internal fun rememberFocusModeReveal(settings: FocusModeSettings): FocusModeRevealState {
     val state = remember { FocusModeRevealState() }
+    FocusModeEdge.entries.forEach { edge ->
+        EdgeRevealEffects(
+            edge = state[edge],
+            hidden = settings.hides(edge),
+            revealDelayMs = settings.revealDelayMs,
+        )
+    }
+    return state
+}
 
-    // Track hover state on revealed content itself
-    val topBarHovered by state.topBarInteractionSource.collectIsHoveredAsState()
-    val leftSidebarHovered by state.leftSidebarInteractionSource.collectIsHoveredAsState()
-    val rightSidebarHovered by state.rightSidebarInteractionSource.collectIsHoveredAsState()
-    val bottomBarHovered by state.bottomBarInteractionSource.collectIsHoveredAsState()
+/**
+ * The delay-then-reveal and grace-period-then-hide effects for a single edge.
+ *
+ * [hidden] is the whole gate: an edge focus mode does not clear is simply shown and
+ * never runs a timer.
+ */
+@Composable
+private fun EdgeRevealEffects(
+    edge: FocusModeEdgeRevealState,
+    hidden: Boolean,
+    revealDelayMs: Long,
+) {
+    // Hover on the revealed bar itself holds it open while the pointer is on it.
+    val barHovered by edge.interactionSource.collectIsHoveredAsState()
 
     // Apply reveal delay before triggering reveal
-    LaunchedEffect(state.hoveringTopStrip, revealDelayMs) {
-        if (state.hoveringTopStrip) {
+    LaunchedEffect(edge.hoveringStrip, revealDelayMs) {
+        if (edge.hoveringStrip) {
             delay(revealDelayMs)
-            state.hoverRevealTop = true
+            edge.hoverRevealed = true
         } else {
-            state.hoverRevealTop = false
-        }
-    }
-
-    LaunchedEffect(state.hoveringLeftStrip, revealDelayMs) {
-        if (state.hoveringLeftStrip) {
-            delay(revealDelayMs)
-            state.hoverRevealLeft = true
-        } else {
-            state.hoverRevealLeft = false
-        }
-    }
-
-    LaunchedEffect(state.hoveringRightStrip, revealDelayMs) {
-        if (state.hoveringRightStrip) {
-            delay(revealDelayMs)
-            state.hoverRevealRight = true
-        } else {
-            state.hoverRevealRight = false
-        }
-    }
-
-    LaunchedEffect(state.hoveringBottomStrip, revealDelayMs) {
-        if (state.hoveringBottomStrip) {
-            delay(revealDelayMs)
-            state.hoverRevealBottom = true
-        } else {
-            state.hoverRevealBottom = false
+            edge.hoverRevealed = false
         }
     }
 
     // Add grace period before hiding to prevent flicker when moving mouse from strip to sidebar
-    LaunchedEffect(state.hoverRevealTop, topBarHovered, isFocusModeEnabled) {
-        if (!isFocusModeEnabled) {
-            state.showTopBar = true
-        } else if (state.hoverRevealTop || topBarHovered) {
-            state.showTopBar = true
+    LaunchedEffect(edge.hoverRevealed, barHovered, hidden) {
+        if (!hidden || edge.hoverRevealed || barHovered) {
+            edge.shown = true
         } else {
-            // Add 2000ms delay before hiding for menu interactions
-            delay(2000)
-            if (!state.hoverRevealTop && !topBarHovered) {
-                state.showTopBar = false
+            // Hold the bar briefly so an open menu is not yanked away
+            delay(HIDE_GRACE_PERIOD_MS)
+            if (!edge.hoverRevealed && !barHovered) {
+                edge.shown = false
             }
         }
     }
-
-    LaunchedEffect(state.hoverRevealLeft, leftSidebarHovered, isFocusModeEnabled) {
-        if (!isFocusModeEnabled) {
-            state.showLeftSidebar = true
-        } else if (state.hoverRevealLeft || leftSidebarHovered) {
-            state.showLeftSidebar = true
-        } else {
-            // Add 2000ms delay before hiding for menu interactions
-            delay(2000)
-            if (!state.hoverRevealLeft && !leftSidebarHovered) {
-                state.showLeftSidebar = false
-            }
-        }
-    }
-
-    LaunchedEffect(state.hoverRevealRight, rightSidebarHovered, isFocusModeEnabled) {
-        if (!isFocusModeEnabled) {
-            state.showRightSidebar = true
-        } else if (state.hoverRevealRight || rightSidebarHovered) {
-            state.showRightSidebar = true
-        } else {
-            // Add 2000ms delay before hiding for menu interactions
-            delay(2000)
-            if (!state.hoverRevealRight && !rightSidebarHovered) {
-                state.showRightSidebar = false
-            }
-        }
-    }
-
-    LaunchedEffect(state.hoverRevealBottom, bottomBarHovered, isFocusModeEnabled) {
-        if (!isFocusModeEnabled) {
-            state.showBottomBar = true
-        } else if (state.hoverRevealBottom || bottomBarHovered) {
-            state.showBottomBar = true
-        } else {
-            // Add 2000ms delay before hiding for menu interactions
-            delay(2000)
-            if (!state.hoverRevealBottom && !bottomBarHovered) {
-                state.showBottomBar = false
-            }
-        }
-    }
-
-    return state
 }
 
 /**
  * Hover reveal strips for focus mode — dynamic sizing to avoid blocking clicks.
  * Each strip uses revealOffset when hidden, 1dp when visible (doesn't block clicks).
+ *
+ * A strip is laid out only for an edge focus mode actually clears. An edge that
+ * stays visible has nothing to reveal, and its strip would otherwise be an
+ * invisible [revealOffsetDp]-wide band sitting over the edge of live content.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun BoxScope.FocusModeHoverStrips(
     state: FocusModeRevealState,
-    isFocusModeEnabled: Boolean,
-    isAutoRevealEnabled: Boolean,
+    settings: FocusModeSettings,
     revealOffsetDp: Dp,
 ) {
-    if (!isFocusModeEnabled || !isAutoRevealEnabled) return
+    if (!settings.autoRevealEnabled) return
 
-    // Top hover strip
+    FocusModeEdge.entries.forEach { edge ->
+        if (settings.hides(edge)) {
+            val edgeState = state[edge]
+            val thickness = if (edgeState.shown) 1.dp else revealOffsetDp
+            HoverStrip(
+                edge = edge,
+                modifier =
+                    when (edge) {
+                        FocusModeEdge.TOP -> Modifier.fillMaxWidth().height(thickness).align(Alignment.TopStart)
+                        FocusModeEdge.BOTTOM -> Modifier.fillMaxWidth().height(thickness).align(Alignment.BottomStart)
+                        FocusModeEdge.LEFT -> Modifier.fillMaxHeight().width(thickness).align(Alignment.CenterStart)
+                        FocusModeEdge.RIGHT -> Modifier.fillMaxHeight().width(thickness).align(Alignment.CenterEnd)
+                    },
+                onHoverChange = { edgeState.hoveringStrip = it },
+            )
+        }
+    }
+}
+
+/**
+ * Test tag of [edge]'s hover strip. The strips are invisible and hold no content,
+ * so a tag is the only way a test can tell one is there - see `FocusModeRevealTest`.
+ */
+internal fun focusStripTag(edge: FocusModeEdge) = "focus-strip-${edge.name.lowercase()}"
+
+/** One transparent edge band that reports the pointer entering and leaving it. */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun HoverStrip(
+    edge: FocusModeEdge,
+    modifier: Modifier,
+    onHoverChange: (Boolean) -> Unit,
+) {
     Box(
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(if (state.showTopBar) 1.dp else revealOffsetDp)
-                .align(Alignment.TopStart)
+            modifier
                 .zIndex(10f)
+                .testTag(focusStripTag(edge))
                 .background(Color.Transparent)
-                .onPointerEvent(PointerEventType.Enter) {
-                    state.hoveringTopStrip = true
-                }.onPointerEvent(PointerEventType.Exit) {
-                    state.hoveringTopStrip = false
-                },
-    )
-
-    // Left hover strip
-    Box(
-        modifier =
-            Modifier
-                .fillMaxHeight()
-                .width(if (state.showLeftSidebar) 1.dp else revealOffsetDp)
-                .align(Alignment.CenterStart)
-                .zIndex(10f)
-                .background(Color.Transparent)
-                .onPointerEvent(PointerEventType.Enter) {
-                    state.hoveringLeftStrip = true
-                }.onPointerEvent(PointerEventType.Exit) {
-                    state.hoveringLeftStrip = false
-                },
-    )
-
-    // Right hover strip
-    Box(
-        modifier =
-            Modifier
-                .fillMaxHeight()
-                .width(if (state.showRightSidebar) 1.dp else revealOffsetDp)
-                .align(Alignment.CenterEnd)
-                .zIndex(10f)
-                .background(Color.Transparent)
-                .onPointerEvent(PointerEventType.Enter) {
-                    state.hoveringRightStrip = true
-                }.onPointerEvent(PointerEventType.Exit) {
-                    state.hoveringRightStrip = false
-                },
-    )
-
-    // Bottom hover strip
-    Box(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(if (state.showBottomBar) 1.dp else revealOffsetDp)
-                .align(Alignment.BottomStart)
-                .zIndex(10f)
-                .background(Color.Transparent)
-                .onPointerEvent(PointerEventType.Enter) {
-                    state.hoveringBottomStrip = true
-                }.onPointerEvent(PointerEventType.Exit) {
-                    state.hoveringBottomStrip = false
-                },
+                .onPointerEvent(PointerEventType.Enter) { onHoverChange(true) }
+                .onPointerEvent(PointerEventType.Exit) { onHoverChange(false) },
     )
 }
+
+/** How long a bar stays up after the pointer leaves, so menu interactions survive. */
+private const val HIDE_GRACE_PERIOD_MS = 2000L

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FreshStartWorkspace.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FreshStartWorkspace.kt
@@ -1,0 +1,53 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.window_panel.SplitViewState
+import ai.rever.boss.components.workspaces.LayoutWorkspace
+import ai.rever.boss.components.workspaces.WorkspaceSettingsManager
+import ai.rever.boss.components.workspaces.applyWorkspace
+import ai.rever.boss.components.workspaces.requiresProject
+import ai.rever.boss.components.workspaces.workspaceManager
+import ai.rever.boss.window.WindowProjectState
+
+/**
+ * Whether a window that restored nothing should apply [workspace] as its starting layout.
+ *
+ * Two conditions, and both are load-bearing:
+ * - **No project selected.** With a project, the reactive apply in
+ *   `BossAppStartupEffects` already owns this and would apply the same workspace a
+ *   second time.
+ * - **The workspace can stand without one.** `{projectPath}` silently falls back to the
+ *   user's home directory, so applying the Claude Code default here would open a
+ *   terminal running `claude --dangerously-skip-permissions` in `~` on the first launch
+ *   of a fresh install. Browser-only needs nothing, which is why the Windows default
+ *   reaches first launch and the terminal-first defaults keep waiting for a project,
+ *   on every platform, exactly as before.
+ */
+internal fun shouldApplyOnFreshStart(
+    workspace: LayoutWorkspace?,
+    hasProject: Boolean,
+): Boolean = workspace != null && !hasProject && !workspace.requiresProject()
+
+/**
+ * Apply the configured default workspace to a first window that restored nothing - no
+ * Last Session, no project - so a fresh install comes up on its default layout rather
+ * than on an empty window.
+ *
+ * Returns the workspace applied, or null if [shouldApplyOnFreshStart] declined. Must be
+ * called before `markHandlersReady`: [applyWorkspace] clears all panels, which would
+ * destroy tabs a handler had already created.
+ */
+internal suspend fun applyDefaultWorkspaceOnFreshStart(
+    splitViewState: SplitViewState,
+    windowProjectState: WindowProjectState,
+): LayoutWorkspace? {
+    val selectedProject = windowProjectState.selectedProject.value
+    val hasProject = selectedProject.path.isNotEmpty()
+    val workspace = WorkspaceSettingsManager.getDefaultWorkspace()
+    if (!shouldApplyOnFreshStart(workspace, hasProject) || workspace == null) return null
+
+    // restoreProject = false: the workspace carries no project and there is none to
+    // restore, so nothing should touch the window's project selection here.
+    applyWorkspace(workspace, splitViewState, windowProjectState, restoreProject = false)
+    workspaceManager.loadWorkspace(workspace)
+    return workspace
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FreshStartWorkspace.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FreshStartWorkspace.kt
@@ -43,11 +43,18 @@ internal suspend fun applyDefaultWorkspaceOnFreshStart(
     val selectedProject = windowProjectState.selectedProject.value
     val hasProject = selectedProject.path.isNotEmpty()
     val workspace = WorkspaceSettingsManager.getDefaultWorkspace()
-    if (!shouldApplyOnFreshStart(workspace, hasProject) || workspace == null) return null
+    if (workspace == null || !shouldApplyOnFreshStart(workspace, hasProject)) return null
+
+    // loadWorkspace FIRST, exactly as the Last Session path does and for the same reason:
+    // it sets currentWorkspace, which is what makes the fresh-install fallback timeout
+    // stand down. applyWorkspace can outlast that timeout (it waits for plugin tab types
+    // to register, and the timeout defaults to 1000ms), and a timeout firing mid-apply
+    // would clearAllPanels over the tabs this apply is still creating and mark handlers
+    // ready early - the very failure the Last Session ordering comment guards against.
+    workspaceManager.loadWorkspace(workspace)
 
     // restoreProject = false: the workspace carries no project and there is none to
     // restore, so nothing should touch the window's project selection here.
     applyWorkspace(workspace, splitViewState, windowProjectState, restoreProject = false)
-    workspaceManager.loadWorkspace(workspace)
     return workspace
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/StartupPanelPolicy.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/StartupPanelPolicy.kt
@@ -15,7 +15,7 @@ import ai.rever.boss.utils.SystemUtils
  * sidebar click, menu item, deep link or CLI command away; only the automatic
  * open is suppressed.
  */
-object StartupPanelPolicy {
+internal object StartupPanelPolicy {
     /** Platform-explicit form, so both branches are reachable from a test on any host. */
     fun autoOpensProjectPanelsFor(isWindows: Boolean): Boolean = !isWindows
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/StartupPanelPolicy.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/StartupPanelPolicy.kt
@@ -1,0 +1,43 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.events.PanelEventBus
+import ai.rever.boss.components.plugin.PanelIds
+import ai.rever.boss.utils.SystemUtils
+
+/**
+ * Whether selecting a project also opens the host's project panels (Codebase and
+ * Run Configurations) on its own.
+ *
+ * Windows starts as a plain browser - see `defaultWorkspaceIdFor` - so nothing
+ * but the chosen workspace comes up there: no sidebar panel opens by itself, and
+ * no plugin panel either, since Codebase and Run Configurations are the only
+ * panels the host ever opens without being asked. Every panel is still one
+ * sidebar click, menu item, deep link or CLI command away; only the automatic
+ * open is suppressed.
+ */
+object StartupPanelPolicy {
+    /** Platform-explicit form, so both branches are reachable from a test on any host. */
+    fun autoOpensProjectPanelsFor(isWindows: Boolean): Boolean = !isWindows
+
+    /** [autoOpensProjectPanelsFor] resolved against the running platform. */
+    val autoOpensProjectPanels: Boolean
+        get() = autoOpensProjectPanelsFor(SystemUtils.isWindows)
+}
+
+/**
+ * The single place the host opens its project panels from.
+ *
+ * Three startup effects need this - a pending project handed over by "Open in New
+ * Window", a project already selected when the window composes, and a project
+ * selected later - and they must agree about the policy above, so they all route
+ * through here. `ProjectPanelOpenerTest` fails if a call to
+ * [PanelEventBus.openPanel] reappears in `BossAppStartupEffects.kt`.
+ */
+internal suspend fun openProjectPanels(
+    windowId: String,
+    autoOpen: Boolean = StartupPanelPolicy.autoOpensProjectPanels,
+) {
+    if (!autoOpen) return
+    PanelEventBus.openPanel(PanelIds.CODEBASE, sourceWindowId = windowId)
+    PanelEventBus.openPanel(PanelIds.RUN_CONFIGURATIONS, sourceWindowId = windowId)
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/LayoutWorkspace.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/LayoutWorkspace.kt
@@ -5,7 +5,6 @@ package ai.rever.boss.components.workspaces
 import ai.rever.boss.plugin.workspace.SplitConfig.HorizontalSplit
 import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
 import ai.rever.boss.plugin.workspace.SplitConfig.VerticalSplit
-import java.util.concurrent.atomic.AtomicInteger
 import ai.rever.boss.plugin.workspace.extractPanels as pluginExtractPanels
 
 /**
@@ -35,9 +34,10 @@ object PredefinedWorkspaces {
     // A counter, not a timestamp plus a random draw: this whole list is built in one
     // initializer, so every id would be minted in the same millisecond and collide on
     // a 1-in-10000 draw. Panel ids key the split tree, so a collision is not cosmetic.
-    private val panelIdCounter = AtomicInteger()
+    // A plain var is enough - the only caller is the single-threaded initializer below.
+    private var panelIdCounter = 0
 
-    private fun generatePanelId() = "panel-predefined-${panelIdCounter.incrementAndGet()}"
+    private fun generatePanelId() = "panel-predefined-${++panelIdCounter}"
 
     /** Id of the browser-only workspace, the platform default on Windows. */
     const val BROWSER_ONLY_ID = "workspace-browser"
@@ -56,34 +56,6 @@ object PredefinedWorkspaces {
 
     val allWorkspaces =
         listOf(
-            // Browser only: a single browser panel on the BOSS home page.
-            // The default on Windows, where the terminal-first layouts are a poor
-            // first run (see defaultWorkspaceIdFor in WorkspaceSettingsManager.kt).
-            //
-            // "Browser Only", not "Browser": WorkspaceManager identifies predefined
-            // workspaces by NAME (WorkspaceManager.kt:63 drops a saved workspace whose
-            // name collides, and WorkspaceButton decides renameable/deletable the same
-            // way), so a short generic name would silently swallow a user's own
-            // hand-rolled single-browser layout.
-            LayoutWorkspace(
-                id = BROWSER_ONLY_ID,
-                name = "Browser Only",
-                description = "A single browser panel on $BROWSER_ONLY_URL",
-                layout =
-                    SinglePanel(
-                        PanelConfig(
-                            id = generatePanelId(),
-                            tabs =
-                                listOf(
-                                    TabConfig(
-                                        type = "browser",
-                                        title = "RISA Labs",
-                                        url = BROWSER_ONLY_URL,
-                                    ),
-                                ),
-                        ),
-                    ),
-            ),
             // Claude Code: Terminal + Browser
             LayoutWorkspace(
                 id = CLAUDE_CODE_ID,
@@ -370,6 +342,38 @@ object PredefinedWorkspaces {
                                         ),
                                 ),
                             ),
+                    ),
+            ),
+            // Browser only: a single browser panel on the BOSS home page.
+            // The default on Windows, where the terminal-first layouts are a poor
+            // first run (see defaultWorkspaceIdFor in WorkspaceSettingsManager.kt).
+            //
+            // Appended rather than prepended: this list is the order of the Settings
+            // picker and the workspace menu on every platform, and one platform's
+            // default is not a reason to reshuffle what everyone else sees.
+            //
+            // "Browser Only", not "Browser": WorkspaceManager identifies predefined
+            // workspaces by NAME (WorkspaceManager.kt:63 drops a saved workspace whose
+            // name collides, and WorkspaceButton decides renameable/deletable the same
+            // way), so a short generic name would silently swallow a user's own
+            // hand-rolled single-browser layout.
+            LayoutWorkspace(
+                id = BROWSER_ONLY_ID,
+                name = "Browser Only",
+                description = "A single browser panel on $BROWSER_ONLY_URL",
+                layout =
+                    SinglePanel(
+                        PanelConfig(
+                            id = generatePanelId(),
+                            tabs =
+                                listOf(
+                                    TabConfig(
+                                        type = "browser",
+                                        title = "RISA Labs",
+                                        url = BROWSER_ONLY_URL,
+                                    ),
+                                ),
+                        ),
                     ),
             ),
         )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/LayoutWorkspace.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/LayoutWorkspace.kt
@@ -5,6 +5,7 @@ package ai.rever.boss.components.workspaces
 import ai.rever.boss.plugin.workspace.SplitConfig.HorizontalSplit
 import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
 import ai.rever.boss.plugin.workspace.SplitConfig.VerticalSplit
+import java.util.concurrent.atomic.AtomicInteger
 import ai.rever.boss.plugin.workspace.extractPanels as pluginExtractPanels
 
 /**
@@ -31,7 +32,12 @@ fun SplitConfig.extractPanels(prefix: String = ""): List<Pair<String, String>> =
  * Note: This object stays in composeApp as it contains project-specific configuration.
  */
 object PredefinedWorkspaces {
-    private fun generatePanelId() = "panel-${System.currentTimeMillis()}-${(Math.random() * 10000).toInt()}"
+    // A counter, not a timestamp plus a random draw: this whole list is built in one
+    // initializer, so every id would be minted in the same millisecond and collide on
+    // a 1-in-10000 draw. Panel ids key the split tree, so a collision is not cosmetic.
+    private val panelIdCounter = AtomicInteger()
+
+    private fun generatePanelId() = "panel-predefined-${panelIdCounter.incrementAndGet()}"
 
     /** Id of the browser-only workspace, the platform default on Windows. */
     const val BROWSER_ONLY_ID = "workspace-browser"
@@ -39,17 +45,29 @@ object PredefinedWorkspaces {
     /** Id of the terminal + browser workspace, the platform default everywhere else. */
     const val CLAUDE_CODE_ID = "workspace-claude-code"
 
-    /** Home page the browser-only workspace opens with. */
-    const val BROWSER_ONLY_URL = "https://risalabs.ai"
+    /**
+     * Home page the browser-only workspace opens with.
+     *
+     * The `www` host, matching `JxBrowserConfig.defaultUrl`, `Fluck`'s fallback and the
+     * recent-pages seed: the apex 301s here, so the other spelling would cost a redirect
+     * and put the default workspace on a different origin from the browser's own default.
+     */
+    const val BROWSER_ONLY_URL = "https://www.risalabs.ai"
 
     val allWorkspaces =
         listOf(
             // Browser only: a single browser panel on the BOSS home page.
             // The default on Windows, where the terminal-first layouts are a poor
-            // first run (see WorkspaceSettings.defaultWorkspaceIdForPlatform).
+            // first run (see defaultWorkspaceIdFor in WorkspaceSettingsManager.kt).
+            //
+            // "Browser Only", not "Browser": WorkspaceManager identifies predefined
+            // workspaces by NAME (WorkspaceManager.kt:63 drops a saved workspace whose
+            // name collides, and WorkspaceButton decides renameable/deletable the same
+            // way), so a short generic name would silently swallow a user's own
+            // hand-rolled single-browser layout.
             LayoutWorkspace(
                 id = BROWSER_ONLY_ID,
-                name = "Browser",
+                name = "Browser Only",
                 description = "A single browser panel on $BROWSER_ONLY_URL",
                 layout =
                     SinglePanel(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/LayoutWorkspace.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/LayoutWorkspace.kt
@@ -33,11 +33,42 @@ fun SplitConfig.extractPanels(prefix: String = ""): List<Pair<String, String>> =
 object PredefinedWorkspaces {
     private fun generatePanelId() = "panel-${System.currentTimeMillis()}-${(Math.random() * 10000).toInt()}"
 
+    /** Id of the browser-only workspace, the platform default on Windows. */
+    const val BROWSER_ONLY_ID = "workspace-browser"
+
+    /** Id of the terminal + browser workspace, the platform default everywhere else. */
+    const val CLAUDE_CODE_ID = "workspace-claude-code"
+
+    /** Home page the browser-only workspace opens with. */
+    const val BROWSER_ONLY_URL = "https://risalabs.ai"
+
     val allWorkspaces =
         listOf(
+            // Browser only: a single browser panel on the BOSS home page.
+            // The default on Windows, where the terminal-first layouts are a poor
+            // first run (see WorkspaceSettings.defaultWorkspaceIdForPlatform).
+            LayoutWorkspace(
+                id = BROWSER_ONLY_ID,
+                name = "Browser",
+                description = "A single browser panel on $BROWSER_ONLY_URL",
+                layout =
+                    SinglePanel(
+                        PanelConfig(
+                            id = generatePanelId(),
+                            tabs =
+                                listOf(
+                                    TabConfig(
+                                        type = "browser",
+                                        title = "RISA Labs",
+                                        url = BROWSER_ONLY_URL,
+                                    ),
+                                ),
+                        ),
+                    ),
+            ),
             // Claude Code: Terminal + Browser
             LayoutWorkspace(
-                id = "workspace-claude-code",
+                id = CLAUDE_CODE_ID,
                 name = "Claude Code",
                 description = "Terminal with Claude CLI + Browser with GitHub",
                 layout =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceProjectRequirement.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceProjectRequirement.kt
@@ -1,0 +1,44 @@
+package ai.rever.boss.components.workspaces
+
+import ai.rever.boss.plugin.workspace.SplitConfig.HorizontalSplit
+import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
+import ai.rever.boss.plugin.workspace.SplitConfig.VerticalSplit
+
+/**
+ * Placeholders that only mean something once a project is selected.
+ *
+ * `{projectPath}` falls back to the user's home directory and `{gitRemoteUrl}` to
+ * google.com when there is no project, so a workspace using them does not fail - it
+ * quietly does the wrong thing. The Claude Code default, applied with no project,
+ * would open a terminal running `claude --dangerously-skip-permissions` in the user's
+ * home directory.
+ */
+private val PROJECT_PLACEHOLDERS =
+    listOf(
+        "{projectPath}",
+        "{gitRemoteUrl}",
+        "{currentFile}",
+        "{claudeContinueFlag}",
+    )
+
+/**
+ * Whether this workspace only makes sense with a project selected.
+ *
+ * Used by the fresh-start apply: a window that restored nothing and has no project
+ * applies the configured default only if the default can stand on its own. That keeps
+ * the rule platform-neutral - browser-only comes up on a fresh Windows install because
+ * it needs nothing, and the terminal-first defaults keep waiting for a project on every
+ * platform exactly as they did before.
+ */
+fun LayoutWorkspace.requiresProject(): Boolean = layout.collectTabs().any { it.usesProjectPlaceholder() }
+
+private fun TabConfig.usesProjectPlaceholder(): Boolean =
+    listOfNotNull(url, filePath, initialCommand, workingDirectory)
+        .any { field -> PROJECT_PLACEHOLDERS.any { it in field } }
+
+private fun SplitConfig.collectTabs(): List<TabConfig> =
+    when (this) {
+        is SinglePanel -> panel.tabs
+        is VerticalSplit -> left.collectTabs() + right.collectTabs()
+        is HorizontalSplit -> top.collectTabs() + bottom.collectTabs()
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceSettingsManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceSettingsManager.kt
@@ -57,13 +57,19 @@ data class WorkspaceSettings(
  */
 object WorkspaceSettingsMigrations {
     /**
-     * Returns the settings to use, migrated if the file predates a platform
-     * default change, or null when nothing needed to change.
+     * Returns the settings to use, or null when the file is already current.
      *
-     * The version 0 -> 1 step only rewrites a Windows install still sitting on
-     * the old universal default. A Windows user who deliberately picked some
-     * other workspace keeps it, and the step runs at most once because the
-     * migrated file records the new version.
+     * A non-null result does not mean the default moved: every pre-v1 file is
+     * returned with the version stamped, whether or not anything else changed.
+     * The caller distinguishes the two (see `DesktopWorkspaceSettingsManager`).
+     *
+     * The version 0 -> 1 step rewrites a Windows install sitting on the old
+     * universal default. It cannot tell that apart from a Windows user who picked
+     * Claude Code deliberately - `encodeDefaults = true` wrote the same value
+     * either way and there was no version field to distinguish them - so such a
+     * user is moved once, deliberately. Every *other* value, including "none", is
+     * preserved, and the step runs at most once because the migrated file records
+     * the new version.
      */
     fun migrate(
         loaded: WorkspaceSettings,
@@ -71,16 +77,14 @@ object WorkspaceSettingsMigrations {
     ): WorkspaceSettings? {
         if (loaded.settingsVersion >= WorkspaceSettings.CURRENT_SETTINGS_VERSION) return null
 
-        val migrated =
-            if (isWindows && loaded.defaultWorkspaceId == PredefinedWorkspaces.CLAUDE_CODE_ID) {
-                loaded.copy(
-                    defaultWorkspaceId = PredefinedWorkspaces.BROWSER_ONLY_ID,
-                    settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION,
-                )
-            } else {
-                loaded.copy(settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION)
-            }
-        return migrated
+        return if (isWindows && loaded.defaultWorkspaceId == PredefinedWorkspaces.CLAUDE_CODE_ID) {
+            loaded.copy(
+                defaultWorkspaceId = PredefinedWorkspaces.BROWSER_ONLY_ID,
+                settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION,
+            )
+        } else {
+            loaded.copy(settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION)
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceSettingsManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceSettingsManager.kt
@@ -1,7 +1,26 @@
 package ai.rever.boss.components.workspaces
 
+import ai.rever.boss.utils.SystemUtils
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
+
+/**
+ * The workspace applied on a fresh install, per platform.
+ *
+ * Windows opens browser-only on the BOSS home page; every other platform keeps
+ * the terminal + browser Claude Code layout. Only the *default* differs - the
+ * full workspace list stays the same everywhere, so a Windows user can still
+ * pick any layout in Settings.
+ */
+fun defaultWorkspaceIdFor(isWindows: Boolean): String =
+    if (isWindows) {
+        PredefinedWorkspaces.BROWSER_ONLY_ID
+    } else {
+        PredefinedWorkspaces.CLAUDE_CODE_ID
+    }
+
+/** [defaultWorkspaceIdFor] resolved against the running platform. */
+fun defaultWorkspaceIdForPlatform(): String = defaultWorkspaceIdFor(SystemUtils.isWindows)
 
 /**
  * Settings for workspace behavior.
@@ -12,8 +31,58 @@ data class WorkspaceSettings(
      * The ID of the default workspace to apply when a project is selected.
      * Use "none" to disable auto-applying workspace.
      */
-    val defaultWorkspaceId: String = "workspace-claude-code",
-)
+    val defaultWorkspaceId: String = defaultWorkspaceIdForPlatform(),
+    /**
+     * Schema version of this file, used to apply one-time migrations to installs
+     * that already have a settings file written by an older build.
+     *
+     * The default is deliberately 0, not [CURRENT_SETTINGS_VERSION]: a missing key
+     * decodes to the default, and every file written before this field existed is
+     * missing it. The manager stamps the current version when it writes.
+     */
+    val settingsVersion: Int = 0,
+) {
+    companion object {
+        /**
+         * Bump when a migration is added to [WorkspaceSettingsMigrations.migrate].
+         * 1: Windows moves from the Claude Code default to browser-only.
+         */
+        const val CURRENT_SETTINGS_VERSION = 1
+    }
+}
+
+/**
+ * One-time migrations for [WorkspaceSettings] files written by older builds.
+ * Kept in commonMain (and pure) so it is directly testable.
+ */
+object WorkspaceSettingsMigrations {
+    /**
+     * Returns the settings to use, migrated if the file predates a platform
+     * default change, or null when nothing needed to change.
+     *
+     * The version 0 -> 1 step only rewrites a Windows install still sitting on
+     * the old universal default. A Windows user who deliberately picked some
+     * other workspace keeps it, and the step runs at most once because the
+     * migrated file records the new version.
+     */
+    fun migrate(
+        loaded: WorkspaceSettings,
+        isWindows: Boolean = SystemUtils.isWindows,
+    ): WorkspaceSettings? {
+        if (loaded.settingsVersion >= WorkspaceSettings.CURRENT_SETTINGS_VERSION) return null
+
+        val migrated =
+            if (isWindows && loaded.defaultWorkspaceId == PredefinedWorkspaces.CLAUDE_CODE_ID) {
+                loaded.copy(
+                    defaultWorkspaceId = PredefinedWorkspaces.BROWSER_ONLY_ID,
+                    settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION,
+                )
+            } else {
+                loaded.copy(settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION)
+            }
+        return migrated
+    }
+}
 
 /**
  * Manager for workspace settings.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/focusmode/FocusModeSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/focusmode/FocusModeSettings.kt
@@ -96,22 +96,48 @@ data class FocusModeSettings(
             )
 
         /**
-         * Decode a stored settings file, filling every key it predates from [defaults].
+         * Keys introduced with the per-edge switches, and the *only* ones an absence may be
+         * resolved from the platform defaults.
          *
-         * A plain decode would fill a missing key from the *class* default, which is the same on
+         * The distinction is not cosmetic. Files written before this build used
+         * `encodeDefaults = false`, so they omit every value that equals the CLASS default -
+         * an absence there means "the user's choice happened to match the class default", not
+         * "never chosen". Resolving those from the platform defaults would silently revert a
+         * real preference: a Windows user who deliberately switched hover-to-reveal ON wrote a
+         * file with `autoRevealEnabled` absent (it equals the class default `true`), and the
+         * Windows platform default is `false`. These four keys are safe precisely because no
+         * file written before this build can contain them.
+         */
+        private val PLATFORM_DEFAULTED_KEYS =
+            setOf("hideTopBar", "hideLeftSidebar", "hideRightSidebar", "hideBottomBar")
+
+        /**
+         * Decode a stored settings file, resolving the keys it predates from [defaults].
+         *
+         * A plain decode fills a missing key from the *class* default, which is the same on
          * every platform - so a Windows install that already had a settings file would come up
          * hiding both sidebars with no way to reveal them, which is exactly what
-         * [defaultHidesSidebars] exists to prevent. Merging against the platform defaults instead
-         * means "absent" reads as "never chosen", and every future field added here inherits the
-         * same treatment. Keys present in the file always win, so a real choice is never
-         * overwritten.
+         * [defaultHidesSidebars] exists to prevent.
+         *
+         * Only the keys in [PLATFORM_DEFAULTED_KEYS] are resolved that way. Every other absent
+         * key keeps the old meaning and falls back to the class default, because an older
+         * writer omitted class-default values and an absence there is a choice, not a gap. Keys
+         * present in the file always win either way.
+         *
+         * A future platform-specific default needs its key added to that set, in the build that
+         * introduces it - which is the same discipline as bumping a schema version, expressed as
+         * the thing it actually protects.
          */
         fun decodeWithDefaults(
             content: String,
             defaults: FocusModeSettings,
         ): FocusModeSettings {
             val stored = storageJson.parseToJsonElement(content).jsonObject
-            val defaulted = storageJson.encodeToJsonElement(serializer(), defaults).jsonObject
+            val defaulted =
+                storageJson
+                    .encodeToJsonElement(serializer(), defaults)
+                    .jsonObject
+                    .filterKeys { it in PLATFORM_DEFAULTED_KEYS }
             return storageJson.decodeFromJsonElement(serializer(), JsonObject(defaulted + stored))
         }
 
@@ -129,7 +155,7 @@ data class FocusModeSettings(
          * user switching a sidebar back on would write nothing and find it off again next
          * launch - on the one platform where that switch is the whole escape hatch.
          */
-        val storageJson =
+        internal val storageJson =
             Json {
                 prettyPrint = true
                 ignoreUnknownKeys = true

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/focusmode/FocusModeSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/focusmode/FocusModeSettings.kt
@@ -1,6 +1,19 @@
 package ai.rever.boss.focusmode
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * The four window edges focus mode can clear, each independently switchable.
+ */
+enum class FocusModeEdge {
+    TOP,
+    LEFT,
+    RIGHT,
+    BOTTOM,
+}
 
 /**
  * Configuration for Focus Mode feature.
@@ -11,6 +24,10 @@ import kotlinx.serialization.Serializable
  * @property autoRevealEnabled Whether to auto-reveal hidden bars on mouse hover at edges
  * @property revealOffsetPx Distance in pixels from window edge to trigger auto-reveal
  * @property revealDelayMs Delay in milliseconds before reveal triggers after hovering at edge
+ * @property hideTopBar Whether focus mode clears the top action bar
+ * @property hideLeftSidebar Whether focus mode clears the left sidebar
+ * @property hideRightSidebar Whether focus mode clears the right sidebar
+ * @property hideBottomBar Whether focus mode clears the bottom status bar
  */
 @Serializable
 data class FocusModeSettings(
@@ -18,7 +35,24 @@ data class FocusModeSettings(
     val autoRevealEnabled: Boolean = true,
     val revealOffsetPx: Float = 30f,
     val revealDelayMs: Long = 500L,
+    val hideTopBar: Boolean = true,
+    val hideLeftSidebar: Boolean = true,
+    val hideRightSidebar: Boolean = true,
+    val hideBottomBar: Boolean = true,
 ) {
+    /** Whether [edge] is cleared right now: focus mode is on and that edge opted in. */
+    fun hides(edge: FocusModeEdge): Boolean =
+        enabled &&
+            when (edge) {
+                FocusModeEdge.TOP -> hideTopBar
+                FocusModeEdge.LEFT -> hideLeftSidebar
+                FocusModeEdge.RIGHT -> hideRightSidebar
+                FocusModeEdge.BOTTOM -> hideBottomBar
+            }
+
+    /** Whether any edge is cleared - focus mode with all four off changes nothing. */
+    fun hidesAnything(): Boolean = FocusModeEdge.entries.any { hides(it) }
+
     companion object {
         /**
          * Whether edge hover-to-reveal should be on out of the box, for [osName].
@@ -38,9 +72,56 @@ data class FocusModeSettings(
          * Windows branch here would silently disable a feature that works perfectly well there.
          * The same trap is pinned in `ResourceModeTest` and `JxBrowserRenderingModeTest`.
          */
-        fun defaultAutoReveal(osName: String): Boolean = !osName.lowercase().startsWith("win")
+        fun defaultAutoReveal(osName: String): Boolean = !isWindows(osName)
+
+        /**
+         * Whether focus mode clears the two sidebars out of the box, for [osName].
+         *
+         * **Off on Windows**, for the same reason [defaultAutoReveal] is: with hover-reveal
+         * unable to fire there, hiding a sidebar is a one-way door. The top and bottom bars are
+         * still cleared, so focus mode does something on Windows; the sidebars stay, because they
+         * are what a user reaches for mid-task and what they could not get back.
+         *
+         * This is only the starting point. All four edges are individually switchable in
+         * Settings, so a Windows user who wants the full sweep can have it.
+         */
+        fun defaultHidesSidebars(osName: String): Boolean = !isWindows(osName)
 
         /** Fresh settings for [osName], used on first run and by "Reset to defaults". */
-        fun defaultsFor(osName: String) = FocusModeSettings(autoRevealEnabled = defaultAutoReveal(osName))
+        fun defaultsFor(osName: String) =
+            FocusModeSettings(
+                autoRevealEnabled = defaultAutoReveal(osName),
+                hideLeftSidebar = defaultHidesSidebars(osName),
+                hideRightSidebar = defaultHidesSidebars(osName),
+            )
+
+        /**
+         * Decode a stored settings file, filling every key it predates from [defaults].
+         *
+         * A plain decode would fill a missing key from the *class* default, which is the same on
+         * every platform - so a Windows install that already had a settings file would come up
+         * hiding both sidebars with no way to reveal them, which is exactly what
+         * [defaultHidesSidebars] exists to prevent. Merging against the platform defaults instead
+         * means "absent" reads as "never chosen", and every future field added here inherits the
+         * same treatment. Keys present in the file always win, so a real choice is never
+         * overwritten.
+         */
+        fun decodeWithDefaults(
+            content: String,
+            defaults: FocusModeSettings,
+        ): FocusModeSettings {
+            val stored = mergeJson.parseToJsonElement(content).jsonObject
+            val defaulted = mergeJson.encodeToJsonElement(serializer(), defaults).jsonObject
+            return mergeJson.decodeFromJsonElement(serializer(), JsonObject(defaulted + stored))
+        }
+
+        private fun isWindows(osName: String) = osName.lowercase().startsWith("win")
+
+        /** Needs `encodeDefaults` so the merge sees every key, including ones left at a default. */
+        private val mergeJson =
+            Json {
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/focusmode/FocusModeSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/focusmode/FocusModeSettings.kt
@@ -110,16 +110,28 @@ data class FocusModeSettings(
             content: String,
             defaults: FocusModeSettings,
         ): FocusModeSettings {
-            val stored = mergeJson.parseToJsonElement(content).jsonObject
-            val defaulted = mergeJson.encodeToJsonElement(serializer(), defaults).jsonObject
-            return mergeJson.decodeFromJsonElement(serializer(), JsonObject(defaulted + stored))
+            val stored = storageJson.parseToJsonElement(content).jsonObject
+            val defaulted = storageJson.encodeToJsonElement(serializer(), defaults).jsonObject
+            return storageJson.decodeFromJsonElement(serializer(), JsonObject(defaulted + stored))
         }
 
         private fun isWindows(osName: String) = osName.lowercase().startsWith("win")
 
-        /** Needs `encodeDefaults` so the merge sees every key, including ones left at a default. */
-        private val mergeJson =
+        /**
+         * The one encoder for the settings file - used by `FocusModeSettingsManager` to write
+         * it and by [decodeWithDefaults] to merge it.
+         *
+         * `encodeDefaults` is load-bearing, and the two halves have to agree about it, which
+         * is why they share an instance rather than each configuring their own. Without it a
+         * value equal to the CLASS default is omitted on write, and the merge reads that
+         * absence as "never chosen" and substitutes the PLATFORM default. On Windows those
+         * disagree for `autoRevealEnabled`, `hideLeftSidebar` and `hideRightSidebar`, so a
+         * user switching a sidebar back on would write nothing and find it off again next
+         * launch - on the one platform where that switch is the whole escape hatch.
+         */
+        val storageJson =
             Json {
+                prettyPrint = true
                 ignoreUnknownKeys = true
                 encodeDefaults = true
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/FocusModeSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/FocusModeSettings.kt
@@ -42,7 +42,7 @@ fun FocusModeSettings() {
                         )
                     }
                 },
-                description = "Hide top bar, sidebars, and bottom bar to maximize content area",
+                description = "Clear the window chrome you pick below to maximize content area",
             )
         }
 
@@ -55,13 +55,55 @@ fun FocusModeSettings() {
             }
         }
 
-        // What gets hidden
+        // What gets hidden - one switch per window edge
         SettingsSection(title = "What Gets Hidden") {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                InfoItem(text = "× Top action bar - project selector, settings, etc.")
-                InfoItem(text = "× Left sidebar - plugin panels")
-                InfoItem(text = "× Right sidebar - plugin panels")
-                InfoItem(text = "× Bottom status bar")
+                SettingsToggle(
+                    label = "Top action bar",
+                    checked = settings.hideTopBar,
+                    onCheckedChange = { hide ->
+                        coroutineScope.launch {
+                            FocusModeSettingsManager.updateSettings(settings.copy(hideTopBar = hide))
+                        }
+                    },
+                    description = "Project selector, settings, etc.",
+                    enabled = settings.enabled,
+                )
+                SettingsToggle(
+                    label = "Left sidebar",
+                    checked = settings.hideLeftSidebar,
+                    onCheckedChange = { hide ->
+                        coroutineScope.launch {
+                            FocusModeSettingsManager.updateSettings(settings.copy(hideLeftSidebar = hide))
+                        }
+                    },
+                    description = "Plugin panels docked to the left edge",
+                    enabled = settings.enabled,
+                )
+                SettingsToggle(
+                    label = "Right sidebar",
+                    checked = settings.hideRightSidebar,
+                    onCheckedChange = { hide ->
+                        coroutineScope.launch {
+                            FocusModeSettingsManager.updateSettings(settings.copy(hideRightSidebar = hide))
+                        }
+                    },
+                    description = "Plugin panels docked to the right edge",
+                    enabled = settings.enabled,
+                )
+                SettingsToggle(
+                    label = "Bottom status bar",
+                    checked = settings.hideBottomBar,
+                    onCheckedChange = { hide ->
+                        coroutineScope.launch {
+                            FocusModeSettingsManager.updateSettings(settings.copy(hideBottomBar = hide))
+                        }
+                    },
+                    enabled = settings.enabled,
+                )
+                if (settings.enabled && !settings.hidesAnything()) {
+                    InfoItem(text = "Focus mode is on but hides nothing - pick at least one edge above.")
+                }
             }
         }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/FocusModeSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/FocusModeSettings.kt
@@ -67,7 +67,6 @@ fun FocusModeSettings() {
                         }
                     },
                     description = "Project selector, settings, etc.",
-                    enabled = settings.enabled,
                 )
                 SettingsToggle(
                     label = "Left sidebar",
@@ -78,7 +77,6 @@ fun FocusModeSettings() {
                         }
                     },
                     description = "Plugin panels docked to the left edge",
-                    enabled = settings.enabled,
                 )
                 SettingsToggle(
                     label = "Right sidebar",
@@ -89,7 +87,6 @@ fun FocusModeSettings() {
                         }
                     },
                     description = "Plugin panels docked to the right edge",
-                    enabled = settings.enabled,
                 )
                 SettingsToggle(
                     label = "Bottom status bar",
@@ -99,8 +96,10 @@ fun FocusModeSettings() {
                             FocusModeSettingsManager.updateSettings(settings.copy(hideBottomBar = hide))
                         }
                     },
-                    enabled = settings.enabled,
                 )
+                // Deliberately not gated on settings.enabled: you would have to turn focus
+                // mode on, losing the top bar, before you could choose what it clears.
+                // hides() gates on enabled anyway, so these are inert until it is on.
                 if (settings.enabled && !settings.hidesAnything()) {
                     InfoItem(text = "Focus mode is on but hides nothing - pick at least one edge above.")
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceSettingsManager.kt
@@ -28,51 +28,69 @@ actual object WorkspaceSettingsManager {
             encodeDefaults = true
         }
 
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
-    private val _currentSettings = MutableStateFlow(WorkspaceSettings())
+    // Seeded at the CURRENT version, so 0 means exactly one thing: a key absent from a
+    // file on disk. An in-memory default carrying 0 would re-arm the 0 -> 1 migration
+    // for the next launch as soon as anything persisted it through updateSettings.
+    private val _currentSettings =
+        MutableStateFlow(WorkspaceSettings(settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION))
     actual val currentSettings: StateFlow<WorkspaceSettings> = _currentSettings.asStateFlow()
 
     init {
-        scope.launch {
-            loadSettingsAsync()
+        // Synchronous, like FocusModeSettingsManager, and for the same reason: this
+        // object initialises on first access, and its first accessor is the startup
+        // effect that immediately reads getDefaultWorkspace(). An async load loses that
+        // race every time, so the compiled-in default would win over the stored choice -
+        // on Windows that means applying the browser workspace over the layout of a user
+        // who picked something else, or "none". One small JSON file, read once.
+        loadSettingsSync()
+    }
+
+    private fun loadSettingsSync() {
+        try {
+            settingsFile.parentFile?.mkdirs()
+
+            if (!settingsFile.exists()) {
+                writeSettings(_currentSettings.value)
+                logger.debug(LogCategory.SYSTEM, "Created default settings file")
+                return
+            }
+
+            val settings = json.decodeFromString<WorkspaceSettings>(settingsFile.readText())
+            val migrated = WorkspaceSettingsMigrations.migrate(settings)
+            _currentSettings.value = migrated ?: settings
+            if (migrated == null) {
+                logger.debug(LogCategory.SYSTEM, "Loaded settings")
+                return
+            }
+
+            writeSettings(migrated)
+            // INFO only when a default actually moved. Every pre-v1 file is stamped, so
+            // logging the stamp at INFO would put a "Migrated" line on every existing
+            // install of every platform while nothing changed.
+            if (migrated.defaultWorkspaceId != settings.defaultWorkspaceId) {
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "Migrated default workspace",
+                    mapOf(
+                        "from" to settings.defaultWorkspaceId,
+                        "to" to migrated.defaultWorkspaceId,
+                    ),
+                )
+            } else {
+                logger.debug(LogCategory.SYSTEM, "Stamped workspace settings version")
+            }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Error loading settings", error = e)
         }
     }
 
-    private suspend fun loadSettingsAsync() =
-        withContext(Dispatchers.IO) {
-            try {
-                settingsFile.parentFile?.mkdirs()
-
-                if (settingsFile.exists()) {
-                    val content = settingsFile.readText()
-                    val settings = json.decodeFromString<WorkspaceSettings>(content)
-                    val migrated = WorkspaceSettingsMigrations.migrate(settings)
-                    _currentSettings.value = migrated ?: settings
-                    if (migrated != null) {
-                        logger.info(
-                            LogCategory.SYSTEM,
-                            "Migrated workspace settings",
-                            mapOf(
-                                "fromVersion" to settings.settingsVersion.toString(),
-                                "defaultWorkspaceId" to migrated.defaultWorkspaceId,
-                            ),
-                        )
-                        saveSettings()
-                    } else {
-                        logger.debug(LogCategory.SYSTEM, "Loaded settings")
-                    }
-                } else {
-                    _currentSettings.value =
-                        _currentSettings.value.copy(settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION)
-                    val content = json.encodeToString(WorkspaceSettings.serializer(), _currentSettings.value)
-                    settingsFile.writeText(content)
-                    logger.debug(LogCategory.SYSTEM, "Created default settings file")
-                }
-            } catch (e: Exception) {
-                logger.warn(LogCategory.SYSTEM, "Error loading settings", error = e)
-            }
+    private fun writeSettings(settings: WorkspaceSettings) {
+        try {
+            settingsFile.writeText(json.encodeToString(WorkspaceSettings.serializer(), settings))
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Error saving settings", error = e)
         }
+    }
 
     actual suspend fun saveSettings() =
         withContext(Dispatchers.IO) {
@@ -91,12 +109,14 @@ actual object WorkspaceSettingsManager {
     }
 
     actual suspend fun setDefaultWorkspaceId(workspaceId: String) {
-        // Stamp the schema version too: an explicit choice must never be rewritten
-        // by a migration on the next launch.
+        // Stamp the schema version too: an explicit choice must never be rewritten by a
+        // migration on the next launch. maxOf, so an older build writing over a newer
+        // file cannot stamp the version backwards and re-arm a step that already ran.
         updateSettings(
             _currentSettings.value.copy(
                 defaultWorkspaceId = workspaceId,
-                settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION,
+                settingsVersion =
+                    maxOf(_currentSettings.value.settingsVersion, WorkspaceSettings.CURRENT_SETTINGS_VERSION),
             ),
         )
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceSettingsManager.kt
@@ -47,9 +47,24 @@ actual object WorkspaceSettingsManager {
                 if (settingsFile.exists()) {
                     val content = settingsFile.readText()
                     val settings = json.decodeFromString<WorkspaceSettings>(content)
-                    _currentSettings.value = settings
-                    logger.debug(LogCategory.SYSTEM, "Loaded settings")
+                    val migrated = WorkspaceSettingsMigrations.migrate(settings)
+                    _currentSettings.value = migrated ?: settings
+                    if (migrated != null) {
+                        logger.info(
+                            LogCategory.SYSTEM,
+                            "Migrated workspace settings",
+                            mapOf(
+                                "fromVersion" to settings.settingsVersion.toString(),
+                                "defaultWorkspaceId" to migrated.defaultWorkspaceId,
+                            ),
+                        )
+                        saveSettings()
+                    } else {
+                        logger.debug(LogCategory.SYSTEM, "Loaded settings")
+                    }
                 } else {
+                    _currentSettings.value =
+                        _currentSettings.value.copy(settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION)
                     val content = json.encodeToString(WorkspaceSettings.serializer(), _currentSettings.value)
                     settingsFile.writeText(content)
                     logger.debug(LogCategory.SYSTEM, "Created default settings file")
@@ -76,7 +91,14 @@ actual object WorkspaceSettingsManager {
     }
 
     actual suspend fun setDefaultWorkspaceId(workspaceId: String) {
-        updateSettings(_currentSettings.value.copy(defaultWorkspaceId = workspaceId))
+        // Stamp the schema version too: an explicit choice must never be rewritten
+        // by a migration on the next launch.
+        updateSettings(
+            _currentSettings.value.copy(
+                defaultWorkspaceId = workspaceId,
+                settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION,
+            ),
+        )
     }
 
     actual fun getDefaultWorkspace(): LayoutWorkspace? {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/DesktopWorkspaceSettingsManager.kt
@@ -3,16 +3,12 @@ package ai.rever.boss.components.workspaces
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import java.io.File
 
 /**
  * Desktop implementation of WorkspaceSettingsManager.
@@ -87,20 +83,17 @@ actual object WorkspaceSettingsManager {
     private fun writeSettings(settings: WorkspaceSettings) {
         try {
             settingsFile.writeText(json.encodeToString(WorkspaceSettings.serializer(), settings))
+            logger.debug(LogCategory.SYSTEM, "Settings saved")
         } catch (e: Exception) {
             logger.warn(LogCategory.SYSTEM, "Error saving settings", error = e)
         }
     }
 
+    // One write path. The load runs it on whatever thread touched this object first
+    // (see init); every other caller gets it off the IO dispatcher.
     actual suspend fun saveSettings() =
         withContext(Dispatchers.IO) {
-            try {
-                val content = json.encodeToString(WorkspaceSettings.serializer(), _currentSettings.value)
-                settingsFile.writeText(content)
-                logger.debug(LogCategory.SYSTEM, "Settings saved")
-            } catch (e: Exception) {
-                logger.warn(LogCategory.SYSTEM, "Error saving settings", error = e)
-            }
+            writeSettings(_currentSettings.value)
         }
 
     actual suspend fun updateSettings(settings: WorkspaceSettings) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/focusmode/FocusModeSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/focusmode/FocusModeSettingsManager.kt
@@ -30,9 +30,9 @@ actual object FocusModeSettingsManager {
         }
 
     /**
-     * Fresh settings for this platform. Hover-to-reveal starts OFF on Windows, where the
-     * HARDWARE browser surface swallows the pointer events the reveal depends on - see
-     * [FocusModeSettings.defaultAutoReveal].
+     * Fresh settings for this platform. Hover-to-reveal and sidebar hiding both start OFF on
+     * Windows, where the HARDWARE browser surface swallows the pointer events the reveal depends
+     * on - see [FocusModeSettings.defaultAutoReveal] and [FocusModeSettings.defaultHidesSidebars].
      */
     private val platformDefaults: FocusModeSettings
         get() = FocusModeSettings.defaultsFor(System.getProperty("os.name").orEmpty())
@@ -56,7 +56,10 @@ actual object FocusModeSettingsManager {
         try {
             if (settingsFile.exists()) {
                 val content = settingsFile.readText()
-                val settings = json.decodeFromString<FocusModeSettings>(content)
+                // Merge against the platform defaults rather than plain-decoding: a file written
+                // before the per-edge switches existed has no opinion about them, and the class
+                // defaults would hide both sidebars on Windows with no way to reveal them.
+                val settings = FocusModeSettings.decodeWithDefaults(content, platformDefaults)
                 _currentSettings.value = settings
                 logger.debug(LogCategory.SYSTEM, "Loaded settings", mapOf("path" to settingsFile.absolutePath))
             } else {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/focusmode/FocusModeSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/focusmode/FocusModeSettingsManager.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import java.io.File
 
 /**
@@ -23,11 +22,10 @@ import java.io.File
 actual object FocusModeSettingsManager {
     private val logger = BossLogger.forComponent("FocusModeSettingsManager")
     private val settingsFile = BossDirectories.resolve("focus-mode-settings.json")
-    private val json =
-        Json {
-            prettyPrint = true
-            ignoreUnknownKeys = true
-        }
+
+    // The encoder lives with decodeWithDefaults, because the two have to agree about
+    // encodeDefaults: see FocusModeSettings.storageJson for what breaks when they do not.
+    private val json = FocusModeSettings.storageJson
 
     /**
      * Fresh settings for this platform. Hover-to-reveal and sidebar hiding both start OFF on

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -163,6 +163,22 @@ fun main(args: Array<String>) {
     ai.rever.boss.services.llm.BrokeredCredentialAccess
         .initialize(ai.rever.boss.llm.BrokeredCredentialProviderImpl)
 
+    // Warm the two settings singletons that load their file synchronously in `init`
+    // (WorkspaceSettingsManager and FocusModeSettingsManager). Both must be readable the
+    // instant a startup effect asks - the workspace one decides which layout a window opens
+    // on, and losing that read to an async load is the bug this replaced - but their first
+    // accessor would otherwise be a composition-thread LaunchedEffect, putting mkdirs, a
+    // read, and on the first launch after an upgrade a migration write, on the UI thread.
+    //
+    // This narrows that rather than eliminating it, and is correct either way: JVM class
+    // initialisation is locked, so a window that gets there first simply waits for this to
+    // finish instead of racing it. Launched here, hundreds of milliseconds of setup before
+    // any window composes, it has essentially always finished by then.
+    startupScope.launch(Dispatchers.IO) {
+        ai.rever.boss.components.workspaces.WorkspaceSettingsManager.currentSettings
+        ai.rever.boss.focusmode.FocusModeSettingsManager.currentSettings
+    }
+
     // Set WM_CLASS for Linux desktop integration (must be before any AWT init)
     setLinuxWMClass()
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeRevealTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeRevealTest.kt
@@ -32,9 +32,12 @@ class FocusModeRevealTest {
     val rule = createComposeRule()
 
     /**
-     * Mount the reveal for [settings] and settle it. The grace period before a bar
-     * hides is 2s, so the clock has to pass it or every edge would still read
-     * "shown" and the test would pass for the wrong reason.
+     * Mount the reveal for [settings] and settle it, past the 2s hide grace period.
+     *
+     * Note what this does and does not prove: `shown` starts false, so a hidden edge
+     * reads false whether or not the effects ran. The load-bearing assertions are the
+     * `assertTrue` ones - an edge focus mode does not clear has to be actively turned
+     * back on by [EdgeRevealEffects]. The hover path is covered separately below.
      */
     private fun revealFor(settings: FocusModeSettings): FocusModeRevealState {
         lateinit var state: FocusModeRevealState
@@ -151,6 +154,48 @@ class FocusModeRevealTest {
         }
     }
 
+    /**
+     * The path this refactor actually rewrote: strip hover -> reveal delay -> shown, then
+     * pointer out -> grace period -> hidden again. Four copy-pasted effect pairs became one
+     * parameterised composable, and nothing else here drives that sequence.
+     */
+    @Test
+    fun `hovering a strip reveals its bar and leaving hides it again`() {
+        val settings = FocusModeSettings.defaultsFor("Mac OS X").copy(enabled = true)
+        val state = revealFor(settings)
+        assertFalse(state.showLeftSidebar, "precondition: focus mode cleared it")
+
+        state[FocusModeEdge.LEFT].hoveringStrip = true
+        rule.mainClock.advanceTimeBy(settings.revealDelayMs + FRAME_MS)
+        rule.waitForIdle()
+
+        assertTrue(state.showLeftSidebar, "hovering the strip past the reveal delay must show the bar")
+        assertFalse(state.showRightSidebar, "only the hovered edge reveals")
+
+        state[FocusModeEdge.LEFT].hoveringStrip = false
+        rule.mainClock.advanceTimeBy(GRACE_PERIOD_MS)
+        rule.waitForIdle()
+
+        assertFalse(state.showLeftSidebar, "leaving the strip must hide it again after the grace period")
+    }
+
+    /** The delay is a real wait, not a formality: the bar must not appear before it elapses. */
+    @Test
+    fun `the bar does not appear before the reveal delay elapses`() {
+        val settings = FocusModeSettings.defaultsFor("Mac OS X").copy(enabled = true, revealDelayMs = 500L)
+        val state = revealFor(settings)
+
+        state[FocusModeEdge.TOP].hoveringStrip = true
+        rule.mainClock.advanceTimeBy(settings.revealDelayMs / 2)
+        rule.waitForIdle()
+
+        assertFalse(state.showTopBar, "revealed early, so the delay is not being honoured")
+
+        rule.mainClock.advanceTimeBy(settings.revealDelayMs)
+        rule.waitForIdle()
+        assertTrue(state.showTopBar)
+    }
+
     /** Tags are derived, so a renamed edge cannot silently detach a test from its strip. */
     @Test
     fun `every edge has its own strip tag`() {
@@ -162,5 +207,8 @@ class FocusModeRevealTest {
     private companion object {
         /** Matches the hide delay in `rememberFocusModeReveal`, plus a frame. */
         const val GRACE_PERIOD_MS = 2_500L
+
+        /** One frame past a deadline, so the effect has resumed rather than being mid-delay. */
+        const val FRAME_MS = 100L
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeRevealTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeRevealTest.kt
@@ -1,0 +1,166 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.focusmode.FocusModeEdge
+import ai.rever.boss.focusmode.FocusModeSettings
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The per-edge switches, exercised through the composable that actually drives the
+ * chrome rather than through the settings object alone.
+ *
+ * `FocusModeSettingsTest` proves what the Windows defaults *say*; this proves the
+ * bars follow them - the sidebars stay up on Windows, and no hover strip is laid
+ * over an edge that was never hidden. Neither could be seen from the data class,
+ * because `rememberFocusModeReveal` writes `show*` from four `LaunchedEffect`s
+ * whose keys are the ones this change rewrote.
+ */
+class FocusModeRevealTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    /**
+     * Mount the reveal for [settings] and settle it. The grace period before a bar
+     * hides is 2s, so the clock has to pass it or every edge would still read
+     * "shown" and the test would pass for the wrong reason.
+     */
+    private fun revealFor(settings: FocusModeSettings): FocusModeRevealState {
+        lateinit var state: FocusModeRevealState
+        rule.setContent {
+            state = rememberFocusModeReveal(settings)
+        }
+        rule.waitForIdle()
+        rule.mainClock.advanceTimeBy(GRACE_PERIOD_MS)
+        rule.waitForIdle()
+        return state
+    }
+
+    @Test
+    fun `windows defaults keep both sidebars while clearing top and bottom`() {
+        val state = revealFor(FocusModeSettings.defaultsFor("Windows 11").copy(enabled = true))
+
+        assertTrue(state.showLeftSidebar, "left sidebar must stay visible on Windows")
+        assertTrue(state.showRightSidebar, "right sidebar must stay visible on Windows")
+        assertFalse(state.showTopBar, "focus mode must still clear the top bar on Windows")
+        assertFalse(state.showBottomBar, "focus mode must still clear the bottom bar on Windows")
+    }
+
+    @Test
+    fun `other platforms clear all four`() {
+        val state = revealFor(FocusModeSettings.defaultsFor("Mac OS X").copy(enabled = true))
+
+        assertFalse(state.showTopBar)
+        assertFalse(state.showLeftSidebar)
+        assertFalse(state.showRightSidebar)
+        assertFalse(state.showBottomBar)
+    }
+
+    @Test
+    fun `focus mode off shows everything`() {
+        val state = revealFor(FocusModeSettings.defaultsFor("Mac OS X").copy(enabled = false))
+
+        assertTrue(state.showTopBar)
+        assertTrue(state.showLeftSidebar)
+        assertTrue(state.showRightSidebar)
+        assertTrue(state.showBottomBar)
+    }
+
+    /** Turning an edge's switch off mid-session brings that bar back, and only it. */
+    @Test
+    fun `switching an edge off returns its bar`() {
+        var settings by mutableStateOf(FocusModeSettings.defaultsFor("Linux").copy(enabled = true))
+        lateinit var state: FocusModeRevealState
+        rule.setContent { state = rememberFocusModeReveal(settings) }
+        rule.waitForIdle()
+        rule.mainClock.advanceTimeBy(GRACE_PERIOD_MS)
+        rule.waitForIdle()
+        assertFalse(state.showLeftSidebar, "precondition: Linux starts by clearing the left sidebar")
+
+        settings = settings.copy(hideLeftSidebar = false)
+        rule.waitForIdle()
+
+        assertTrue(state.showLeftSidebar)
+        assertFalse(state.showRightSidebar, "the other edges are untouched")
+        assertFalse(state.showTopBar)
+    }
+
+    /**
+     * A strip is an invisible band the width of the reveal offset. Laying one over an
+     * edge that is never hidden would put dead space over live content - on Windows,
+     * over both sidebars, which is where the plugin panels are.
+     *
+     * Auto-reveal is turned on explicitly here: a Windows install has it off by
+     * default, which is a separate switch and the subject of the next test.
+     */
+    @Test
+    fun `strips exist only for edges that are actually hidden`() {
+        val settings =
+            FocusModeSettings
+                .defaultsFor("Windows 11")
+                .copy(enabled = true, autoRevealEnabled = true)
+        rule.setContent {
+            val state = rememberFocusModeReveal(settings)
+            Box(modifier = Modifier.fillMaxSize()) {
+                FocusModeHoverStrips(state = state, settings = settings, revealOffsetDp = 30.dp)
+            }
+        }
+        rule.waitForIdle()
+        rule.mainClock.advanceTimeBy(GRACE_PERIOD_MS)
+        rule.waitForIdle()
+
+        rule.onNodeWithTag(focusStripTag(FocusModeEdge.TOP)).assertExists()
+        rule.onNodeWithTag(focusStripTag(FocusModeEdge.BOTTOM)).assertExists()
+        rule.onNodeWithTag(focusStripTag(FocusModeEdge.LEFT)).assertDoesNotExist()
+        rule.onNodeWithTag(focusStripTag(FocusModeEdge.RIGHT)).assertDoesNotExist()
+    }
+
+    /**
+     * With auto-reveal off there is nothing to hover, so no strip is laid out at all.
+     *
+     * This is the state a stock Windows install is in - `defaultAutoReveal` is false
+     * there - so on Windows focus mode clears the top and bottom bars and lays down
+     * no strips at all. Toggling focus mode back off is what returns those two bars,
+     * and the sidebars never left.
+     */
+    @Test
+    fun `no strips at all when auto-reveal is off`() {
+        val settings = FocusModeSettings.defaultsFor("Windows 11").copy(enabled = true)
+        assertFalse(settings.autoRevealEnabled, "precondition: Windows starts with hover-reveal off")
+        rule.setContent {
+            val state = rememberFocusModeReveal(settings)
+            Box(modifier = Modifier.fillMaxSize()) {
+                FocusModeHoverStrips(state = state, settings = settings, revealOffsetDp = 30.dp)
+            }
+        }
+        rule.waitForIdle()
+
+        for (edge in FocusModeEdge.entries) {
+            rule.onNodeWithTag(focusStripTag(edge)).assertDoesNotExist()
+        }
+    }
+
+    /** Tags are derived, so a renamed edge cannot silently detach a test from its strip. */
+    @Test
+    fun `every edge has its own strip tag`() {
+        val tags = FocusModeEdge.entries.map { focusStripTag(it) }
+        assertEquals(tags.size, tags.toSet().size, "duplicate strip tags: $tags")
+        assertEquals("focus-strip-left", focusStripTag(FocusModeEdge.LEFT))
+    }
+
+    private companion object {
+        /** Matches the hide delay in `rememberFocusModeReveal`, plus a frame. */
+        const val GRACE_PERIOD_MS = 2_500L
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FreshStartWorkspaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FreshStartWorkspaceTest.kt
@@ -1,0 +1,86 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.workspaces.PredefinedWorkspaces
+import ai.rever.boss.components.workspaces.requiresProject
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rule that decides whether a window which restored nothing opens on the default
+ * workspace.
+ *
+ * Review of the first version of this PR found the gap this closes: the default workspace
+ * was applied only from `LaunchedEffect(selectedProject.path)`, and a fresh profile has no
+ * project, so a new Windows install never reached `workspace-browser` at all - the very
+ * case the default exists for.
+ *
+ * The predicate is deliberately about the *workspace*, not the platform. Applying a
+ * project-shaped workspace with no project is worse than applying nothing: `{projectPath}`
+ * falls back to the user's home directory, so the Claude Code default would open a
+ * terminal running `claude --dangerously-skip-permissions` in `~` on first launch.
+ */
+class FreshStartWorkspaceTest {
+    private val browserOnly =
+        PredefinedWorkspaces.allWorkspaces.single { it.id == PredefinedWorkspaces.BROWSER_ONLY_ID }
+    private val claudeCode =
+        PredefinedWorkspaces.allWorkspaces.single { it.id == PredefinedWorkspaces.CLAUDE_CODE_ID }
+
+    @Test
+    fun `a fresh window opens on a workspace that needs no project`() {
+        assertTrue(shouldApplyOnFreshStart(browserOnly, hasProject = false))
+    }
+
+    @Test
+    fun `a project-shaped workspace is never applied without a project`() {
+        assertFalse(
+            shouldApplyOnFreshStart(claudeCode, hasProject = false),
+            "would run the Claude CLI in the user's home directory",
+        )
+    }
+
+    /** With a project the reactive apply owns this, so applying here would do it twice. */
+    @Test
+    fun `nothing is applied when a project is already selected`() {
+        assertFalse(shouldApplyOnFreshStart(browserOnly, hasProject = true))
+        assertFalse(shouldApplyOnFreshStart(claudeCode, hasProject = true))
+    }
+
+    /** `getDefaultWorkspace()` returns null for "none", which means "do not auto-apply". */
+    @Test
+    fun `auto-apply disabled applies nothing`() {
+        assertFalse(shouldApplyOnFreshStart(null, hasProject = false))
+        assertFalse(shouldApplyOnFreshStart(null, hasProject = true))
+    }
+
+    /** Each project placeholder is enough on its own to hold a workspace back. */
+    @Test
+    fun `every project placeholder marks a workspace as needing one`() {
+        val placeholders =
+            listOf("{projectPath}", "{gitRemoteUrl}", "{currentFile}", "{claudeContinueFlag}")
+        for (placeholder in placeholders) {
+            val inUrl = browserOnly.copy(layout = singleBrowserLayout(url = placeholder))
+            assertTrue(inUrl.requiresProject(), placeholder)
+            assertFalse(shouldApplyOnFreshStart(inUrl, hasProject = false), placeholder)
+        }
+    }
+
+    /** A placeholder embedded in a longer string still counts. */
+    @Test
+    fun `an embedded placeholder counts`() {
+        val embedded = browserOnly.copy(layout = singleBrowserLayout(url = "https://example.com/{projectPath}/tree"))
+        assertTrue(embedded.requiresProject())
+    }
+
+    private fun singleBrowserLayout(url: String) =
+        ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel(
+            ai.rever.boss.plugin.workspace.PanelConfig(
+                id = "panel-test",
+                tabs =
+                    listOf(
+                        ai.rever.boss.plugin.workspace
+                            .TabConfig(type = "browser", title = "t", url = url),
+                    ),
+            ),
+        )
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FreshStartWorkspaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FreshStartWorkspaceTest.kt
@@ -3,6 +3,9 @@ package ai.rever.boss.app
 import ai.rever.boss.components.workspaces.PredefinedWorkspaces
 import ai.rever.boss.components.workspaces.requiresProject
 import ai.rever.boss.dashboard.SplitTemplatesManager
+import ai.rever.boss.plugin.workspace.PanelConfig
+import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
+import ai.rever.boss.plugin.workspace.TabConfig
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -97,14 +100,10 @@ class FreshStartWorkspaceTest {
     }
 
     private fun singleBrowserLayout(url: String) =
-        ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel(
-            ai.rever.boss.plugin.workspace.PanelConfig(
+        SinglePanel(
+            PanelConfig(
                 id = "panel-test",
-                tabs =
-                    listOf(
-                        ai.rever.boss.plugin.workspace
-                            .TabConfig(type = "browser", title = "t", url = url),
-                    ),
+                tabs = listOf(TabConfig(type = "browser", title = "t", url = url)),
             ),
         )
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FreshStartWorkspaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FreshStartWorkspaceTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.app
 
 import ai.rever.boss.components.workspaces.PredefinedWorkspaces
 import ai.rever.boss.components.workspaces.requiresProject
+import ai.rever.boss.dashboard.SplitTemplatesManager
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -62,6 +63,29 @@ class FreshStartWorkspaceTest {
             val inUrl = browserOnly.copy(layout = singleBrowserLayout(url = placeholder))
             assertTrue(inUrl.requiresProject(), placeholder)
             assertFalse(shouldApplyOnFreshStart(inUrl, hasProject = false), placeholder)
+        }
+    }
+
+    /**
+     * The placeholder list mirrors `SplitTemplatesManager.processPlaceholders`, and nothing
+     * links the two. A fifth placeholder added there and missed here would not mark a
+     * workspace as project-requiring, and the failure mode is the one the KDoc warns about:
+     * a CLI running in the user's home directory.
+     */
+    @Test
+    fun `every placeholder the substitution handles is treated as project-requiring`() {
+        val handled = listOf("{projectPath}", "{gitRemoteUrl}", "{currentFile}", "{claudeContinueFlag}")
+        for (placeholder in handled) {
+            val substituted =
+                SplitTemplatesManager.processPlaceholders(placeholder, "/tmp/project", currentFile = "/tmp/f.kt")
+            assertFalse(
+                substituted.contains(placeholder),
+                "$placeholder is substituted from the project, so requiresProject must know about it",
+            )
+            assertTrue(
+                browserOnly.copy(layout = singleBrowserLayout(url = placeholder)).requiresProject(),
+                placeholder,
+            )
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ProjectPanelOpenerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ProjectPanelOpenerTest.kt
@@ -1,0 +1,117 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.events.PanelEventBus
+import ai.rever.boss.components.plugin.PanelIds
+import ai.rever.boss.utils.SystemUtils
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.yield
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Windows comes up as a plain browser, so nothing may open a panel there on its
+ * own - not Codebase, not Run Configurations, and not a plugin panel behind
+ * either of them.
+ *
+ * The platform branch is driven explicitly through the `autoOpen` parameter so
+ * both halves run on every CI leg; the host-resolved value is asserted
+ * separately, since that is the only check that this OS is wired to the right
+ * branch at all.
+ */
+class ProjectPanelOpenerTest {
+    /** Unique per case: [PanelEventBus] replays its last open event to new collectors. */
+    private fun windowId(case: String) = "test-window-$case"
+
+    @Test
+    fun `non-windows opens codebase and run configurations`() =
+        runTest {
+            val window = windowId("auto-open")
+            val collected =
+                async {
+                    withTimeoutOrNull(TIMEOUT_MS) {
+                        PanelEventBus.panelOpenEvents
+                            .filter { it.sourceWindowId == window }
+                            .take(2)
+                            .toList()
+                    }
+                }
+            // Let the collector subscribe before emitting: replay is 1, so a late
+            // subscriber would miss the first of the two events.
+            yield()
+
+            openProjectPanels(window, autoOpen = true)
+
+            val events = assertNotNull(collected.await(), "expected both panels to open")
+            assertEquals(listOf(PanelIds.CODEBASE, PanelIds.RUN_CONFIGURATIONS), events.map { it.panelId })
+        }
+
+    @Test
+    fun `windows opens nothing`() =
+        runTest {
+            val window = windowId("suppressed")
+            val collected =
+                async {
+                    withTimeoutOrNull(TIMEOUT_MS) {
+                        PanelEventBus.panelOpenEvents.first { it.sourceWindowId == window }
+                    }
+                }
+            yield()
+
+            openProjectPanels(window, autoOpen = false)
+
+            assertNull(collected.await(), "no panel may open by itself on Windows")
+        }
+
+    @Test
+    fun `the policy suppresses auto-open on windows only`() {
+        assertTrue(StartupPanelPolicy.autoOpensProjectPanelsFor(isWindows = false))
+        assertFalse(StartupPanelPolicy.autoOpensProjectPanelsFor(isWindows = true))
+    }
+
+    @Test
+    fun `host resolution follows this platform`() {
+        assertEquals(!SystemUtils.isWindows, StartupPanelPolicy.autoOpensProjectPanels)
+    }
+
+    /**
+     * The three startup effects that open project panels must keep routing
+     * through [openProjectPanels]. A fourth call site written straight against
+     * the bus would open panels on Windows again and no behavioural test would
+     * catch it, because those effects only run inside a composed window.
+     */
+    @Test
+    fun `startup effects never open a panel directly`() {
+        val source = File(repoRoot, "composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt")
+        assertTrue(source.isFile, "source moved: ${source.absolutePath}")
+        val text = source.readText()
+
+        assertEquals(
+            0,
+            Regex("""PanelEventBus\.openPanel\(""").findAll(text).count(),
+            "BossAppStartupEffects must open project panels via openProjectPanels(), " +
+                "so the Windows suppression cannot be bypassed",
+        )
+        assertTrue(text.contains("openProjectPanels("), "the opener seam disappeared from BossAppStartupEffects")
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 2_000L
+
+        /** Same repo-root walk as WindowsArm64SourceIsolationTest - the test CWD is not pinned. */
+        val repoRoot: File =
+            generateSequence(File("").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile }
+                ?: error("could not locate the repository root from ${File("").absolutePath}")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ProjectPanelOpenerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ProjectPanelOpenerTest.kt
@@ -96,13 +96,21 @@ class ProjectPanelOpenerTest {
         assertTrue(source.isFile, "source moved: ${source.absolutePath}")
         val text = source.readText()
 
+        // Code lines only: a KDoc or comment naming the call is not a call, and this guard
+        // firing on prose would be a false positive nobody could fix except by rewording.
+        val code =
+            text
+                .lines()
+                .filterNot { it.trimStart().startsWith("//") || it.trimStart().startsWith("*") }
+                .joinToString("\n")
+
         assertEquals(
             0,
-            Regex("""PanelEventBus\.openPanel\(""").findAll(text).count(),
+            Regex("""PanelEventBus\.openPanel\(""").findAll(code).count(),
             "BossAppStartupEffects must open project panels via openProjectPanels(), " +
                 "so the Windows suppression cannot be bypassed",
         )
-        assertTrue(text.contains("openProjectPanels("), "the opener seam disappeared from BossAppStartupEffects")
+        assertTrue(code.contains("openProjectPanels("), "the opener seam disappeared from BossAppStartupEffects")
     }
 
     private companion object {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceDefaultsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceDefaultsTest.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.utils.SystemUtils
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -42,17 +44,57 @@ class WorkspaceDefaultsTest {
     @Test
     fun `the browser-only workspace is a single browser panel on the boss home page`() {
         val workspace = PredefinedWorkspaces.allWorkspaces.single { it.id == PredefinedWorkspaces.BROWSER_ONLY_ID }
-        val layout = workspace.layout
-        assertTrue(layout is SinglePanel, "browser-only must not split the window: $layout")
+        val layout = assertIs<SinglePanel>(workspace.layout, "browser-only must not split the window")
         val tab = layout.panel.tabs.single()
         assertEquals("browser", tab.type)
-        assertEquals("https://risalabs.ai", tab.url)
+        assertEquals("https://www.risalabs.ai", tab.url)
+    }
+
+    /**
+     * The browser-only workspace must stand without a project, or the fresh-start apply
+     * declines it and a new Windows install comes up on an empty window instead - see
+     * [ai.rever.boss.app.shouldApplyOnFreshStart].
+     */
+    @Test
+    fun `the browser-only workspace needs no project`() {
+        val workspace = PredefinedWorkspaces.allWorkspaces.single { it.id == PredefinedWorkspaces.BROWSER_ONLY_ID }
+        assertFalse(workspace.requiresProject())
+    }
+
+    /** Every other predefined workspace does need one, which is why it is not applied unasked. */
+    @Test
+    fun `every other predefined workspace needs a project`() {
+        PredefinedWorkspaces.allWorkspaces
+            .filterNot { it.id == PredefinedWorkspaces.BROWSER_ONLY_ID }
+            .forEach { assertTrue(it.requiresProject(), it.id) }
     }
 
     @Test
     fun `every predefined workspace id is unique`() {
         val ids = PredefinedWorkspaces.allWorkspaces.map { it.id }
         assertEquals(ids.size, ids.toSet().size, "duplicate workspace ids: $ids")
+    }
+
+    /**
+     * Names, not just ids: `WorkspaceManager.loadAllWorkspaces` drops a saved workspace
+     * whose NAME matches a predefined one, and `WorkspaceButton` decides what is
+     * renameable the same way. A duplicate name here would make one built-in unreachable.
+     */
+    @Test
+    fun `every predefined workspace name is unique`() {
+        val names = PredefinedWorkspaces.allWorkspaces.map { it.name }
+        assertEquals(names.size, names.toSet().size, "duplicate workspace names: $names")
+    }
+
+    /**
+     * Panel ids key the split tree. They used to be `currentTimeMillis()` plus a
+     * 1-in-10000 random draw, all minted inside one initializer - so a collision was a
+     * dice roll on every launch rather than something a test could catch.
+     */
+    @Test
+    fun `every predefined panel id is unique`() {
+        val panelIds = PredefinedWorkspaces.allWorkspaces.flatMap { it.layout.extractPanels().map { p -> p.first } }
+        assertEquals(panelIds.size, panelIds.toSet().size, "duplicate panel ids: $panelIds")
     }
 
     /**
@@ -95,6 +137,33 @@ class WorkspaceDefaultsTest {
 
         val migrated = assertNotNull(WorkspaceSettingsMigrations.migrate(none, isWindows = true))
         assertEquals("none", migrated.defaultWorkspaceId)
+    }
+
+    /**
+     * The one-shot property depends on the version surviving a write. The manager encodes
+     * with `encodeDefaults = true` for exactly this reason - without it a value equal to
+     * the class default (0) is omitted, and the next launch decodes 0 and migrates again.
+     */
+    @Test
+    fun `the stamped version survives a write and read`() {
+        val encoder =
+            Json {
+                prettyPrint = true
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            }
+        val stamped =
+            WorkspaceSettings(
+                defaultWorkspaceId = PredefinedWorkspaces.BROWSER_ONLY_ID,
+                settingsVersion = WorkspaceSettings.CURRENT_SETTINGS_VERSION,
+            )
+
+        val written = encoder.encodeToString(WorkspaceSettings.serializer(), stamped)
+        assertTrue("settingsVersion" in written, "the version must be written, not omitted: $written")
+        assertNull(
+            WorkspaceSettingsMigrations.migrate(json.decodeFromString<WorkspaceSettings>(written), isWindows = true),
+            "a file written after migration must not migrate again",
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceDefaultsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceDefaultsTest.kt
@@ -1,0 +1,108 @@
+package ai.rever.boss.components.workspaces
+
+import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
+import ai.rever.boss.utils.SystemUtils
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Locks down the platform default workspace and its one-time migration.
+ *
+ * The platform branch is driven explicitly through [defaultWorkspaceIdFor] and
+ * the `isWindows` parameter of [WorkspaceSettingsMigrations.migrate], so both
+ * branches run on every CI leg rather than only on the matching runner. The
+ * host-resolved [defaultWorkspaceIdForPlatform] is checked separately - that is
+ * the only assertion that this OS is wired to the right branch at all.
+ */
+class WorkspaceDefaultsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `windows defaults to the browser-only workspace`() {
+        assertEquals(PredefinedWorkspaces.BROWSER_ONLY_ID, defaultWorkspaceIdFor(isWindows = true))
+    }
+
+    @Test
+    fun `other platforms keep the claude code workspace`() {
+        assertEquals(PredefinedWorkspaces.CLAUDE_CODE_ID, defaultWorkspaceIdFor(isWindows = false))
+    }
+
+    @Test
+    fun `host resolution follows this platform`() {
+        val expected =
+            if (SystemUtils.isWindows) PredefinedWorkspaces.BROWSER_ONLY_ID else PredefinedWorkspaces.CLAUDE_CODE_ID
+        assertEquals(expected, defaultWorkspaceIdForPlatform())
+        assertEquals(expected, WorkspaceSettings().defaultWorkspaceId)
+    }
+
+    @Test
+    fun `the browser-only workspace is a single browser panel on the boss home page`() {
+        val workspace = PredefinedWorkspaces.allWorkspaces.single { it.id == PredefinedWorkspaces.BROWSER_ONLY_ID }
+        val layout = workspace.layout
+        assertTrue(layout is SinglePanel, "browser-only must not split the window: $layout")
+        val tab = layout.panel.tabs.single()
+        assertEquals("browser", tab.type)
+        assertEquals("https://risalabs.ai", tab.url)
+    }
+
+    @Test
+    fun `every predefined workspace id is unique`() {
+        val ids = PredefinedWorkspaces.allWorkspaces.map { it.id }
+        assertEquals(ids.size, ids.toSet().size, "duplicate workspace ids: $ids")
+    }
+
+    /**
+     * The settings file predates the version field, so a file written by any
+     * older build decodes as version 0 - which is what makes the migration
+     * reachable at all. If the field ever defaults to the current version, every
+     * install silently skips every migration.
+     */
+    @Test
+    fun `a settings file without the version field decodes as version zero`() {
+        val legacy = json.decodeFromString<WorkspaceSettings>("""{"defaultWorkspaceId":"workspace-claude-code"}""")
+        assertEquals(0, legacy.settingsVersion)
+        assertEquals(PredefinedWorkspaces.CLAUDE_CODE_ID, legacy.defaultWorkspaceId)
+    }
+
+    @Test
+    fun `an existing windows install on the old default moves to browser-only once`() {
+        val legacy = WorkspaceSettings(defaultWorkspaceId = PredefinedWorkspaces.CLAUDE_CODE_ID, settingsVersion = 0)
+
+        val migrated = assertNotNull(WorkspaceSettingsMigrations.migrate(legacy, isWindows = true))
+        assertEquals(PredefinedWorkspaces.BROWSER_ONLY_ID, migrated.defaultWorkspaceId)
+        assertEquals(WorkspaceSettings.CURRENT_SETTINGS_VERSION, migrated.settingsVersion)
+
+        // Stamped version, so the next launch is a no-op rather than a rewrite.
+        assertNull(WorkspaceSettingsMigrations.migrate(migrated, isWindows = true))
+    }
+
+    @Test
+    fun `a windows install that chose another workspace keeps it`() {
+        val chosen = WorkspaceSettings(defaultWorkspaceId = "workspace-dual-terminal", settingsVersion = 0)
+
+        val migrated = assertNotNull(WorkspaceSettingsMigrations.migrate(chosen, isWindows = true))
+        assertEquals("workspace-dual-terminal", migrated.defaultWorkspaceId)
+        assertEquals(WorkspaceSettings.CURRENT_SETTINGS_VERSION, migrated.settingsVersion)
+    }
+
+    @Test
+    fun `disabled auto-apply survives the migration on windows`() {
+        val none = WorkspaceSettings(defaultWorkspaceId = "none", settingsVersion = 0)
+
+        val migrated = assertNotNull(WorkspaceSettingsMigrations.migrate(none, isWindows = true))
+        assertEquals("none", migrated.defaultWorkspaceId)
+    }
+
+    @Test
+    fun `non-windows installs are only stamped, never repointed`() {
+        val legacy = WorkspaceSettings(defaultWorkspaceId = PredefinedWorkspaces.CLAUDE_CODE_ID, settingsVersion = 0)
+
+        val migrated = assertNotNull(WorkspaceSettingsMigrations.migrate(legacy, isWindows = false))
+        assertEquals(PredefinedWorkspaces.CLAUDE_CODE_ID, migrated.defaultWorkspaceId)
+        assertEquals(WorkspaceSettings.CURRENT_SETTINGS_VERSION, migrated.settingsVersion)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/focusmode/FocusModeSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/focusmode/FocusModeSettingsTest.kt
@@ -248,11 +248,42 @@ class FocusModeSettingsTest {
         assertTrue(decoded.hideLeftSidebar)
     }
 
-    /** An empty object is the same situation as a missing file: every value comes from defaults. */
+    /**
+     * An empty object resolves the NEW keys from the platform defaults and everything else
+     * from the class defaults. It is not the same as a missing file: a missing file means
+     * nobody has ever chosen anything (the manager writes the platform defaults straight
+     * out), while `{}` was written by a build that omitted every class-default value.
+     */
     @Test
-    fun `an empty file decodes to the platform defaults`() {
+    fun `an empty file resolves only the new keys from the platform defaults`() {
         val defaults = FocusModeSettings.defaultsFor("Windows 11")
-        assertEquals(defaults, FocusModeSettings.decodeWithDefaults("{}", defaults))
+
+        val decoded = FocusModeSettings.decodeWithDefaults("{}", defaults)
+
+        assertFalse(decoded.hideLeftSidebar, "a new key resolves from the platform default")
+        assertFalse(decoded.hideRightSidebar)
+        assertTrue(decoded.autoRevealEnabled, "an old key keeps the class default, not the platform one")
+    }
+
+    /**
+     * The regression this scoping exists to prevent. Before this build the writer used
+     * `encodeDefaults = false`, so a Windows user who deliberately switched hover-to-reveal
+     * ON produced a file with `autoRevealEnabled` absent - it equals the class default. If
+     * absence were resolved from the platform defaults, their choice would silently flip off
+     * on upgrade, on the platform whose default is the opposite.
+     */
+    @Test
+    fun `a windows user who turned hover-reveal on keeps it across the upgrade`() {
+        // What the old encodeDefaults = false writer produced for that user.
+        val oldFile = """{"enabled":true}"""
+
+        val decoded = FocusModeSettings.decodeWithDefaults(oldFile, FocusModeSettings.defaultsFor("Windows 11"))
+
+        assertTrue(decoded.autoRevealEnabled, "a pre-existing preference must survive the upgrade")
+        assertTrue(decoded.enabled)
+        // The new keys still take the Windows defaults, which is the point of the merge.
+        assertFalse(decoded.hideLeftSidebar)
+        assertFalse(decoded.hideRightSidebar)
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/focusmode/FocusModeSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/focusmode/FocusModeSettingsTest.kt
@@ -255,5 +255,54 @@ class FocusModeSettingsTest {
         assertEquals(defaults, FocusModeSettings.decodeWithDefaults("{}", defaults))
     }
 
+    /**
+     * The round trip through the manager's own encoder, which is where merging over
+     * *platform* defaults turns a missing `encodeDefaults` into silent data loss.
+     *
+     * Without it, a value equal to the CLASS default is omitted from the file, and the
+     * merge then reads that absence as "never chosen" and substitutes the platform
+     * default. On Windows the two disagree for exactly the fields this feature adds, so a
+     * user switching a sidebar back on would write nothing and find it off next launch -
+     * on the one platform where the escape hatch is the whole point.
+     */
+    @Test
+    fun `a chosen value survives a save and load on windows`() {
+        val platform = FocusModeSettings.defaultsFor("Windows 11")
+        // Every one of these equals the class default and differs from the Windows default.
+        val chosen = platform.copy(hideLeftSidebar = true, hideRightSidebar = true, autoRevealEnabled = true)
+
+        val written = managerJson.encodeToString(FocusModeSettings.serializer(), chosen)
+        val reloaded = FocusModeSettings.decodeWithDefaults(written, platform)
+
+        assertEquals(chosen, reloaded, "a deliberate choice must not revert on restart: $written")
+        assertTrue(reloaded.hideLeftSidebar)
+        assertTrue(reloaded.hideRightSidebar)
+        assertTrue(reloaded.autoRevealEnabled)
+    }
+
+    /** The reverse direction: turning an edge off on a platform whose default is on. */
+    @Test
+    fun `switching an edge off survives a save and load elsewhere`() {
+        val platform = FocusModeSettings.defaultsFor("Mac OS X")
+        val chosen = platform.copy(hideTopBar = false, hideLeftSidebar = false)
+
+        val reloaded =
+            FocusModeSettings.decodeWithDefaults(
+                managerJson.encodeToString(FocusModeSettings.serializer(), chosen),
+                platform,
+            )
+
+        assertEquals(chosen, reloaded)
+    }
+
+    private companion object {
+        /**
+         * The encoder the manager actually writes with, not a copy of its settings. A mirror
+         * here would keep passing after someone dropped `encodeDefaults` from the real one,
+         * which is precisely the bug these two tests exist to catch.
+         */
+        val managerJson = FocusModeSettings.storageJson
+    }
+
     // endregion
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/focusmode/FocusModeSettingsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/focusmode/FocusModeSettingsTest.kt
@@ -111,7 +111,11 @@ class FocusModeSettingsTest {
         assertTrue(FocusModeSettings.defaultAutoReveal("darwin"))
     }
 
-    /** Only the reveal default is platform-specific; focus mode itself stays off everywhere. */
+    /**
+     * Reveal and the two sidebars are the only platform-specific defaults; focus mode itself
+     * stays off everywhere, and the top and bottom bars are still cleared on Windows, so focus
+     * mode does something there.
+     */
     @Test
     fun `the platform default changes nothing else`() {
         val win = FocusModeSettings.defaultsFor("Windows 11")
@@ -120,6 +124,135 @@ class FocusModeSettingsTest {
         assertFalse(mac.enabled)
         assertEquals(mac.revealOffsetPx, win.revealOffsetPx)
         assertEquals(mac.revealDelayMs, win.revealDelayMs)
+        assertEquals(mac.hideTopBar, win.hideTopBar)
+        assertEquals(mac.hideBottomBar, win.hideBottomBar)
+    }
+
+    /**
+     * Windows keeps both sidebars in focus mode for the same reason hover-to-reveal starts off
+     * there: with the reveal unable to fire, hiding a sidebar is a one-way door.
+     */
+    @Test
+    fun `windows keeps both sidebars visible in focus mode`() {
+        for (os in listOf("Windows 10", "Windows 11", "Windows Server 2022", "windows")) {
+            assertFalse(FocusModeSettings.defaultHidesSidebars(os), os)
+            val defaults = FocusModeSettings.defaultsFor(os)
+            assertFalse(defaults.hideLeftSidebar, os)
+            assertFalse(defaults.hideRightSidebar, os)
+            // Focus mode still trims the horizontal chrome, so it is not a no-op there.
+            assertTrue(defaults.hideTopBar, os)
+            assertTrue(defaults.hideBottomBar, os)
+            assertTrue(defaults.copy(enabled = true).hidesAnything(), os)
+        }
+    }
+
+    @Test
+    fun `every other platform clears all four edges`() {
+        for (os in listOf("Mac OS X", "macOS", "Linux", "FreeBSD", "SunOS", "darwin", "")) {
+            val defaults = FocusModeSettings.defaultsFor(os).copy(enabled = true)
+            for (edge in FocusModeEdge.entries) {
+                assertTrue(defaults.hides(edge), "$os / $edge")
+            }
+        }
+    }
+
+    // endregion
+
+    // region per-edge switches
+
+    /** Every edge stays visible while focus mode is off, whatever the switches say. */
+    @Test
+    fun `focus mode off hides nothing`() {
+        val allOn = FocusModeSettings(enabled = false)
+        for (edge in FocusModeEdge.entries) {
+            assertFalse(allOn.hides(edge), edge.name)
+        }
+        assertFalse(allOn.hidesAnything())
+    }
+
+    @Test
+    fun `each switch controls exactly its own edge`() {
+        val settings =
+            FocusModeSettings(
+                enabled = true,
+                hideTopBar = true,
+                hideLeftSidebar = false,
+                hideRightSidebar = false,
+                hideBottomBar = true,
+            )
+
+        assertTrue(settings.hides(FocusModeEdge.TOP))
+        assertFalse(settings.hides(FocusModeEdge.LEFT))
+        assertFalse(settings.hides(FocusModeEdge.RIGHT))
+        assertTrue(settings.hides(FocusModeEdge.BOTTOM))
+        assertTrue(settings.hidesAnything())
+    }
+
+    @Test
+    fun `focus mode with every edge off hides nothing`() {
+        val settings =
+            FocusModeSettings(
+                enabled = true,
+                hideTopBar = false,
+                hideLeftSidebar = false,
+                hideRightSidebar = false,
+                hideBottomBar = false,
+            )
+        assertFalse(settings.hidesAnything())
+    }
+
+    // endregion
+
+    // region decoding stored files
+
+    /**
+     * The case this merge exists for: a Windows install that already had a settings file, written
+     * before the per-edge switches existed. A plain decode fills the missing keys from the class
+     * defaults, which hide both sidebars - on the one platform that cannot reveal them again.
+     */
+    @Test
+    fun `a settings file predating the switches takes the platform default`() {
+        val legacy = """{"enabled":true,"autoRevealEnabled":false,"revealOffsetPx":30.0,"revealDelayMs":500}"""
+
+        val decoded = FocusModeSettings.decodeWithDefaults(legacy, FocusModeSettings.defaultsFor("Windows 11"))
+
+        assertFalse(decoded.hideLeftSidebar, "an absent key must not hide a sidebar on Windows")
+        assertFalse(decoded.hideRightSidebar)
+        assertTrue(decoded.hideTopBar)
+        assertTrue(decoded.hideBottomBar)
+        // The keys the file did carry are still the file's own.
+        assertTrue(decoded.enabled)
+        assertFalse(decoded.autoRevealEnabled)
+        assertEquals(500L, decoded.revealDelayMs)
+    }
+
+    /** A deliberate choice always wins over the platform default, in both directions. */
+    @Test
+    fun `stored keys win over the defaults`() {
+        val stored = """{"hideLeftSidebar":true,"hideRightSidebar":true,"hideTopBar":false}"""
+
+        val decoded = FocusModeSettings.decodeWithDefaults(stored, FocusModeSettings.defaultsFor("Windows 11"))
+
+        assertTrue(decoded.hideLeftSidebar, "a Windows user who asked for the full sweep keeps it")
+        assertTrue(decoded.hideRightSidebar)
+        assertFalse(decoded.hideTopBar)
+    }
+
+    @Test
+    fun `an unknown key from a newer build is ignored`() {
+        val fromTheFuture = """{"enabled":true,"hideDiagonalBar":true}"""
+
+        val decoded = FocusModeSettings.decodeWithDefaults(fromTheFuture, FocusModeSettings.defaultsFor("Linux"))
+
+        assertTrue(decoded.enabled)
+        assertTrue(decoded.hideLeftSidebar)
+    }
+
+    /** An empty object is the same situation as a missing file: every value comes from defaults. */
+    @Test
+    fun `an empty file decodes to the platform defaults`() {
+        val defaults = FocusModeSettings.defaultsFor("Windows 11")
+        assertEquals(defaults, FocusModeSettings.decodeWithDefaults("{}", defaults))
     }
 
     // endregion


### PR DESCRIPTION
## What

Three Windows startup defaults, so BOSS comes up there as **a plain browser on https://risalabs.ai with nothing else on screen** - plus one feature that is useful everywhere.

1. **The default workspace is browser-only** instead of the terminal-first Claude Code layout, applied on first launch as well as on project selection.
2. **No panel opens by itself**: Codebase and Run Configurations no longer auto-open when a project is selected.
3. **Focus mode is now per-edge**, and on Windows it keeps both sidebars.

Only the Windows *defaults* move. The new "Browser" workspace is listed on every platform, the four focus-mode switches are available on every platform, and every panel is still one sidebar click, menu item, deep link or CLI command away.

## How

| Piece | File |
|---|---|
| `workspace-browser` - a `SinglePanel` with one browser tab, no split | `LayoutWorkspace.kt` |
| `shouldApplyOnFreshStart` - the fresh-launch apply, declined for any workspace needing a project | `FreshStartWorkspace.kt`, `WorkspaceProjectRequirement.kt` |
| `defaultWorkspaceIdFor(isWindows)` behind `WorkspaceSettings.defaultWorkspaceId` | `WorkspaceSettingsManager.kt` |
| One-time migration for installs that already have a workspace settings file | `DesktopWorkspaceSettingsManager.kt` |
| `StartupPanelPolicy` + the single `openProjectPanels(windowId)` seam | `StartupPanelPolicy.kt` |
| Three startup effects routed through that seam | `BossAppStartupEffects.kt` |
| `hideTopBar` / `hideLeftSidebar` / `hideRightSidebar` / `hideBottomBar` + `hides(edge)` | `FocusModeSettings.kt` |
| Per-edge gating, strips only for hidden edges | `FocusModeReveal.kt` |
| One switch per edge in Settings | `settings/sections/FocusModeSettings.kt` |

Every platform read sits behind a thin wrapper taking an explicit `isWindows` / `autoOpen` / `osName`, so both branches are reachable from a test on any host - the seam `ShellUtilsTest` and `FocusModeSettingsTest` already use.

## Why the sidebars stay on Windows in focus mode

This repo already documents why hover-to-reveal starts **off** on Windows: reveal is driven by Compose `onPointerEvent` on edge strips, and the HARDWARE browser surface owns those pixels, so a strip under a browser tab never sees the pointer.

With reveal unable to fire, hiding a sidebar is a one-way door - the plugin panels go and no hover brings them back. So Windows clears the top and bottom bars (focus mode still does something) and keeps the sidebars. Any Windows user who wants the full sweep switches it on.

## Why there are two default-carrying migrations

Both settings files are written on first launch, so a changed default would never reach a machine that has already run BOSS - which is every machine this is for.

- **Workspace**: a `settingsVersion` field drives a 0 -> 1 step that repoints a Windows install **only if** it is still on the old universal default. An explicit choice, including `"none"`, is preserved and stamped. The field defaults to `0`, not to the current version, because a missing key decodes to the default - defaulting to current would make this and every future migration unreachable. `setDefaultWorkspaceId` stamps the version too, so a deliberate pick is never rewritten.
- **Focus mode**: `decodeWithDefaults` merges the stored object over the *platform* defaults, so an absent key reads as "never chosen" rather than as the class default (which would hide both sidebars on the one platform that cannot reveal them). Keys the file carries always win, in both directions.

## Why the panel opener is a seam rather than three `if`s

Those effects only run inside a composed window, so a fourth call site written straight against `PanelEventBus` would reopen the panels on Windows and no behavioural test could catch it. One seam, and `ProjectPanelOpenerTest` fails if a direct `PanelEventBus.openPanel` reappears in `BossAppStartupEffects.kt`.

Worth stating explicitly, since the ask was "no plugin either": Codebase and Run Configurations are the only panels the host opens unasked, all panel slots start `visibility = false`, and no bundled plugin opens a panel at registration - the three plugin-side `openPanel` calls (plugin-manager twice, tool-evolver once) each sit behind a user action.

## Incidental cleanup

Collapsing the four copy-pasted reveal effect pairs into one `EdgeRevealEffects` retired two detekt suppressions for `rememberFocusModeReveal` (LongMethod, CyclomaticComplexMethod) rather than re-baselining them. A third stale entry (`MatchingDeclarationName`) went with it. `BossAppScaffold`'s existing LongMethod entry was re-keyed for its new parameter list.

## Fixed after review

Three passes ran on this branch. The substantive findings, and what changed:

- **The default never reached a fresh install.** It was applied only from `LaunchedEffect(selectedProject.path)`, and a new profile has no project, so a new Windows install came up on an empty window - the exact case this PR exists for. The two startup branches that finish having restored nothing now apply the default first, before `markHandlersReady`. The guard is about the workspace, not the platform: any workspace using `{projectPath}` and friends is declined, because that placeholder falls back to the user's home directory and would run `claude --dangerously-skip-permissions` in `~` on first launch.
- **The settings load lost a race to its only reader.** `WorkspaceSettingsManager` loaded asynchronously from `init`, and the object initialises on first access - the startup effect that immediately calls `getDefaultWorkspace()`. The compiled-in default therefore won over the file, which was invisible while the two agreed and is not on Windows: a user who picked `"none"` would have had the browser applied over their layout. Now synchronous in `init`, as `FocusModeSettingsManager` already is.
- **`https://www.risalabs.ai`**, matching the rest of the app. The apex 301s there (verified), so the other spelling cost a redirect and a different origin from the browser's own default.
- **Named "Browser Only"**, because `WorkspaceManager` identifies predefined workspaces by *name* and a built-in called "Browser" would silently swallow a user's own saved layout of that name. Names now have a uniqueness test alongside ids.
- **Predefined panel ids come from a counter**, not `currentTimeMillis()` plus a 1-in-10000 random draw minted inside a single initializer.
- Smaller: `_currentSettings` seeded at the current version so `0` means only "absent from a file"; INFO logged only when a default actually moved; `setDefaultWorkspaceId` stamps `maxOf(existing, CURRENT)`; the focus-mode edge switches are no longer disabled while focus mode is off.

Deliberately not changed: `StartupPanelPolicy` stays keyed on the platform rather than on the chosen workspace, per the original request. The consequence either way is stated above.

## Test plan

- [x] `WorkspaceDefaultsTest` - 16 tests. Both platform branches, the legacy decode, the Windows repoint, the "chose something else" case, `"none"`, the non-Windows stamp-only path, the migration re-run as a no-op, id/name/panel-id uniqueness, the project-requirement of every predefined workspace, and a round trip proving the stamped version survives a write.
- [x] `FreshStartWorkspaceTest` - 6 tests. The fresh-launch predicate, each project placeholder, "none", and the already-has-a-project case.
- [x] `ProjectPanelOpenerTest` - 5 tests. Both policy branches, host resolution, both panels emitted when auto-open is on, nothing emitted when off, and the no-direct-call guard.
- [x] `FocusModeSettingsTest` - 21 tests (was 11). Per-edge `hides`, the Windows sidebar default, all-four elsewhere, and four decode cases including a file written before the switches existed.
- [x] `FocusModeRevealTest` - 7 new Compose tests driving the real composable: Windows defaults keep both sidebars while top and bottom go, switching an edge off mid-session returns that bar and only it, and strips exist for exactly the hidden edges.
- [x] Mutation-checked three times: deleting the `if (!autoOpen) return` gate fails "windows opens nothing" and nothing else; reverting the sidebar gating to `settings.enabled` fails exactly the two focus-mode tests that should; dropping the `requiresProject` guard fails exactly the two fresh-start tests that should.
- [x] Full `:composeApp:desktopTest` - 1865 tests, 160 classes, 0 failures. `ktlintCheck` and `detekt` green.
- [ ] **Not verified: the on-Windows result.** No Mac CI leg can observe it, and forcing `os.name` would exercise the wrong code everywhere else. Worth one manual pass on a Windows box: a fresh profile comes up as one browser page on www.risalabs.ai with no sidebar panel; focus mode there clears top and bottom only; an upgraded profile that never changed either setting picks up both new defaults once.
