### PR TITLE
Give every user their own secret vault

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/llm/LlmProviderAPIAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/llm/LlmProviderAPIAccess.kt
@@ -66,6 +66,38 @@ object LlmProviderAPIAccess {
         return remember(registryVersion) { getProvider() }
     }
 
+    /**
+     * The permissions the current user is missing for the plugin that owns AI provider
+     * settings, or an empty list when permissions are not why it is absent.
+     *
+     * `DynamicPluginManager` does not merely hide a plugin the user cannot access - it
+     * skips `register()` entirely, so the API is never contributed and this class's
+     * [getProvider] returns null. That is indistinguishable from "not installed" and
+     * "still starting up" at this layer, and the Settings section used to report all
+     * three as "isn't loaded yet" - which for the permission case is simply false: it
+     * will never load, and nothing told the user what to ask an admin for.
+     *
+     * Observes `pluginStates` rather than a permission flow because that is the public
+     * one, and it is written on exactly the transitions that matter: a plugin moving
+     * into or out of `hiddenPlugins` updates its state.
+     */
+    @Composable
+    fun rememberMissingPermissions(): List<String> {
+        val plugin = cachedDefaultPlugin ?: return emptyList()
+        val manager = plugin.dynamicPluginManager
+        val states by manager.pluginStates.collectAsState()
+        return remember(states) {
+            manager
+                .getInaccessiblePlugins()
+                .firstOrNull { it.pluginId == SECRET_MANAGER_PLUGIN_ID }
+                ?.missingPermissions
+                .orEmpty()
+        }
+    }
+
+    /** The plugin that owns AI provider settings. Also the credential vault. */
+    private const val SECRET_MANAGER_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.secretmanager"
+
     // ==================== Composable Bridges (Settings) ====================
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LLMProvidersSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LLMProvidersSettings.kt
@@ -24,8 +24,17 @@ fun LLMProvidersSettings() {
     // supportsSettingsPanel distinguishes "no panel" from "blank panel": the API's panel
     // member has a default no-op, so a plugin that registers without overriding it would
     // otherwise render an empty section with no explanation.
+    val missingPermissions = LlmProviderAPIAccess.rememberMissingPermissions()
     if (provider != null && provider.supportsSettingsPanel) {
         provider.LlmProviderSettingsPanel(modifier = Modifier.fillMaxSize())
+    } else if (missingPermissions.isNotEmpty()) {
+        // Not a loading state. The host skips register() for a plugin the user cannot
+        // access, so this section will stay empty until an admin grants the permission.
+        // Naming it is the difference between a dead end and an actionable one.
+        PluginSettingsUnavailableNotice(
+            "AI provider settings are provided by the Secret Manager plugin, which you do not have " +
+                "access to. Ask an administrator to grant: ${missingPermissions.joinToString(", ")}.",
+        )
     } else {
         PluginSettingsUnavailableNotice(
             "AI provider settings are provided by the Secret Manager plugin, which isn't loaded yet.",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
@@ -94,6 +94,10 @@ object PluginListProvider {
             // Productivity
             "ai.rever.boss.plugin.dynamic.bookmarks" to PluginCategory.PRODUCTIVITY,
             "ai.rever.boss.plugin.dynamic.topofmind" to PluginCategory.PRODUCTIVITY,
+            // Not an admin tool, despite living here until 9.4.7. It is a per-user
+            // credential vault (every RPC behind it is auth.uid()-scoped) and, since AI
+            // provider settings moved into it, the only place anyone adds their own key.
+            "ai.rever.boss.plugin.dynamic.secretmanager" to PluginCategory.PRODUCTIVITY,
             // Automation
             "ai.rever.boss.plugin.dynamic.llmrpa" to PluginCategory.AUTOMATION,
             "ai.rever.boss.plugin.dynamic.rparecorder" to PluginCategory.AUTOMATION,
@@ -101,7 +105,6 @@ object PluginListProvider {
             // Admin
             "ai.rever.boss.plugin.dynamic.adminrolemanagement" to PluginCategory.ADMIN,
             "ai.rever.boss.plugin.dynamic.rolecreation" to PluginCategory.ADMIN,
-            "ai.rever.boss.plugin.dynamic.secretmanager" to PluginCategory.ADMIN,
         )
 
     /**
@@ -412,11 +415,11 @@ object PluginListProvider {
                 WizardPluginInfo(
                     id = "ai.rever.boss.plugin.dynamic.secretmanager",
                     name = "Secret Manager",
-                    description = "Securely manage API keys and secrets",
+                    description = "Your encrypted credential vault, and where you add AI provider keys",
                     version = "1.0.0",
                     icon = Icons.Default.Key,
                     isDefault = false,
-                    category = PluginCategory.ADMIN,
+                    category = PluginCategory.PRODUCTIVITY,
                 ),
             )
 }

--- a/docs/RBAC_GUIDE.md
+++ b/docs/RBAC_GUIDE.md
@@ -23,10 +23,29 @@ the duplicate path is harmless because `get_role_descendants` uses `UNION`.
 
 **`boss_plugin_admin`** is the least-privilege plugin author: `plugins.create` +
 `api_key.create`, plus the inherited `user.*` baseline. It deliberately holds no
-`plugins.admin.*` moderation permission, no role/finance/RPA verb, and no
-`secret.read`. Note it cannot assign any role despite `user` being a strict
-descendant - `assign_role_to_user` requires `role.assign` first, which this role
-does not have. See migration `20260731000000_plugin_create_permission.sql`.
+`plugins.admin.*` moderation permission and no role/finance/RPA verb. Note it cannot
+assign any role despite `user` being a strict descendant - `assign_role_to_user`
+requires `role.assign` first, which this role does not have. See migration
+`20260731000000_plugin_create_permission.sql`. (It held no `secret.read` either until
+`20260809000000` put that on the `user` baseline; it now inherits it like everyone
+else, and still holds no `secret.share.role`.)
+
+**The `user` baseline** carries `user.read/write/update/delete`,
+`organisation.create`, `organisation.read` and `secret.read`. Each of those is a
+deliberate kill switch: revoking one from `user` disables that capability
+deployment-wide without touching any other role. `secret.read` is what makes the
+Secret Manager panel - and with it `Settings > AI Providers`, which that plugin owns -
+available to ordinary users. It was admin-only until `20260809000000`; see that
+migration's header for why that was a leftover from the pre-RBAC `requiresAdmin` flag
+rather than a security posture. The vault's RPCs are granted to `authenticated` and
+self-scope with `auth.uid()` regardless of the permission.
+
+**`secret.share.role`** (admin + boss_admin) is the one secret capability that is not
+everyone's. A role share reaches every holder of that role, and `user` is a descendant
+of every role, so a role target publishes a credential deployment-wide with no undo.
+`share_secret` enforces it; the Secret Manager panel hides the Roles tab without it.
+Sharing with an individual user is ungated, and sharing with an organisation requires
+membership of that organisation instead.
 
 - **Effective permissions** - a user's permissions = the union of permissions on each assigned role plus all of that role's descendants. Computed by `get_role_descendants(role_id)` (recursive, cycle-safe) and `get_effective_permissions(user_id)`. `authorize(permission)` walks this closure, so a permission granted to `user` is automatically held by `boss_admin`, `finance_admin`, and `admin`.
 - **JWT claim** - `custom_access_token_hook` injects the effective set as the `user_permissions` claim (for both magic-link and passkey logins). The client parses it into `RoleClaims.permissions` / `UserInfo.permissions` (UI/visibility only - server still enforces).

--- a/supabase/migrations/20260809000000_secret_read_for_user_role.sql
+++ b/supabase/migrations/20260809000000_secret_read_for_user_role.sql
@@ -1,0 +1,270 @@
+-- ============================================================================
+-- BOSS Database Schema: the Secret Manager becomes a per-user vault
+-- ============================================================================
+-- File: 20260809000000_secret_read_for_user_role.sql
+-- Description:
+--   Grants `secret.read` to the baseline `user` role, so every authenticated
+--   user can open the Secret Manager panel and Settings > AI Providers.
+--
+--   WHY THIS IS A CORRECTION, NOT A WIDENING OF ACCESS.
+--   20260628000000 created `secret.read` and granted it to admin + boss_admin.
+--   Read its header: the panel "was historically gated by the legacy
+--   `requiresAdmin` flag (admin role only)", and that migration existed to let
+--   boss_admin in. It translated the old admin-only behaviour forward verbatim.
+--   Nobody ever decided a normal user should not have a vault -- and the data
+--   layer says the opposite at every level:
+--
+--     * every secret RPC is granted TO "authenticated" with no permission check
+--       (20260802000000, SECTION "GRANTS"),
+--     * every one of them self-scopes with auth.uid()
+--       (create_secret, delete_secret, get_user_secrets, search_user_secrets),
+--     * all four RLS policies on public.secrets are auth.uid() = user_id
+--       (20251023000013).
+--
+--   So `secret.read` is a client-side visibility gate over a store that is
+--   already per-user. This migration widens server-side access by zero rows.
+--
+--   WHAT IT ACTUALLY UNBLOCKS. Since the AI provider settings moved into the
+--   secret-manager plugin, that plugin owns Settings > AI Providers and the
+--   LlmProviderSettingsAPI behind PluginContext.llmProvider. DynamicPluginManager
+--   skips register() entirely for a plugin the user cannot access, so a non-admin
+--   got no AI provider settings, no way to add their own key, and a null
+--   llmProvider in every other plugin. All AI in BOSS was admin-only by accident.
+--
+--   THE TIGHTENING THAT COMES WITH IT. `share_secret` gated role targets on
+--   can_manage_secret alone -- i.e. any owner could share a secret with any
+--   global role, including `user`, which is a descendant of everything and
+--   therefore means "everyone" (20260802010000 states this). That was survivable
+--   only because non-admins could not reach the panel. It is not survivable
+--   afterwards, so role targets now require a new `secret.share.role`
+--   permission, granted to admin + boss_admin. User and organisation targets are
+--   unchanged.
+--
+--   NOT CHANGED HERE, deliberately:
+--     * the explicit admin/boss_admin grants of `secret.read` stay. They are
+--       redundant once `user` holds it (both are ancestors of `user`), but
+--       removing a grant is destructive and buys nothing.
+--     * `secret.read` stays is_system and stays on the org-grantable allowlist.
+--       Its meaning shifts from "who may use the vault" to "who may still use
+--       the vault" -- a deployment that wants it locked down revokes it from
+--       `user`, which is a supported operation.
+--
+-- Dependencies:
+--   - 20260628000000_secret_read_permission.sql  (creates secret.read)
+--   - 20260625000000_role_hierarchy_and_granular_rbac.sql  (the `user` role)
+--   - 20260802000000_secrets_org_ownership.sql   (the share_secret recreated here)
+--   - 20260801010000_organisation_permissions_and_guards.sql (is_org_grantable_permission)
+--
+-- CREATE OR REPLACE is correct for share_secret: the argument list and the jsonb
+-- return type are both unchanged, so no second overload is created and the
+-- existing GRANTs survive on the preserved function OID. (A signature change
+-- would need the DROP-then-recreate dance -- see 20260802000000 hazard 1.)
+--
+-- All seed data is idempotent (ON CONFLICT DO NOTHING); safe to re-run.
+-- ============================================================================
+
+
+-- ============================================================================
+-- SECTION 1: secret.read for the baseline role
+-- ============================================================================
+
+INSERT INTO "public"."role_permissions" ("role_id", "permission_id")
+SELECT r."id", p."id"
+FROM "public"."roles" r
+JOIN "public"."permissions" p ON p."name" = 'secret.read'
+WHERE r."name" = 'user'
+ON CONFLICT ("role_id", "permission_id") DO NOTHING;
+
+
+-- ============================================================================
+-- SECTION 2: secret.share.role, and the gate that uses it
+-- ============================================================================
+
+-- is_system so delete_permission() refuses to drop it. Domain `secret` is on the
+-- reserved deny-list in is_org_grantable_permission, and this name is NOT on that
+-- function's short allowlist (only `secret.read` is) -- so an organisation admin
+-- cannot attach it to an org role and mint a global-role sharer. That is intended:
+-- an org admin's sharing power is over their own organisation, which the
+-- p_target_org_id branch already serves.
+INSERT INTO "public"."permissions" ("name", "description", "is_system")
+VALUES ('secret.share.role', 'Share a secret with an RBAC role (fans out to every holder)', true)
+ON CONFLICT ("name") DO NOTHING;
+
+INSERT INTO "public"."role_permissions" ("role_id", "permission_id")
+SELECT r."id", p."id"
+FROM (VALUES ('admin'), ('boss_admin')) AS grant_map("role_name")
+JOIN "public"."roles" r ON r."name" = grant_map."role_name"
+JOIN "public"."permissions" p ON p."name" = 'secret.share.role'
+ON CONFLICT ("role_id", "permission_id") DO NOTHING;
+
+
+CREATE OR REPLACE FUNCTION "public"."share_secret"(
+    "p_secret_id" "uuid",
+    "p_target_user_id" "uuid" DEFAULT NULL::"uuid",
+    "p_target_role_id" "uuid" DEFAULT NULL::"uuid",
+    "p_notes" "text" DEFAULT NULL::"text",
+    "p_expires_at" timestamp with time zone DEFAULT NULL::timestamp with time zone,
+    "p_target_org_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_is_owner BOOLEAN;
+    v_is_org_admin BOOLEAN;
+    v_target_email TEXT;
+    v_target_role_name TEXT;
+    v_target_org_slug TEXT;
+    v_secret_website TEXT;
+    v_secret_org UUID;
+    v_target_count INTEGER;
+    v_via TEXT;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    -- Was an inline "owner OR literal admin role" check. can_manage_secret keeps
+    -- both of those and additionally lets an admin of the OWNING organisation
+    -- share an organisation secret -- which is the point of org ownership.
+    IF NOT public.can_manage_secret(p_secret_id) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'Unauthorized: You must be the owner, an organisation administrator, or an admin to share this secret');
+    END IF;
+
+    SELECT s.website, s.user_id = auth.uid(), s.org_id
+      INTO v_secret_website, v_is_owner, v_secret_org
+      FROM public.secrets s WHERE s.id = p_secret_id;
+
+    IF v_secret_website IS NULL AND NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Secret not found');
+    END IF;
+
+    v_is_org_admin := v_secret_org IS NOT NULL AND public.is_org_admin(v_secret_org);
+
+    -- Exactly one of three targets. share_target_check would catch this at insert
+    -- time, but a clear message beats a constraint violation.
+    v_target_count := (CASE WHEN p_target_user_id IS NOT NULL THEN 1 ELSE 0 END)
+                    + (CASE WHEN p_target_role_id IS NOT NULL THEN 1 ELSE 0 END)
+                    + (CASE WHEN p_target_org_id  IS NOT NULL THEN 1 ELSE 0 END);
+    IF v_target_count <> 1 THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'Must specify exactly one of target_user_id, target_role_id or target_org_id');
+    END IF;
+
+    IF p_target_user_id IS NOT NULL THEN
+        SELECT u.email INTO v_target_email FROM auth.users u WHERE u.id = p_target_user_id;
+        IF v_target_email IS NULL THEN
+            RETURN jsonb_build_object('success', false, 'error', 'User not found');
+        END IF;
+
+        INSERT INTO public.secret_shares (
+            secret_id, shared_with_user_id, shared_with_role_id, shared_with_org_id,
+            shared_by, access_level, expires_at, notes
+        ) VALUES (
+            p_secret_id, p_target_user_id, NULL, NULL,
+            auth.uid(), 'read', p_expires_at, p_notes
+        )
+        ON CONFLICT (secret_id, shared_with_user_id)
+        DO UPDATE SET expires_at = EXCLUDED.expires_at, notes = EXCLUDED.notes, created_at = now();
+    END IF;
+
+    IF p_target_role_id IS NOT NULL THEN
+        -- NEW: role targets require `secret.share.role`.
+        --
+        -- Owning a secret has never been enough to justify this. A global role is not a
+        -- person: `user` is a descendant of every role, so a share with it is visible to
+        -- every account in the deployment (20260802010000 says so in its own header), and
+        -- there is no undo for a credential a whole company has read. Until now the only
+        -- thing standing between any secret owner and that button was that non-admins
+        -- could not see the Secret Manager panel at all -- which is exactly what this
+        -- migration stops being true.
+        --
+        -- User targets and organisation targets are deliberately NOT gated: the first is
+        -- one named person, and the second already requires membership of the target org
+        -- (checked below), which is the anti-phishing gate that branch needs. Neither
+        -- fans out beyond people the sharer can already name.
+        IF NOT public.authorize('secret.share.role') THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                'Unauthorized: sharing with a role requires the secret.share.role permission. '
+                || 'Share with a specific user or with your organisation instead.');
+        END IF;
+
+        SELECT r.name INTO v_target_role_name FROM public.roles r WHERE r.id = p_target_role_id;
+        IF v_target_role_name IS NULL THEN
+            RETURN jsonb_build_object('success', false, 'error', 'Role not found');
+        END IF;
+
+        INSERT INTO public.secret_shares (
+            secret_id, shared_with_user_id, shared_with_role_id, shared_with_org_id,
+            shared_by, access_level, expires_at, notes
+        ) VALUES (
+            p_secret_id, NULL, p_target_role_id, NULL,
+            auth.uid(), 'read', p_expires_at, p_notes
+        )
+        ON CONFLICT (secret_id, shared_with_role_id)
+        DO UPDATE SET expires_at = EXCLUDED.expires_at, notes = EXCLUDED.notes, created_at = now();
+    END IF;
+
+    IF p_target_org_id IS NOT NULL THEN
+        SELECT o.slug INTO v_target_org_slug
+        FROM public.organisations o WHERE o.id = p_target_org_id;
+        IF v_target_org_slug IS NULL THEN
+            RETURN jsonb_build_object('success', false, 'error', 'Organisation not found');
+        END IF;
+
+        -- You may only share INTO an organisation you belong to. Otherwise any
+        -- user could push a credential at an arbitrary organisation's members --
+        -- a phishing primitive, since the Secret Manager would then display it
+        -- to them as a legitimately shared secret.
+        IF NOT public.is_org_member(p_target_org_id) THEN
+            RETURN jsonb_build_object('success', false, 'error',
+                'You can only share with an organisation you belong to');
+        END IF;
+
+        INSERT INTO public.secret_shares (
+            secret_id, shared_with_user_id, shared_with_role_id, shared_with_org_id,
+            shared_by, access_level, expires_at, notes
+        ) VALUES (
+            p_secret_id, NULL, NULL, p_target_org_id,
+            auth.uid(), 'read', p_expires_at, p_notes
+        )
+        ON CONFLICT (secret_id, shared_with_org_id)
+        DO UPDATE SET expires_at = EXCLUDED.expires_at, notes = EXCLUDED.notes, created_at = now();
+    END IF;
+
+    v_via := CASE WHEN v_is_owner THEN 'owner'
+                  WHEN v_is_org_admin THEN 'org_admin'
+                  ELSE 'admin_override' END;
+
+    INSERT INTO public.secret_access_log (
+        secret_id, user_id, operation, access_granted_via, metadata
+    ) VALUES (
+        p_secret_id, auth.uid(), 'share', v_via,
+        jsonb_build_object(
+            'target_user_id', p_target_user_id,
+            'target_role_id', p_target_role_id,
+            'target_org_id', p_target_org_id,
+            'target_email', v_target_email,
+            'target_role_name', v_target_role_name,
+            'target_org_slug', v_target_org_slug,
+            'secret_website', v_secret_website,
+            'expires_at', p_expires_at,
+            'notes', p_notes
+        )
+    );
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'message', 'Secret shared successfully',
+        'target_email', v_target_email,
+        'target_role', v_target_role_name,
+        'target_org', v_target_org_slug
+    );
+END;
+$$;
+
+
+ALTER FUNCTION "public"."share_secret"("uuid","uuid","uuid","text",timestamp with time zone,"uuid") OWNER TO "postgres";
+
+COMMENT ON FUNCTION "public"."share_secret"("uuid","uuid","uuid","text",timestamp with time zone,"uuid") IS 'Shares a secret with exactly one of a user, a role, or an organisation. Authorization is can_manage_secret, so organisation admins can share organisation-owned secrets. Sharing INTO an organisation requires membership of it, which prevents pushing a credential at strangers. Sharing with a ROLE additionally requires secret.share.role: a role share fans out to every holder, and `user` is a descendant of every role, so an ungated role target is a one-click broadcast to the whole deployment. access_granted_via gains org_admin.';

--- a/supabase/tests/plugin_create_permission_test.sql
+++ b/supabase/tests/plugin_create_permission_test.sql
@@ -10,7 +10,7 @@
 -- auth.users row fires handle_new_user(), which assigns the 'user' role.
 
 begin;
-select plan(22);
+select plan(23);
 
 -- ---------------------------------------------------------------------------
 -- Fixtures
@@ -64,7 +64,12 @@ select set_eq(
               -- role (20260801010000), and boss_plugin_admin inherits from it.
               -- Revoking them from `user` is the kill-switch for self-service
               -- organisation creation, so this list tracks that grant.
-              ('organisation.create'),('organisation.read') $$,
+              ('organisation.create'),('organisation.read'),
+              -- Likewise `secret.read`, granted to `user` by 20260809000000 so that
+              -- everyone gets their own vault and Settings > AI Providers. Inherited,
+              -- not direct: this role still cannot share a secret with a role, which is
+              -- what the secret.share.role assertion below pins.
+              ('secret.read') $$,
     'boss_plugin_admin EFFECTIVE = direct + the inherited user.* baseline'
 );
 
@@ -78,11 +83,16 @@ select is(
     0,
     'boss_plugin_admin holds NO plugins.admin.* moderation permission'
 );
+-- `secret.read` is exempted rather than dropped from the family list: it is now part
+-- of the `user` baseline every role inherits (20260809000000), so its presence here is
+-- expected. Any OTHER secret.* -- notably secret.share.role -- must still be absent,
+-- which is the half of this assertion that still has teeth.
 select is(
     (select count(*)::int from unnest(public.get_effective_permissions('11111111-1111-1111-1111-111111111111')) perm
-     where perm like 'role.%' or perm like 'finance.%' or perm like 'rpa.%' or perm like 'secret.%'),
+     where perm like 'role.%' or perm like 'finance.%' or perm like 'rpa.%'
+        or (perm like 'secret.%' and perm <> 'secret.read')),
     0,
-    'boss_plugin_admin holds NO role.*, finance.*, rpa.* or secret.* permission'
+    'boss_plugin_admin holds NO role.*, finance.*, rpa.* or non-baseline secret.* permission'
 );
 
 -- ---------------------------------------------------------------------------
@@ -113,7 +123,12 @@ select is( public.authorize('plugins.create'), true,  'boss_plugin_admin authori
 select is( public.authorize('api_key.create'), true,  'boss_plugin_admin authorize(api_key.create) = true' );
 select is( public.authorize('plugins.admin.publish'), false,
            'boss_plugin_admin authorize(plugins.admin.publish) = false (moderation stays separate)' );
-select is( public.authorize('secret.read'), false, 'boss_plugin_admin authorize(secret.read) = false' );
+-- Was `false`. `user` holds secret.read from 20260809000000 and this role inherits it,
+-- so the vault is open to it like everyone else. The permission that still separates a
+-- plugin author from an admin is the role-share fan-out, asserted next.
+select is( public.authorize('secret.read'), true, 'boss_plugin_admin authorize(secret.read) = true (inherited from user)' );
+select is( public.authorize('secret.share.role'), false,
+           'boss_plugin_admin authorize(secret.share.role) = false (role shares stay admin-only)' );
 
 -- ---------------------------------------------------------------------------
 -- Delegated assignment. boss_plugin_admin is a grantable TARGET for boss_admin,

--- a/supabase/tests/secret_read_for_user_role_test.sql
+++ b/supabase/tests/secret_read_for_user_role_test.sql
@@ -198,7 +198,7 @@ select is(
 -- unprivileged caller which role ids are real.
 select set_config('request.jwt.claims',
     '{"sub":"60000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
-select like(
+select alike(
     public.share_secret(
         p_secret_id => (select v from t_vault where k='own'),
         p_target_role_id => '00000000-0000-0000-0000-0000000000ff'
@@ -211,7 +211,7 @@ select like(
 -- not a replacement for can_manage_secret.
 select set_config('request.jwt.claims',
     '{"sub":"60000000-0000-0000-0000-000000000003","role":"authenticated"}', true);
-select like(
+select alike(
     public.share_secret(
         p_secret_id => (select v from t_vault where k='own'),
         p_target_user_id => '60000000-0000-0000-0000-000000000002'

--- a/supabase/tests/secret_read_for_user_role_test.sql
+++ b/supabase/tests/secret_read_for_user_role_test.sql
@@ -1,0 +1,224 @@
+-- pgTAP tests for the per-user vault (migration 20260809000000).
+-- Run with: supabase test db
+--
+-- Two halves, and they pull in opposite directions on purpose:
+--
+--   1. WIDENING. `secret.read` reaches the baseline `user` role, so a plain
+--      user can open the Secret Manager and Settings > AI Providers. This is
+--      the point of the migration.
+--   2. TIGHTENING. Sharing a secret with a ROLE now needs `secret.share.role`,
+--      which `user` does NOT get. A role share fans out to every holder and
+--      `user` is a descendant of every role, so an ungated role target is a
+--      one-click broadcast to the whole deployment. That was survivable only
+--      while non-admins could not reach the panel at all.
+--
+-- The share assertions check the secret_shares TABLE, not just the RPC's
+-- success flag: a gate that returns an error while still writing the row would
+-- pass a message-only assertion and leak exactly what it claims to prevent.
+--
+-- The suite provisions the Vault master key itself, inside the transaction, so
+-- it passes on a fresh `supabase db reset`. Everything rolls back.
+
+begin;
+select plan(19);
+
+-- ---------------------------------------------------------------------------
+-- Vault key (rolled back). Without it encrypt_text raises and nothing works.
+-- ---------------------------------------------------------------------------
+select vault.create_secret(
+    'cGd0YXAtdGVzdC1rZXktMzItYnl0ZXMtYWVzLW9r',
+    'master_encryption_key',
+    'pgTAP test key (transaction-local)');
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. handle_new_user assigns 'user' to each; the admin gets it as well
+-- as its own role, which is the real shape of an admin account.
+-- ---------------------------------------------------------------------------
+insert into auth.users (id, email, email_confirmed_at) values
+    ('60000000-0000-0000-0000-000000000001', 'vaultplain@pgtap.test',  now()),
+    ('60000000-0000-0000-0000-000000000002', 'vaultadmin@pgtap.test',  now()),
+    ('60000000-0000-0000-0000-000000000003', 'vaultmate@pgtap.test',   now());
+
+insert into public.user_roles (user_id, role_id)
+select '60000000-0000-0000-0000-000000000002', id
+from public.roles where name = 'admin'
+on conflict do nothing;
+
+create temporary table t_vault (k text primary key, v uuid);
+insert into t_vault select 'role_user', id from public.roles where name = 'user';
+
+
+-- ===========================================================================
+-- SECTION 1: the widening
+-- ===========================================================================
+select ok(
+    exists (
+        select 1 from public.role_permissions rp
+        join public.roles r on r.id = rp.role_id
+        join public.permissions p on p.id = rp.permission_id
+        where r.name = 'user' and p.name = 'secret.read'
+    ),
+    'the `user` role holds secret.read directly'
+);
+
+select ok(
+    public.get_effective_permissions('60000000-0000-0000-0000-000000000001') @> array['secret.read']::text[],
+    'a plain user effectively holds secret.read'
+);
+
+select set_config('request.jwt.claims',
+    '{"sub":"60000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
+select is( public.authorize('secret.read'), true,
+    'authorize(secret.read) = true for a plain user (this is what the panel gate reads)' );
+
+-- The vault was ALWAYS per-user server-side; the gate was client-side only.
+-- These pin that, so a future "tighten secret.read" change cannot quietly
+-- assume the RPCs were ever the thing enforcing it.
+insert into t_vault
+select 'own',
+       (public.create_secret('example.com','plainuser','pw-plain') ->> 'secret_id')::uuid;
+select isnt((select v from t_vault where k='own'), NULL,
+    'a plain user can create a secret (the RPC never checked a permission)');
+select is(
+    (select password from public.get_user_secrets(50,0) where id=(select v from t_vault where k='own')),
+    'pw-plain',
+    'a plain user can read back their own secret'
+);
+
+
+-- ===========================================================================
+-- SECTION 2: secret.share.role exists and is scoped
+-- ===========================================================================
+select ok(
+    exists (select 1 from public.permissions where name = 'secret.share.role' and is_system),
+    'secret.share.role exists and is a system permission (delete_permission refuses it)'
+);
+
+select set_eq(
+    $$ select r.name from public.role_permissions rp
+       join public.roles r on r.id = rp.role_id
+       join public.permissions p on p.id = rp.permission_id
+       where p.name = 'secret.share.role' $$,
+    $$ values ('admin'),('boss_admin') $$,
+    'secret.share.role is granted to admin and boss_admin only'
+);
+
+select ok(
+    not (public.get_effective_permissions('60000000-0000-0000-0000-000000000001') @> array['secret.share.role']::text[]),
+    'a plain user does NOT hold secret.share.role'
+);
+
+-- The org-grantability boundary. `secret` is a reserved domain and only
+-- `secret.read` is on the allowlist, so an organisation admin cannot mint a
+-- global-role sharer inside their own org.
+select ok(
+    not public.is_org_grantable_permission(
+        (select id from public.permissions where name='secret.share.role')),
+    'secret.share.role is NOT org-grantable (reserved domain, not on the allowlist)'
+);
+select ok(
+    public.is_org_grantable_permission(
+        (select id from public.permissions where name='secret.read')),
+    'secret.read IS still org-grantable (unchanged by this migration)'
+);
+
+
+-- ===========================================================================
+-- SECTION 3: share_secret enforces it, and only for role targets
+-- ===========================================================================
+-- Still acting as the plain user, who OWNS the secret. Ownership passes
+-- can_manage_secret, so the role gate is the only thing that can refuse this.
+select is(
+    (public.share_secret(
+        p_secret_id => (select v from t_vault where k='own'),
+        p_target_role_id => (select v from t_vault where k='role_user')
+     ) ->> 'success')::boolean,
+    false,
+    'a plain OWNER cannot share their own secret with a role'
+);
+select is(
+    (select count(*)::int from public.secret_shares
+     where secret_id = (select v from t_vault where k='own')
+       and shared_with_role_id is not null),
+    0,
+    'and no role share row was written (the refusal is not message-only)'
+);
+
+-- Sharing with a named person is untouched: one recipient the sharer chose.
+select is(
+    (public.share_secret(
+        p_secret_id => (select v from t_vault where k='own'),
+        p_target_user_id => '60000000-0000-0000-0000-000000000003'
+     ) ->> 'success')::boolean,
+    true,
+    'a plain user CAN still share with an individual user'
+);
+select is(
+    (select count(*)::int from public.secret_shares
+     where secret_id = (select v from t_vault where k='own')
+       and shared_with_user_id = '60000000-0000-0000-0000-000000000003'),
+    1,
+    'and that user share row exists'
+);
+
+-- The recipient sees it, which is the whole point of the untouched path.
+select set_config('request.jwt.claims',
+    '{"sub":"60000000-0000-0000-0000-000000000003","role":"authenticated"}', true);
+select is(
+    (select count(*)::int from public.get_user_secrets_with_shared(50,0)
+     where id = (select v from t_vault where k='own') and is_owner = false),
+    1,
+    'the recipient sees the shared secret'
+);
+
+-- An admin may still create a role share.
+select set_config('request.jwt.claims',
+    '{"sub":"60000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+insert into t_vault
+select 'adminown',
+       (public.create_secret('admin.example.com','vaultadmin','pw-admin') ->> 'secret_id')::uuid;
+select is(
+    (public.share_secret(
+        p_secret_id => (select v from t_vault where k='adminown'),
+        p_target_role_id => (select v from t_vault where k='role_user')
+     ) ->> 'success')::boolean,
+    true,
+    'an admin CAN share with a role'
+);
+select is(
+    (select count(*)::int from public.secret_shares
+     where secret_id = (select v from t_vault where k='adminown')
+       and shared_with_role_id = (select v from t_vault where k='role_user')),
+    1,
+    'and the admin role share row exists'
+);
+
+-- The refusal must not depend on the role being findable. A nonexistent role id
+-- has to hit the permission check FIRST, or the error message tells an
+-- unprivileged caller which role ids are real.
+select set_config('request.jwt.claims',
+    '{"sub":"60000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
+select like(
+    public.share_secret(
+        p_secret_id => (select v from t_vault where k='own'),
+        p_target_role_id => '00000000-0000-0000-0000-0000000000ff'
+    ) ->> 'error',
+    '%secret.share.role%',
+    'the permission check runs before the role lookup (no role-existence oracle)'
+);
+
+-- Ownership is still required on top of the permission: the gate is additive,
+-- not a replacement for can_manage_secret.
+select set_config('request.jwt.claims',
+    '{"sub":"60000000-0000-0000-0000-000000000003","role":"authenticated"}', true);
+select like(
+    public.share_secret(
+        p_secret_id => (select v from t_vault where k='own'),
+        p_target_user_id => '60000000-0000-0000-0000-000000000002'
+    ) ->> 'error',
+    '%Unauthorized%',
+    'a non-owner still cannot share someone else''s secret with anyone'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/secret_role_share_hierarchy_test.sql
+++ b/supabase/tests/secret_role_share_hierarchy_test.sql
@@ -32,6 +32,12 @@ select u.id, r.id from auth.users u join public.roles r on
     (u.email = 'hadmin@pgtap.test'   and r.name = 'admin')
  or (u.email = 'hboss@pgtap.test'    and r.name = 'boss_admin')
  or (u.email = 'hfinance@pgtap.test' and r.name = 'finance_admin')
+ -- The owner needs boss_admin purely for its `secret.share.role`: since
+ -- 20260809000000, creating a role share takes that permission and a plain owner
+ -- is refused. This suite is about who can SEE a role share, not who may create
+ -- one, so the fixture buys the ability and moves on. The refusal itself is
+ -- covered in secret_read_for_user_role_test.sql.
+ or (u.email = 'howner@pgtap.test'   and r.name = 'boss_admin')
 on conflict do nothing;
 
 -- The owner creates a secret and shares it with finance_admin.


### PR DESCRIPTION
## The question this answers

"Why was the Secret Manager admin-only?" There was never a decision. `20260628000000_secret_read_permission.sql` says so in its own header: the panel "was historically gated by the legacy `requiresAdmin` flag (admin role only)", and that migration existed to let `boss_admin` in. It translated admin-only forward verbatim and nobody revisited whether a normal user should have a vault.

The data layer has always said the opposite:

- every secret RPC is granted `TO "authenticated"` with no permission check (`20260802000000`),
- each self-scopes with `auth.uid()` (`create_secret:92`, `delete_secret:219`, `get_user_secrets:281`, `search_user_secrets:460`),
- all four RLS policies on `public.secrets` are `auth.uid() = user_id` (`20251023000013`).

So `secret.read` is a client-side visibility gate over a store that is already per-user. **This grants it to `user` and widens server-side access by zero rows.**

## What it actually unblocks

Since AI provider settings moved into the secret-manager plugin, that plugin owns `Settings > AI Providers` and the `LlmProviderSettingsAPI` behind `PluginContext.llmProvider`. `DynamicPluginManager.kt:860` is `if (enabled && accessible)` - it skips `register()` entirely for a plugin the user cannot access, not merely hides it. So for every non-admin:

1. the API was never contributed,
2. `Settings > AI Providers` showed "isn't loaded yet" forever,
3. `PluginContext.llmProvider` was null in jupyter-notebook, llmrpa and every other consumer.

All AI in BOSS was admin-only by accident.

## The tightening that has to come with it

`share_secret` gated role targets on `can_manage_secret` alone, so any owner could share a secret with any global role - including `user`, which is a descendant of every role and therefore means everyone (`20260802010000` states this in its header). That was survivable only because non-admins could not open the panel. It is not survivable afterwards.

Role targets now require a new `secret.share.role` (admin + boss_admin), checked **before** the role lookup so the error is not a role-existence oracle. User targets and organisation targets are unchanged - the first is one named person, the second already requires membership of the target org.

`secret.share.role` is not org-grantable: `secret` is a reserved domain and only `secret.read` is on the allowlist, so an org admin cannot mint a global-role sharer.

## Also here

- **The misleading notice.** `Settings > AI Providers` reported a permission problem as "isn't loaded yet", which will never resolve on its own and named nothing to ask for. It now distinguishes the two, using the `getInaccessiblePlugins()` diagnostics that already existed for the Plugin Manager banner.
- **The first-run wizard** listed Secret Manager under "Admin Tools". Moved to Productivity. `isDefault` deliberately unchanged - see Open question.
- **`plugin_create_permission_test`** asserted `boss_plugin_admin` holds no `secret.*` at all and `authorize('secret.read') = false`. It now inherits `secret.read` like every role, so those become the absence of `secret.share.role`, which is the fact that still has teeth.

## Verification

- `ktlintCheck` + `detekt` green; `:composeApp:compileKotlinDesktop` green; `PluginAccessGateTest` / `McpToolRegistryCoreTest` green.
- **The pgTAP suites have NOT been executed** - Docker is not running on this machine, so `supabase test db` could not start a local stack. `secret_read_for_user_role_test.sql` (19 assertions) and the `plugin_create_permission_test.sql` edits are reviewed and structurally checked (plan counts match assertion counts, dollar-quoting balanced) but unrun. **Please let CI run them before merging.**

The new suite asserts against the `secret_shares` table, not just the RPC's `success` flag: a gate that returns an error while still writing the row would pass a message-only assertion and leak exactly what it claims to prevent.

## Rollout

1. This migration.
2. risa-labs-inc/boss-plugin-user-secret-list#8 - **merge and release first if possible.** `my_secret_get` lacks the `ai-provider` refusal its sibling `secret_get` carries, so widening `secret.read` turns an admin-only bypass into an every-user one.
3. risa-labs-inc/boss-plugin-secret-manager#17 - hides the Roles tab without the permission. Not required for correctness (the RPC refuses either way), so it can follow.

Note `authorize()` reads the database, not the JWT, so the server accepts a plain user's calls the moment the migration lands. **Panel visibility waits for the next token refresh** (up to `jwt_expiry`, default 1h), because `DynamicPluginManager` gates on the `user_permissions` claim.

## Open question

Should Secret Manager become `isDefault = true` in the first-run wizard? It is now the only way to configure AI, and several plugins degrade without it - but flipping that changes what gets installed for everyone on first run, which is a product call rather than mine.
