### PR TITLE
fix(logging): route navigation-target tracing through BossLogger

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -754,7 +754,6 @@
     <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$private val _reloadPluginEvents = MutableSharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt;(extraBufferCapacity = 10)</ID>
     <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$val checkPluginUpdatesEvents: SharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt; = _checkPluginUpdatesEvents.asSharedFlow()</ID>
     <ID>MaxLineLength:MenuActionsHandler.kt$MenuActionsHandler$val reloadPluginEvents: SharedFlow&lt;Pair&lt;String, ai.rever.boss.plugin.api.PanelId&gt;&gt; = _reloadPluginEvents.asSharedFlow()</ID>
-    <ID>MaxLineLength:NavigationTargetProviderImpl.kt$NavigationTargetProviderImpl$"[HOST-DEBUG] NavigationTargetProviderImpl: received event from NavigationTargetBus: ${event.filePath}:${event.line}:${event.column}"</ID>
     <ID>MaxLineLength:NewTabDialog.kt$(selectedSuggestionIndex + 1).coerceAtMost(urlSuggestions.size - 1)</ID>
     <ID>MaxLineLength:NewTabDialog.kt$(selectedType == TabType.TERMINAL || selectedType == TabType.JUPYTER || inputText.isNotBlank())</ID>
     <ID>MaxLineLength:NewTabDialog.kt$// Always consume arrow keys to prevent cursor movement in text field</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/NavigationTargetProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/NavigationTargetProviderImpl.kt
@@ -3,6 +3,8 @@ package ai.rever.boss.components.plugin.providers
 import ai.rever.boss.components.events.NavigationTargetBus
 import ai.rever.boss.plugin.api.NavigationTargetEvent
 import ai.rever.boss.plugin.api.NavigationTargetProvider
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,6 +20,7 @@ import kotlinx.coroutines.launch
  * and position their editor cursors appropriately.
  */
 object NavigationTargetProviderImpl : NavigationTargetProvider {
+    private val logger = BossLogger.forComponent("NavigationTargetProviderImpl")
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private val _targets =
@@ -28,13 +31,15 @@ object NavigationTargetProviderImpl : NavigationTargetProvider {
     override val targets: SharedFlow<NavigationTargetEvent> = _targets.asSharedFlow()
 
     init {
-        println("[HOST-DEBUG] NavigationTargetProviderImpl: init - starting collector")
+        logger.debug(LogCategory.EDITOR, "Starting navigation-target collector")
         // Forward events from NavigationTargetBus to our flow
         scope.launch {
-            println("[HOST-DEBUG] NavigationTargetProviderImpl: collector started")
+            logger.debug(LogCategory.EDITOR, "Navigation-target collector started")
             NavigationTargetBus.targets.collect { event ->
-                println(
-                    "[HOST-DEBUG] NavigationTargetProviderImpl: received event from NavigationTargetBus: ${event.filePath}:${event.line}:${event.column}",
+                logger.debug(
+                    LogCategory.EDITOR,
+                    "Forwarding navigation target to plugins",
+                    mapOf("target" to "${event.filePath}:${event.line}:${event.column}"),
                 )
                 _targets.emit(
                     NavigationTargetEvent(
@@ -44,7 +49,7 @@ object NavigationTargetProviderImpl : NavigationTargetProvider {
                         sourceWindowId = event.sourceWindowId,
                     ),
                 )
-                println("[HOST-DEBUG] NavigationTargetProviderImpl: emitted to plugin targets")
+                logger.debug(LogCategory.EDITOR, "Navigation target emitted to plugin flow")
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/NavigationTargetProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/NavigationTargetProviderImpl.kt
@@ -31,6 +31,10 @@ object NavigationTargetProviderImpl : NavigationTargetProvider {
     override val targets: SharedFlow<NavigationTargetEvent> = _targets.asSharedFlow()
 
     init {
+        // EDITOR, not UI, even though the hop that feeds this one
+        // (SplitViewOperationsImpl.openFileAtPosition) logs under UI: what lands here is a cursor
+        // position for a plugin's editor, and EDITOR is what someone debugging that would turn on.
+        // The cost is that tracing one navigation end to end needs both categories enabled.
         logger.debug(LogCategory.EDITOR, "Starting navigation-target collector")
         // Forward events from NavigationTargetBus to our flow
         scope.launch {
@@ -39,7 +43,11 @@ object NavigationTargetProviderImpl : NavigationTargetProvider {
                 logger.debug(
                     LogCategory.EDITOR,
                     "Forwarding navigation target to plugins",
-                    mapOf("target" to "${event.filePath}:${event.line}:${event.column}"),
+                    mapOf(
+                        "path" to event.filePath,
+                        "line" to event.line,
+                        "column" to event.column,
+                    ),
                 )
                 _targets.emit(
                     NavigationTargetEvent(

--- a/plugin-platform/plugin-sandbox/detekt-baseline.xml
+++ b/plugin-platform/plugin-sandbox/detekt-baseline.xml
@@ -12,7 +12,6 @@
     <ID>MaxLineLength:SandboxedPluginContext.kt$SandboxedPluginContext$override fun unregisterDeepLinkActionHandler(handlerId: String)</ID>
     <ID>MaxLineLength:SandboxedPluginContext.kt$SandboxedPluginContext$override fun unregisterPanelMenuContribution(contributionId: String)</ID>
     <ID>MaxLineLength:SandboxedPluginContext.kt$SandboxedPluginContext$override fun unregisterShortcutActionProvider(providerId: String)</ID>
-    <ID>MaxLineLength:SandboxedPluginContext.kt$SandboxedPluginContext$println("[HOST-DEBUG] SandboxedPluginContext.navigationTargetProvider: delegate=${delegate::class.simpleName}, result=$result")</ID>
     <ID>NestedBlockDepth:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun attributeToPlugin( throwable: Throwable, thread: Thread? = null, ): String?</ID>
     <ID>NestedBlockDepth:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun register( pluginId: String, onError: (Throwable) -&gt; Unit, ): Registration</ID>
     <ID>ReturnCount:PluginCrashInterceptor.kt$PluginCrashInterceptor$fun attributeToPlugin( throwable: Throwable, thread: Thread? = null, ): String?</ID>

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
@@ -222,11 +222,7 @@ class SandboxedPluginContext(
 
     // Navigation target provider - delegate to underlying context
     override val navigationTargetProvider: NavigationTargetProvider?
-        get() {
-            val result = delegate.navigationTargetProvider
-            println("[HOST-DEBUG] SandboxedPluginContext.navigationTargetProvider: delegate=${delegate::class.simpleName}, result=$result")
-            return result
-        }
+        get() = delegate.navigationTargetProvider
 
     // Clipboard provider - delegate to underlying context
     override val clipboardProvider: ClipboardProvider?


### PR DESCRIPTION
Five `[HOST-DEBUG]` printlns were left behind on the navigation-target path: four in
`NavigationTargetProviderImpl` and one in `SandboxedPluginContext`.

They fire on every navigation event (clicking a terminal link, jumping to a file:line),
unconditionally to stdout, with no category or level to filter by. One of them prints the full
`filePath:line:column` every time. In a terminal app, stdout is the one channel worth keeping quiet.

They now log through `BossLogger` at debug under `LogCategory.EDITOR`, with the target passed as
structured data rather than interpolated into the message.

Two things fell out of it:

- `SandboxedPluginContext.navigationTargetProvider` had a block getter that existed only to log:
  take the delegate value into a local, print it, return it. With the println gone it is just the
  delegation, so it goes back to being an expression.
- Both detekt baselines had an entry suppressing `MaxLineLength` for a println line this deletes,
  so those retire with them: `plugin-sandbox` (26 entries down to 25) and `composeApp`. Detekt does
  not fail on unmatched baseline entries, so nothing in CI would have caught them being left
  behind, but the IDs embed the offending source text and can never match again.

Cleanup only, no behaviour change beyond what is logged and where it goes.

## Verification

`:composeApp:compileKotlinDesktop` and `:plugin-platform:plugin-sandbox:compileKotlinDesktop`
green, plus `detekt` and `ktlintCheck`.

## Not included

`TrackingPluginContext.kt` has four more `println("[TrackingPluginContext] ...")` calls of the same
kind. Left alone deliberately: that is plugin lifecycle rather than navigation, and it belongs in
its own change.
