### PR TITLE
Reach Settings, Search and Sign Out while focus mode hides the top bar

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.components.dialogs.CloneProjectDialog
 import ai.rever.boss.components.dialogs.ConfirmationDialog
 import ai.rever.boss.components.dialogs.GlobalSearchDialog
+import ai.rever.boss.components.dialogs.LogoutConfirmationDialog
 import ai.rever.boss.components.dialogs.NewProjectWizardDialog
 import ai.rever.boss.components.dialogs.NewTabDialog
 import ai.rever.boss.components.dialogs.ProjectOpenModeDialog
@@ -408,6 +409,17 @@ internal fun BossAppDialogs(state: BossAppState) {
     }
 
     // Keyboard Shortcut Help Dialog
+    // Sign-out confirmation, raised by the top bar's Sign Out and by the focus-mode quick actions.
+    // Hosted here with every other state.show*Dialog flag rather than in the scaffold: the cluster's
+    // buttons live in a separate, content-sized overlay window with no room for a dialog, and one
+    // owner is what stops the two entry points each opening their own. Tree position does not affect
+    // z-order - LogoutConfirmationDialog is a BossDialog, a real platform window on both paths.
+    if (state.showLogoutDialog) {
+        LogoutConfirmationDialog(
+            onDismiss = { state.showLogoutDialog = false },
+        )
+    }
+
     if (state.showShortcutHelpDialog) {
         ShortcutHelpDialog(
             keymapSettings = keymapSettings,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -102,8 +102,13 @@ private val TOAST_OVERLAY_INITIAL_SIZE = DpSize(432.dp, 600.dp)
  *    (`BossPluginNotificationService.notifyPluginDisabled`, an ERROR toast with a "Re-enable"
  *    action - precisely the kind a user leaves sitting while they go elsewhere). Escaping the
  *    scene is only worth anything while the user is looking at this window, so an unfocused window
- *    draws toasts in place, exactly as before this overlay existed. That also stops
- *    `HeavyweightCorner`'s frame-clock loop, which would otherwise run for as long as the toast.
+ *    draws toasts in place, exactly as before this overlay existed.
+ *
+ *    This guard used to carry a second justification: it also stopped `HeavyweightCorner`'s
+ *    frame-clock loop, which would otherwise have run for as long as the toast. That loop is gone -
+ *    the corner renderer is event-driven now - so the reason is gone with it. **The guard is not.**
+ *    The dead click region over another application is on its own sufficient, and it is the reason
+ *    that was always doing the work.
  *
  * Guarding on content matches what `TabCycleOverlayHost` and both drag ghosts already do.
  *
@@ -200,10 +205,6 @@ internal fun BossAppScaffold(
     val splitViewState = state.splitViewState
     val selectedProject by state.windowProjectState.selectedProject.collectAsState()
 
-    // Sign-out is reachable from the focus-mode quick actions, whose buttons live in a separate
-    // overlay window. The confirmation is owned here so the dialog is drawn in the MAIN
-    // composition: a content-sized overlay window has nowhere to put one.
-    var showLogoutDialog by remember { mutableStateOf(false) }
     // The content area's distance from the window's end and bottom edges, i.e. the right sidebar's
     // width plus the bottom bar's height, whatever they currently are. Measured rather than derived
     // from the reveal flags because both animate, and the quick actions have to follow them.
@@ -330,6 +331,9 @@ internal fun BossAppScaffold(
                             onShowSearch = {
                                 state.showGlobalSearchDialog = true
                             },
+                            onSignOut = {
+                                state.showLogoutDialog = true
+                            },
                             onNewProject = {
                                 state.showNewProjectDialog = true
                             },
@@ -391,18 +395,20 @@ internal fun BossAppScaffold(
                         // Composed inside the content area so the lightweight path aligns where it
                         // draws; contentInset is what makes the heavyweight path agree.
                         //
-                        // Stood down while either dialog it opens is up. On the heavyweight path a
-                        // modal takes window focus and the focus guard would drop it in place
-                        // anyway, but that is an emergent consequence rather than a stated rule,
-                        // and it does not hold on the lightweight path - there the cluster would
-                        // keep drawing over the dialog's bottom-right and keep eating clicks in it.
-                        // Saying so here is free and makes the invariant hold on both paths.
+                        // Deliberately NOT also gated on "is a dialog open". An earlier revision
+                        // listed the two dialogs this cluster opens, which would have had to grow
+                        // every time anyone added a dialog to BossAppDialogs and would have gone
+                        // stale silently. It is not needed on either path: a lightweight BossDialog
+                        // falls back to Compose's own Dialog, a real platform window ABOVE the
+                        // composition, so an in-place cluster is underneath it and never over it;
+                        // and a heavyweight modal takes window focus, which drops this to the same
+                        // in-place path by the focus guard in FocusModeQuickActions.
                         FocusModeQuickActions(
-                            visible = !reveal.showTopBar && !state.showGlobalSearchDialog && !showLogoutDialog,
+                            visible = !reveal.showTopBar,
                             inset = { contentInset },
                             onShowSettings = { state.showSettingsDialog = true },
                             onShowSearch = { state.showGlobalSearchDialog = true },
-                            onSignOut = { showLogoutDialog = true },
+                            onSignOut = { state.showLogoutDialog = true },
                         )
                     }
 
@@ -457,11 +463,13 @@ internal fun BossAppScaffold(
                 revealOffsetDp = revealOffsetDp,
             )
 
-            // Raised by the focus-mode quick actions, drawn here rather than in their overlay
-            // window - which is sized to its content and so has no room for a dialog.
-            if (showLogoutDialog) {
+            // Raised by the top bar's Sign Out and by the focus-mode quick actions, and drawn
+            // here for both. The cluster's buttons live in a separate, content-sized overlay
+            // window with no room for a dialog; the flag is window-scoped so the two entry points
+            // cannot each open one. See BossAppState.showLogoutDialog.
+            if (state.showLogoutDialog) {
                 LogoutConfirmationDialog(
-                    onDismiss = { showLogoutDialog = false },
+                    onDismiss = { state.showLogoutDialog = false },
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -5,7 +5,6 @@ import ai.rever.boss.components.bars.horizontal.BossTitleBar
 import ai.rever.boss.components.bars.horizontal.BossTopBar
 import ai.rever.boss.components.bars.vertical.BossLeftSideBar
 import ai.rever.boss.components.bars.vertical.BossRightSideBar
-import ai.rever.boss.components.dialogs.LogoutConfirmationDialog
 import ai.rever.boss.components.overlays.DraggingItemOverlay
 import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.components.overlays.TabDraggingOverlay
@@ -473,16 +472,6 @@ internal fun BossAppScaffold(
                 settings = focusModeSettings,
                 revealOffsetDp = revealOffsetDp,
             )
-
-            // Raised by the top bar's Sign Out and by the focus-mode quick actions, and drawn
-            // here for both. The cluster's buttons live in a separate, content-sized overlay
-            // window with no room for a dialog; the flag is window-scoped so the two entry points
-            // cannot each open one. See BossAppState.showLogoutDialog.
-            if (state.showLogoutDialog) {
-                LogoutConfirmationDialog(
-                    onDismiss = { state.showLogoutDialog = false },
-                )
-            }
 
             // Draw the dragging item overlay (ghost) if an item is being dragged
             DraggingItemOverlay()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -19,7 +19,6 @@ import ai.rever.boss.components.window_panel.components.main_window_panels.TabCy
 import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
-import ai.rever.boss.focusmode.FocusModeEdge
 import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.handleTabDropResult
 import ai.rever.boss.plugin.api.LocalBookmarkDataProvider
@@ -414,7 +413,7 @@ internal fun BossAppScaffold(
                         // visible. Gating on the setting is also just the honest condition: the
                         // cluster exists because focus mode clears the top bar.
                         FocusModeQuickActions(
-                            visible = focusModeSettings.hides(FocusModeEdge.TOP) && !reveal.showTopBar,
+                            visible = focusQuickActionsVisible(focusModeSettings, reveal.showTopBar),
                             inset = { contentInset },
                             onShowSettings = { state.showSettingsDialog = true },
                             onShowSearch = { state.showGlobalSearchDialog = true },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.components.bars.horizontal.BossTitleBar
 import ai.rever.boss.components.bars.horizontal.BossTopBar
 import ai.rever.boss.components.bars.vertical.BossLeftSideBar
 import ai.rever.boss.components.bars.vertical.BossRightSideBar
+import ai.rever.boss.components.dialogs.LogoutConfirmationDialog
 import ai.rever.boss.components.overlays.DraggingItemOverlay
 import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.components.overlays.TabDraggingOverlay
@@ -56,9 +57,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
@@ -194,6 +199,16 @@ internal fun BossAppScaffold(
     val coroutineScope = state.coroutineScope
     val splitViewState = state.splitViewState
     val selectedProject by state.windowProjectState.selectedProject.collectAsState()
+
+    // Sign-out is reachable from the focus-mode quick actions, whose buttons live in a separate
+    // overlay window. The confirmation is owned here so the dialog is drawn in the MAIN
+    // composition: a content-sized overlay window has nowhere to put one.
+    var showLogoutDialog by remember { mutableStateOf(false) }
+    // The content area's distance from the window's end and bottom edges, i.e. the right sidebar's
+    // width plus the bottom bar's height, whatever they currently are. Measured rather than derived
+    // from the reveal flags because both animate, and the quick actions have to follow them.
+    var contentInset by remember { mutableStateOf(DpSize.Zero) }
+    val density = LocalDensity.current.density
 
     with(state.draggablePanelComponent) {
         Box(
@@ -343,19 +358,39 @@ internal fun BossAppScaffold(
                     }
 
                     // Main content area - always visible (contains tabs)
-                    BossWindow(
-                        modifier = Modifier.weight(1f),
-                        tabsComponent = state.tabsComponent,
-                        panelComponentStore = state.panelComponentStore,
-                        splitViewState = splitViewState,
-                        tabDragComponent = state.tabDragComponent,
-                        onTabDropResult = { result ->
-                            handleTabDropResult(result, splitViewState)
-                        },
-                        onShowSettings = { state.showSettingsDialog = true },
-                        onOpenProjectDialog = { state.showProjectDialog = true },
-                        onNewProject = { state.showNewProjectDialog = true },
-                    )
+                    Box(
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .reportContentInset(density) { next ->
+                                    if (next != contentInset) contentInset = next
+                                },
+                    ) {
+                        BossWindow(
+                            modifier = Modifier.fillMaxSize(),
+                            tabsComponent = state.tabsComponent,
+                            panelComponentStore = state.panelComponentStore,
+                            splitViewState = splitViewState,
+                            tabDragComponent = state.tabDragComponent,
+                            onTabDropResult = { result ->
+                                handleTabDropResult(result, splitViewState)
+                            },
+                            onShowSettings = { state.showSettingsDialog = true },
+                            onOpenProjectDialog = { state.showProjectDialog = true },
+                            onNewProject = { state.showNewProjectDialog = true },
+                        )
+
+                        // Settings / Search / Sign Out, which the top bar otherwise owns outright.
+                        // Composed inside the content area so the lightweight path aligns where it
+                        // draws; contentInset is what makes the heavyweight path agree.
+                        FocusModeQuickActions(
+                            visible = !reveal.showTopBar,
+                            inset = contentInset,
+                            onShowSettings = { state.showSettingsDialog = true },
+                            onShowSearch = { state.showGlobalSearchDialog = true },
+                            onSignOut = { showLogoutDialog = true },
+                        )
+                    }
 
                     // Right sidebar - hidden in focus mode with smooth expand/shrink animation
                     AnimatedVisibility(
@@ -407,6 +442,14 @@ internal fun BossAppScaffold(
                 settings = focusModeSettings,
                 revealOffsetDp = revealOffsetDp,
             )
+
+            // Raised by the focus-mode quick actions, drawn here rather than in their overlay
+            // window - which is sized to its content and so has no room for a dialog.
+            if (showLogoutDialog) {
+                LogoutConfirmationDialog(
+                    onDismiss = { showLogoutDialog = false },
+                )
+            }
 
             // Draw the dragging item overlay (ghost) if an item is being dragged
             DraggingItemOverlay()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -207,6 +207,13 @@ internal fun BossAppScaffold(
     // The content area's distance from the window's end and bottom edges, i.e. the right sidebar's
     // width plus the bottom bar's height, whatever they currently are. Measured rather than derived
     // from the reveal flags because both animate, and the quick actions have to follow them.
+    //
+    // Written from onGloballyPositioned, which BossActionButton deliberately avoids ("non-observable
+    // holders: avoid triggering remeasure during the layout phase"). Safe here, and the difference
+    // is worth stating: this value feeds only the overlay WINDOW's placement, never the layout of
+    // the Box that reports it, so the write cannot feed back into its own measurement. It is passed
+    // to the cluster as a lambda so the read lands in that composable's restart scope rather than
+    // this one - see FocusModeQuickActions.
     var contentInset by remember { mutableStateOf(DpSize.Zero) }
     val density = LocalDensity.current.density
 
@@ -383,9 +390,16 @@ internal fun BossAppScaffold(
                         // Settings / Search / Sign Out, which the top bar otherwise owns outright.
                         // Composed inside the content area so the lightweight path aligns where it
                         // draws; contentInset is what makes the heavyweight path agree.
+                        //
+                        // Stood down while either dialog it opens is up. On the heavyweight path a
+                        // modal takes window focus and the focus guard would drop it in place
+                        // anyway, but that is an emergent consequence rather than a stated rule,
+                        // and it does not hold on the lightweight path - there the cluster would
+                        // keep drawing over the dialog's bottom-right and keep eating clicks in it.
+                        // Saying so here is free and makes the invariant hold on both paths.
                         FocusModeQuickActions(
-                            visible = !reveal.showTopBar,
-                            inset = contentInset,
+                            visible = !reveal.showTopBar && !state.showGlobalSearchDialog && !showLogoutDialog,
+                            inset = { contentInset },
                             onShowSettings = { state.showSettingsDialog = true },
                             onShowSearch = { state.showGlobalSearchDialog = true },
                             onSignOut = { showLogoutDialog = true },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -20,6 +20,7 @@ import ai.rever.boss.components.window_panel.components.main_window_panels.TabCy
 import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
+import ai.rever.boss.focusmode.FocusModeEdge
 import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.handleTabDropResult
 import ai.rever.boss.plugin.api.LocalBookmarkDataProvider
@@ -373,9 +374,7 @@ internal fun BossAppScaffold(
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .reportContentInset(density) { next ->
-                                    if (next != contentInset) contentInset = next
-                                },
+                                .reportContentInset(density) { contentInset = it },
                     ) {
                         BossWindow(
                             modifier = Modifier.fillMaxSize(),
@@ -403,8 +402,20 @@ internal fun BossAppScaffold(
                         // composition, so an in-place cluster is underneath it and never over it;
                         // and a heavyweight modal takes window focus, which drops this to the same
                         // in-place path by the focus guard in FocusModeQuickActions.
+                        //
+                        // `hides(TOP)` is not redundant with `!showTopBar`, it is what keeps this
+                        // off the launch path entirely. `FocusModeEdgeRevealState.shown` starts
+                        // false and is only turned back on by a LaunchedEffect, so on the FIRST
+                        // composition of every window `!showTopBar` is true whether or not focus
+                        // mode is even enabled. Without this the heavyweight path would create and
+                        // immediately dispose a native always-on-top window on every window open,
+                        // flash it in the corner for users who never turn focus mode on, and call
+                        // contentPaneBounds before the pane is reliably showing - which can burn
+                        // the one-per-session warning flag that exists to make a REAL failure
+                        // visible. Gating on the setting is also just the honest condition: the
+                        // cluster exists because focus mode clears the top bar.
                         FocusModeQuickActions(
-                            visible = !reveal.showTopBar,
+                            visible = focusModeSettings.hides(FocusModeEdge.TOP) && !reveal.showTopBar,
                             inset = { contentInset },
                             onShowSettings = { state.showSettingsDialog = true },
                             onShowSearch = { state.showGlobalSearchDialog = true },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -86,6 +86,17 @@ internal class BossAppState(
     var settingsInitialSection by mutableStateOf<String?>(null)
     var showShortcutHelpDialog by mutableStateOf(false)
 
+    /**
+     * The sign-out confirmation, raised from two places: the top bar's Sign Out button and the
+     * focus-mode quick actions.
+     *
+     * Window-scoped rather than owned by either, because two owners is two dialogs. The reveal is
+     * pointer-driven and this dialog does not block it, so raising the confirmation from the
+     * cluster and then hovering the top edge puts a second Sign Out button in reach of a
+     * confirmation that is already up - and each would open its own.
+     */
+    var showLogoutDialog by mutableStateOf(false)
+
     // Terminal link open dialog (Issue #346)
     var showTerminalLinkDialog by mutableStateOf(false)
     var pendingTerminalLinkUrl by mutableStateOf("")

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 
@@ -33,12 +34,27 @@ import androidx.compose.ui.unit.dp
  * Hard upper bound on the quick-actions overlay: its size before measurement, and the ceiling every
  * later measurement is taken against.
  *
- * A bound, not an estimate - content that would exceed it is CLIPPED. Three `BossActionButton`s in
- * `imageVector` mode are 28.dp square each, plus the row's padding and the surface border, so this
- * clears the real content comfortably while staying small enough that the dead click region it
- * defines stays small too.
+ * A bound, not an estimate - content that would exceed it is CLIPPED. The real content is ~94x30dp:
+ * three `BossActionButton`s at 28.dp square in `imageVector` mode, plus `space.xs` on each end of
+ * the row and the 1.dp border. Kept close to that rather than round, because until measurement
+ * lands this is also the region the overlay swallows clicks in - the same reason
+ * `TOAST_OVERLAY_INITIAL_SIZE` gives for keeping itself no larger than it needs to be. The margin
+ * is deliberately NOT in here; it rides in the inset (see [QUICK_ACTIONS_MARGIN]).
  */
-private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(160.dp, 56.dp)
+private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(120.dp, 40.dp)
+
+/**
+ * Gap between the cluster and the corner it sits in.
+ *
+ * Applied as *padding* on the lightweight path and as extra *inset* on the heavyweight one, and
+ * that asymmetry is the whole point rather than an inconsistency. Padding inside the overlay window
+ * is transparent but still eats clicks - there is no portable click-through - so a margin drawn
+ * that way would put a dead band across the content area's bottom-right corner, which on some
+ * platforms is the window's own resize hit area and is where a scrollbar's corner lands. Adding it
+ * to the inset instead moves the whole window inward, so the region it swallows is exactly the
+ * surface you can see.
+ */
+internal val QUICK_ACTIONS_MARGIN = 8.dp
 
 /** Test tag of the cluster - see `FocusModeQuickActionsTest`. */
 internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"
@@ -79,8 +95,13 @@ internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"
  * That guard is load-bearing for a second reason, which is easy to miss when deciding it is too
  * cautious: `SettingsWindow` is a separate window this cluster's own Settings button opens, and the
  * guard is the only thing that stops an always-on-top overlay of the MAIN window sitting on top of
- * it. The two in-window dialogs are handled the other way, by `BossAppScaffold` withholding
- * [visible] while either is up, because focus alone does not cover the lightweight path.
+ * it. The same holds for a heavyweight modal, which is also a window and also takes focus.
+ *
+ * In-window dialogs need nothing extra, and deliberately get nothing: a lightweight `BossDialog`
+ * falls back to Compose's own `Dialog`, a platform window ABOVE the composition, so the in-place
+ * cluster is underneath it. An earlier revision listed the dialogs this cluster opens in [visible];
+ * that enumeration would have had to grow with every dialog anyone added, and it was guarding
+ * against something neither path does.
  *
  * [inset] is the content area's distance from the window's end and bottom edges. The lightweight
  * path aligns inside this `BoxScope` and needs nothing, but the heavyweight path places a window
@@ -106,16 +127,22 @@ internal fun BoxScope.FocusModeQuickActions(
 
     if (!LocalWindowInfo.current.isWindowFocused) {
         Box(modifier = Modifier.align(Alignment.BottomEnd)) {
-            QuickActions(onShowSettings, onShowSearch, onSignOut)
+            QuickActions(QUICK_ACTIONS_MARGIN, onShowSettings, onShowSearch, onSignOut)
         }
         return
     }
+    val measured = inset()
     OverlayCorner(
         alignment = Alignment.BottomEnd,
         initialSize = QUICK_ACTIONS_OVERLAY_SIZE,
-        inset = inset(),
+        // The margin rides in the inset rather than in the content - see QUICK_ACTIONS_MARGIN.
+        inset =
+            DpSize(
+                measured.width + QUICK_ACTIONS_MARGIN,
+                measured.height + QUICK_ACTIONS_MARGIN,
+            ),
     ) {
-        QuickActions(onShowSettings, onShowSearch, onSignOut)
+        QuickActions(margin = 0.dp, onShowSettings, onShowSearch, onSignOut)
     }
 }
 
@@ -154,9 +181,14 @@ internal fun Modifier.reportContentInset(
         )
     }
 
-/** The cluster itself, identical on both paths - only where it is drawn differs. */
+/**
+ * The cluster itself, identical on both paths apart from [margin]: the heavyweight path passes
+ * zero and carries the gap in its inset instead, because padding inside that window would be a
+ * transparent strip that still swallows clicks. See [QUICK_ACTIONS_MARGIN].
+ */
 @Composable
 private fun QuickActions(
+    margin: Dp,
     onShowSettings: () -> Unit,
     onShowSearch: () -> Unit,
     onSignOut: () -> Unit,
@@ -166,7 +198,7 @@ private fun QuickActions(
     Surface(
         modifier =
             Modifier
-                .padding(BossTheme.space.sm)
+                .padding(margin)
                 .border(1.dp, BossTheme.colors.line, BossTheme.radius.cardShape)
                 .testTag(FOCUS_QUICK_ACTIONS_TAG),
         color = BossTheme.colors.raised,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.app
 
 import ai.rever.boss.components.buttons.BossActionButton
+import ai.rever.boss.components.buttons.QuickActionHints
 import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.ui.BossTheme
@@ -75,15 +76,28 @@ internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"
  * costs nothing: reaching it means focusing this window first, and by then it is a real overlay
  * again.
  *
+ * That guard is load-bearing for a second reason, which is easy to miss when deciding it is too
+ * cautious: `SettingsWindow` is a separate window this cluster's own Settings button opens, and the
+ * guard is the only thing that stops an always-on-top overlay of the MAIN window sitting on top of
+ * it. The two in-window dialogs are handled the other way, by `BossAppScaffold` withholding
+ * [visible] while either is up, because focus alone does not cover the lightweight path.
+ *
  * [inset] is the content area's distance from the window's end and bottom edges. The lightweight
  * path aligns inside this `BoxScope` and needs nothing, but the heavyweight path places a window
  * against the whole content pane - so without it the cluster sits over the status bar and the right
  * sidebar, which Windows focus-mode defaults leave visible.
+ *
+ * It is a **lambda, not a value**, so the state read lands in this composable's restart scope. The
+ * scaffold builds its tree entirely out of `Box`/`Column`/`Row` content lambdas, which are inline
+ * and so create no restart scope of their own: reading the inset there subscribes the whole
+ * scaffold body to it, and it changes every frame of a 250ms sidebar reveal - the case the measured
+ * inset exists to follow. Deferring the read costs nothing, since this function is non-skippable
+ * anyway (fresh lambdas each pass).
  */
 @Composable
 internal fun BoxScope.FocusModeQuickActions(
     visible: Boolean,
-    inset: DpSize,
+    inset: () -> DpSize,
     onShowSettings: () -> Unit,
     onShowSearch: () -> Unit,
     onSignOut: () -> Unit,
@@ -99,7 +113,7 @@ internal fun BoxScope.FocusModeQuickActions(
     OverlayCorner(
         alignment = Alignment.BottomEnd,
         initialSize = QUICK_ACTIONS_OVERLAY_SIZE,
-        inset = inset,
+        inset = inset(),
     ) {
         QuickActions(onShowSettings, onShowSearch, onSignOut)
     }
@@ -129,8 +143,13 @@ internal fun Modifier.reportContentInset(
         val root = coordinates.findRootCoordinates().size
         onInset(
             DpSize(
-                ((root.width - bounds.right) / density).dp,
-                ((root.height - bounds.bottom) / density).dp,
+                // Floored at the source as well as inside `insetBounds`. That one only guards the
+                // other direction, so a negative component would GROW the region and place the
+                // overlay outside the content pane - the failure `cornerPosition`'s floor prevents,
+                // reintroduced a layer up. `boundsInRoot` clips to the root so it cannot go
+                // negative today; this costs nothing and stops that being load-bearing.
+                ((root.width - bounds.right).coerceAtLeast(0f) / density).dp,
+                ((root.height - bounds.bottom).coerceAtLeast(0f) / density).dp,
             ),
         )
     }
@@ -155,30 +174,34 @@ private fun QuickActions(
         elevation = BossTheme.elevation.popover,
     ) {
         Row(modifier = Modifier.padding(horizontal = BossTheme.space.xs)) {
+            // Same order as BossTopRightBar, which is not only about muscle memory: it puts Sign
+            // Out at the INNER end, so the destructive action is not the one at the very corner of
+            // the window, where it is easiest to hit by accident.
+            //
             // hintDirection = top throughout: the cluster sits on the bottom edge of the content
             // area, so a hint below it would be off the window on the lightweight path. (On the
             // heavyweight path BossActionButton routes hints to SwingTooltip, which places itself,
             // and this is ignored.)
-            BossActionButton(
-                imageVector = Icons.Outlined.Settings,
-                text = "Settings",
-                hintText = "Configure application settings",
-                hintDirection = top,
-                onClick = onShowSettings,
-            )
-            BossActionButton(
-                imageVector = Icons.Outlined.Search,
-                text = "Search",
-                hintText = "Search files, tabs, bookmarks (⇧⇧)",
-                hintDirection = top,
-                onClick = onShowSearch,
-            )
             BossActionButton(
                 imageVector = Icons.AutoMirrored.Outlined.Logout,
                 text = "Sign Out",
                 hintText = signOutHint(currentUser?.email),
                 hintDirection = top,
                 onClick = onSignOut,
+            )
+            BossActionButton(
+                imageVector = Icons.Outlined.Search,
+                text = "Search",
+                hintText = QuickActionHints.SEARCH,
+                hintDirection = top,
+                onClick = onShowSearch,
+            )
+            BossActionButton(
+                imageVector = Icons.Outlined.Settings,
+                text = "Settings",
+                hintText = QuickActionHints.SETTINGS,
+                hintDirection = top,
+                onClick = onShowSettings,
             )
         }
     }
@@ -195,6 +218,6 @@ private fun QuickActions(
  * test cannot see without driving the clock.
  */
 internal fun signOutHint(email: String?): String {
-    val signedInAs = email?.takeIf { it.isNotBlank() } ?: return "Sign out of your account"
+    val signedInAs = email?.takeIf { it.isNotBlank() } ?: return QuickActionHints.SIGN_OUT
     return "Sign out - $signedInAs"
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -4,6 +4,8 @@ import ai.rever.boss.components.buttons.BossActionButton
 import ai.rever.boss.components.buttons.QuickActionHints
 import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.components.overlays.overlayCornerIsHeavyweight
+import ai.rever.boss.focusmode.FocusModeEdge
+import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.services.supabase.AuthService
@@ -42,7 +44,7 @@ import androidx.compose.ui.unit.dp
  * `TOAST_OVERLAY_INITIAL_SIZE` gives for keeping itself no larger than it needs to be. The margin
  * is deliberately NOT in here; it rides in the inset (see [QUICK_ACTIONS_MARGIN]).
  */
-private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(100.dp, 34.dp)
+internal val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(100.dp, 34.dp)
 
 /**
  * Gap between the cluster and the corner it sits in.
@@ -56,6 +58,26 @@ private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(100.dp, 34.dp)
  * surface you can see.
  */
 internal val QUICK_ACTIONS_MARGIN = 8.dp
+
+/**
+ * Whether the cluster belongs on screen: focus mode clears the top bar, and it is not showing now.
+ *
+ * Both halves, and the first is the one that looks redundant and is not.
+ * `FocusModeEdgeRevealState.shown` starts false and is only turned back on by a `LaunchedEffect`,
+ * so on the FIRST composition of every window `!showTopBar` is true whether or not focus mode is
+ * even enabled. Without the settings half, the heavyweight path creates and immediately disposes a
+ * native always-on-top window on every window open, flashes it in the corner for users who never
+ * turn focus mode on, and reads the content pane before it is showing - which can spend the
+ * one-per-session warning flag that exists to make a real failure visible.
+ *
+ * Pure and named because the alternative is a conjunction inlined in the scaffold that no test can
+ * see, whose failure mode is a corner flash nothing else would notice. Same reason [signOutHint] is
+ * out here.
+ */
+internal fun focusQuickActionsVisible(
+    settings: FocusModeSettings,
+    showTopBar: Boolean,
+): Boolean = settings.hides(FocusModeEdge.TOP) && !showTopBar
 
 /** Test tag of the cluster - see `FocusModeQuickActionsTest`. */
 internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.app
 import ai.rever.boss.components.buttons.BossActionButton
 import ai.rever.boss.components.buttons.QuickActionHints
 import ai.rever.boss.components.overlays.OverlayCorner
+import ai.rever.boss.components.overlays.overlayCornerIsHeavyweight
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.services.supabase.AuthService
@@ -133,18 +134,35 @@ internal fun BoxScope.FocusModeQuickActions(
         }
         return
     }
+    // Which path OverlayCorner will take, asked before choosing where to put the margin. Its
+    // lightweight branch aligns inside this BoxScope and ignores `inset` entirely, so folding the
+    // margin into the inset unconditionally loses it there - the cluster ends up flush in the
+    // corner, and jumps by 8dp whenever the window loses and regains focus. Reachable today via
+    // BOSS_RENDERING_MODE=OFF_SCREEN, which is a supported escape hatch rather than a dead branch.
+    val heavyweight = overlayCornerIsHeavyweight()
     val measured = inset()
     OverlayCorner(
         alignment = Alignment.BottomEnd,
         initialSize = QUICK_ACTIONS_OVERLAY_SIZE,
-        // The margin rides in the inset rather than in the content - see QUICK_ACTIONS_MARGIN.
         inset =
-            DpSize(
-                measured.width + QUICK_ACTIONS_MARGIN,
-                measured.height + QUICK_ACTIONS_MARGIN,
-            ),
+            if (heavyweight) {
+                DpSize(
+                    measured.width + QUICK_ACTIONS_MARGIN,
+                    measured.height + QUICK_ACTIONS_MARGIN,
+                )
+            } else {
+                DpSize.Zero
+            },
     ) {
-        QuickActions(margin = 0.dp, onShowSettings, onShowSearch, onSignOut)
+        // Margin as inset on the heavyweight path so it is not a dead band on the corner, and as
+        // ordinary padding on the lightweight one, where nothing is swallowed and the inset would
+        // be double-counted. See QUICK_ACTIONS_MARGIN.
+        QuickActions(
+            margin = if (heavyweight) 0.dp else QUICK_ACTIONS_MARGIN,
+            onShowSettings,
+            onShowSearch,
+            onSignOut,
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -1,0 +1,200 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.buttons.BossActionButton
+import ai.rever.boss.components.overlays.OverlayCorner
+import ai.rever.boss.plugin.api.Panel.Companion.top
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.services.supabase.AuthService
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Surface
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Logout
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.findRootCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+/**
+ * Hard upper bound on the quick-actions overlay: its size before measurement, and the ceiling every
+ * later measurement is taken against.
+ *
+ * A bound, not an estimate - content that would exceed it is CLIPPED. Three `BossActionButton`s in
+ * `imageVector` mode are 28.dp square each, plus the row's padding and the surface border, so this
+ * clears the real content comfortably while staying small enough that the dead click region it
+ * defines stays small too.
+ */
+private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(160.dp, 56.dp)
+
+/** Test tag of the cluster - see `FocusModeQuickActionsTest`. */
+internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"
+
+/**
+ * Settings, Search and Sign Out, pinned to the bottom-right of the main content area while focus
+ * mode has the top bar cleared.
+ *
+ * These three live in `BossTopRightBar` and nowhere else, so clearing the top bar takes them with
+ * it. The documented way back is to hover the top edge - and that is driven by Compose
+ * `onPointerEvent` on an edge strip, which **cannot fire over a browser tab**: in
+ * `HARDWARE_ACCELERATED` mode Chromium owns a foreign native window that composites over the
+ * Compose scene rather than inside it, so the pointer never crosses the strip as far as Compose is
+ * concerned. That is why `FocusModeSettings.defaultAutoReveal` turns hover-reveal off on Windows
+ * out of the box, and it is the state this exists for: focus mode plus a browser tab, where these
+ * actions are otherwise reachable only from the menu bar.
+ *
+ * Three things about the shape, all consequences of that same case:
+ *
+ *  - **It draws through [OverlayCorner], not in place.** A plain Compose overlay is behind the
+ *    browser surface for exactly the same reason the hover strip is under it - present, invisible,
+ *    unclickable. Drawing in place would leave this working everywhere except where it is needed.
+ *  - **Nothing is composed when [visible] is false.** Load-bearing rather than an optimisation: the
+ *    heavyweight overlay is a non-focusable always-on-top AWT window, the JVM has no portable
+ *    click-through, so one composed unconditionally is a permanently dead region of this app and of
+ *    whatever is in front of it. `ToastOverlay` guards the same way for the same reason.
+ *  - **The buttons only raise callbacks.** The sign-out confirmation is a dialog, and a dialog
+ *    composed inside a content-sized overlay window has nowhere to go; `BossAppScaffold` owns that
+ *    state and draws the dialog in the main composition.
+ *
+ * **An unfocused window draws in place**, exactly as `ToastOverlay` does. The escape is only worth
+ * anything while the user is looking at this window, and the overlay is always-on-top over every
+ * other application too - so leaving one up while BOSS is in the background would put a dead click
+ * region over whatever the user switched to. In place it may sit behind the browser surface, which
+ * costs nothing: reaching it means focusing this window first, and by then it is a real overlay
+ * again.
+ *
+ * [inset] is the content area's distance from the window's end and bottom edges. The lightweight
+ * path aligns inside this `BoxScope` and needs nothing, but the heavyweight path places a window
+ * against the whole content pane - so without it the cluster sits over the status bar and the right
+ * sidebar, which Windows focus-mode defaults leave visible.
+ */
+@Composable
+internal fun BoxScope.FocusModeQuickActions(
+    visible: Boolean,
+    inset: DpSize,
+    onShowSettings: () -> Unit,
+    onShowSearch: () -> Unit,
+    onSignOut: () -> Unit,
+) {
+    if (!visible) return
+
+    if (!LocalWindowInfo.current.isWindowFocused) {
+        Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+            QuickActions(onShowSettings, onShowSearch, onSignOut)
+        }
+        return
+    }
+    OverlayCorner(
+        alignment = Alignment.BottomEnd,
+        initialSize = QUICK_ACTIONS_OVERLAY_SIZE,
+        inset = inset,
+    ) {
+        QuickActions(onShowSettings, onShowSearch, onSignOut)
+    }
+}
+
+/**
+ * Reports this layout's distance from the window's END and BOTTOM edges, in Dp, whenever it moves.
+ *
+ * This is the [FocusModeQuickActions] `inset`, measured rather than derived. Deriving it from the
+ * reveal flags would need this file to know each bar's thickness and to re-derive it mid-animation;
+ * asking the layout is one question with one answer, and it stays right when a sidebar is resized.
+ *
+ * Two details that are easy to get subtly wrong, and silently:
+ *
+ *  - **Against the ROOT, not the parent.** The `Row` this sits in already excludes the bottom bar,
+ *    so `positionInParent` would report a bottom inset of zero while the bar is right there.
+ *  - **px divided by density, not raw px.** `HeavyweightCorner` places its window in AWT logical
+ *    units and converts its own measurements the same way. Passing px straight through compiles,
+ *    passes every gate, and puts the overlay off by the display's scale factor.
+ */
+internal fun Modifier.reportContentInset(
+    density: Float,
+    onInset: (DpSize) -> Unit,
+): Modifier =
+    onGloballyPositioned { coordinates ->
+        val bounds = coordinates.boundsInRoot()
+        val root = coordinates.findRootCoordinates().size
+        onInset(
+            DpSize(
+                ((root.width - bounds.right) / density).dp,
+                ((root.height - bounds.bottom) / density).dp,
+            ),
+        )
+    }
+
+/** The cluster itself, identical on both paths - only where it is drawn differs. */
+@Composable
+private fun QuickActions(
+    onShowSettings: () -> Unit,
+    onShowSearch: () -> Unit,
+    onSignOut: () -> Unit,
+) {
+    val currentUser by AuthService.currentUser.collectAsState()
+
+    Surface(
+        modifier =
+            Modifier
+                .padding(BossTheme.space.sm)
+                .border(1.dp, BossTheme.colors.line, BossTheme.radius.cardShape)
+                .testTag(FOCUS_QUICK_ACTIONS_TAG),
+        color = BossTheme.colors.raised,
+        shape = BossTheme.radius.cardShape,
+        elevation = BossTheme.elevation.popover,
+    ) {
+        Row(modifier = Modifier.padding(horizontal = BossTheme.space.xs)) {
+            // hintDirection = top throughout: the cluster sits on the bottom edge of the content
+            // area, so a hint below it would be off the window on the lightweight path. (On the
+            // heavyweight path BossActionButton routes hints to SwingTooltip, which places itself,
+            // and this is ignored.)
+            BossActionButton(
+                imageVector = Icons.Outlined.Settings,
+                text = "Settings",
+                hintText = "Configure application settings",
+                hintDirection = top,
+                onClick = onShowSettings,
+            )
+            BossActionButton(
+                imageVector = Icons.Outlined.Search,
+                text = "Search",
+                hintText = "Search files, tabs, bookmarks (⇧⇧)",
+                hintDirection = top,
+                onClick = onShowSearch,
+            )
+            BossActionButton(
+                imageVector = Icons.AutoMirrored.Outlined.Logout,
+                text = "Sign Out",
+                hintText = signOutHint(currentUser?.email),
+                hintDirection = top,
+                onClick = onSignOut,
+            )
+        }
+    }
+}
+
+/**
+ * Hover hint for the sign-out button, naming [email] when there is one.
+ *
+ * The top bar shows the signed-in address next to this button as plain text; the cluster is
+ * icon-only, so the hint is where that identity goes instead. Which account is about to be signed
+ * out is worth confirming before clicking, not after.
+ *
+ * Pure, and separate, because the hint itself is only reachable through a 500ms hover that a UI
+ * test cannot see without driving the clock.
+ */
+internal fun signOutHint(email: String?): String {
+    val signedInAs = email?.takeIf { it.isNotBlank() } ?: return "Sign out of your account"
+    return "Sign out - $signedInAs"
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -112,8 +112,10 @@ internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"
  * scaffold builds its tree entirely out of `Box`/`Column`/`Row` content lambdas, which are inline
  * and so create no restart scope of their own: reading the inset there subscribes the whole
  * scaffold body to it, and it changes every frame of a 250ms sidebar reveal - the case the measured
- * inset exists to follow. Deferring the read costs nothing, since this function is non-skippable
- * anyway (fresh lambdas each pass).
+ * inset exists to follow. Deferring the read costs nothing here, since this function is
+ * non-skippable anyway (fresh lambdas each pass). Note the deferral only buys anything on the
+ * heavyweight path: `OverlayCorner` takes a value, so the lightweight branch still reads it and
+ * subscribes to something it does not use.
  */
 @Composable
 internal fun BoxScope.FocusModeQuickActions(
@@ -203,7 +205,10 @@ private fun QuickActions(
                 .testTag(FOCUS_QUICK_ACTIONS_TAG),
         color = BossTheme.colors.raised,
         shape = BossTheme.radius.cardShape,
-        elevation = BossTheme.elevation.popover,
+        // No elevation, deliberately. The overlay window shrinks to the measured content, so a
+        // drop shadow would fall outside it and simply vanish on the heavyweight path while
+        // showing on the lightweight one - the two paths have to look the same. The hairline
+        // border is what separates the cluster from the content underneath.
     ) {
         Row(modifier = Modifier.padding(horizontal = BossTheme.space.xs)) {
             // Same order as BossTopRightBar, which is not only about muscle memory: it puts Sign

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.unit.dp
  * `TOAST_OVERLAY_INITIAL_SIZE` gives for keeping itself no larger than it needs to be. The margin
  * is deliberately NOT in here; it rides in the inset (see [QUICK_ACTIONS_MARGIN]).
  */
-private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(120.dp, 40.dp)
+private val QUICK_ACTIONS_OVERLAY_SIZE = DpSize(100.dp, 34.dp)
 
 /**
  * Gap between the cluster and the corner it sits in.
@@ -114,9 +114,9 @@ internal const val FOCUS_QUICK_ACTIONS_TAG = "focus-quick-actions"
  * and so create no restart scope of their own: reading the inset there subscribes the whole
  * scaffold body to it, and it changes every frame of a 250ms sidebar reveal - the case the measured
  * inset exists to follow. Deferring the read costs nothing here, since this function is
- * non-skippable anyway (fresh lambdas each pass). Note the deferral only buys anything on the
- * heavyweight path: `OverlayCorner` takes a value, so the lightweight branch still reads it and
- * subscribes to something it does not use.
+ * non-skippable anyway (fresh lambdas each pass). It is invoked only on the heavyweight branch,
+ * which is the only one `OverlayCorner` applies an inset on - reading it above the branch would
+ * subscribe the lightweight path to a value it ignores.
  */
 @Composable
 internal fun BoxScope.FocusModeQuickActions(
@@ -140,16 +140,15 @@ internal fun BoxScope.FocusModeQuickActions(
     // corner, and jumps by 8dp whenever the window loses and regains focus. Reachable today via
     // BOSS_RENDERING_MODE=OFF_SCREEN, which is a supported escape hatch rather than a dead branch.
     val heavyweight = overlayCornerIsHeavyweight()
-    val measured = inset()
     OverlayCorner(
         alignment = Alignment.BottomEnd,
         initialSize = QUICK_ACTIONS_OVERLAY_SIZE,
+        // inset() is invoked INSIDE the branch, not above it. Read unconditionally, the lightweight
+        // path subscribes to a value it then ignores and recomposes on every frame of a 250ms
+        // sidebar animation - the exact cost the lambda parameter exists to avoid.
         inset =
             if (heavyweight) {
-                DpSize(
-                    measured.width + QUICK_ACTIONS_MARGIN,
-                    measured.height + QUICK_ACTIONS_MARGIN,
-                )
+                inset().let { DpSize(it.width + QUICK_ACTIONS_MARGIN, it.height + QUICK_ACTIONS_MARGIN) }
             } else {
                 DpSize.Zero
             },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -65,6 +65,7 @@ fun BossDraggableComponent.BossTopBar(
     onShowTopOfMind: (() -> Unit)? = null,
     onShowSettings: (() -> Unit)? = null,
     onShowSearch: (() -> Unit)? = null,
+    onSignOut: (() -> Unit)? = null,
     onNewProject: (() -> Unit)? = null,
     onCloneProject: (() -> Unit)? = null,
 ) {
@@ -90,7 +91,7 @@ fun BossDraggableComponent.BossTopBar(
             // Run/debug controls (Issue #91 / #321)
             BossTopRunBar()
             Spacer(modifier = Modifier.weight(0.1f))
-            BossTopRightBar(onShowSettings = onShowSettings, onShowSearch = onShowSearch)
+            BossTopRightBar(onShowSettings = onShowSettings, onShowSearch = onShowSearch, onSignOut = onSignOut)
         }
     }
     Divider(color = BossTheme.colors.line)
@@ -795,8 +796,8 @@ fun BossDraggableComponent.BossTopLeftBar(
 fun BossTopRightBar(
     onShowSettings: (() -> Unit)? = null,
     onShowSearch: (() -> Unit)? = null,
+    onSignOut: (() -> Unit)? = null,
 ) {
-    var showLogoutDialog by remember { mutableStateOf(false) }
     val currentUser by AuthService.currentUser.collectAsState()
 
     // Show user email if logged in
@@ -816,7 +817,7 @@ fun BossTopRightBar(
         text = "Sign Out",
         hintText = QuickActionHints.SIGN_OUT,
     ) {
-        showLogoutDialog = true
+        onSignOut?.invoke()
     }
 
     // Global search button (Issue #92)
@@ -836,12 +837,9 @@ fun BossTopRightBar(
         onShowSettings?.invoke()
     }
 
-    // Logout confirmation dialog
-    if (showLogoutDialog) {
-        LogoutConfirmationDialog(
-            onDismiss = { showLogoutDialog = false },
-        )
-    }
+    // The confirmation itself is raised by BossAppScaffold, which owns the flag: the focus-mode
+    // quick actions offer the same action, and two owners would be two stacked dialogs. See
+    // BossAppState.showLogoutDialog.
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -3,7 +3,6 @@ package ai.rever.boss.components.bars.horizontal
 import ai.rever.boss.components.buttons.BossActionButton
 import ai.rever.boss.components.buttons.QuickActionHints
 import ai.rever.boss.components.dialogs.CommitDialog
-import ai.rever.boss.components.dialogs.LogoutConfirmationDialog
 import ai.rever.boss.components.dialogs.ProjectOpenModeDialog
 import ai.rever.boss.components.dialogs.ProjectSelectionDialog
 import ai.rever.boss.components.events.PanelEventBus

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -64,7 +64,11 @@ fun BossDraggableComponent.BossTopBar(
     onShowTopOfMind: (() -> Unit)? = null,
     onShowSettings: (() -> Unit)? = null,
     onShowSearch: (() -> Unit)? = null,
-    onSignOut: (() -> Unit)? = null,
+    // Required, unlike its neighbours. Those were always callback-only; this one used to open the
+    // confirmation itself, and moving that to BossAppState turned Sign Out into a button that
+    // renders, hovers, shows its hint and does nothing if the argument is dropped. A required
+    // parameter makes that a compile error at the single call site instead.
+    onSignOut: () -> Unit,
     onNewProject: (() -> Unit)? = null,
     onCloneProject: (() -> Unit)? = null,
 ) {
@@ -795,7 +799,8 @@ fun BossDraggableComponent.BossTopLeftBar(
 fun BossTopRightBar(
     onShowSettings: (() -> Unit)? = null,
     onShowSearch: (() -> Unit)? = null,
-    onSignOut: (() -> Unit)? = null,
+    // Required - see BossTopBar's onSignOut.
+    onSignOut: () -> Unit,
 ) {
     val currentUser by AuthService.currentUser.collectAsState()
 
@@ -816,7 +821,7 @@ fun BossTopRightBar(
         text = "Sign Out",
         hintText = QuickActionHints.SIGN_OUT,
     ) {
-        onSignOut?.invoke()
+        onSignOut()
     }
 
     // Global search button (Issue #92)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.bars.horizontal
 
 import ai.rever.boss.components.buttons.BossActionButton
+import ai.rever.boss.components.buttons.QuickActionHints
 import ai.rever.boss.components.dialogs.CommitDialog
 import ai.rever.boss.components.dialogs.LogoutConfirmationDialog
 import ai.rever.boss.components.dialogs.ProjectOpenModeDialog
@@ -808,10 +809,12 @@ fun BossTopRightBar(
         )
     }
 
+    // Hint strings are shared with the focus-mode quick actions, which are these same three
+    // buttons drawn in the other place they are reachable from. See QuickActionHints.
     BossActionButton(
         imageVector = Icons.AutoMirrored.Outlined.Logout,
         text = "Sign Out",
-        hintText = "Sign out of your account",
+        hintText = QuickActionHints.SIGN_OUT,
     ) {
         showLogoutDialog = true
     }
@@ -820,7 +823,7 @@ fun BossTopRightBar(
     BossActionButton(
         imageVector = Icons.Outlined.Search,
         text = "Search",
-        hintText = "Search files, tabs, bookmarks (⇧⇧)",
+        hintText = QuickActionHints.SEARCH,
     ) {
         onShowSearch?.invoke()
     }
@@ -828,7 +831,7 @@ fun BossTopRightBar(
     BossActionButton(
         imageVector = Icons.Outlined.Settings,
         text = "Settings",
-        hintText = "Configure application settings",
+        hintText = QuickActionHints.SETTINGS,
     ) {
         onShowSettings?.invoke()
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/QuickActionHints.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/QuickActionHints.kt
@@ -1,0 +1,18 @@
+package ai.rever.boss.components.buttons
+
+/**
+ * Hover hints for the three actions that appear in both the top bar and the focus-mode cluster.
+ *
+ * `BossTopRightBar` and `FocusModeQuickActions` are the same three buttons rendered in two places,
+ * so the strings are shared rather than copied. The search hint is the reason this exists: it names
+ * a keyboard shortcut, and a duplicated shortcut is wrong in one of the two places from the day it
+ * changes, silently and only for whoever is reading the copy nobody updated.
+ *
+ * A leaf next to `BossActionButton` so both callers can reach it without either package depending
+ * on the other.
+ */
+internal object QuickActionHints {
+    const val SETTINGS = "Configure application settings"
+    const val SEARCH = "Search files, tabs, bookmarks (⇧⇧)"
+    const val SIGN_OUT = "Sign out of your account"
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -254,6 +254,21 @@ fun BoxScope.OverlayCorner(
 }
 
 /**
+ * Whether [OverlayCorner] would escape into its own window right here.
+ *
+ * Exists because [OverlayCorner]'s two paths do not accept the same description of where to sit.
+ * The heavyweight one is placed against the whole content pane and so needs an `inset`; the
+ * lightweight one aligns inside the caller's own `BoxScope`, where that same inset would be
+ * double-counted and is therefore ignored. A caller whose spacing must survive both has to know
+ * which it is getting - the alternative is spacing that silently disappears on one path, which is
+ * exactly what happened to this cluster's corner margin.
+ *
+ * Asks the same question [OverlayCorner] does, in the same composition, so the two cannot disagree.
+ */
+@Composable
+internal fun overlayCornerIsHeavyweight(): Boolean = routeOverlayHeavyweight(OverlayConfig.heavyweightCorner != null)
+
+/**
  * A drag ghost of [size] following the pointer, layered above the browser.
  *
  * [windowOffset] positions it on the lightweight path, in the calling layout's coordinates, exactly

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -144,11 +144,16 @@ object OverlayConfig {
      * up for as long as a key is held. Toasts linger for seconds while the user keeps working, so
      * their overlay must cover no more than itself. Null until injected; callers fall back to
      * drawing in place.
+     *
+     * `inset` shrinks the parent rectangle at its END and BOTTOM edges before the corner is
+     * resolved, so a caller anchored to a sub-region of the window (rather than to the window
+     * itself) can say so. See [OverlayCorner].
      */
     var heavyweightCorner: (
         @Composable (
             alignment: Alignment,
             initialSize: DpSize,
+            inset: DpSize,
             content: @Composable () -> Unit,
         ) -> Unit
     )? = null
@@ -223,16 +228,26 @@ fun BoxScope.OverlayHud(
  * [initialSize] is the size of the window before its content has been measured, so it must be a
  * generous UPPER bound - too small and the content measures clipped, then the overlay settles at
  * the clipped size. On the lightweight path it is unused, as the content sizes itself normally.
+ *
+ * [inset] exists because the two paths anchor to different things. The lightweight path aligns
+ * inside the CALLER's `BoxScope`, but the heavyweight one is a separate window placed against the
+ * parent window's whole content pane - so a caller that draws in a sub-region of the window (the
+ * main content area, say, rather than over the sidebars and status bar) is correct on one path and
+ * lands in the wrong corner on the other. Passing the sub-region's distance from the window's end
+ * and bottom edges makes both agree. It is applied to the heavyweight path only, where it shrinks
+ * the rectangle the corner is resolved inside; the overlay itself is not made any larger, so the
+ * region it covers - and therefore the region whose clicks it swallows - is unchanged.
  */
 @Composable
 fun BoxScope.OverlayCorner(
     alignment: Alignment,
     initialSize: DpSize,
+    inset: DpSize = DpSize.Zero,
     content: @Composable () -> Unit,
 ) {
     val hw = OverlayConfig.heavyweightCorner
     if (routeOverlayHeavyweight(hw != null) && hw != null) {
-        hw(alignment, initialSize) { content() }
+        hw(alignment, initialSize, inset) { content() }
     } else {
         Box(modifier = Modifier.align(alignment)) { content() }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -35,7 +35,7 @@ private const val MEASURE_RETRY_MS = 50L
  * How many measurement attempts before giving up, so a parent that never becomes measurable costs a
  * bounded number of wakeups rather than one per [MEASURE_RETRY_MS] for the session.
  */
-private const val MEASURE_ATTEMPTS = 100
+internal const val MEASURE_ATTEMPTS = 100
 
 /**
  * Heavyweight host for a corner overlay that outlives a keypress - toast notifications.
@@ -68,7 +68,7 @@ private const val MEASURE_ATTEMPTS = 100
  *    is showing, the next toast is then measured inside that smaller window, measures clipped, and
  *    the overlay can never grow back.
  *  - Parent bounds come from the CONTENT PANE, not the window (see [contentPaneBounds]), and are
- *    re-read on the frame clock rather than remembered once.
+ *    re-read as the window moves rather than remembered once (see [trackedContentPaneBounds]).
  *
  * [inset] narrows that parent rectangle at its end and bottom edges (see [insetBounds]). It is how
  * a caller anchored to a SUB-REGION of the window - the main content area, say, rather than the
@@ -182,8 +182,7 @@ private fun trackedContentPaneBounds(parent: AwtWindow?): IntArray? {
 
         fun refresh() {
             val next = contentPaneBounds(parent) ?: return
-            val current = bounds
-            if (current == null || !next.contentEquals(current)) bounds = next
+            if (boundsChanged(bounds, next)) bounds = next
         }
 
         val listener =
@@ -215,7 +214,7 @@ private fun trackedContentPaneBounds(parent: AwtWindow?): IntArray? {
     // session, which is the shape of the problem this whole change exists to remove.
     LaunchedEffect(parent) {
         var attempts = 0
-        while (bounds == null && attempts < MEASURE_ATTEMPTS) {
+        while (shouldKeepMeasuring(bounds, attempts)) {
             delay(MEASURE_RETRY_MS)
             bounds = contentPaneBounds(parent)
             attempts++
@@ -288,7 +287,11 @@ internal fun contentPaneBounds(parent: AwtWindow?): IntArray? {
     return bounds
 }
 
-/** One warning per session for [contentPaneBounds]; it is consulted on the frame clock. */
+/**
+ * One warning per session for [contentPaneBounds]. It is consulted on every window move and resize,
+ * and up to [MEASURE_ATTEMPTS] times while waiting for a parent to start showing, so an unguarded
+ * log line here would repeat.
+ */
 private val unmeasurableParentReported =
     java.util.concurrent.atomic
         .AtomicBoolean(false)
@@ -329,6 +332,33 @@ internal fun cornerPosition(
             }
     return x to y
 }
+
+/**
+ * Whether [next] is worth storing over [current].
+ *
+ * Named and pure because the alternative is invisible: a listener fires on every step of a window
+ * drag, and each assignment is a native `setLocation` on the overlay. Assigning unconditionally
+ * still *looks* right on screen, so nothing but a test distinguishes it from this.
+ */
+internal fun boundsChanged(
+    current: IntArray?,
+    next: IntArray,
+): Boolean = current == null || !next.contentEquals(current)
+
+/**
+ * Whether the mount-time measurement retry should run again, given [bounds] so far and how many
+ * [attempts] have been made.
+ *
+ * Two terminating conditions and both matter. The first measurement ends it, which is the normal
+ * case. The cap ends it when no measurement is ever going to land - a null parent, which is what a
+ * test host or a headless entry point looks like - so the fallback for a window that has not
+ * appeared yet cannot become a wakeup timer that outlives the session. That would be the same
+ * always-awake cost this renderer moved off the frame clock to escape.
+ */
+internal fun shouldKeepMeasuring(
+    bounds: IntArray?,
+    attempts: Int,
+): Boolean = bounds == null && attempts < MEASURE_ATTEMPTS
 
 /**
  * [bounds], with [inset] taken off its END and BOTTOM edges - the sub-region a caller anchored to

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -5,12 +5,12 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
@@ -22,8 +22,20 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
+import kotlinx.coroutines.delay
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
 import javax.swing.RootPaneContainer
 import java.awt.Window as AwtWindow
+
+/** How long to wait between attempts to measure a parent that is not showing yet. */
+private const val MEASURE_RETRY_MS = 50L
+
+/**
+ * How many measurement attempts before giving up, so a parent that never becomes measurable costs a
+ * bounded number of wakeups rather than one per [MEASURE_RETRY_MS] for the session.
+ */
+private const val MEASURE_ATTEMPTS = 100
 
 /**
  * Heavyweight host for a corner overlay that outlives a keypress - toast notifications.
@@ -75,11 +87,11 @@ fun HeavyweightCorner(
     val density = LocalDensity.current.density
     var measured by remember { mutableStateOf<DpSize?>(null) }
     val size = measured ?: initialSize
-    var bounds by remember(parent) { mutableStateOf(contentPaneBounds(parent)) }
+    val bounds = trackedContentPaneBounds(parent)
     // The rectangle the corner is actually resolved inside: the content pane, less whatever the
     // caller says is not theirs. Remembered rather than computed inline so it is a STABLE instance -
-    // `bounds` only changes identity on a real change (see the frame-clock effect below), and a
-    // fresh array every recomposition would re-run the placement effect, and with it a native
+    // `bounds` only changes identity on a real change (see [trackedContentPaneBounds]), and a fresh
+    // array every recomposition would re-run the placement effect, and with it a native
     // setLocation, for nothing.
     val region = remember(bounds, inset) { insetBounds(bounds, inset) }
     // Clamp the ceiling to the region. The ceiling is a hard clip, not a soft start, and toast text
@@ -95,19 +107,6 @@ fun HeavyweightCorner(
             size = size,
             position = cornerPosition(region, size, alignment).let { WindowPosition(it.first.dp, it.second.dp) },
         )
-
-    // Track the parent on the frame clock. `rememberOverlayParentBounds` is keyed on the window
-    // INSTANCE, which never changes, so it captures the bounds once - fine for the sub-second
-    // overlays that came before, wrong for one that is up while the user can drag or resize the
-    // window out from under it. Only assign on an actual change: each one is a native setLocation.
-    LaunchedEffect(parent) {
-        while (true) {
-            withFrameNanos { }
-            val next = contentPaneBounds(parent) ?: continue
-            val current = bounds
-            if (current == null || !next.contentEquals(current)) bounds = next
-        }
-    }
 
     // Assign window state from an effect, never during composition - writing it inline during
     // composition is what made the cursor overlay jitter.
@@ -149,6 +148,81 @@ fun HeavyweightCorner(
             content()
         }
     }
+}
+
+/**
+ * The parent content pane's screen bounds, kept current as the window moves and resizes.
+ *
+ * Split out of [HeavyweightCorner] so the tracking is one idea in one place, and because the two
+ * effects below are the whole of it.
+ */
+@Composable
+private fun trackedContentPaneBounds(parent: AwtWindow?): IntArray? {
+    var bounds by remember(parent) { mutableStateOf(contentPaneBounds(parent)) }
+
+    // Track the parent. `rememberOverlayParentBounds` is keyed on the window INSTANCE, which never
+    // changes, so it captures the bounds once - fine for the sub-second overlays that came before,
+    // wrong for one that is up while the user can drag or resize the window out from under it.
+    // Only assign on an actual change: each one is a native setLocation.
+    //
+    // Event-driven, NOT polled on the frame clock. This used to be `while (true) { withFrameNanos
+    // { } ... }`, and a registered frame awaiter keeps the Compose scene from ever going idle - a
+    // full repaint plus a native locationOnScreen every frame, for a rectangle that changes only
+    // when the user moves or resizes the window. That was affordable when the only caller was a
+    // toast up for a few seconds; the focus-mode quick actions are up for the whole focus-mode
+    // session, which on the configuration they target (auto-reveal off, so the top bar stays
+    // cleared) is the whole time the app is open.
+    //
+    // Two listeners, because they see different events. The WINDOW reports its own moves and
+    // resizes; the content pane reports resizes that are not the window's, such as a menu bar
+    // appearing. The pane never reports a MOVE when the window is dragged - its position inside
+    // the window has not changed - so the window listener is the one that cannot be dropped.
+    DisposableEffect(parent) {
+        val pane = (parent as? RootPaneContainer)?.contentPane
+
+        fun refresh() {
+            val next = contentPaneBounds(parent) ?: return
+            val current = bounds
+            if (current == null || !next.contentEquals(current)) bounds = next
+        }
+
+        val listener =
+            object : ComponentAdapter() {
+                override fun componentMoved(e: ComponentEvent?) = refresh()
+
+                override fun componentResized(e: ComponentEvent?) = refresh()
+
+                override fun componentShown(e: ComponentEvent?) = refresh()
+            }
+        parent?.addComponentListener(listener)
+        pane?.addComponentListener(listener)
+        onDispose {
+            parent?.removeComponentListener(listener)
+            pane?.removeComponentListener(listener)
+        }
+    }
+
+    // Listeners fire on a CHANGE, so a parent that is not yet showing when this mounts would never
+    // be measured at all: `contentPaneBounds` returns null until the pane is showing, and
+    // `cornerPosition` then falls back to the screen origin, detaching the overlay from the window
+    // entirely. The frame-clock loop covered that by accident, retrying every frame until the pane
+    // appeared - the one thing lost by going event-driven, so it is restored deliberately rather
+    // than left to chance.
+    //
+    // Bounded twice over: it stops at the first successful measurement, and gives up after
+    // [MEASURE_ATTEMPTS] regardless. Without the cap, a null parent - `LocalAwtWindow` unprovided,
+    // which is what a test host looks like - would leave a wakeup timer running for the whole
+    // session, which is the shape of the problem this whole change exists to remove.
+    LaunchedEffect(parent) {
+        var attempts = 0
+        while (bounds == null && attempts < MEASURE_ATTEMPTS) {
+            delay(MEASURE_RETRY_MS)
+            bounds = contentPaneBounds(parent)
+            attempts++
+        }
+    }
+
+    return bounds
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -57,11 +57,18 @@ import java.awt.Window as AwtWindow
  *    the overlay can never grow back.
  *  - Parent bounds come from the CONTENT PANE, not the window (see [contentPaneBounds]), and are
  *    re-read on the frame clock rather than remembered once.
+ *
+ * [inset] narrows that parent rectangle at its end and bottom edges (see [insetBounds]). It is how
+ * a caller anchored to a SUB-REGION of the window - the main content area, say, rather than the
+ * sidebars and status bar around it - lands where it draws on the lightweight path. It changes
+ * where the overlay is placed and never how big it is, so the region whose clicks it swallows is
+ * the same either way.
  */
 @Composable
 fun HeavyweightCorner(
     alignment: Alignment,
     initialSize: DpSize,
+    inset: DpSize = DpSize.Zero,
     content: @Composable () -> Unit,
 ) {
     val parent = LocalAwtWindow.current
@@ -69,18 +76,24 @@ fun HeavyweightCorner(
     var measured by remember { mutableStateOf<DpSize?>(null) }
     val size = measured ?: initialSize
     var bounds by remember(parent) { mutableStateOf(contentPaneBounds(parent)) }
-    // Clamp the ceiling to the parent. The ceiling is a hard clip, not a soft start, and toast text
+    // The rectangle the corner is actually resolved inside: the content pane, less whatever the
+    // caller says is not theirs. Remembered rather than computed inline so it is a STABLE instance -
+    // `bounds` only changes identity on a real change (see the frame-clock effect below), and a
+    // fresh array every recomposition would re-run the placement effect, and with it a native
+    // setLocation, for nothing.
+    val region = remember(bounds, inset) { insetBounds(bounds, inset) }
+    // Clamp the ceiling to the region. The ceiling is a hard clip, not a soft start, and toast text
     // is arbitrary plugin content: three wordy toasts can exceed a fixed height, and because the
     // window is CONTENT-sized the overflow is not cosmetic - the bottom toast's dismiss button ends
     // up outside the window, unclickable, on the INDEFINITE path where dismissing is the only way
-    // out. Clamping to the parent keeps the overlay inside the window without reintroducing any
-    // dependency on the overlay's OWN size, which is what the ratchet was.
-    val ceiling = clampCeiling(initialSize, bounds)
+    // out. Clamping to the region keeps the overlay inside it without reintroducing any dependency
+    // on the overlay's OWN size, which is what the ratchet was.
+    val ceiling = clampCeiling(initialSize, region)
 
     val state =
         rememberWindowState(
             size = size,
-            position = cornerPosition(bounds, size, alignment).let { WindowPosition(it.first.dp, it.second.dp) },
+            position = cornerPosition(region, size, alignment).let { WindowPosition(it.first.dp, it.second.dp) },
         )
 
     // Track the parent on the frame clock. `rememberOverlayParentBounds` is keyed on the window
@@ -98,9 +111,9 @@ fun HeavyweightCorner(
 
     // Assign window state from an effect, never during composition - writing it inline during
     // composition is what made the cursor overlay jitter.
-    LaunchedEffect(size, bounds, alignment) {
+    LaunchedEffect(size, region, alignment) {
         state.size = size
-        val at = cornerPosition(bounds, size, alignment)
+        val at = cornerPosition(region, size, alignment)
         state.position = WindowPosition(at.first.dp, at.second.dp)
     }
 
@@ -241,6 +254,39 @@ internal fun cornerPosition(
                 else -> slackY / 2
             }
     return x to y
+}
+
+/**
+ * [bounds], with [inset] taken off its END and BOTTOM edges - the sub-region a caller anchored to
+ * part of the window is actually placing itself in.
+ *
+ * Only the far edges, and that is the whole meaning rather than a simplification. The origin is
+ * where a `TopStart` overlay goes, and a caller inset from the right and the bottom has not moved
+ * its top-left corner anywhere - so a near-corner anchor must be unaffected while a far-corner one
+ * moves by exactly the inset. Expressing it as a smaller rectangle rather than as an offset added
+ * after the fact is what gets that for free, and keeps [cornerPosition]'s floor-at-the-origin
+ * behaviour applying to the region rather than to the window.
+ *
+ * Widths floor at zero: an inset wider than the window would otherwise produce a negative extent,
+ * and [cornerPosition] would read that as slack and place the overlay outside the parent.
+ *
+ * A zero inset returns [bounds] ITSELF, not a copy. Every caller that predates this passes zero,
+ * and the result is a `remember` key: an equal-but-new array would change identity on every
+ * recomposition and re-run the placement effect, which is a native `setLocation` each time.
+ */
+internal fun insetBounds(
+    bounds: IntArray?,
+    inset: DpSize,
+): IntArray? {
+    // An unmeasurable parent stays unmeasurable, and a zero inset returns the SAME instance - see
+    // the KDoc on identity above.
+    if (bounds == null || inset == DpSize.Zero) return bounds
+    return intArrayOf(
+        bounds[0],
+        bounds[1],
+        (bounds[2] - inset.width.value.toInt()).coerceAtLeast(0),
+        (bounds[3] - inset.height.value.toInt()).coerceAtLeast(0),
+    )
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -313,6 +313,11 @@ internal fun contentPaneBounds(parent: AwtWindow?): IntArray? {
  * flag exists to prevent, inverted.
  */
 private fun reportUnmeasurableParent(parent: AwtWindow?) {
+    // No parent at all is host wiring - LocalAwtWindow unprovided, which is what a test host or a
+    // headless entry point looks like - not an overlay that failed to measure a window it had. That
+    // condition exhausts all MEASURE_ATTEMPTS by construction, so reporting it would reliably spend
+    // the one-per-session flag that a real locationOnScreen failure later needs.
+    if (parent == null) return
     if (!unmeasurableParentReported.compareAndSet(false, true)) return
     val pane = (parent as? RootPaneContainer)?.contentPane
     logger.warn(
@@ -321,7 +326,7 @@ private fun reportUnmeasurableParent(parent: AwtWindow?) {
         mapOf(
             "reason" to
                 when {
-                    pane == null -> "no content pane"
+                    pane == null -> "window has no content pane"
                     !pane.isShowing -> "content pane never started showing"
                     else -> "locationOnScreen failed"
                 },

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -212,11 +212,20 @@ private fun trackedContentPaneBounds(parent: AwtWindow?): IntArray? {
     // [MEASURE_ATTEMPTS] regardless. Without the cap, a null parent - `LocalAwtWindow` unprovided,
     // which is what a test host looks like - would leave a wakeup timer running for the whole
     // session, which is the shape of the problem this whole change exists to remove.
+    // Through the same guard the listeners use, not a bare assignment. The two writers interleave:
+    // this one sleeps for MEASURE_RETRY_MS, and a componentShown/componentResized landing inside
+    // that window stores a good rectangle which a bare `bounds = contentPaneBounds(parent)` would
+    // then overwrite - with null, if the pane happens not to be showing at that instant, which puts
+    // the overlay at the primary display's origin. Even when it succeeds it would store an
+    // equal-but-fresh IntArray, and since IntArray equality is by reference that reads as a change:
+    // new region identity, placement effect restart, native setLocation.
     LaunchedEffect(parent) {
         var attempts = 0
         while (shouldKeepMeasuring(bounds, attempts)) {
             delay(MEASURE_RETRY_MS)
-            bounds = contentPaneBounds(parent)
+            contentPaneBounds(parent)?.let { next ->
+                if (boundsChanged(bounds, next)) bounds = next
+            }
             attempts++
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.delay
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import javax.swing.RootPaneContainer
+import kotlin.math.roundToInt
 import java.awt.Window as AwtWindow
 
 /** How long to wait between attempts to measure a parent that is not showing yet. */
@@ -70,6 +71,16 @@ internal const val MEASURE_ATTEMPTS = 100
  *  - Parent bounds come from the CONTENT PANE, not the window (see [contentPaneBounds]), and are
  *    re-read as the window moves rather than remembered once (see [trackedContentPaneBounds]).
  *
+ * **No window is composed until the parent has been measured.** `cornerPosition(null, ...)` returns
+ * the screen origin, so composing through that gap put an undecorated always-on-top overlay at the
+ * top-left of the PRIMARY monitor - over whatever was there - until the first retry tick. That gap
+ * is not hypothetical: the focus-mode quick actions mount on the very first composition of a window,
+ * routinely before the AWT content pane is showing. The frame clock used to paper over it by
+ * correcting within a frame; the retry takes [MEASURE_RETRY_MS], so it had to stop being papered
+ * over. If the retry gives up entirely, staying hidden is the deliberate choice: a permanently
+ * misplaced always-on-top window is worse than none, and every caller only composes this while its
+ * own window is focused, so a measurable pane is the normal case rather than the lucky one.
+ *
  * [inset] narrows that parent rectangle at its end and bottom edges (see [insetBounds]). It is how
  * a caller anchored to a SUB-REGION of the window - the main content area, say, rather than the
  * sidebars and status bar around it - lands where it draws on the lightweight path. It changes
@@ -87,7 +98,7 @@ fun HeavyweightCorner(
     val density = LocalDensity.current.density
     var measured by remember { mutableStateOf<DpSize?>(null) }
     val size = measured ?: initialSize
-    val bounds = trackedContentPaneBounds(parent)
+    val bounds = trackedContentPaneBounds(parent) ?: return
     // The rectangle the corner is actually resolved inside: the content pane, less whatever the
     // caller says is not theirs. Remembered rather than computed inline so it is a STABLE instance -
     // `bounds` only changes identity on a real change (see [trackedContentPaneBounds]), and a fresh
@@ -416,8 +427,10 @@ internal fun insetBounds(
     return intArrayOf(
         bounds[0],
         bounds[1],
-        (bounds[2] - inset.width.value.toInt()).coerceAtLeast(0),
-        (bounds[3] - inset.height.value.toInt()).coerceAtLeast(0),
+        // Rounded, not truncated: the inset is derived as px / density, which is not integral at
+        // fractional scale factors, and truncating loses up to a unit per axis.
+        (bounds[2] - inset.width.value.roundToInt()).coerceAtLeast(0),
+        (bounds[3] - inset.height.value.roundToInt()).coerceAtLeast(0),
     )
 }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -228,6 +228,8 @@ private fun trackedContentPaneBounds(parent: AwtWindow?): IntArray? {
             }
             attempts++
         }
+        // Only now is an unmeasurable parent a real finding rather than a slow one.
+        if (bounds == null) reportUnmeasurableParent(parent)
     }
 
     return bounds
@@ -276,31 +278,48 @@ internal fun Modifier.measuredAgainst(ceiling: DpSize): Modifier =
  */
 internal fun contentPaneBounds(parent: AwtWindow?): IntArray? {
     val pane = (parent as? RootPaneContainer)?.contentPane?.takeIf { it.isShowing }
-    val bounds =
-        pane?.let {
-            runCatching { it.locationOnScreen }.getOrNull()?.let { at ->
-                intArrayOf(at.x, at.y, it.width, it.height)
-            }
+    return pane?.let {
+        runCatching { it.locationOnScreen }.getOrNull()?.let { at ->
+            intArrayOf(at.x, at.y, it.width, it.height)
         }
-    // Loud, once. A null here does not degrade gracefully: cornerPosition falls back to 0,0, which
-    // is the top-left of the PRIMARY display, so the overlay detaches from the window entirely.
-    // OverlayWindowBounds makes the same condition loud for the same reason - it was silent once,
-    // and an intermittent report of exactly this had nothing to correlate against.
-    if (bounds == null && unmeasurableParentReported.compareAndSet(false, true)) {
-        logger.warn(
-            LogCategory.UI,
-            "Corner overlay could not measure its parent content pane - placing at the screen origin",
-            mapOf("reason" to if (pane == null) "no showing content pane" else "locationOnScreen failed"),
-        )
     }
-    return bounds
 }
 
 /**
- * One warning per session for [contentPaneBounds]. It is consulted on every window move and resize,
- * and up to [MEASURE_ATTEMPTS] times while waiting for a parent to start showing, so an unguarded
- * log line here would repeat.
+ * Report, once per session, that the parent could never be measured.
+ *
+ * Loud, because this does not degrade gracefully: [cornerPosition] falls back to 0,0, which is the
+ * top-left of the PRIMARY display, so the overlay detaches from the window entirely.
+ * `OverlayWindowBounds` makes the same condition loud for the same reason - it was silent once, and
+ * an intermittent report of exactly this had nothing to correlate against.
+ *
+ * Called only when the retry gives up, never from [contentPaneBounds] itself, and that distinction
+ * is now load-bearing. A single unmeasurable read is no longer evidence of anything: the quick
+ * actions mount on the FIRST composition of a window in focus mode, routinely before the content
+ * pane is showing, and the retry repairs it 50ms later. Warning on the read would spend the
+ * one-per-session flag on that transient for precisely the users this overlay was built for, and a
+ * genuine failure later in the same session would then be silent - which is the failure mode the
+ * flag exists to prevent, inverted.
  */
+private fun reportUnmeasurableParent(parent: AwtWindow?) {
+    if (!unmeasurableParentReported.compareAndSet(false, true)) return
+    val pane = (parent as? RootPaneContainer)?.contentPane
+    logger.warn(
+        LogCategory.UI,
+        "Corner overlay could not measure its parent content pane - placing at the screen origin",
+        mapOf(
+            "reason" to
+                when {
+                    pane == null -> "no content pane"
+                    !pane.isShowing -> "content pane never started showing"
+                    else -> "locationOnScreen failed"
+                },
+            "attempts" to MEASURE_ATTEMPTS.toString(),
+        ),
+    )
+}
+
+/** One warning per session for [reportUnmeasurableParent]; every overlay would otherwise report. */
 private val unmeasurableParentReported =
     java.util.concurrent.atomic
         .AtomicBoolean(false)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -498,10 +498,11 @@ fun main(args: Array<String>) {
     ai.rever.boss.components.overlays.OverlayConfig.heavyweightCorner = {
         alignment,
         initialSize,
+        inset,
         cornerContent,
         ->
         ai.rever.boss.components.overlays
-            .HeavyweightCorner(alignment, initialSize, cornerContent)
+            .HeavyweightCorner(alignment, initialSize, inset, cornerContent)
     }
     // plugin-ui-core owns the modal registry (plugins draw dialogs too) and depends on nothing but
     // Compose, so it cannot log. Give it this logger instead: the condition it reports is a dialog

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ContentInsetLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ContentInsetLayoutTest.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -67,7 +67,7 @@ class ContentInsetLayoutTest {
         onInset: (DpSize) -> Unit,
     ) {
         val density = LocalDensity.current.density
-        Column(modifier = Modifier.size(WINDOW_WIDTH, WINDOW_HEIGHT)) {
+        Column(modifier = Modifier.fillMaxSize()) {
             if (topBar) Bar(modifier = Modifier.fillMaxWidth().height(TOP_BAR))
             Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
                 if (leftSidebar) Bar(modifier = Modifier.fillMaxHeight().width(LEFT_SIDEBAR))
@@ -120,8 +120,11 @@ class ContentInsetLayoutTest {
 
     private companion object {
         const val TEST_DENSITY = 2f
-        val WINDOW_WIDTH = 1200.dp
-        val WINDOW_HEIGHT = 800.dp
+
+        // No fixed window size: at TEST_DENSITY a 1200x800dp Column is 2400x1600px, larger than
+        // the test surface, so `size` was clamped and the constants did nothing - a knob a later
+        // reader would turn and see no effect. The assertions never depended on them anyway, only
+        // on the bars' thicknesses, so the tree fills whatever surface it is given.
         val TOP_BAR = 40.dp
         val LEFT_SIDEBAR = 48.dp
         val RIGHT_SIDEBAR = 56.dp

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ContentInsetLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ContentInsetLayoutTest.kt
@@ -1,0 +1,122 @@
+package ai.rever.boss.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins [reportContentInset] against the shape `BossAppScaffold` actually builds.
+ *
+ * This is the arithmetic that decides where the quick actions land on the heavyweight path, and it
+ * is the classic silently-wrong kind: measuring against the parent instead of the root, or
+ * forgetting the density divide, both compile and both pass every other gate while putting the
+ * overlay somewhere visibly wrong on screen. Nothing short of measuring a real layout tree can tell
+ * the difference, so the tree here mirrors the scaffold - a `Column` of a content `Row` (left
+ * sidebar, main area, right sidebar) over a bottom bar - rather than asserting on the formula.
+ */
+class ContentInsetLayoutTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    /**
+     * Build a scaffold-shaped tree with the given chrome present or absent, and return what the
+     * main content area reports as its inset.
+     */
+    private fun insetFor(
+        rightSidebar: Boolean,
+        bottomBar: Boolean,
+    ): DpSize {
+        var reported = DpSize(-1.dp, -1.dp)
+        rule.setContent {
+            // A density of exactly 1 is what makes the px-to-Dp conversion untestable: every wrong
+            // answer equals the right one. Verified by mutation - dropping the divide passes at 1x
+            // and fails here. The scale is arbitrary, only its being non-unit matters.
+            CompositionLocalProvider(LocalDensity provides Density(TEST_DENSITY)) {
+                ScaffoldShape(rightSidebar, bottomBar) { reported = it }
+            }
+        }
+        rule.waitForIdle()
+        return reported
+    }
+
+    /** The scaffold's chrome layout: a top bar, a content row between two sidebars, a bottom bar. */
+    @Composable
+    private fun ScaffoldShape(
+        rightSidebar: Boolean,
+        bottomBar: Boolean,
+        onInset: (DpSize) -> Unit,
+    ) {
+        val density = LocalDensity.current.density
+        Column(modifier = Modifier.size(WINDOW_WIDTH, WINDOW_HEIGHT)) {
+            Bar(modifier = Modifier.fillMaxWidth().height(TOP_BAR))
+            Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                Bar(modifier = Modifier.fillMaxHeight().width(LEFT_SIDEBAR))
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxHeight()
+                            .weight(1f)
+                            .reportContentInset(density, onInset),
+                )
+                if (rightSidebar) Bar(modifier = Modifier.fillMaxHeight().width(RIGHT_SIDEBAR))
+            }
+            if (bottomBar) Bar(modifier = Modifier.fillMaxWidth().height(BOTTOM_BAR))
+        }
+    }
+
+    @Composable
+    private fun Bar(modifier: Modifier) = Box(modifier = modifier)
+
+    @Test
+    fun `the inset is the right sidebar's width and the bottom bar's height`() {
+        // The Windows focus-mode default: the top bar is cleared while both sidebars and - here,
+        // to prove both axes at once - a bottom bar stay up. Anchoring to the window instead of to
+        // the content area is what would put the cluster on top of them.
+        assertEquals(DpSize(RIGHT_SIDEBAR, BOTTOM_BAR), insetFor(rightSidebar = true, bottomBar = true))
+    }
+
+    @Test
+    fun `full focus mode leaves no inset at all`() {
+        // Every edge cleared, so the content area IS the window and the cluster belongs in its
+        // corner. A non-zero answer here would hold it off the corner by a phantom margin.
+        assertEquals(DpSize.Zero, insetFor(rightSidebar = false, bottomBar = false))
+    }
+
+    @Test
+    fun `the left sidebar and top bar do not count`() {
+        // Only the END and BOTTOM edges displace a bottom-right anchor. Chrome on the near edges
+        // moves the content area's origin, not its far corner, and counting it would drag the
+        // cluster inward by the width of a sidebar that is nowhere near it.
+        val withNearChrome = insetFor(rightSidebar = true, bottomBar = true)
+
+        assertEquals(RIGHT_SIDEBAR, withNearChrome.width)
+        assertEquals(BOTTOM_BAR, withNearChrome.height)
+    }
+
+    private companion object {
+        const val TEST_DENSITY = 2f
+        val WINDOW_WIDTH = 1200.dp
+        val WINDOW_HEIGHT = 800.dp
+        val TOP_BAR = 40.dp
+        val LEFT_SIDEBAR = 48.dp
+        val RIGHT_SIDEBAR = 56.dp
+        val BOTTOM_BAR = 24.dp
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ContentInsetLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ContentInsetLayoutTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -42,6 +41,8 @@ class ContentInsetLayoutTest {
     private fun insetFor(
         rightSidebar: Boolean,
         bottomBar: Boolean,
+        topBar: Boolean = true,
+        leftSidebar: Boolean = true,
     ): DpSize {
         var reported = DpSize(-1.dp, -1.dp)
         rule.setContent {
@@ -49,7 +50,7 @@ class ContentInsetLayoutTest {
             // answer equals the right one. Verified by mutation - dropping the divide passes at 1x
             // and fails here. The scale is arbitrary, only its being non-unit matters.
             CompositionLocalProvider(LocalDensity provides Density(TEST_DENSITY)) {
-                ScaffoldShape(rightSidebar, bottomBar) { reported = it }
+                ScaffoldShape(rightSidebar, bottomBar, topBar, leftSidebar) { reported = it }
             }
         }
         rule.waitForIdle()
@@ -61,13 +62,15 @@ class ContentInsetLayoutTest {
     private fun ScaffoldShape(
         rightSidebar: Boolean,
         bottomBar: Boolean,
+        topBar: Boolean,
+        leftSidebar: Boolean,
         onInset: (DpSize) -> Unit,
     ) {
         val density = LocalDensity.current.density
         Column(modifier = Modifier.size(WINDOW_WIDTH, WINDOW_HEIGHT)) {
-            Bar(modifier = Modifier.fillMaxWidth().height(TOP_BAR))
+            if (topBar) Bar(modifier = Modifier.fillMaxWidth().height(TOP_BAR))
             Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
-                Bar(modifier = Modifier.fillMaxHeight().width(LEFT_SIDEBAR))
+                if (leftSidebar) Bar(modifier = Modifier.fillMaxHeight().width(LEFT_SIDEBAR))
                 Box(
                     modifier =
                         Modifier
@@ -101,13 +104,18 @@ class ContentInsetLayoutTest {
 
     @Test
     fun `the left sidebar and top bar do not count`() {
-        // Only the END and BOTTOM edges displace a bottom-right anchor. Chrome on the near edges
-        // moves the content area's origin, not its far corner, and counting it would drag the
-        // cluster inward by the width of a sidebar that is nowhere near it.
-        val withNearChrome = insetFor(rightSidebar = true, bottomBar = true)
+        // Only the END and BOTTOM edges displace a bottom-right anchor. Chrome on the NEAR edges
+        // moves the content area's origin, not its far corner, so adding or removing it must not
+        // change the answer at all - counting it would drag the cluster inward by the width of a
+        // sidebar nowhere near it.
+        //
+        // Asserted as invariance across the near-chrome variants, not as the same two numbers test
+        // 1 already asserts. Re-asserting those would make this test unable to fail on its own:
+        // same inputs, same expectations, no independent claim.
+        val withNearChrome = insetFor(rightSidebar = true, bottomBar = true, topBar = true, leftSidebar = true)
+        val withoutNearChrome = insetFor(rightSidebar = true, bottomBar = true, topBar = false, leftSidebar = false)
 
-        assertEquals(RIGHT_SIDEBAR, withNearChrome.width)
-        assertEquals(BOTTOM_BAR, withNearChrome.height)
+        assertEquals(withNearChrome, withoutNearChrome)
     }
 
     private companion object {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -1,0 +1,132 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.overlays.OverlayConfig
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.unit.DpSize
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the two guards on [FocusModeQuickActions], and the identity its sign-out hint carries.
+ *
+ * Both guards are one line and nothing else in the build would notice either going missing - but on
+ * the heavyweight path this composable opens a non-focusable always-on-top AWT window, and the JVM
+ * has no portable click-through. One composed while the top bar is showing is a dead click region
+ * over live content; one left up while BOSS is in the background is a dead click region over
+ * whatever the user switched to. `ToastOverlayTest` pins the same two lines in the toast overlay for
+ * the same reasons.
+ */
+class FocusModeQuickActionsTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val previousRenderer = OverlayConfig.heavyweightCorner
+    private val previousUseHeavyweight = OverlayConfig.useHeavyweightPopups
+
+    @After
+    fun restore() {
+        // OverlayConfig is a process-global registry; leaving a fake in it would leak into any
+        // other test that routes an overlay.
+        OverlayConfig.heavyweightCorner = previousRenderer
+        OverlayConfig.useHeavyweightPopups = previousUseHeavyweight
+    }
+
+    private class FakeWindowInfo(
+        override val isWindowFocused: Boolean,
+    ) : WindowInfo
+
+    /**
+     * Mount the cluster and report whether the heavyweight renderer was asked for a window.
+     *
+     * Presence, not a count: a tally would count COMPOSITIONS, so any extra recomposition would
+     * break an equality assertion without anything being wrong.
+     */
+    private fun windowRequestedFor(
+        visible: Boolean,
+        focused: Boolean = true,
+        heavyweight: Boolean = true,
+    ): Boolean {
+        var requested = false
+        OverlayConfig.useHeavyweightPopups = heavyweight
+        OverlayConfig.heavyweightCorner = { _, _, _, _ ->
+            // Recorded, not composed: composing a real Window needs a display.
+            requested = true
+        }
+        rule.setContent {
+            CompositionLocalProvider(
+                LocalHeavyweightOverlays provides heavyweight,
+                LocalWindowInfo provides FakeWindowInfo(focused),
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    FocusModeQuickActions(
+                        visible = visible,
+                        inset = DpSize.Zero,
+                        onShowSettings = {},
+                        onShowSearch = {},
+                        onSignOut = {},
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+        return requested
+    }
+
+    @Test
+    fun `nothing is composed while the top bar is showing`() {
+        assertFalse(windowRequestedFor(visible = false))
+        rule.onAllNodesWithTag(FOCUS_QUICK_ACTIONS_TAG).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the cluster appears once the top bar is hidden`() {
+        assertTrue(windowRequestedFor(visible = true))
+    }
+
+    @Test
+    fun `no overlay window is opened while the parent window is unfocused`() {
+        assertFalse(
+            windowRequestedFor(visible = true, focused = false),
+            "the overlay is always-on-top over every other application, so one held open while " +
+                "BOSS is in the background is a dead click region in whatever the user switched to",
+        )
+    }
+
+    @Test
+    fun `an unfocused window still draws the cluster in place`() {
+        // Falling back rather than vanishing: the cluster is part of the chrome while the top bar
+        // is cleared, and disappearing whenever the window loses focus would read as a bug.
+        windowRequestedFor(visible = true, focused = false)
+
+        rule.onAllNodesWithTag(FOCUS_QUICK_ACTIONS_TAG).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the sign-out hint names the signed-in account`() {
+        // The cluster is icon-only, so the hint is the only place the address the top bar prints
+        // next to this button still appears - and which account is about to be signed out is worth
+        // confirming before the click, not after.
+        assertEquals("Sign out - operator@example.com", signOutHint("operator@example.com"))
+    }
+
+    @Test
+    fun `the sign-out hint falls back when there is no account`() {
+        assertEquals("Sign out of your account", signOutHint(null))
+        // Blank is not an identity. An empty string reaching the hint would render "Sign out - "
+        // and read as a truncation bug rather than as a signed-out state.
+        assertEquals("Sign out of your account", signOutHint("   "))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -12,7 +12,9 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -172,6 +174,42 @@ class FocusModeQuickActionsTest {
         windowRequestedFor(visible = true, focused = false)
 
         rule.onAllNodesWithTag(FOCUS_QUICK_ACTIONS_TAG).assertCountEquals(1)
+    }
+
+    @Test
+    fun `each button reaches its own callback`() {
+        // Reachability of these three is the entire point of the feature, and nothing pinned it:
+        // swapping Search and Settings inside QuickActions, or wiring Sign Out to onShowSettings,
+        // left every other test in this suite green. Mirrors BossTopRightBarTest, which exists for
+        // the same reason on the other copy of these buttons.
+        //
+        // On the lightweight path, so the real content is composed rather than handed to a fake
+        // renderer. The buttons are icon-only, so `text` is the content description.
+        val fired = mutableListOf<String>()
+        OverlayConfig.useHeavyweightPopups = false
+        rule.setContent {
+            CompositionLocalProvider(
+                LocalHeavyweightOverlays provides false,
+                LocalWindowInfo provides FakeWindowInfo(isWindowFocused = true),
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    FocusModeQuickActions(
+                        visible = true,
+                        inset = { DpSize.Zero },
+                        onShowSettings = { fired += "settings" },
+                        onShowSearch = { fired += "search" },
+                        onSignOut = { fired += "signOut" },
+                    )
+                }
+            }
+        }
+
+        rule.onNodeWithContentDescription("Settings").performClick()
+        rule.onNodeWithContentDescription("Search").performClick()
+        rule.onNodeWithContentDescription("Sign Out").performClick()
+        rule.waitForIdle()
+
+        assertEquals(listOf("settings", "search", "signOut"), fired)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -103,17 +103,23 @@ class FocusModeQuickActionsTest {
     }
 
     @Test
-    fun `the measured inset reaches the renderer`() {
+    fun `the measured inset reaches the renderer, with the margin folded in`() {
         // The whole design rests on this one argument, and two plausible regressions would leave
         // every other test in the suite green: OverlayCorner forwarding DpSize.Zero (easy, since
         // the parameter has a default) or this composable passing zero instead of its own inset.
         // Either puts the cluster back over the right sidebar and the status bar, which is exactly
         // what the parameter exists to prevent.
+        //
+        // The margin is part of the assertion, not an offset to look past. It rides in the inset
+        // rather than as padding on the surface precisely because padding inside the overlay window
+        // would be transparent and still swallow clicks, right on the corner where a resize handle
+        // and a scrollbar corner live. Moving it back into the content would restore that dead band
+        // and change nothing else observable.
         val measured = DpSize(56.dp, 24.dp)
 
         windowRequestedFor(visible = true, inset = measured)
 
-        assertEquals(measured, receivedInset)
+        assertEquals(DpSize(56.dp + QUICK_ACTIONS_MARGIN, 24.dp + QUICK_ACTIONS_MARGIN), receivedInset)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -8,9 +8,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import org.junit.After
@@ -129,6 +132,37 @@ class FocusModeQuickActionsTest {
             "the overlay is always-on-top over every other application, so one held open while " +
                 "BOSS is in the background is a dead click region in whatever the user switched to",
         )
+    }
+
+    @Test
+    fun `the lightweight path draws in place and keeps its corner margin`() {
+        // The path a BOSS_RENDERING_MODE=OFF_SCREEN user gets, and the one no test covered:
+        // `heavyweight` defaulted to true everywhere, so "focused, lightweight" was never composed.
+        // That gap hid a real bug - OverlayCorner's lightweight branch ignores `inset`, so folding
+        // the margin into the inset unconditionally dropped it here and put the cluster flush in
+        // the corner, 8dp from where the unfocused branch puts it.
+        assertFalse(
+            windowRequestedFor(visible = true, heavyweight = false),
+            "no overlay window should be asked for when the corner is routed lightweight",
+        )
+        rule.onAllNodesWithTag(FOCUS_QUICK_ACTIONS_TAG).assertCountEquals(1)
+        assertEquals(
+            QUICK_ACTIONS_MARGIN,
+            marginOf(rule.onNodeWithTag(FOCUS_QUICK_ACTIONS_TAG)),
+            "the margin has to survive the path that ignores the inset",
+        )
+    }
+
+    /**
+     * The gap between the tagged surface and the bottom-right of its parent, which is what the
+     * margin actually buys. Read from the layout rather than from the modifier, because the bug
+     * this catches was a modifier that was present and doing nothing.
+     */
+    private fun marginOf(node: SemanticsNodeInteraction): Dp {
+        val bounds = node.fetchSemanticsNode().boundsInRoot
+        val root = node.fetchSemanticsNode().root!!.let { it.semanticsOwner.rootSemanticsNode.boundsInRoot }
+        val density = rule.density
+        return with(density) { (root.bottom - bounds.bottom).toDp() }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -155,6 +155,30 @@ class FocusModeQuickActionsTest {
         )
     }
 
+    @Test
+    fun `the content fits inside the overlay's clip ceiling`() {
+        // QUICK_ACTIONS_OVERLAY_SIZE is a hard clip on the heavyweight path, not a first guess, and
+        // exceeding it loses part of a button with nothing logged and every other test still green.
+        // Bumping space.xs, growing the icon button or adding a fourth action would all do it.
+        //
+        // Measured on the lightweight path because that is where the real content lays out; its
+        // margin is padding on the same node, so it comes back off before the comparison.
+        windowRequestedFor(visible = true, heavyweight = false)
+        val outer = sizeOf(rule.onNodeWithTag(FOCUS_QUICK_ACTIONS_TAG))
+        val content = DpSize(outer.width - QUICK_ACTIONS_MARGIN * 2, outer.height - QUICK_ACTIONS_MARGIN * 2)
+
+        assertTrue(
+            content.width <= QUICK_ACTIONS_OVERLAY_SIZE.width && content.height <= QUICK_ACTIONS_OVERLAY_SIZE.height,
+            "content is $content but the ceiling that clips it is $QUICK_ACTIONS_OVERLAY_SIZE",
+        )
+    }
+
+    /** The tagged surface's own size, margin included. */
+    private fun sizeOf(node: SemanticsNodeInteraction): DpSize {
+        val bounds = node.fetchSemanticsNode().boundsInRoot
+        return with(rule.density) { DpSize(bounds.width.toDp(), bounds.height.toDp()) }
+    }
+
     /**
      * The gap between the tagged surface and the bottom-right of its parent, which is what the
      * margin actually buys. Read from the layout rather than from the modifier, because the bug

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
@@ -36,6 +37,9 @@ class FocusModeQuickActionsTest {
     private val previousRenderer = OverlayConfig.heavyweightCorner
     private val previousUseHeavyweight = OverlayConfig.useHeavyweightPopups
 
+    /** What the fake renderer was handed, so the wiring can be asserted and not just assumed. */
+    private var receivedInset: DpSize? = null
+
     @After
     fun restore() {
         // OverlayConfig is a process-global registry; leaving a fake in it would leak into any
@@ -58,12 +62,14 @@ class FocusModeQuickActionsTest {
         visible: Boolean,
         focused: Boolean = true,
         heavyweight: Boolean = true,
+        inset: DpSize = DpSize.Zero,
     ): Boolean {
         var requested = false
         OverlayConfig.useHeavyweightPopups = heavyweight
-        OverlayConfig.heavyweightCorner = { _, _, _, _ ->
+        OverlayConfig.heavyweightCorner = { _, _, cornerInset, _ ->
             // Recorded, not composed: composing a real Window needs a display.
             requested = true
+            receivedInset = cornerInset
         }
         rule.setContent {
             CompositionLocalProvider(
@@ -73,7 +79,7 @@ class FocusModeQuickActionsTest {
                 Box(modifier = Modifier.fillMaxSize()) {
                     FocusModeQuickActions(
                         visible = visible,
-                        inset = DpSize.Zero,
+                        inset = { inset },
                         onShowSettings = {},
                         onShowSearch = {},
                         onSignOut = {},
@@ -94,6 +100,20 @@ class FocusModeQuickActionsTest {
     @Test
     fun `the cluster appears once the top bar is hidden`() {
         assertTrue(windowRequestedFor(visible = true))
+    }
+
+    @Test
+    fun `the measured inset reaches the renderer`() {
+        // The whole design rests on this one argument, and two plausible regressions would leave
+        // every other test in the suite green: OverlayCorner forwarding DpSize.Zero (easy, since
+        // the parameter has a default) or this composable passing zero instead of its own inset.
+        // Either puts the cluster back over the right sidebar and the status bar, which is exactly
+        // what the parameter exists to prevent.
+        val measured = DpSize(56.dp, 24.dp)
+
+        windowRequestedFor(visible = true, inset = measured)
+
+        assertEquals(measured, receivedInset)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeVisibilityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeVisibilityTest.kt
@@ -1,0 +1,51 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.focusmode.FocusModeSettings
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins [focusQuickActionsVisible], which was the highest-consequence line in this feature with no
+ * test behind it.
+ *
+ * The `hides(TOP)` half looks redundant next to `!showTopBar` and is not. `showTopBar` is written
+ * from a `LaunchedEffect`, so it reads false on the first composition of every window regardless of
+ * whether focus mode is enabled - and dropping the conjunct is a native always-on-top window
+ * created and disposed on every window open, a corner flash for users who never enable focus mode,
+ * and a content-pane read before the pane is showing. None of that is visible to any other test.
+ */
+class FocusModeVisibilityTest {
+    private val focusOnHidingTop = FocusModeSettings(enabled = true, hideTopBar = true)
+
+    @Test
+    fun `hidden once focus mode has cleared the top bar`() {
+        assertTrue(focusQuickActionsVisible(focusOnHidingTop, showTopBar = false))
+    }
+
+    @Test
+    fun `stands down while the top bar is revealed`() {
+        assertFalse(focusQuickActionsVisible(focusOnHidingTop, showTopBar = true))
+    }
+
+    @Test
+    fun `never composed when focus mode is off, whatever the reveal state says`() {
+        // The launch path: showTopBar is false on the first composition of every window because the
+        // effect that turns it back on has not run yet. This is the case the settings half exists
+        // for, and the only one where the two conjuncts disagree.
+        val off = focusOnHidingTop.copy(enabled = false)
+
+        assertFalse(focusQuickActionsVisible(off, showTopBar = false))
+        assertFalse(focusQuickActionsVisible(off, showTopBar = true))
+    }
+
+    @Test
+    fun `never composed when focus mode is on but keeps the top bar`() {
+        // Per-edge settings: focus mode enabled with hideTopBar off leaves the bar in place, so the
+        // three actions were never taken away and the cluster has nothing to restore.
+        val keepsTop = focusOnHidingTop.copy(hideTopBar = false)
+
+        assertFalse(focusQuickActionsVisible(keepsTop, showTopBar = false))
+        assertFalse(focusQuickActionsVisible(keepsTop, showTopBar = true))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
@@ -65,7 +65,7 @@ class ToastOverlayTest {
     ): Boolean {
         var requested = false
         OverlayConfig.useHeavyweightPopups = true
-        OverlayConfig.heavyweightCorner = { _, _, _ ->
+        OverlayConfig.heavyweightCorner = { _, _, _, _ ->
             // Recorded, not composed: composing a real Window needs a display.
             requested = true
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/BossTopRightBarTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/BossTopRightBarTest.kt
@@ -1,0 +1,83 @@
+package ai.rever.boss.components.bars.horizontal
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins that the top bar's three right-hand buttons still reach their callbacks.
+ *
+ * Sign Out is the one that needed a test. `BossTopRightBar` used to own the confirmation dialog
+ * outright - its own `showLogoutDialog` and its own `LogoutConfirmationDialog` - and that moved to
+ * `BossAppState` so the focus-mode quick actions could raise the same dialog without there being
+ * two of them. Ownership moves like that break quietly: the button still renders, still hovers,
+ * still has its hint, and does nothing at all. Nothing else in the build would notice.
+ *
+ * The buttons are icon-only (`BossActionButton` in `imageVector` mode draws no text), so `text` is
+ * the content description and that is what they are found by here.
+ */
+class BossTopRightBarTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private fun clickAndRecord(contentDescription: String): List<String> {
+        val fired = mutableListOf<String>()
+        rule.setContent {
+            Row {
+                BossTopRightBar(
+                    onShowSettings = { fired += "settings" },
+                    onShowSearch = { fired += "search" },
+                    onSignOut = { fired += "signOut" },
+                )
+            }
+        }
+        rule.onNodeWithContentDescription(contentDescription).performClick()
+        rule.waitForIdle()
+        return fired
+    }
+
+    @Test
+    fun `sign out reaches its callback rather than a dialog this bar no longer owns`() {
+        assertEquals(listOf("signOut"), clickAndRecord("Sign Out"))
+    }
+
+    @Test
+    fun `search reaches its callback`() {
+        assertEquals(listOf("search"), clickAndRecord("Search"))
+    }
+
+    @Test
+    fun `settings reaches its callback`() {
+        assertEquals(listOf("settings"), clickAndRecord("Settings"))
+    }
+
+    @Test
+    fun `the bar raises no confirmation of its own`() {
+        // The whole point of moving ownership: the quick actions offer the same action, and two
+        // owners would stack two confirmations. This bar must now raise none.
+        //
+        // Anchored on the dialog's own title rather than on the button label. The buttons are
+        // icon-only, so "Sign Out" is a content description and never appears as TEXT here - an
+        // earlier version of this test asserted on the text and was really asserting that the
+        // button exists, which it does not.
+        val fired = clickAndRecord("Sign Out")
+
+        assertTrue(fired.isNotEmpty(), "the callback is the only path left, so it has to fire")
+        assertEquals(
+            0,
+            rule.onAllNodesWithText(LOGOUT_DIALOG_TITLE).fetchSemanticsNodes().size,
+            "this bar drew a confirmation again, so the cluster's would be a second one",
+        )
+    }
+
+    private companion object {
+        /** `LogoutConfirmationDialog`'s title - the cheapest proof that it is or is not up. */
+        const val LOGOUT_DIALOG_TITLE = "Confirm Logout"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 /**
  * Pins [cornerPosition], the only part of the toast overlay reachable without a display.
@@ -51,5 +53,50 @@ class HeavyweightCornerTest {
     @Test
     fun `unmeasured parent falls back to the origin`() {
         assertEquals(0 to 0, cornerPosition(null, size, Alignment.TopEnd))
+    }
+
+    // --- insetBounds: anchoring to a sub-region of the window ---
+
+    @Test
+    fun `a zero inset is the parent itself`() {
+        // Identity, not merely equal contents: every existing caller passes zero, and returning a
+        // fresh array would make the placement effect's key change on every recomposition - one
+        // native setLocation per frame, for nothing.
+        assertSame(parent, insetBounds(parent, DpSize.Zero))
+    }
+
+    @Test
+    fun `an inset shrinks the far edges and leaves the origin alone`() {
+        val region = insetBounds(parent, DpSize(48.dp, 24.dp))
+        assertEquals(listOf(100, 50, 952, 776), region?.toList())
+    }
+
+    @Test
+    fun `bottom end moves in by exactly the inset while top start does not move at all`() {
+        // The whole point of expressing this as a smaller rectangle: a caller inset from the right
+        // and the bottom has not moved its top-left corner, so a near-corner anchor must not move.
+        val region = insetBounds(parent, DpSize(48.dp, 24.dp))
+
+        assertEquals(620 to 626, cornerPosition(region, size, Alignment.BottomEnd))
+        assertEquals(
+            cornerPosition(parent, size, Alignment.TopStart),
+            cornerPosition(region, size, Alignment.TopStart),
+        )
+    }
+
+    @Test
+    fun `an inset wider than the parent floors at zero rather than going negative`() {
+        // A negative extent reads as slack in cornerPosition, which would place the overlay outside
+        // the parent entirely - the failure mode the floor in cornerPosition exists to prevent,
+        // reintroduced one layer up.
+        val region = insetBounds(parent, DpSize(4000.dp, 4000.dp))
+
+        assertEquals(listOf(100, 50, 0, 0), region?.toList())
+        assertEquals(100 to 50, cornerPosition(region, size, Alignment.BottomEnd))
+    }
+
+    @Test
+    fun `an unmeasured parent stays unmeasured through an inset`() {
+        assertNull(insetBounds(null, DpSize(48.dp, 24.dp)))
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightCornerTest.kt
@@ -5,8 +5,10 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 /**
  * Pins [cornerPosition], the only part of the toast overlay reachable without a display.
@@ -98,5 +100,40 @@ class HeavyweightCornerTest {
     @Test
     fun `an unmeasured parent stays unmeasured through an inset`() {
         assertNull(insetBounds(null, DpSize(48.dp, 24.dp)))
+    }
+
+    // --- bounds tracking: the decisions the AWT listeners make ---
+
+    @Test
+    fun `an unchanged rectangle is not stored again`() {
+        // The listeners fire on every step of a window drag and each assignment is a native
+        // setLocation. Assigning unconditionally looks identical on screen, so this is the only
+        // thing standing between a drag and one window move per event.
+        assertFalse(boundsChanged(parent, parent.copyOf()))
+    }
+
+    @Test
+    fun `a moved or resized rectangle is stored`() {
+        assertTrue(boundsChanged(parent, intArrayOf(120, 50, 1000, 800)), "moved")
+        assertTrue(boundsChanged(parent, intArrayOf(100, 50, 900, 800)), "resized")
+    }
+
+    @Test
+    fun `the first measurement is always stored`() {
+        assertTrue(boundsChanged(null, parent))
+    }
+
+    @Test
+    fun `the measurement retry stops at the first success`() {
+        assertTrue(shouldKeepMeasuring(bounds = null, attempts = 0))
+        assertFalse(shouldKeepMeasuring(bounds = parent, attempts = 0))
+    }
+
+    @Test
+    fun `the measurement retry gives up rather than becoming a session-long timer`() {
+        // A parent that never becomes measurable - a null LocalAwtWindow, which is what a test host
+        // looks like - would otherwise leave this waking up forever, which is the cost the move off
+        // the frame clock exists to remove.
+        assertFalse(shouldKeepMeasuring(bounds = null, attempts = MEASURE_ATTEMPTS))
     }
 }


### PR DESCRIPTION
## What

Settings, Search and Sign Out as a small icon cluster in the bottom-right of the main content area, shown exactly while focus mode has the top bar cleared.

## Why

Those three live in `BossTopRightBar` and nowhere else, so clearing the top bar takes them with it. The documented way back is hovering the top edge, and that is driven by Compose `onPointerEvent` on an edge strip, so it **cannot fire over a browser tab**: in `HARDWARE_ACCELERATED` mode Chromium owns a foreign native window that composites over the Compose scene rather than inside it. That is exactly why `FocusModeSettings.defaultAutoReveal` is off on Windows out of the box.

So today, focus mode plus a browser tab leaves these three reachable only from the menu bar. That is the state this fixes.

## The non-obvious part

The cluster renders through `OverlayCorner`, not in place. A plain Compose overlay sits behind the browser surface for the same reason the hover strip is unreachable under it, so drawing in place would leave this working everywhere except where it is needed.

Two guards come with that, both taken from `ToastOverlay`, because a non-focusable always-on-top AWT window still receives mouse events and the JVM has no portable click-through:

- **Nothing is composed while the top bar is showing.** Otherwise it is a permanently dead click region over live content.
- **An unfocused window draws in place.** Otherwise the overlay holds a dead click region over whatever application the user switched to.

`OverlayCorner` gains an optional `inset: DpSize`. The lightweight path aligns inside the caller's `BoxScope`, but the heavyweight path places a window against the whole content pane, so `BottomEnd` alone lands on top of the status bar and the right sidebar, which the Windows focus-mode defaults leave visible. The inset shrinks the rectangle the corner is resolved inside: it moves the window without enlarging it, so the region whose clicks it swallows is unchanged. Every existing caller passes zero and is unaffected, including the identity of the `remember` key (a zero inset returns the same array instance, not a copy, so the placement effect does not re-run and issue a native `setLocation` on every recomposition).

## Known trade-off

The overlay eats clicks in its own footprint, roughly 120x44dp at the bottom-right of the content area. Same trade `ToastOverlay` already makes, and bounded the same way: it only exists while the top bar is hidden, and it goes away the moment the top bar reveals.

## Tests

49 tests green across the six affected classes; `ktlintCheck` and `detekt` green.

- `ContentInsetLayoutTest` (new) measures a **scaffold-shaped layout tree** rather than asserting on the formula, because both ways of getting this wrong compile and pass every other gate. **Mutation-checked**: `boundsInParent` in place of `boundsInRoot` fails it, and so does dropping the density divide. That second one initially passed, since the harness runs at density 1 where every wrong answer equals the right one, so the test now runs at 2x.
- `FocusModeQuickActionsTest` (new) pins both guards and the sign-out hint.
- `HeavyweightCornerTest` gains the inset arithmetic, including that a near-corner anchor does not move and that an oversized inset floors at the origin rather than placing the overlay outside the parent.

## Not covered by CI, please check by hand

1. Focus mode on, cluster lands bottom-right of the content and clear of the status bar.
2. Windows-style settings (both sidebars kept, top bar cleared): it sits left of the right sidebar, not over it.
3. **A browser tab in focus mode**: still visible and clickable over the page. This is the case the feature exists for.
4. Hover Sign Out shows the signed-in address; clicking raises the confirmation in the main window.
5. Hover the top edge, cluster gives way to the top bar; leave, wait out the 2s grace period, it returns.
6. Focus mode off changes nothing anywhere, and no corner flash on window open.
7. **Sign Out confirmation and the Settings window under HARDWARE_ACCELERATED**: the focus guard should drop the cluster in place, but "overlay sitting over a dialog's buttons, eating the click" is worth eyeballing rather than deducing. Check the confirmation is fully *clickable*, not just that it appears.
8. **Drag and resize the window with the cluster up** and confirm it tracks. That is the behaviour the move off the frame clock could break, and the listeners are display-bound so no test covers them.
9. **A very wide right sidebar**: `clampCeiling` clamps to the inset region and the ceiling is a hard clip, so dragging the sidebar out until the content area is under ~94dp starts cutting buttons off. Confirm it degrades rather than doing something odd.
10. **With `BOSS_RENDERING_MODE=OFF_SCREEN`**, focus mode with the bottom bar and right sidebar hidden and auto-reveal on: the hover strips are `zIndex(10f)` siblings of the whole content `Column`, so they can out-rank the in-place cluster and swallow its clicks. Known and not restructured - see the PR discussion - but worth confirming how it actually behaves. Not reachable on the default path, where the in-place render only happens while the window is unfocused.
11. **With all chrome cleared**, the window can still be resized from the bottom-right corner and the content's scrollbar corner is still usable - the margin now rides in the inset specifically so that corner is not dead.
