### PR TITLE
New-tab dialog: open no-input plugin tab types on click

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.platform.rememberFilePicker
 import ai.rever.boss.plugin.api.FileNodeData
 import ai.rever.boss.plugin.api.FileTreeUtils
 import ai.rever.boss.plugin.api.NewTabContext
+import ai.rever.boss.plugin.api.NewTabSpec
 import ai.rever.boss.plugin.api.NodeLoadingStateData
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.api.TabRegistry
@@ -152,6 +153,13 @@ private fun encodeUrlParameter(input: String): String =
         .replace("=", "%3D")
         .replace("/", "%2F")
 
+/**
+ * A spec that declares no input at all (blank label and placeholder, input
+ * optional): clicking the tab type opens it instantly, no input step.
+ */
+private fun NewTabSpec.needsNoInput(): Boolean =
+    inputOptional && inputLabel.isBlank() && inputPlaceholder.isBlank()
+
 // Platform-specific URL history provider
 expect object UrlHistoryProvider {
     fun getSuggestions(
@@ -215,15 +223,13 @@ fun NewTabDialog(
     val selectedPluginTypeInfo = selectedPluginType?.let { id -> pluginTypes.firstOrNull { it.typeId == id } }
     var pluginInput by remember(selectedPluginType) { mutableStateOf("") }
 
-    // Confirm a plugin tab type: the plugin builds the TabInfo (null = input
-    // rejected, dialog stays open). Crash-isolated — plugin code.
-    val confirmPluginTab: () -> Unit = confirm@{
-        val typeInfo = selectedPluginTypeInfo ?: return@confirm
-        val spec = typeInfo.newTabSpec ?: return@confirm
-        if (!spec.inputOptional && pluginInput.isBlank()) return@confirm
+    // Open a plugin tab type with the given input: the plugin builds the
+    // TabInfo (null = input rejected, dialog stays open). Crash-isolated —
+    // plugin code.
+    val openPluginTab: (TabTypeInfo, String) -> Unit = { typeInfo, input ->
         val tabInfo =
             try {
-                typeInfo.createTabInfo(pluginInput.trim(), NewTabContext(projectPath = projectPath, windowId = windowId))
+                typeInfo.createTabInfo(input.trim(), NewTabContext(projectPath = projectPath, windowId = windowId))
             } catch (e: Exception) {
                 newTabDialogLogger.warn(
                     LogCategory.UI,
@@ -239,6 +245,14 @@ fun NewTabDialog(
             onCreateTabInfo?.invoke(tabInfo)
             onDismiss()
         }
+    }
+
+    // Confirm the selected plugin tab type with the typed input.
+    val confirmPluginTab: () -> Unit = confirm@{
+        val typeInfo = selectedPluginTypeInfo ?: return@confirm
+        val spec = typeInfo.newTabSpec ?: return@confirm
+        if (!spec.inputOptional && pluginInput.isBlank()) return@confirm
+        openPluginTab(typeInfo, pluginInput)
     }
     var urlText by remember { mutableStateOf("") }
     var fileText by remember { mutableStateOf("") }
@@ -443,6 +457,12 @@ fun NewTabDialog(
                                 label = pluginType.displayName,
                                 isSelected = selectedPluginType == pluginType.typeId,
                                 onClick = {
+                                    // Types that declare no input (e.g. Arcade)
+                                    // open on the click itself — no input step.
+                                    if (pluginType.newTabSpec?.needsNoInput() == true) {
+                                        openPluginTab(pluginType, "")
+                                        return@TabTypeOption
+                                    }
                                     when (selectedType) {
                                         TabType.URL -> {
                                             urlText = inputText

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -156,6 +156,19 @@ private fun encodeUrlParameter(input: String): String =
 /**
  * A spec that declares no input at all (blank label and placeholder, input
  * optional): clicking the tab type opens it instantly, no input step.
+ *
+ * **Not reachable by omission**, which is what makes a heuristic acceptable here
+ * instead of an explicit flag. Checked against the pinned boss-plugin-api 1.0.76
+ * jar: `inputLabel` defaults to "Input" and `inputOptional` to false, so a plugin
+ * writing `NewTabSpec(order = 5, confirmLabel = "Open")` fails two of the three
+ * conditions. Opting in means setting all three deliberately - blank label, blank
+ * placeholder, optional - which no author does by accident.
+ *
+ * That property is load-bearing and lives in a different repo, so it is worth
+ * re-checking if the api ever changes those defaults: flipping `inputOptional` to
+ * true would silently take the input field away from every spec that omits a label.
+ * An explicit `opensImmediately` on NewTabSpec would retire the heuristic, but it
+ * ships in the external artifact and so needs an api release.
  */
 internal fun NewTabSpec.needsNoInput(): Boolean = inputOptional && inputLabel.isBlank() && inputPlaceholder.isBlank()
 
@@ -227,6 +240,11 @@ fun NewTabDialog(
     // clicks in that gap open two tabs. The confirm button always had this, but
     // a TILE is a far more natural thing to double-click than a confirm button,
     // so the instant-open path is where it actually becomes reachable.
+    //
+    // Latched, never reset: it is only ever set on a path that also calls
+    // onDismiss, so this composable is on its way out. That makes it depend on
+    // the caller honouring onDismiss - one that keeps the dialog composed would
+    // leave it permanently unable to create a plugin tab.
     var opening by remember { mutableStateOf(false) }
 
     // Open a plugin tab type with the given input: the plugin builds the
@@ -479,9 +497,16 @@ fun NewTabDialog(
                                     // does not even become selected, so a broken
                                     // no-input type is a button that visibly does
                                     // nothing, forever, with only a log line to say
-                                    // why. Selecting degrades it to the old flow.
+                                    // why. Selecting shows the confirm button, so the
+                                    // refusal is at least visible and retryable.
+                                    //
+                                    // `!opening` distinguishes the two falses
+                                    // openPluginTab returns. A refusal means select;
+                                    // "a create is already in flight" - the second half
+                                    // of a double-click - must NOT, or the dialog
+                                    // rearranges itself on its way out.
                                     if (pluginType.newTabSpec?.needsNoInput() == true) {
-                                        if (!openPluginTab(pluginType, "")) {
+                                        if (!openPluginTab(pluginType, "") && !opening) {
                                             selectedPluginType = pluginType.typeId
                                         }
                                         return@TabTypeOption
@@ -545,57 +570,71 @@ fun NewTabDialog(
                         // type's NewTabSpec; the plugin validates via createTabInfo.
                         //
                         // Gated on the same predicate as the tile click, so the two
-                        // paths agree. A no-input type can still arrive here without
-                        // ever being clicked: when no built-in types are available
-                        // the dialog auto-selects the first plugin type, which would
+                        // paths agree. A no-input type can arrive here without ever
+                        // being clicked: when no built-in types are available the
+                        // dialog auto-selects the first plugin type, which would
                         // otherwise open showing the empty "(optional)" field, the
                         // focus grab and the confirm button that this change exists
                         // to remove.
-                        if (selectedPluginTypeInfo != null && selectedPluginTypeInfo.newTabSpec?.needsNoInput() != true) {
+                        //
+                        // The no-input case is a branch INSIDE this one, never a
+                        // narrower condition on it. This `if` heads a chain that ends in
+                        // an unconditional `else` drawing the URL field, so excluding a
+                        // type here does not render nothing - it falls through to
+                        // whichever built-in matches `selectedType`, which starts as URL.
+                        // That put a focused "Enter URL or search term" next to a "Play"
+                        // button that discards whatever is typed, and on the refusal path
+                        // a whole file tree beside a button that silently fails again.
+                        if (selectedPluginTypeInfo != null) {
                             val spec = selectedPluginTypeInfo.newTabSpec!!
-                            val pluginFocusRequester = remember { FocusRequester() }
-                            LaunchedEffect(selectedPluginType) {
-                                pluginFocusRequester.requestFocus()
+                            // Nothing to ask for. The confirm button below is already
+                            // plugin-scoped on this same condition, so it keeps carrying
+                            // spec.confirmLabel and confirmPluginTab.
+                            if (!spec.needsNoInput()) {
+                                val pluginFocusRequester = remember { FocusRequester() }
+                                LaunchedEffect(selectedPluginType) {
+                                    pluginFocusRequester.requestFocus()
+                                }
+                                OutlinedTextField(
+                                    value = pluginInput,
+                                    onValueChange = { pluginInput = it },
+                                    label = {
+                                        Text(
+                                            spec.inputLabel + if (spec.inputOptional) " (optional)" else "",
+                                            color = BossTheme.colors.textSecondary,
+                                        )
+                                    },
+                                    placeholder = {
+                                        Text(
+                                            spec.inputPlaceholder,
+                                            color = BossTheme.colors.textMuted,
+                                        )
+                                    },
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .focusRequester(pluginFocusRequester)
+                                            .onPreviewKeyEvent { event ->
+                                                if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                                                    confirmPluginTab()
+                                                    true
+                                                } else {
+                                                    false
+                                                }
+                                            },
+                                    colors =
+                                        TextFieldDefaults.outlinedTextFieldColors(
+                                            textColor = BossTheme.colors.textPrimary,
+                                            cursorColor = BossTheme.colors.textPrimary,
+                                            focusedBorderColor = BossTheme.colors.signal,
+                                            unfocusedBorderColor = BossTheme.colors.line,
+                                            backgroundColor = BossTheme.colors.panel,
+                                        ),
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                    keyboardActions = KeyboardActions(onDone = { confirmPluginTab() }),
+                                )
                             }
-                            OutlinedTextField(
-                                value = pluginInput,
-                                onValueChange = { pluginInput = it },
-                                label = {
-                                    Text(
-                                        spec.inputLabel + if (spec.inputOptional) " (optional)" else "",
-                                        color = BossTheme.colors.textSecondary,
-                                    )
-                                },
-                                placeholder = {
-                                    Text(
-                                        spec.inputPlaceholder,
-                                        color = BossTheme.colors.textMuted,
-                                    )
-                                },
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .focusRequester(pluginFocusRequester)
-                                        .onPreviewKeyEvent { event ->
-                                            if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
-                                                confirmPluginTab()
-                                                true
-                                            } else {
-                                                false
-                                            }
-                                        },
-                                colors =
-                                    TextFieldDefaults.outlinedTextFieldColors(
-                                        textColor = BossTheme.colors.textPrimary,
-                                        cursorColor = BossTheme.colors.textPrimary,
-                                        focusedBorderColor = BossTheme.colors.signal,
-                                        unfocusedBorderColor = BossTheme.colors.line,
-                                        backgroundColor = BossTheme.colors.panel,
-                                    ),
-                                singleLine = true,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                keyboardActions = KeyboardActions(onDone = { confirmPluginTab() }),
-                            )
                         } else if (selectedType == TabType.TERMINAL) {
                             // Terminal command input
                             LaunchedEffect(selectedType) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/NewTabDialog.kt
@@ -157,8 +157,7 @@ private fun encodeUrlParameter(input: String): String =
  * A spec that declares no input at all (blank label and placeholder, input
  * optional): clicking the tab type opens it instantly, no input step.
  */
-private fun NewTabSpec.needsNoInput(): Boolean =
-    inputOptional && inputLabel.isBlank() && inputPlaceholder.isBlank()
+internal fun NewTabSpec.needsNoInput(): Boolean = inputOptional && inputLabel.isBlank() && inputPlaceholder.isBlank()
 
 // Platform-specific URL history provider
 expect object UrlHistoryProvider {
@@ -223,27 +222,42 @@ fun NewTabDialog(
     val selectedPluginTypeInfo = selectedPluginType?.let { id -> pluginTypes.firstOrNull { it.typeId == id } }
     var pluginInput by remember(selectedPluginType) { mutableStateOf("") }
 
+    // Guards the create action against a second click landing before the dialog
+    // leaves composition. onCreateTabInfo + onDismiss are state-driven, so two
+    // clicks in that gap open two tabs. The confirm button always had this, but
+    // a TILE is a far more natural thing to double-click than a confirm button,
+    // so the instant-open path is where it actually becomes reachable.
+    var opening by remember { mutableStateOf(false) }
+
     // Open a plugin tab type with the given input: the plugin builds the
     // TabInfo (null = input rejected, dialog stays open). Crash-isolated —
-    // plugin code.
-    val openPluginTab: (TabTypeInfo, String) -> Unit = { typeInfo, input ->
-        val tabInfo =
-            try {
-                typeInfo.createTabInfo(input.trim(), NewTabContext(projectPath = projectPath, windowId = windowId))
-            } catch (e: Exception) {
-                newTabDialogLogger.warn(
-                    LogCategory.UI,
-                    "Plugin createTabInfo failed",
-                    mapOf(
-                        "typeId" to typeInfo.typeId.typeId,
-                    ),
-                    e,
-                )
-                null
+    // plugin code. Returns whether a tab was actually opened, which the
+    // instant-open path needs: with no input on screen there is nothing for the
+    // user to correct, so a refusal has to surface as something.
+    val openPluginTab: (TabTypeInfo, String) -> Boolean = { typeInfo, input ->
+        if (opening) {
+            false
+        } else {
+            val tabInfo =
+                try {
+                    typeInfo.createTabInfo(input.trim(), NewTabContext(projectPath = projectPath, windowId = windowId))
+                } catch (e: Exception) {
+                    newTabDialogLogger.warn(
+                        LogCategory.UI,
+                        "Plugin createTabInfo failed",
+                        mapOf(
+                            "typeId" to typeInfo.typeId.typeId,
+                        ),
+                        e,
+                    )
+                    null
+                }
+            if (tabInfo != null) {
+                opening = true
+                onCreateTabInfo?.invoke(tabInfo)
+                onDismiss()
             }
-        if (tabInfo != null) {
-            onCreateTabInfo?.invoke(tabInfo)
-            onDismiss()
+            tabInfo != null
         }
     }
 
@@ -459,8 +473,17 @@ fun NewTabDialog(
                                 onClick = {
                                     // Types that declare no input (e.g. Arcade)
                                     // open on the click itself — no input step.
+                                    //
+                                    // If the plugin refuses, fall back to selecting
+                                    // the type. Without that the tile is inert: it
+                                    // does not even become selected, so a broken
+                                    // no-input type is a button that visibly does
+                                    // nothing, forever, with only a log line to say
+                                    // why. Selecting degrades it to the old flow.
                                     if (pluginType.newTabSpec?.needsNoInput() == true) {
-                                        openPluginTab(pluginType, "")
+                                        if (!openPluginTab(pluginType, "")) {
+                                            selectedPluginType = pluginType.typeId
+                                        }
                                         return@TabTypeOption
                                     }
                                     when (selectedType) {
@@ -520,7 +543,15 @@ fun NewTabDialog(
                     Column {
                         // Plugin tab type input — one generic field driven by the
                         // type's NewTabSpec; the plugin validates via createTabInfo.
-                        if (selectedPluginTypeInfo != null) {
+                        //
+                        // Gated on the same predicate as the tile click, so the two
+                        // paths agree. A no-input type can still arrive here without
+                        // ever being clicked: when no built-in types are available
+                        // the dialog auto-selects the first plugin type, which would
+                        // otherwise open showing the empty "(optional)" field, the
+                        // focus grab and the confirm button that this change exists
+                        // to remove.
+                        if (selectedPluginTypeInfo != null && selectedPluginTypeInfo.newTabSpec?.needsNoInput() != true) {
                             val spec = selectedPluginTypeInfo.newTabSpec!!
                             val pluginFocusRequester = remember { FocusRequester() }
                             LaunchedEffect(selectedPluginType) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabSpecNeedsNoInputTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/dialogs/NewTabSpecNeedsNoInputTest.kt
@@ -1,0 +1,63 @@
+package ai.rever.boss.components.dialogs
+
+import ai.rever.boss.plugin.api.NewTabSpec
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins [needsNoInput], the predicate that decides whether clicking a plugin tab type opens it
+ * immediately or drops into the input step.
+ *
+ * It is a heuristic over three fields rather than a declared flag, because `NewTabSpec` ships in
+ * the external `boss-plugin-api` artifact and an explicit `opensImmediately` would need an api
+ * release. That makes the exact boundary worth pinning: getting it wrong in the permissive
+ * direction takes an input field away from a plugin that wanted one, and the plugin author has no
+ * way to see why from their side.
+ */
+class NewTabSpecNeedsNoInputTest {
+    private fun spec(
+        label: String = "",
+        placeholder: String = "",
+        optional: Boolean = true,
+    ) = NewTabSpec(
+        order = 0,
+        inputLabel = label,
+        inputPlaceholder = placeholder,
+        inputOptional = optional,
+        confirmLabel = "Play",
+    )
+
+    @Test
+    fun `blank label, blank placeholder and optional input declares no input`() {
+        // Arcade, the one type this describes today.
+        assertTrue(spec().needsNoInput())
+    }
+
+    @Test
+    fun `a placeholder alone keeps the input step`() {
+        // The case most likely to regress: a plugin that omits the label but still prompts through
+        // the placeholder is asking for input, and instant-opening would silently discard it.
+        assertFalse(spec(placeholder = "Search term").needsNoInput())
+    }
+
+    @Test
+    fun `a label alone keeps the input step`() {
+        assertFalse(spec(label = "Query").needsNoInput())
+    }
+
+    @Test
+    fun `required input keeps the input step even with nothing to show`() {
+        // Blank on both strings but not optional is a contradictory spec. Opening instantly would
+        // hand the plugin the empty string it just said it would not accept, so the conservative
+        // reading wins and the user still gets a field.
+        assertFalse(spec(optional = false).needsNoInput())
+    }
+
+    @Test
+    fun `whitespace counts as blank`() {
+        // isBlank, not isEmpty: a spec padded with a space is not declaring an input, and treating
+        // it as one would leave an empty labelled field that looks like a bug.
+        assertTrue(spec(label = "   ", placeholder = "\t").needsNoInput())
+    }
+}


### PR DESCRIPTION
## What

Clicking a plugin tab type in the new-tab dialog now opens the tab immediately when its `NewTabSpec` declares no input - blank `inputLabel`, blank `inputPlaceholder`, and `inputOptional = true`. Today that's exactly one type, **Arcade**, which currently shows an empty "(optional)" text field and a Play button that serve no purpose.

## How

- `NewTabSpec.needsNoInput()` - private helper defining the "declares no input" contract.
- The plugin-tab confirm path is split into `openPluginTab(typeInfo, input)` (create + open + dismiss, crash-isolated as before) and the existing `confirmPluginTab` which now delegates to it.
- The tile `onClick` for plugin types calls `openPluginTab(type, "")` directly when the spec needs no input; all other types keep the select → type → confirm flow unchanged.

## Why not in the plugin?

The dialog only lists plugin types with a non-null `newTabSpec` (`NewTabDialog.kt`), so a plugin can't opt out of the input step without disappearing from the menu entirely. Any future no-input tab type (games, dashboards) gets the instant-open behavior for free - no API change needed.

## Testing

- `composeApp:compileKotlinDesktop` passes.
- Manual: needs a locally built app - click Arcade in the new-tab dialog → tab opens instantly; URL/File/Terminal/Jupyter and input-declaring plugin types unaffected.

## Follow-up commit

`68ef2ad0e` fixes the red build and three review findings:

- **ktlint on `needsNoInput`** was failing `code-quality` and, since CI's `build` runs `check`, all three `build-test` jobs. One line.
- **A refused instant-open was a silent no-op** - the tile did not even become selected, so a plugin returning null left a button that visibly did nothing. `openPluginTab` now reports whether it opened and the tile falls back to selecting the type.
- **The auto-select path bypassed the change** - with no built-in types registered the dialog preselects the first plugin type, showing the very input step this PR removes. The input block is now gated on the same predicate as the tile.
- **Double-clicking a tile opened two tabs.** Guarded.
- `needsNoInput` is `internal` with a truth-table test, mutation-checked.

Still open for the author: an explicit `opensImmediately` flag on `NewTabSpec` would replace the heuristic, but that ships in the external `boss-plugin-api` artifact and needs an api release.
