### PR TITLE
Stop a sleeping laptop from silently disabling every plugin

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1402,40 +1402,34 @@ class DynamicPluginManager(
                     )
                 }
 
-                try {
+                val outcome =
                     PluginExecutionBoundary.runAttributed(pluginId) {
-                        trackingContext.unregisterAll()
-                        // A dispose() that throws must not stop the re-register.
-                        // Stopping there would leave the plugin unregistered and
-                        // strictly worse off than before the restart.
-                        runCatching { loadedPlugin.instance.dispose() }
-                        loadedPlugin.instance.register(trackingContext)
+                        reregisterInPlace(
+                            unregisterAll = { trackingContext.unregisterAll() },
+                            dispose = { loadedPlugin.instance.dispose() },
+                            register = { loadedPlugin.instance.register(trackingContext) },
+                        )
                     }
-                    logger.info(
-                        LogCategory.SYSTEM,
-                        "Re-registered plugin after sandbox restart",
-                        mapOf(
-                            "pluginId" to pluginId,
-                        ),
-                    )
-                    Result.success(Unit)
-                } catch (e: Throwable) {
-                    logger.error(
-                        LogCategory.SYSTEM,
-                        "Failed to re-register plugin after sandbox restart",
-                        mapOf(
-                            "pluginId" to pluginId,
-                            "errorType" to e.javaClass.simpleName,
-                        ),
-                        e,
-                    )
-                    // register() may have got half way - panels or MCP tools
-                    // already registered - before throwing. Same teardown as
-                    // enablePlugin, so a plugin that failed to come back cannot
-                    // leave agent-callable tools live.
-                    runCatching { trackingContext.unregisterAll() }
-                    Result.failure(e)
-                }
+                outcome
+                    .onSuccess {
+                        logger.info(
+                            LogCategory.SYSTEM,
+                            "Re-registered plugin after sandbox restart",
+                            mapOf(
+                                "pluginId" to pluginId,
+                            ),
+                        )
+                    }.onFailure { e ->
+                        logger.error(
+                            LogCategory.SYSTEM,
+                            "Failed to re-register plugin after sandbox restart",
+                            mapOf(
+                                "pluginId" to pluginId,
+                                "errorType" to e.javaClass.simpleName,
+                            ),
+                            e,
+                        )
+                    }
             }
         // Outside the mutex, same as enablePlugin: a panel open across the
         // restart still holds its pre-restart component.
@@ -2090,6 +2084,40 @@ class DynamicPluginManager(
         }
     }
 }
+
+/**
+ * The unregister / dispose / register sequence [DynamicPluginManager.reregisterAfterRestart]
+ * runs, as a pure ordering so the three failure rules can be tested without a
+ * loaded jar behind them.
+ *
+ * - A [dispose] that throws does not abort the sequence. Stopping there would
+ *   leave the plugin unregistered, which is strictly worse than the restarted
+ *   state it was called to repair.
+ * - A [register] that throws tears down whatever it managed to register first.
+ *   Half of a `register()` is panels and agent-callable MCP tools belonging to
+ *   a plugin that is not running, which is how a failed recovery leaves live
+ *   tools behind.
+ * - That teardown is itself best effort: its failure must not mask the original
+ *   one, which is the failure worth reporting.
+ */
+// Throwable, not Exception: this runs plugin code across a classloader
+// boundary, where a NoClassDefFoundError from a lazily-resolved class is a
+// routine outcome and must be contained exactly like a thrown exception.
+@Suppress("TooGenericExceptionCaught")
+internal fun reregisterInPlace(
+    unregisterAll: () -> Unit,
+    dispose: () -> Unit,
+    register: () -> Unit,
+): Result<Unit> =
+    try {
+        unregisterAll()
+        runCatching { dispose() }
+        register()
+        Result.success(Unit)
+    } catch (e: Throwable) {
+        runCatching { unregisterAll() }
+        Result.failure(e)
+    }
 
 /**
  * Whether a plugin whose sandbox just restarted should have `register()` run

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -19,7 +19,9 @@ import ai.rever.boss.plugin.loader.PluginBinaryIncompatibilityException
 import ai.rever.boss.plugin.loader.PluginUnloadException
 import ai.rever.boss.plugin.sandbox.PluginErrorClassifier
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
+import ai.rever.boss.plugin.sandbox.PluginSandboxListener
 import ai.rever.boss.plugin.sandbox.PluginSandboxManager
+import ai.rever.boss.plugin.sandbox.PluginSandboxManagerImpl
 import ai.rever.boss.plugin.sandbox.SandboxConfig
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import ai.rever.boss.plugin.sandbox.ui.PluginRecoveryQuarantine
@@ -522,8 +524,33 @@ class DynamicPluginManager(
         }
     }
 
+    /**
+     * Re-runs `register()` after the sandbox restarts a plugin.
+     *
+     * Held as a field because [PluginSandboxManagerImpl] keeps its listeners
+     * weakly - an anonymous listener passed straight to `addListener` would be
+     * collected at the next GC and the re-registration would simply stop
+     * happening, silently and non-deterministically.
+     */
+    private val restartListener =
+        object : PluginSandboxListener {
+            override fun onPluginRestarted(pluginId: String) {
+                // Detached from the sandbox manager's scope on purpose: this is
+                // called inside the watchdog's own coroutine, which disabling
+                // the plugin cancels, and a re-registration abandoned half way
+                // through would leave the plugin unregistered.
+                //
+                // On Main because register() is where plugins touch Compose
+                // state and build panel factories - the two existing paths that
+                // re-register a loaded instance, handleAccessChange and the
+                // Toolbox's enable, both already run there.
+                managerScope.launch(Dispatchers.Main) { reregisterAfterRestart(pluginId) }
+            }
+        }
+
     init {
         liveManagers.add(WeakReference(this))
+        (sandboxManager as? PluginSandboxManagerImpl)?.addListener(restartListener)
 
         // Observe access changes (admin status + effective permissions) and
         // reconcile plugin visibility whenever either changes.
@@ -1328,6 +1355,94 @@ class DynamicPluginManager(
         return result
     }
 
+    /**
+     * Re-run a plugin's `register()` after its sandbox restarted.
+     *
+     * A restart cancels everything the plugin had in flight. Work the user
+     * starts afterwards runs again - the scope survives the restart, see
+     * `InProcessPluginSandbox.sandboxScope` - but a subscription the plugin
+     * opened once inside `register()` is gone for good, because nothing else
+     * ever calls `register()` a second time. That is not a corner case: the
+     * Toolbox's realtime channel and update-prompt loop, terminal-tab's
+     * approval collector, tool-creator's event job and analytics' pipes are
+     * all opened exactly once, there. A restarted plugin looked alive and
+     * quietly stopped reacting to anything it had not been asked to do.
+     *
+     * This is the disable/enable cycle without the disable: drop what the
+     * plugin contributed, dispose it, register it again, and refresh any panel
+     * still open so it is rebuilt from the new factories rather than left
+     * holding components from before the restart.
+     *
+     * The runaway case - a plugin whose `register()` is itself what wedges it -
+     * is bounded by `maxRestartAttempts`, which only became reachable once
+     * `restartAttempts` stopped being zeroed by every restart. Without that
+     * fix this method would be a restart loop.
+     */
+    suspend fun reregisterAfterRestart(pluginId: String): Result<Unit> {
+        val result =
+            mutex.withLock {
+                val info = _pluginStates.value[pluginId]
+                if (!shouldReregisterAfterRestart(info)) {
+                    logger.debug(
+                        LogCategory.SYSTEM,
+                        "Skipping re-registration for a plugin that is not running",
+                        mapOf(
+                            "pluginId" to pluginId,
+                            "state" to (info?.state?.name ?: "absent"),
+                        ),
+                    )
+                    return@withLock Result.success(Unit)
+                }
+
+                val loadedPlugin = pluginLoader.getPlugin(pluginId)
+                val trackingContext = trackingContexts[pluginId]
+                if (loadedPlugin == null || trackingContext == null) {
+                    return@withLock Result.failure(
+                        IllegalStateException("No loaded plugin or context to re-register: $pluginId"),
+                    )
+                }
+
+                try {
+                    PluginExecutionBoundary.runAttributed(pluginId) {
+                        trackingContext.unregisterAll()
+                        // A dispose() that throws must not stop the re-register.
+                        // Stopping there would leave the plugin unregistered and
+                        // strictly worse off than before the restart.
+                        runCatching { loadedPlugin.instance.dispose() }
+                        loadedPlugin.instance.register(trackingContext)
+                    }
+                    logger.info(
+                        LogCategory.SYSTEM,
+                        "Re-registered plugin after sandbox restart",
+                        mapOf(
+                            "pluginId" to pluginId,
+                        ),
+                    )
+                    Result.success(Unit)
+                } catch (e: Throwable) {
+                    logger.error(
+                        LogCategory.SYSTEM,
+                        "Failed to re-register plugin after sandbox restart",
+                        mapOf(
+                            "pluginId" to pluginId,
+                            "errorType" to e.javaClass.simpleName,
+                        ),
+                        e,
+                    )
+                    // register() may have got half way - panels or MCP tools
+                    // already registered - before throwing. Same teardown as
+                    // enablePlugin, so a plugin that failed to come back cannot
+                    // leave agent-callable tools live.
+                    runCatching { trackingContext.unregisterAll() }
+                    Result.failure(e)
+                }
+            }
+        // Outside the mutex, same as enablePlugin: a panel open across the
+        // restart still holds its pre-restart component.
+        if (result.isSuccess) notifyPanelsRefresh(pluginId)
+        return result
+    }
+
     /** Invoke [pluginPanelsRefresh] with [pluginId]'s currently-registered panels; never throws. */
     private fun notifyPanelsRefresh(pluginId: String) {
         val refresh = pluginPanelsRefresh ?: return
@@ -1975,6 +2090,23 @@ class DynamicPluginManager(
         }
     }
 }
+
+/**
+ * Whether a plugin whose sandbox just restarted should have `register()` run
+ * again. Extracted from [DynamicPluginManager.reregisterAfterRestart] so it can
+ * be unit-tested in isolation.
+ *
+ * Only a plugin that is meant to be running qualifies. A restart is decided by
+ * a watchdog on its own coroutine and lands some time later, by which point the
+ * user may have disabled the plugin or uninstalled it - and re-registering then
+ * would put its panels, tab types and agent-callable MCP tools straight back,
+ * undoing exactly what they asked for. `enabled` and [PluginState.LOADED] are
+ * both required because they can disagree: [DynamicPluginManager.installPlugin]
+ * records a DISABLED state for a plugin that was rejected as binary
+ * incompatible while other paths leave `enabled` set.
+ */
+internal fun shouldReregisterAfterRestart(info: DynamicPluginInfo?): Boolean =
+    info != null && info.enabled && info.state == PluginState.LOADED
 
 /**
  * Pure access predicate for permission-based plugin gating. Extracted from

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -294,54 +294,6 @@ class DynamicPluginManager(
          * that never loaded the plugin failing is expected and not a failure of
          * the operation.
          */
-
-        /**
-         * Restart a plugin through its manager, in every window that has it.
-         *
-         * The error boundary's Restart button used to call `sandbox.restart()`
-         * directly. That restarts the sandbox but notifies no listener, so
-         * nothing re-runs `register()` - leaving the plugin with its scope alive
-         * and every subscription it opened in `register()` still closed, which
-         * is the state this whole change exists to remove, on the path a user
-         * reaches *after* noticing a plugin is wedged.
-         *
-         * The manual restart also forgives the restart budget. `sandbox.restart()`
-         * banks an attempt and the counter now survives, so three presses of a
-         * button offered to the user as the remedy would have pushed a plugin to
-         * `maxRestartAttempts` and let the next watchdog request disable it. The
-         * budget exists to bound an *automatic* loop; a person asking for a
-         * restart is the same deliberate re-arm as `resetHealth`.
-         *
-         * @return true if at least one manager restarted the plugin.
-         */
-        suspend fun restartEverywhere(pluginId: String): Boolean {
-            val managers = activeManagers()
-            var anyRestarted = false
-            for (manager in managers.filter { it.getPluginInfo(pluginId) != null }) {
-                val result = runCatching { manager.sandboxManager.restartPlugin(pluginId) }
-                if (result.getOrNull()?.isSuccess == true) {
-                    anyRestarted = true
-                    manager.sandboxManager.getSandbox(pluginId)?.resetRestartAttempts()
-                } else {
-                    val cause = result.exceptionOrNull() ?: result.getOrNull()?.exceptionOrNull()
-                    companionLogger.warn(
-                        LogCategory.SYSTEM,
-                        "Failed to restart a plugin in one manager",
-                        mapOf("pluginId" to pluginId),
-                        cause,
-                    )
-                }
-            }
-            if (!anyRestarted) {
-                companionLogger.warn(
-                    LogCategory.SYSTEM,
-                    "No live plugin manager could restart the plugin",
-                    mapOf("pluginId" to pluginId),
-                )
-            }
-            return anyRestarted
-        }
-
         suspend fun disableEverywhere(pluginId: String): Boolean {
             val managers = activeManagers()
             if (managers.isEmpty()) {
@@ -384,6 +336,79 @@ class DynamicPluginManager(
                 ),
             )
             return anyDisabled
+        }
+
+        /**
+         * Restart [sandbox]'s plugin through the manager that owns it.
+         *
+         * The error boundary's Restart button used to call `sandbox.restart()`
+         * directly. That restarts the sandbox but notifies no listener, so
+         * nothing re-runs `register()` - leaving the plugin's scope alive and
+         * every subscription it opened in `register()` still closed, which is
+         * the state this whole change exists to remove, on the path a user
+         * reaches *after* noticing a plugin is wedged.
+         *
+         * Scoped to the owning window, unlike [disableEverywhere]. That one is
+         * deliberately global because a plugin left crashing in another window
+         * keeps crashing; a restart is the opposite case - sandboxes are
+         * per-window, and cancelling every in-flight coroutine of a plugin that
+         * is perfectly healthy in windows B..N is not what someone clicking
+         * Restart on window A's wedged panel asked for. The caller holds the
+         * sandbox instance, which identifies its manager exactly.
+         *
+         * A plugin that spent its restart budget needs enabling, not
+         * restarting: the give-up path stopped its watchdog and recorded it in
+         * `disabledPlugins`, and a bare restart would leave it running,
+         * still reported disabled, and unmonitored for the rest of the session.
+         *
+         * The budget is forgiven either way. `restart()` banks an attempt and
+         * the counter now survives, so three presses of the button offered to
+         * the user as the remedy would push a plugin to `maxRestartAttempts`
+         * and let the next watchdog request disable it. The budget exists to
+         * bound an *automatic* loop; a person asking for a restart is the same
+         * deliberate re-arm as `resetHealth`.
+         *
+         * @return true if the plugin was restarted.
+         */
+        suspend fun restartOwning(sandbox: PluginSandboxRef): Boolean {
+            val pluginId = sandbox.pluginId
+            val manager =
+                activeManagers().firstOrNull { it.sandboxManager.getSandbox(pluginId) === sandbox }
+            if (manager == null) {
+                companionLogger.warn(
+                    LogCategory.SYSTEM,
+                    "No live manager owns this sandbox, cannot restart",
+                    mapOf("pluginId" to pluginId),
+                )
+                return false
+            }
+
+            val sandboxManager = manager.sandboxManager
+            val result =
+                runCatching {
+                    if (sandboxManager.isPluginDisabled(pluginId)) {
+                        // Clears disabledPlugins, rebuilds the watchdog and
+                        // starts the sandbox. It does not notify
+                        // onPluginRestarted, so re-registration is explicit.
+                        sandboxManager.enablePlugin(pluginId).also {
+                            if (it.isSuccess) manager.reregisterAfterRestart(pluginId)
+                        }
+                    } else {
+                        sandboxManager.restartPlugin(pluginId)
+                    }
+                }
+            val restarted = result.getOrNull()?.isSuccess == true
+            if (restarted) {
+                sandboxManager.getSandbox(pluginId)?.resetRestartAttempts()
+            } else {
+                companionLogger.warn(
+                    LogCategory.SYSTEM,
+                    "Failed to restart plugin",
+                    mapOf("pluginId" to pluginId),
+                    result.exceptionOrNull() ?: result.getOrNull()?.exceptionOrNull(),
+                )
+            }
+            return restarted
         }
 
         /**
@@ -1513,11 +1538,18 @@ class DynamicPluginManager(
      * another direction. DISABLED is what `PluginErrorBoundary` gates its
      * fallback on, and what gives the user something to re-enable.
      */
-    private fun disableAfterFailedReregister(
+    private suspend fun disableAfterFailedReregister(
         pluginId: String,
         info: DynamicPluginInfo,
     ) {
-        (sandboxManager.getSandbox(pluginId) as? InProcessPluginSandbox)?.setDisabled()
+        // Through the sandbox manager, not a bare setDisabled(). That alone
+        // left disabledPlugins untouched (so isPluginDisabled kept saying the
+        // plugin was fine), raised no onPluginDisabled notification (the same
+        // "told nobody" failure the watchdog consolidation fixed), and its
+        // `as? InProcessPluginSandbox` silently did nothing at all for an
+        // out-of-process sandbox. disablePlugin does all three and stops the
+        // watchdog.
+        sandboxManager.disablePlugin(pluginId)
         updatePluginState(pluginId, info.copy(state = PluginState.DISABLED, enabled = false))
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -387,12 +387,20 @@ class DynamicPluginManager(
             val result =
                 runCatching {
                     if (sandboxManager.isPluginDisabled(pluginId)) {
-                        // Clears disabledPlugins, rebuilds the watchdog and
-                        // starts the sandbox. It does not notify
-                        // onPluginRestarted, so re-registration is explicit.
-                        sandboxManager.enablePlugin(pluginId).also {
-                            if (it.isSuccess) manager.reregisterAfterRestart(pluginId)
-                        }
+                        // The manager's enable, not the sandbox manager's.
+                        // Pairing the sandbox-level enable with
+                        // reregisterAfterRestart looked equivalent and was not:
+                        // disableAfterFailedReregister leaves _pluginStates at
+                        // DISABLED/disabled, which is exactly what
+                        // shouldReregisterAfterRestart refuses, so register()
+                        // never ran and the button reported success over a
+                        // plugin with zero registrations. That gate is right -
+                        // it cannot tell a user's disable from the host's - so
+                        // the caller has to use the path that repairs the state
+                        // first. This one registers, fixes _pluginStates,
+                        // clears the crash registry, enables the sandbox and
+                        // refreshes open panels.
+                        manager.enablePlugin(pluginId)
                     } else {
                         sandboxManager.restartPlugin(pluginId)
                     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -17,6 +17,7 @@ import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.loader.DynamicPluginLoaderImpl
 import ai.rever.boss.plugin.loader.PluginBinaryIncompatibilityException
 import ai.rever.boss.plugin.loader.PluginUnloadException
+import ai.rever.boss.plugin.sandbox.InProcessPluginSandbox
 import ai.rever.boss.plugin.sandbox.PluginErrorClassifier
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import ai.rever.boss.plugin.sandbox.PluginSandboxListener
@@ -112,7 +113,7 @@ interface OutOfProcessPluginSpawner {
 class DynamicPluginManager(
     private val panelRegistry: PanelRegistry,
     private val tabRegistry: TabRegistry,
-    private val sandboxManager: PluginSandboxManager,
+    internal val sandboxManager: PluginSandboxManager,
     private val createSandboxedContext: (pluginId: String, config: SandboxConfig) -> PluginContext,
     private val outOfProcessSpawner: OutOfProcessPluginSpawner? = null,
 ) {
@@ -293,6 +294,54 @@ class DynamicPluginManager(
          * that never loaded the plugin failing is expected and not a failure of
          * the operation.
          */
+
+        /**
+         * Restart a plugin through its manager, in every window that has it.
+         *
+         * The error boundary's Restart button used to call `sandbox.restart()`
+         * directly. That restarts the sandbox but notifies no listener, so
+         * nothing re-runs `register()` - leaving the plugin with its scope alive
+         * and every subscription it opened in `register()` still closed, which
+         * is the state this whole change exists to remove, on the path a user
+         * reaches *after* noticing a plugin is wedged.
+         *
+         * The manual restart also forgives the restart budget. `sandbox.restart()`
+         * banks an attempt and the counter now survives, so three presses of a
+         * button offered to the user as the remedy would have pushed a plugin to
+         * `maxRestartAttempts` and let the next watchdog request disable it. The
+         * budget exists to bound an *automatic* loop; a person asking for a
+         * restart is the same deliberate re-arm as `resetHealth`.
+         *
+         * @return true if at least one manager restarted the plugin.
+         */
+        suspend fun restartEverywhere(pluginId: String): Boolean {
+            val managers = activeManagers()
+            var anyRestarted = false
+            for (manager in managers.filter { it.getPluginInfo(pluginId) != null }) {
+                val result = runCatching { manager.sandboxManager.restartPlugin(pluginId) }
+                if (result.getOrNull()?.isSuccess == true) {
+                    anyRestarted = true
+                    manager.sandboxManager.getSandbox(pluginId)?.resetRestartAttempts()
+                } else {
+                    val cause = result.exceptionOrNull() ?: result.getOrNull()?.exceptionOrNull()
+                    companionLogger.warn(
+                        LogCategory.SYSTEM,
+                        "Failed to restart a plugin in one manager",
+                        mapOf("pluginId" to pluginId),
+                        cause,
+                    )
+                }
+            }
+            if (!anyRestarted) {
+                companionLogger.warn(
+                    LogCategory.SYSTEM,
+                    "No live plugin manager could restart the plugin",
+                    mapOf("pluginId" to pluginId),
+                )
+            }
+            return anyRestarted
+        }
+
         suspend fun disableEverywhere(pluginId: String): Boolean {
             val managers = activeManagers()
             if (managers.isEmpty()) {
@@ -544,7 +593,13 @@ class DynamicPluginManager(
                 // state and build panel factories - the two existing paths that
                 // re-register a loaded instance, handleAccessChange and the
                 // Toolbox's enable, both already run there.
-                managerScope.launch(Dispatchers.Main) { reregisterAfterRestart(pluginId) }
+                // runCatching, because managerScope carries a SupervisorJob but
+                // no CoroutineExceptionHandler: runAttributed rethrows, and
+                // Dispatchers.Main throws outright on a headless host, either of
+                // which would otherwise reach the default handler.
+                managerScope.launch(Dispatchers.Main) {
+                    runCatching { reregisterAfterRestart(pluginId) }
+                }
             }
         }
 
@@ -1378,11 +1433,11 @@ class DynamicPluginManager(
      * `restartAttempts` stopped being zeroed by every restart. Without that
      * fix this method would be a restart loop.
      */
-    suspend fun reregisterAfterRestart(pluginId: String): Result<Unit> {
+    internal suspend fun reregisterAfterRestart(pluginId: String): Result<Unit> {
         val result =
             mutex.withLock {
                 val info = _pluginStates.value[pluginId]
-                if (!shouldReregisterAfterRestart(info)) {
+                if (info == null || !shouldReregisterAfterRestart(info)) {
                     logger.debug(
                         LogCategory.SYSTEM,
                         "Skipping re-registration for a plugin that is not running",
@@ -1436,11 +1491,34 @@ class DynamicPluginManager(
                             e,
                         )
                     }
+                if (outcome.isFailure) disableAfterFailedReregister(pluginId, info)
+                outcome
             }
         // Outside the mutex, same as enablePlugin: a panel open across the
-        // restart still holds its pre-restart component.
-        if (result.isSuccess) notifyPanelsRefresh(pluginId)
+        // restart still holds its pre-restart component. Refreshed on failure
+        // too - the plugin has just been unregistered and disabled, and a panel
+        // still drawing the old component over nothing is worse than one
+        // rebuilt against an empty registry, which is what shows the fallback.
+        notifyPanelsRefresh(pluginId)
         return result
+    }
+
+    /**
+     * Mark a plugin that failed to come back from a restart as disabled.
+     *
+     * Logging alone left it with zero registrations, state still LOADED and
+     * enabled still true: no fallback UI, no toast, and an open panel rendering
+     * its pre-restart component over an empty registry. That is the same
+     * looks-alive-does-nothing failure this change removes, reached from
+     * another direction. DISABLED is what `PluginErrorBoundary` gates its
+     * fallback on, and what gives the user something to re-enable.
+     */
+    private fun disableAfterFailedReregister(
+        pluginId: String,
+        info: DynamicPluginInfo,
+    ) {
+        (sandboxManager.getSandbox(pluginId) as? InProcessPluginSandbox)?.setDisabled()
+        updatePluginState(pluginId, info.copy(state = PluginState.DISABLED, enabled = false))
     }
 
     /** Invoke [pluginPanelsRefresh] with [pluginId]'s currently-registered panels; never throws. */

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1391,7 +1391,14 @@ class DynamicPluginManager(
                             "state" to (info?.state?.name ?: "absent"),
                         ),
                     )
-                    return@withLock Result.success(Unit)
+                    // Returns from the whole function, not just the lock, so the
+                    // refresh below is skipped too. Reporting success and
+                    // falling through rebuilt the components of a plugin nothing
+                    // had re-registered - discarding an open panel's in-memory
+                    // state for nothing, which is the same cost enablePlugin
+                    // avoids with wasAlreadyEnabled, and racing an unload that
+                    // is still in progress.
+                    return Result.success(Unit)
                 }
 
                 val loadedPlugin = pluginLoader.getPlugin(pluginId)
@@ -1406,7 +1413,6 @@ class DynamicPluginManager(
                     PluginExecutionBoundary.runAttributed(pluginId) {
                         reregisterInPlace(
                             unregisterAll = { trackingContext.unregisterAll() },
-                            dispose = { loadedPlugin.instance.dispose() },
                             register = { loadedPlugin.instance.register(trackingContext) },
                         )
                     }
@@ -2086,13 +2092,24 @@ class DynamicPluginManager(
 }
 
 /**
- * The unregister / dispose / register sequence [DynamicPluginManager.reregisterAfterRestart]
- * runs, as a pure ordering so the three failure rules can be tested without a
- * loaded jar behind them.
+ * The unregister / register sequence [DynamicPluginManager.reregisterAfterRestart]
+ * runs, as a pure ordering so its failure rules can be tested without a loaded
+ * jar behind them.
  *
- * - A [dispose] that throws does not abort the sequence. Stopping there would
- *   leave the plugin unregistered, which is strictly worse than the restarted
- *   state it was called to repair.
+ * **`dispose()` is deliberately not called.** An earlier version did, on the
+ * reasoning that disposing before registering is the documented lifecycle - but
+ * it is only the documented *unload* lifecycle. `dispose()` has never been
+ * followed by anything: the sole other caller is `DynamicPluginLoader`,
+ * immediately before it closes the classloader, and `disablePlugin` does not
+ * dispose at all, which is why `enablePlugin` can call `register()` straight
+ * onto the live instance. A `dispose()` -> `register()` transition is one no
+ * plugin has been written against, and the pattern most at risk is the very one
+ * this change exists to fix: a plugin that cancels a scope it owns as a field
+ * would come back from `register()` attaching its work to a permanently
+ * cancelled scope, silently. Matching disable/enable exactly keeps the
+ * sequence to one plugins already survive - and it is enough, because what the
+ * restart cancelled was their coroutines, which `register()` starts again.
+ *
  * - A [register] that throws tears down whatever it managed to register first.
  *   Half of a `register()` is panels and agent-callable MCP tools belonging to
  *   a plugin that is not running, which is how a failed recovery leaves live
@@ -2106,12 +2123,10 @@ class DynamicPluginManager(
 @Suppress("TooGenericExceptionCaught")
 internal fun reregisterInPlace(
     unregisterAll: () -> Unit,
-    dispose: () -> Unit,
     register: () -> Unit,
 ): Result<Unit> =
     try {
         unregisterAll()
-        runCatching { dispose() }
         register()
         Result.success(Unit)
     } catch (e: Throwable) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -627,9 +627,15 @@ class DynamicPluginManager(
                 // re-register a loaded instance, handleAccessChange and the
                 // Toolbox's enable, both already run there.
                 // runCatching, because managerScope carries a SupervisorJob but
-                // no CoroutineExceptionHandler: runAttributed rethrows, and
-                // Dispatchers.Main throws outright on a headless host, either of
+                // no CoroutineExceptionHandler, and runAttributed rethrows -
                 // which would otherwise reach the default handler.
+                //
+                // It does NOT cover a missing main dispatcher, though an earlier
+                // version of this comment claimed it did: that fails at dispatch
+                // time, which completes the coroutine exceptionally before the
+                // body - and so before this runCatching - ever runs. composeApp
+                // always has a main dispatcher, so the gap is theoretical, but
+                // it is not what this line protects.
                 managerScope.launch(Dispatchers.Main) {
                     runCatching { reregisterAfterRestart(pluginId) }
                 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -1002,7 +1002,7 @@ fun BossTabsComponent.BossMainPanelContent(
                             // Through the manager, never sandbox.restart()
                             // directly - see SidePanel's copy of this.
                             scope.launch {
-                                val restarted = DynamicPluginManager.restartEverywhere(sandbox.pluginId)
+                                val restarted = DynamicPluginManager.restartOwning(sandbox)
                                 if (!restarted) {
                                     pluginLogger?.error(
                                         LogCategory.UI,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -21,6 +21,7 @@ import ai.rever.boss.components.model.TabDropResult
 import ai.rever.boss.components.model.TabDropTarget
 import ai.rever.boss.components.overlays.ContextMenuItem
 import ai.rever.boss.components.overlays.contextMenu
+import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.TabUpdateRegistry
 import ai.rever.boss.components.plugin.providers.publishSystemEvent
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
@@ -998,15 +999,16 @@ fun BossTabsComponent.BossMainPanelContent(
                         pluginId = sandbox.pluginId,
                         sandbox = sandbox,
                         onRestart = {
+                            // Through the manager, never sandbox.restart()
+                            // directly - see SidePanel's copy of this.
                             scope.launch {
-                                val result = sandbox.restart()
-                                if (result.isFailure) {
+                                val restarted = DynamicPluginManager.restartEverywhere(sandbox.pluginId)
+                                if (!restarted) {
                                     pluginLogger?.error(
                                         LogCategory.UI,
                                         "Failed to restart plugin",
                                         mapOf(
                                             "pluginId" to sandbox.pluginId,
-                                            "error" to (result.exceptionOrNull()?.message ?: "unknown"),
                                         ),
                                     )
                                     StatusMessageManager.showMessage(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.window_panel.components.side_panel
 
 import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.components.model.BossDraggableComponent
+import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.LocalPanelPluginIdResolver
 import ai.rever.boss.components.plugin.PluginUpdateRegistry
 import ai.rever.boss.components.registery.PanelComponentStore
@@ -239,16 +240,18 @@ internal fun RenderPanelContent(
             pluginId = sandbox.pluginId,
             sandbox = sandbox,
             onRestart = {
-                // Restart the sandbox when user clicks restart
+                // Through the manager, never sandbox.restart() directly: only
+                // the manager notifies the listener that re-runs register(),
+                // and without that the plugin comes back with every
+                // subscription it opened there still closed.
                 scope.launch {
-                    val result = sandbox.restart()
-                    if (result.isFailure) {
+                    val restarted = DynamicPluginManager.restartEverywhere(sandbox.pluginId)
+                    if (!restarted) {
                         logger.error(
                             LogCategory.UI,
                             "Failed to restart plugin",
                             mapOf(
                                 "pluginId" to sandbox.pluginId,
-                                "error" to (result.exceptionOrNull()?.message ?: "unknown"),
                             ),
                         )
                         // Show status message to user about failure

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
@@ -245,7 +245,7 @@ internal fun RenderPanelContent(
                 // and without that the plugin comes back with every
                 // subscription it opened there still closed.
                 scope.launch {
-                    val restarted = DynamicPluginManager.restartEverywhere(sandbox.pluginId)
+                    val restarted = DynamicPluginManager.restartOwning(sandbox)
                     if (!restarted) {
                         logger.error(
                             LogCategory.UI,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/ReregisterAfterRestartTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/ReregisterAfterRestartTest.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.api.PluginType
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -69,5 +70,75 @@ class ReregisterAfterRestartTest {
             shouldReregisterAfterRestart(null),
             "uninstalled between the restart and this callback",
         )
+    }
+
+    @Test
+    fun `the sequence unregisters, disposes and registers in that order`() {
+        val calls = mutableListOf<String>()
+
+        val result =
+            reregisterInPlace(
+                unregisterAll = { calls.add("unregister") },
+                dispose = { calls.add("dispose") },
+                register = { calls.add("register") },
+            )
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("unregister", "dispose", "register"), calls)
+    }
+
+    @Test
+    fun `a dispose that throws does not stop the re-register`() {
+        val calls = mutableListOf<String>()
+
+        val result =
+            reregisterInPlace(
+                unregisterAll = { calls.add("unregister") },
+                dispose = { throw IllegalStateException("plugin dispose blew up") },
+                register = { calls.add("register") },
+            )
+
+        assertTrue(result.isSuccess, "stopping here would leave the plugin unregistered")
+        assertEquals(listOf("unregister", "register"), calls)
+    }
+
+    @Test
+    fun `a register that throws tears down what it half-registered`() {
+        val calls = mutableListOf<String>()
+
+        val result =
+            reregisterInPlace(
+                unregisterAll = { calls.add("unregister") },
+                dispose = {},
+                register = {
+                    calls.add("register")
+                    error("register blew up")
+                },
+            )
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            listOf("unregister", "register", "unregister"),
+            calls,
+            "a half-registered plugin leaves agent-callable MCP tools live",
+        )
+    }
+
+    @Test
+    fun `a teardown that throws does not mask the original failure`() {
+        var unregisterCalls = 0
+
+        val result =
+            reregisterInPlace(
+                unregisterAll = {
+                    unregisterCalls++
+                    if (unregisterCalls == 2) error("teardown blew up too")
+                },
+                dispose = {},
+                register = { throw IllegalStateException("the real problem") },
+            )
+
+        assertTrue(result.isFailure)
+        assertEquals("the real problem", result.exceptionOrNull()?.message)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/ReregisterAfterRestartTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/ReregisterAfterRestartTest.kt
@@ -1,0 +1,73 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.api.PluginType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [shouldReregisterAfterRestart] - the predicate that decides
+ * whether a restarted plugin gets `register()` run again.
+ *
+ * The restart is decided by a watchdog on its own coroutine and lands some
+ * time later, so what matters here is everything the user might have done in
+ * between. Re-registering a plugin they disabled would put its panels, tab
+ * types and agent-callable MCP tools straight back.
+ */
+class ReregisterAfterRestartTest {
+    private fun info(
+        state: PluginState,
+        enabled: Boolean,
+    ) = DynamicPluginInfo(
+        manifest =
+            PluginManifest(
+                pluginId = "ai.rever.boss.plugin.dynamic.example",
+                displayName = "Example",
+                version = "1.0.0",
+                apiVersion = "1.0",
+                mainClass = "com.example.ExamplePlugin",
+                type = PluginType.PANEL,
+            ),
+        jarPath = "/plugins/example.jar",
+        state = state,
+        loadedAt = 0L,
+        enabled = enabled,
+    )
+
+    @Test
+    fun `a running plugin is re-registered`() {
+        assertTrue(shouldReregisterAfterRestart(info(PluginState.LOADED, enabled = true)))
+    }
+
+    @Test
+    fun `a plugin disabled while the restart was in flight is left alone`() {
+        assertFalse(
+            shouldReregisterAfterRestart(info(PluginState.LOADED, enabled = false)),
+            "re-registering would undo the disable the user just asked for",
+        )
+    }
+
+    @Test
+    fun `a plugin whose state says disabled is left alone even when the enabled flag disagrees`() {
+        // installPlugin records DISABLED for a plugin rejected as binary
+        // incompatible; other paths leave `enabled` set. Either half saying no
+        // has to be enough.
+        assertFalse(shouldReregisterAfterRestart(info(PluginState.DISABLED, enabled = true)))
+    }
+
+    @Test
+    fun `a plugin mid-unload is left alone`() {
+        assertFalse(shouldReregisterAfterRestart(info(PluginState.UNLOADING, enabled = true)))
+        assertFalse(shouldReregisterAfterRestart(info(PluginState.UNLOADED, enabled = true)))
+    }
+
+    @Test
+    fun `a plugin that is gone entirely is left alone`() {
+        assertFalse(
+            shouldReregisterAfterRestart(null),
+            "uninstalled between the restart and this callback",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/ReregisterAfterRestartTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/ReregisterAfterRestartTest.kt
@@ -73,32 +73,21 @@ class ReregisterAfterRestartTest {
     }
 
     @Test
-    fun `the sequence unregisters, disposes and registers in that order`() {
+    fun `the sequence unregisters then registers, and does not dispose`() {
         val calls = mutableListOf<String>()
 
         val result =
             reregisterInPlace(
                 unregisterAll = { calls.add("unregister") },
-                dispose = { calls.add("dispose") },
                 register = { calls.add("register") },
             )
 
         assertTrue(result.isSuccess)
-        assertEquals(listOf("unregister", "dispose", "register"), calls)
-    }
-
-    @Test
-    fun `a dispose that throws does not stop the re-register`() {
-        val calls = mutableListOf<String>()
-
-        val result =
-            reregisterInPlace(
-                unregisterAll = { calls.add("unregister") },
-                dispose = { throw IllegalStateException("plugin dispose blew up") },
-                register = { calls.add("register") },
-            )
-
-        assertTrue(result.isSuccess, "stopping here would leave the plugin unregistered")
+        // Exactly what disablePlugin/enablePlugin do between them. dispose()
+        // has only ever preceded a classloader close, so a dispose() ->
+        // register() no plugin was written against would relocate this PR's own
+        // bug into them: one that cancels a scope it owns as a field comes back
+        // attaching every launch to a cancelled scope, silently.
         assertEquals(listOf("unregister", "register"), calls)
     }
 
@@ -109,7 +98,6 @@ class ReregisterAfterRestartTest {
         val result =
             reregisterInPlace(
                 unregisterAll = { calls.add("unregister") },
-                dispose = {},
                 register = {
                     calls.add("register")
                     error("register blew up")
@@ -134,8 +122,7 @@ class ReregisterAfterRestartTest {
                     unregisterCalls++
                     if (unregisterCalls == 2) error("teardown blew up too")
                 },
-                dispose = {},
-                register = { throw IllegalStateException("the real problem") },
+                register = { error("the real problem") },
             )
 
         assertTrue(result.isFailure)

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandbox.kt
@@ -146,4 +146,14 @@ data class SandboxConfig(
      * is cleared. At the default interval this is a minute of good behaviour.
      */
     val healthyChecksToClearRestarts: Int = 12,
+    /**
+     * Ticks in a row that may skip the health check, before one runs anyway.
+     *
+     * Counted in ticks, so its wall-clock meaning is entirely
+     * [heartbeatIntervalMs] - which is why it belongs here rather than in a
+     * constant. A plugin declaring a 500ms interval would get a 3 second
+     * ceiling on suppression from a hardcoded 6; one declaring 60s would get
+     * six minutes of a watchdog that is not watching.
+     */
+    val maxSkippedChecks: Int = 6,
 )

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandbox.kt
@@ -66,6 +66,18 @@ interface PluginSandbox : PluginSandboxRef {
      * Does NOT count as a crash or restart attempt.
      */
     fun resetHealth()
+
+    /**
+     * Clear the restart counter after the plugin has proven itself healthy
+     * again for a sustained period.
+     *
+     * This is deliberately separate from "the restart call returned": a
+     * restart that merely completes says nothing about whether the plugin
+     * recovered, and zeroing the counter there makes [SandboxConfig.maxRestartAttempts]
+     * unreachable. The watchdog calls this only after
+     * [SandboxConfig.healthyChecksToClearRestarts] consecutive healthy checks.
+     */
+    fun resetRestartAttempts()
 }
 
 /**
@@ -112,4 +124,20 @@ data class SandboxConfig(
      * Maximum delay in milliseconds for restart backoff.
      */
     val restartBackoffMaxMs: Long = 30000,
+    /**
+     * How far the watchdog's own check loop may overrun [heartbeatIntervalMs]
+     * before that tick is discarded as evidence about plugin health.
+     *
+     * Heartbeat age is wall-clock, so anything that freezes the whole process
+     * - the machine sleeping, a long GC pause, a debugger breakpoint - ages
+     * every plugin's heartbeat at once while the plugins themselves are doing
+     * nothing wrong. The watchdog's loop is frozen by the same thing, and that
+     * overrun is the signal used to tell the two apart.
+     */
+    val stallGraceMs: Long = 2000,
+    /**
+     * Consecutive healthy checks a plugin must pass before its restart counter
+     * is cleared. At the default interval this is a minute of good behaviour.
+     */
+    val healthyChecksToClearRestarts: Int = 12,
 )

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandbox.kt
@@ -64,6 +64,12 @@ interface PluginSandbox : PluginSandboxRef {
      * Reset health metrics after a user-initiated reset.
      * Clears consecutive errors and marks the sandbox as healthy again.
      * Does NOT count as a crash or restart attempt.
+     *
+     * This clears the restart budget too. It is the user saying "this
+     * recovered", and while `restartAttempts` was zeroed by every restart that
+     * was moot; now that the counter survives, a plugin sitting at two attempts
+     * whose user was told it had been reset would still be one hiccup from
+     * being disabled outright.
      */
     fun resetHealth()
 

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginHealthMetrics.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginHealthMetrics.kt
@@ -69,12 +69,28 @@ data class PluginHealthMetrics(
         )
 
     /**
-     * Creates updated metrics after a successful restart (resets restart attempts).
+     * Creates updated metrics after a restart completed.
+     *
+     * [restartAttempts] deliberately survives. A restart returning without
+     * throwing is not evidence that the plugin recovered - for the in-process
+     * sandbox it cannot throw at all - so zeroing the counter here made
+     * `maxRestartAttempts` unreachable and let a plugin restart-loop forever,
+     * every attempt logged as "attempt 1". The counter is cleared by
+     * [withRestartAttemptsCleared] once the watchdog has actually observed the
+     * plugin stay healthy.
      */
     fun withSuccessfulRestart(): PluginHealthMetrics =
         copy(
             consecutiveErrors = 0,
-            restartAttempts = 0,
             lastHeartbeat = System.currentTimeMillis(),
+        )
+
+    /**
+     * Creates updated metrics after the plugin has proven healthy for a
+     * sustained run, forgiving its earlier restarts.
+     */
+    fun withRestartAttemptsCleared(): PluginHealthMetrics =
+        copy(
+            restartAttempts = 0,
         )
 }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -214,6 +214,9 @@ class InProcessPluginSandbox(
      */
     private fun ensureRunnable() {
         synchronized(restartLock) {
+            // isShutdown is only ever produced by stop(); restart() replaces
+            // the reference before retiring the old pool, so a live sandbox
+            // never observes its own executor shut down.
             if (executor.isShutdown) {
                 executor = newExecutor()
                 dispatcher.swap(executor.asCoroutineDispatcher())
@@ -328,13 +331,25 @@ class InProcessPluginSandbox(
             heartbeatJob?.cancel()
             heartbeatJob = null
 
-            // Cancel everything the plugin has in flight. The scope object
-            // stays, inert, so a later start() can re-arm it in place rather
-            // than handing the plugin a scope it will never read again.
-            _sandboxScope.cancelJob()
+            // Under the same lock restart() and ensureRunnable() use. Without
+            // it, a stop() racing a start() could cancel the job and kill the
+            // pool *after* ensureRunnable had inspected both and decided
+            // nothing needed re-arming, leaving the sandbox reporting RUNNING
+            // over a cancelled scope and a dead executor - the silent-inert
+            // state this class exists to prevent. A stop() racing a restart()
+            // could equally cancel the job restart() had just installed, or
+            // retire a pool it no longer owns.
+            val retiring: ExecutorService
+            synchronized(restartLock) {
+                // Cancel everything the plugin has in flight. The scope object
+                // stays, inert, so a later start() can re-arm it in place rather
+                // than handing the plugin a scope it will never read again.
+                _sandboxScope.cancelJob()
+                retiring = executor
+            }
 
-            // Shutdown the executor and wait for termination
-            shutdownExecutor(executor)
+            // Outside the lock, as restart() does: this blocks for seconds.
+            shutdownExecutor(retiring)
         }
     }
 

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -234,6 +234,7 @@ class InProcessPluginSandbox(
      */
     private suspend fun shutdownExecutor(target: ExecutorService) {
         withContext(Dispatchers.IO) {
+            // Idempotent; stop() has already called it under the lock.
             target.shutdown()
             try {
                 if (!target.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
@@ -346,9 +347,17 @@ class InProcessPluginSandbox(
                 // than handing the plugin a scope it will never read again.
                 _sandboxScope.cancelJob()
                 retiring = executor
+                // shutdown() itself does not block - only awaitTermination
+                // does - so marking the pool dead happens under the lock. Doing
+                // it outside left a window where a concurrent start() ran
+                // ensureRunnable, saw isShutdown still false, kept the pool and
+                // re-armed the job onto it, and only then did this shut it
+                // down: RUNNING state, live scope, dead executor, every
+                // dispatch silently cancelled.
+                retiring.shutdown()
             }
 
-            // Outside the lock, as restart() does: this blocks for seconds.
+            // Outside the lock, as restart() does: awaiting termination blocks.
             shutdownExecutor(retiring)
         }
     }
@@ -386,6 +395,9 @@ class InProcessPluginSandbox(
                 retiredExecutor = executor
                 executor = newExecutor()
                 dispatcher.swap(executor.asCoroutineDispatcher())
+                // Under the lock, so a concurrent stop() cannot capture the
+                // pool this restart just installed and retire it instead.
+                retiredExecutor.shutdown()
             }
 
             // Retire the old pool outside the lock: awaitTermination blocks for

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -37,7 +37,8 @@ import kotlin.coroutines.CoroutineContext
  */
 class InProcessPluginSandbox(
     override val pluginId: String,
-    private val config: SandboxConfig = SandboxConfig(),
+    /** Readable by the manager, which enforces this plugin's restart budget. */
+    internal val config: SandboxConfig = SandboxConfig(),
 ) : PluginSandbox {
     private val logger = BossLogger.forComponent("InProcessPluginSandbox")
 
@@ -466,17 +467,29 @@ class InProcessPluginSandbox(
             ),
         )
         _healthMetrics.update {
-            it.copy(
-                consecutiveErrors = 0,
-                restartAttempts = 0,
-                lastHeartbeat = System.currentTimeMillis(),
-            )
+            // Composed, so "clear the counter" has one definition shared
+            // with resetRestartAttempts rather than two to keep in sync.
+            it
+                .withRestartAttemptsCleared()
+                .copy(
+                    consecutiveErrors = 0,
+                    lastHeartbeat = System.currentTimeMillis(),
+                )
         }
         // If sandbox was unhealthy, mark it as running again
         if (_state.value == SandboxState.UNHEALTHY) {
             _state.value = SandboxState.RUNNING
         }
     }
+
+    /**
+     * Whether the plugin's thread pool actually went away.
+     *
+     * Exposed for the teardown test: the pool is non-daemon and fixed-size, so
+     * a stop that silently skipped its shutdown strands two threads for the
+     * life of the process with nothing else to observe it by.
+     */
+    internal fun isExecutorTerminated(): Boolean = executor.isTerminated
 
     override fun resetRestartAttempts() {
         _healthMetrics.update { it.withRestartAttemptsCleared() }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -4,12 +4,13 @@ import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
 import ai.rever.boss.plugin.sandbox.health.PluginHealthMetrics
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,9 +18,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
 
 /**
  * In-process sandbox implementation for UI plugins.
@@ -43,15 +46,15 @@ class InProcessPluginSandbox(
     private val _healthMetrics = MutableStateFlow(PluginHealthMetrics.initial())
     override val healthMetrics: StateFlow<PluginHealthMetrics> = _healthMetrics.asStateFlow()
 
-    // Thread pool and coroutine scope - @Volatile for visibility across threads during restart
+    // Thread pool - @Volatile for visibility across threads during restart
     @Volatile
-    private var executor =
-        Executors.newFixedThreadPool(config.maxThreads) { runnable ->
-            Thread(runnable, "plugin-sandbox-$pluginId-${System.currentTimeMillis()}")
-        }
+    private var executor: ExecutorService = newExecutor()
 
-    @Volatile
-    private var dispatcher = executor.asCoroutineDispatcher()
+    /**
+     * Dispatcher indirection, so the backing thread pool can be replaced on
+     * restart without replacing the dispatcher the plugin scope was built from.
+     */
+    private val dispatcher = SwappableDispatcher(executor.asCoroutineDispatcher())
 
     private val exceptionHandler =
         CoroutineExceptionHandler { _, throwable ->
@@ -71,29 +74,131 @@ class InProcessPluginSandbox(
             recordError(throwable)
         }
 
-    @Volatile
-    private var _sandboxScope: CoroutineScope = createScope()
+    private val _sandboxScope = SandboxScope()
 
     /**
      * The coroutine scope for plugin operations.
      *
-     * **Thread Safety Note**: Access during [SandboxState.RESTARTING] may return a scope
-     * that is being cancelled. Callers should check [state] before launching long-running
-     * coroutines, or handle [CancellationException] gracefully.
+     * **This object is created once and never replaced.** Plugins read
+     * `PluginContext.pluginScope` in `register()` and hand it to components,
+     * view models and background jobs that outlive any single restart, so
+     * handing out a *new* scope on restart left every one of those holding a
+     * permanently cancelled one. `launch` on a cancelled scope neither runs nor
+     * throws, so the plugin went silently inert - a panel would sit on a
+     * spinner for ever with nothing in the logs - until the user reloaded it by
+     * hand. What a restart cancels now is the scope's children; the scope
+     * itself keeps working.
+     *
+     * **Thread Safety Note**: work launched during [SandboxState.RESTARTING]
+     * may be cancelled along with the rest of the pre-restart children.
+     * Callers should handle `CancellationException` gracefully.
      */
     override val sandboxScope: CoroutineScope
         get() = _sandboxScope
 
     private val isRunning = AtomicBoolean(false)
 
-    // Lock for synchronizing executor/scope recreation during restart
+    // Lock for synchronizing executor/job recreation during restart
     private val restartLock = Any()
 
     // Heartbeat job for automatic heartbeat recording
     @Volatile
     private var heartbeatJob: Job? = null
 
-    private fun createScope(): CoroutineScope = CoroutineScope(dispatcher + SupervisorJob() + exceptionHandler)
+    private fun newExecutor(): ExecutorService =
+        Executors.newFixedThreadPool(config.maxThreads) { runnable ->
+            Thread(runnable, "plugin-sandbox-$pluginId-${System.currentTimeMillis()}")
+        }
+
+    /**
+     * A dispatcher whose backing pool can be swapped underneath it.
+     *
+     * A dispatch that reads the delegate just before a swap can land on a pool
+     * that is shutting down; kotlinx's [CoroutineDispatcher] for an executor
+     * already handles that by cancelling the job and falling back, so the race
+     * needs no handling of its own here.
+     */
+    private class SwappableDispatcher(
+        initial: CoroutineDispatcher,
+    ) : CoroutineDispatcher() {
+        @Volatile
+        private var delegate: CoroutineDispatcher = initial
+
+        fun swap(next: CoroutineDispatcher) {
+            delegate = next
+        }
+
+        override fun dispatch(
+            context: CoroutineContext,
+            block: Runnable,
+        ) = delegate.dispatch(context, block)
+    }
+
+    /**
+     * The plugin-facing scope. Its identity is fixed for the life of the
+     * sandbox; only the [Job] underneath it is replaced, so cancelling
+     * everything a plugin has in flight does not cost it the ability to start
+     * anything new.
+     */
+    private inner class SandboxScope : CoroutineScope {
+        @Volatile
+        private var job: CompletableJob = SupervisorJob()
+
+        override val coroutineContext: CoroutineContext
+            get() = dispatcher + job + exceptionHandler
+
+        /** Cancel everything in flight and re-arm for new work. */
+        fun resetJob() {
+            job.cancel()
+            job = SupervisorJob()
+        }
+
+        /** Cancel everything in flight, leaving the scope inert until re-armed. */
+        fun cancelJob() {
+            job.cancel()
+        }
+
+        /** Re-arm after a [cancelJob], for a disable/enable cycle. */
+        fun ensureActive() {
+            if (!job.isActive) job = SupervisorJob()
+        }
+    }
+
+    /**
+     * Re-arm the pool and the scope's job if a previous [stop] retired them.
+     *
+     * Without this, disable-then-enable handed the plugin a scope whose job was
+     * cancelled and whose executor was shut down, and the sandbox only ever
+     * recovered by way of a watchdog restart.
+     */
+    private fun ensureRunnable() {
+        synchronized(restartLock) {
+            if (executor.isShutdown) {
+                executor = newExecutor()
+                dispatcher.swap(executor.asCoroutineDispatcher())
+            }
+            _sandboxScope.ensureActive()
+        }
+    }
+
+    private fun shutdownExecutor(target: ExecutorService) {
+        target.shutdown()
+        try {
+            if (!target.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Executor didn't terminate gracefully, forcing shutdown",
+                    mapOf(
+                        "pluginId" to pluginId,
+                    ),
+                )
+                target.shutdownNow()
+            }
+        } catch (e: InterruptedException) {
+            target.shutdownNow()
+            Thread.currentThread().interrupt()
+        }
+    }
 
     override suspend fun start(): Result<Unit> {
         return runCatching {
@@ -116,6 +221,10 @@ class InProcessPluginSandbox(
                     "maxThreads" to config.maxThreads,
                 ),
             )
+
+            // A prior stop() retired the pool and the scope's job; bring both
+            // back before anything is launched into them.
+            ensureRunnable()
 
             _state.value = SandboxState.RUNNING
             _healthMetrics.value = PluginHealthMetrics.initial()
@@ -169,26 +278,13 @@ class InProcessPluginSandbox(
             heartbeatJob?.cancel()
             heartbeatJob = null
 
-            // Cancel the coroutine scope
-            _sandboxScope.cancel()
+            // Cancel everything the plugin has in flight. The scope object
+            // stays, inert, so a later start() can re-arm it in place rather
+            // than handing the plugin a scope it will never read again.
+            _sandboxScope.cancelJob()
 
             // Shutdown the executor and wait for termination
-            executor.shutdown()
-            try {
-                if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
-                    logger.warn(
-                        LogCategory.SYSTEM,
-                        "Executor didn't terminate gracefully, forcing shutdown",
-                        mapOf(
-                            "pluginId" to pluginId,
-                        ),
-                    )
-                    executor.shutdownNow()
-                }
-            } catch (e: InterruptedException) {
-                executor.shutdownNow()
-                Thread.currentThread().interrupt()
-            }
+            shutdownExecutor(executor)
         }
     }
 
@@ -212,30 +308,24 @@ class InProcessPluginSandbox(
             heartbeatJob?.cancel()
             heartbeatJob = null
 
-            // Synchronize executor/scope swap to prevent other threads from accessing stale references
+            // Synchronize executor/job swap to prevent other threads from accessing stale references
+            val retiredExecutor: ExecutorService
             synchronized(restartLock) {
-                // Cancel existing scope
-                _sandboxScope.cancel()
+                // Cancel the plugin's in-flight coroutines and re-arm the scope
+                // for new work. The scope object itself is deliberately kept -
+                // see the note on [sandboxScope].
+                _sandboxScope.resetJob()
 
-                // Shutdown old executor and wait for termination (consistent with stop())
-                executor.shutdown()
-                try {
-                    if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
-                        executor.shutdownNow()
-                    }
-                } catch (e: InterruptedException) {
-                    executor.shutdownNow()
-                    Thread.currentThread().interrupt()
-                }
-
-                // Create new executor and scope atomically
-                executor =
-                    Executors.newFixedThreadPool(config.maxThreads) { runnable ->
-                        Thread(runnable, "plugin-sandbox-$pluginId-${System.currentTimeMillis()}")
-                    }
-                dispatcher = executor.asCoroutineDispatcher()
-                _sandboxScope = createScope()
+                // Put the fresh pool in place before retiring the old one, so
+                // nothing dispatched during the swap meets a dead executor.
+                retiredExecutor = executor
+                executor = newExecutor()
+                dispatcher.swap(executor.asCoroutineDispatcher())
             }
+
+            // Retire the old pool outside the lock: awaitTermination blocks for
+            // seconds and would hold every other caller of restartLock behind it.
+            shutdownExecutor(retiredExecutor)
 
             // Mark as running with successful restart metrics
             _healthMetrics.update { it.withSuccessfulRestart() }
@@ -338,6 +428,10 @@ class InProcessPluginSandbox(
         }
     }
 
+    override fun resetRestartAttempts() {
+        _healthMetrics.update { it.withRestartAttemptsCleared() }
+    }
+
     /**
      * Mark the sandbox as disabled.
      * This is called by the PluginSandboxManager when a plugin is disabled.
@@ -368,5 +462,9 @@ class InProcessPluginSandbox(
             ),
         )
         _state.value = newState
+    }
+
+    private companion object {
+        const val EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 2L
     }
 }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -114,9 +116,18 @@ class InProcessPluginSandbox(
      * A dispatcher whose backing pool can be swapped underneath it.
      *
      * A dispatch that reads the delegate just before a swap can land on a pool
-     * that is shutting down; kotlinx's [CoroutineDispatcher] for an executor
-     * already handles that by cancelling the job and falling back, so the race
-     * needs no handling of its own here.
+     * that is shutting down. kotlinx's executor dispatcher already handles that
+     * - it cancels the job and re-dispatches - so the race needs no handling of
+     * its own here. Worth knowing what it re-dispatches *to*, though: kotlinx's
+     * own shared executor, so for that one block the thread isolation this
+     * sandbox exists to provide is not in force. The window predates this class
+     * and is not widened by it.
+     *
+     * [Delay] is deliberately not forwarded. The pools here are plain fixed
+     * thread pools, never scheduled ones, so the wrapped dispatcher had no
+     * `Delay` to offer either and `delay()` inside plugin coroutines has always
+     * used kotlinx's default. Swapping in a scheduled pool later would need
+     * this revisited.
      */
     private class SwappableDispatcher(
         initial: CoroutineDispatcher,
@@ -144,13 +155,30 @@ class InProcessPluginSandbox(
         @Volatile
         private var job: CompletableJob = SupervisorJob()
 
+        /**
+         * Composed once per job generation rather than per read.
+         *
+         * Two reasons. Plugins launch a great deal of work on this scope and
+         * every `launch` reads this, so rebuilding the context each time is
+         * pure waste. More importantly a single volatile read cannot tear:
+         * composing `dispatcher + job + exceptionHandler` on the fly let a
+         * `launch` racing [resetJob] pick up the job that was about to be
+         * cancelled, and a coroutine attached to an already-cancelled job does
+         * not run and does not throw - the exact failure this class is being
+         * changed to stop. It cannot be eliminated (a caller can always read
+         * microseconds before the swap) but it is bounded to one restart rather
+         * than composed of two different generations.
+         */
+        @Volatile
+        private var context: CoroutineContext = dispatcher + job + exceptionHandler
+
         override val coroutineContext: CoroutineContext
-            get() = dispatcher + job + exceptionHandler
+            get() = context
 
         /** Cancel everything in flight and re-arm for new work. */
         fun resetJob() {
             job.cancel()
-            job = SupervisorJob()
+            install(SupervisorJob())
         }
 
         /** Cancel everything in flight, leaving the scope inert until re-armed. */
@@ -158,9 +186,21 @@ class InProcessPluginSandbox(
             job.cancel()
         }
 
-        /** Re-arm after a [cancelJob], for a disable/enable cycle. */
-        fun ensureActive() {
-            if (!job.isActive) job = SupervisorJob()
+        /**
+         * Re-arm after a [cancelJob], for a disable/enable cycle.
+         *
+         * Deliberately NOT called `ensureActive`: `CoroutineScope.ensureActive()`
+         * is a kotlinx extension that *throws* when the job is cancelled, a
+         * member of that name would win over it inside this class, and the two
+         * meanings are opposites.
+         */
+        fun rearmIfCancelled() {
+            if (!job.isActive) install(SupervisorJob())
+        }
+
+        private fun install(fresh: CompletableJob) {
+            job = fresh
+            context = dispatcher + fresh + exceptionHandler
         }
     }
 
@@ -177,26 +217,35 @@ class InProcessPluginSandbox(
                 executor = newExecutor()
                 dispatcher.swap(executor.asCoroutineDispatcher())
             }
-            _sandboxScope.ensureActive()
+            _sandboxScope.rearmIfCancelled()
         }
     }
 
-    private fun shutdownExecutor(target: ExecutorService) {
-        target.shutdown()
-        try {
-            if (!target.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "Executor didn't terminate gracefully, forcing shutdown",
-                    mapOf(
-                        "pluginId" to pluginId,
-                    ),
-                )
+    /**
+     * Retire a pool, off whatever coroutine worker asked for it.
+     *
+     * [ExecutorService.awaitTermination] blocks for up to two seconds and both
+     * callers are suspend functions reached from Dispatchers.Default, whose
+     * workers are a small shared pool.
+     */
+    private suspend fun shutdownExecutor(target: ExecutorService) {
+        withContext(Dispatchers.IO) {
+            target.shutdown()
+            try {
+                if (!target.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Executor didn't terminate gracefully, forcing shutdown",
+                        mapOf(
+                            "pluginId" to pluginId,
+                        ),
+                    )
+                    target.shutdownNow()
+                }
+            } catch (e: InterruptedException) {
                 target.shutdownNow()
+                Thread.currentThread().interrupt()
             }
-        } catch (e: InterruptedException) {
-            target.shutdownNow()
-            Thread.currentThread().interrupt()
         }
     }
 
@@ -419,6 +468,7 @@ class InProcessPluginSandbox(
         _healthMetrics.update {
             it.copy(
                 consecutiveErrors = 0,
+                restartAttempts = 0,
                 lastHeartbeat = System.currentTimeMillis(),
             )
         }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandbox.kt
@@ -362,64 +362,121 @@ class InProcessPluginSandbox(
         }
     }
 
-    override suspend fun restart(): Result<Unit> =
-        runCatching {
-            logger.info(
-                LogCategory.SYSTEM,
-                "Restarting plugin sandbox",
-                mapOf(
-                    "pluginId" to pluginId,
-                    "restartAttempt" to (_healthMetrics.value.restartAttempts + 1),
-                ),
-            )
+    /**
+     * Restart the sandbox: cancel everything the plugin has in flight, give it
+     * a fresh thread pool, and re-arm the scope it captured at register() time.
+     *
+     * Split in two on purpose. Everything that moves the sandbox out of
+     * [SandboxState.RESTARTING] happens in [swapInFreshRuntime], which does not
+     * suspend; only retiring the *old* pool does, and by then the sandbox is
+     * already RUNNING on the new one.
+     *
+     * The order used to be the other way round, and it left a hole: retiring
+     * the old pool suspends in `withContext(Dispatchers.IO)`, so cancelling
+     * there stopped the coroutine before it ever set RUNNING or re-armed the
+     * heartbeat. The sandbox stayed in RESTARTING, which [PluginWatchdog]
+     * skips outright - so nothing restarted it, nothing marked it unhealthy,
+     * and `PluginErrorBoundary` showed no fallback because the state was not
+     * DISABLED. The plugin was invisible to every recovery path there is.
+     *
+     * Reachable, too: both error-boundary Restart buttons run on a Compose
+     * `rememberCoroutineScope`, so closing the tab or switching side panels
+     * during the up-to-two-second `awaitTermination` cancelled exactly here.
+     */
+    override suspend fun restart(): Result<Unit> {
+        logger.info(
+            LogCategory.SYSTEM,
+            "Restarting plugin sandbox",
+            mapOf(
+                "pluginId" to pluginId,
+                "restartAttempt" to (_healthMetrics.value.restartAttempts + 1),
+            ),
+        )
 
-            _state.value = SandboxState.RESTARTING
+        val retiredExecutor =
+            runCatching { swapInFreshRuntime() }
+                .getOrElse { error ->
+                    // Only reachable if the fresh pool cannot be created at all.
+                    // UNHEALTHY rather than RESTARTING because the watchdog
+                    // still looks at UNHEALTHY, so a sandbox this failed on can
+                    // still be seen and retried.
+                    _state.value = SandboxState.UNHEALTHY
+                    logger.error(
+                        LogCategory.SYSTEM,
+                        "Failed to restart plugin sandbox",
+                        mapOf(
+                            "pluginId" to pluginId,
+                        ),
+                        error,
+                    )
+                    return Result.failure(error)
+                }
 
-            // Record the crash
-            _healthMetrics.update { it.withCrash() }
+        logger.info(
+            LogCategory.SYSTEM,
+            "Plugin sandbox restarted successfully",
+            mapOf(
+                "pluginId" to pluginId,
+            ),
+        )
 
-            // Cancel heartbeat job
-            heartbeatJob?.cancel()
-            heartbeatJob = null
+        // Cleanup of the pool the plugin no longer runs on. It has already had
+        // shutdown() called under the lock, so it drains either way; this only
+        // waits for it and force-kills a pool that will not go. Cancellation
+        // here is allowed to propagate - the sandbox is already running, and
+        // swallowing a CancellationException into Result.failure would report a
+        // restart that did happen as one that did not.
+        shutdownExecutor(retiredExecutor)
+        return Result.success(Unit)
+    }
 
-            // Synchronize executor/job swap to prevent other threads from accessing stale references
-            val retiredExecutor: ExecutorService
-            synchronized(restartLock) {
-                // Cancel the plugin's in-flight coroutines and re-arm the scope
-                // for new work. The scope object itself is deliberately kept -
-                // see the note on [sandboxScope].
-                _sandboxScope.resetJob()
+    /**
+     * Swap in a fresh pool and bring the sandbox back to [SandboxState.RUNNING].
+     *
+     * Every statement here is non-suspending, which is the point: the sandbox
+     * passes through RESTARTING - a state the watchdog ignores - and must not
+     * be able to stop inside it.
+     *
+     * @return the retired pool, for the caller to wait on.
+     */
+    private fun swapInFreshRuntime(): ExecutorService {
+        _state.value = SandboxState.RESTARTING
 
-                // Put the fresh pool in place before retiring the old one, so
-                // nothing dispatched during the swap meets a dead executor.
-                retiredExecutor = executor
-                executor = newExecutor()
-                dispatcher.swap(executor.asCoroutineDispatcher())
-                // Under the lock, so a concurrent stop() cannot capture the
-                // pool this restart just installed and retire it instead.
-                retiredExecutor.shutdown()
-            }
+        // Record the crash
+        _healthMetrics.update { it.withCrash() }
 
-            // Retire the old pool outside the lock: awaitTermination blocks for
-            // seconds and would hold every other caller of restartLock behind it.
-            shutdownExecutor(retiredExecutor)
+        // Cancel heartbeat job
+        heartbeatJob?.cancel()
+        heartbeatJob = null
 
-            // Mark as running with successful restart metrics
-            _healthMetrics.update { it.withSuccessfulRestart() }
-            _state.value = SandboxState.RUNNING
-            isRunning.set(true)
+        // Synchronize executor/job swap to prevent other threads from accessing stale references
+        val retiredExecutor: ExecutorService
+        synchronized(restartLock) {
+            // Cancel the plugin's in-flight coroutines and re-arm the scope
+            // for new work. The scope object itself is deliberately kept -
+            // see the note on [sandboxScope].
+            _sandboxScope.resetJob()
 
-            // Start automatic heartbeat recording
-            startHeartbeatJob()
-
-            logger.info(
-                LogCategory.SYSTEM,
-                "Plugin sandbox restarted successfully",
-                mapOf(
-                    "pluginId" to pluginId,
-                ),
-            )
+            // Put the fresh pool in place before retiring the old one, so
+            // nothing dispatched during the swap meets a dead executor.
+            retiredExecutor = executor
+            executor = newExecutor()
+            dispatcher.swap(executor.asCoroutineDispatcher())
+            // Under the lock, so a concurrent stop() cannot capture the
+            // pool this restart just installed and retire it instead.
+            retiredExecutor.shutdown()
         }
+
+        // Mark as running with successful restart metrics
+        _healthMetrics.update { it.withSuccessfulRestart() }
+        _state.value = SandboxState.RUNNING
+        isRunning.set(true)
+
+        // Start automatic heartbeat recording
+        startHeartbeatJob()
+
+        return retiredExecutor
+    }
 
     override fun recordHeartbeat() {
         _healthMetrics.update { it.withHeartbeat() }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/OutOfProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/OutOfProcessPluginSandbox.kt
@@ -127,11 +127,14 @@ class OutOfProcessPluginSandbox(
     override fun resetHealth() {
         logger.info(LogCategory.SYSTEM, "Resetting out-of-process sandbox health", mapOf("pluginId" to pluginId))
         _healthMetrics.update {
-            it.copy(
-                consecutiveErrors = 0,
-                restartAttempts = 0,
-                lastHeartbeat = System.currentTimeMillis(),
-            )
+            // Composed, so "clear the counter" has one definition shared
+            // with resetRestartAttempts rather than two to keep in sync.
+            it
+                .withRestartAttemptsCleared()
+                .copy(
+                    consecutiveErrors = 0,
+                    lastHeartbeat = System.currentTimeMillis(),
+                )
         }
         if (_state.value == SandboxState.UNHEALTHY) {
             _state.value = SandboxState.RUNNING

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/OutOfProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/OutOfProcessPluginSandbox.kt
@@ -129,6 +129,7 @@ class OutOfProcessPluginSandbox(
         _healthMetrics.update {
             it.copy(
                 consecutiveErrors = 0,
+                restartAttempts = 0,
                 lastHeartbeat = System.currentTimeMillis(),
             )
         }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/OutOfProcessPluginSandbox.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/OutOfProcessPluginSandbox.kt
@@ -136,4 +136,8 @@ class OutOfProcessPluginSandbox(
             _state.value = SandboxState.RUNNING
         }
     }
+
+    override fun resetRestartAttempts() {
+        _healthMetrics.update { it.withRestartAttemptsCleared() }
+    }
 }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -236,12 +236,40 @@ class PluginSandboxManagerImpl(
 
     /**
      * Notify all active listeners and clean up dead references.
+     *
+     * A listener that throws is contained, matching the equivalent helper in
+     * `DynamicPluginManager`. The asymmetry mattered once `onPluginRestarted`
+     * started doing real work: it is dispatched from `restartPlugin`, which on
+     * the automatic path runs inside the watchdog's own coroutine
+     * (checkHealth -> triggerRestart -> onRestartRequested -> handleRestartRequest).
+     * An exception escaping a listener escapes `PluginWatchdog`'s
+     * `while (isActive)` loop and completes that job exceptionally, and
+     * `managerScope` carries a SupervisorJob with no CoroutineExceptionHandler -
+     * so the plugin would be left with no health monitoring at all for the rest
+     * of the session, with a default-handler stack trace as the only trace.
+     *
+     * Throwable rather than Exception: this calls out to listeners that reach
+     * plugin code and Compose dispatchers, where an Error is as plausible as an
+     * exception and just as fatal to the loop.
      */
+    @Suppress("TooGenericExceptionCaught")
     private fun notifyListeners(action: (PluginSandboxListener) -> Unit) {
         listeners.removeIf { ref ->
             val listener = ref.get()
             if (listener != null) {
-                action(listener)
+                try {
+                    action(listener)
+                } catch (e: Throwable) {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Plugin sandbox listener threw, continuing",
+                        mapOf(
+                            "listener" to (listener::class.simpleName ?: "unknown"),
+                            "error" to (e.message ?: e::class.simpleName ?: "unknown"),
+                        ),
+                        e,
+                    )
+                }
                 false // Keep reference
             } else {
                 true // Remove dead reference

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -185,6 +185,16 @@ class PluginSandboxManagerImpl(
     private val sandboxes = ConcurrentHashMap<String, InProcessPluginSandbox>()
     private val watchdogs = ConcurrentHashMap<String, PluginWatchdog>()
 
+    // The config each sandbox was created with. Plugins can declare their own
+    // sandbox settings in the manifest, so the restart budget and backoff below
+    // have to be read per plugin: they used to be enforced by the watchdog,
+    // which is built with the plugin's own config, and reading defaultConfig
+    // here would quietly apply the wrong thresholds to any plugin that asked
+    // for something else.
+    private val sandboxConfigs = ConcurrentHashMap<String, SandboxConfig>()
+
+    private fun configFor(pluginId: String): SandboxConfig = sandboxConfigs[pluginId] ?: defaultConfig
+
     // Weak references to prevent memory leaks from listeners that aren't removed
     private val listeners = CopyOnWriteArrayList<WeakReference<PluginSandboxListener>>()
 
@@ -261,6 +271,7 @@ class PluginSandboxManagerImpl(
 
         val sandbox = InProcessPluginSandbox(pluginId, config)
         sandboxes[pluginId] = sandbox
+        sandboxConfigs[pluginId] = config
         healthMonitor.registerSandbox(sandbox)
 
         // Create and start watchdog
@@ -295,6 +306,7 @@ class PluginSandboxManagerImpl(
         // Stop and remove sandbox
         sandboxes[pluginId]?.stop()
         sandboxes.remove(pluginId)
+        sandboxConfigs.remove(pluginId)
 
         // Unregister from health monitor
         healthMonitor.unregisterSandbox(pluginId)
@@ -333,6 +345,7 @@ class PluginSandboxManagerImpl(
             // 3. Stop sandbox
             sandboxes[pluginId]?.stop()
             sandboxes.remove(pluginId)
+            sandboxConfigs.remove(pluginId)
 
             // 4. Remove from disabled set if present
             disabledPlugins.remove(pluginId)
@@ -434,7 +447,7 @@ class PluginSandboxManagerImpl(
                 val watchdog =
                     PluginWatchdog(
                         sandbox = sandbox,
-                        config = defaultConfig,
+                        config = configFor(pluginId),
                         scope = managerScope,
                         onRestartRequested = { id -> handleRestartRequest(id) },
                     )
@@ -453,9 +466,17 @@ class PluginSandboxManagerImpl(
     private suspend fun handleRestartRequest(pluginId: String) {
         val sandbox = sandboxes[pluginId] ?: return
         val metrics = sandbox.healthMetrics.value
+        val config = configFor(pluginId)
 
-        // Check if we've exceeded max restarts
-        if (metrics.restartAttempts >= defaultConfig.maxRestartAttempts) {
+        // Check if we've exceeded max restarts.
+        //
+        // This is the ONLY place the restart budget is enforced. PluginWatchdog
+        // used to hold a copy that ran first and so shadowed this one; it
+        // stopped the sandbox without calling setDisabled(), which meant no
+        // fallback UI, no notification and isPluginDisabled() still false. The
+        // branch was unreachable while every restart zeroed restartAttempts,
+        // and became reachable when the counter started surviving.
+        if (metrics.restartAttempts >= config.maxRestartAttempts) {
             logger.error(
                 LogCategory.SYSTEM,
                 "Plugin exceeded max restart attempts, disabling",
@@ -474,7 +495,7 @@ class PluginSandboxManagerImpl(
         }
 
         // Calculate backoff delay
-        val backoffDelay = calculateBackoff(metrics.restartAttempts)
+        val backoffDelay = calculateBackoff(metrics.restartAttempts, config)
         logger.info(
             LogCategory.SYSTEM,
             "Scheduling plugin restart with backoff",
@@ -488,13 +509,16 @@ class PluginSandboxManagerImpl(
         restartPlugin(pluginId)
     }
 
-    private fun calculateBackoff(attempt: Int): Long {
+    private fun calculateBackoff(
+        attempt: Int,
+        config: SandboxConfig,
+    ): Long {
         // Exponential backoff: baseMs * 2^attempt (e.g., 1s, 2s, 4s, 8s... max 30s)
         // Uses bit shift (1L shl n) as efficient equivalent of 2^n
         // coerceIn handles both negative values and overflow prevention
         val safeAttempt = attempt.coerceIn(0, 30)
-        val delay = defaultConfig.restartBackoffBaseMs * (1L shl safeAttempt)
-        return minOf(delay, defaultConfig.restartBackoffMaxMs)
+        val delay = config.restartBackoffBaseMs * (1L shl safeAttempt)
+        return minOf(delay, config.restartBackoffMaxMs)
     }
 
     override fun getAllSandboxes(): Map<String, PluginSandbox> = sandboxes.toMap()
@@ -512,6 +536,7 @@ class PluginSandboxManagerImpl(
         // Stop all sandboxes
         sandboxes.values.forEach { it.stop() }
         sandboxes.clear()
+        sandboxConfigs.clear()
 
         // Brief delay to allow pending coroutines to complete before scope cancellation
         kotlinx.coroutines.delay(100)

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -185,15 +185,18 @@ class PluginSandboxManagerImpl(
     private val sandboxes = ConcurrentHashMap<String, InProcessPluginSandbox>()
     private val watchdogs = ConcurrentHashMap<String, PluginWatchdog>()
 
-    // The config each sandbox was created with. Plugins can declare their own
-    // sandbox settings in the manifest, so the restart budget and backoff below
-    // have to be read per plugin: they used to be enforced by the watchdog,
-    // which is built with the plugin's own config, and reading defaultConfig
-    // here would quietly apply the wrong thresholds to any plugin that asked
-    // for something else.
-    private val sandboxConfigs = ConcurrentHashMap<String, SandboxConfig>()
-
-    private fun configFor(pluginId: String): SandboxConfig = sandboxConfigs[pluginId] ?: defaultConfig
+    /**
+     * The config a plugin's sandbox was actually created with.
+     *
+     * Plugins can declare their own sandbox settings, so the restart budget and
+     * backoff have to be read per plugin. They used to be enforced by the
+     * watchdog, which is constructed with the plugin's own config; now that the
+     * decision lives here, reading [defaultConfig] would quietly apply the
+     * wrong thresholds to any plugin that asked for something else. Read off
+     * the sandbox rather than a parallel map, so there is nothing to keep in
+     * sync.
+     */
+    private fun configFor(pluginId: String): SandboxConfig = sandboxes[pluginId]?.config ?: defaultConfig
 
     // Weak references to prevent memory leaks from listeners that aren't removed
     private val listeners = CopyOnWriteArrayList<WeakReference<PluginSandboxListener>>()
@@ -271,7 +274,6 @@ class PluginSandboxManagerImpl(
 
         val sandbox = InProcessPluginSandbox(pluginId, config)
         sandboxes[pluginId] = sandbox
-        sandboxConfigs[pluginId] = config
         healthMonitor.registerSandbox(sandbox)
 
         // Create and start watchdog
@@ -306,7 +308,6 @@ class PluginSandboxManagerImpl(
         // Stop and remove sandbox
         sandboxes[pluginId]?.stop()
         sandboxes.remove(pluginId)
-        sandboxConfigs.remove(pluginId)
 
         // Unregister from health monitor
         healthMonitor.unregisterSandbox(pluginId)
@@ -345,7 +346,6 @@ class PluginSandboxManagerImpl(
             // 3. Stop sandbox
             sandboxes[pluginId]?.stop()
             sandboxes.remove(pluginId)
-            sandboxConfigs.remove(pluginId)
 
             // 4. Remove from disabled set if present
             disabledPlugins.remove(pluginId)
@@ -463,7 +463,12 @@ class PluginSandboxManagerImpl(
 
     override fun getDisabledPlugins(): Set<String> = disabledPlugins.toSet()
 
-    private suspend fun handleRestartRequest(pluginId: String) {
+    /**
+     * What the watchdog asks for when a plugin looks dead. Internal rather than
+     * private so the budget-exhaustion branch - the one path that disables a
+     * plugin outright - is reachable from a test.
+     */
+    internal suspend fun handleRestartRequest(pluginId: String) {
         val sandbox = sandboxes[pluginId] ?: return
         val metrics = sandbox.healthMetrics.value
         val config = configFor(pluginId)
@@ -485,12 +490,22 @@ class PluginSandboxManagerImpl(
                     "attempts" to metrics.restartAttempts,
                 ),
             )
-            // Stop watchdog to prevent further restart attempts
-            watchdogs[pluginId]?.stop()
+            // Order matters, and it is the opposite of what reads naturally.
+            // This runs inside the watchdog's own coroutine (checkHealth ->
+            // triggerRestart -> onRestartRequested), so stopping the watchdog
+            // cancels the coroutine executing these very lines. Everything
+            // after it that suspends is then skipped - and sandbox.stop()
+            // suspends, in the withContext that retires the thread pool, with
+            // the CancellationException swallowed by its own runCatching. Every
+            // plugin disabled this way stranded a two-thread non-daemon pool
+            // for the life of the process. So: tear the sandbox down first,
+            // and stop the watchdog once nothing is left that needs to suspend.
             sandbox.stop()
             sandbox.setDisabled()
             disabledPlugins.add(pluginId)
             notifyListeners { it.onPluginDisabled(pluginId) }
+            // Last: prevents further restart attempts, and cancels us.
+            watchdogs[pluginId]?.stop()
             return
         }
 
@@ -536,7 +551,6 @@ class PluginSandboxManagerImpl(
         // Stop all sandboxes
         sandboxes.values.forEach { it.stop() }
         sandboxes.clear()
-        sandboxConfigs.clear()
 
         // Brief delay to allow pending coroutines to complete before scope cancellation
         kotlinx.coroutines.delay(100)

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManager.kt
@@ -292,6 +292,14 @@ class PluginSandboxManagerImpl(
 
     override fun getSandbox(pluginId: String): PluginSandbox? = sandboxes[pluginId]
 
+    /**
+     * Note the watchdog-then-sandbox order here, in [disablePlugin] and in
+     * [fullyUnloadPlugin]. It is safe at these three sites only because none of
+     * them is reached from inside a watchdog coroutine. The same order in
+     * [handleRestartRequest] stopped the coroutine that was executing it and so
+     * skipped the suspending pool teardown entirely - see the comment there
+     * before reordering any of these to match.
+     */
     override suspend fun removeSandbox(pluginId: String) {
         logger.info(
             LogCategory.SYSTEM,

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -60,15 +60,21 @@ class PluginWatchdog(
     @Volatile
     private var suppressChecksUntilMonotonic = NO_SUPPRESSION
 
-    // Consecutive ticks discarded as host stalls. Bounded, because a host that
-    // is chronically slow rather than briefly frozen would otherwise re-arm the
-    // suppression on every tick and mute this watchdog for the life of the
-    // process - no checks, no escalation, one INFO line per tick as the only
-    // trace. Sustained scheduler starvation is a condition a watchdog exists to
-    // notice, so past the bound it checks anyway and degrades to late
+    // Ticks in a row that did not reach checkHealth, for any reason. Bounded,
+    // because a host that is chronically slow rather than briefly frozen would
+    // otherwise re-arm the suppression for ever and mute this watchdog for the
+    // life of the process - no checks, no escalation, one INFO line per tick as
+    // the only trace. Sustained scheduler starvation is a condition a watchdog
+    // exists to notice, so past the bound it checks anyway and degrades to late
     // detection rather than none.
+    //
+    // Counting SKIPPED CHECKS rather than consecutive stalls, because the two
+    // differ exactly where it matters: a stall on every other tick resets any
+    // consecutive counter, while the 15s deadline each one arms keeps
+    // suppressing the ticks in between. That pattern muted the watchdog just as
+    // completely and slipped straight through a consecutive bound.
     @Volatile
-    private var consecutiveStalls = 0
+    private var skippedChecks = 0
 
     private companion object {
         const val NANOS_PER_MILLI = 1_000_000L
@@ -76,8 +82,8 @@ class PluginWatchdog(
         /** Sentinel for "no stall recovery in progress". */
         const val NO_SUPPRESSION = Long.MIN_VALUE
 
-        /** Stalled ticks in a row before checks resume regardless. */
-        const val MAX_CONSECUTIVE_STALLS = 6
+        /** Ticks in a row without a health check before one runs regardless. */
+        const val MAX_SKIPPED_CHECKS = 6
     }
 
     /**
@@ -129,7 +135,12 @@ class PluginWatchdog(
                             wallClockElapsed = nowWallClock - beforeWallClock,
                             nowMonotonic = nowMonotonic,
                         )
-                    if (!stalled && nowMonotonic >= suppressChecksUntilMonotonic) {
+                    val suppressed = stalled || nowMonotonic < suppressChecksUntilMonotonic
+                    if (suppressed && skippedChecks < MAX_SKIPPED_CHECKS) {
+                        skippedChecks++
+                    } else {
+                        if (suppressed) resumeDespiteStall()
+                        skippedChecks = 0
                         checkHealth()
                     }
                 }
@@ -167,14 +178,8 @@ class PluginWatchdog(
         val suspendedMs = wallClockElapsed - monotonicElapsed
         val overrunMs = monotonicElapsed - config.heartbeatIntervalMs
         val stalledMs = maxOf(suspendedMs, overrunMs)
-        val stalled = stalledMs > config.stallGraceMs
-        consecutiveStalls = if (stalled) consecutiveStalls + 1 else 0
-
-        return when {
-            !stalled -> false
-            consecutiveStalls > MAX_CONSECUTIVE_STALLS -> resumeDespiteStall(stalledMs)
-            else -> beginStallSuppression(nowMonotonic, stalledMs, suspendedMs > overrunMs)
-        }
+        if (stalledMs <= config.stallGraceMs) return false
+        return beginStallSuppression(nowMonotonic, stalledMs, suspendedMs > overrunMs)
     }
 
     /**
@@ -203,23 +208,17 @@ class PluginWatchdog(
         return true
     }
 
-    /**
-     * Give up on waiting for a chronically slow host and check anyway.
-     *
-     * @return false, so the caller treats the tick as usable.
-     */
-    private fun resumeDespiteStall(stalledMs: Long): Boolean {
+    /** Give up on waiting for a chronically slow host and check anyway. */
+    private fun resumeDespiteStall() {
         logger.warn(
             LogCategory.SYSTEM,
             "Host still stalling, checking plugin health anyway",
             mapOf(
                 "pluginId" to sandbox.pluginId,
-                "consecutiveStalls" to consecutiveStalls,
-                "stalledMs" to stalledMs,
+                "skippedChecks" to skippedChecks,
             ),
         )
         suppressChecksUntilMonotonic = NO_SUPPRESSION
-        return false
     }
 
     /**
@@ -241,7 +240,7 @@ class PluginWatchdog(
         // restarted instance to bank is not state worth keeping.
         healthyChecks = 0
         suppressChecksUntilMonotonic = NO_SUPPRESSION
-        consecutiveStalls = 0
+        skippedChecks = 0
     }
 
     private suspend fun checkHealth() {

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -77,19 +77,29 @@ class PluginWatchdog(
 
         watchdogJob =
             scope.launch {
-                var lastTickMonotonic = monotonicMillis()
-                var lastTickWallClock = wallClockMillis()
                 while (isActive) {
+                    // Sampled either side of the sleep and nowhere else, so the
+                    // measurement covers the sleep alone. Measuring tick to tick
+                    // instead folded in whatever checkHealth() had just done -
+                    // and it can do a lot: a restart it triggers waits out an
+                    // exponential backoff (up to restartBackoffMaxMs) and then
+                    // blocks in awaitTermination. That reliably overran the
+                    // grace, so every restart of a genuinely wedged plugin
+                    // logged a bogus "host frozen" and then suppressed checks
+                    // for a full unhealthy window, slowing down the one case
+                    // this watchdog is actually for.
+                    val beforeMonotonic = monotonicMillis()
+                    val beforeWallClock = wallClockMillis()
                     delay(config.heartbeatIntervalMs)
-
                     val nowMonotonic = monotonicMillis()
                     val nowWallClock = wallClockMillis()
-                    val monotonicElapsed = nowMonotonic - lastTickMonotonic
-                    val wallClockElapsed = nowWallClock - lastTickWallClock
-                    lastTickMonotonic = nowMonotonic
-                    lastTickWallClock = nowWallClock
 
-                    val stalled = detectStall(monotonicElapsed, wallClockElapsed, nowWallClock)
+                    val stalled =
+                        suppressIfHostStalled(
+                            monotonicElapsed = nowMonotonic - beforeMonotonic,
+                            wallClockElapsed = nowWallClock - beforeWallClock,
+                            nowWallClock = nowWallClock,
+                        )
                     if (!stalled && nowWallClock >= suppressChecksUntilMs) {
                         checkHealth()
                     }
@@ -115,9 +125,12 @@ class PluginWatchdog(
      * that evidence takes down every loaded plugin at once, which is exactly
      * what used to happen after a laptop lid was closed.
      *
+     * Named for its side effect: a detected stall also suppresses the checks
+     * that follow it, for one unhealthy window.
+     *
      * @return true when this tick must be discarded.
      */
-    private fun detectStall(
+    private fun suppressIfHostStalled(
         monotonicElapsed: Long,
         wallClockElapsed: Long,
         nowWallClock: Long,
@@ -157,14 +170,26 @@ class PluginWatchdog(
         )
         watchdogJob?.cancel()
         watchdogJob = null
+        // Bookkeeping that only means anything within one monitoring run.
+        // enablePlugin builds a fresh watchdog today, so nothing inherits these
+        // in practice, but leaving a half-finished healthy streak behind for a
+        // restarted instance to bank is not state worth keeping.
+        healthyChecks = 0
+        suppressChecksUntilMs = 0
     }
 
     private suspend fun checkHealth() {
         val metrics = sandbox.healthMetrics.value
         val currentState = sandbox.state.value
 
-        // Skip checks if sandbox is already stopped or restarting
-        if (currentState == SandboxState.STOPPED || currentState == SandboxState.RESTARTING) {
+        // Skip checks if the sandbox is stopped, restarting or disabled.
+        // DISABLED matters because recordError sets it for binary
+        // incompatibility WITHOUT stopping this watchdog, and a plugin the host
+        // has given up on should not be having its restart budget forgiven.
+        if (currentState == SandboxState.STOPPED ||
+            currentState == SandboxState.RESTARTING ||
+            currentState == SandboxState.DISABLED
+        ) {
             return
         }
 
@@ -231,7 +256,15 @@ class PluginWatchdog(
      */
     private fun recordHealthyCheck(metrics: PluginHealthMetrics) {
         healthyChecks++
-        if (healthyChecks < config.healthyChecksToClearRestarts || metrics.restartAttempts <= 0) return
+        if (healthyChecks < config.healthyChecksToClearRestarts) return
+        // Banked before the restartAttempts test, not after. Returning early on
+        // a zero counter while leaving the streak running let a long-healthy
+        // plugin accumulate an unbounded one, so a restart arriving by a path
+        // that does not reset it - the error boundary's own Restart button -
+        // was forgiven by the very next check. "Cleared after a sustained run"
+        // then would not have been true.
+        healthyChecks = 0
+        if (metrics.restartAttempts <= 0) return
 
         logger.info(
             LogCategory.SYSTEM,
@@ -262,23 +295,22 @@ class PluginWatchdog(
         try {
             val metrics = sandbox.healthMetrics.value
 
-            // Check if we've exceeded max restart attempts
-            if (metrics.restartAttempts >= config.maxRestartAttempts) {
-                logger.error(
-                    LogCategory.SYSTEM,
-                    "Plugin exceeded max restart attempts, disabling",
-                    mapOf(
-                        "pluginId" to sandbox.pluginId,
-                        "restartAttempts" to metrics.restartAttempts,
-                        "maxAttempts" to config.maxRestartAttempts,
-                    ),
-                )
-                sandbox.stop()
-                // Stop watchdog to release resources and prevent further monitoring
-                stop()
-                return
-            }
-
+            // The restart budget is deliberately NOT checked here. This used to
+            // hold a copy of the check in PluginSandboxManager.handleRestartRequest,
+            // and because this one runs first, the manager's was unreachable -
+            // which did not matter while restartAttempts was zeroed by every
+            // restart and neither could fire.
+            //
+            // Making the counter survive a restart made the branch live, and the
+            // copy that won was the worse one: it stopped the sandbox without
+            // calling setDisabled(), so the state landed on STOPPED, and
+            // PluginErrorBoundary only synthesises its fallback UI for DISABLED.
+            // The plugin kept rendering normally over a dead scope, isPluginDisabled()
+            // stayed false, and no notification was raised - the exact
+            // looks-alive-does-nothing state this watchdog change exists to
+            // remove, arrived at from the other side. The manager's version
+            // disables the sandbox, records it and notifies listeners, so the
+            // decision belongs there and only there.
             logger.info(
                 LogCategory.SYSTEM,
                 "Triggering plugin restart",

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -40,6 +40,7 @@ class PluginWatchdog(
 
     // Consecutive checks that found the plugin healthy. Clears the restart
     // counter once the plugin has stayed healthy long enough to have earned it.
+    @Volatile
     private var healthyChecks = 0
 
     // Deadline until which health checks are suppressed after a process-wide
@@ -56,6 +57,7 @@ class PluginWatchdog(
     // is asleep, so the grace covers the resume instead of being spent on it.
     // NO_SUPPRESSION rather than 0 because monotonic values are not anchored
     // anywhere in particular.
+    @Volatile
     private var suppressChecksUntilMonotonic = NO_SUPPRESSION
 
     // Consecutive ticks discarded as host stalls. Bounded, because a host that
@@ -65,6 +67,7 @@ class PluginWatchdog(
     // trace. Sustained scheduler starvation is a condition a watchdog exists to
     // notice, so past the bound it checks anyway and degrades to late
     // detection rather than none.
+    @Volatile
     private var consecutiveStalls = 0
 
     private companion object {
@@ -342,7 +345,6 @@ class PluginWatchdog(
             ),
         )
         sandbox.resetRestartAttempts()
-        healthyChecks = 0
     }
 
     private suspend fun triggerRestart(reason: String) {

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -81,9 +81,6 @@ class PluginWatchdog(
 
         /** Sentinel for "no stall recovery in progress". */
         const val NO_SUPPRESSION = Long.MIN_VALUE
-
-        /** Ticks in a row without a health check before one runs regardless. */
-        const val MAX_SKIPPED_CHECKS = 6
     }
 
     /**
@@ -136,7 +133,7 @@ class PluginWatchdog(
                             nowMonotonic = nowMonotonic,
                         )
                     val suppressed = stalled || nowMonotonic < suppressChecksUntilMonotonic
-                    if (suppressed && skippedChecks < MAX_SKIPPED_CHECKS) {
+                    if (suppressed && skippedChecks < config.maxSkippedChecks) {
                         skippedChecks++
                     } else {
                         if (suppressed) resumeDespiteStall()

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -27,12 +27,29 @@ class PluginWatchdog(
     private val config: SandboxConfig,
     private val scope: CoroutineScope,
     private val onRestartRequested: suspend (String) -> Unit,
+    /** Monotonic clock, injectable so the stall guard can be tested. */
+    private val monotonicMillis: () -> Long = { System.nanoTime() / NANOS_PER_MILLI },
+    /** Wall clock, injectable so the stall guard can be tested. */
+    private val wallClockMillis: () -> Long = System::currentTimeMillis,
 ) {
     private val logger = BossLogger.forComponent("PluginWatchdog")
     private var watchdogJob: Job? = null
 
     // Prevent concurrent restart attempts from rapid successive health check failures
     private val restartInProgress = AtomicBoolean(false)
+
+    // Consecutive checks that found the plugin healthy. Clears the restart
+    // counter once the plugin has stayed healthy long enough to have earned it.
+    private var healthyChecks = 0
+
+    // Wall-clock deadline until which health checks are suppressed after a
+    // process-wide stall, giving every plugin's heartbeat coroutine - frozen by
+    // the same stall - a full unhealthy window to run again and prove liveness.
+    private var suppressChecksUntilMs = 0L
+
+    private companion object {
+        const val NANOS_PER_MILLI = 1_000_000L
+    }
 
     /**
      * Start the watchdog monitoring.
@@ -60,11 +77,71 @@ class PluginWatchdog(
 
         watchdogJob =
             scope.launch {
+                var lastTickMonotonic = monotonicMillis()
+                var lastTickWallClock = wallClockMillis()
                 while (isActive) {
                     delay(config.heartbeatIntervalMs)
-                    checkHealth()
+
+                    val nowMonotonic = monotonicMillis()
+                    val nowWallClock = wallClockMillis()
+                    val monotonicElapsed = nowMonotonic - lastTickMonotonic
+                    val wallClockElapsed = nowWallClock - lastTickWallClock
+                    lastTickMonotonic = nowMonotonic
+                    lastTickWallClock = nowWallClock
+
+                    val stalled = detectStall(monotonicElapsed, wallClockElapsed, nowWallClock)
+                    if (!stalled && nowWallClock >= suppressChecksUntilMs) {
+                        checkHealth()
+                    }
                 }
             }
+    }
+
+    /**
+     * Decide whether this tick can say anything about plugin health.
+     *
+     * Two ways the process itself stalls, each with its own signature:
+     *
+     * - **The machine slept** (or the wall clock jumped). A monotonic clock does
+     *   not advance across suspend on macOS or Linux, so wall-clock time runs
+     *   ahead of it. Every plugin's heartbeat looks exactly that much older
+     *   than it is.
+     * - **The process froze while awake** - a long GC pause, a breakpoint, a
+     *   starved dispatcher. Both clocks advance together, and this loop's own
+     *   overrun is what gives it away.
+     *
+     * In both cases the heartbeats did not go stale because the plugins are
+     * wedged; they went stale because nothing in this JVM ran. Restarting on
+     * that evidence takes down every loaded plugin at once, which is exactly
+     * what used to happen after a laptop lid was closed.
+     *
+     * @return true when this tick must be discarded.
+     */
+    private fun detectStall(
+        monotonicElapsed: Long,
+        wallClockElapsed: Long,
+        nowWallClock: Long,
+    ): Boolean {
+        val suspendedMs = wallClockElapsed - monotonicElapsed
+        val overrunMs = monotonicElapsed - config.heartbeatIntervalMs
+        val stalledMs = maxOf(suspendedMs, overrunMs)
+        if (stalledMs <= config.stallGraceMs) return false
+
+        // Suppress for a full unhealthy window so the plugins' own heartbeat
+        // coroutines - overdue for the same reason - get to run first.
+        suppressChecksUntilMs = nowWallClock + config.unhealthyThresholdMs
+        healthyChecks = 0
+        logger.info(
+            LogCategory.SYSTEM,
+            "Host stalled, skipping plugin health check",
+            mapOf(
+                "pluginId" to sandbox.pluginId,
+                "stalledMs" to stalledMs,
+                "cause" to if (suspendedMs > overrunMs) "host suspended" else "host frozen",
+                "resumeChecksInMs" to config.unhealthyThresholdMs,
+            ),
+        )
+        return true
     }
 
     /**
@@ -91,10 +168,11 @@ class PluginWatchdog(
             return
         }
 
-        val timeSinceHeartbeat = System.currentTimeMillis() - metrics.lastHeartbeat
+        val timeSinceHeartbeat = wallClockMillis() - metrics.lastHeartbeat
 
         // Check for heartbeat timeout (early return prevents duplicate restart triggers)
         if (timeSinceHeartbeat > config.unhealthyThresholdMs) {
+            healthyChecks = 0
             logger.warn(
                 LogCategory.SYSTEM,
                 "Plugin heartbeat timeout",
@@ -111,6 +189,7 @@ class PluginWatchdog(
 
         // Check for consecutive error threshold (early return prevents duplicate restart triggers)
         if (metrics.consecutiveErrors >= config.maxConsecutiveErrors) {
+            healthyChecks = 0
             logger.warn(
                 LogCategory.SYSTEM,
                 "Plugin exceeded error threshold",
@@ -126,6 +205,7 @@ class PluginWatchdog(
 
         // Log if unhealthy but not yet requiring restart
         if (currentState == SandboxState.UNHEALTHY) {
+            healthyChecks = 0
             logger.debug(
                 LogCategory.SYSTEM,
                 "Plugin is unhealthy but monitoring",
@@ -134,7 +214,35 @@ class PluginWatchdog(
                     "consecutiveErrors" to metrics.consecutiveErrors,
                 ),
             )
+            return
         }
+
+        recordHealthyCheck(metrics)
+    }
+
+    /**
+     * Count a check the plugin passed, and once it has passed enough of them in
+     * a row, forgive its earlier restarts.
+     *
+     * Without this a plugin that hiccups once a week eventually reaches
+     * `maxRestartAttempts` and is disabled for a fault it recovered from days
+     * ago. The counter is cleared here rather than when a restart returns,
+     * because a restart returning is not evidence that anything recovered.
+     */
+    private fun recordHealthyCheck(metrics: PluginHealthMetrics) {
+        healthyChecks++
+        if (healthyChecks < config.healthyChecksToClearRestarts || metrics.restartAttempts <= 0) return
+
+        logger.info(
+            LogCategory.SYSTEM,
+            "Plugin healthy again, clearing restart counter",
+            mapOf(
+                "pluginId" to sandbox.pluginId,
+                "clearedAttempts" to metrics.restartAttempts,
+            ),
+        )
+        sandbox.resetRestartAttempts()
+        healthyChecks = 0
     }
 
     private suspend fun triggerRestart(reason: String) {

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -42,13 +42,27 @@ class PluginWatchdog(
     // counter once the plugin has stayed healthy long enough to have earned it.
     private var healthyChecks = 0
 
-    // Wall-clock deadline until which health checks are suppressed after a
-    // process-wide stall, giving every plugin's heartbeat coroutine - frozen by
-    // the same stall - a full unhealthy window to run again and prove liveness.
-    private var suppressChecksUntilMs = 0L
+    // Deadline until which health checks are suppressed after a process-wide
+    // stall, giving every plugin's heartbeat coroutine - frozen by the same
+    // stall - a full unhealthy window to run again and prove liveness.
+    //
+    // On the MONOTONIC clock, deliberately. A wall-clock deadline is kept on
+    // the one clock this guard exists to distrust: an NTP correction on wake
+    // can step currentTimeMillis backwards, and an hour of correction is an
+    // hour in which no check for this plugin ever runs again - a genuinely
+    // wedged plugin never restarted, with one "Host stalled" line an hour
+    // earlier as the only trace. It also behaves better across a second
+    // suspend, since a monotonic deadline does not advance while the machine
+    // is asleep, so the grace covers the resume instead of being spent on it.
+    // NO_SUPPRESSION rather than 0 because monotonic values are not anchored
+    // anywhere in particular.
+    private var suppressChecksUntilMonotonic = NO_SUPPRESSION
 
     private companion object {
         const val NANOS_PER_MILLI = 1_000_000L
+
+        /** Sentinel for "no stall recovery in progress". */
+        const val NO_SUPPRESSION = Long.MIN_VALUE
     }
 
     /**
@@ -98,9 +112,9 @@ class PluginWatchdog(
                         suppressIfHostStalled(
                             monotonicElapsed = nowMonotonic - beforeMonotonic,
                             wallClockElapsed = nowWallClock - beforeWallClock,
-                            nowWallClock = nowWallClock,
+                            nowMonotonic = nowMonotonic,
                         )
-                    if (!stalled && nowWallClock >= suppressChecksUntilMs) {
+                    if (!stalled && nowMonotonic >= suppressChecksUntilMonotonic) {
                         checkHealth()
                     }
                 }
@@ -133,7 +147,7 @@ class PluginWatchdog(
     private fun suppressIfHostStalled(
         monotonicElapsed: Long,
         wallClockElapsed: Long,
-        nowWallClock: Long,
+        nowMonotonic: Long,
     ): Boolean {
         val suspendedMs = wallClockElapsed - monotonicElapsed
         val overrunMs = monotonicElapsed - config.heartbeatIntervalMs
@@ -142,7 +156,7 @@ class PluginWatchdog(
 
         // Suppress for a full unhealthy window so the plugins' own heartbeat
         // coroutines - overdue for the same reason - get to run first.
-        suppressChecksUntilMs = nowWallClock + config.unhealthyThresholdMs
+        suppressChecksUntilMonotonic = nowMonotonic + config.unhealthyThresholdMs
         healthyChecks = 0
         logger.info(
             LogCategory.SYSTEM,
@@ -175,7 +189,7 @@ class PluginWatchdog(
         // in practice, but leaving a half-finished healthy streak behind for a
         // restarted instance to bank is not state worth keeping.
         healthyChecks = 0
-        suppressChecksUntilMs = 0
+        suppressChecksUntilMonotonic = NO_SUPPRESSION
     }
 
     private suspend fun checkHealth() {

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdog.kt
@@ -58,11 +58,23 @@ class PluginWatchdog(
     // anywhere in particular.
     private var suppressChecksUntilMonotonic = NO_SUPPRESSION
 
+    // Consecutive ticks discarded as host stalls. Bounded, because a host that
+    // is chronically slow rather than briefly frozen would otherwise re-arm the
+    // suppression on every tick and mute this watchdog for the life of the
+    // process - no checks, no escalation, one INFO line per tick as the only
+    // trace. Sustained scheduler starvation is a condition a watchdog exists to
+    // notice, so past the bound it checks anyway and degrades to late
+    // detection rather than none.
+    private var consecutiveStalls = 0
+
     private companion object {
         const val NANOS_PER_MILLI = 1_000_000L
 
         /** Sentinel for "no stall recovery in progress". */
         const val NO_SUPPRESSION = Long.MIN_VALUE
+
+        /** Stalled ticks in a row before checks resume regardless. */
+        const val MAX_CONSECUTIVE_STALLS = 6
     }
 
     /**
@@ -152,10 +164,27 @@ class PluginWatchdog(
         val suspendedMs = wallClockElapsed - monotonicElapsed
         val overrunMs = monotonicElapsed - config.heartbeatIntervalMs
         val stalledMs = maxOf(suspendedMs, overrunMs)
-        if (stalledMs <= config.stallGraceMs) return false
+        val stalled = stalledMs > config.stallGraceMs
+        consecutiveStalls = if (stalled) consecutiveStalls + 1 else 0
 
-        // Suppress for a full unhealthy window so the plugins' own heartbeat
-        // coroutines - overdue for the same reason - get to run first.
+        return when {
+            !stalled -> false
+            consecutiveStalls > MAX_CONSECUTIVE_STALLS -> resumeDespiteStall(stalledMs)
+            else -> beginStallSuppression(nowMonotonic, stalledMs, suspendedMs > overrunMs)
+        }
+    }
+
+    /**
+     * Arm the recovery window, so the plugins' own heartbeat coroutines -
+     * overdue for the same reason - get to run before anything is judged.
+     *
+     * @return true, so the caller discards this tick.
+     */
+    private fun beginStallSuppression(
+        nowMonotonic: Long,
+        stalledMs: Long,
+        suspended: Boolean,
+    ): Boolean {
         suppressChecksUntilMonotonic = nowMonotonic + config.unhealthyThresholdMs
         healthyChecks = 0
         logger.info(
@@ -164,11 +193,30 @@ class PluginWatchdog(
             mapOf(
                 "pluginId" to sandbox.pluginId,
                 "stalledMs" to stalledMs,
-                "cause" to if (suspendedMs > overrunMs) "host suspended" else "host frozen",
+                "cause" to if (suspended) "host suspended" else "host frozen",
                 "resumeChecksInMs" to config.unhealthyThresholdMs,
             ),
         )
         return true
+    }
+
+    /**
+     * Give up on waiting for a chronically slow host and check anyway.
+     *
+     * @return false, so the caller treats the tick as usable.
+     */
+    private fun resumeDespiteStall(stalledMs: Long): Boolean {
+        logger.warn(
+            LogCategory.SYSTEM,
+            "Host still stalling, checking plugin health anyway",
+            mapOf(
+                "pluginId" to sandbox.pluginId,
+                "consecutiveStalls" to consecutiveStalls,
+                "stalledMs" to stalledMs,
+            ),
+        )
+        suppressChecksUntilMonotonic = NO_SUPPRESSION
+        return false
     }
 
     /**
@@ -190,6 +238,7 @@ class PluginWatchdog(
         // restarted instance to bank is not state worth keeping.
         healthyChecks = 0
         suppressChecksUntilMonotonic = NO_SUPPRESSION
+        consecutiveStalls = 0
     }
 
     private suspend fun checkHealth() {
@@ -204,6 +253,10 @@ class PluginWatchdog(
             currentState == SandboxState.RESTARTING ||
             currentState == SandboxState.DISABLED
         ) {
+            // Reset like every other non-healthy branch, so a streak cannot
+            // span a restart and mean something other than "consecutive
+            // healthy checks".
+            healthyChecks = 0
             return
         }
 

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandboxTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandboxTest.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.plugin.sandbox
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -9,7 +11,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -251,16 +255,112 @@ class InProcessPluginSandboxTest {
             }
 
         @Test
-        fun `restart creates new sandboxScope`() =
+        fun `restart keeps the same sandboxScope instance`() =
             runTest {
                 sandbox.start()
                 val originalScope = sandbox.sandboxScope
 
                 sandbox.restart()
 
-                // After restart, scope should be different (new instance)
-                // We can verify this by checking the scope is still active
+                // Plugins read pluginScope once, in register(), and hand it to
+                // components that outlive any restart. Handing out a fresh
+                // scope here left all of them holding a cancelled one, and a
+                // cancelled scope swallows launch() without running or
+                // throwing - so the plugin went quietly inert until the user
+                // reloaded it by hand.
+                assertSame(originalScope, sandbox.sandboxScope)
                 assertTrue(sandbox.sandboxScope.isActive)
+            }
+
+        @Test
+        fun `work launched after a restart still runs`() =
+            runTest {
+                sandbox.start()
+                val scopeCapturedAtRegisterTime = sandbox.sandboxScope
+
+                sandbox.restart()
+
+                val ran = CompletableDeferred<Boolean>()
+                scopeCapturedAtRegisterTime.launch { ran.complete(true) }
+
+                assertTrue(ran.await(), "the scope a plugin captured before the restart is dead")
+            }
+
+        @Test
+        fun `restart cancels work that was in flight`() =
+            runTest {
+                sandbox.start()
+                val started = CompletableDeferred<Unit>()
+                val job =
+                    sandbox.sandboxScope.launch {
+                        started.complete(Unit)
+                        awaitCancellation()
+                    }
+                started.await()
+
+                sandbox.restart()
+
+                job.join()
+                assertTrue(job.isCancelled)
+            }
+
+        @Test
+        fun `a stopped sandbox runs nothing`() =
+            runTest {
+                sandbox.start()
+                sandbox.stop()
+
+                var executed = false
+                sandbox.sandboxScope.launch { executed = true }.join()
+
+                assertFalse(executed, "a stopped sandbox must not keep running plugin code")
+            }
+
+        @Test
+        fun `starting again after a stop re-arms the same scope`() =
+            runTest {
+                sandbox.start()
+                val scopeCapturedAtRegisterTime = sandbox.sandboxScope
+                sandbox.stop()
+
+                // What a disable/enable cycle does. The plugin is never handed
+                // a new scope, so this one has to come back to life.
+                sandbox.start()
+
+                val ran = CompletableDeferred<Boolean>()
+                scopeCapturedAtRegisterTime.launch { ran.complete(true) }
+
+                assertSame(scopeCapturedAtRegisterTime, sandbox.sandboxScope)
+                assertTrue(ran.await(), "enable left the plugin with a dead scope")
+            }
+    }
+
+    @Nested
+    inner class RestartAccountingTests {
+        @Test
+        fun `restart attempts accumulate across restarts`() =
+            runTest {
+                sandbox.start()
+
+                sandbox.restart()
+                sandbox.restart()
+
+                // A restart that merely returned is not proof the plugin
+                // recovered. Zeroing the counter here made maxRestartAttempts
+                // unreachable, so a plugin could restart-loop forever with
+                // every attempt logged as "attempt 1".
+                assertEquals(2, sandbox.healthMetrics.value.restartAttempts)
+            }
+
+        @Test
+        fun `resetRestartAttempts clears the counter`() =
+            runTest {
+                sandbox.start()
+                sandbox.restart()
+
+                sandbox.resetRestartAttempts()
+
+                assertEquals(0, sandbox.healthMetrics.value.restartAttempts)
             }
     }
 

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandboxTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/InProcessPluginSandboxTest.kt
@@ -1,15 +1,19 @@
 package ai.rever.boss.plugin.sandbox
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -332,6 +336,52 @@ class InProcessPluginSandboxTest {
 
                 assertSame(scopeCapturedAtRegisterTime, sandbox.sandboxScope)
                 assertTrue(ran.await(), "enable left the plugin with a dead scope")
+            }
+    }
+
+    @Nested
+    inner class CancelledRestartTests {
+        /**
+         * The Restart buttons run on a Compose `rememberCoroutineScope`, so
+         * closing the tab or switching side panels mid-restart cancels this.
+         *
+         * The window is widened deliberately: a thread blocked in a latch is
+         * not interruptible by coroutine cancellation, so the retiring pool
+         * cannot terminate and `awaitTermination` waits its full timeout.
+         */
+        @Test
+        fun `a cancelled restart does not strand the sandbox in RESTARTING`() =
+            runBlocking {
+                sandbox.start()
+                val holdThePool = CountDownLatch(1)
+                sandbox.sandboxScope.launch { holdThePool.await() }
+                // Let it actually occupy a pool thread before the swap.
+                withTimeoutOrNull(2_000) {
+                    while (sandbox.healthMetrics.value.lastHeartbeat == 0L) delay(10)
+                }
+
+                val restart = launch(Dispatchers.Default) { sandbox.restart() }
+                // Past the swap: the state has moved off STOPPED either way -
+                // to RUNNING with the fix, to RESTARTING without it.
+                withTimeoutOrNull(2_000) {
+                    while (sandbox.state.value == SandboxState.STOPPED) delay(5)
+                }
+                restart.cancel()
+                restart.join()
+                holdThePool.countDown()
+
+                // RESTARTING is the state PluginWatchdog skips outright, so a
+                // sandbox left there is never restarted, never marked
+                // unhealthy, and shows no fallback UI. It is invisible to every
+                // recovery path there is.
+                assertEquals(SandboxState.RUNNING, sandbox.state.value)
+
+                val ran = CompletableDeferred<Boolean>()
+                sandbox.sandboxScope.launch { ran.complete(true) }
+                assertTrue(
+                    withTimeoutOrNull(5_000) { ran.await() } == true,
+                    "the scope did not survive a cancelled restart",
+                )
             }
     }
 

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.plugin.sandbox
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -298,6 +301,107 @@ class PluginSandboxManagerTest {
                 manager.dispose()
 
                 assertTrue(manager.getAllSandboxes().isEmpty())
+            }
+    }
+
+    /**
+     * The give-up path, which used to be unreachable: `restartAttempts` was
+     * zeroed by every restart, so no plugin ever reached its budget. It is
+     * reachable now, and it is the branch that produces the user-visible
+     * "plugin disabled" outcome, so all of its effects matter.
+     */
+    @Nested
+    inner class RestartBudgetTests {
+        /**
+         * Driven through a real watchdog rather than by calling
+         * [PluginSandboxManagerImpl.handleRestartRequest] directly, because the
+         * bug this pins only exists when that code runs *inside* the watchdog's
+         * own coroutine - which is where the real path puts it (checkHealth ->
+         * triggerRestart -> onRestartRequested). Called directly from a test
+         * coroutine, stopping the watchdog cancels somebody else and the
+         * teardown completes either way: the first version of this test passed
+         * against the bug it was written for.
+         *
+         * The trigger is the consecutive-error threshold, not a stale
+         * heartbeat, because the sandbox's own heartbeat job keeps beating and
+         * a heartbeat timeout would need the test to outwait it.
+         */
+        @Test
+        fun `exhausting the budget disables the plugin and does not strand its thread pool`() =
+            runBlocking {
+                val config =
+                    SandboxConfig(
+                        maxThreads = 2,
+                        heartbeatIntervalMs = 50,
+                        // Neither the heartbeat nor the stall guard should be
+                        // what fires here.
+                        unhealthyThresholdMs = 60_000,
+                        stallGraceMs = 60_000,
+                        maxConsecutiveErrors = 1,
+                        // So the very first request is already over budget.
+                        maxRestartAttempts = 0,
+                    )
+                val budgetManager = PluginSandboxManagerImpl(config)
+                try {
+                    var disabledNotification: String? = null
+                    val listener =
+                        object : PluginSandboxListener {
+                            override fun onPluginDisabled(pluginId: String) {
+                                disabledNotification = pluginId
+                            }
+                        }
+                    budgetManager.addListener(listener)
+
+                    // Passed explicitly: createSandbox defaults to a stock
+                    // SandboxConfig, not the manager's defaultConfig.
+                    val sandbox = budgetManager.createSandbox("plugin-1", config) as InProcessPluginSandbox
+                    sandbox.start()
+                    sandbox.recordError(RuntimeException("wedged"))
+
+                    val disabled =
+                        withTimeoutOrNull(10_000) {
+                            while (sandbox.state.value != SandboxState.DISABLED) delay(20)
+                            true
+                        } ?: false
+
+                    // All four have to happen. Landing on STOPPED without
+                    // setDisabled() leaves PluginErrorBoundary rendering the
+                    // plugin normally over a dead scope, with no notification
+                    // and isPluginDisabled() false - invisible to the user.
+                    assertTrue(disabled, "the plugin was never marked disabled")
+                    assertTrue(budgetManager.isPluginDisabled("plugin-1"))
+                    assertEquals("plugin-1", disabledNotification)
+
+                    val terminated =
+                        withTimeoutOrNull(5_000) {
+                            while (!sandbox.isExecutorTerminated()) delay(20)
+                            true
+                        } ?: false
+                    assertTrue(
+                        terminated,
+                        "the thread pool leaked: stopping the watchdog first cancels the very coroutine " +
+                            "running this teardown, and sandbox.stop() suspends to retire the pool",
+                    )
+                } finally {
+                    budgetManager.dispose()
+                }
+            }
+
+        @Test
+        fun `a plugin's own restart budget is used, not the manager default`() =
+            runTest {
+                // The manager default is 3 (see setUp). Nothing about
+                // cancellation here, so the request can be made directly.
+                val generous = SandboxConfig(maxRestartAttempts = 5)
+                manager.createSandbox("plugin-generous", generous).start()
+
+                repeat(4) { manager.restartPlugin("plugin-generous") }
+                manager.handleRestartRequest("plugin-generous")
+
+                assertFalse(
+                    manager.isPluginDisabled("plugin-generous"),
+                    "a plugin declaring its own budget had the manager default applied to it",
+                )
             }
     }
 }

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/PluginSandboxManagerTest.kt
@@ -259,6 +259,36 @@ class PluginSandboxManagerTest {
             }
 
         @Test
+        fun `a listener that throws does not stop the others or the caller`() =
+            runTest {
+                var secondListenerSaw: String? = null
+                val thrower =
+                    object : PluginSandboxListener {
+                        override fun onPluginRestarted(pluginId: String) = error("listener blew up")
+                    }
+                val survivor =
+                    object : PluginSandboxListener {
+                        override fun onPluginRestarted(pluginId: String) {
+                            secondListenerSaw = pluginId
+                        }
+                    }
+                manager.addListener(thrower)
+                manager.addListener(survivor)
+                val sandbox = manager.createSandbox("plugin-1")
+                sandbox.start()
+
+                // On the automatic path this is dispatched from inside the
+                // watchdog's own coroutine, so an escaping exception completes
+                // that job - leaving the plugin with no health monitoring for
+                // the rest of the session, and only a default-handler stack
+                // trace to show for it.
+                val result = manager.restartPlugin("plugin-1")
+
+                assertTrue(result.isSuccess, "a throwing listener must not fail the restart")
+                assertEquals("plugin-1", secondListenerSaw, "later listeners were skipped")
+            }
+
+        @Test
         fun `removeListener stops receiving events`() =
             runTest {
                 var callCount = 0

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
@@ -120,6 +120,12 @@ class PluginWatchdogTest {
     ) {
         val restartsRequested = mutableListOf<String>()
 
+        /** Clock cost a restart incurs inside the tick that triggered it. */
+        var restartCost: () -> Unit = {}
+
+        /** Model a plugin that stays silent even after being restarted. */
+        var stopBeatingOnRestart = false
+
         /** Run one watchdog check interval of virtual time. */
         fun tick(count: Int = 1) {
             repeat(count) {
@@ -143,9 +149,13 @@ class PluginWatchdogTest {
                 scope = this,
                 onRestartRequested = {
                     harness.restartsRequested.add(it)
+                    // Restarting is not free: the manager waits out a backoff
+                    // and the sandbox blocks in awaitTermination, all inside
+                    // this tick.
+                    harness.restartCost()
                     // A real restart refreshes the heartbeat, which is what
                     // stops the watchdog asking again on the very next tick.
-                    harness.beat()
+                    if (!harness.stopBeatingOnRestart) harness.beat()
                 },
                 monotonicMillis = clocks::monotonic,
                 wallClockMillis = clocks::wallClock,
@@ -166,7 +176,9 @@ class PluginWatchdogTest {
                 h.tick()
                 h.beat()
 
-                // The lid closes for 48 seconds. Only the wall clock moves.
+                // The lid closes: 43s of skew on top of the 5s tick, so the
+                // heartbeat ages the 48 seconds the real logs showed. Only the
+                // wall clock moves.
                 h.clocks.suspendedMs += 43_000
                 h.tick()
 
@@ -186,7 +198,8 @@ class PluginWatchdogTest {
                 h.tick()
                 h.beat()
 
-                // A 48 second stop-the-world pause: both clocks jump together.
+                // A stop-the-world pause of the same length, but both clocks
+                // jump together.
                 h.clocks.frozenMs += 43_000
                 h.tick()
 
@@ -203,7 +216,7 @@ class PluginWatchdogTest {
                 h.tick()
                 h.beat()
 
-                // Wake up with every heartbeat 43 seconds stale.
+                // Wake up with every heartbeat 48 seconds stale.
                 h.clocks.suspendedMs += 43_000
                 h.tick()
 
@@ -263,15 +276,61 @@ class PluginWatchdogTest {
             }
 
         @Test
-        fun `a plugin past its restart budget is stopped rather than restarted`() =
+        fun `a plugin past its restart budget is still delegated, not stopped here`() =
             runTest {
                 val h = harness()
                 h.sandbox.setRestartAttempts(config.maxRestartAttempts)
 
                 h.tick(4)
 
-                assertTrue(h.restartsRequested.isEmpty())
-                assertEquals(1, h.sandbox.stopCount, "the budget is spent, so the plugin is stopped")
+                // The watchdog used to enforce the budget itself, duplicating
+                // the check in PluginSandboxManager.handleRestartRequest and
+                // shadowing it - and the copy that ran was the one that stopped
+                // the sandbox WITHOUT marking it disabled, so no fallback UI,
+                // no notification and no isPluginDisabled. The manager's copy
+                // does all three, so the decision has to reach it.
+                assertEquals(listOf("test-plugin"), h.restartsRequested)
+                assertEquals(0, h.sandbox.stopCount, "stopping is the manager's call, with its own bookkeeping")
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `ordinary jitter under the grace still gets the plugin checked`() =
+            runTest {
+                val h = harness()
+
+                // A late tick, but only by a fraction of the grace - a busy
+                // scheduler, not a stalled host. Discarding these would put the
+                // original bug straight back.
+                h.clocks.frozenMs += 1_500
+                h.tick(4)
+
+                assertEquals(listOf("test-plugin"), h.restartsRequested)
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `the time checkHealth spends restarting is not read as a host freeze`() =
+            runTest {
+                val h = harness()
+                // What a real restart costs inside the tick: an exponential
+                // backoff and then awaitTermination, comfortably over the
+                // grace. Measured tick-to-tick it looked like a frozen host and
+                // suppressed the next 15 seconds of checks on the one plugin
+                // that actually needed watching.
+                h.restartCost = { h.clocks.frozenMs += 4_000 }
+
+                h.tick(4)
+                assertEquals(1, h.restartsRequested.size)
+
+                // Still quiet, so the next window must convict it again rather
+                // than being written off as a stall.
+                h.stopBeatingOnRestart = true
+                h.tick(4)
+
+                assertEquals(2, h.restartsRequested.size, "the watchdog's own restart cost suppressed the next check")
 
                 h.watchdog.stop()
             }

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
@@ -1,0 +1,323 @@
+package ai.rever.boss.plugin.sandbox.health
+
+import ai.rever.boss.plugin.sandbox.PluginSandbox
+import ai.rever.boss.plugin.sandbox.SandboxConfig
+import ai.rever.boss.plugin.sandbox.SandboxState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [PluginWatchdog], centred on the question it exists to answer:
+ * is a stale heartbeat evidence about the plugin, or about the host?
+ *
+ * The watchdog is driven with two injected clocks so a host suspend (wall
+ * clock runs ahead of the monotonic one) and a host freeze (both run ahead of
+ * the loop's own interval) can be reproduced exactly, without sleeping a
+ * laptop or provoking a garbage collection.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PluginWatchdogTest {
+    private val config =
+        SandboxConfig(
+            heartbeatIntervalMs = 5_000,
+            unhealthyThresholdMs = 15_000,
+            stallGraceMs = 2_000,
+            maxRestartAttempts = 3,
+            // Comfortably more than the four checks a silent plugin takes to
+            // time out, so a run of good checks cannot be ended by the very
+            // timeout it was counting towards.
+            healthyChecksToClearRestarts = 8,
+        )
+
+    /**
+     * Clocks derived from the test scheduler's virtual time, each with a skew
+     * the test can inject.
+     *
+     * - [frozenMs] advances both clocks: the process was stopped while awake
+     *   (a long GC pause, a breakpoint).
+     * - [suspendedMs] advances only the wall clock: the machine slept, which
+     *   a monotonic clock does not count on macOS or Linux.
+     */
+    private class Clocks(
+        private val scope: TestScope,
+    ) {
+        var frozenMs = 0L
+        var suspendedMs = 0L
+
+        fun monotonic(): Long = scope.testScheduler.currentTime + frozenMs
+
+        fun wallClock(): Long = scope.testScheduler.currentTime + frozenMs + suspendedMs
+    }
+
+    private class FakeSandbox : PluginSandbox {
+        override val pluginId: String = "test-plugin"
+
+        private val _state = MutableStateFlow(SandboxState.RUNNING)
+        override val state: StateFlow<SandboxState> = _state.asStateFlow()
+
+        private val _healthMetrics = MutableStateFlow(PluginHealthMetrics.initial())
+        override val healthMetrics: StateFlow<PluginHealthMetrics> = _healthMetrics.asStateFlow()
+
+        override val sandboxScope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined)
+
+        var stopCount = 0
+        var markUnhealthyCount = 0
+        var resetRestartAttemptsCount = 0
+
+        fun beatAt(wallClockMs: Long) {
+            _healthMetrics.update { it.copy(lastHeartbeat = wallClockMs) }
+        }
+
+        fun setRestartAttempts(attempts: Int) {
+            _healthMetrics.update { it.copy(restartAttempts = attempts) }
+        }
+
+        override suspend fun start(): Result<Unit> = Result.success(Unit)
+
+        override suspend fun stop(): Result<Unit> {
+            stopCount++
+            _state.value = SandboxState.STOPPED
+            return Result.success(Unit)
+        }
+
+        override suspend fun restart(): Result<Unit> = Result.success(Unit)
+
+        override fun recordHeartbeat() = Unit
+
+        override fun recordSuccess() = Unit
+
+        override fun recordError(error: Throwable) = Unit
+
+        override fun markUnhealthy() {
+            markUnhealthyCount++
+        }
+
+        override fun resetHealth() = Unit
+
+        override fun resetRestartAttempts() {
+            resetRestartAttemptsCount++
+            _healthMetrics.update { it.withRestartAttemptsCleared() }
+        }
+    }
+
+    private class Harness(
+        val sandbox: FakeSandbox,
+        val clocks: Clocks,
+        val watchdog: PluginWatchdog,
+        val scope: TestScope,
+    ) {
+        val restartsRequested = mutableListOf<String>()
+
+        /** Run one watchdog check interval of virtual time. */
+        fun tick(count: Int = 1) {
+            repeat(count) {
+                scope.testScheduler.advanceTimeBy(5_000)
+                scope.runCurrent()
+            }
+        }
+
+        /** Refresh the plugin's heartbeat to "now", as its heartbeat job does. */
+        fun beat() = sandbox.beatAt(clocks.wallClock())
+    }
+
+    private fun TestScope.harness(): Harness {
+        val sandbox = FakeSandbox()
+        val clocks = Clocks(this)
+        lateinit var harness: Harness
+        val watchdog =
+            PluginWatchdog(
+                sandbox = sandbox,
+                config = config,
+                scope = this,
+                onRestartRequested = {
+                    harness.restartsRequested.add(it)
+                    // A real restart refreshes the heartbeat, which is what
+                    // stops the watchdog asking again on the very next tick.
+                    harness.beat()
+                },
+                monotonicMillis = clocks::monotonic,
+                wallClockMillis = clocks::wallClock,
+            )
+        harness = Harness(sandbox, clocks, watchdog, this)
+        harness.beat()
+        watchdog.start()
+        return harness
+    }
+
+    @Nested
+    inner class HostStallTests {
+        @Test
+        fun `a sleeping machine does not restart the plugin`() =
+            runTest {
+                val h = harness()
+
+                h.tick()
+                h.beat()
+
+                // The lid closes for 48 seconds. Only the wall clock moves.
+                h.clocks.suspendedMs += 43_000
+                h.tick()
+
+                assertTrue(
+                    h.restartsRequested.isEmpty(),
+                    "a host suspend aged every heartbeat at once and must not be read as a plugin fault",
+                )
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `a frozen host does not restart the plugin`() =
+            runTest {
+                val h = harness()
+
+                h.tick()
+                h.beat()
+
+                // A 48 second stop-the-world pause: both clocks jump together.
+                h.clocks.frozenMs += 43_000
+                h.tick()
+
+                assertTrue(h.restartsRequested.isEmpty())
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `the plugin gets a grace window to beat again after a stall`() =
+            runTest {
+                val h = harness()
+
+                h.tick()
+                h.beat()
+
+                // Wake up with every heartbeat 43 seconds stale.
+                h.clocks.suspendedMs += 43_000
+                h.tick()
+
+                // The plugin's own heartbeat job is overdue too and has not run
+                // yet. The checks in this window must stay silent rather than
+                // race it.
+                h.tick(2)
+                assertTrue(
+                    h.restartsRequested.isEmpty(),
+                    "checks resumed before the plugin's heartbeat job could run",
+                )
+
+                // It catches up, and the sandbox stays up.
+                repeat(4) {
+                    h.beat()
+                    h.tick()
+                }
+                assertTrue(h.restartsRequested.isEmpty())
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `a plugin that never beats again is still restarted after the stall`() =
+            runTest {
+                val h = harness()
+
+                h.tick()
+                h.beat()
+
+                h.clocks.suspendedMs += 43_000
+                h.tick()
+
+                // Grace expires and the plugin has gone quiet for real.
+                h.tick(6)
+
+                assertEquals(listOf("test-plugin"), h.restartsRequested)
+                assertEquals(1, h.sandbox.markUnhealthyCount)
+
+                h.watchdog.stop()
+            }
+    }
+
+    @Nested
+    inner class GenuineFailureTests {
+        @Test
+        fun `a wedged plugin is restarted`() =
+            runTest {
+                val h = harness()
+
+                // No clock jumps, no heartbeats: this one really is gone.
+                h.tick(4)
+
+                assertEquals(listOf("test-plugin"), h.restartsRequested)
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `a plugin past its restart budget is stopped rather than restarted`() =
+            runTest {
+                val h = harness()
+                h.sandbox.setRestartAttempts(config.maxRestartAttempts)
+
+                h.tick(4)
+
+                assertTrue(h.restartsRequested.isEmpty())
+                assertEquals(1, h.sandbox.stopCount, "the budget is spent, so the plugin is stopped")
+
+                h.watchdog.stop()
+            }
+    }
+
+    @Nested
+    inner class RestartCounterTests {
+        @Test
+        fun `sustained health forgives earlier restarts`() =
+            runTest {
+                val h = harness()
+                h.sandbox.setRestartAttempts(2)
+
+                repeat(config.healthyChecksToClearRestarts) {
+                    h.beat()
+                    h.tick()
+                }
+
+                assertEquals(1, h.sandbox.resetRestartAttemptsCount)
+                assertEquals(0, h.sandbox.healthMetrics.value.restartAttempts)
+
+                h.watchdog.stop()
+            }
+
+        @Test
+        fun `a run of good checks broken by a timeout does not forgive anything`() =
+            runTest {
+                val h = harness()
+                h.sandbox.setRestartAttempts(2)
+
+                repeat(3) {
+                    h.beat()
+                    h.tick()
+                }
+
+                // Going quiet long enough to be restarted ends the run, however
+                // many good checks it had accumulated.
+                h.tick(4)
+                assertEquals(listOf("test-plugin"), h.restartsRequested)
+
+                h.beat()
+                h.tick()
+
+                assertEquals(0, h.sandbox.resetRestartAttemptsCount)
+
+                h.watchdog.stop()
+            }
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
@@ -263,6 +263,27 @@ class PluginWatchdogTest {
             }
 
         @Test
+        fun `a host that stalls every other tick does not mute the watchdog either`() =
+            runTest {
+                val h = harness()
+
+                // The pattern a consecutive-stall bound misses entirely: the
+                // good ticks reset any such counter, while the 15s deadline
+                // each stalled tick arms suppresses the ticks between them.
+                repeat(16) { tick ->
+                    if (tick % 2 == 0) h.clocks.frozenMs += 4_000
+                    h.tick()
+                }
+
+                assertTrue(
+                    h.restartsRequested.isNotEmpty(),
+                    "alternating stalls suppressed every check without ever counting as consecutive",
+                )
+
+                h.watchdog.stop()
+            }
+
+        @Test
         fun `a plugin that never beats again is still restarted after the stall`() =
             runTest {
                 val h = harness()

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/health/PluginWatchdogTest.kt
@@ -240,6 +240,29 @@ class PluginWatchdogTest {
             }
 
         @Test
+        fun `a chronically slow host does not mute the watchdog for ever`() =
+            runTest {
+                val h = harness()
+
+                // Every tick overruns the grace: not a lid close, a host that
+                // is simply always late. Re-arming the suppression on each one
+                // would mean checkHealth never runs again for the life of the
+                // watchdog - no restarts, no escalation, one INFO line per tick
+                // as the only trace.
+                repeat(12) {
+                    h.clocks.frozenMs += 4_000
+                    h.tick()
+                }
+
+                assertTrue(
+                    h.restartsRequested.isNotEmpty(),
+                    "a permanently slow host must degrade to late detection, not none",
+                )
+
+                h.watchdog.stop()
+            }
+
+        @Test
         fun `a plugin that never beats again is still restarted after the stall`() =
             runTest {
                 val h = harness()


### PR DESCRIPTION
## The bug

Closing the lid was enough to leave a plugin panel spinning for ever, with nothing in any log.

The watchdog measures heartbeat age against the wall clock. A machine that suspends for 48 seconds ages every plugin's heartbeat by 48 seconds at once, so the watchdog convicts all of them in the same millisecond:

```
13:15:15.767  codebase             timeSinceHeartbeatMs=48096
13:15:15.767  rpaengine            timeSinceHeartbeatMs=48092
13:15:15.770  adminrolemanagement  timeSinceHeartbeatMs=48095
... 21 more, all within 6ms, all ~48000ms
```

Every plugin reporting the same gap is the tell: the plugins were fine, the JVM was not running. The watchdog's own loop was frozen for those same 48 seconds - it should have fired at 15 - and that overrun was discarded rather than used.

## Why the state was unrecoverable

`InProcessPluginSandbox.restart()` cancelled the sandbox scope and installed a fresh one, but nothing re-registers the plugin, so every component built in `register()` kept holding the cancelled one. `launch` on a cancelled scope neither runs nor throws.

In the Codebase panel that reads as: `toggleExpanded` adds the path to `expandedPaths` synchronously, the tree renders a `Loading` row, and the `scope.launch { loadNodeChildren(path) }` that would fill it in never runs. No exception, no log, no error boundary - and a toast saying the plugin restarted successfully. Only a manual plugin reload brought it back.

The same shape applies to every plugin that captures `context.pluginScope` in `register()`: toolbox, user-secret-list, secret-manager, terminal-tab, tool-creator, console, analytics, atlas, flow-tab, organisation, topofmind, run-configurations and codebase.

## The fixes

All host-side. No plugin needs to change.

**The watchdog stops judging plugins for the host's stalls.** It compares a monotonic clock against the wall clock and discards any tick that overran. A machine suspend shows up as the wall clock running ahead of the monotonic one (neither macOS nor Linux counts suspend in the monotonic clock); a freeze while awake - long GC, breakpoint, starved dispatcher - shows up as both running ahead of the check interval. After either, checks pause for one unhealthy window, so the plugins' own heartbeat jobs, overdue for exactly the same reason, get to run before anything is judged.

**The plugin scope survives a restart.** It is created once and never replaced. A restart cancels its children and gives it a fresh `Job`, so wedged work still dies while the scope a plugin captured at `register()` keeps working. The dispatcher indirects through a swappable delegate so the thread pool can still be replaced underneath it. The same change repairs disable-then-enable, which left the scope cancelled and the pool shut down with nothing to revive either.

**`restartAttempts` survives a restart.** It was zeroed the moment `restart()` returned, and the in-process restart cannot fail, so `maxRestartAttempts` was unreachable - every attempt in the logs above says `attempt=1`, three hours apart. It is now cleared only after the plugin passes a sustained run of healthy checks, which is the only thing that evidences recovery.

**A restarted plugin gets its `register()` subscriptions back.** A surviving scope keeps a plugin usable, but it cannot re-open what the plugin subscribed to once inside `register()` - the Toolbox's realtime channel and update-prompt loop, terminal-tab's approval collector, tool-creator's event job, analytics' pipes. Nothing calls `register()` twice, so a restarted plugin looked alive while ignoring everything it was not asked to do directly. `DynamicPluginManager` now listens for the restart and runs the disable/enable cycle without the disable: unregister, dispose, register, then refresh any open panel so it is rebuilt from the new factories.

Four things about that last one:

- **The listener is a field, not an inline object.** `PluginSandboxManagerImpl` holds listeners weakly, so an anonymous one would be collected at some later GC and re-registration would stop happening non-deterministically.
- **It runs on `Dispatchers.Main`**, where `handleAccessChange` and the Toolbox's enable already re-register a loaded instance. That also makes the unregister/register pair atomic from the UI's point of view, so no frame sees the plugin with its panels missing.
- **It is detached onto the manager's own scope.** The callback arrives inside the watchdog's coroutine, which disabling the plugin cancels, and a re-registration abandoned half way through would leave the plugin unregistered - worse than doing nothing.
- **A plugin disabled or uninstalled in the meantime is left alone.** `shouldReregisterAfterRestart` requires both `enabled` and `state == LOADED`; those two can disagree, and either half saying no is enough. Otherwise a restart landing after a disable would put the plugin's panels and agent-callable MCP tools straight back.

The runaway case - a plugin whose `register()` is itself what wedges it - is bounded by `maxRestartAttempts`, which only became reachable because of the counter fix above. Without it, re-registration would be a restart loop.

## Tests

New `PluginWatchdogTest` drives the watchdog with two injected clocks, so a laptop sleep and a stop-the-world pause are reproducible without either: a sleeping machine and a frozen host do not restart anything, the plugin gets a grace window to beat again, a plugin that stays silent past that window still gets restarted, and a plugin past its restart budget is stopped rather than looped.

`InProcessPluginSandboxTest` gains the scope contract: the instance survives a restart, work launched afterwards on the pre-restart reference runs, in-flight work is cancelled, a stopped sandbox runs nothing, and start-after-stop re-arms the same object. The old `restart creates new sandboxScope` test asserted the behaviour this PR removes and is replaced.

New `ReregisterAfterRestartTest` covers the re-registration gate across every state a plugin can be in when the callback lands.

`:plugin-platform:plugin-sandbox:desktopTest`, `:composeApp:desktopTest`, `ktlintCheck` and `detekt` for both modules all pass.

## Known behaviour change

An open panel is rebuilt after a genuine restart, so it loses in-memory view state - an expanded tree collapses. That is the same trade `resetComponent` already makes on disable/enable, and the alternative is the panel this PR exists to fix. Restarts should also be far rarer now that the false positives are gone.