### PR TITLE
panel: keep the header controls flush right, and name the store-version action

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -975,6 +975,7 @@
     <ID>PackageNaming:BookmarksDialogProviderImpl.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
     <ID>PackageNaming:BossMainWindowPanel.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
     <ID>PackageNaming:BossPanelTopBar.kt$package ai.rever.boss.components.window_panel.components</ID>
+    <ID>PackageNaming:BossPanelTopBarLayoutTest.kt$package ai.rever.boss.components.window_panel.components</ID>
     <ID>PackageNaming:BossPanelTopBarMenuTest.kt$package ai.rever.boss.components.window_panel.components</ID>
     <ID>PackageNaming:BossResizablePanel.kt$package ai.rever.boss.components.window_panel.components</ID>
     <ID>PackageNaming:BossTabBar.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginBuildTag.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginBuildTag.kt
@@ -37,6 +37,13 @@ fun PluginBuildTag(
         color = BossTheme.colors.signalText,
         fontSize = 9.sp,
         fontWeight = FontWeight.Bold,
+        // Clip rather than wrap when starved. The tag is laid out inside the title group, so at a
+        // narrow panel width it can be offered less room than the four characters need - and a
+        // panel can get very narrow indeed (BossResizablePanel floors it at 2% of the parent, or
+        // 20.dp). Left to wrap, "DEBUG" breaks onto a second line inside a row with a hard
+        // height(28.dp), which reads as a rendering fault rather than as a tag running out of space.
+        maxLines = 1,
+        softWrap = false,
         modifier =
             modifier
                 .clip(RoundedCornerShape(3.dp))

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.MonitorHeart
@@ -97,6 +98,17 @@ fun BossPanelTopBar(
                         onClick = { onBuildTagClick?.invoke() },
                     ),
                 )
+                // The way back to the released build, named as the action it is. The version row
+                // above already carries it, but that row reads as a statement of fact, so the only
+                // discoverable route was clicking the tag - and the tag is a 10sp pill that
+                // disappears entirely once the panel is narrow enough to ellipsize the title.
+                add(
+                    ContextMenuItem(
+                        text = "Install Store Version",
+                        icon = Icons.Outlined.CloudDownload,
+                        onClick = { onBuildTagClick?.invoke() },
+                    ),
+                )
                 add(ContextMenuItem(isDivider = true))
             }
             // "Reload Panel" is the user-facing name for what is really a reload of the owning
@@ -147,35 +159,41 @@ fun BossPanelTopBar(
     ) {
         Spacer(modifier = Modifier.width(8.dp))
 
-        Text(
-            text = title ?: "",
-            color = BossThemeColors.TextPrimary,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Medium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier =
-                Modifier
-                    // Give way rather than grow: an unbounded title in a narrow side panel would push
-                    // the build tag - the entire signal - off the end of the row. fill = false so a
-                    // short title still hugs its text and the tag sits next to it, not at the edge.
-                    .weight(1f, fill = false)
-                    .align(Alignment.CenterVertically),
-        )
-
-        // Next to the name, not out at the edge: the tag qualifies which build of this panel you are
-        // looking at, so it belongs with the thing it qualifies. Not hover-gated - a panel running
-        // unreleased code should say so whether or not the pointer is over it.
-        if (buildInfo?.isTagged == true) {
-            Spacer(modifier = Modifier.width(6.dp))
-            PluginBuildTag(
-                info = buildInfo,
-                modifier = Modifier.align(Alignment.CenterVertically),
-                onClick = onBuildTagClick,
+        // Title and tag are one group, and the group takes all the free space. This has to be a
+        // nested Row rather than a weighted title beside a weighted spacer: two weights in one Row
+        // split the free space 1:1, and because the title is fill = false, the half it did not use
+        // was laid out AFTER the trailing controls - so Minimize and the kebab sat short of the
+        // right edge by half the title's unused width, drifting further in the shorter the title.
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title ?: "",
+                color = BossThemeColors.TextPrimary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier =
+                    Modifier
+                        // Give way rather than grow: an unbounded title in a narrow side panel would push
+                        // the build tag - the entire signal - off the end of the row. fill = false so a
+                        // short title still hugs its text and the tag sits next to it, not at the edge.
+                        .weight(1f, fill = false),
             )
-        }
 
-        Spacer(modifier = Modifier.weight(1f))
+            // Next to the name, not out at the edge: the tag qualifies which build of this panel you
+            // are looking at, so it belongs with the thing it qualifies. Not hover-gated - a panel
+            // running unreleased code should say so whether or not the pointer is over it.
+            if (buildInfo?.isTagged == true) {
+                Spacer(modifier = Modifier.width(6.dp))
+                PluginBuildTag(
+                    info = buildInfo,
+                    onClick = onBuildTagClick,
+                )
+            }
+        }
 
         // "Update available" badge — always visible (not hover-gated) when a compatible update
         // exists for this plugin. Clicking it prompts to update.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
@@ -89,24 +89,32 @@ fun BossPanelTopBar(
             // Which build is running, first and clickable, for a plugin that is not on the released
             // version. The version has to be the item's TEXT rather than a badge widget: with no
             // trailing icon this menu is native-representable, so on macOS it renders as a real
-            // NSMenu whose items are a label and an enabled flag, nothing more.
-            buildInfo?.takeIf { it.isTagged }?.let { info ->
+            // NSMenu, whose items carry a label, an enabled flag and a rasterised leading icon -
+            // but nothing that is a widget, which is what a badge would need.
+            //
+            // Both rows are gated on the action existing, not merely on the build being tagged:
+            // onBuildTagClick is null whenever the panel has no resolvable window (LocalWindowId
+            // defaults to null), and a row named as an imperative that silently does nothing is a
+            // worse failure than no row at all. The tag itself is inert in exactly that case.
+            val installStoreVersion = onBuildTagClick
+            val taggedBuild = buildInfo?.takeIf { it.isTagged }
+            if (taggedBuild != null && installStoreVersion != null) {
                 add(
                     ContextMenuItem(
-                        text = "Version ${info.displayVersion}",
+                        text = "Version ${taggedBuild.displayVersion}",
                         icon = Icons.Outlined.Info,
-                        onClick = { onBuildTagClick?.invoke() },
+                        onClick = installStoreVersion,
                     ),
                 )
                 // The way back to the released build, named as the action it is. The version row
                 // above already carries it, but that row reads as a statement of fact, so the only
-                // discoverable route was clicking the tag - and the tag is a 10sp pill that
-                // disappears entirely once the panel is narrow enough to ellipsize the title.
+                // discoverable route was clicking the tag - and the tag is a 9sp pill that is the
+                // first thing to run out of room once the panel narrows.
                 add(
                     ContextMenuItem(
                         text = "Install Store Version",
                         icon = Icons.Outlined.CloudDownload,
-                        onClick = { onBuildTagClick?.invoke() },
+                        onClick = installStoreVersion,
                     ),
                 )
                 add(ContextMenuItem(isDivider = true))

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarLayoutTest.kt
@@ -10,7 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.width
 import org.junit.Rule
 import org.junit.Test
 import kotlin.math.abs
@@ -31,18 +34,42 @@ class BossPanelTopBarLayoutTest {
     private companion object {
         val BAR_WIDTH = 420.dp
 
-        /** The bar's own trailing padding (2.dp) plus the button's content padding (2.dp). */
+        /**
+         * The bar's trailing padding (2.dp) plus the button's content padding (2.dp), and 2.dp of
+         * slack so the assertion does not turn on sub-pixel rounding at fractional densities.
+         */
         val EDGE_TOLERANCE = 6.dp
+
+        /**
+         * Narrow enough that the title group is offered less than the tag's own width. The panel
+         * floor is `2% of parent, min 20.dp` (BossResizablePanel), and the header's fixed cost is
+         * already the leading spacer plus both buttons, so this band is reachable in the product.
+         */
+        val STARVED_WIDTH = 60.dp
 
         const val SHORT_TITLE = "A"
         const val LONG_TITLE = "A panel title long enough that it has to be ellipsized in here"
+
+        /** The tag's own semantics, which carry the version rather than the four-character pill. */
+        const val TAG_DESC = "Local build, not the store version: 1.0.3-debug"
     }
 
     private var title by mutableStateOf(SHORT_TITLE)
+    private var barWidth by mutableStateOf(BAR_WIDTH)
+
+    private fun localBuild() =
+        PluginBuildInfo(
+            pluginId = "p",
+            displayName = "Probe",
+            version = "1.0.3",
+            signedBytes = false,
+            storeSourced = false,
+            reloadStamp = null,
+        )
 
     private fun show(buildInfo: PluginBuildInfo? = null) {
         compose.setContent {
-            Box(modifier = Modifier.width(BAR_WIDTH)) {
+            Box(modifier = Modifier.width(barWidth)) {
                 BossPanelTopBar(
                     title = title,
                     isHovered = true,
@@ -60,6 +87,9 @@ class BossPanelTopBarLayoutTest {
 
     /** Laid-out bounds of a header control, in the root's coordinates. */
     private fun bounds(label: String) = control(label).getUnclippedBoundsInRoot()
+
+    /** Laid-out bounds of a text node - the title, which carries text rather than a description. */
+    private fun textBounds(text: String) = compose.onNodeWithText(text).getUnclippedBoundsInRoot()
 
     @Test
     fun `Minimize sits at the right edge of the bar`() {
@@ -93,13 +123,73 @@ class BossPanelTopBarLayoutTest {
         show()
         val withShortTitle = bounds("Minimize").right
 
-        title = LONG_TITLE
+        compose.runOnIdle { title = LONG_TITLE }
         compose.waitForIdle()
         val withLongTitle = bounds("Minimize").right
 
         assertTrue(
             abs((withShortTitle - withLongTitle).value) < 1f,
             "the right edge moved with the title: $withShortTitle vs $withLongTitle",
+        )
+    }
+
+    @Test
+    fun `a starved header keeps the tag on one line`() {
+        // Grouping the tag with the title reversed the measurement priority: the tag used to be
+        // measured against nearly the whole bar and now gets what the controls leave. Winning that
+        // trade for the controls is deliberate, but it means the tag must degrade by clipping. Left
+        // to wrap, four characters break onto a second line inside a hard height(28.dp) row.
+        show(buildInfo = localBuild())
+        val roomy = bounds(TAG_DESC).height
+
+        compose.runOnIdle { barWidth = STARVED_WIDTH }
+        compose.waitForIdle()
+        val starved = bounds(TAG_DESC).height
+
+        assertTrue(
+            abs((starved - roomy).value) < 1f,
+            "the tag grew taller when starved, so it wrapped: $roomy roomy vs $starved starved",
+        )
+    }
+
+    @Test
+    fun `a starved header keeps the controls at the right edge and the tag present`() {
+        // The other half of the trade: the title gives way first, the tag survives, and the
+        // controls stay put. This is the "narrow sidebar" case the change is riskiest in.
+        show(buildInfo = localBuild())
+        compose.runOnIdle {
+            title = LONG_TITLE
+            barWidth = STARVED_WIDTH
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithContentDescription(TAG_DESC).assertExists()
+        val gap = STARVED_WIDTH - bounds("Minimize").right
+        assertTrue(
+            gap <= EDGE_TOLERANCE,
+            "Minimize should stay flush right in a starved header; it is $gap short of the edge",
+        )
+    }
+
+    @Test
+    fun `the title gives way before the tag does`() {
+        // The PR claims the title ellipsizes ahead of the tag. Nothing asserted it until now.
+        show(buildInfo = localBuild())
+        compose.runOnIdle { title = LONG_TITLE }
+        compose.waitForIdle()
+        val roomyTitle = textBounds(LONG_TITLE).width
+        val roomyTag = bounds(TAG_DESC).width
+
+        compose.runOnIdle { barWidth = 200.dp }
+        compose.waitForIdle()
+
+        assertTrue(
+            textBounds(LONG_TITLE).width < roomyTitle,
+            "the title should shrink as the bar narrows",
+        )
+        assertTrue(
+            abs((bounds(TAG_DESC).width - roomyTag).value) < 1f,
+            "the tag should keep its width while the title still has room to give",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarLayoutTest.kt
@@ -1,0 +1,128 @@
+package ai.rever.boss.components.window_panel.components
+
+import ai.rever.boss.components.plugin.PluginBuildInfo
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.test.assertTrue
+
+/**
+ * Where the header's trailing controls actually land.
+ *
+ * A unit test of this file's model would have passed throughout the bug this pins: every child was
+ * present, in the right order, with the right callbacks. The defect was purely in measurement -
+ * two weighted children sharing free space 1:1, so the half the title did not use was laid out
+ * past the buttons - and only a laid-out screen can see it.
+ */
+class BossPanelTopBarLayoutTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private companion object {
+        val BAR_WIDTH = 420.dp
+
+        /** The bar's own trailing padding (2.dp) plus the button's content padding (2.dp). */
+        val EDGE_TOLERANCE = 6.dp
+
+        const val SHORT_TITLE = "A"
+        const val LONG_TITLE = "A panel title long enough that it has to be ellipsized in here"
+    }
+
+    private var title by mutableStateOf(SHORT_TITLE)
+
+    private fun show(buildInfo: PluginBuildInfo? = null) {
+        compose.setContent {
+            Box(modifier = Modifier.width(BAR_WIDTH)) {
+                BossPanelTopBar(
+                    title = title,
+                    isHovered = true,
+                    onMinimize = {},
+                    buildInfo = buildInfo,
+                    onBuildTagClick = {},
+                )
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    /** A header control, found by the content description its icon carries. */
+    private fun control(label: String) = compose.onNodeWithContentDescription(label)
+
+    /** Laid-out bounds of a header control, in the root's coordinates. */
+    private fun bounds(label: String) = control(label).getUnclippedBoundsInRoot()
+
+    @Test
+    fun `Minimize sits at the right edge of the bar`() {
+        show()
+
+        val gap = BAR_WIDTH - bounds("Minimize").right
+        assertTrue(
+            gap <= EDGE_TOLERANCE,
+            "Minimize should be flush right; it is $gap short of the edge (bar $BAR_WIDTH)",
+        )
+    }
+
+    @Test
+    fun `the More kebab sits directly left of Minimize, not adrift in the middle`() {
+        show()
+
+        val more = bounds("More")
+        val minimize = bounds("Minimize")
+
+        assertTrue(
+            more.right <= minimize.left && (minimize.left - more.right) <= EDGE_TOLERANCE,
+            "More should abut Minimize; More ends at ${more.right}, Minimize starts at ${minimize.left}",
+        )
+    }
+
+    @Test
+    fun `the trailing controls do not drift with the length of the title`() {
+        // The sharpest form of the bug: the leftover was half the title's *unused* width, so the
+        // controls crept further from the edge the shorter the title. A single-title assertion with
+        // a generous tolerance could pass while that was still true.
+        show()
+        val withShortTitle = bounds("Minimize").right
+
+        title = LONG_TITLE
+        compose.waitForIdle()
+        val withLongTitle = bounds("Minimize").right
+
+        assertTrue(
+            abs((withShortTitle - withLongTitle).value) < 1f,
+            "the right edge moved with the title: $withShortTitle vs $withLongTitle",
+        )
+    }
+
+    @Test
+    fun `the build tag does not push the controls off the right edge`() {
+        // The tag is laid out inside the title group, so it must consume the group's space and not
+        // the trailing controls'.
+        show(
+            buildInfo =
+                PluginBuildInfo(
+                    pluginId = "p",
+                    displayName = "Probe",
+                    version = "1.0.3",
+                    signedBytes = false,
+                    storeSourced = false,
+                    reloadStamp = 1_754_890_231_447L,
+                ),
+        )
+
+        val gap = BAR_WIDTH - bounds("Minimize").right
+        assertTrue(
+            gap <= EDGE_TOLERANCE,
+            "Minimize should stay flush right with a tag present; it is $gap short of the edge",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarMenuTest.kt
@@ -152,6 +152,48 @@ class BossPanelTopBarMenuTest {
     }
 
     @Test
+    fun `a local build offers Install Store Version, on the same action as the tag`() {
+        // The point of the row is discoverability, so what matters is that it is named as an action
+        // and reaches the same place the tag does - not that some clickable thing exists.
+        show(buildInfo = localBuild())
+        openMenu()
+
+        compose.onNodeWithText("Install Store Version").performClick()
+
+        assertEquals(1, tagClicked)
+    }
+
+    @Test
+    fun `a released build is not offered Install Store Version`() {
+        show(
+            buildInfo =
+                PluginBuildInfo(
+                    pluginId = "p",
+                    displayName = "Probe",
+                    version = "1.0.3",
+                    signedBytes = true,
+                    storeSourced = true,
+                    reloadStamp = null,
+                ),
+        )
+        openMenu()
+
+        compose.onNodeWithText("Install Store Version").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a hot reloaded build is offered Install Store Version too`() {
+        // HOT is a local build that was overwritten in place, so the way back to the released jar
+        // matters at least as much as it does for DEBUG.
+        show(buildInfo = localBuild(reloadStamp = 1_754_890_231_447L))
+        openMenu()
+
+        compose.onNodeWithText("Install Store Version").performClick()
+
+        assertEquals(1, tagClicked)
+    }
+
+    @Test
     fun `clicking the tag itself raises the store-version prompt`() {
         show(buildInfo = localBuild())
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarMenuTest.kt
@@ -64,6 +64,7 @@ class BossPanelTopBarMenuTest {
     private fun show(
         buildInfo: PluginBuildInfo? = null,
         uninstallEnabled: Boolean = true,
+        withTagAction: Boolean = true,
     ) {
         compose.setContent {
             BossPanelTopBar(
@@ -74,7 +75,7 @@ class BossPanelTopBarMenuTest {
                 uninstallEnabled = uninstallEnabled,
                 onMinimize = {},
                 buildInfo = buildInfo,
-                onBuildTagClick = { tagClicked++ },
+                onBuildTagClick = if (withTagAction) ({ tagClicked++ }) else null,
             )
         }
     }
@@ -161,6 +162,20 @@ class BossPanelTopBarMenuTest {
         compose.onNodeWithText("Install Store Version").performClick()
 
         assertEquals(1, tagClicked)
+    }
+
+    @Test
+    fun `neither build row is offered when there is no action behind it`() {
+        // onBuildTagClick is null when the panel has no resolvable window. Offering a row named as
+        // an imperative that silently does nothing is worse than offering no row, so both go - the
+        // factual version row with the action row, since they are the same click.
+        show(buildInfo = localBuild(), withTagAction = false)
+        openMenu()
+
+        compose.onNodeWithText("Install Store Version").assertDoesNotExist()
+        compose.onNodeWithText("Version 1.0.3-debug").assertDoesNotExist()
+        // The rest of the menu is unaffected.
+        compose.onNodeWithText("Reload Panel").assertExists()
     }
 
     @Test


### PR DESCRIPTION
Two fixes to the sidebar panel header, both follow-ups to #169.

## The trailing controls were not on the right edge

The title carried `weight(1f, fill = false)` and the `Spacer` beside it carried `weight(1f)`, so the two split the free space **1:1**. Because a `fill = false` child does not fill its share, the half the title left over was laid out *after* Minimize and the kebab rather than before them. The controls therefore sat short of the right edge by half the title's unused width, and drifted further in the shorter the title was.

Measured in a 420dp bar: a short title left Minimize **170dp** clear of the edge, and its right edge moved from 250dp to 418dp purely as a function of title length.

Title and tag are now one nested `Row` that owns the free space, so the controls end where the bar does. The tag still sits beside the name and the title still ellipsizes ahead of it.

Two side effects worth knowing when reading a screenshot diff, since neither is what the title describes: the title now gets 100% of the free space rather than 50%, so it ellipsizes considerably later, and the update badge sits against the controls rather than floating mid-bar.

## "Install Store Version" is now named as an action

The overflow menu (one list shared by the kebab and right-click, so both get it) offers **Install Store Version** for a plugin running a DEBUG or HOT build, wired to the same callback the tag itself fires. It raises the same prompt, including the "no published version" branch.

The existing `Version 1.0.3-debug+<millis>` row keeps its click rather than being demoted, so nothing that worked before stops working. It just is not the only route any more: that row reads as a statement of fact, so the way back to the released build was discoverable only by guessing that either it or a 10sp pill was clickable. A released build is offered neither row.

## Verification

**2088 tests, 0 failures, 0 skipped**; ktlint and detekt clean. The test total was cross-checked against an independent count of `<testcase>` elements rather than trusting the summary line.

`BossPanelTopBarLayoutTest` is new and asserts against a laid-out screen on purpose. The model was correct throughout this bug - every child present, in the right order, with the right callbacks - so only measurement could see it. It was mutation-checked: reinstating the two-weight layout fails three of its four cases with the geometry quoted above. The fourth (More abutting Minimize) does **not** catch this bug, since those two never moved relative to each other; it guards a different regression.

Three cases added to `BossPanelTopBarMenuTest` cover the new item on a DEBUG build, on a HOT build, and its absence on a released one.

One detekt baseline entry was added: `PackageNaming` for the new test file, matching the 46 existing entries for this repo's `window_panel` package convention. The `MaxLineLength` finding was fixed properly instead.

## Verified running

Launched from this branch against the real dev host (`~/.boss_debug/plugins`, 41 plugins loaded).

- **The trailing controls sit at the right edge.** Confirmed on the running build.
- **The DEBUG pill renders beside the panel name**, on `Codebase` and `Run Configurations` among others.
- **The build probe produced 28 verdicts against real jars**, and they are correct: 28 unsigned local builds tagged (`codebase 1.5.6-debug`, `secretmanager 1.2.15-debug`, and so on), and all **11 store-signed jars left untagged** - aigateway, docker, finances, jupyternotebook, organisation, toolevolver, api, bookmarks, editor-tab, plugin-manager, terminal-tab. Every one of those loaded that run and not one appears in the tagged set.

That last point is the real-world confirmation of finding 1 from #169: DEBUG must not fire on a genuinely store-installed plugin, and it does not.

## Still not exercised live

- **The HOT path.** Nothing was hot reloaded that run, so no `+<millis>` suffix has been seen rendering.
- **The click-through from the new menu row to the prompt**, and its "no published version" branch.

## Review round

Both substantive findings from the review are fixed, and both are mutation-checked.

- **The tag wrapped when starved.** Grouping it with the title reversed the measurement priority, and `PluginBuildTag` set neither `maxLines` nor `softWrap`. Measured, a starved pill went from 13dp tall to 28dp - a second line exactly filling the bar's hard height. It now clips.
- **Both build rows could render dead.** They were gated on the build being tagged, but the click is `onBuildTagClick`, which `SidePanel` leaves null when the panel has no resolvable window (`LocalWindowId` defaults to null). Both are now gated on the action existing.

One claim I narrowed: the dead row is reachable only through the null-window path, not the null-panel one, because `buildInfo` is derived from the panel id and would be null with it.

One item the review resolved rather than raised: a **leading** icon keeps the menu on the native macOS path. `isNativeRepresentable` only rejects trailing icons and non-representable submenus, and `collectIcons()` rasterises the leading one. The comment that claimed otherwise was stale and is corrected, and this drops off the list below.

Worth a reviewer's eye:

- Plugin **tabs** render the tag and it is clickable, but tabs do not share this overflow menu, so the new row exists only in the sidebar panel header. That is the scope asked for, not an oversight.
- Whether the `Version ...` row still wants to be clickable now that a named action sits directly beneath it. Both fire the same callback, which is unusual enough to invite a future cleanup that deletes one.
