### PR TITLE
fix(windows): relaunch BOSS after an update installs, as macOS and Linux already do

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -20,6 +20,19 @@ private const val MACOS_APP_BUNDLE_SUFFIX = ".app"
 private const val MACOS_APPLICATIONS_DIRECTORY = "/Applications"
 private const val SPOTLIGHT_LOOKUP_TIMEOUT_SECONDS = 5L
 
+/** jpackage sets this on every packaged launch, to the launcher executable itself. */
+private const val JPACKAGE_APP_PATH_PROPERTY = "jpackage.app-path"
+
+/** Filename of the Windows launcher jpackage emits, as `WindowsProtocolHandler` also assumes. */
+private const val WINDOWS_LAUNCHER_NAME = "BOSS.exe"
+
+/**
+ * How far up from the running code to look for the launcher. The jpackage layout puts
+ * it two levels up (`<install>\app\*.jar` -> `<install>\BOSS.exe`); the slack costs
+ * nothing and covers a jar nested deeper.
+ */
+private const val WINDOWS_LAUNCHER_SEARCH_DEPTH = 5
+
 /** Staging directory (inside the platform temp directory) that downloads land in. */
 internal const val UPDATE_STAGING_DIR_NAME = "boss-updates"
 
@@ -67,6 +80,38 @@ internal fun realAppPathFor(
     if (appExists(applicationsPath)) return applicationsPath
 
     return installedAppLookup()?.takeIf(appExists) ?: path
+}
+
+/**
+ * Resolve the installed Windows launcher to relaunch after the MSI runs, without
+ * touching the filesystem itself so the ordering stays unit-testable.
+ *
+ * Returns null when there is nothing to relaunch - a development run, or an install
+ * shape neither method recognises. Null is not an error: the caller installs anyway
+ * and only skips the relaunch, which is exactly the behaviour Windows had before.
+ *
+ * @param jpackageAppPath `jpackage.app-path`, the launcher path jpackage itself set.
+ * @param codeSourcePath Absolute path of the running jar or classes directory.
+ * @param exists Filesystem probe, injected.
+ */
+internal fun windowsLauncherPathFor(
+    jpackageAppPath: String?,
+    codeSourcePath: String?,
+    exists: (String) -> Boolean,
+): String? {
+    // jpackage's own answer, and the same property WindowsProtocolHandler trusts
+    // first. It names the launcher directly, so nothing has to be inferred from the
+    // install layout.
+    jpackageAppPath?.takeIf { it.isNotBlank() && exists(it) }?.let { return it }
+
+    // Otherwise walk up from the running code looking for the launcher beside a
+    // directory we are inside: `<install>\app\composeApp.jar` -> `<install>\BOSS.exe`.
+    return codeSourcePath
+        ?.let(::File)
+        ?.let { code -> generateSequence(code.parentFile) { it.parentFile } }
+        ?.take(WINDOWS_LAUNCHER_SEARCH_DEPTH)
+        ?.map { File(it, WINDOWS_LAUNCHER_NAME).path }
+        ?.firstOrNull(exists)
 }
 
 /**
@@ -530,6 +575,18 @@ object UpdateInstaller {
                 // Validate download file for security (early check)
                 validateDownloadFile(downloadFile, ".msi")
 
+                // Resolve the launcher while BOSS is still running - the script needs
+                // it to bring the app back, and after msiexec there is no process left
+                // to ask. Unlike the macOS path an unresolvable one is not fatal: the
+                // install still happens, the user just starts BOSS themselves.
+                val launcherPath = getWindowsLauncherPath()
+                if (launcherPath == null) {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Could not determine the BOSS launcher path - the update will not relaunch",
+                    )
+                }
+
                 // Generate update script with current process PID
                 val currentPid = ProcessHandle.current().pid()
                 logger.debug(LogCategory.SYSTEM, "Generating update script", mapOf("pid" to currentPid))
@@ -538,6 +595,7 @@ object UpdateInstaller {
                     UpdateScriptGenerator.generateWindowsUpdateScript(
                         msiPath = downloadFile.absolutePath,
                         appPid = currentPid,
+                        targetExePath = launcherPath,
                     )
 
                 // Launch the script in the background
@@ -660,6 +718,66 @@ object UpdateInstaller {
                 logger.error(LogCategory.SYSTEM, "Error during RPM update preparation", error = e)
                 InstallResult.Error(e.message ?: "Unknown error")
             }
+        }
+
+    /**
+     * Path of the installed `BOSS.exe` for the update script to relaunch, or null when
+     * it cannot be resolved or would be refused by [UpdatePathValidator].
+     *
+     * The validation is swallowed here rather than left to the script generator on
+     * purpose. The generator throws, and a throw on this argument would abort an
+     * update that is otherwise fine - trading "installs but does not relaunch" for
+     * "does not install", which is strictly worse. In practice it cannot trigger: the
+     * MSI path passed alongside it lives under the same user profile and so carries
+     * the same account name, and the filename component is the constant `BOSS.exe`.
+     */
+    internal fun getWindowsLauncherPath(): String? {
+        val launcher =
+            try {
+                windowsLauncherPathFor(
+                    jpackageAppPath = System.getProperty(JPACKAGE_APP_PATH_PROPERTY),
+                    codeSourcePath = currentCodeSourceFile()?.path,
+                    exists = { File(it).exists() },
+                )
+            } catch (e: Exception) {
+                logger.warn(LogCategory.SYSTEM, "Error resolving the Windows launcher path", error = e)
+                null
+            } ?: return null
+
+        return try {
+            UpdatePathValidator.validatePathAndFileName(launcher, "Target exe path")
+            logger.debug(LogCategory.SYSTEM, "Resolved Windows launcher for relaunch", mapOf("path" to launcher))
+            launcher
+        } catch (e: SecurityException) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Launcher path refused by validation - installing without a relaunch",
+                mapOf("reason" to (e.message ?: "unknown")),
+            )
+            null
+        }
+    }
+
+    /**
+     * The jar or classes directory this code is running from, or null if the location
+     * is unavailable. Goes through [java.net.URI] rather than `location.path`: that is
+     * URL-encoded, so a Windows install under a profile with a space in it yields a
+     * `%20` no filesystem call resolves.
+     */
+    private fun currentCodeSourceFile(): File? =
+        try {
+            UpdateInstaller::class.java.protectionDomain
+                ?.codeSource
+                ?.location
+                ?.toURI()
+                ?.let(::File)
+        } catch (e: Exception) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not resolve the current code source",
+                mapOf("error" to (e.message ?: "unknown")),
+            )
+            null
         }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateInstaller.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.utils.AppVersion
 import ai.rever.boss.utils.BOSS_MACOS_APP_BUNDLE_NAME
 import ai.rever.boss.utils.BOSS_MACOS_BUNDLE_ID
 import ai.rever.boss.utils.Version
+import ai.rever.boss.utils.WindowsProtocolCleanup
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
@@ -28,10 +29,24 @@ private const val WINDOWS_LAUNCHER_NAME = "BOSS.exe"
 
 /**
  * How far up from the running code to look for the launcher. The jpackage layout puts
- * it two levels up (`<install>\app\*.jar` -> `<install>\BOSS.exe`); the slack costs
- * nothing and covers a jar nested deeper.
+ * it two levels up (`<install>\app\*.jar` -> `<install>\BOSS.exe`); the slack covers a
+ * jar nested deeper, and [WINDOWS_INSTALL_MARKER_DIRS] is what keeps it from wandering.
  */
 private const val WINDOWS_LAUNCHER_SEARCH_DEPTH = 5
+
+/**
+ * Directories jpackage always puts beside the launcher, used to require that a candidate
+ * directory actually looks like a BOSS install.
+ *
+ * Without this the walk could accept any `BOSS.exe` sitting in an ancestor directory, and
+ * above `<install>` for a per-user install those ancestors are `%LOCALAPPDATA%`,
+ * `C:\Users\<account>\AppData` and `C:\Users\<account>` - all user-writable, and the
+ * result is handed straight to `start`. Reaching that needs `jpackage.app-path` absent or
+ * stale *and* the real launcher gone, so it was never likely; "we could not find the
+ * launcher" is still a much better outcome than launching whatever is named right three
+ * directories up.
+ */
+private val WINDOWS_INSTALL_MARKER_DIRS = listOf("app", "runtime")
 
 /** Staging directory (inside the platform temp directory) that downloads land in. */
 internal const val UPDATE_STAGING_DIR_NAME = "boss-updates"
@@ -92,7 +107,7 @@ internal fun realAppPathFor(
  *
  * @param jpackageAppPath `jpackage.app-path`, the launcher path jpackage itself set.
  * @param codeSourcePath Absolute path of the running jar or classes directory.
- * @param exists Filesystem probe, injected.
+ * @param exists Filesystem probe, injected. Answers for directories as well as files.
  */
 internal fun windowsLauncherPathFor(
     jpackageAppPath: String?,
@@ -106,13 +121,21 @@ internal fun windowsLauncherPathFor(
 
     // Otherwise walk up from the running code looking for the launcher beside a
     // directory we are inside: `<install>\app\composeApp.jar` -> `<install>\BOSS.exe`.
+    // Nearest match wins, and each candidate has to look like an install.
     return codeSourcePath
         ?.let(::File)
         ?.let { code -> generateSequence(code.parentFile) { it.parentFile } }
         ?.take(WINDOWS_LAUNCHER_SEARCH_DEPTH)
+        ?.filter { directory -> isWindowsInstallDir(directory, exists) }
         ?.map { File(it, WINDOWS_LAUNCHER_NAME).path }
         ?.firstOrNull(exists)
 }
+
+/** Whether [directory] carries one of the [WINDOWS_INSTALL_MARKER_DIRS] jpackage emits. */
+private fun isWindowsInstallDir(
+    directory: File,
+    exists: (String) -> Boolean,
+): Boolean = WINDOWS_INSTALL_MARKER_DIRS.any { exists(File(directory, it).path) }
 
 /**
  * Platform-specific update installation logic
@@ -746,7 +769,13 @@ object UpdateInstaller {
 
         return try {
             UpdatePathValidator.validatePathAndFileName(launcher, "Target exe path")
-            logger.debug(LogCategory.SYSTEM, "Resolved Windows launcher for relaunch", mapOf("path" to launcher))
+            // Masked: a per-user install puts the Windows account name in this path, and
+            // `maskUserPath` is the sibling helper written for exactly that shape.
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Resolved Windows launcher for relaunch",
+                mapOf("path" to WindowsProtocolCleanup.maskUserPath(launcher)),
+            )
             launcher
         } catch (e: SecurityException) {
             logger.warn(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -42,6 +42,114 @@ internal fun resolveUpdaterLogFile(
 internal fun updaterTempDir(): File = createRestrictedDir(resolveUpdaterTempDir())
 
 /**
+ * The body of the Windows helper script: wait for BOSS to quit, install, relaunch.
+ *
+ * File-level rather than a member of [UpdateScriptGenerator] because it is pure text
+ * assembly with no escaping of its own - both paths arrive already escaped - and
+ * because the object is at detekt's function-count ceiling.
+ *
+ * Every wait is a `ping`, not the obvious `timeout`: [UpdateScriptGenerator.launchScript]
+ * starts this with ProcessBuilder, so stdin is a pipe, and `timeout` refuses to run at
+ * all under redirected input ("ERROR: Input redirection is not supported"). It failed
+ * instantly rather than waiting, which turned the quit poll into a hot loop hammering
+ * tasklist and wrote three errors into the one log anybody diagnosing a failed update
+ * would read.
+ *
+ * @param escapedMsiPath The MSI path, already through the Windows batch escaper.
+ * @param escapedExePath The launcher to relaunch, already escaped, or null for none.
+ */
+internal fun windowsUpdateScript(
+    escapedMsiPath: String,
+    appPid: Long,
+    escapedExePath: String?,
+): String {
+    val install =
+        """
+        @echo off
+        REM BOSS Update Helper Script
+
+        echo BOSS Update Helper started
+        echo Waiting for BOSS to quit (PID: $appPid)...
+
+        REM Wait for process to terminate (ping, not timeout - see the KDoc)
+        :waitloop
+        tasklist /FI "PID eq $appPid" 2>NUL | find /I /N "$appPid">NUL
+        if "%ERRORLEVEL%"=="0" (
+            ping -n 2 127.0.0.1 >NUL
+            goto waitloop
+        )
+
+        echo BOSS has quit. Starting installation...
+        ping -n 3 127.0.0.1 >NUL
+
+        REM Launch MSI installer (using escaped path for security)
+        echo Installing update...
+        msiexec /i $escapedMsiPath /quiet /norestart
+
+        REM Capture the code before anything else overwrites ERRORLEVEL, and treat the
+        REM two "installed, wants a reboot" codes as success: /norestart makes msiexec
+        REM report 3010 rather than 0 whenever a file was in use, so branching on NEQ 0
+        REM would call a completed install a failure and hand the user an installer
+        REM they do not need.
+        set MSI_RESULT=%ERRORLEVEL%
+        if %MSI_RESULT% EQU 3010 set MSI_RESULT=0
+        if %MSI_RESULT% EQU 1641 set MSI_RESULT=0
+
+        REM No relaunch on this branch, deliberately: the interactive installer is now
+        REM driving, and a running BOSS holding its own files open is what it needs
+        REM least.
+        if not %MSI_RESULT% EQU 0 (
+            echo Installation failed with exit code %MSI_RESULT%. Opening installer manually...
+            start "" $escapedMsiPath
+            goto cleanup
+        )
+
+        echo Installation successful!
+        """.trimIndent()
+
+    val cleanup =
+        """
+        :cleanup
+        REM Clean up
+        ping -n 3 127.0.0.1 >NUL
+        del "%~f0"
+        """.trimIndent()
+
+    // Joined rather than interpolated into one template: `trimIndent` runs after
+    // interpolation, so a multi-line block spliced into an indented template leaves
+    // its own continuation lines at column 0, which makes the common indent 0 and
+    // emits every other line still indented. Batch tolerates that for commands but it
+    // is not worth relying on for the `:labels` `goto` depends on.
+    return listOf(install, windowsRelaunchBlock(escapedExePath), cleanup).joinToString("\n\n")
+}
+
+/**
+ * The relaunch, the step macOS and Linux always had and Windows never did: the MSI leg
+ * installed and then simply ended, so clicking "Install update" quit BOSS and nothing
+ * came back.
+ *
+ * `if exist` because a major upgrade is only *usually* into the same INSTALLDIR - a
+ * per-user install replaced by a per-machine one lands elsewhere - and `start` on a
+ * missing path raises a Windows error dialog rather than failing quietly. When the
+ * launcher could not be resolved at all the block is a message instead, so the updater
+ * log says which of the two happened.
+ */
+private fun windowsRelaunchBlock(escapedExePath: String?): String {
+    if (escapedExePath == null) {
+        return "echo Could not determine the BOSS install path - please start BOSS manually"
+    }
+
+    return """
+        echo Relaunching BOSS...
+        if exist $escapedExePath (
+            start "" $escapedExePath
+        ) else (
+            echo BOSS was not found at $escapedExePath - please start BOSS manually
+        )
+        """.trimIndent()
+}
+
+/**
  * Generates platform-specific update helper scripts
  *
  * These scripts run AFTER the main app quits and handle:
@@ -315,14 +423,19 @@ object UpdateScriptGenerator {
      *
      * @param msiPath Path to the downloaded MSI file
      * @param appPid Process ID of the running app to wait for
+     * @param targetExePath Path of the installed launcher to relaunch (e.g.
+     *   `%LOCALAPPDATA%\BOSS\BOSS.exe`), or null when it could not be resolved -
+     *   the update is still installed, just without the relaunch.
      * @return File object pointing to the generated script
      */
     fun generateWindowsUpdateScript(
         msiPath: String,
         appPid: Long,
+        targetExePath: String? = null,
     ): File {
         // Validate input for security
         validatePath(msiPath, "MSI path")
+        targetExePath?.let { validatePath(it, "Target exe path") }
 
         // Escape path for Windows batch file (handles quotes, percent signs, etc.)
         val escapedMsiPath = escapeWindowsArg(msiPath)
@@ -333,44 +446,26 @@ object UpdateScriptGenerator {
 
         val scriptFile = File(tempDir, "update_boss_${System.currentTimeMillis()}.bat")
 
+        // CRLF, not the LF `writeText` would otherwise leave: cmd.exe parses an
+        // LF-only batch file by seeking byte offsets that assume CRLF, so `goto` into
+        // a label - which the failure branch now needs - is the case that misbehaves,
+        // and it misbehaves by jumping to the wrong place rather than by failing.
         val script =
-            """
-            @echo off
-            REM BOSS Update Helper Script
-
-            echo BOSS Update Helper started
-            echo Waiting for BOSS to quit (PID: $appPid)...
-
-            REM Wait for process to terminate
-            :waitloop
-            tasklist /FI "PID eq $appPid" 2>NUL | find /I /N "$appPid">NUL
-            if "%ERRORLEVEL%"=="0" (
-                timeout /t 1 /nobreak >NUL
-                goto waitloop
+            windowsUpdateScript(
+                escapedMsiPath = escapedMsiPath,
+                appPid = appPid,
+                escapedExePath = targetExePath?.let(::escapeWindowsArg),
             )
+        scriptFile.writeText(script.replace("\n", "\r\n"))
 
-            echo BOSS has quit. Starting installation...
-            timeout /t 2 /nobreak >NUL
-
-            REM Launch MSI installer (using escaped path for security)
-            echo Installing update...
-            msiexec /i $escapedMsiPath /quiet /norestart
-
-            if %ERRORLEVEL% NEQ 0 (
-                echo Installation failed. Opening installer manually...
-                start "" $escapedMsiPath
-            ) else (
-                echo Installation successful!
-            )
-
-            REM Clean up
-            timeout /t 2 /nobreak >NUL
-            del "%~f0"
-            """.trimIndent()
-
-        scriptFile.writeText(script)
-
-        logger.debug(LogCategory.SYSTEM, "Generated Windows update script", mapOf("path" to scriptFile.absolutePath))
+        logger.debug(
+            LogCategory.SYSTEM,
+            "Generated Windows update script",
+            mapOf(
+                "path" to scriptFile.absolutePath,
+                "relaunches" to (targetExePath != null).toString(),
+            ),
+        )
         return scriptFile
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/UpdateScriptGenerator.kt
@@ -41,6 +41,45 @@ internal fun resolveUpdaterLogFile(
  */
 internal fun updaterTempDir(): File = createRestrictedDir(resolveUpdaterTempDir())
 
+/** Whether [updaterLaunchCommand] recognises [osName], i.e. is not falling back to bash. */
+internal fun isKnownUpdaterOs(osName: String): Boolean =
+    osName.contains("mac") || osName.contains("darwin") || osName.contains("linux") || osName.contains("win")
+
+/**
+ * The command that runs a generated helper script detached, for [osName].
+ *
+ * The Windows form carries an **empty title argument**, and it is load-bearing.
+ * ProcessBuilder quotes any argument containing a space, so for an account whose name
+ * has one - `C:\Users\Bob Smith\AppData\Local\Temp\boss-updater\...`, i.e. anyone whose
+ * Windows account is their real name - `cmd /c start /b "<script>"` reaches `start` with
+ * the script path as its first *quoted* token, which `start` takes as a window title.
+ * The helper then never ran at all: no install, no relaunch, nothing in the log, for
+ * exactly the users most likely to have an awkward path. Verified through ProcessBuilder
+ * on Windows 11: without the `""` the script does not execute, with it it does.
+ *
+ * @param osName A lowercased `os.name`.
+ * @param scriptPath Absolute path of the script to run.
+ */
+internal fun updaterLaunchCommand(
+    osName: String,
+    scriptPath: String,
+): List<String> =
+    when {
+        // macOS/Linux: Launch in background with nohup
+        osName.contains("mac") || osName.contains("darwin") || osName.contains("linux") -> {
+            listOf("nohup", "bash", scriptPath)
+        }
+
+        // Windows: launch detached, with the empty title `start` needs (see above)
+        osName.contains("win") -> {
+            listOf("cmd", "/c", "start", "", "/b", scriptPath)
+        }
+
+        else -> {
+            listOf("bash", scriptPath)
+        }
+    }
+
 /**
  * The body of the Windows helper script: wait for BOSS to quit, install, relaunch.
  *
@@ -55,6 +94,11 @@ internal fun updaterTempDir(): File = createRestrictedDir(resolveUpdaterTempDir(
  * tasklist and wrote three errors into the one log anybody diagnosing a failed update
  * would read.
  *
+ * The blocks are joined rather than interpolated into one template because `trimIndent`
+ * runs *after* interpolation: a multi-line block spliced into an indented template keeps
+ * its own continuation lines at column 0, which makes the common indent 0 and emits every
+ * other line still indented - including the `:labels` `goto` depends on.
+ *
  * @param escapedMsiPath The MSI path, already through the Windows batch escaper.
  * @param escapedExePath The launcher to relaunch, already escaped, or null for none.
  */
@@ -63,50 +107,6 @@ internal fun windowsUpdateScript(
     appPid: Long,
     escapedExePath: String?,
 ): String {
-    val install =
-        """
-        @echo off
-        REM BOSS Update Helper Script
-
-        echo BOSS Update Helper started
-        echo Waiting for BOSS to quit (PID: $appPid)...
-
-        REM Wait for process to terminate (ping, not timeout - see the KDoc)
-        :waitloop
-        tasklist /FI "PID eq $appPid" 2>NUL | find /I /N "$appPid">NUL
-        if "%ERRORLEVEL%"=="0" (
-            ping -n 2 127.0.0.1 >NUL
-            goto waitloop
-        )
-
-        echo BOSS has quit. Starting installation...
-        ping -n 3 127.0.0.1 >NUL
-
-        REM Launch MSI installer (using escaped path for security)
-        echo Installing update...
-        msiexec /i $escapedMsiPath /quiet /norestart
-
-        REM Capture the code before anything else overwrites ERRORLEVEL, and treat the
-        REM two "installed, wants a reboot" codes as success: /norestart makes msiexec
-        REM report 3010 rather than 0 whenever a file was in use, so branching on NEQ 0
-        REM would call a completed install a failure and hand the user an installer
-        REM they do not need.
-        set MSI_RESULT=%ERRORLEVEL%
-        if %MSI_RESULT% EQU 3010 set MSI_RESULT=0
-        if %MSI_RESULT% EQU 1641 set MSI_RESULT=0
-
-        REM No relaunch on this branch, deliberately: the interactive installer is now
-        REM driving, and a running BOSS holding its own files open is what it needs
-        REM least.
-        if not %MSI_RESULT% EQU 0 (
-            echo Installation failed with exit code %MSI_RESULT%. Opening installer manually...
-            start "" $escapedMsiPath
-            goto cleanup
-        )
-
-        echo Installation successful!
-        """.trimIndent()
-
     val cleanup =
         """
         :cleanup
@@ -115,13 +115,70 @@ internal fun windowsUpdateScript(
         del "%~f0"
         """.trimIndent()
 
-    // Joined rather than interpolated into one template: `trimIndent` runs after
-    // interpolation, so a multi-line block spliced into an indented template leaves
-    // its own continuation lines at column 0, which makes the common indent 0 and
-    // emits every other line still indented. Batch tolerates that for commands but it
-    // is not worth relying on for the `:labels` `goto` depends on.
-    return listOf(install, windowsRelaunchBlock(escapedExePath), cleanup).joinToString("\n\n")
+    return listOf(
+        windowsInstallBlock(escapedMsiPath, appPid),
+        windowsRelaunchBlock(escapedExePath),
+        cleanup,
+    ).joinToString("\n\n")
 }
+
+/**
+ * Wait for BOSS to quit, then run the MSI, ending on the success path.
+ *
+ * `MSI_RAW` is kept alongside `MSI_RESULT` so the reboot-pending outcome stays
+ * diagnosable. 3010 means the install completed but files were in use and the
+ * replacement is pending a reboot, so relaunching can bring back a partially-updated
+ * install: the user would see "Installation successful!", get an app still reporting the
+ * old version, and be offered the same update again on the next check, with nothing in
+ * the log to explain it. Relaunching is still better than not, so the branching is
+ * unchanged - only the report.
+ */
+private fun windowsInstallBlock(
+    escapedMsiPath: String,
+    appPid: Long,
+): String =
+    """
+    @echo off
+    REM BOSS Update Helper Script
+
+    echo BOSS Update Helper started
+    echo Waiting for BOSS to quit (PID: $appPid)...
+
+    REM Wait for process to terminate (ping, not timeout - see the KDoc)
+    :waitloop
+    tasklist /FI "PID eq $appPid" 2>NUL | find /I /N "$appPid">NUL
+    if "%ERRORLEVEL%"=="0" (
+        ping -n 2 127.0.0.1 >NUL
+        goto waitloop
+    )
+
+    echo BOSS has quit. Starting installation...
+    ping -n 3 127.0.0.1 >NUL
+
+    REM Launch MSI installer (using escaped path for security)
+    echo Installing update...
+    msiexec /i $escapedMsiPath /quiet /norestart
+
+    REM Capture the code before anything else overwrites ERRORLEVEL, and treat the two
+    REM "installed, wants a reboot" codes as success: /norestart makes msiexec report
+    REM 3010 rather than 0 whenever a file was in use, so branching on NEQ 0 would call
+    REM a completed install a failure and hand the user an installer they do not need.
+    set MSI_RESULT=%ERRORLEVEL%
+    set MSI_RAW=%MSI_RESULT%
+    if %MSI_RESULT% EQU 3010 set MSI_RESULT=0
+    if %MSI_RESULT% EQU 1641 set MSI_RESULT=0
+
+    REM No relaunch on this branch, deliberately: the interactive installer is now
+    REM driving, and a running BOSS holding its own files open is what it needs least.
+    if not %MSI_RESULT% EQU 0 (
+        echo Installation failed with exit code %MSI_RESULT%. Opening installer manually...
+        start "" $escapedMsiPath
+        goto cleanup
+    )
+
+    echo Installation successful!
+    if not %MSI_RAW% EQU %MSI_RESULT% echo Completed with code %MSI_RAW% - a reboot is pending, so BOSS may still report the old version until Windows restarts
+    """.trimIndent()
 
 /**
  * The relaunch, the step macOS and Linux always had and Windows never did: the MSI leg
@@ -907,23 +964,10 @@ ASKPASS_EOF
             val logFile = resolveUpdaterLogFile(timestamp)
 
             val os = System.getProperty("os.name").lowercase()
-            val command =
-                when {
-                    os.contains("mac") || os.contains("darwin") || os.contains("linux") -> {
-                        // macOS/Linux: Launch in background with nohup
-                        listOf("nohup", "bash", scriptFile.absolutePath)
-                    }
-
-                    os.contains("win") -> {
-                        // Windows: Launch detached
-                        listOf("cmd", "/c", "start", "/b", scriptFile.absolutePath)
-                    }
-
-                    else -> {
-                        logger.warn(LogCategory.SYSTEM, "Unknown OS, attempting direct execution")
-                        listOf("bash", scriptFile.absolutePath)
-                    }
-                }
+            if (!isKnownUpdaterOs(os)) {
+                logger.warn(LogCategory.SYSTEM, "Unknown OS, attempting direct execution")
+            }
+            val command = updaterLaunchCommand(os, scriptFile.absolutePath)
 
             logger.info(
                 LogCategory.SYSTEM,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/WindowsUpdateRelaunchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/WindowsUpdateRelaunchTest.kt
@@ -1,7 +1,9 @@
 package ai.rever.boss.updater
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -48,6 +50,23 @@ class WindowsUpdateRelaunchTest {
     }
 
     /**
+     * Ordering after `msiexec` alone would also be satisfied by a relaunch sitting past
+     * `:cleanup`, which `goto cleanup` would then skip on the *success* path too. What
+     * encodes the control flow is that it sits between the success echo and the label.
+     */
+    @Test
+    fun `the relaunch sits between the success echo and cleanup`() {
+        val script = script(exePath)
+
+        val success = script.indexOf("Installation successful!")
+        val relaunch = script.indexOf("""start "" "$exePath"""")
+        val cleanup = script.indexOf("\n:cleanup")
+
+        assertTrue(success in 0 until relaunch, "Relaunch must follow the success echo:\n$script")
+        assertTrue(relaunch < cleanup, "Relaunch must precede :cleanup, or goto would skip it:\n$script")
+    }
+
+    /**
      * A major upgrade is only *usually* into the same INSTALLDIR - a per-user install
      * replaced by a per-machine one lands elsewhere - and `start` on a missing path
      * raises a Windows error dialog rather than failing quietly.
@@ -71,18 +90,23 @@ class WindowsUpdateRelaunchTest {
     fun `a failed install does not relaunch`() {
         val script = script(exePath)
 
+        // Sliced on the `goto cleanup` line rather than the first `)`: a path containing
+        // a paren would truncate the branch and quietly weaken this, and
+        // `C:\Program Files (x86)\...` is not exotic.
         val failureBranch =
             script
-                .substringAfter("if not %MSI_RESULT% EQU 0 (")
-                .substringBefore(")")
+                .lines()
+                .dropWhile { !it.contains("if not %MSI_RESULT% EQU 0 (") }
+                .takeWhile { !it.contains("goto cleanup") }
 
+        assertTrue(failureBranch.isNotEmpty(), "Could not find the failure branch:\n$script")
         assertFalse(
-            failureBranch.contains(exePath),
+            failureBranch.any { it.contains(exePath) },
             "The failure branch must not relaunch BOSS:\n$failureBranch",
         )
         assertTrue(
-            failureBranch.contains("goto cleanup"),
-            "The failure branch should skip to cleanup:\n$failureBranch",
+            script.lines().any { it.contains("goto cleanup") },
+            "The failure branch should skip to cleanup:\n$script",
         )
     }
 
@@ -98,6 +122,29 @@ class WindowsUpdateRelaunchTest {
 
         assertTrue(script.contains("if %MSI_RESULT% EQU 3010 set MSI_RESULT=0"), script)
         assertTrue(script.contains("if %MSI_RESULT% EQU 1641 set MSI_RESULT=0"), script)
+    }
+
+    /**
+     * 3010 means the install completed but the replacement is pending a reboot, so the
+     * relaunch can bring back a partially-updated install: "Installation successful!", an
+     * app still reporting the old version, and the same update offered again next check.
+     * The raw code has to survive the mapping or there is nothing in the log to explain
+     * that.
+     */
+    @Test
+    fun `the raw installer code is kept and reported when it differs`() {
+        val script = script(exePath)
+
+        assertTrue(
+            script.contains("set MSI_RAW=%MSI_RESULT%"),
+            "The raw code must be captured before the mapping rewrites it:\n$script",
+        )
+        val report = script.lines().single { it.startsWith("if not %MSI_RAW% EQU %MSI_RESULT%") }
+        assertTrue(report.contains("reboot is pending"), "The report should say why:\n$report")
+        assertTrue(
+            script.indexOf("Installation successful!") < script.indexOf(report),
+            "The reboot note belongs on the success path, after the failure branch has gone",
+        )
     }
 
     /** An unresolvable launcher must not stop the update - it only loses the relaunch. */
@@ -138,6 +185,11 @@ class WindowsUpdateRelaunchTest {
             script.contains(Regex("(?<!\r)\n")),
             "Every newline in a .bat must be a CRLF",
         )
+        // `core.autocrlf` is on for Windows clones and there is no .gitattributes, so the
+        // source file itself arrives with CRLF. That is harmless only because every block
+        // goes through `trimIndent`, which rejoins with "\n" - if one ever stops doing so,
+        // the CRLF conversion would double the CR and the assertion above would not notice.
+        assertFalse(script.contains("\r\r"), "The CRLF conversion must not double the CR")
     }
 
     /**
@@ -161,9 +213,18 @@ class WindowsUpdateRelaunchTest {
     // a literal `C:\...\app\composeApp.jar` has no parent at all on a POSIX CI leg,
     // which would make these pass for the wrong reason there.
 
-    private val installDir = File(File(System.getProperty("java.io.tmpdir")), "BOSS")
+    private val tempRoot = File(System.getProperty("java.io.tmpdir"))
+    private val installDir = File(tempRoot, "BOSS")
     private val installedLauncher = File(installDir, "BOSS.exe").path
     private val runningJar = File(File(installDir, "app"), "composeApp.jar").path
+
+    /** A real jpackage install: the launcher plus the `app\` and `runtime\` beside it. */
+    private val realInstall =
+        setOf(
+            installedLauncher,
+            File(installDir, "app").path,
+            File(installDir, "runtime").path,
+        )
 
     @Test
     fun `jpackage app-path wins when it points at something real`() {
@@ -171,7 +232,7 @@ class WindowsUpdateRelaunchTest {
             windowsLauncherPathFor(
                 jpackageAppPath = exePath,
                 codeSourcePath = runningJar,
-                exists = { it == exePath || it == installedLauncher },
+                exists = { it == exePath || it in realInstall },
             )
 
         assertEquals(exePath, resolved, "The property jpackage set should be preferred over any inference")
@@ -186,9 +247,9 @@ class WindowsUpdateRelaunchTest {
     fun `a stale jpackage app-path falls through to the install layout`() {
         val resolved =
             windowsLauncherPathFor(
-                jpackageAppPath = File(File(File(System.getProperty("java.io.tmpdir")), "Old BOSS"), "BOSS.exe").path,
+                jpackageAppPath = File(File(tempRoot, "Old BOSS"), "BOSS.exe").path,
                 codeSourcePath = runningJar,
-                exists = { it == installedLauncher },
+                exists = { it in realInstall },
             )
 
         assertEquals(installedLauncher, resolved)
@@ -200,10 +261,49 @@ class WindowsUpdateRelaunchTest {
             windowsLauncherPathFor(
                 jpackageAppPath = "",
                 codeSourcePath = runningJar,
-                exists = { it == installedLauncher },
+                exists = { it in realInstall },
             )
 
         assertEquals(installedLauncher, resolved)
+    }
+
+    /**
+     * Every other resolver case has exactly one `exists` hit, so a walk that returned the
+     * *furthest* match would pass them all. The nearest one is the install we are running
+     * from; a further one is somebody else's.
+     */
+    @Test
+    fun `the nearest launcher in the parent chain wins`() {
+        val outerLauncher = File(tempRoot, "BOSS.exe").path
+        val alsoLooksInstalled = realInstall + outerLauncher + File(tempRoot, "app").path
+
+        val resolved =
+            windowsLauncherPathFor(
+                jpackageAppPath = null,
+                codeSourcePath = runningJar,
+                exists = { it in alsoLooksInstalled },
+            )
+
+        assertEquals(installedLauncher, resolved, "Resolved the outer launcher instead of the one we run from")
+    }
+
+    /**
+     * The walk is five deep to cover a jar nested deeper than jpackage's two, but above
+     * `<install>` every ancestor is user-writable and the result goes straight to `start`.
+     * A bare `BOSS.exe` with no `app\` or `runtime\` beside it is not an install.
+     */
+    @Test
+    fun `a stray exe in a user-writable ancestor is not accepted`() {
+        val strayInAppData = File(tempRoot, "BOSS.exe").path
+
+        assertNull(
+            windowsLauncherPathFor(
+                jpackageAppPath = null,
+                codeSourcePath = runningJar,
+                exists = { it == strayInAppData },
+            ),
+            "A directory with no jpackage marker beside the exe must not count as an install",
+        )
     }
 
     /** A development run has no launcher anywhere above it, and must resolve to null. */
@@ -227,5 +327,74 @@ class WindowsUpdateRelaunchTest {
                 exists = { true },
             ),
         )
+    }
+
+    /**
+     * The most consequential invariant in the feature: a launcher path the validator
+     * refuses must lose the *relaunch*, not the *update*. The generator throws on a bad
+     * argument, so `getWindowsLauncherPath` swallows the SecurityException and returns
+     * null; letting it propagate would trade "installs but does not relaunch" for "does
+     * not install", which is strictly worse.
+     */
+    @Test
+    fun `a launcher path the validator refuses yields null, not a throw`(
+        @TempDir tempDir: Path,
+    ) {
+        val root = tempDir.toFile()
+        File(root, "BOSS.exe").createNewFile()
+        File(root, "sub").mkdirs()
+        // Resolves and exists, so it is selected - and carries `..`, which validatePath
+        // refuses over the whole path.
+        val traversing = File(File(root, "sub"), "..${File.separator}BOSS.exe").path
+
+        val previous: String? = System.getProperty("jpackage.app-path")
+        try {
+            System.setProperty("jpackage.app-path", traversing)
+
+            assertNull(
+                UpdateInstaller.getWindowsLauncherPath(),
+                "A refused path must degrade to no relaunch rather than aborting the update",
+            )
+        } finally {
+            if (previous == null) {
+                System.clearProperty("jpackage.app-path")
+            } else {
+                System.setProperty("jpackage.app-path", previous)
+            }
+        }
+    }
+
+    // ==================== Launching the helper ====================
+
+    /**
+     * ProcessBuilder quotes any argument containing a space, and `start` treats its first
+     * quoted token as a window *title*. So `cmd /c start /b "<script>"` never ran the
+     * script for an account whose name has a space - no install, no relaunch, nothing in
+     * the log. The empty title argument is what makes the path a command again.
+     */
+    @Test
+    fun `the Windows launch command carries the empty title argument`() {
+        val command = updaterLaunchCommand("windows 11", """C:\Users\Bob Smith\AppData\Local\Temp\boss-updater\u.bat""")
+
+        assertEquals(
+            listOf("cmd", "/c", "start", "", "/b", """C:\Users\Bob Smith\AppData\Local\Temp\boss-updater\u.bat"""),
+            command,
+        )
+        assertEquals("", command[3], "The token after `start` must be the empty title, not the script path")
+    }
+
+    @Test
+    fun `the posix launch commands are unchanged`() {
+        assertEquals(listOf("nohup", "bash", "/tmp/u.sh"), updaterLaunchCommand("mac os x", "/tmp/u.sh"))
+        assertEquals(listOf("nohup", "bash", "/tmp/u.sh"), updaterLaunchCommand("linux", "/tmp/u.sh"))
+        assertEquals(listOf("bash", "/tmp/u.sh"), updaterLaunchCommand("plan 9", "/tmp/u.sh"))
+    }
+
+    @Test
+    fun `the bash fallback is the only case reported as unknown`() {
+        listOf("mac os x", "darwin", "linux", "windows 11").forEach {
+            assertTrue(isKnownUpdaterOs(it), "$it should not warn about an unknown OS")
+        }
+        assertFalse(isKnownUpdaterOs("plan 9"), "An unrecognised OS should warn")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/WindowsUpdateRelaunchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/WindowsUpdateRelaunchTest.kt
@@ -1,0 +1,231 @@
+package ai.rever.boss.updater
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The Windows update helper installed the MSI and then simply ended, so "Install
+ * update" quit BOSS and nothing came back - while the macOS script always finished
+ * with `open` and the Linux one with `nohup .../BOSS`. These pin the relaunch, and
+ * the resolution of the launcher path it needs.
+ */
+class WindowsUpdateRelaunchTest {
+    private val msiPath = """C:\Users\Bob\AppData\Local\Temp\boss-updates\BOSS-9.9.9.msi"""
+    private val exePath = """C:\Users\Bob\AppData\Local\BOSS\BOSS.exe"""
+
+    private fun script(targetExePath: String?): String {
+        val scriptFile =
+            UpdateScriptGenerator.generateWindowsUpdateScript(
+                msiPath = msiPath,
+                appPid = 12345,
+                targetExePath = targetExePath,
+            )
+        try {
+            return scriptFile.readText()
+        } finally {
+            scriptFile.delete()
+        }
+    }
+
+    // ==================== The script ====================
+
+    @Test
+    fun `the Windows script relaunches the installed launcher after a successful install`() {
+        val script = script(exePath)
+
+        assertTrue(
+            script.contains("""start "" "$exePath""""),
+            "The script must launch the installed exe:\n$script",
+        )
+        assertTrue(
+            script.indexOf("msiexec") < script.indexOf("""start "" "$exePath""""),
+            "The relaunch must come after the install, not before it",
+        )
+    }
+
+    /**
+     * A major upgrade is only *usually* into the same INSTALLDIR - a per-user install
+     * replaced by a per-machine one lands elsewhere - and `start` on a missing path
+     * raises a Windows error dialog rather than failing quietly.
+     */
+    @Test
+    fun `the relaunch is guarded by an existence check`() {
+        val script = script(exePath)
+
+        assertTrue(
+            script.contains("""if exist "$exePath""""),
+            "The relaunch should be guarded by if exist:\n$script",
+        )
+    }
+
+    /**
+     * The failure branch hands the user the interactive installer. Relaunching into
+     * that would put a BOSS holding its own files open in front of an installer that
+     * needs them free.
+     */
+    @Test
+    fun `a failed install does not relaunch`() {
+        val script = script(exePath)
+
+        val failureBranch =
+            script
+                .substringAfter("if not %MSI_RESULT% EQU 0 (")
+                .substringBefore(")")
+
+        assertFalse(
+            failureBranch.contains(exePath),
+            "The failure branch must not relaunch BOSS:\n$failureBranch",
+        )
+        assertTrue(
+            failureBranch.contains("goto cleanup"),
+            "The failure branch should skip to cleanup:\n$failureBranch",
+        )
+    }
+
+    /**
+     * `/norestart` makes msiexec report 3010 ("installed, wants a reboot") instead of
+     * 0 whenever a file was in use, which is routine when replacing a running app's
+     * directory. Branching on `NEQ 0` would call that a failure and open an installer
+     * the user does not need.
+     */
+    @Test
+    fun `the reboot-pending exit codes count as success`() {
+        val script = script(exePath)
+
+        assertTrue(script.contains("if %MSI_RESULT% EQU 3010 set MSI_RESULT=0"), script)
+        assertTrue(script.contains("if %MSI_RESULT% EQU 1641 set MSI_RESULT=0"), script)
+    }
+
+    /** An unresolvable launcher must not stop the update - it only loses the relaunch. */
+    @Test
+    fun `an unknown launcher path still produces an installing script`() {
+        val script = script(null)
+
+        assertTrue(script.contains("msiexec /i \"$msiPath\""), "The install must still happen:\n$script")
+        assertFalse(script.contains("if exist"), "There is nothing to relaunch:\n$script")
+        assertTrue(script.contains("please start BOSS manually"), "The log should say why:\n$script")
+    }
+
+    /**
+     * `trimIndent` runs *after* interpolation, so splicing a multi-line block into an
+     * indented template leaves the block's own lines at column 0, makes the common
+     * indent 0, and emits every other line still carrying the Kotlin template's
+     * indent - including the `:labels` `goto` depends on.
+     */
+    @Test
+    fun `directives and labels sit at column 0`() {
+        listOf(script(exePath), script(null)).forEach { script ->
+            assertTrue(script.startsWith("@echo off"), "Script should open with an unindented @echo off:\n$script")
+            assertTrue(script.lines().contains(":waitloop"), "The waitloop label must not be indented:\n$script")
+            assertTrue(script.lines().contains(":cleanup"), "The cleanup label must not be indented:\n$script")
+        }
+    }
+
+    /**
+     * cmd.exe parses a batch file by seeking byte offsets that assume CRLF, so an
+     * LF-only file breaks `goto` into a label - and breaks it by jumping somewhere
+     * wrong rather than by failing. The failure branch depends on that `goto`.
+     */
+    @Test
+    fun `the batch file is written with CRLF line endings`() {
+        val script = script(exePath)
+
+        assertFalse(
+            script.contains(Regex("(?<!\r)\n")),
+            "Every newline in a .bat must be a CRLF",
+        )
+    }
+
+    /**
+     * `launchScript` starts the helper with ProcessBuilder, so its stdin is a pipe, and
+     * `timeout` refuses to run at all under redirected input - it exited immediately
+     * with "ERROR: Input redirection is not supported", which turned the quit poll into
+     * a hot loop and wrote three errors into the one log anybody diagnosing a failed
+     * update would read.
+     */
+    @Test
+    fun `the waits survive the redirected stdin the script is launched with`() {
+        val script = script(exePath)
+
+        assertFalse(script.contains("timeout /t"), "timeout cannot run under redirected stdin:\n$script")
+        assertTrue(script.contains("ping -n 2 127.0.0.1 >NUL"), "The quit poll needs a working sleep:\n$script")
+    }
+
+    // ==================== Resolving the launcher ====================
+    //
+    // Paths are built with File so the parent walk exercises the *host* separator:
+    // a literal `C:\...\app\composeApp.jar` has no parent at all on a POSIX CI leg,
+    // which would make these pass for the wrong reason there.
+
+    private val installDir = File(File(System.getProperty("java.io.tmpdir")), "BOSS")
+    private val installedLauncher = File(installDir, "BOSS.exe").path
+    private val runningJar = File(File(installDir, "app"), "composeApp.jar").path
+
+    @Test
+    fun `jpackage app-path wins when it points at something real`() {
+        val resolved =
+            windowsLauncherPathFor(
+                jpackageAppPath = exePath,
+                codeSourcePath = runningJar,
+                exists = { it == exePath || it == installedLauncher },
+            )
+
+        assertEquals(exePath, resolved, "The property jpackage set should be preferred over any inference")
+    }
+
+    /**
+     * jpackage sets the property on every packaged launch, but an installation whose
+     * directory moved leaves it naming a path that is gone. Falling through to the
+     * layout walk is what keeps the relaunch working there.
+     */
+    @Test
+    fun `a stale jpackage app-path falls through to the install layout`() {
+        val resolved =
+            windowsLauncherPathFor(
+                jpackageAppPath = File(File(File(System.getProperty("java.io.tmpdir")), "Old BOSS"), "BOSS.exe").path,
+                codeSourcePath = runningJar,
+                exists = { it == installedLauncher },
+            )
+
+        assertEquals(installedLauncher, resolved)
+    }
+
+    @Test
+    fun `a blank jpackage app-path is ignored`() {
+        val resolved =
+            windowsLauncherPathFor(
+                jpackageAppPath = "",
+                codeSourcePath = runningJar,
+                exists = { it == installedLauncher },
+            )
+
+        assertEquals(installedLauncher, resolved)
+    }
+
+    /** A development run has no launcher anywhere above it, and must resolve to null. */
+    @Test
+    fun `a dev run resolves to null rather than guessing`() {
+        assertNull(
+            windowsLauncherPathFor(
+                jpackageAppPath = null,
+                codeSourcePath = runningJar,
+                exists = { false },
+            ),
+        )
+    }
+
+    @Test
+    fun `an absent code source resolves to null`() {
+        assertNull(
+            windowsLauncherPathFor(
+                jpackageAppPath = null,
+                codeSourcePath = null,
+                exists = { true },
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## The bug

On Windows, clicking **Install** in the update banner installs correctly and then nothing comes back: BOSS quits, `msiexec` runs, and the user is left with no app. On macOS the same flow restarts.

Relaunching is entirely the helper script's job - the Kotlin side is identical on all three platforms (`InstallResult.RequiresRestart`, then `UpdateManager` quits the app). Comparing how each generated script ends:

| Platform | Final step |
|---|---|
| macOS | `open "<app>"`, with one retry |
| Linux | `nohup /opt/boss/bin/BOSS &` |
| Windows | `del "%~f0"` - the script just ends |

There was also nothing to relaunch *with*: `UpdateInstaller.getCurrentApplicationPath()` only resolves a macOS `.app` bundle, and `generateWindowsUpdateScript` took no install path at all.

## The fix

**`UpdateInstaller`** - `windowsLauncherPathFor` resolves the launcher from `jpackage.app-path` first, then by walking up from the running jar for a sibling `BOSS.exe` (`<install>\app\*.jar` -> `<install>\BOSS.exe`). Pure, with an injected `exists`, matching the neighbouring `realAppPathFor`. It runs while BOSS is still alive, because after `msiexec` there is no process left to ask.

An unresolvable path is **not** fatal - it installs without relaunching, exactly what Windows did before. That includes the case where `UpdatePathValidator` would refuse the path: the generator throws on a bad argument, and a throw there would trade "installs but does not relaunch" for "does not install".

**`UpdateScriptGenerator`** - the script now ends with a guarded relaunch. Three things beyond the obvious:

- **3010 and 1641 now count as success.** `/norestart` makes `msiexec` report 3010 rather than 0 whenever a file was in use, which is routine when replacing a running app's directory. The old `if %ERRORLEVEL% NEQ 0` called a completed install a failure and handed the user an installer they did not need.
- **The failure branch deliberately does not relaunch.** It hands over the interactive installer, and a BOSS holding its own files open is what that needs least.
- **CRLF line endings.** cmd.exe parses a batch file by seeking byte offsets that assume CRLF, so `goto` into a label misbehaves in an LF-only file by jumping to the wrong place rather than by failing - and the failure branch now needs a `goto`.

## One extra defect found on the way

Every `timeout /t N /nobreak` in that script was failing outright. `launchScript` starts the helper with `ProcessBuilder`, so stdin is a pipe, and `timeout` refuses to run under redirected input:

```
ERROR: Input redirection is not supported, exiting the process immediately.
```

So the waits never happened, the quit poll was a hot loop hammering `tasklist`, and three errors went into the one log anybody diagnosing a failed update would read. Now `ping -n N 127.0.0.1 >NUL`. Pre-existing, but in the script this PR already touches and directly in the way of diagnosing this bug.

## Verification

13 new tests in `WindowsUpdateRelaunchTest` (relaunch present and ordered after the install, the `if exist` guard, no relaunch on failure, the reboot-pending codes, CRLF, labels at column 0, and each branch of the launcher resolution). Resolver tests build paths with `File` so the parent walk exercises the host separator rather than passing for the wrong reason on a POSIX CI leg.

Beyond the unit tests, the **actual generated bytes** were dumped and executed with only `msiexec` and `start` stubbed:

- success (3010) -> `Installation successful!` then relaunch
- missing exe -> logs "please start BOSS manually", no `start`
- failure (1603) -> opens the installer, skips the relaunch

All three reach `:cleanup` and self-delete, and the input-redirection errors are gone.

`./gradlew :composeApp:desktopTest --tests "ai.rever.boss.updater.*" ktlintCheck :composeApp:detekt` passes.

## Note for whoever tests this

The helper script is generated by the **old** running app, so updating *from* an installed 9.4.x still will not restart. The relaunch first appears on the update after the one that ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
