### PR TITLE
Stop every window but the main one showing the Java icon on Windows

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.overlays
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -135,6 +136,7 @@ fun HeavyweightCorner(
         alwaysOnTop = true,
         focusable = false,
         resizable = false,
+        icon = bossWindowIcon(),
     ) {
         EnsureOverlayWindowTransparent(window)
         Box(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -3,7 +3,8 @@ package ai.rever.boss.components.overlays
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -136,9 +137,10 @@ fun HeavyweightCorner(
         alwaysOnTop = true,
         focusable = false,
         resizable = false,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
         EnsureOverlayWindowTransparent(window)
+        ApplyBossWindowIcon(window)
         Box(
             modifier =
                 Modifier

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.overlays
 
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -102,9 +103,10 @@ fun HeavyweightGhost(
         alwaysOnTop = true,
         focusable = false,
         resizable = false,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
         EnsureOverlayWindowTransparent(window)
+        ApplyBossWindowIcon(window)
         Box(modifier = Modifier.fillMaxSize()) {
             content()
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.overlays
 
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -101,6 +102,7 @@ fun HeavyweightGhost(
         alwaysOnTop = true,
         focusable = false,
         resizable = false,
+        icon = bossWindowIcon(),
     ) {
         EnsureOverlayWindowTransparent(window)
         Box(modifier = Modifier.fillMaxSize()) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightHud.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightHud.kt
@@ -1,7 +1,8 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -46,9 +47,10 @@ fun HeavyweightHud(
         alwaysOnTop = true,
         focusable = false,
         resizable = false,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
         EnsureOverlayWindowTransparent(window)
+        ApplyBossWindowIcon(window)
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = alignment) {
             content()
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightHud.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightHud.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -45,6 +46,7 @@ fun HeavyweightHud(
         alwaysOnTop = true,
         focusable = false,
         resizable = false,
+        icon = bossWindowIcon(),
     ) {
         EnsureOverlayWindowTransparent(window)
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = alignment) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightModal.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightModal.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
@@ -57,6 +58,7 @@ fun HeavyweightModal(
         alwaysOnTop = true,
         focusable = true,
         resizable = false,
+        icon = bossWindowIcon(),
         onKeyEvent = { event ->
             // dismissOnBackPress is what Compose maps Escape to, and only this window can honour it:
             // Escape is handled here, not by anything inside the content. A caller that passed

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightModal.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightModal.kt
@@ -1,7 +1,8 @@
 package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
@@ -58,7 +59,7 @@ fun HeavyweightModal(
         alwaysOnTop = true,
         focusable = true,
         resizable = false,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
         onKeyEvent = { event ->
             // dismissOnBackPress is what Compose maps Escape to, and only this window can honour it:
             // Escape is handled here, not by anything inside the content. A caller that passed
@@ -73,6 +74,7 @@ fun HeavyweightModal(
         },
     ) {
         EnsureOverlayWindowTransparent(window)
+        ApplyBossWindowIcon(window)
 
         // Dismiss when the modal loses focus (clicked elsewhere), matching modal expectations —
         // but NOT when one of our own heavyweight popups took the focus.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
@@ -2,7 +2,8 @@ package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.plugin.ui.BossPopupAnchoring
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -115,7 +116,7 @@ fun HeavyweightPopup(
         alwaysOnTop = true,
         focusable = focusable,
         resizable = false,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
         onKeyEvent = { event ->
             if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
                 onDismissRequest()
@@ -126,6 +127,7 @@ fun HeavyweightPopup(
         },
     ) {
         EnsureOverlayWindowTransparent(window)
+        ApplyBossWindowIcon(window)
         RegisterOpenPopup()
 
         if (focusable) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightPopup.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.plugin.ui.BossPopupAnchoring
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -114,6 +115,7 @@ fun HeavyweightPopup(
         alwaysOnTop = true,
         focusable = focusable,
         resizable = false,
+        icon = bossWindowIcon(),
         onKeyEvent = { event ->
             if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
                 onDismissRequest()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.plugin.browser.LocalAwtWindow
 import ai.rever.boss.plugin.browser.installPopupWindowChrome
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -263,6 +264,7 @@ private fun configureBrowserPopupHandler(
 
                         frame.title = "Popup"
                         frame.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                        frame.iconImages = BossWindowIcon.images
                         frame.setLocation(initialBounds.origin().x(), initialBounds.origin().y())
                         frame.setSize(initialBounds.size().width(), initialBounds.size().height())
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/shared/SettingsComponents.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/shared/SettingsComponents.kt
@@ -8,7 +8,8 @@ import ai.rever.boss.components.settings.shared.SettingsTheme.TextMuted
 import ai.rever.boss.components.settings.shared.SettingsTheme.TextPrimary
 import ai.rever.boss.components.settings.shared.SettingsTheme.TextSecondary
 import ai.rever.boss.plugin.ui.BossTheme
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -1023,8 +1024,9 @@ fun ColorPickerDialog(
         // Redundant on paper - this composes inside the Settings window, and a dialog inherits its
         // owner frame's icon - but set anyway so no window in this repo is a special case, and so
         // it survives being lifted out to application scope.
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
+        ApplyBossWindowIcon(window)
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = BackgroundColor,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/shared/SettingsComponents.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/shared/SettingsComponents.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.components.settings.shared.SettingsTheme.TextMuted
 import ai.rever.boss.components.settings.shared.SettingsTheme.TextPrimary
 import ai.rever.boss.components.settings.shared.SettingsTheme.TextSecondary
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -1019,6 +1020,10 @@ fun ColorPickerDialog(
         title = "Select Color",
         resizable = false,
         state = rememberDialogState(size = DpSize(340.dp, 520.dp)),
+        // Redundant on paper - this composes inside the Settings window, and a dialog inherits its
+        // owner frame's icon - but set anyway so no window in this repo is a special case, and so
+        // it survives being lifted out to application scope.
+        icon = bossWindowIcon(),
     ) {
         Surface(
             modifier = Modifier.fillMaxSize(),

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
@@ -25,7 +25,8 @@ import ai.rever.boss.startup.StartupSettingsManager
 import ai.rever.boss.terminal.TerminalLinkSettingsManager
 import ai.rever.boss.updater.UpdateSettingsSection
 import ai.rever.boss.utils.DisplayUtils
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -67,8 +68,10 @@ actual fun SettingsWindow(
         onCloseRequest = onClose,
         title = "BOSS Settings",
         state = windowState,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
+        ApplyBossWindowIcon(window)
+
         // Raise this window whenever Settings is asked for again. Keyed on the counter, so it
         // runs once per request and once on the first composition - which is harmless, the
         // window is brand new and coming to the front is what it should be doing anyway.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
@@ -25,6 +25,7 @@ import ai.rever.boss.startup.StartupSettingsManager
 import ai.rever.boss.terminal.TerminalLinkSettingsManager
 import ai.rever.boss.updater.UpdateSettingsSection
 import ai.rever.boss.utils.DisplayUtils
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -66,6 +67,7 @@ actual fun SettingsWindow(
         onCloseRequest = onClose,
         title = "BOSS Settings",
         state = windowState,
+        icon = bossWindowIcon(),
     ) {
         // Raise this window whenever Settings is asked for again. Keyed on the counter, so it
         // runs once per request and once on the first composition - which is harmless, the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallWizardWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallWizardWindow.kt
@@ -2,7 +2,8 @@ package ai.rever.boss.components.wizard.plugin
 
 import ai.rever.boss.components.wizard.WizardStepIndicator
 import ai.rever.boss.plugin.ui.BossTheme
-import ai.rever.boss.window.bossWindowIcon
+import ai.rever.boss.window.ApplyBossWindowIcon
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -75,8 +76,9 @@ fun PluginInstallWizardWindow(
         title = "BOSS Plugin Setup",
         resizable = false,
         state = rememberDialogState(size = DpSize(700.dp, 600.dp)),
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
+        ApplyBossWindowIcon(window)
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = BossTheme.colors.panel,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallWizardWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginInstallWizardWindow.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.components.wizard.plugin
 
 import ai.rever.boss.components.wizard.WizardStepIndicator
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -74,6 +75,7 @@ fun PluginInstallWizardWindow(
         title = "BOSS Plugin Setup",
         resizable = false,
         state = rememberDialogState(size = DpSize(700.dp, 600.dp)),
+        icon = bossWindowIcon(),
     ) {
         Surface(
             modifier = Modifier.fillMaxSize(),

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.utils.AppVersion
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.ui.awt.ComposePanel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -757,6 +758,11 @@ object CrashHandler {
             // recovered nothing, which is how the three exits came to disagree.
             frame.defaultCloseOperation = WindowConstants.DO_NOTHING_ON_CLOSE
             frame.addWindowListener(controller.windowClosingAdapter())
+
+            // Inside the try, and reading a list that is empty rather than throwing when the icon
+            // resource cannot be read: a missing icon must never be the reason a crash report goes
+            // unshown. Empty is what every window here did before, so the fallback is status quo.
+            frame.iconImages = BossWindowIcon.images
 
             val composePanel = ComposePanel()
             // Sized here rather than on the frame so the dialog gets these dimensions exactly;

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -29,7 +29,9 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.window.AWTKeyboardInterceptor
 import ai.rever.boss.window.BossWindow
+import ai.rever.boss.window.DefaultWindowIcon
 import ai.rever.boss.window.WindowManager
+import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -227,6 +229,18 @@ fun main(args: Array<String>) {
     // Disable lightweight popups for HARDWARE_ACCELERATED rendering mode (#258)
     // This ensures Swing popup menus (context menus) appear above the browser view
     JPopupMenu.setDefaultLightWeightPopupEnabled(false)
+
+    // Brand any window BOSS does not compose itself - JxBrowser's own Swing dialogs, JFileChooser,
+    // a frame opened by a plugin - so none of them shows the JDK's default Java icon on Windows.
+    // Every window this app opens sets its own icon; this is only the net under them.
+    //
+    // Position is load-bearing in BOTH directions. It registers an AWT event listener, so it
+    // initialises the toolkit - which is why it cannot go up beside setLinuxWMClass: the
+    // ChromiumFlagsSettingsManager and BOSS_SKIKO_RENDER_API blocks above both have to publish their
+    // system properties before AWT/Skiko reads them, and skiko.renderApi in particular is read at
+    // init and never again. It only has to be earlier than the first window, and every window is
+    // still a long way below here.
+    DefaultWindowIcon.install()
 
     // Uninstall hook (Windows): `BOSS.exe --unregister-protocol` removes the boss://
     // handler that WindowsProtocolHandler registers at runtime, so uninstalling does not
@@ -836,6 +850,9 @@ fun main(args: Array<String>) {
                     state = downloadWindowState,
                     title = "BOSS - Setup",
                     resizable = false,
+                    // This is the one window that opens before any main window exists, so it can
+                    // inherit an icon from nothing - and it is the first thing a new user sees.
+                    icon = bossWindowIcon(),
                 ) {
                     // Start download when dialog opens
                     LaunchedEffect(Unit) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -28,10 +28,11 @@ import ai.rever.boss.utils.WindowsProtocolHandler
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.window.AWTKeyboardInterceptor
+import ai.rever.boss.window.ApplyBossWindowIcon
 import ai.rever.boss.window.BossWindow
+import ai.rever.boss.window.BossWindowIcon
 import ai.rever.boss.window.DefaultWindowIcon
 import ai.rever.boss.window.WindowManager
-import ai.rever.boss.window.bossWindowIcon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -230,18 +231,6 @@ fun main(args: Array<String>) {
     // This ensures Swing popup menus (context menus) appear above the browser view
     JPopupMenu.setDefaultLightWeightPopupEnabled(false)
 
-    // Brand any window BOSS does not compose itself - JxBrowser's own Swing dialogs, JFileChooser,
-    // a frame opened by a plugin - so none of them shows the JDK's default Java icon on Windows.
-    // Every window this app opens sets its own icon; this is only the net under them.
-    //
-    // Position is load-bearing in BOTH directions. It registers an AWT event listener, so it
-    // initialises the toolkit - which is why it cannot go up beside setLinuxWMClass: the
-    // ChromiumFlagsSettingsManager and BOSS_SKIKO_RENDER_API blocks above both have to publish their
-    // system properties before AWT/Skiko reads them, and skiko.renderApi in particular is read at
-    // init and never again. It only has to be earlier than the first window, and every window is
-    // still a long way below here.
-    DefaultWindowIcon.install()
-
     // Uninstall hook (Windows): `BOSS.exe --unregister-protocol` removes the boss://
     // handler that WindowsProtocolHandler registers at runtime, so uninstalling does not
     // leave a registry handler pointing at a deleted executable. Handled before any
@@ -384,6 +373,20 @@ fun main(args: Array<String>) {
             exitProcess(0)
         }
     }
+
+    // Brand any window BOSS does not compose itself - JxBrowser's own Swing dialogs, JFileChooser,
+    // a frame opened by a plugin - so none of them shows the JDK's default Java icon on Windows.
+    // Every window this app opens sets its own icon; this is only the net under them.
+    //
+    // Position is fenced on both sides. Registering an AWT event listener initialises the toolkit,
+    // so this cannot go up beside setLinuxWMClass: the ChromiumFlagsSettingsManager and
+    // BOSS_SKIKO_RENDER_API blocks up there have to publish their system properties before AWT/Skiko
+    // reads them, and skiko.renderApi in particular is read at init and never again. It also has to
+    // stay below the two paths that exit without ever showing a window - `--unregister-protocol`
+    // (an installer action) and the single-instance deep-link forward - which is why it is here
+    // rather than beside JPopupMenu.setDefaultLightWeightPopupEnabled: neither should be made to
+    // start a window system to do its job. Everything from here on is a session that gets a window.
+    DefaultWindowIcon.install()
 
     // Register shutdown hook to release the single-instance lock AND close browser engine
     Runtime.getRuntime().addShutdownHook(
@@ -852,8 +855,10 @@ fun main(args: Array<String>) {
                     resizable = false,
                     // This is the one window that opens before any main window exists, so it can
                     // inherit an icon from nothing - and it is the first thing a new user sees.
-                    icon = bossWindowIcon(),
+                    icon = BossWindowIcon.painter,
                 ) {
+                    ApplyBossWindowIcon(window)
+
                     // Start download when dialog opens
                     LaunchedEffect(Unit) {
                         ChromiumAutoDownloader.downloadChromium { progress ->

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -10,6 +10,7 @@ import ai.rever.boss.utils.MacOSGestureHandler
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
@@ -1723,6 +1724,7 @@ internal class BrowserHandleImpl(
 
                             frame.title = "Popup" // Will be updated by page title
                             frame.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                            frame.iconImages = BossWindowIcon.images
 
                             // Set position and size from bounds
                             frame.setLocation(initialBounds.origin().x(), initialBounds.origin().y())

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/tabfullscreen/FullscreenBrowserWindow.kt
@@ -6,6 +6,7 @@ import ai.rever.boss.utils.hasFullscreenSignal
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.ComponentLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.BossWindowIcon
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.BorderLayout
@@ -383,6 +384,7 @@ private fun prepareBorderlessOverlayFrame(
 
     val overlayFrame = graphicsConfiguration?.let(::JFrame) ?: JFrame()
     overlayFrame.defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
+    overlayFrame.iconImages = BossWindowIcon.images
     overlayFrame.background = Color.BLACK
     overlayFrame.contentPane.background = Color.BLACK
     overlayFrame.contentPane.layout = BorderLayout()
@@ -768,6 +770,7 @@ object FullscreenBrowserWindow {
             val frame = ownerWindow?.graphicsConfiguration?.let(::JFrame) ?: JFrame()
             createdFrame = frame
             frame.defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
+            frame.iconImages = BossWindowIcon.images
             frame.background = Color.BLACK
             frame.contentPane.background = Color.BLACK
             frame.contentPane.layout = BorderLayout()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -142,8 +142,10 @@ fun ApplicationScope.BossWindow(
         onCloseRequest = onCloseRequest,
         title = windowState.title,
         state = composeWindowState,
-        icon = bossWindowIcon(),
+        icon = BossWindowIcon.painter,
     ) {
+        ApplyBossWindowIcon(window)
+
         // Apply programmatic resize requests (BossTerm "Fit host to my screen").
         // Lives inside Window {} so it can read this window's `window` (AWT
         // ComposeWindow) for the display scale + per-monitor bounds, and runs on

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -47,12 +47,9 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.*
-import boss_kotlin.composeapp.generated.resources.Res
-import boss_kotlin.composeapp.generated.resources.boss_icon
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.painterResource
 import java.awt.Color
 import java.awt.Frame
 
@@ -145,7 +142,7 @@ fun ApplicationScope.BossWindow(
         onCloseRequest = onCloseRequest,
         title = windowState.title,
         state = composeWindowState,
-        icon = painterResource(Res.drawable.boss_icon),
+        icon = bossWindowIcon(),
     ) {
         // Apply programmatic resize requests (BossTerm "Fit host to my screen").
         // Lives inside Window {} so it can read this window's `window` (AWT

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowIcon.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowIcon.kt
@@ -1,0 +1,167 @@
+package ai.rever.boss.window
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import java.awt.AWTEvent
+import java.awt.Frame
+import java.awt.RenderingHints
+import java.awt.Toolkit
+import java.awt.event.WindowEvent
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
+
+/**
+ * The BOSS icon, as every window BOSS opens should wear it.
+ *
+ * `jpackage` puts `boss_icon.ico` on the launcher `.exe` (see `composeApp/build.gradle.kts`), which
+ * is why the Start-menu entry and the executable have always looked right - but that icon never
+ * reaches a live AWT window. A Compose `Window` given no `icon` leaves `Frame.iconImages` empty, and
+ * Windows then draws the JDK's default Java icon in the title bar, the taskbar button and the
+ * Alt-Tab card. macOS takes its icon from the `.app` bundle and ignores per-window icons entirely,
+ * and Linux takes it from the `.desktop` file - which is why this only ever showed up on Windows,
+ * and why it went unnoticed: every window except the main one was affected.
+ *
+ * Two shapes, because the two families of window in this app take icons differently:
+ *
+ * - [bossWindowIcon] hands a Compose `Window` / `DialogWindow` its `icon` parameter.
+ * - [images] hands a raw AWT [Frame] its `iconImages`, which is what the Swing frames
+ *   (crash dialog, fullscreen browser, browser popups) and [DefaultWindowIcon] need.
+ *
+ * Both read the same single decode.
+ */
+object BossWindowIcon {
+    private val logger = BossLogger.forComponent("BossWindowIcon")
+
+    /**
+     * Sizes Windows actually asks for: 16 for the title bar, 32 for the taskbar button and
+     * Alt-Tab, the rest for high-DPI variants of those two. AWT picks the nearest and scales, so
+     * handing it pre-scaled variants beats letting it squeeze one 256px bitmap into 16px.
+     */
+    private val derivedSizes = intArrayOf(16, 20, 24, 32, 40, 48, 64, 128)
+
+    /** The 256x256 source, decoded once. Null only if the resource is missing from the classpath. */
+    private val source: BufferedImage? by lazy { decodeSource() }
+
+    /**
+     * Multi-resolution icon list for `Frame.iconImages`.
+     *
+     * Empty rather than throwing when the resource cannot be read. Callers include
+     * [ai.rever.boss.crash.CrashHandler], which is already handling a crash - a missing icon must
+     * not become the reason the crash report never gets shown. `iconImages = emptyList()` is
+     * exactly the state every window is in today, so the fallback is the current behaviour.
+     */
+    val images: List<BufferedImage> by lazy {
+        val original = source ?: return@lazy emptyList()
+        buildList {
+            derivedSizes.forEach { size -> add(original.scaledTo(size)) }
+            add(original)
+        }
+    }
+
+    private fun decodeSource(): BufferedImage? {
+        // `/boss_icon.png` rather than the Compose resource: this has to be readable from plain AWT
+        // code and from a crash handler, neither of which can call into a composition, and one
+        // decode shared by both families beats two loaders.
+        val decoded =
+            runCatching {
+                javaClass.getResourceAsStream("/boss_icon.png")?.use(ImageIO::read)
+            }.getOrElse { e ->
+                logger.warn(LogCategory.UI, "Could not decode /boss_icon.png", error = e)
+                return null
+            }
+        if (decoded == null) {
+            logger.warn(LogCategory.UI, "/boss_icon.png is not on the classpath - windows will be unbranded")
+        }
+        return decoded
+    }
+
+    private fun BufferedImage.scaledTo(size: Int): BufferedImage {
+        val scaled = BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB)
+        val g = scaled.createGraphics()
+        try {
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC)
+            g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            g.drawImage(this, 0, 0, size, size, null)
+        } finally {
+            g.dispose()
+        }
+        return scaled
+    }
+
+    /** The source as a Compose bitmap, decoded and converted once for every window that asks. */
+    internal val composeBitmap by lazy { source?.toComposeImageBitmap() }
+}
+
+/**
+ * The `icon` for a Compose `Window` or `DialogWindow`.
+ *
+ * Deliberately not `painterResource(Res.drawable.boss_icon)` at each call site. The five
+ * `Heavyweight*` overlay windows are created and torn down constantly, and `painterResource` plus
+ * the `Painter.toAwtImage` conversion Compose does for the icon would re-decode and re-rasterise a
+ * 256px image on every one. This shares [BossWindowIcon]'s single decode.
+ *
+ * Returns null when the resource could not be read, which is what `Window(icon = null)` already
+ * means - see [BossWindowIcon.images] for why this degrades rather than throws.
+ *
+ * Note the asymmetry with [BossWindowIcon.images], which is deliberate: Compose rasterises this
+ * painter at a fixed 192dp and calls the single-image `Window.setIconImage`, so a Compose window
+ * gets one bitmap that Windows downscales for the 16px title bar, not the multi-resolution list. The
+ * main window has worked exactly this way since it was written, so it is good enough; the AWT sites
+ * take the list because there the API allows it. The Compose `icon` parameter is still what the
+ * Compose sites use, because it is applied before the window is shown - assigning `iconImages` from
+ * inside the window body would leave one frame of Java icon on screen first.
+ */
+@Composable
+fun bossWindowIcon(): Painter? {
+    val bitmap = BossWindowIcon.composeBitmap ?: return null
+    return remember(bitmap) { BitmapPainter(bitmap) }
+}
+
+/**
+ * Brands windows BOSS does not create itself.
+ *
+ * JxBrowser raises Swing dialogs of its own, `JFileChooser` makes its own frames, a plugin can open
+ * one, and the next window added to this app can forget its `icon`. This catches all of them.
+ *
+ * A net, not the fix. `WINDOW_OPENED` is delivered after `setVisible(true)`, so a window caught here
+ * shows the Java icon for one frame first - invisible for a foreign dialog, but not good enough for
+ * ours, which is why every window in this repo sets its icon explicitly and is held to it by
+ * `WindowIconConventionTest`.
+ *
+ * Only [Frame] is touched: `java.awt.Dialog` has no icon of its own and takes its owner frame's, so
+ * fixing the frames fixes the dialogs over them.
+ */
+object DefaultWindowIcon {
+    private val logger = BossLogger.forComponent("DefaultWindowIcon")
+
+    /**
+     * Registers the listener. Call once, before any window exists - `main` does this next to
+     * `setLinuxWMClass`, which has the same ordering requirement.
+     */
+    fun install() {
+        val icons = BossWindowIcon.images
+        if (icons.isEmpty()) return
+
+        runCatching {
+            Toolkit.getDefaultToolkit().addAWTEventListener({ event ->
+                if (event.id != WindowEvent.WINDOW_OPENED) return@addAWTEventListener
+                val frame = (event as? WindowEvent)?.window as? Frame ?: return@addAWTEventListener
+                // Only when nothing set one: an explicit icon - including a deliberately different
+                // one - is never overwritten here.
+                if (frame.iconImages.isEmpty()) {
+                    frame.iconImages = icons
+                }
+            }, AWTEvent.WINDOW_EVENT_MASK)
+        }.onFailure { e ->
+            // A SecurityManager can refuse the listener. Losing the net is survivable; every
+            // window this app opens sets its own icon.
+            logger.warn(LogCategory.UI, "Could not install the default window icon listener", error = e)
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowIcon.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowIcon.kt
@@ -3,12 +3,13 @@ package ai.rever.boss.window
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import java.awt.AWTEvent
 import java.awt.Frame
+import java.awt.Image
 import java.awt.RenderingHints
 import java.awt.Toolkit
 import java.awt.event.WindowEvent
@@ -26,16 +27,26 @@ import javax.imageio.ImageIO
  * and Linux takes it from the `.desktop` file - which is why this only ever showed up on Windows,
  * and why it went unnoticed: every window except the main one was affected.
  *
- * Two shapes, because the two families of window in this app take icons differently:
+ * Every window ends up with [images], the multi-resolution list, but by two routes:
  *
- * - [bossWindowIcon] hands a Compose `Window` / `DialogWindow` its `icon` parameter.
- * - [images] hands a raw AWT [Frame] its `iconImages`, which is what the Swing frames
- *   (crash dialog, fullscreen browser, browser popups) and [DefaultWindowIcon] need.
+ * - A Compose `Window` / `DialogWindow` passes [painter] as its `icon` (applied before the window is
+ *   shown, so nothing flashes) and then calls [ApplyBossWindowIcon], which upgrades it to the list.
+ * - A raw AWT [Frame] assigns [images] directly.
  *
- * Both read the same single decode.
+ * Both read one decode.
+ *
+ * The five `Heavyweight*` overlays are branded too, which is worth stating because it looks
+ * pointless: they are `undecorated` and `transparent`, so they have no title bar to put an icon in.
+ * They are still plain `Frame`s with no `Window.Type` set, so Windows gives them taskbar buttons and
+ * Alt-Tab cards of their own - which is where an unbranded one shows a coffee cup. The one window
+ * deliberately left alone is `FluckEngine`'s find bar: it is a `JDialog` and `Window.Type.UTILITY`,
+ * so it has no icon surface at all.
  */
 object BossWindowIcon {
     private val logger = BossLogger.forComponent("BossWindowIcon")
+
+    /** Lives in `composeApp/src/desktopMain/resources`, so it lands at the jar root. */
+    private const val ICON_RESOURCE = "/boss_icon.png"
 
     /**
      * Sizes Windows actually asks for: 16 for the title bar, 32 for the taskbar button and
@@ -44,16 +55,17 @@ object BossWindowIcon {
      */
     private val derivedSizes = intArrayOf(16, 20, 24, 32, 40, 48, 64, 128)
 
-    /** The 256x256 source, decoded once. Null only if the resource is missing from the classpath. */
+    /** The 256x256 source, decoded once. Null only if the resource cannot be read. */
     private val source: BufferedImage? by lazy { decodeSource() }
 
     /**
-     * Multi-resolution icon list for `Frame.iconImages`.
+     * Multi-resolution icon list for `Window.iconImages`.
      *
      * Empty rather than throwing when the resource cannot be read. Callers include
      * [ai.rever.boss.crash.CrashHandler], which is already handling a crash - a missing icon must
      * not become the reason the crash report never gets shown. `iconImages = emptyList()` is
-     * exactly the state every window is in today, so the fallback is the current behaviour.
+     * exactly the state every window was in before this existed, so the fallback is the old
+     * behaviour rather than a new failure.
      */
     val images: List<BufferedImage> by lazy {
         val original = source ?: return@lazy emptyList()
@@ -63,24 +75,77 @@ object BossWindowIcon {
         }
     }
 
+    /**
+     * The `icon` for a Compose `Window` or `DialogWindow`.
+     *
+     * A plain shared value, not a `@Composable` returning `remember { … }`: it is a process-wide
+     * singleton that never changes, so a remember slot per call site would buy nothing and would
+     * make "one decode, one bitmap" less obvious than it is.
+     *
+     * Null when the resource could not be read, which is what `Window(icon = null)` already means.
+     *
+     * This is only half of what a Compose window needs. Compose rasterises the painter at a fixed
+     * 192dp and calls the single-image `Window.setIconImage`, so on its own it leaves Windows to
+     * squeeze one bitmap down to a 16px title bar - the exact downscale [derivedSizes] exists to
+     * avoid. [ApplyBossWindowIcon] supplies the list; this supplies an icon early enough that the
+     * window never appears unbranded first.
+     */
+    val painter: Painter? by lazy {
+        source?.toComposeImageBitmap()?.let(::BitmapPainter)
+    }
+
     private fun decodeSource(): BufferedImage? {
         // `/boss_icon.png` rather than the Compose resource: this has to be readable from plain AWT
         // code and from a crash handler, neither of which can call into a composition, and one
-        // decode shared by both families beats two loaders.
+        // decode shared by both routes beats two loaders.
         val decoded =
             runCatching {
-                javaClass.getResourceAsStream("/boss_icon.png")?.use(ImageIO::read)
+                javaClass.getResourceAsStream(ICON_RESOURCE)?.use(ImageIO::read)
             }.getOrElse { e ->
-                logger.warn(LogCategory.UI, "Could not decode /boss_icon.png", error = e)
-                return null
+                logger.warn(LogCategory.UI, "Could not read $ICON_RESOURCE", error = e)
+                null
             }
         if (decoded == null) {
-            logger.warn(LogCategory.UI, "/boss_icon.png is not on the classpath - windows will be unbranded")
+            logger.warn(LogCategory.UI, missingIconReason())
         }
         return decoded
     }
 
+    /**
+     * Why there is no icon, resolved only when there isn't one.
+     *
+     * "Present but undecodable" and "absent" are different bugs in different places - a truncated PNG
+     * versus a packaging mistake - and reporting the first as the second would send whoever debugs it
+     * looking in the wrong place.
+     */
+    private fun missingIconReason(): String =
+        if (javaClass.getResource(ICON_RESOURCE) == null) {
+            "$ICON_RESOURCE is not on the classpath - windows will be unbranded"
+        } else {
+            "$ICON_RESOURCE is present but ImageIO could not decode it - windows will be unbranded"
+        }
+
+    /**
+     * Downscales by repeated halving rather than one jump to the target.
+     *
+     * A single bicubic `drawImage` from 256 to 16 samples far too few source pixels and aliases -
+     * roughly the same result as letting AWT squeeze the 256px bitmap itself, which would give back
+     * most of the quality [derivedSizes] is here to buy. Halving keeps every source pixel
+     * contributing. Runs once per process for eight small images, so the extra passes are free.
+     */
     private fun BufferedImage.scaledTo(size: Int): BufferedImage {
+        var current = this
+        // Halve while the result would still be at or above the target, so the final step is always
+        // a reduction of less than 2x - the range bicubic handles well.
+        var next = current.width / 2
+        while (next > size) {
+            current = current.drawnInto(next)
+            next /= 2
+        }
+        return current.drawnInto(size)
+    }
+
+    private fun BufferedImage.drawnInto(size: Int): BufferedImage {
         val scaled = BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB)
         val g = scaled.createGraphics()
         try {
@@ -93,75 +158,89 @@ object BossWindowIcon {
         }
         return scaled
     }
-
-    /** The source as a Compose bitmap, decoded and converted once for every window that asks. */
-    internal val composeBitmap by lazy { source?.toComposeImageBitmap() }
 }
 
 /**
- * The `icon` for a Compose `Window` or `DialogWindow`.
+ * Gives the enclosing Compose window the multi-resolution icon.
  *
- * Deliberately not `painterResource(Res.drawable.boss_icon)` at each call site. The five
- * `Heavyweight*` overlay windows are created and torn down constantly, and `painterResource` plus
- * the `Painter.toAwtImage` conversion Compose does for the icon would re-decode and re-rasterise a
- * 256px image on every one. This shares [BossWindowIcon]'s single decode.
+ * Call inside a `Window { }` / `DialogWindow { }` body, passing the scope's `window`. Works for both
+ * because `java.awt.Window.setIconImages` is defined on `Window`, not only on `Frame`.
  *
- * Returns null when the resource could not be read, which is what `Window(icon = null)` already
- * means - see [BossWindowIcon.images] for why this degrades rather than throws.
+ * Keyed on `window` via [DisposableEffect], not a bare `SideEffect`: the latter would re-assign and
+ * re-push the native icon on every recomposition of the window content, which for the overlay
+ * windows is constantly.
  *
- * Note the asymmetry with [BossWindowIcon.images], which is deliberate: Compose rasterises this
- * painter at a fixed 192dp and calls the single-image `Window.setIconImage`, so a Compose window
- * gets one bitmap that Windows downscales for the 16px title bar, not the multi-resolution list. The
- * main window has worked exactly this way since it was written, so it is good enough; the AWT sites
- * take the list because there the API allows it. The Compose `icon` parameter is still what the
- * Compose sites use, because it is applied before the window is shown - assigning `iconImages` from
- * inside the window body would leave one frame of Java icon on screen first.
+ * Safe alongside `icon = BossWindowIcon.painter`. Compose applies `icon` from its own update pass
+ * only when the value changes, and that value is a stable singleton, so it lands once at window
+ * creation and never fights this. The ordering is deliberate: `icon` gets a correct - if
+ * single-resolution - icon onto the window before it is shown, and this upgrades it to the list.
  */
 @Composable
-fun bossWindowIcon(): Painter? {
-    val bitmap = BossWindowIcon.composeBitmap ?: return null
-    return remember(bitmap) { BitmapPainter(bitmap) }
+fun ApplyBossWindowIcon(window: java.awt.Window) {
+    DisposableEffect(window) {
+        val icons = BossWindowIcon.images
+        if (icons.isNotEmpty()) {
+            runCatching { window.iconImages = icons }
+        }
+        onDispose {}
+    }
 }
 
 /**
  * Brands windows BOSS does not create itself.
  *
  * JxBrowser raises Swing dialogs of its own, `JFileChooser` makes its own frames, a plugin can open
- * one, and the next window added to this app can forget its `icon`. This catches all of them.
+ * one, and the next window added to this app can forget its icon. This catches all of them.
  *
  * A net, not the fix. `WINDOW_OPENED` is delivered after `setVisible(true)`, so a window caught here
  * shows the Java icon for one frame first - invisible for a foreign dialog, but not good enough for
- * ours, which is why every window in this repo sets its icon explicitly and is held to it by
+ * ours, which is why every window in this repo brands itself and is held to it by
  * `WindowIconConventionTest`.
  *
  * Only [Frame] is touched: `java.awt.Dialog` has no icon of its own and takes its owner frame's, so
- * fixing the frames fixes the dialogs over them.
+ * branding the frames brands the dialogs over them.
  */
 object DefaultWindowIcon {
     private val logger = BossLogger.forComponent("DefaultWindowIcon")
 
     /**
-     * Registers the listener. Call once, before any window exists - `main` does this next to
-     * `setLinuxWMClass`, which has the same ordering requirement.
+     * Registers the listener. Call once, from `main`, after the paths that exit without a window and
+     * before the first window - see the call site for why both ends of that are fenced.
      */
     fun install() {
-        val icons = BossWindowIcon.images
-        if (icons.isEmpty()) return
-
         runCatching {
             Toolkit.getDefaultToolkit().addAWTEventListener({ event ->
-                if (event.id != WindowEvent.WINDOW_OPENED) return@addAWTEventListener
-                val frame = (event as? WindowEvent)?.window as? Frame ?: return@addAWTEventListener
-                // Only when nothing set one: an explicit icon - including a deliberately different
-                // one - is never overwritten here.
-                if (frame.iconImages.isEmpty()) {
-                    frame.iconImages = icons
+                if (event.id == WindowEvent.WINDOW_OPENED) {
+                    ((event as? WindowEvent)?.window as? Frame)?.let(::brandIfUnbranded)
                 }
             }, AWTEvent.WINDOW_EVENT_MASK)
         }.onFailure { e ->
-            // A SecurityManager can refuse the listener. Losing the net is survivable; every
-            // window this app opens sets its own icon.
+            // A SecurityManager can refuse the listener. Losing the net is survivable; every window
+            // this app opens brands itself.
             logger.warn(LogCategory.UI, "Could not install the default window icon listener", error = e)
         }
+    }
+
+    private fun brandIfUnbranded(frame: Frame) {
+        iconsToApply(frame.iconImages)?.let { icons -> runCatching { frame.iconImages = icons } }
+    }
+
+    /**
+     * The listener's actual decision: what to assign to a frame that already carries [existing],
+     * or null to leave it alone.
+     *
+     * Pure, and separated out for two reasons. It is the interesting half, and testing it through a
+     * real [Frame] would not work anyway - constructing one throws `HeadlessException`, so any such
+     * test would pass here and fail on every CI runner.
+     *
+     * Reads [BossWindowIcon.images] here rather than in [install]: forcing the decode at registration
+     * time would put a PNG read and eight rescales on the startup critical path, for a list only
+     * needed if an unbranded foreign window ever actually opens.
+     */
+    internal fun iconsToApply(existing: List<Image>): List<BufferedImage>? {
+        // Only when nothing set one: an explicit icon - including a deliberately different one - is
+        // never overwritten here.
+        if (existing.isNotEmpty()) return null
+        return BossWindowIcon.images.ifEmpty { null }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NoRawDialogConventionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/NoRawDialogConventionTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.overlays
 
-import java.io.File
+import ai.rever.boss.testsupport.kotlinSourcesUnder
+import ai.rever.boss.testsupport.repoRoot
 import kotlin.test.Test
 import kotlin.test.fail
 
@@ -31,14 +32,8 @@ class NoRawDialogConventionTest {
     @Test
     fun `no host source imports the raw Compose Dialog`() {
         val root = repoRoot()
-        val roots =
-            listOf(File(root, "composeApp/src"), File(root, "plugin-platform"))
-                .filter { it.isDirectory }
-        check(roots.isNotEmpty()) { "no source roots found under $root" }
-
         val offenders =
-            roots
-                .flatMap { it.walkTopDown().filter { f -> f.isFile && f.extension == "kt" } }
+            kotlinSourcesUnder(root, "composeApp/src", "plugin-platform")
                 .filter { it.name !in allowed }
                 .filter { file ->
                     file.readLines().any { it.trim() == "import androidx.compose.ui.window.Dialog" }
@@ -52,15 +47,5 @@ class NoRawDialogConventionTest {
                     "(ai.rever.boss.plugin.ui.BossDialog) instead:\n  " + offenders.joinToString("\n  "),
             )
         }
-    }
-
-    /** Walks up from the test's working directory to the checkout root. */
-    private fun repoRoot(): File {
-        var dir: File? = File(".").absoluteFile
-        while (dir != null) {
-            if (File(dir, "composeApp").isDirectory && File(dir, "version.properties").isFile) return dir
-            dir = dir.parentFile
-        }
-        fail("could not locate the repository root from ${File(".").absolutePath}")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/testsupport/RepoRoot.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/testsupport/RepoRoot.kt
@@ -1,0 +1,30 @@
+package ai.rever.boss.testsupport
+
+import java.io.File
+
+/**
+ * Locates the checkout root by walking up from the test's working directory.
+ *
+ * Shared because the source-scanning convention tests all need it and had started copying it
+ * verbatim - `NoRawDialogConventionTest` and `WindowIconConventionTest` held identical copies before
+ * this existed. Gradle runs desktopTest from the module directory, and a git worktree puts the
+ * checkout somewhere else again, so no test can assume a fixed relative path.
+ */
+fun repoRoot(): File {
+    var dir: File? = File(".").absoluteFile
+    while (dir != null) {
+        if (File(dir, "composeApp").isDirectory && File(dir, "version.properties").isFile) return dir
+        dir = dir.parentFile
+    }
+    error("could not locate the repository root from ${File(".").absolutePath}")
+}
+
+/** Every `.kt` file under the given repo-relative roots that exist. */
+fun kotlinSourcesUnder(
+    root: File,
+    vararg relativeRoots: String,
+): List<File> {
+    val roots = relativeRoots.map { File(root, it) }.filter { it.isDirectory }
+    check(roots.isNotEmpty()) { "none of ${relativeRoots.toList()} found under $root" }
+    return roots.flatMap { it.walkTopDown().filter { f -> f.isFile && f.extension == "kt" } }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconConventionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconConventionTest.kt
@@ -1,11 +1,13 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.testsupport.kotlinSourcesUnder
+import ai.rever.boss.testsupport.repoRoot
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.fail
 
 /**
- * Asserts every file that opens a top-level window also brands it.
+ * Asserts every site that opens a top-level window also brands it.
  *
  * A Compose `Window` given no `icon`, or a bare `JFrame`, leaves `Frame.iconImages` empty, and
  * Windows then draws the JDK's default Java icon in the title bar, the taskbar button and the
@@ -15,86 +17,122 @@ import kotlin.test.fail
  * window works perfectly in every other respect. Nine windows shipped that way, for years, before
  * anyone noticed the Settings window was wearing a coffee cup.
  *
- * Deliberately a text check, like [ai.rever.boss.components.overlays.NoRawDialogConventionTest]
- * next door. It cannot see a fully-qualified call or a window opened through a helper, but it
- * catches the shape every real call site in this repo takes and it costs nothing.
+ * **Per call site, not per file.** An earlier version of this test asked "does this file open a
+ * window and fail to mention the icon", which meant one branded site immunised the whole file -
+ * `FullscreenBrowserWindow.kt` already has two `JFrame()` sites and `main.kt` has a `Window(`, so a
+ * third added tomorrow would have passed unbranded. Since the entire premise here is that the
+ * omission hides in a file that otherwise looks correct, that was the most likely hole in the guard.
+ *
+ * Still a text check, like [ai.rever.boss.components.overlays.NoRawDialogConventionTest] next door,
+ * and it inherits that test's limits: a fully-qualified call or a window opened through some helper
+ * of its own would slip past. It catches the shape every real call site in this repo takes.
  */
 class WindowIconConventionTest {
     /**
      * The call shapes that open a window with an icon surface.
      *
      * `\b` before each name matters: without it `Window\(` also matches `positionInWindow()` and
-     * `boundsInWindow()`, which are on half the layout code in this repo. It is also why
+     * `boundsInWindow()`, which are all over the layout code in this repo. It is also why
      * `DialogWindow` needs its own entry - the `g` before its `W` is a word character, so the
      * `Window` pattern never sees it.
      */
-    private val windowOpeners =
-        listOf(
-            Regex("""\bWindow\("""),
-            Regex("""\bDialogWindow\("""),
-            Regex("""\bsingleWindowApplication\("""),
-            Regex("""\bJFrame\("""),
-        )
+    private val windowOpener =
+        Regex("""\bWindow\(|\bDialogWindow\(|\bsingleWindowApplication\(|\bJFrame\(""")
 
-    /** Either shape of the shared icon: the Compose painter, or the AWT image list. */
-    private val brandingReference = Regex("""\bbossWindowIcon\b|\bBossWindowIcon\b""")
+    /** Any shape of the shared icon: the Compose painter, the AWT image list, or the upgrade call. */
+    private val branding = Regex("""\bBossWindowIcon\b|\bApplyBossWindowIcon\b""")
+
+    /**
+     * How far after an opener the branding may appear.
+     *
+     * Generous on purpose. A Compose `Window(` carries `icon =` within a few lines, but the raw
+     * `JFrame` sites assign `iconImages` after a run of other frame setup, and `CrashHandler` puts a
+     * controller and a comment block in between. Wide enough not to be brittle, narrow enough that
+     * branding one site cannot vouch for an unrelated one further down the file.
+     */
+    private val lookaheadLines = 40
+
+    /**
+     * Files where an opener match is prose or a definition rather than a call site.
+     *
+     * `WindowIcon.kt` documents `Window(icon = null)` in its KDoc; the tests quote the patterns.
+     */
+    private val allowed = setOf("WindowIcon.kt", "WindowIconConventionTest.kt", "WindowIconTest.kt")
 
     @Test
-    fun `every file that opens a window references the shared BOSS icon`() {
+    fun `every window call site brands the window`() {
         val root = repoRoot()
-        val roots =
-            listOf(File(root, "composeApp/src"), File(root, "plugin-platform"))
-                .filter { it.isDirectory }
-        check(roots.isNotEmpty()) { "no source roots found under $root" }
-
         val offenders =
-            roots
-                .flatMap { it.walkTopDown().filter { f -> f.isFile && f.extension == "kt" } }
-                .filter { file ->
-                    val text = file.readText()
-                    windowOpeners.any { it.containsMatchIn(text) } && !brandingReference.containsMatchIn(text)
-                }.map { it.relativeTo(root).path }
+            kotlinSourcesUnder(root, "composeApp/src", "plugin-platform")
+                .filter { it.name !in allowed }
+                .flatMap { file -> unbrandedSitesIn(file, root) }
                 .sorted()
 
         if (offenders.isNotEmpty()) {
             fail(
-                "These files open a top-level window without referencing the shared BOSS icon, so on " +
-                    "Windows it will show the default Java icon in the title bar, taskbar and Alt-Tab. " +
-                    "Pass `icon = bossWindowIcon()` to a Compose Window/DialogWindow, or assign " +
-                    "`frame.iconImages = BossWindowIcon.images` to a raw JFrame " +
-                    "(ai.rever.boss.window.WindowIcon):\n  " + offenders.joinToString("\n  "),
+                "These window call sites do not brand the window, so on Windows it will show the " +
+                    "default Java icon in the title bar, taskbar and Alt-Tab. Pass " +
+                    "`icon = BossWindowIcon.painter` and call `ApplyBossWindowIcon(window)` in a " +
+                    "Compose Window/DialogWindow body, or assign `frame.iconImages = " +
+                    "BossWindowIcon.images` on a raw JFrame (ai.rever.boss.window.WindowIcon):\n  " +
+                    offenders.joinToString("\n  "),
             )
         }
     }
 
+    /** Repo-relative `path:line` for every opener in [file] with no branding within the lookahead. */
+    private fun unbrandedSitesIn(
+        file: File,
+        root: File,
+    ): List<String> {
+        val lines = file.readLines()
+        return lines.indices
+            .filter { windowOpener.containsMatchIn(lines[it]) }
+            .filterNot { i ->
+                val end = minOf(lines.size, i + lookaheadLines)
+                (i until end).any { branding.containsMatchIn(lines[it]) }
+            }.map { "${file.relativeTo(root).path.replace('\\', '/')}:${it + 1}" }
+    }
+
     /**
-     * Guards the guard: if the patterns above ever stop matching anything, the test above passes
-     * vacuously and would keep passing while every window in the app went unbranded.
+     * Guards the guard: if the opener pattern ever stops matching, the test above passes vacuously
+     * and would keep passing while every window in the app went unbranded.
+     *
+     * Counts call sites rather than files, and skips [allowed] so that prose in this feature's own
+     * KDoc cannot be what satisfies it - the earlier version's floor was partly met by
+     * `WindowIcon.kt` documenting `Window(icon = null)`, which is a little too self-referential to
+     * be a safety net.
      */
     @Test
-    fun `the window-opening patterns still match the known call sites`() {
+    fun `the window-opening pattern still matches the known call sites`() {
         val root = repoRoot()
-        val matched =
-            File(root, "composeApp/src")
-                .walkTopDown()
-                .filter { it.isFile && it.extension == "kt" }
-                .count { file -> windowOpeners.any { it.containsMatchIn(file.readText()) } }
+        val sites =
+            kotlinSourcesUnder(root, "composeApp/src")
+                .filter { it.name !in allowed }
+                .sumOf { file -> file.readLines().count { windowOpener.containsMatchIn(it) } }
 
-        // Fifteen at the time of writing (ten Compose windows, five raw frames, spread over
-        // fourteen files, plus WindowIcon.kt's own KDoc). A floor, not an equality: adding a window
-        // must not fail this test, only the one above.
-        if (matched < 10) {
-            fail("expected the window-opening patterns to match many files, matched only $matched")
+        // Fifteen real sites at the time of writing: ten Compose windows and five raw frames. A
+        // floor, not an equality - adding a window must fail the test above, never this one.
+        if (sites < 12) {
+            fail("expected the window-opening pattern to match many call sites, matched only $sites")
         }
     }
 
-    /** Walks up from the test's working directory to the checkout root. */
-    private fun repoRoot(): File {
-        var dir: File? = File(".").absoluteFile
-        while (dir != null) {
-            if (File(dir, "composeApp").isDirectory && File(dir, "version.properties").isFile) return dir
-            dir = dir.parentFile
+    /**
+     * The net is one line in `main.kt` and nothing else references it. Delete that line and every
+     * test here still passes while windows BOSS does not compose go back to the Java icon.
+     */
+    @Test
+    fun `main installs the default window icon net`() {
+        val main = File(repoRoot(), "composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt")
+        check(main.isFile) { "main.kt not found at ${main.absolutePath}" }
+
+        if (!main.readText().contains("DefaultWindowIcon.install()")) {
+            fail(
+                "main.kt no longer calls DefaultWindowIcon.install(), so windows BOSS does not " +
+                    "compose itself (JxBrowser's Swing dialogs, JFileChooser, plugin frames) will " +
+                    "show the default Java icon on Windows",
+            )
         }
-        fail("could not locate the repository root from ${File(".").absolutePath}")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconConventionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconConventionTest.kt
@@ -1,0 +1,100 @@
+package ai.rever.boss.window
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Asserts every file that opens a top-level window also brands it.
+ *
+ * A Compose `Window` given no `icon`, or a bare `JFrame`, leaves `Frame.iconImages` empty, and
+ * Windows then draws the JDK's default Java icon in the title bar, the taskbar button and the
+ * Alt-Tab card. macOS reads the `.app` bundle and Linux the `.desktop` file, so neither shows it -
+ * which is exactly why this needs a test rather than review vigilance. The omission is invisible in
+ * a diff (an absent argument), invisible on the two platforms most of this is developed on, and the
+ * window works perfectly in every other respect. Nine windows shipped that way, for years, before
+ * anyone noticed the Settings window was wearing a coffee cup.
+ *
+ * Deliberately a text check, like [ai.rever.boss.components.overlays.NoRawDialogConventionTest]
+ * next door. It cannot see a fully-qualified call or a window opened through a helper, but it
+ * catches the shape every real call site in this repo takes and it costs nothing.
+ */
+class WindowIconConventionTest {
+    /**
+     * The call shapes that open a window with an icon surface.
+     *
+     * `\b` before each name matters: without it `Window\(` also matches `positionInWindow()` and
+     * `boundsInWindow()`, which are on half the layout code in this repo. It is also why
+     * `DialogWindow` needs its own entry - the `g` before its `W` is a word character, so the
+     * `Window` pattern never sees it.
+     */
+    private val windowOpeners =
+        listOf(
+            Regex("""\bWindow\("""),
+            Regex("""\bDialogWindow\("""),
+            Regex("""\bsingleWindowApplication\("""),
+            Regex("""\bJFrame\("""),
+        )
+
+    /** Either shape of the shared icon: the Compose painter, or the AWT image list. */
+    private val brandingReference = Regex("""\bbossWindowIcon\b|\bBossWindowIcon\b""")
+
+    @Test
+    fun `every file that opens a window references the shared BOSS icon`() {
+        val root = repoRoot()
+        val roots =
+            listOf(File(root, "composeApp/src"), File(root, "plugin-platform"))
+                .filter { it.isDirectory }
+        check(roots.isNotEmpty()) { "no source roots found under $root" }
+
+        val offenders =
+            roots
+                .flatMap { it.walkTopDown().filter { f -> f.isFile && f.extension == "kt" } }
+                .filter { file ->
+                    val text = file.readText()
+                    windowOpeners.any { it.containsMatchIn(text) } && !brandingReference.containsMatchIn(text)
+                }.map { it.relativeTo(root).path }
+                .sorted()
+
+        if (offenders.isNotEmpty()) {
+            fail(
+                "These files open a top-level window without referencing the shared BOSS icon, so on " +
+                    "Windows it will show the default Java icon in the title bar, taskbar and Alt-Tab. " +
+                    "Pass `icon = bossWindowIcon()` to a Compose Window/DialogWindow, or assign " +
+                    "`frame.iconImages = BossWindowIcon.images` to a raw JFrame " +
+                    "(ai.rever.boss.window.WindowIcon):\n  " + offenders.joinToString("\n  "),
+            )
+        }
+    }
+
+    /**
+     * Guards the guard: if the patterns above ever stop matching anything, the test above passes
+     * vacuously and would keep passing while every window in the app went unbranded.
+     */
+    @Test
+    fun `the window-opening patterns still match the known call sites`() {
+        val root = repoRoot()
+        val matched =
+            File(root, "composeApp/src")
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .count { file -> windowOpeners.any { it.containsMatchIn(file.readText()) } }
+
+        // Fifteen at the time of writing (ten Compose windows, five raw frames, spread over
+        // fourteen files, plus WindowIcon.kt's own KDoc). A floor, not an equality: adding a window
+        // must not fail this test, only the one above.
+        if (matched < 10) {
+            fail("expected the window-opening patterns to match many files, matched only $matched")
+        }
+    }
+
+    /** Walks up from the test's working directory to the checkout root. */
+    private fun repoRoot(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            if (File(dir, "composeApp").isDirectory && File(dir, "version.properties").isFile) return dir
+            dir = dir.parentFile
+        }
+        fail("could not locate the repository root from ${File(".").absolutePath}")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconTest.kt
@@ -1,0 +1,47 @@
+package ai.rever.boss.window
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins that the icon actually loads.
+ *
+ * [BossWindowIcon] degrades to an empty list rather than throwing when `/boss_icon.png` cannot be
+ * read, because [ai.rever.boss.crash.CrashHandler] is one of its callers and a missing icon must not
+ * be the reason a crash report goes unshown. That fallback is also how this whole feature could
+ * become a silent no-op: every window would carry on showing the Java icon and nothing would say so.
+ * Hence a test on the resource, not just on the call sites.
+ */
+class WindowIconTest {
+    @Test
+    fun `the window icon resource is on the classpath`() {
+        assertTrue(
+            BossWindowIcon.images.isNotEmpty(),
+            "/boss_icon.png did not load - every window would silently fall back to the Java icon",
+        )
+    }
+
+    @Test
+    fun `the icon list is square, distinct and covers the sizes Windows asks for`() {
+        val sizes = BossWindowIcon.images.map { it.width }
+
+        BossWindowIcon.images.forEach { image ->
+            assertEquals(image.width, image.height, "icon variants must be square")
+        }
+        assertEquals(sizes.distinct(), sizes, "duplicate icon sizes waste memory and help nothing")
+        // 16 for the title bar and 32 for the taskbar button and Alt-Tab card are the two Windows
+        // actually asks for; the source is kept so a high-DPI request has something to work from.
+        assertTrue(16 in sizes, "no 16px variant, which is what the Windows title bar asks for")
+        assertTrue(32 in sizes, "no 32px variant, which is what the taskbar and Alt-Tab ask for")
+        assertTrue(sizes.max() >= 256, "the full-size source should be kept for high-DPI requests")
+    }
+
+    @Test
+    fun `the compose painter resolves from the same decode`() {
+        assertTrue(
+            BossWindowIcon.composeBitmap != null,
+            "bossWindowIcon() would return null and every Compose window would go unbranded",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowIconTest.kt
@@ -1,11 +1,15 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.testsupport.repoRoot
+import java.awt.image.BufferedImage
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Pins that the icon actually loads.
+ * Pins that the icon loads, that the list is the shape Windows wants, and that the net's decision is
+ * the one it claims.
  *
  * [BossWindowIcon] degrades to an empty list rather than throwing when `/boss_icon.png` cannot be
  * read, because [ai.rever.boss.crash.CrashHandler] is one of its callers and a missing icon must not
@@ -25,11 +29,14 @@ class WindowIconTest {
     @Test
     fun `the icon list is square, distinct and covers the sizes Windows asks for`() {
         val sizes = BossWindowIcon.images.map { it.width }
+        // Asserted rather than assumed: on an empty list the checks below would throw
+        // NoSuchElementException instead of failing with something a reader can act on.
+        assertTrue(sizes.isNotEmpty(), "no icon variants at all - see the resource test above")
 
         BossWindowIcon.images.forEach { image ->
             assertEquals(image.width, image.height, "icon variants must be square")
         }
-        assertEquals(sizes.distinct(), sizes, "duplicate icon sizes waste memory and help nothing")
+        assertEquals(sizes, sizes.distinct(), "duplicate icon sizes waste memory and help nothing")
         // 16 for the title bar and 32 for the taskbar button and Alt-Tab card are the two Windows
         // actually asks for; the source is kept so a high-DPI request has something to work from.
         assertTrue(16 in sizes, "no 16px variant, which is what the Windows title bar asks for")
@@ -38,10 +45,69 @@ class WindowIconTest {
     }
 
     @Test
+    fun `the small variants are not blank`() {
+        // A progressive downscale that got its loop bounds wrong would still produce correctly sized
+        // images, just empty ones - and nothing else here would notice.
+        val small = BossWindowIcon.images.first { it.width == 16 }
+        val opaquePixels =
+            (0 until small.width).sumOf { x ->
+                (0 until small.height).count { y -> (small.getRGB(x, y) ushr 24) != 0 }
+            }
+        assertTrue(opaquePixels > 0, "the 16px variant is fully transparent")
+    }
+
+    @Test
     fun `the compose painter resolves from the same decode`() {
         assertTrue(
-            BossWindowIcon.composeBitmap != null,
-            "bossWindowIcon() would return null and every Compose window would go unbranded",
+            BossWindowIcon.painter != null,
+            "BossWindowIcon.painter is null, so every Compose window would go unbranded",
+        )
+    }
+
+    @Test
+    fun `the net brands a frame carrying no icon`() {
+        assertEquals(
+            BossWindowIcon.images.size,
+            DefaultWindowIcon.iconsToApply(emptyList())?.size,
+            "a frame with no icon should be given the full list",
+        )
+    }
+
+    @Test
+    fun `the net leaves an already-branded frame alone`() {
+        // The whole point of the emptiness check: a window that deliberately carries a different
+        // icon - including every window in this repo, which sets its own before this ever runs -
+        // must not be overwritten.
+        val existing = BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB)
+        assertEquals(
+            null,
+            DefaultWindowIcon.iconsToApply(listOf(existing)),
+            "an existing icon must not be replaced",
+        )
+    }
+
+    /**
+     * The two copies of the art are byte-identical today, and this keeps them that way.
+     *
+     * `desktopMain/resources` is what every window title bar now reads; `commonMain/composeResources`
+     * is what `AuthFormComponents`, `LoadingScreen` and `OfflineScreen` render. The duplication
+     * predates this feature, but this feature makes it load-bearing in a second place: a designer
+     * updating only the Compose resource would leave every window on the old art, with nothing
+     * failing to say so.
+     */
+    @Test
+    fun `both copies of the icon art are identical`() {
+        val root = repoRoot()
+        val windowCopy = File(root, "composeApp/src/desktopMain/resources/boss_icon.png")
+        val uiCopy = File(root, "composeApp/src/commonMain/composeResources/drawable/boss_icon.png")
+        check(windowCopy.isFile) { "missing ${windowCopy.absolutePath}" }
+        check(uiCopy.isFile) { "missing ${uiCopy.absolutePath}" }
+
+        assertTrue(
+            windowCopy.readBytes().contentEquals(uiCopy.readBytes()),
+            "boss_icon.png differs between desktopMain/resources (window icons) and " +
+                "commonMain/composeResources (in-app logos). Update both, or the title bars and the " +
+                "in-app logo will show different art.",
         )
     }
 }


### PR DESCRIPTION
## What

On Windows the Settings window showed the JDK's default Java coffee cup in its title bar, taskbar button and Alt-Tab card - and so did every other window BOSS opens.

`jpackage` puts `boss_icon.ico` on the launcher `.exe`, which is why the Start-menu entry and the executable have always looked right, but that icon never reaches a live AWT window. A Compose `Window` given no `icon` leaves `Frame.iconImages` empty and Windows falls back to its own default. macOS reads the `.app` bundle and Linux the `.desktop` file, so neither platform ever showed it - which is why this went unnoticed on nine windows for years.

Exactly one of the fifteen window sites in the repo passed an icon: the main window.

## How

New `ai.rever.boss.window.WindowIcon` is the single source - one `ImageIO` decode of `/boss_icon.png`, in the two shapes the two families of window need:

- `bossWindowIcon()` for the ten Compose `Window` / `DialogWindow` sites (Settings, the "BOSS - Setup" Chromium download window, the plugin install wizard, the colour picker, the five `Heavyweight*` overlays, and the main window switched off `painterResource` onto the shared cache).
- `BossWindowIcon.images` - a pre-scaled 16..256 list, since Windows asks for 16 in the title bar and 32 in the taskbar - for the five raw Swing frames: the crash dialog, the fullscreen browser frame and its borderless overlay, and the two browser popup frames.

`DefaultWindowIcon.install()` is the net under windows BOSS does not create itself - JxBrowser's own Swing dialogs, `JFileChooser`, a frame opened by a plugin. It brands only frames whose `iconImages` are still empty, so an explicit icon is never overwritten.

## Three things worth a reviewer's attention

- **`install()`'s position in `main()` is load-bearing in both directions.** It registers an AWT event listener, so it initialises the toolkit. It therefore cannot sit up beside `setLinuxWMClass`, where it would run ahead of the `ChromiumFlagsSettingsManager` and `BOSS_SKIKO_RENDER_API` blocks that must publish their system properties before AWT/Skiko reads them - `skiko.renderApi` is read at init and never again. It only needs to be earlier than the first window.
- **The Compose sites use the `icon` parameter, not `iconImages` from inside the window body.** Compose applies `icon` before the window is shown; the listener fires on `WINDOW_OPENED`, one frame after. So the net is a net, and every window we own is fixed explicitly. The trade is that Compose rasterises the painter at a fixed 192dp and calls the single-image `setIconImage`, so a Compose window does not get the multi-resolution list - which is exactly what the main window has done since it was written.
- **`bossWindowIcon()` is not `painterResource(Res.drawable.boss_icon)`.** The five overlay windows are created and torn down constantly, and `painterResource` plus Compose's `toAwtImage` conversion would re-decode and re-rasterise a 256px image on every one.

`FluckEngine`'s find-bar `JDialog` is deliberately untouched: it is undecorated and `Window.Type.UTILITY`, so it has no icon surface at all.

## Tests

- `WindowIconConventionTest` - every file that opens a `Window` / `DialogWindow` / `singleWindowApplication` / `JFrame` must reference the shared icon. A convention test rather than review vigilance because the omission is an *absent argument*: invisible in a diff, and invisible on the two platforms most of this is developed on. A second case guards the guard, so the patterns cannot silently stop matching and pass vacuously.
- `WindowIconTest` - the classpath resource actually resolves. `BossWindowIcon` degrades to an empty list rather than throwing, because `CrashHandler` is one of its callers and a missing icon must never be the reason a crash report goes unshown - which is also how this whole change could have become a silent no-op.

`./gradlew :composeApp:ktlintCheck :composeApp:detekt` clean; the five new tests pass. Verified in a running Windows build: with Settings open, `WM_GETICON` returns a non-zero per-window icon for both windows instead of falling through to the Java class icon, and the title bar was confirmed by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
