### PR TITLE
Let an optional dependency stop vetoing its provider's unload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,21 @@ dependency was absent produced no signal at all and the user met the consequence
 feature that silently did nothing. The AI Gateway made that concrete: three plugins declare it
 `optional: true` and each falls back to an unconfigured state.
 
+**Both readers now agree on what `optional` means.** `checkCanUnload` counted *any* declaration,
+so the same `optional: true` that the install prompt words as "works without it" was a hard veto
+at unload time - and because the Toolbox updates a plugin by uninstalling and reinstalling it,
+the veto landed on the Update button. The AI Gateway could not be updated or removed while
+jupyter-notebook, flow-tab or llmrpa was loaded, which is all three of its consumers. The
+predicate is `PluginDependencyResolution.blockingDependentsOf`, next to `missingFor` so the two
+cannot drift again; it also drops a manifest that names itself, which would otherwise make that
+plugin permanently unremovable.
+
+Refusals must stay visible. `PluginLoaderDelegateImpl.unloadPlugin` returns a bare `Boolean`, and
+`uninstallPlugin` logs `Uninstalling plugin` *before* it decides - so a refusal used to leave the
+log stopping mid-sequence with the manager's reasons dropped at the delegate boundary. It now logs
+`Plugin unload refused` with them. The plugin side cannot receive those reasons through a
+`Boolean`, so the Toolbox's message points at the host log rather than restating the failure.
+
 `PluginDependencyResolution.missingFor(manifest, installedIds)` now answers what is absent, and
 `MissingDependencyDialog` offers to install it. Four things about the placement:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,11 +79,30 @@ predicate is `PluginDependencyResolution.blockingDependentsOf`, next to `missing
 cannot drift again; it also drops a manifest that names itself, which would otherwise make that
 plugin permanently unremovable.
 
+**A disabled dependent does not veto either.** `disablePlugin` unregisters the tracking context
+and flips the state to `DISABLED` but never calls `pluginLoader.unloadPlugin`, so a disabled
+plugin is still in `getLoadedPlugins()` and would refuse on behalf of something that is not
+running. `blockingDependentsOf` therefore takes an `isDisabled` predicate with **no default**, so
+a new call site has to answer; it **fails closed**, since `PluginState` has more members than
+LOADED and DISABLED and treating "not exactly LOADED" as "not running" would drop real dependents.
+
 Refusals must stay visible. `PluginLoaderDelegateImpl.unloadPlugin` returns a bare `Boolean`, and
 `uninstallPlugin` logs `Uninstalling plugin` *before* it decides - so a refusal used to leave the
 log stopping mid-sequence with the manager's reasons dropped at the delegate boundary. It now logs
-`Plugin unload refused` with them. The plugin side cannot receive those reasons through a
-`Boolean`, so the Toolbox's message points at the host log rather than restating the failure.
+`Plugin unload refused` with them, read off `PluginUnloadException.reasons` rather than the joined
+message. Refusal and failure log **separately**: `uninstallPlugin` returns `Result.failure` for
+both, and they send a reader to opposite places - a refusal means another plugin is in the way,
+while "Plugin not found" or a `pluginLoader.unloadPlugin` error is a fault that wants a stack
+trace. The plugin side cannot receive those reasons through a `Boolean`, so the Toolbox's message
+points at the host log rather than restating the failure.
+
+**Known, and deliberate: the veto does not distinguish Update from Remove.** The host's own update
+paths pass `force = true` (`PluginUpdateBridge`, `PluginStoreVersionBridge`), so they never meet
+it. The one path that does is the plugin-facing `PluginLoaderDelegateImpl.unloadPlugin`, which
+cannot tell which button was pressed - so a plugin with a *required* loaded dependent can still not
+be updated from the Toolbox, even though an update ends with it present again at a newer version.
+Refusing the removal is right; refusing the update is much harder to justify, and closing it needs
+an update-shaped verb (or an intent parameter) on the api rather than a change to this predicate.
 
 `PluginDependencyResolution.missingFor(manifest, installedIds)` now answers what is absent, and
 `MissingDependencyDialog` offers to install it. Four things about the placement:

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1188,14 +1188,16 @@ class DynamicPluginManager(
             }
         }
 
-        // Check for dependent plugins
-        val loadedPlugins = pluginLoader.getLoadedPlugins()
-        for (plugin in loadedPlugins) {
-            val hasDependency = plugin.manifest.dependencies.any { it.pluginId == pluginId }
-            if (hasDependency) {
-                reasons.add("Plugin '${plugin.manifest.displayName}' depends on this plugin")
-            }
-        }
+        // Check for dependent plugins. Only plugins that actually require this one veto the
+        // unload; see PluginDependencyResolution.blockingDependentsOf for why optional
+        // declarations must not.
+        reasons.addAll(
+            PluginDependencyResolution
+                .blockingDependentsOf(
+                    pluginId = pluginId,
+                    loadedManifests = pluginLoader.getLoadedPlugins().map { it.manifest },
+                ).map { displayName -> "Plugin '$displayName' depends on this plugin" },
+        )
 
         return if (reasons.isEmpty()) {
             CanUnloadResult.Ok

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1196,6 +1196,9 @@ class DynamicPluginManager(
                 .blockingDependentsOf(
                     pluginId = pluginId,
                     loadedManifests = pluginLoader.getLoadedPlugins().map { it.manifest },
+                    // Fails closed: only a state we positively recognise as DISABLED stops a
+                    // dependent counting. An untracked plugin, or any other state, still vetoes.
+                    isDisabled = { id -> _pluginStates.value[id]?.state == PluginState.DISABLED },
                 ).map { displayName -> "Plugin '$displayName' depends on this plugin" },
         )
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -167,13 +167,30 @@ object PluginDependencyResolution {
      * loaded. The Toolbox's update path is an uninstall followed by a reinstall, so what the
      * user saw was an Update button that did nothing at all.
      *
+     * **A disabled dependent does not count.** `DynamicPluginManager.disablePlugin` unregisters
+     * the tracking context and flips the state to `DISABLED`, but never calls
+     * `pluginLoader.unloadPlugin` - so a disabled plugin is still in `getLoadedPlugins()`. It
+     * would otherwise veto on behalf of something that cannot break, because it is not running:
+     * the same shape as the optional case above, and the reason shown would name a plugin the
+     * user had already turned off.
+     *
      * **Presence is by id only.** `PluginDependency.version` is ignored, matching [missingFor]:
      * a dependent needing 2.x is "satisfied" by 1.x here too, so this never refuses an unload
      * over a version range it has no way to act on.
+     *
+     * @param isDisabled whether a dependent is switched off; the host asks its `_pluginStates`.
+     *   Deliberately **has no default**, so a new call site has to answer rather than silently
+     *   getting the over-vetoing behaviour this exists to remove. It is asked only about
+     *   plugins that already declare a hard dependency, and it **fails closed**: the host
+     *   answers false for a state it does not recognise or does not track, so an unfamiliar
+     *   state still vetoes. `PluginState` has more members than LOADED and DISABLED
+     *   (REGISTERED, INITIALIZING, ...), and treating "not exactly LOADED" as "not running"
+     *   would drop real dependents.
      */
     fun blockingDependentsOf(
         pluginId: String,
         loadedManifests: List<PluginManifest>,
+        isDisabled: (pluginId: String) -> Boolean,
     ): List<String> =
         loadedManifests
             // A manifest naming itself is a mistake ([missingFor] drops it on the install side
@@ -184,7 +201,8 @@ object PluginDependencyResolution {
                 manifest.dependencies.any { dependency ->
                     dependency.pluginId == pluginId && !dependency.optional
                 }
-            }.map { manifest -> manifest.displayName }
+            }.filterNot { manifest -> isDisabled(manifest.pluginId) }
+            .map { manifest -> manifest.displayName }
 
     private fun PluginManifest.toMissing(dependency: PluginDependency) =
         MissingPluginDependency(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -153,6 +153,39 @@ object PluginDependencyResolution {
             .map { (_, declarations) -> declarations.minBy { it.optional } }
             .map { dependency -> manifest.toMissing(dependency) }
 
+    /**
+     * Display names of the [loadedManifests] that would actually break if [pluginId] were
+     * unloaded, for `DynamicPluginManager.checkCanUnload`.
+     *
+     * **Only non-optional declarations count.** `optional: true` is how a manifest says the
+     * plugin works without the dependency and merely lights up extra features when it is
+     * there - [missingFor] reports exactly that, and [MissingPluginDependency.description]
+     * words it as "works without X, but some of its features need it". Vetoing an unload on
+     * that same declaration contradicts the manifest, and it is not a small contradiction:
+     * jupyter-notebook, flow-tab and llmrpa all declare the AI Gateway optional, so with the
+     * optional filter missing the gateway could not be unloaded while any one of them was
+     * loaded. The Toolbox's update path is an uninstall followed by a reinstall, so what the
+     * user saw was an Update button that did nothing at all.
+     *
+     * **Presence is by id only.** `PluginDependency.version` is ignored, matching [missingFor]:
+     * a dependent needing 2.x is "satisfied" by 1.x here too, so this never refuses an unload
+     * over a version range it has no way to act on.
+     */
+    fun blockingDependentsOf(
+        pluginId: String,
+        loadedManifests: List<PluginManifest>,
+    ): List<String> =
+        loadedManifests
+            // A manifest naming itself is a mistake ([missingFor] drops it on the install side
+            // too), but here it would be a permanent one: the plugin could never be unloaded,
+            // updated or removed, and the reason shown would name the plugin being unloaded.
+            .filterNot { manifest -> manifest.pluginId == pluginId }
+            .filter { manifest ->
+                manifest.dependencies.any { dependency ->
+                    dependency.pluginId == pluginId && !dependency.optional
+                }
+            }.map { manifest -> manifest.displayName }
+
     private fun PluginManifest.toMissing(dependency: PluginDependency) =
         MissingPluginDependency(
             dependentPluginId = pluginId,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -171,6 +171,21 @@ class PluginLoaderDelegateImpl(
         try {
             logger.info(LogCategory.SYSTEM, "Unloading plugin via delegate", mapOf("pluginId" to pluginId))
             val result = dynamicPluginManager.uninstallPlugin(pluginId, force = false)
+            // The Boolean this returns is all the caller gets, so a refusal would otherwise
+            // leave no trace anywhere: uninstallPlugin logs "Uninstalling plugin" *before*
+            // deciding, so the log just stopped mid-sequence and the reasons the manager
+            // assembled (which name the plugins standing in the way) were dropped here. That is
+            // what made the Toolbox's Update button look like it did nothing at all.
+            result.exceptionOrNull()?.let { cause ->
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Plugin unload refused",
+                    mapOf(
+                        "pluginId" to pluginId,
+                        "reason" to (cause.message ?: cause::class.simpleName ?: "unknown"),
+                    ),
+                )
+            }
             result.isSuccess
         } catch (e: Exception) {
             logger.error(LogCategory.SYSTEM, "Exception unloading plugin", error = e)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
+import ai.rever.boss.plugin.loader.PluginUnloadException
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
 import ai.rever.boss.plugin.sandbox.TabSandboxRegistry
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
@@ -171,19 +172,35 @@ class PluginLoaderDelegateImpl(
         try {
             logger.info(LogCategory.SYSTEM, "Unloading plugin via delegate", mapOf("pluginId" to pluginId))
             val result = dynamicPluginManager.uninstallPlugin(pluginId, force = false)
-            // The Boolean this returns is all the caller gets, so a refusal would otherwise
+            // The Boolean this returns is all the caller gets, so a failure would otherwise
             // leave no trace anywhere: uninstallPlugin logs "Uninstalling plugin" *before*
             // deciding, so the log just stopped mid-sequence and the reasons the manager
             // assembled (which name the plugins standing in the way) were dropped here. That is
             // what made the Toolbox's Update button look like it did nothing at all.
-            result.exceptionOrNull()?.let { cause ->
+            //
+            // Refusal and failure are logged apart because uninstallPlugin returns
+            // Result.failure for both, and they send a reader to opposite places: a refusal
+            // means some other plugin is in the way, while "Plugin not found" or a
+            // pluginLoader.unloadPlugin error is a fault worth a stack trace. Reasons come off
+            // PluginUnloadException.reasons rather than the joined message, so this keeps
+            // working if that message is ever reworded.
+            val cause = result.exceptionOrNull()
+            val refusalReasons = (cause as? PluginUnloadException)?.reasons.orEmpty()
+            if (refusalReasons.isNotEmpty()) {
                 logger.warn(
                     LogCategory.SYSTEM,
                     "Plugin unload refused",
                     mapOf(
                         "pluginId" to pluginId,
-                        "reason" to (cause.message ?: cause::class.simpleName ?: "unknown"),
+                        "reasons" to refusalReasons.joinToString("; "),
                     ),
+                )
+            } else if (cause != null) {
+                logger.error(
+                    LogCategory.SYSTEM,
+                    "Plugin unload failed",
+                    mapOf("pluginId" to pluginId),
+                    cause,
                 )
             }
             result.isSuccess

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -346,6 +346,7 @@ class PluginDependencyResolutionTest {
                             dependencies = listOf(dependency("com.example.gateway", optional = true)),
                         ),
                     ),
+                isDisabled = { false },
             )
 
         assertEquals(emptyList(), blocking)
@@ -364,6 +365,7 @@ class PluginDependencyResolutionTest {
                             dependencies = listOf(dependency("com.example.gateway")),
                         ),
                     ),
+                isDisabled = { false },
             )
 
         // The display name, because it goes straight into a reason the user reads.
@@ -385,6 +387,7 @@ class PluginDependencyResolutionTest {
                             dependencies = listOf(dependency("com.example.gateway")),
                         ),
                     ),
+                isDisabled = { false },
             )
 
         assertEquals(emptyList(), blocking)
@@ -403,6 +406,7 @@ class PluginDependencyResolutionTest {
                             dependencies = listOf(dependency("com.example.unrelated")),
                         ),
                     ),
+                isDisabled = { false },
             )
 
         assertEquals(emptyList(), blocking)
@@ -431,9 +435,79 @@ class PluginDependencyResolutionTest {
                             dependencies = listOf(dependency("com.example.gateway", optional = true)),
                         ),
                     ),
+                isDisabled = { false },
             )
 
         assertEquals(listOf("Flow"), blocking)
+    }
+
+    @Test
+    fun `a disabled dependent does not block an unload`() {
+        // disablePlugin unregisters the tracking context and flips state to DISABLED but never
+        // calls pluginLoader.unloadPlugin, so a disabled plugin is still in getLoadedPlugins().
+        // Letting it veto raises a refusal on behalf of something that is not running.
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.jupyter",
+                            displayName = "Jupyter Notebook",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                    ),
+                isDisabled = { it == "com.example.jupyter" },
+            )
+
+        assertEquals(emptyList(), blocking)
+    }
+
+    @Test
+    fun `an enabled dependent still blocks when a disabled one does not`() {
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.jupyter",
+                            displayName = "Jupyter Notebook",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                    ),
+                isDisabled = { it == "com.example.jupyter" },
+            )
+
+        assertEquals(listOf("Flow"), blocking)
+    }
+
+    @Test
+    fun `the disabled check fails closed`() {
+        // The host answers false for a state it does not recognise or does not track, so an
+        // untracked-but-loaded dependent still vetoes. Over-vetoing an unfamiliar state is
+        // recoverable; dropping a real dependent silently is what this whole predicate is
+        // about not doing.
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.untracked",
+                            displayName = "Untracked",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                    ),
+                isDisabled = { false },
+            )
+
+        assertEquals(listOf("Untracked"), blocking)
     }
 
     @Test
@@ -456,6 +530,7 @@ class PluginDependencyResolutionTest {
                                 ),
                         ),
                     ),
+                isDisabled = { false },
             )
 
         assertEquals(listOf("Flow"), blocking)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -324,6 +324,142 @@ class PluginDependencyResolutionTest {
         // has to name something rather than reading "Flow needs null".
         assertTrue(required.description("com.example.gateway").contains("com.example.gateway"))
     }
+
+    // What `DynamicPluginManager.checkCanUnload` refuses on. The install side above and the
+    // unload side here read the same declarations, and they disagreed: an optional dependency
+    // was reported as "works without it" at install time and then treated as a hard veto at
+    // unload time.
+
+    @Test
+    fun `an optional dependent does not block an unload`() {
+        // The AI Gateway case. jupyter-notebook, flow-tab and llmrpa each declare the gateway
+        // optional, so treating that as a veto made the gateway impossible to unload - and the
+        // Toolbox's update path is uninstall-then-reinstall, so its Update button did nothing.
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.jupyter",
+                            displayName = "Jupyter Notebook",
+                            dependencies = listOf(dependency("com.example.gateway", optional = true)),
+                        ),
+                    ),
+            )
+
+        assertEquals(emptyList(), blocking)
+    }
+
+    @Test
+    fun `a required dependent blocks an unload and is named`() {
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.jupyter",
+                            displayName = "Jupyter Notebook",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                    ),
+            )
+
+        // The display name, because it goes straight into a reason the user reads.
+        assertEquals(listOf("Jupyter Notebook"), blocking)
+    }
+
+    @Test
+    fun `a plugin declaring itself does not block its own unload`() {
+        // Otherwise a manifest typo is permanent: the plugin could never be unloaded, updated
+        // or removed, and the reason would name the plugin being unloaded.
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.gateway",
+                            displayName = "AI Gateway",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                    ),
+            )
+
+        assertEquals(emptyList(), blocking)
+    }
+
+    @Test
+    fun `a plugin depending on something else does not block`() {
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.other",
+                            displayName = "Other",
+                            dependencies = listOf(dependency("com.example.unrelated")),
+                        ),
+                    ),
+            )
+
+        assertEquals(emptyList(), blocking)
+    }
+
+    @Test
+    fun `one required dependent among optional ones still blocks`() {
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.jupyter",
+                            displayName = "Jupyter Notebook",
+                            dependencies = listOf(dependency("com.example.gateway", optional = true)),
+                        ),
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                        manifest(
+                            pluginId = "com.example.llmrpa",
+                            displayName = "LLM RPA",
+                            dependencies = listOf(dependency("com.example.gateway", optional = true)),
+                        ),
+                    ),
+            )
+
+        assertEquals(listOf("Flow"), blocking)
+    }
+
+    @Test
+    fun `a dependency declared both ways blocks, as the stricter declaration`() {
+        // Mirrors `missingFor`, which resolves a doubled declaration to the stricter one: a
+        // plugin that requires something does not stop requiring it by also listing it
+        // optionally.
+        val blocking =
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies =
+                                listOf(
+                                    dependency("com.example.gateway", optional = true),
+                                    dependency("com.example.gateway"),
+                                ),
+                        ),
+                    ),
+            )
+
+        assertEquals(listOf("Flow"), blocking)
+    }
 }
 
 /**


### PR DESCRIPTION
## The report

Updating **AI Gateway** from the Toolbox did nothing. The button cleared its spinner and the row still offered the update, three attempts in a row, with no error shown and no error logged.

## What was happening

`checkCanUnload` counted *any* plugin naming the target in its manifest `dependencies`, including declarations marked `optional`:

```kotlin
val hasDependency = plugin.manifest.dependencies.any { it.pluginId == pluginId }
```

jupyter-notebook, flow-tab and llmrpa each declare the gateway `optional: true`, so between them they vetoed its unload permanently. The Toolbox updates a plugin by uninstalling and reinstalling it, so the veto landed on the Update button, and it would have blocked Remove too.

The same declaration was already read the other way at install time: `missingFor` reports an optional dependency as "works without it, but some of its features need it". Being a suggestion at install and a hard veto at unload is a contradiction in one manifest field.

The refusal was also invisible. `uninstallPlugin` logs `Uninstalling plugin` *before* it decides, and `PluginLoaderDelegateImpl.unloadPlugin` reduces `Result<Unit>` to a `Boolean` - so the reasons the manager assembled, which name the plugins standing in the way, were dropped at that boundary and the log simply stopped mid-sequence. That is why there was nothing to find.

## The change

- `PluginDependencyResolution.blockingDependentsOf` answers the unload question, counting only non-optional declarations. It lives next to `missingFor` so the two readers of these declarations cannot drift again.
- It also ignores a manifest that names itself, which would otherwise make that plugin permanently unremovable.
- `unloadPlugin` logs `Plugin unload refused` with the reasons.

`PluginDependency.version` stays ignored, matching `missingFor` - this never refuses an unload over a version range it could not act on anyway.

## Tests

Six new cases in `PluginDependencyResolutionTest`. **Three fail against the previous behaviour** (optional does not block, one required among optionals still blocks, self-declaration does not block); the other three pin behaviour that must *not* change - a required dependent still blocks and is still named by display name.

Verified by reverting the predicate to the old semantics and re-running: 3 failures, then 0 with the fix restored. Full gate green - 508 tests across 46 classes, `ktlintCheck` and `detekt` clean.

## Paired with

risa-labs-inc/boss-plugin-plugin-manager#36 surfaces the refusal in the UI. This PR alone fixes the AI Gateway case; that one stops any future refusal from being silent.