### PR TITLE
Let a plugin open another plugin's panel as a main-area tab

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -13,6 +13,7 @@ import ai.rever.boss.components.events.URLEventBus
 import ai.rever.boss.components.events.WorkspaceEventBus
 import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
+import ai.rever.boss.components.plugin.resolveRegisteredPanelId
 import ai.rever.boss.components.window_panel.SplitOrientation
 import ai.rever.boss.components.workspaces.WorkspaceSerializer
 import ai.rever.boss.components.workspaces.applyWorkspace
@@ -402,11 +403,28 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
     // promote path has (the cached component and its state carry into the tab, the sidebar copy is
     // collapsed without being destroyed) and the single-instance rule (already open => focus that
     // tab, never a second copy). ProcessPendingPromoteToTab, which has SplitView access, performs it.
-    LaunchedEffect(state.draggablePanelComponent, windowId) {
+    LaunchedEffect(state.draggablePanelComponent, state.panelRegistry, windowId) {
         PanelEventBus.panelPromoteToTabEvents
             .filter { event -> event.sourceWindowId == windowId }
             .onEach { event ->
-                state.draggablePanelComponent.requestOpenAsTab(event.panelId)
+                // Normalise the id against the registry first. A plugin knows the panel's id
+                // string but not its defaultOrder, and everything downstream — the component
+                // store, the hosted-as-tab counts — keys on the whole data class, so an id
+                // carrying a guessed order would promote nothing and say nothing. The panel-open
+                // handler above matches the same way; this shares the rule rather than copying it.
+                val resolved = state.panelRegistry.resolveRegisteredPanelId(event.panelId)
+                if (resolved == null) {
+                    logger.warn(
+                        LogCategory.UI,
+                        "Dropping panel promote-to-tab event - panel is not registered",
+                        mapOf(
+                            "panelId" to event.panelId.panelId,
+                            "pluginId" to event.panelId.pluginId,
+                        ),
+                    )
+                    return@onEach
+                }
+                state.draggablePanelComponent.requestOpenAsTab(resolved)
             }.launchIn(this)
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -396,6 +396,20 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
             }.launchIn(this)
     }
 
+    // Listen for "open this panel as a main-area tab" requests — SplitViewOperations.openPanelAsTab.
+    // Deliberately routed to requestOpenAsTab rather than doing the work here: that is the same
+    // entry point the header drag-out uses, so a plugin inherits the move semantics the host's own
+    // promote path has (the cached component and its state carry into the tab, the sidebar copy is
+    // collapsed without being destroyed) and the single-instance rule (already open => focus that
+    // tab, never a second copy). ProcessPendingPromoteToTab, which has SplitView access, performs it.
+    LaunchedEffect(state.draggablePanelComponent, windowId) {
+        PanelEventBus.panelPromoteToTabEvents
+            .filter { event -> event.sourceWindowId == windowId }
+            .onEach { event ->
+                state.draggablePanelComponent.requestOpenAsTab(event.panelId)
+            }.launchIn(this)
+    }
+
     // Listen for panel close events
     // Issue #506: Filter by window to prevent panel closing in all windows
     LaunchedEffect(state.draggablePanelComponent, windowId) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/PanelEventBus.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/PanelEventBus.kt
@@ -36,6 +36,18 @@ data class PanelToggleEvent(
     val sourceWindowId: String,
 )
 
+/**
+ * Event emitted when a panel should be opened as a tab in the main area — the
+ * programmatic form of the panel header's "Open as Tab". A move, not a copy: the
+ * handler reuses the panel's cached component and collapses the sidebar copy.
+ * @property panelId The panel to promote
+ * @property sourceWindowId The window that initiated this event (required for multi-window support)
+ */
+data class PanelPromoteToTabEvent(
+    val panelId: PanelId,
+    val sourceWindowId: String,
+)
+
 object PanelEventBus {
     /** Optional IPC bridge for forwarding events cross-process in kernel mode. */
     @Volatile var ipcBridge: IpcEventBridge? = null
@@ -55,6 +67,15 @@ object PanelEventBus {
             extraBufferCapacity = 10,
         )
     val panelToggleEvents: SharedFlow<PanelToggleEvent> = _panelToggleEvents.asSharedFlow()
+
+    private val _panelPromoteToTabEvents =
+        MutableSharedFlow<PanelPromoteToTabEvent>(
+            // Deliberately NO replay, unlike panelOpenEvents. Replay there covers the
+            // startup race for a panel that should end up open; replaying a promote would
+            // make every window opened afterwards spawn its own copy of that tab.
+            extraBufferCapacity = 10,
+        )
+    val panelPromoteToTabEvents: SharedFlow<PanelPromoteToTabEvent> = _panelPromoteToTabEvents.asSharedFlow()
 
     suspend fun closePanel(
         panelId: PanelId,
@@ -81,5 +102,14 @@ object PanelEventBus {
         val event = PanelToggleEvent(panelId, sourceWindowId)
         _panelToggleEvents.emit(event)
         ipcBridge?.forward("PanelToggleEvent", event, sourceWindowId)
+    }
+
+    suspend fun promotePanelToTab(
+        panelId: PanelId,
+        sourceWindowId: String,
+    ) {
+        val event = PanelPromoteToTabEvent(panelId, sourceWindowId)
+        _panelPromoteToTabEvents.emit(event)
+        ipcBridge?.forward("PanelPromoteToTabEvent", event, sourceWindowId)
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/model/BossDraggableComponent.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/model/BossDraggableComponent.kt
@@ -153,6 +153,26 @@ class BossDraggableComponent(
         pendingPromoteToTab = null
     }
 
+    /**
+     * "Open this panel in the main area", with the single-instance rule applied: focus the
+     * tab already hosting [panelId] if there is one, otherwise promote it.
+     *
+     * The guard is not optional. [ai.rever.boss.components.window_panel.components.main_window_panels.BossTabsComponent.addTab]
+     * does not dedupe on [ai.rever.boss.plugin.api.TabInfo.id], so promoting twice would leave
+     * two tabs rendering one cached panel component and break the at-most-one assumption
+     * `ProcessPendingFocusHostedTab` scans on. Every entry point that is not itself already
+     * gated on visibility goes through here: the header drag-out below, and
+     * `SplitViewOperations.openPanelAsTab` via `PanelEventBus`. (The panel header's own
+     * "Open as Tab" is only reachable while the panel is showing in the sidebar, which a
+     * hosted-as-tab panel is not, so it calls [requestPromoteToTab] directly.)
+     */
+    fun requestOpenAsTab(
+        panelId: PanelId,
+        target: TabDropTarget? = null,
+    ) {
+        if (isHostedAsTab(panelId)) requestFocusHostedTab(panelId) else requestPromoteToTab(panelId, target)
+    }
+
     private fun leftHalf(r: Rect) = Rect(r.left, r.top, r.left + r.width / 2f, r.bottom)
 
     private fun rightHalf(r: Rect) = Rect(r.left + r.width / 2f, r.top, r.right, r.bottom)
@@ -390,8 +410,7 @@ class BossDraggableComponent(
         // a tab (e.g. dragging its still-visible icon out again), focus that tab instead
         // of creating a duplicate (single-instance — see panelsHostedAsTab).
         if (currentDraggingItem != null && mainTarget != null && currentDropTarget == null) {
-            val pid = currentDraggingItem.first.pluginContentId
-            if (isHostedAsTab(pid)) requestFocusHostedTab(pid) else requestPromoteToTab(pid, mainTarget)
+            requestOpenAsTab(currentDraggingItem.first.pluginContentId, mainTarget)
             return
         }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelIdResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelIdResolution.kt
@@ -1,0 +1,27 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelRegistry
+
+/**
+ * The registry's own [PanelId] for [requested], or null when no registered panel matches.
+ *
+ * [PanelId] is a data class of three fields and [PanelRegistry] keys on all of them, but a
+ * caller from outside the host knows only the panel's id string. [PanelId.defaultOrder] is a
+ * sidebar-ordering detail it has no way to look up - the api's own helpers guess it
+ * (`AiAvailability` builds `PanelId(TOOLBOX_PANEL_ID, 0)`) - so a promote or open addressed
+ * with the wrong number would find nothing and report no error.
+ *
+ * Matching on `panelId` + `pluginId` and returning the REGISTERED id is what the panel-open
+ * event handler already does inline; this is the same rule, shared, so every id arriving from
+ * a plugin is normalised the same way before it reaches anything keyed on the whole class
+ * (`PanelComponentStore`, the hosted-as-tab counts).
+ *
+ * `pluginId` is part of the match, not dropped: it defaults to `"ai.rever.boss"` and the few
+ * plugins that do set it (docker, kubernetes, organisation, dna-origami) are distinguishing
+ * themselves on purpose.
+ */
+fun PanelRegistry.resolveRegisteredPanelId(requested: PanelId): PanelId? =
+    getAllPanels()
+        .find { it.id.panelId == requested.panelId && it.id.pluginId == requested.pluginId }
+        ?.id

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/SplitViewOperationsImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/SplitViewOperationsImpl.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.plugin.providers
 
 import ai.rever.boss.components.events.FileEventBus
+import ai.rever.boss.components.events.PanelEventBus
 import ai.rever.boss.components.window_panel.SplitOrientation
 import ai.rever.boss.components.window_panel.SplitViewState
 import ai.rever.boss.plugin.api.SplitViewOperations
@@ -147,6 +148,22 @@ class SplitViewOperationsImpl(
                     splitViewState.splitPanel(source, SplitOrientation.HORIZONTAL, tabToMove = tabInfo)
                 }
             }
+        }
+    }
+
+    override val supportsOpenPanelAsTab: Boolean = true
+
+    override fun openPanelAsTab(panelId: ai.rever.boss.plugin.api.PanelId) {
+        // Via PanelEventBus rather than directly, for the same reason PanelEventProvider's
+        // open/close go that way: this class holds only the SplitViewState and a window id,
+        // while the promote trigger lives on that window's BossDraggableComponent — which the
+        // plugin-context construction site (DefaultPlugin) has no handle on. The bus is already
+        // window-filtered and already forwards over IPC.
+        //
+        // scope is Dispatchers.Main: a plugin may call this from a background thread and the
+        // handler ends in Compose state writes (same reason openTab launches).
+        scope.launch {
+            PanelEventBus.promotePanelToTab(panelId, windowId)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/tab_types/PanelHostTab.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/tab_types/PanelHostTab.kt
@@ -8,11 +8,15 @@ import ai.rever.boss.plugin.api.TabComponentWithUI
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.api.TabTypeId
 import ai.rever.boss.plugin.api.TabTypeInfo
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Tab
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.arkivanov.decompose.ComponentContext
+
+private val panelHostTabLogger = BossLogger.forComponent("PanelHostTab")
 
 /**
  * Host-internal tab type that renders a sidebar plugin's panel inside a main tab.
@@ -36,6 +40,18 @@ data class PanelHostTabInfo(
     override val typeId: TabTypeId = PanelHostTabType.typeId
 }
 
+/**
+ * The panel a panel-host tab renders, or null when [config] did not come from the host.
+ *
+ * `SplitViewOperations.openTab` resolves a factory purely by [TabInfo.typeId], so any plugin
+ * can hand this one a [TabInfo] of its own carrying [PanelHostTabType]'s id — and until
+ * `openPanelAsTab` existed, one had a reason to try. Reading the panel id with a checked cast
+ * instead of `as` is what keeps that a dead tab and a log line rather than a
+ * ClassCastException thrown from inside the host. Top-level so the rule is testable without a
+ * ComponentContext or a PanelComponentStore.
+ */
+fun panelIdFor(config: TabInfo): PanelId? = (config as? PanelHostTabInfo)?.panelId
+
 class PanelHostTabComponent(
     override val config: TabInfo,
     componentContext: ComponentContext,
@@ -45,11 +61,19 @@ class PanelHostTabComponent(
     ComponentContext by componentContext {
     override val tabTypeInfo: TabTypeInfo = PanelHostTabType
 
-    private val panelId: PanelId = (config as PanelHostTabInfo).panelId
+    private val panelId: PanelId? = panelIdFor(config)
 
     init {
         // One more live tab instance hosting this panel.
-        draggable.markHostedAsTab(panelId)
+        if (panelId != null) {
+            draggable.markHostedAsTab(panelId)
+        } else {
+            panelHostTabLogger.warn(
+                LogCategory.UI,
+                "Ignoring a panel-host tab whose config is not a PanelHostTabInfo",
+                mapOf("tabId" to config.id, "configClass" to config::class.java.name),
+            )
+        }
     }
 
     /**
@@ -62,13 +86,15 @@ class PanelHostTabComponent(
      * sidebar location.
      */
     fun onClosed() {
-        draggable.unmarkHostedAsTab(panelId)
+        // Nothing was marked for a config we could not read, so nothing to unmark.
+        panelId?.let { draggable.unmarkHostedAsTab(it) }
     }
 
     @Composable
     override fun Content() {
-        val component = store.getOrCreateComponent(panelId)
-        RenderPanelContent(component = component, panelId = panelId)
+        val id = panelId ?: return
+        val component = store.getOrCreateComponent(id)
+        RenderPanelContent(component = component, panelId = id)
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/events/PanelPromoteToTabEventTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/events/PanelPromoteToTabEventTest.kt
@@ -1,0 +1,74 @@
+package ai.rever.boss.components.events
+
+import ai.rever.boss.plugin.api.PanelId
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * `SplitViewOperations.openPanelAsTab` reaches the window's BossDraggableComponent through
+ * [PanelEventBus.promotePanelToTab], so the bus carries the two properties the handler relies
+ * on: it is addressed to ONE window, and it never replays.
+ */
+class PanelPromoteToTabEventTest {
+    private val panel = PanelId("codebase", 1)
+
+    @Test
+    fun `only the addressed window sees the promote`() =
+        runTest {
+            val mine = "window-addressed"
+            val theirs = "window-bystander"
+
+            val received =
+                async {
+                    withTimeoutOrNull(TIMEOUT_MS) {
+                        PanelEventBus.panelPromoteToTabEvents.first { it.sourceWindowId == mine }
+                    }
+                }
+            val bystander =
+                async {
+                    withTimeoutOrNull(TIMEOUT_MS) {
+                        PanelEventBus.panelPromoteToTabEvents.first { it.sourceWindowId == theirs }
+                    }
+                }
+            yield()
+
+            PanelEventBus.promotePanelToTab(panel, sourceWindowId = mine)
+
+            assertEquals(panel, assertNotNull(received.await()).panelId)
+            assertNull(bystander.await(), "a promote in one window must not open a tab in another")
+        }
+
+    /**
+     * Unlike `panelOpenEvents`, this flow has no replay - and must not gain one. Replay there
+     * covers a startup race for a panel that should end up open; a replayed promote would give
+     * every window opened afterwards its own copy of that tab, over the one cached component.
+     */
+    @Test
+    fun `a window that opens later does not replay someone else's promote`() =
+        runTest {
+            val window = "window-late-collector"
+
+            PanelEventBus.promotePanelToTab(panel, sourceWindowId = window)
+            yield()
+
+            val late =
+                async {
+                    withTimeoutOrNull(TIMEOUT_MS) {
+                        PanelEventBus.panelPromoteToTabEvents.first { it.sourceWindowId == window }
+                    }
+                }
+
+            assertNull(late.await(), "the promote was already delivered - a late window must not repeat it")
+        }
+
+    private companion object {
+        const val TIMEOUT_MS = 2_000L
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/model/BossDraggableComponentOpenAsTabTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/model/BossDraggableComponentOpenAsTabTest.kt
@@ -1,0 +1,91 @@
+package ai.rever.boss.components.model
+
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [BossDraggableComponent.requestOpenAsTab] is the single-instance rule for "open this panel
+ * in the main area", and it has to hold for every caller of it - the header drag-out and,
+ * since BossConsole#177, `SplitViewOperations.openPanelAsTab`.
+ *
+ * The rule matters because nothing downstream enforces it. `BossTabsComponent.addTab` does not
+ * dedupe on `TabInfo.id`, so a second promote would leave two tabs rendering one cached panel
+ * component, and `ProcessPendingFocusHostedTab` stops its scan at the first hosting tab.
+ */
+class BossDraggableComponentOpenAsTabTest {
+    private fun component() = BossDraggableComponent(PanelRegistry())
+
+    private val panel = PanelId("codebase", 1)
+
+    @Test
+    fun `promotes a panel that is not open as a tab`() {
+        val draggable = component()
+
+        draggable.requestOpenAsTab(panel)
+
+        assertEquals(panel, draggable.pendingPromoteToTab?.panelId)
+        assertNull(draggable.pendingPromoteToTab?.target, "the plugin-facing call targets the active panel")
+        assertNull(draggable.pendingFocusHostedTab, "nothing to focus - no tab hosts it yet")
+    }
+
+    @Test
+    fun `carries the drop target through, for the header drag-out`() {
+        val draggable = component()
+        val target = TabDropTarget.ExistingPanel("panel-2")
+
+        draggable.requestOpenAsTab(panel, target)
+
+        assertEquals(target, draggable.pendingPromoteToTab?.target)
+    }
+
+    @Test
+    fun `focuses the existing tab instead of promoting a second copy`() {
+        val draggable = component()
+        draggable.markHostedAsTab(panel)
+
+        draggable.requestOpenAsTab(panel)
+
+        assertEquals(panel, draggable.pendingFocusHostedTab)
+        assertNull(
+            draggable.pendingPromoteToTab,
+            "a second promote would create a duplicate tab over the same cached component",
+        )
+    }
+
+    @Test
+    fun `an unrelated hosted panel does not suppress the promote`() {
+        val draggable = component()
+        draggable.markHostedAsTab(PanelId("git-log", 15))
+
+        draggable.requestOpenAsTab(panel)
+
+        assertEquals(panel, draggable.pendingPromoteToTab?.panelId)
+        assertNull(draggable.pendingFocusHostedTab)
+    }
+
+    /**
+     * The hosted marker is a count, not a flag: a cross-panel move creates the new hosting tab
+     * before closing the old one, so the count goes 1 -> 2 -> 1 and must not read as unhosted
+     * in between.
+     */
+    @Test
+    fun `hosted stays true until the last hosting tab is unmarked`() {
+        val draggable = component()
+
+        draggable.markHostedAsTab(panel)
+        draggable.markHostedAsTab(panel)
+        draggable.unmarkHostedAsTab(panel)
+        assertTrue(draggable.isHostedAsTab(panel), "one hosting tab is still live")
+        draggable.requestOpenAsTab(panel)
+        assertNull(draggable.pendingPromoteToTab)
+
+        draggable.clearPendingFocusHostedTab()
+        draggable.unmarkHostedAsTab(panel)
+        draggable.requestOpenAsTab(panel)
+        assertEquals(panel, draggable.pendingPromoteToTab?.panelId, "the last tab closed - promote again")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelHostTabConfigTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelHostTabConfigTest.kt
@@ -1,0 +1,61 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.components.plugin.tab_types.PanelHostTabInfo
+import ai.rever.boss.components.plugin.tab_types.PanelHostTabType
+import ai.rever.boss.components.plugin.tab_types.panelIdFor
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabTypeId
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Tab
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * `SplitViewOperations.openTab` picks a factory by [TabInfo.typeId] alone, so any plugin can hand
+ * the host's panel-host factory a config of its own - and before `openPanelAsTab` existed, one
+ * had a reason to try (BossConsole#177). Reading the panel id has to survive that.
+ */
+class PanelHostTabConfigTest {
+    private val icon: ImageVector = Icons.Outlined.Tab
+
+    @Test
+    fun `reads the panel id from the host's own config`() {
+        val panel = PanelId("codebase", 1)
+
+        assertEquals(panel, panelIdFor(PanelHostTabInfo(panel, "Codebase", icon)))
+    }
+
+    /**
+     * The point of the whole test: a look-alike returns null instead of throwing a
+     * ClassCastException from inside the host, on a call a plugin made.
+     */
+    @Test
+    fun `a plugin's look-alike config resolves to nothing rather than throwing`() {
+        val impostor =
+            object : TabInfo {
+                override val id: String = "panel-tab:codebase"
+                override val typeId: TabTypeId = PanelHostTabType.typeId
+                override val title: String = "Codebase"
+                override val icon: ImageVector = this@PanelHostTabConfigTest.icon
+            }
+
+        assertEquals(PanelHostTabType.typeId, impostor.typeId, "the impostor must reach the same factory")
+        assertNull(panelIdFor(impostor))
+    }
+
+    @Test
+    fun `an unrelated tab config resolves to nothing`() {
+        val other =
+            object : TabInfo {
+                override val id: String = "terminal-1"
+                override val typeId: TabTypeId = TabTypeId("terminal")
+                override val title: String = "Terminal"
+                override val icon: ImageVector = this@PanelHostTabConfigTest.icon
+            }
+
+        assertNull(panelIdFor(other))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelIdResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelIdResolutionTest.kt
@@ -1,0 +1,79 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.Panel
+import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.Panel.Companion.top
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelInfo
+import ai.rever.boss.plugin.api.PanelRegistry
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Tab
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A plugin addressing a panel - `SplitViewOperations.openPanelAsTab`, `PanelEventProvider.openPanel` -
+ * knows the panel's id STRING and nothing else. [PanelId] is a data class of three fields and
+ * [PanelRegistry] keys on all of them, so an id built with a guessed `defaultOrder` matches
+ * nothing and fails silently.
+ *
+ * That is not hypothetical: the api's own `AiAvailability` builds `PanelId(TOOLBOX_PANEL_ID, 0)`,
+ * and the Toolbox panel registers as order 6.
+ */
+class PanelIdResolutionTest {
+    private fun registryOf(vararg ids: PanelId) =
+        object : PanelRegistry() {
+            override fun getAllPanels(): List<PanelInfo> = ids.map(::FakePanelInfo)
+        }
+
+    private class FakePanelInfo(
+        override val id: PanelId,
+    ) : PanelInfo {
+        override val displayName: String = id.panelId
+        override val icon: ImageVector = Icons.Outlined.Tab
+        override val defaultSlotPosition: Panel = left.top
+    }
+
+    /** The case that would otherwise be a silent no-op. */
+    @Test
+    fun `a guessed defaultOrder still finds the panel, and yields the registered id`() {
+        val registered = PanelId("plugin-manager", 6)
+        val registry = registryOf(registered)
+
+        assertEquals(registered, registry.resolveRegisteredPanelId(PanelId("plugin-manager", 0)))
+    }
+
+    @Test
+    fun `an exact id resolves to itself`() {
+        val registered = PanelId("codebase", 1)
+
+        assertEquals(registered, registryOf(registered).resolveRegisteredPanelId(registered))
+    }
+
+    @Test
+    fun `an unregistered panel resolves to nothing`() {
+        assertNull(registryOf(PanelId("codebase", 1)).resolveRegisteredPanelId(PanelId("git-log", 15)))
+    }
+
+    /**
+     * `pluginId` stays part of the match. It defaults to "ai.rever.boss", and the few plugins
+     * that set it (docker, kubernetes, organisation, dna-origami) are distinguishing themselves
+     * deliberately - dropping it would let one plugin address another's panel by name collision.
+     */
+    @Test
+    fun `a different owning plugin is a different panel`() {
+        val registry = registryOf(PanelId("containers", 20, pluginId = "ai.rever.boss.plugin.dynamic.docker"))
+
+        assertNull(registry.resolveRegisteredPanelId(PanelId("containers", 20)))
+    }
+
+    @Test
+    fun `the owner is matched, not merely tolerated`() {
+        val docker = PanelId("containers", 20, pluginId = "ai.rever.boss.plugin.dynamic.docker")
+        val registry = registryOf(PanelId("containers", 1), docker)
+
+        assertEquals(docker, registry.resolveRegisteredPanelId(PanelId("containers", 999, pluginId = docker.pluginId)))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,20 +71,23 @@ intellij-platform = "243.21565.199"
 # releases ONLY: plugin-platform/plugin-api-core downloads this release's jar and
 # filters the api package locally (no Maven registry involved).
 #
-# 1.0.76 is the release cut by risa-labs-inc/boss-plugin-api#25, which adds the
-# browser telemetry events this branch publishes (BrowserEvent's navigation and
-# engagement fields, BrowserInteractionEvent, BrowserNavigationType,
-# BrowserInteractionType).
+# 1.0.77 is the release cut by risa-labs-inc/boss-plugin-api#33, which adds
+# SplitViewOperations.openPanelAsTab + supportsOpenPanelAsTab - the members
+# SplitViewOperationsImpl on this branch implements (BossConsole#177).
 #
-# It is a SUPERSET of the 1.0.74 this replaces, verified against the release jar
-# rather than assumed - releases are cut from the api repo's main, so 1.0.76
-# carries #31's AiGatewayAPI and BrokeredCredentialProvider (the reason for the
-# 1.0.74 pin), #32's AiAvailability and AiReadiness, and 1.0.75's
-# LlmApiFormat.OPENAI_RESPONSES. Worth checking rather than trusting the ordering:
+# That interface is @HostImplemented: plugin-api-core filters it into the host and
+# serves it parent-first, so THIS pin is what every plugin resolves. Nothing a
+# plugin declares can reach these members before this bump lands in a release -
+# minApiVersion cannot, which is why the api documents them as a minBossVersion gate.
+#
+# It is a SUPERSET of the 1.0.76 it replaces, verified against the release jar
+# rather than assumed - releases are cut from the api repo's main, so 1.0.77 keeps
+# #25's browser telemetry events (the reason for the 1.0.76 pin) along with
+# everything below them. Worth checking rather than trusting the ordering:
 # fetchApiPluginJar has no Maven fallback, so a pin that dropped a type would
 # surface as an unrelated compile error, and this comment is the only record of
 # which api PR a pin corresponds to.
-boss-plugin-api = "1.0.76"
+boss-plugin-api = "1.0.77"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
Closes #177. Host half; the api half is risa-labs-inc/boss-plugin-api#33.

**Draft until v1.0.77 is released.** `plugin-api-core` downloads the pinned release jar with no Maven fallback, so the `boss-plugin-api = "1.0.77"` bump here 404s CI until that PR merges and cuts the tag. Everything below was verified locally against a 1.0.77 jar built from that branch.

## The gap

The host has done this for itself for a while - the panel header's "Open as Tab", and dragging that header onto the centre - but every piece of it is internal, so a plugin could only reveal a panel in the **sidebar**.

`openTab` was not a way in. `PanelHostTabComponent` builds from the concrete `PanelHostTabInfo`, so a plugin-side `TabInfo` carrying `TabTypeId("panel-host")` landed in that cast. The Toolbox reached the constructor reflectively to give each tool an Open button (boss-plugin-plugin-manager#35) and had to accept **losing the panel's state**: the only close a plugin can reach drops the cached component, while the host's own promote path merely hides the sidebar copy.

## What this does

`SplitViewOperations.openPanelAsTab` routes to the existing `requestPromoteToTab` rather than reimplementing the promote, which is what makes it a **move**: the cached component carries the panel's state into the tab, the hosted-as-tab bookkeeping makes the sidebar icon afterwards *focus* that tab rather than open a second copy, and the sidebar collapse goes through `closePanelForItem`, which only hides.

**Why the event bus.** `SplitViewOperationsImpl` holds only a `SplitViewState` and a window id, while the promote trigger lives on that window's `BossDraggableComponent` - which the plugin-context construction site in `DefaultPlugin` has no handle on. `PanelEventBus` is the same window-filtered path `PanelEventProvider`'s open/close already take, and it forwards over IPC for free.

**No replay on that flow, deliberately.** `panelOpenEvents` replays to cover a startup race for a panel that should end up open; a replayed *promote* would give every window opened afterwards its own tab over the one cached component.

**The single-instance rule now lives in one place**, `requestOpenAsTab`. It has to be applied by every caller not already gated on the panel being visible in the sidebar, because nothing downstream enforces it: `BossTabsComponent.addTab` does not dedupe on `TabInfo.id`, so a second promote leaves two tabs rendering one cached component and `ProcessPendingFocusHostedTab` stops its scan at the first. The header drag-out had this inline and now shares it.

## An incoming PanelId is resolved against the registry first

Found answering a review question on the api PR, and it was a real bug rather than a doc gap.

`PanelId` carries a `defaultOrder` and `PanelRegistry` keys on the **whole data class**, but a plugin addressing another plugin's panel knows only the id string - `defaultOrder` is sidebar ordering it has no way to look up. The api's own `AiAvailability` already guesses it, building `PanelId(TOOLBOX_PANEL_ID, 0)` against a panel registered as order 6.

So `openPanelAsTab(PanelId("plugin-manager", 0))` reached `getOrCreateComponent`, found nothing, cleared the request and returned **silently** - while `openPanel` with the identical id worked, because that handler has always matched on `panelId + pluginId`.

Two paths disagreeing about what names a panel is the kind of thing that surfaces as "Open does nothing for this one tool", so the rule is now one shared `resolveRegisteredPanelId` rather than a second inline copy. It returns the **registered** id, so nothing downstream keyed on the full class ever sees a caller-guessed one. `pluginId` stays in the match: it defaults to `"ai.rever.boss"` and the handful of panels that set it (docker, kubernetes, organisation, dna-origami) are distinguishing themselves deliberately. A miss is logged rather than dropped in silence.

## Also: the panel-host factory no longer casts blind

Issue point 2. `openTab` picks a factory by `typeId` alone, so any plugin can hand this one a `TabInfo` of its own. Reading the panel id with a checked cast turns that into a dead tab and a warning instead of a `ClassCastException` thrown from inside the host on a plugin's call. `panelIdFor` is top-level so the rule is testable without a `ComponentContext` or a `PanelComponentStore`. The api PR narrows `openTab`'s KDoc, which promised indirection it does not have for **any** host-registered type.

## Verification

`./gradlew :composeApp:desktopTest :composeApp:detekt :composeApp:ktlintCheck` green.

Fifteen new tests, and each was **run against the pre-fix code first** rather than assumed to be catching anything:

| Mutation | Result |
|---|---|
| drop the `isHostedAsTab` guard in `requestOpenAsTab` | 2 of 5 fail |
| add `replay = 1` to `panelPromoteToTabEvents` | the late-collector case fails |
| restore `config as PanelHostTabInfo` | 2 of 3 fail with `ClassCastException` |
| resolve with `it.id == requested` | 2 of 5 fail |

Still to do live, once this and the api release land: Toolbox Open on a panel plugin lands in the main area, its sidebar icon then focuses that tab, pressing Open again does not duplicate it, and the panel's state survives the move (the part boss-plugin-plugin-manager#35 explicitly could not get).