### PR TITLE
Re-attach the browser view when a committed page never draws

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
@@ -1,0 +1,100 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.engine.RenderingMode
+
+/**
+ * Recovery for a committed document whose view never starts producing frames.
+ *
+ * **The symptom, measured rather than inferred.** Clicking Google's "AI Mode" tab from a results
+ * page lands on `…&udm=50&aep=1`, and the pane goes blank and stays blank. The document itself is
+ * completely healthy: the DOM is complete, layout is correct, `setTimeout` and `setInterval` keep
+ * firing, microtasks resolve, and JS evaluates normally. What never happens is a frame -
+ * `requestAnimationFrame` does not fire once, and painting a fresh background colour into `body`
+ * changes nothing on screen. Measured on the click path, 0 of 5 navigations painted (raf=0 after
+ * 3s) against 5 of 5 for the same queries without the AI Mode click (raf around 420).
+ *
+ * **What it is not.** Reproduced with the GPU fully out of the picture - a build reporting
+ * `Canvas/Compositing/Rasterization: Software only` and `Skia Graphite: Disabled` blanks
+ * identically - so it is not raster, not Graphite and not the hardware path. It is not CSS either:
+ * forcing every element opaque leaves the pane blank, and elements at effective opacity 1 (the
+ * "AI Mode / All / Images" nav row) are just as unpainted as the animated ones. Response headers
+ * are byte-identical to the variant that works, so no process swap is involved, and BOSS logs
+ * nothing at all across the navigation.
+ *
+ * **Why re-attaching is the fix.** Switching to another tab and back restores frame production
+ * immediately and permanently (raf 0 before, 850 after). Nothing about the document changes across
+ * that switch - the surface is even retained under HARDWARE_ACCELERATED. What changes is that the
+ * view leaves and re-enters composition, so the native view is attached again. That makes this a
+ * presentation-side stall, and re-attaching is the same repair the user already performs by hand.
+ *
+ * The underlying fault is inside the JxBrowser/Chromium widget rather than in BOSS, so this is
+ * deliberately a recovery and not a cure: it detects a document that committed but never drew, and
+ * performs the tab-switch repair on the user's behalf.
+ */
+internal object BrowserFrameStall {
+    /**
+     * Arms a one-shot beacon and reports whether a frame has been served yet.
+     *
+     * Returns `"1"` once rAF has run, `"0"` while it has not. Re-running it is what reads the
+     * result, so the same snippet both arms and polls - there is no second script to keep in step
+     * with this one.
+     *
+     * `__bossFrameBeacon` is deliberately re-armed per call site rather than per document: a
+     * document that is replaced under us (a redirect committing between arm and read) would
+     * otherwise be read through a beacon that belonged to the previous page and look stalled.
+     */
+    const val BEACON_SCRIPT: String =
+        """
+        (function () {
+          if (typeof window.__bossFrameBeacon === 'undefined') {
+            window.__bossFrameBeacon = '0';
+            requestAnimationFrame(function () { window.__bossFrameBeacon = '1'; });
+          }
+          return window.__bossFrameBeacon;
+        })()
+        """
+
+    /** The beacon's answer for "a frame has been served". */
+    const val BEACON_PAINTED: String = "1"
+
+    /**
+     * Whether a committed navigation is worth watching.
+     *
+     * Gated to HARDWARE_ACCELERATED because that is the mode where the browser is a real native
+     * view whose attachment can go stale; under OFF_SCREEN the frames are exported as a bitmap and
+     * this failure has never been observed. Gated to http(s) so `about:blank`, `chrome://` and the
+     * dashboard's empty states - none of which a user would call blank - never arm a probe or
+     * trigger a re-attach.
+     */
+    fun shouldWatch(
+        url: String?,
+        mode: RenderingMode,
+    ): Boolean {
+        if (mode != RenderingMode.HARDWARE_ACCELERATED) return false
+        val trimmed = url?.trim().orEmpty()
+        return trimmed.startsWith("http://", ignoreCase = true) ||
+            trimmed.startsWith("https://", ignoreCase = true)
+    }
+
+    /**
+     * Whether the beacon's reading means "stalled".
+     *
+     * A null reading is NOT a stall. It is what a failed or raced JS round-trip returns - a
+     * navigation that committed again mid-probe, a frame that went away, a renderer busy enough to
+     * miss the call - and treating those as stalls would re-attach the view on ordinary pages,
+     * which costs a visible flicker for nothing. Only an explicit "not painted yet" counts.
+     */
+    fun isStalled(beaconReading: String?): Boolean = beaconReading != null && beaconReading != BEACON_PAINTED
+
+    /** How long to give a healthy page before the first reading. */
+    const val FIRST_CHECK_MS: Long = 700L
+
+    /**
+     * How long to wait again before believing the first reading.
+     *
+     * Two readings, not one. A slow page can genuinely have served no frame at 700ms, and a
+     * single reading would re-attach its view mid-load for no reason. Both must say "no frame"
+     * before anything is done.
+     */
+    const val CONFIRM_MS: Long = 900L
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
@@ -160,3 +160,99 @@ internal object BrowserFrameStall {
      */
     const val REATTACH_COOLDOWN_MS: Long = 10_000L
 }
+
+/**
+ * When a frame-stall repair is allowed to run, and when to stop trying.
+ *
+ * Split out of `BrowserHandleImpl` for the reason `EngineWedgeDetector` is: this is the part that
+ * decides whether a user ever sees a flicker loop, it needs no JxBrowser view to exercise, and
+ * left inline it was five `@Volatile` fields testable only by driving a real browser. Lock-guarded
+ * rather than volatile because `attempts += 1` is a read-modify-write, and a superseded probe can
+ * still be between [claim] and its next suspension point while a newer one runs.
+ *
+ * [nowMs] must come from a **monotonic** source. Wall-clock time is wrong for measuring a
+ * cooldown: an NTP step backwards would stretch it and a step forwards would open it early.
+ */
+internal class FrameStallPolicy(
+    private val maxIneffective: Int = BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES,
+    private val cooldownMs: Long = BrowserFrameStall.REATTACH_COOLDOWN_MS,
+) {
+    /** What [claim] decided, including whether this is the first refusal worth logging. */
+    enum class Decision {
+        REATTACH,
+        COOLING_DOWN,
+
+        /** Cap reached, and this is the first refusal - log it once. */
+        GIVE_UP_NOW,
+
+        /** Cap reached and already reported; stay silent. */
+        GIVEN_UP,
+    }
+
+    private var attemptCount = 0
+    private var ineffectiveRun = 0
+    private var lastReattachAt: Long? = null
+    private var gaveUpReported = false
+
+    /** Total re-attaches performed, for the log. */
+    @get:Synchronized val attempts: Int get() = attemptCount
+
+    /** Re-attaches in a row that did not restore painting. */
+    @get:Synchronized val ineffectiveInARow: Int get() = ineffectiveRun
+
+    /** Ask for permission to re-attach, recording the attempt when granted. */
+    @Synchronized
+    fun claim(nowMs: Long): Decision {
+        val last = lastReattachAt
+        return when {
+            ineffectiveRun >= maxIneffective && gaveUpReported -> {
+                Decision.GIVEN_UP
+            }
+
+            ineffectiveRun >= maxIneffective -> {
+                gaveUpReported = true
+                Decision.GIVE_UP_NOW
+            }
+
+            last != null && nowMs - last < cooldownMs -> {
+                Decision.COOLING_DOWN
+            }
+
+            else -> {
+                lastReattachAt = nowMs
+                attemptCount += 1
+                Decision.REATTACH
+            }
+        }
+    }
+
+    /**
+     * Report whether the re-attach actually restored painting.
+     *
+     * A success clears the run *and* the reported flag, so a handle that starts failing again
+     * later still gets its one log line.
+     */
+    @Synchronized
+    fun recordOutcome(recovered: Boolean) {
+        if (recovered) {
+            ineffectiveRun = 0
+            gaveUpReported = false
+        } else {
+            ineffectiveRun += 1
+        }
+    }
+
+    /**
+     * A navigation that painted without help.
+     *
+     * "Consecutive" would otherwise be counted in re-attaches rather than in time: three
+     * ineffective attempts spread over hours and dozens of healthy pages would retire the
+     * watchdog for that tab exactly as if they had happened back to back on one page. Any page
+     * that paints on its own is evidence the tab is fine, so it decays the run.
+     */
+    @Synchronized
+    fun recordHealthyNavigation() {
+        ineffectiveRun = 0
+        gaveUpReported = false
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
@@ -30,20 +30,35 @@ import com.teamdev.jxbrowser.engine.RenderingMode
  * The underlying fault is inside the JxBrowser/Chromium widget rather than in BOSS, so this is
  * deliberately a recovery and not a cure: it detects a document that committed but never drew, and
  * performs the tab-switch repair on the user's behalf.
+ *
+ * **Known and accepted: the page can influence the verdict.** The flag lives on `window`, so a
+ * page could pin it to `"0"` (forcing a re-attach per navigation, costing flicker) or to `"1"`
+ * (suppressing the repair, leaving itself blank). This is the same exposure AGENTS.md already
+ * records for `window.__bossInteraction`, and the worst case either way is cosmetic, so it is
+ * written down rather than defended against. The re-attach cap below bounds the noisy direction.
+ *
+ * **Not injected at document start, on purpose.** [BrowserInjectDispatcher] exists for exactly
+ * that and would make the first reading meaningful, but `ensureCoBrowseInjectCallback` still
+ * claims the browser's single `InjectJsCallback` slot with a direct `browser.set`, so registering
+ * through the dispatcher here would clobber the co-browse recorder or be clobbered by it. Arming
+ * lazily on the first probe keeps this feature out of that conflict; the cost is one extra
+ * round-trip, spelled out in [ARM_DELAY_MS].
  */
 internal object BrowserFrameStall {
     /**
-     * Arms a one-shot beacon and reports whether a frame has been served yet.
+     * Arms a one-shot beacon and reports whether a frame has been served since it was armed.
      *
-     * Returns `"1"` once rAF has run, `"0"` while it has not. Re-running it is what reads the
-     * result, so the same snippet both arms and polls - there is no second script to keep in step
-     * with this one.
+     * Returns `"1"` once rAF has run, `"0"` while it has not, and `"unarmed"` never - the same
+     * call that reads is the call that arms, so the first invocation on a document always returns
+     * `"0"` no matter how healthy the page is. That is why [ARM_DELAY_MS] is named for arming and
+     * why the decision needs two readings *after* it.
      *
-     * `__bossFrameBeacon` is deliberately re-armed per call site rather than per document: a
-     * document that is replaced under us (a redirect committing between arm and read) would
-     * otherwise be read through a beacon that belonged to the previous page and look stalled.
+     * The `typeof` guard makes this arm **once per document**: later calls report the existing
+     * beacon rather than restarting it, which is what lets a second reading confirm the first.
+     * A document replaced mid-probe (a redirect committing between calls) gets a fresh `window`
+     * and therefore a fresh beacon, so a stale page's verdict can never carry over.
      */
-    const val BEACON_SCRIPT: String =
+    val BEACON_SCRIPT: String =
         """
         (function () {
           if (typeof window.__bossFrameBeacon === 'undefined') {
@@ -52,10 +67,13 @@ internal object BrowserFrameStall {
           }
           return window.__bossFrameBeacon;
         })()
-        """
+        """.trimIndent()
 
     /** The beacon's answer for "a frame has been served". */
     const val BEACON_PAINTED: String = "1"
+
+    /** The beacon's answer for "armed, still nothing drawn". */
+    const val BEACON_UNPAINTED: String = "0"
 
     /**
      * Whether a committed navigation is worth watching.
@@ -77,24 +95,68 @@ internal object BrowserFrameStall {
     }
 
     /**
-     * Whether the beacon's reading means "stalled".
+     * Whether a beacon reading means "stalled". Only an explicit [BEACON_UNPAINTED] does.
      *
-     * A null reading is NOT a stall. It is what a failed or raced JS round-trip returns - a
-     * navigation that committed again mid-probe, a frame that went away, a renderer busy enough to
-     * miss the call - and treating those as stalls would re-attach the view on ordinary pages,
-     * which costs a visible flicker for nothing. Only an explicit "not painted yet" counts.
+     * Null is NOT a stall, and that is the whole point of this function. Null is what a failed or
+     * timed-out round-trip returns - a navigation that committed again mid-probe, a frame that
+     * went away, a renderer too busy to answer - and treating those as stalls would re-attach the
+     * view on ordinary pages, which costs a visible flicker for nothing. Any unrecognised value
+     * (a page that overwrote the global with something else) is treated the same cautious way.
      */
-    fun isStalled(beaconReading: String?): Boolean = beaconReading != null && beaconReading != BEACON_PAINTED
-
-    /** How long to give a healthy page before the first reading. */
-    const val FIRST_CHECK_MS: Long = 700L
+    fun isStalled(beaconReading: String?): Boolean = beaconReading == BEACON_UNPAINTED
 
     /**
-     * How long to wait again before believing the first reading.
+     * How long after a commit to arm the beacon.
      *
-     * Two readings, not one. A slow page can genuinely have served no frame at 700ms, and a
-     * single reading would re-attach its view mid-load for no reason. Both must say "no frame"
-     * before anything is done.
+     * Named for arming rather than checking because the reading this call returns is always
+     * [BEACON_UNPAINTED] and carries no information (see [BEACON_SCRIPT]). Delayed rather than
+     * immediate so a page that paints promptly is usually already done by the first real reading.
      */
-    const val CONFIRM_MS: Long = 900L
+    const val ARM_DELAY_MS: Long = 700L
+
+    /**
+     * Gap between the arm and each subsequent reading.
+     *
+     * Two real readings, not one. rAF does not run while rendering is blocked, so a page still
+     * fetching a render-blocking stylesheet or font on a poor connection can honestly have drawn
+     * nothing one gap after arming; re-attaching then would yank a healthy page's view out of
+     * composition mid-load. Both readings must say "no frame" before anything is done.
+     */
+    const val READ_GAP_MS: Long = 900L
+
+    /**
+     * How long to wait for a single beacon round-trip before giving up on it.
+     *
+     * `executeJavaScript` blocks and cannot be interrupted, so this bounds the *wait*, not the
+     * call. A probe that times out reads as null, which [isStalled] treats as "not stalled" - the
+     * safe direction, since the renderer this is interrogating is already suspect.
+     */
+    const val PROBE_TIMEOUT_MS: Long = 800L
+
+    /**
+     * How many re-attaches **in a row that failed to restore painting** a handle may perform
+     * before it gives up.
+     *
+     * `EngineWedgeDetector` in this package carries a ceiling for the same reason: a repair with
+     * none turns any condition that reliably reads [BEACON_UNPAINTED] into a flicker on every
+     * navigation, which is worse than the blank it is fixing. Past it the handle degrades to the
+     * pre-existing behaviour - the user switches tabs themselves - and the log says so once.
+     *
+     * **Consecutive-ineffective, deliberately, rather than a lifetime count.** A lifetime cap
+     * sounds safer and measurably is not: AI Mode is a page people use repeatedly, and a run of
+     * five click-throughs on one tab had the fourth and fifth abandoned while the repair was still
+     * working - it had recovered the page 3 times out of 3. Keying on whether the re-attach
+     * actually helped bounds only what warrants bounding (a false positive, or a stall this cannot
+     * fix), and one success resets the count, so a tab that stays repairable stays repaired.
+     */
+    const val MAX_INEFFECTIVE_REATTACHES: Int = 3
+
+    /**
+     * Minimum spacing between two re-attaches on one handle.
+     *
+     * This is what bounds the *rate* of any flicker, and it does so whether or not the repair is
+     * working - so it, rather than [MAX_INEFFECTIVE_REATTACHES], is the guard against an SPA
+     * navigating in a tight loop.
+     */
+    const val REATTACH_COOLDOWN_MS: Long = 10_000L
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
@@ -48,10 +48,10 @@ internal object BrowserFrameStall {
     /**
      * Arms a one-shot beacon and reports whether a frame has been served since it was armed.
      *
-     * Returns `"1"` once rAF has run, `"0"` while it has not, and `"unarmed"` never - the same
-     * call that reads is the call that arms, so the first invocation on a document always returns
-     * `"0"` no matter how healthy the page is. That is why [ARM_DELAY_MS] is named for arming and
-     * why the decision needs two readings *after* it.
+     * Returns `"1"` once rAF has run and `"0"` while it has not. The same call that reads is the
+     * call that arms, so the first invocation on a document always returns `"0"` no matter how
+     * healthy the page is. That is why [ARM_DELAY_MS] is named for arming and why the decision
+     * needs two readings *after* it.
      *
      * The `typeof` guard makes this arm **once per document**: later calls report the existing
      * beacon rather than restarting it, which is what lets a second reading confirm the first.
@@ -104,6 +104,26 @@ internal object BrowserFrameStall {
      * (a page that overwrote the global with something else) is treated the same cautious way.
      */
     fun isStalled(beaconReading: String?): Boolean = beaconReading == BEACON_UNPAINTED
+
+    /**
+     * What a post-repair reading says about the re-attach: true painting, false still blank, null
+     * unknown.
+     *
+     * **Three states, not two, and [isStalled] must not be reused here.** For the *decision* to
+     * re-attach, null correctly means "leave it alone". For the *outcome*, `!isStalled(null)`
+     * reads as success and credits a repair that was never observed to work - which is worst in
+     * exactly the case the give-up cap exists for. A renderer wedged badly enough that probes stop
+     * answering within [PROBE_TIMEOUT_MS] is a renderer re-attaching will not fix, yet every
+     * post-repair read would come back null, the ineffective run would never leave zero, the cap
+     * would never trip, and the tab would flicker once per [REATTACH_COOLDOWN_MS] forever while
+     * the log claimed it was painting.
+     */
+    fun repairOutcome(beaconReading: String?): Boolean? =
+        when {
+            beaconReading == null -> null
+            isStalled(beaconReading) -> false
+            else -> true
+        }
 
     /**
      * How long after a commit to arm the beacon.
@@ -227,19 +247,32 @@ internal class FrameStallPolicy(
     }
 
     /**
-     * Report whether the re-attach actually restored painting.
+     * Count a re-attach as ineffective **up front**, before its outcome is known.
      *
-     * A success clears the run *and* the reported flag, so a handle that starts failing again
-     * later still gets its one log line.
+     * Pessimistic on purpose. The outcome is read a beat later, and everything that can end the
+     * job in between - a fresh commit superseding it, the view leaving composition, a probe that
+     * never answers - would otherwise leave the attempt unaccounted for. A tab that reliably reads
+     * unpainted and re-navigates inside that window would then re-attach every cooldown forever
+     * and never reach the cap, which is the one guard against a false positive. Counting first and
+     * crediting only an observed recovery makes every path that skips the confirmation fail
+     * towards giving up rather than towards flickering.
      */
     @Synchronized
-    fun recordOutcome(recovered: Boolean) {
-        if (recovered) {
-            ineffectiveRun = 0
-            gaveUpReported = false
-        } else {
-            ineffectiveRun += 1
-        }
+    fun recordAttemptPending() {
+        ineffectiveRun += 1
+    }
+
+    /**
+     * Credit a re-attach that was **observed** to restore painting.
+     *
+     * Clears the run and the reported flag, so a handle that starts failing again later still gets
+     * its one log line. Never call this for an unknown outcome: see
+     * [BrowserFrameStall.repairOutcome].
+     */
+    @Synchronized
+    fun recordRecovered() {
+        ineffectiveRun = 0
+        gaveUpReported = false
     }
 
     /**
@@ -255,4 +288,12 @@ internal class FrameStallPolicy(
         ineffectiveRun = 0
         gaveUpReported = false
     }
+
+    /**
+     * Whether this handle has stopped repairing.
+     *
+     * Exposed only so the caller can say in the log that it is still probing a retired tab - which
+     * it must, since a reading is the only thing that can bring one back.
+     */
+    @get:Synchronized val hasGivenUp: Boolean get() = ineffectiveRun >= maxIneffective
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -419,17 +419,61 @@ internal class BrowserHandleImpl(
     private var viewGeneration by mutableStateOf(0)
 
     /**
-     * Runs the frame-stall probe. Separate from [coBrowseScope] so a co-browse teardown cannot
-     * cancel a pending check, and on Main because `executeJavaScript` is a blocking round-trip
-     * that JxBrowser expects from the UI thread here, as the other injection sites already do.
+     * True while [Content] is in composition, i.e. while this handle's view is actually on screen.
      *
-     * Only ever one check in flight: a redirect chain fires NavigationFinished repeatedly, and
-     * without this each commit would leave its own probe running against a document that has
-     * already been replaced.
+     * The frame-stall probe is meaningless without it. Chromium does not run rAF for a page that
+     * is not visible, so a navigation committing in a background tab - or in a handle a plugin
+     * created and never rendered at all - reads "no frame" perfectly correctly, and re-attaching
+     * a view that is not composed repairs nothing while logging a warning that is simply false.
+     * Session restore with a handful of background tabs would be that warning once per tab.
      */
-    private val frameStallScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    @Volatile private var viewComposed = false
 
-    @Volatile private var frameStallJob: Job? = null
+    /** Re-attaches performed so far, for the log only. The gate is [ineffectiveReattaches]. */
+    @Volatile private var reattachCount = 0
+
+    /**
+     * Re-attaches in a row that did not restore painting, against
+     * [BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES]. Reset by any repair that works.
+     */
+    @Volatile private var ineffectiveReattaches = 0
+
+    /** When the last re-attach happened, for [BrowserFrameStall.REATTACH_COOLDOWN_MS]. */
+    @Volatile private var lastReattachAtMs = 0L
+
+    /** Logged once when the cap trips, so the give-up is visible without repeating per navigation. */
+    @Volatile private var reattachCapLogged = false
+
+    /**
+     * Waits on the frame-stall probe. Separate from [coBrowseScope] so a co-browse teardown cannot
+     * cancel a pending check, and on Default so [withTimeoutOrNull] can actually fire - the
+     * blocking round-trip itself runs on [frameProbeDispatcher], never here and never on the EDT.
+     */
+    private val frameStallScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Off-thread executor for the beacon round-trip, mirroring [contextMenuLookupDispatcher] and
+     * for the same reason spelled out there: `executeJavaScript` blocks and nothing can interrupt
+     * it, so against a wedged renderer this costs one parked daemon thread rather than a frozen
+     * UI. That matters more here than for the context menu - this probe exists to interrogate a
+     * page already suspected of misbehaving, and it runs on every http(s) commit.
+     */
+    private val frameProbeExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "boss-frame-probe-$id").apply { isDaemon = true }
+        }
+    private val frameProbeDispatcher = frameProbeExecutor.asCoroutineDispatcher()
+
+    /**
+     * The in-flight check, swapped atomically.
+     *
+     * A redirect chain fires NavigationFinished repeatedly and only the document that finally
+     * sticks is worth judging. `getAndSet` rather than read-cancel-assign so that does not rest on
+     * an assumption about JxBrowser delivering navigation events on one thread.
+     */
+    private val frameStallJob =
+        java.util.concurrent.atomic
+            .AtomicReference<Job?>(null)
 
     // Off-thread executor for context-menu detail lookups. The form-field inspection is a
     // blocking JS round-trip, and it must not run on the JxBrowser callback thread (which
@@ -516,15 +560,52 @@ internal class BrowserHandleImpl(
     }
 
     /**
-     * Read the frame beacon, or null if the round-trip could not be made.
+     * Read the frame beacon, or null if the round-trip could not be made in time.
      *
-     * Null and "0" are kept apart on purpose: see [BrowserFrameStall.isStalled].
+     * The blocking call is confined to [frameProbeDispatcher] and only the *wait* is bounded, so a
+     * renderer that never answers parks that one daemon thread instead of anything shared. Null
+     * and "0" are kept apart on purpose: see [BrowserFrameStall.isStalled].
      */
-    private fun readFrameBeacon(): String? =
-        runCatching {
-            if (!isValid) return null
-            browser.mainFrame().orElse(null)?.executeJavaScript<String?>(BrowserFrameStall.BEACON_SCRIPT)
-        }.getOrNull()
+    private suspend fun readFrameBeacon(): String? {
+        if (!isValid) return null
+        // Raced rather than wrapped, exactly as the context-menu lookup is: executeJavaScript has
+        // no suspension point, so a cancelled withTimeoutOrNull could not interrupt it.
+        val probe =
+            frameStallScope.async(frameProbeDispatcher) {
+                runCatching {
+                    browser.mainFrame().orElse(null)?.executeJavaScript<String?>(BrowserFrameStall.BEACON_SCRIPT)
+                }.getOrNull()
+            }
+        return withTimeoutOrNull(BrowserFrameStall.PROBE_TIMEOUT_MS) { probe.await() }
+    }
+
+    /**
+     * Whether a re-attach is allowed right now, and record it if so.
+     *
+     * Bounded like `EngineWedgeDetector`'s recycle: past the cap the handle degrades to the
+     * pre-existing behaviour (the user switches tabs themselves) rather than flickering forever.
+     */
+    private fun claimReattachSlot(): Boolean {
+        val now = System.currentTimeMillis()
+        val capped = ineffectiveReattaches >= BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES
+        if (capped && !reattachCapLogged) {
+            reattachCapLogged = true
+            logger.warn(
+                LogCategory.BROWSER,
+                "Re-attaching stopped helping - leaving this tab alone",
+                mapOf(
+                    "ineffectiveInARow" to ineffectiveReattaches.toString(),
+                    "attemptsTotal" to reattachCount.toString(),
+                ),
+            )
+        }
+        val allowed = !capped && now - lastReattachAtMs >= BrowserFrameStall.REATTACH_COOLDOWN_MS
+        if (allowed) {
+            lastReattachAtMs = now
+            reattachCount += 1
+        }
+        return allowed
+    }
 
     /**
      * Watch a freshly committed document and re-attach the view if it never draws.
@@ -536,27 +617,65 @@ internal class BrowserHandleImpl(
      */
     private fun scheduleFrameStallCheck(url: String?) {
         if (!BrowserFrameStall.shouldWatch(url, JxBrowserConfig.renderingMode)) return
-        // Supersede rather than stack: a redirect chain commits several times, and only the
-        // document that finally sticks is worth judging.
-        frameStallJob?.cancel()
-        frameStallJob =
+        val started =
             frameStallScope.launch {
-                delay(BrowserFrameStall.FIRST_CHECK_MS)
-                if (!BrowserFrameStall.isStalled(readFrameBeacon())) return@launch
-                // Give a slow page a second chance before touching anything.
-                delay(BrowserFrameStall.CONFIRM_MS)
-                if (!BrowserFrameStall.isStalled(readFrameBeacon())) return@launch
+                // The first call arms the beacon and always answers "not painted", so it is not a
+                // reading and is not treated as one. See BrowserFrameStall.ARM_DELAY_MS.
+                delay(BrowserFrameStall.ARM_DELAY_MS)
+                if (!viewComposed) return@launch
+                readFrameBeacon()
 
+                // Two real readings. A page still blocked on a render-blocking resource can
+                // honestly have drawn nothing at the first one.
+                repeat(2) {
+                    delay(BrowserFrameStall.READ_GAP_MS)
+                    if (!viewComposed) return@launch
+                    if (!BrowserFrameStall.isStalled(readFrameBeacon())) return@launch
+                }
+
+                if (!claimReattachSlot()) return@launch
                 logger.warn(
                     LogCategory.BROWSER,
                     "Committed page served no frame - re-attaching the browser view",
                     mapOf(
                         "url" to LogSanitizer.maskUriParams(url.orEmpty()),
-                        "generation" to (viewGeneration + 1).toString(),
+                        "attempt" to reattachCount.toString(),
                     ),
                 )
-                viewGeneration += 1
+                withContext(Dispatchers.Main) { viewGeneration += 1 }
+
+                // Did the repair take? This both feeds the give-up counter and is the one datum
+                // worth having if this ever needs escalating to TeamDev, since it is a recovery
+                // for a fault we do not own.
+                //
+                // The beacon is per-document and already armed, so it keeps reporting the same
+                // document across the re-attach - which is exactly what makes this readable as
+                // "did re-attaching start frames for THIS page".
+                delay(BrowserFrameStall.READ_GAP_MS)
+                val recovered = !BrowserFrameStall.isStalled(readFrameBeacon())
+                if (recovered) {
+                    // A working repair must not count towards giving up, or a tab that legitimately
+                    // needs it often would be abandoned while it was still working.
+                    ineffectiveReattaches = 0
+                    reattachCapLogged = false
+                } else {
+                    ineffectiveReattaches += 1
+                }
+                logger.info(
+                    LogCategory.BROWSER,
+                    if (recovered) {
+                        "Browser view re-attached and painting"
+                    } else {
+                        "Browser view re-attached and still not painting"
+                    },
+                    mapOf(
+                        "attempt" to reattachCount.toString(),
+                        "ineffectiveInARow" to ineffectiveReattaches.toString(),
+                    ),
+                )
             }
+        // Supersede rather than stack: only the document that finally sticks is worth judging.
+        frameStallJob.getAndSet(started)?.cancel()
     }
 
     private fun setupEventListeners() {
@@ -2099,7 +2218,13 @@ internal class BrowserHandleImpl(
         // so a consumer that cares can intersect the two.
         DisposableEffect(Unit) {
             visitTracker.setVisible(true)
-            onDispose { visitTracker.setVisible(false) }
+            // Same signal, second consumer: the frame-stall probe must not judge a view that is
+            // not on screen, because Chromium serves no frames to one. See viewComposed.
+            viewComposed = true
+            onDispose {
+                visitTracker.setVisible(false)
+                viewComposed = false
+            }
         }
 
         // Which window telemetry is attributed to, kept current across a tab move. Its own
@@ -2361,9 +2486,12 @@ internal class BrowserHandleImpl(
         coBrowseBridge.onEvent = null
         coBrowseScope.cancel()
         // A pending frame-stall probe outlives the tab otherwise, and its next act is a blocking
-        // executeJavaScript against a browser that is being torn down.
-        frameStallJob?.cancel()
+        // executeJavaScript against a browser that is being torn down. shutdown() not
+        // shutdownNow(), for the same reason as the context-menu executor: a round-trip already
+        // inside executeJavaScript cannot be interrupted, and the thread is daemon.
+        frameStallJob.getAndSet(null)?.cancel()
         frameStallScope.cancel()
+        frameProbeExecutor.shutdown()
         // Stops queued menu lookups from starting. A lookup already blocked inside
         // executeJavaScript cannot be interrupted by cancellation — the delivery site
         // checks `disposed` before handing anything back. shutdown() (not shutdownNow())

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -10,12 +10,14 @@ import ai.rever.boss.utils.MacOSGestureHandler
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.logging.LogSanitizer
 import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -408,6 +410,27 @@ internal class BrowserHandleImpl(
     // Main-thread scope for injection/teardown (rrweb inject + executeJavaScript run on Main).
     private val coBrowseScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
+    /**
+     * Bumped to re-attach the browser view after a committed document never drew. Read in
+     * [Content], so it has to be Compose state rather than a plain field.
+     *
+     * See [BrowserFrameStall] for the measurements behind this.
+     */
+    private var viewGeneration by mutableStateOf(0)
+
+    /**
+     * Runs the frame-stall probe. Separate from [coBrowseScope] so a co-browse teardown cannot
+     * cancel a pending check, and on Main because `executeJavaScript` is a blocking round-trip
+     * that JxBrowser expects from the UI thread here, as the other injection sites already do.
+     *
+     * Only ever one check in flight: a redirect chain fires NavigationFinished repeatedly, and
+     * without this each commit would leave its own probe running against a document that has
+     * already been replaced.
+     */
+    private val frameStallScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    @Volatile private var frameStallJob: Job? = null
+
     // Off-thread executor for context-menu detail lookups. The form-field inspection is a
     // blocking JS round-trip, and it must not run on the JxBrowser callback thread (which
     // is answering the menu request) nor on the UI thread.
@@ -492,6 +515,50 @@ internal class BrowserHandleImpl(
         }
     }
 
+    /**
+     * Read the frame beacon, or null if the round-trip could not be made.
+     *
+     * Null and "0" are kept apart on purpose: see [BrowserFrameStall.isStalled].
+     */
+    private fun readFrameBeacon(): String? =
+        runCatching {
+            if (!isValid) return null
+            browser.mainFrame().orElse(null)?.executeJavaScript<String?>(BrowserFrameStall.BEACON_SCRIPT)
+        }.getOrNull()
+
+    /**
+     * Watch a freshly committed document and re-attach the view if it never draws.
+     *
+     * The repair is the same one a user performs by switching tabs: bumping [viewGeneration]
+     * takes the browser view out of composition and puts it back, which re-attaches the native
+     * view and restarts frame production. Verified end to end - a blanked AI Mode page goes from
+     * 0 rAF callbacks to painting normally. See [BrowserFrameStall].
+     */
+    private fun scheduleFrameStallCheck(url: String?) {
+        if (!BrowserFrameStall.shouldWatch(url, JxBrowserConfig.renderingMode)) return
+        // Supersede rather than stack: a redirect chain commits several times, and only the
+        // document that finally sticks is worth judging.
+        frameStallJob?.cancel()
+        frameStallJob =
+            frameStallScope.launch {
+                delay(BrowserFrameStall.FIRST_CHECK_MS)
+                if (!BrowserFrameStall.isStalled(readFrameBeacon())) return@launch
+                // Give a slow page a second chance before touching anything.
+                delay(BrowserFrameStall.CONFIRM_MS)
+                if (!BrowserFrameStall.isStalled(readFrameBeacon())) return@launch
+
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Committed page served no frame - re-attaching the browser view",
+                    mapOf(
+                        "url" to LogSanitizer.maskUriParams(url.orEmpty()),
+                        "generation" to (viewGeneration + 1).toString(),
+                    ),
+                )
+                viewGeneration += 1
+            }
+    }
+
     private fun setupEventListeners() {
         // Navigation started - track loading state
         subscriptions +=
@@ -530,6 +597,7 @@ internal class BrowserHandleImpl(
                 // incorrectly updating the URL bar in plugins
                 if (event.isInMainFrame) {
                     val url = event.url()
+                    scheduleFrameStallCheck(url)
                     navigationListeners.forEach { listener ->
                         try {
                             listener(url)
@@ -2206,59 +2274,67 @@ internal class BrowserHandleImpl(
         // pinch gate compares AWT logical units against pixel bounds using it.
         val viewDensity = LocalDensity.current.density
 
-        // Render the browser view if available with mouse button handling
+        // Render the browser view if available with mouse button handling.
+        //
+        // Keyed on viewGeneration so the stall watchdog can force the view out of composition and
+        // back, which is what re-attaches the native view when a committed page never drew. The
+        // BrowserViewState is deliberately NOT rebuilt with it: the manual repair this imitates (a
+        // tab switch) reuses the retained surface too, so re-attaching is what matters and
+        // rebuilding the surface would cost far more than it fixes.
         viewState?.let { state ->
-            BrowserView(
-                state = state,
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .offset(y = hardwareTopInsetDp.dp)
-                        // Where this view is, for the pinch gate under HARDWARE_ACCELERATED —
-                        // the only signal available there, since a foreign native surface means
-                        // Compose never reports the pointer entering. Clipped bounds, so a view
-                        // scrolled half out of the window does not claim the hidden half.
-                        .onGloballyPositioned { coords ->
-                            browserViewBoundsInWindow = coords.boundsInWindow()
-                            // Captured with the bounds, from the same layout pass, so the two can
-                            // never describe different displays after a window is dragged between
-                            // monitors. See pointerInsideBounds for why the pairing is required.
-                            browserViewDensity = viewDensity
-                        }
-                        // Hover tracking that gates the window-wide pinch gesture listener to
-                        // this view under OFF_SCREEN (see the DisposableEffect above). Never
-                        // fires under HARDWARE_ACCELERATED; see shouldAllowPinch.
-                        .onPointerEvent(PointerEventType.Enter) { pointerOverBrowserView = true }
-                        .onPointerEvent(PointerEventType.Exit) { pointerOverBrowserView = false }
-                        .onPointerEvent(PointerEventType.Press) { event ->
-                            // Get the native AWT mouse event to check button codes
-                            val awtEvent = event.nativeEvent as? java.awt.event.MouseEvent
-
-                            // Handle mouse back button - navigate back
-                            // Windows/macOS: awtButton=4, Linux: awtButton=6 or 8 (varies by mouse)
-                            if (awtEvent?.button in listOf(4, 6, 8)) {
-                                val now = System.currentTimeMillis()
-                                if (isValid && (now - lastNavigationTime) > 100 && canGoBack()) {
-                                    lastNavigationTime = now
-                                    goBack()
-                                }
-                                event.changes.forEach { it.consume() }
-                                return@onPointerEvent
+            key(viewGeneration) {
+                BrowserView(
+                    state = state,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .offset(y = hardwareTopInsetDp.dp)
+                            // Where this view is, for the pinch gate under HARDWARE_ACCELERATED —
+                            // the only signal available there, since a foreign native surface means
+                            // Compose never reports the pointer entering. Clipped bounds, so a view
+                            // scrolled half out of the window does not claim the hidden half.
+                            .onGloballyPositioned { coords ->
+                                browserViewBoundsInWindow = coords.boundsInWindow()
+                                // Captured with the bounds, from the same layout pass, so the two can
+                                // never describe different displays after a window is dragged between
+                                // monitors. See pointerInsideBounds for why the pairing is required.
+                                browserViewDensity = viewDensity
                             }
+                            // Hover tracking that gates the window-wide pinch gesture listener to
+                            // this view under OFF_SCREEN (see the DisposableEffect above). Never
+                            // fires under HARDWARE_ACCELERATED; see shouldAllowPinch.
+                            .onPointerEvent(PointerEventType.Enter) { pointerOverBrowserView = true }
+                            .onPointerEvent(PointerEventType.Exit) { pointerOverBrowserView = false }
+                            .onPointerEvent(PointerEventType.Press) { event ->
+                                // Get the native AWT mouse event to check button codes
+                                val awtEvent = event.nativeEvent as? java.awt.event.MouseEvent
 
-                            // Handle mouse forward button - navigate forward
-                            // Windows/macOS: awtButton=5, Linux: awtButton=7 or 9 (varies by mouse)
-                            if (awtEvent?.button in listOf(5, 7, 9)) {
-                                val now = System.currentTimeMillis()
-                                if (isValid && (now - lastNavigationTime) > 100 && canGoForward()) {
-                                    lastNavigationTime = now
-                                    goForward()
+                                // Handle mouse back button - navigate back
+                                // Windows/macOS: awtButton=4, Linux: awtButton=6 or 8 (varies by mouse)
+                                if (awtEvent?.button in listOf(4, 6, 8)) {
+                                    val now = System.currentTimeMillis()
+                                    if (isValid && (now - lastNavigationTime) > 100 && canGoBack()) {
+                                        lastNavigationTime = now
+                                        goBack()
+                                    }
+                                    event.changes.forEach { it.consume() }
+                                    return@onPointerEvent
                                 }
-                                event.changes.forEach { it.consume() }
-                                return@onPointerEvent
-                            }
-                        },
-            )
+
+                                // Handle mouse forward button - navigate forward
+                                // Windows/macOS: awtButton=5, Linux: awtButton=7 or 9 (varies by mouse)
+                                if (awtEvent?.button in listOf(5, 7, 9)) {
+                                    val now = System.currentTimeMillis()
+                                    if (isValid && (now - lastNavigationTime) > 100 && canGoForward()) {
+                                        lastNavigationTime = now
+                                        goForward()
+                                    }
+                                    event.changes.forEach { it.consume() }
+                                    return@onPointerEvent
+                                }
+                            },
+                )
+            }
         }
     }
 
@@ -2284,6 +2360,10 @@ internal class BrowserHandleImpl(
         coBrowseSink = null
         coBrowseBridge.onEvent = null
         coBrowseScope.cancel()
+        // A pending frame-stall probe outlives the tab otherwise, and its next act is a blocking
+        // executeJavaScript against a browser that is being torn down.
+        frameStallJob?.cancel()
+        frameStallScope.cancel()
         // Stops queued menu lookups from starting. A lookup already blocked inside
         // executeJavaScript cannot be interrupted by cancellation — the delivery site
         // checks `disposed` before handing anything back. shutdown() (not shutdownNow())

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -100,6 +100,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
@@ -433,11 +435,37 @@ internal class BrowserHandleImpl(
      * frame" perfectly correctly, and re-attaching it repairs nothing while logging a warning that
      * is false. Session restore with N background tabs would be N false warnings per launch.
      */
-    private val composedSurfaces =
-        java.util.concurrent.atomic
-            .AtomicInteger(0)
+    private val composedSurfaces = AtomicInteger(0)
 
-    private val viewComposed: Boolean get() = composedSurfaces.get() > 0
+    /**
+     * The AWT window this handle's view is bound to, for the on-screen half of [viewComposed].
+     * Null until [Content] resolves one, and treated as "assume showing" while it is.
+     */
+    @Volatile private var frameStallHostWindow: Window? = null
+
+    /**
+     * Whether this view is genuinely on screen: composed **and** in a window that is showing and
+     * not minimized.
+     *
+     * Composition alone is not the same thing. A minimized window keeps its composition alive, so
+     * its foreground tab would pass a composed-only gate while Chromium is legitimately not
+     * painting it - and the cost of that false positive is not merely a wasted WARN but a view
+     * rebuild, which drops keyboard focus and IME state in that tab.
+     */
+    private val viewComposed: Boolean
+        get() {
+            if (composedSurfaces.get() <= 0) return false
+            val window = frameStallHostWindow ?: return true
+            // Fully qualified: this file already imports JxBrowser's Frame, and an unqualified
+            // one here resolves to that rather than the AWT window type.
+            return runCatching {
+                val minimized =
+                    (window as? java.awt.Frame)
+                        ?.let { it.extendedState and java.awt.Frame.ICONIFIED != 0 }
+                        ?: false
+                window.isShowing && !minimized
+            }.getOrDefault(true)
+        }
 
     /** Cooldown, give-up counting and the log-once flag, extracted so they are unit-testable. */
     private val frameStallPolicy = FrameStallPolicy()
@@ -480,9 +508,7 @@ internal class BrowserHandleImpl(
      * sticks is worth judging. `getAndSet` rather than read-cancel-assign so that does not rest on
      * an assumption about JxBrowser delivering navigation events on one thread.
      */
-    private val frameStallJob =
-        java.util.concurrent.atomic
-            .AtomicReference<Job?>(null)
+    private val frameStallJob = AtomicReference<Job?>(null)
 
     // Off-thread executor for context-menu detail lookups. The form-field inspection is a
     // blocking JS round-trip, and it must not run on the JxBrowser callback thread (which
@@ -585,7 +611,14 @@ internal class BrowserHandleImpl(
                     browser.mainFrame().orElse(null)?.executeJavaScript<String?>(BrowserFrameStall.BEACON_SCRIPT)
                 }.getOrNull()
             }
-        return withTimeoutOrNull(BrowserFrameStall.PROBE_TIMEOUT_MS) { probe.await() }
+        val reading = withTimeoutOrNull(BrowserFrameStall.PROBE_TIMEOUT_MS) { probe.await() }
+        // The probe is a child of the scope, not of this coroutine, so neither the timeout above
+        // nor a supersede cancels it. Left alone, one still queued behind a blocked probe on the
+        // single-thread executor would run later against whatever document is current by then.
+        // A queued coroutine honours this immediately; one already inside executeJavaScript is
+        // unaffected either way, which is the parked-thread cost frameProbeExecutor documents.
+        if (reading == null) probe.cancel()
+        return reading
     }
 
     /**
@@ -593,6 +626,13 @@ internal class BrowserHandleImpl(
      *
      * Bounded like `EngineWedgeDetector`'s recycle: past the cap the handle degrades to the
      * pre-existing behaviour (the user switches tabs themselves) rather than flickering forever.
+     */
+
+    /**
+     * Note that a handle which has given up still probes on every commit. That reads like waste and
+     * is not: [FrameStallPolicy.recordHealthyNavigation] is only reachable from a reading, so
+     * probing is the only way a retired tab can ever come back. Giving up means "stop re-attaching",
+     * not "stop looking".
      */
     private fun claimReattachSlot(): Boolean {
         // Monotonic, not wall clock: an NTP step must not stretch or shorten the cooldown.
@@ -626,7 +666,12 @@ internal class BrowserHandleImpl(
                 // reading and is not treated as one. See BrowserFrameStall.ARM_DELAY_MS.
                 delay(BrowserFrameStall.ARM_DELAY_MS)
                 if (!viewComposed) return@launch
-                readFrameBeacon()
+                // A null here means the arm never landed - the probe timed out, the main frame was
+                // gone mid-commit. Carrying on would silently spend the first loop iteration
+                // arming, leaving one real reading where the design promises two, and it would do
+                // so against exactly the slow renderers most likely to be honestly mid-paint. A
+                // commit that could not be probed at all is not evidence of a stall.
+                if (readFrameBeacon() == null) return@launch
 
                 // Two real readings. A page still blocked on a render-blocking resource can
                 // honestly have drawn nothing at the first one.
@@ -636,12 +681,29 @@ internal class BrowserHandleImpl(
                     if (!BrowserFrameStall.isStalled(readFrameBeacon())) {
                         // Painted unaided, so this tab is evidently fine - let that decay any
                         // earlier ineffective attempts rather than holding them against it.
+                        // Read before the reset, since the reset is what clears it.
+                        val wasRetired = frameStallPolicy.hasGivenUp
                         frameStallPolicy.recordHealthyNavigation()
+                        if (wasRetired) {
+                            // The counterpart to the give-up line, so a log that says a tab was
+                            // abandoned also says when it came back.
+                            logger.info(
+                                LogCategory.BROWSER,
+                                "Tab painted unaided - frame-stall watchdog active again",
+                                mapOf("attemptsTotal" to frameStallPolicy.attempts.toString()),
+                            )
+                        }
                         return@launch
                     }
                 }
 
                 if (!claimReattachSlot()) return@launch
+                // Booked as ineffective before the repair, upgraded only by an observed recovery.
+                // Everything that can end this job before the confirmation - a fresh commit
+                // superseding it, the view leaving composition, a probe that never answers - would
+                // otherwise leave the attempt uncounted, and a tab that keeps reading unpainted
+                // would re-attach every cooldown forever without ever reaching the cap.
+                frameStallPolicy.recordAttemptPending()
                 logger.warn(
                     LogCategory.BROWSER,
                     "Committed page served no frame - re-attaching the browser view",
@@ -664,20 +726,25 @@ internal class BrowserHandleImpl(
                 // window reads "0" because Chromium does not paint hidden pages, and recording that
                 // as an ineffective repair would retire the watchdog on a false reading.
                 if (!viewComposed) return@launch
-                val recovered = !BrowserFrameStall.isStalled(readFrameBeacon())
-                frameStallPolicy.recordOutcome(recovered)
-                logger.info(
-                    LogCategory.BROWSER,
-                    if (recovered) {
-                        "Browser view re-attached and painting"
-                    } else {
-                        "Browser view re-attached and still not painting"
-                    },
+                // Three outcomes, not two. isStalled(null) is false, so reusing it here would read
+                // a probe that never answered as a success - and credit the repair in exactly the
+                // wedged-renderer case the cap exists to stop. See BrowserFrameStall.repairOutcome.
+                val outcome = BrowserFrameStall.repairOutcome(readFrameBeacon())
+                if (outcome == true) frameStallPolicy.recordRecovered()
+                val detail =
                     mapOf(
                         "attempt" to frameStallPolicy.attempts.toString(),
                         "ineffectiveInARow" to frameStallPolicy.ineffectiveInARow.toString(),
-                    ),
-                )
+                    )
+                when (outcome) {
+                    true -> logger.info(LogCategory.BROWSER, "Browser view re-attached and painting", detail)
+
+                    false -> logger.info(LogCategory.BROWSER, "Browser view re-attached and still not painting", detail)
+
+                    // Counted against the tab by recordAttemptPending, deliberately: an
+                    // unanswerable probe is evidence of a renderer this cannot repair.
+                    null -> logger.info(LogCategory.BROWSER, "Browser view re-attached, outcome unknown", detail)
+                }
             }
         // Supersede rather than stack: only the document that finally sticks is worth judging.
         frameStallJob.getAndSet(started)?.cancel()
@@ -2261,6 +2328,10 @@ internal class BrowserHandleImpl(
                             false
                         }
                     }
+
+            // Published for the frame-stall gate, which needs to know whether the window this view
+            // lives in is actually showing - composition alone stays alive while it is minimized.
+            frameStallHostWindow = awtWindow
 
             // Reuse a retained surface ONLY while it still belongs to this window. This effect is
             // keyed on hostWindowId precisely so a tab moved to another window rebinds (see the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -419,37 +419,46 @@ internal class BrowserHandleImpl(
     private var viewGeneration by mutableStateOf(0)
 
     /**
-     * True while [Content] is in composition, i.e. while this handle's view is actually on screen.
+     * How many compositions currently show this handle's view.
      *
-     * The frame-stall probe is meaningless without it. Chromium does not run rAF for a page that
-     * is not visible, so a navigation committing in a background tab - or in a handle a plugin
-     * created and never rendered at all - reads "no frame" perfectly correctly, and re-attaching
-     * a view that is not composed repairs nothing while logging a warning that is simply false.
-     * Session restore with a handful of background tabs would be that warning once per tab.
+     * **Ref-counted, not a boolean, for the reason [BrowserVisitTracker.setVisible] spells out**:
+     * the caller is a `DisposableEffect` per composition, and a tab moving between windows tears
+     * down one composition while building another in an order the effect does not control. As a
+     * plain boolean the compose-then-dispose order lands on false while the tab is on screen, and
+     * here that would silently disable the watchdog for exactly the tab the user just dragged,
+     * until they hid and re-showed it. Failing safe is not enough when the failure is invisible.
+     *
+     * The gate itself is needed because Chromium serves no frames to a view that is not on screen:
+     * a commit in a background tab, or in a handle a plugin created and never rendered, reads "no
+     * frame" perfectly correctly, and re-attaching it repairs nothing while logging a warning that
+     * is false. Session restore with N background tabs would be N false warnings per launch.
      */
-    @Volatile private var viewComposed = false
+    private val composedSurfaces =
+        java.util.concurrent.atomic
+            .AtomicInteger(0)
 
-    /** Re-attaches performed so far, for the log only. The gate is [ineffectiveReattaches]. */
-    @Volatile private var reattachCount = 0
+    private val viewComposed: Boolean get() = composedSurfaces.get() > 0
 
-    /**
-     * Re-attaches in a row that did not restore painting, against
-     * [BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES]. Reset by any repair that works.
-     */
-    @Volatile private var ineffectiveReattaches = 0
-
-    /** When the last re-attach happened, for [BrowserFrameStall.REATTACH_COOLDOWN_MS]. */
-    @Volatile private var lastReattachAtMs = 0L
-
-    /** Logged once when the cap trips, so the give-up is visible without repeating per navigation. */
-    @Volatile private var reattachCapLogged = false
+    /** Cooldown, give-up counting and the log-once flag, extracted so they are unit-testable. */
+    private val frameStallPolicy = FrameStallPolicy()
 
     /**
      * Waits on the frame-stall probe. Separate from [coBrowseScope] so a co-browse teardown cannot
      * cancel a pending check, and on Default so [withTimeoutOrNull] can actually fire - the
      * blocking round-trip itself runs on [frameProbeDispatcher], never here and never on the EDT.
+     *
+     * Carries a handler for the same reason [contextMenuScope] does: the body hops to Main during
+     * what may be window teardown, and an escaping failure would otherwise reach the default
+     * handler and print to stderr, bypassing BossLogger.
      */
-    private val frameStallScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val frameStallScope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.Default +
+                CoroutineExceptionHandler { _, error ->
+                    logger.warn(LogCategory.BROWSER, "Frame-stall check failed", error = error)
+                },
+        )
 
     /**
      * Off-thread executor for the beacon round-trip, mirroring [contextMenuLookupDispatcher] and
@@ -586,25 +595,19 @@ internal class BrowserHandleImpl(
      * pre-existing behaviour (the user switches tabs themselves) rather than flickering forever.
      */
     private fun claimReattachSlot(): Boolean {
-        val now = System.currentTimeMillis()
-        val capped = ineffectiveReattaches >= BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES
-        if (capped && !reattachCapLogged) {
-            reattachCapLogged = true
+        // Monotonic, not wall clock: an NTP step must not stretch or shorten the cooldown.
+        val decision = frameStallPolicy.claim(System.nanoTime() / 1_000_000L)
+        if (decision == FrameStallPolicy.Decision.GIVE_UP_NOW) {
             logger.warn(
                 LogCategory.BROWSER,
                 "Re-attaching stopped helping - leaving this tab alone",
                 mapOf(
-                    "ineffectiveInARow" to ineffectiveReattaches.toString(),
-                    "attemptsTotal" to reattachCount.toString(),
+                    "ineffectiveInARow" to frameStallPolicy.ineffectiveInARow.toString(),
+                    "attemptsTotal" to frameStallPolicy.attempts.toString(),
                 ),
             )
         }
-        val allowed = !capped && now - lastReattachAtMs >= BrowserFrameStall.REATTACH_COOLDOWN_MS
-        if (allowed) {
-            lastReattachAtMs = now
-            reattachCount += 1
-        }
-        return allowed
+        return decision == FrameStallPolicy.Decision.REATTACH
     }
 
     /**
@@ -630,7 +633,12 @@ internal class BrowserHandleImpl(
                 repeat(2) {
                     delay(BrowserFrameStall.READ_GAP_MS)
                     if (!viewComposed) return@launch
-                    if (!BrowserFrameStall.isStalled(readFrameBeacon())) return@launch
+                    if (!BrowserFrameStall.isStalled(readFrameBeacon())) {
+                        // Painted unaided, so this tab is evidently fine - let that decay any
+                        // earlier ineffective attempts rather than holding them against it.
+                        frameStallPolicy.recordHealthyNavigation()
+                        return@launch
+                    }
                 }
 
                 if (!claimReattachSlot()) return@launch
@@ -639,7 +647,7 @@ internal class BrowserHandleImpl(
                     "Committed page served no frame - re-attaching the browser view",
                     mapOf(
                         "url" to LogSanitizer.maskUriParams(url.orEmpty()),
-                        "attempt" to reattachCount.toString(),
+                        "attempt" to frameStallPolicy.attempts.toString(),
                     ),
                 )
                 withContext(Dispatchers.Main) { viewGeneration += 1 }
@@ -652,15 +660,12 @@ internal class BrowserHandleImpl(
                 // document across the re-attach - which is exactly what makes this readable as
                 // "did re-attaching start frames for THIS page".
                 delay(BrowserFrameStall.READ_GAP_MS)
+                // Gated like the decision reads, and for the same reason: a tab hidden inside this
+                // window reads "0" because Chromium does not paint hidden pages, and recording that
+                // as an ineffective repair would retire the watchdog on a false reading.
+                if (!viewComposed) return@launch
                 val recovered = !BrowserFrameStall.isStalled(readFrameBeacon())
-                if (recovered) {
-                    // A working repair must not count towards giving up, or a tab that legitimately
-                    // needs it often would be abandoned while it was still working.
-                    ineffectiveReattaches = 0
-                    reattachCapLogged = false
-                } else {
-                    ineffectiveReattaches += 1
-                }
+                frameStallPolicy.recordOutcome(recovered)
                 logger.info(
                     LogCategory.BROWSER,
                     if (recovered) {
@@ -669,8 +674,8 @@ internal class BrowserHandleImpl(
                         "Browser view re-attached and still not painting"
                     },
                     mapOf(
-                        "attempt" to reattachCount.toString(),
-                        "ineffectiveInARow" to ineffectiveReattaches.toString(),
+                        "attempt" to frameStallPolicy.attempts.toString(),
+                        "ineffectiveInARow" to frameStallPolicy.ineffectiveInARow.toString(),
                     ),
                 )
             }
@@ -2218,12 +2223,13 @@ internal class BrowserHandleImpl(
         // so a consumer that cares can intersect the two.
         DisposableEffect(Unit) {
             visitTracker.setVisible(true)
-            // Same signal, second consumer: the frame-stall probe must not judge a view that is
-            // not on screen, because Chromium serves no frames to one. See viewComposed.
-            viewComposed = true
+            // Same signal, second consumer, and ref-counted for the same ordering reason: the
+            // frame-stall probe must not judge a view that is not on screen, because Chromium
+            // serves no frames to one. See composedSurfaces.
+            composedSurfaces.incrementAndGet()
             onDispose {
                 visitTracker.setVisible(false)
-                viewComposed = false
+                composedSurfaces.decrementAndGet()
             }
         }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStallTest.kt
@@ -1,0 +1,80 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.engine.RenderingMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards the two decisions in [BrowserFrameStall] that decide whether a user's browser view gets
+ * yanked out of composition and put back.
+ *
+ * Both are cheap to get backwards, and both fail in the direction of doing the re-attach too
+ * often - which is a visible flicker on pages that were never broken.
+ */
+class BrowserFrameStallTest {
+    @Test
+    fun `only http and https pages are watched`() {
+        val mode = RenderingMode.HARDWARE_ACCELERATED
+        assertTrue(BrowserFrameStall.shouldWatch("https://www.google.com/search?q=x&udm=50&aep=1", mode))
+        assertTrue(BrowserFrameStall.shouldWatch("http://example.com", mode))
+        assertTrue(BrowserFrameStall.shouldWatch("  https://example.com  ", mode), "a padded URL is still a web page")
+        assertTrue(BrowserFrameStall.shouldWatch("HTTPS://EXAMPLE.COM", mode), "scheme is case-insensitive")
+    }
+
+    @Test
+    fun `internal and empty pages are never watched`() {
+        val mode = RenderingMode.HARDWARE_ACCELERATED
+        // about:blank and the dashboard's empty URL are what a tab shows when it is *meant* to be
+        // empty. Probing them would arm a beacon on a page with no rAF work and then re-attach the
+        // view for it, so the blank the user asked for would flicker.
+        for (url in listOf(null, "", "   ", "about:blank", "chrome://gpu", "file:///tmp/x.html", "boss://terminal")) {
+            assertFalse(BrowserFrameStall.shouldWatch(url, mode), "should not watch $url")
+        }
+    }
+
+    @Test
+    fun `OFF_SCREEN is never watched`() {
+        // The stall is an attachment fault in the native-view path. OFF_SCREEN exports frames as a
+        // bitmap and has never shown it, so watching there would be pure risk with no upside.
+        assertFalse(
+            BrowserFrameStall.shouldWatch("https://www.google.com/search?q=x&udm=50&aep=1", RenderingMode.OFF_SCREEN),
+        )
+    }
+
+    @Test
+    fun `a failed beacon read is not a stall`() {
+        // The distinction this test exists for: null means the JS round-trip did not happen (a
+        // navigation raced the probe, the frame went away), NOT that the page failed to draw.
+        // Treating null as a stall re-attaches the view on ordinary pages.
+        assertFalse(BrowserFrameStall.isStalled(null))
+    }
+
+    @Test
+    fun `a painted beacon is not a stall and an unpainted one is`() {
+        assertFalse(BrowserFrameStall.isStalled(BrowserFrameStall.BEACON_PAINTED))
+        assertTrue(BrowserFrameStall.isStalled("0"))
+    }
+
+    @Test
+    fun `the beacon script reports the value it also arms`() {
+        // The same snippet arms and polls, so a rename on one side cannot silently stop the other
+        // from ever matching - which would re-attach the view on every single navigation.
+        assertTrue(BrowserFrameStall.BEACON_SCRIPT.contains("__bossFrameBeacon"))
+        assertTrue(BrowserFrameStall.BEACON_SCRIPT.contains("requestAnimationFrame"))
+        assertTrue(
+            BrowserFrameStall.BEACON_SCRIPT.contains("'${BrowserFrameStall.BEACON_PAINTED}'"),
+            "the script must assign the exact value isStalled compares against",
+        )
+    }
+
+    @Test
+    fun `both waits are non-trivial`() {
+        // A first check that fires immediately would call every page stalled, since no page has
+        // painted at commit time.
+        assertTrue(BrowserFrameStall.FIRST_CHECK_MS >= 500)
+        assertTrue(BrowserFrameStall.CONFIRM_MS >= 500)
+        assertEquals(1600L, BrowserFrameStall.FIRST_CHECK_MS + BrowserFrameStall.CONFIRM_MS)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStallTest.kt
@@ -2,7 +2,9 @@ package ai.rever.boss.plugin.browser
 
 import com.teamdev.jxbrowser.engine.RenderingMode
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -61,6 +63,26 @@ class BrowserFrameStallTest {
         // on ordinary pages, and does it hardest against exactly the slow renderers least able to
         // afford it.
         assertFalse(BrowserFrameStall.isStalled(null))
+    }
+
+    @Test
+    fun `an unknown post-repair reading is neither a recovery nor a failure`() {
+        // The highest-severity finding from review, and the reason repairOutcome exists rather
+        // than reusing isStalled: `!isStalled(null)` is true, so an unanswered probe read as a
+        // successful repair. That cleared the ineffective run in exactly the case the cap exists
+        // for - a renderer too wedged to answer at all - so the cap could never trip, the tab
+        // flickered once per cooldown forever, and the log claimed it was painting.
+        assertNull(BrowserFrameStall.repairOutcome(null))
+        assertEquals(false, BrowserFrameStall.repairOutcome(BrowserFrameStall.BEACON_UNPAINTED))
+        assertEquals(true, BrowserFrameStall.repairOutcome(BrowserFrameStall.BEACON_PAINTED))
+    }
+
+    @Test
+    fun `an unrecognised post-repair reading counts as recovered, matching isStalled`() {
+        // Deliberately the same cautious polarity as isStalled: only the exact unpainted marker
+        // is evidence of failure, so a page that overwrote the global cannot force the cap to
+        // trip and retire its own repair.
+        assertEquals(true, BrowserFrameStall.repairOutcome("[object Object]"))
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStallTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStallTest.kt
@@ -2,16 +2,20 @@ package ai.rever.boss.plugin.browser
 
 import com.teamdev.jxbrowser.engine.RenderingMode
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Guards the two decisions in [BrowserFrameStall] that decide whether a user's browser view gets
- * yanked out of composition and put back.
+ * Guards the pure decisions in [BrowserFrameStall] - the ones that decide whether a user's browser
+ * view gets yanked out of composition and put back.
  *
- * Both are cheap to get backwards, and both fail in the direction of doing the re-attach too
- * often - which is a visible flicker on pages that were never broken.
+ * Both fail in the same direction when got wrong: re-attaching too often, which is a visible
+ * flicker on pages that were never broken.
+ *
+ * **What this does not cover**, so green here is not mistaken for a verified mechanism: the
+ * supersede-per-redirect logic, the visibility gate, the cap and cooldown, and the re-attach
+ * itself all need a live JxBrowser view and are covered only by the manual run recorded in the PR
+ * (same click path: 0/5 painted before, 5/5 after, watchdog firing only on the AI Mode commits).
  */
 class BrowserFrameStallTest {
     @Test
@@ -44,21 +48,32 @@ class BrowserFrameStallTest {
     }
 
     @Test
-    fun `a failed beacon read is not a stall`() {
-        // The distinction this test exists for: null means the JS round-trip did not happen (a
-        // navigation raced the probe, the frame went away), NOT that the page failed to draw.
-        // Treating null as a stall re-attaches the view on ordinary pages.
+    fun `only an explicit unpainted reading is a stall`() {
+        assertTrue(BrowserFrameStall.isStalled(BrowserFrameStall.BEACON_UNPAINTED))
+        assertFalse(BrowserFrameStall.isStalled(BrowserFrameStall.BEACON_PAINTED))
+    }
+
+    @Test
+    fun `a failed or timed-out beacon read is not a stall`() {
+        // The distinction this test exists for: null means the JS round-trip did not happen or did
+        // not answer in time (a navigation raced the probe, the frame went away, the renderer is
+        // busy), NOT that the page failed to draw. Treating null as a stall re-attaches the view
+        // on ordinary pages, and does it hardest against exactly the slow renderers least able to
+        // afford it.
         assertFalse(BrowserFrameStall.isStalled(null))
     }
 
     @Test
-    fun `a painted beacon is not a stall and an unpainted one is`() {
-        assertFalse(BrowserFrameStall.isStalled(BrowserFrameStall.BEACON_PAINTED))
-        assertTrue(BrowserFrameStall.isStalled("0"))
+    fun `an unrecognised reading is not a stall`() {
+        // The beacon is a window global, so a page can overwrite it with anything. Anything that
+        // is not the exact unpainted marker is treated as "do not touch this".
+        for (reading in listOf("", "true", "0.0", "unarmed", "[object Object]")) {
+            assertFalse(BrowserFrameStall.isStalled(reading), "should not treat $reading as a stall")
+        }
     }
 
     @Test
-    fun `the beacon script reports the value it also arms`() {
+    fun `the beacon script arms once per document and reports what isStalled compares against`() {
         // The same snippet arms and polls, so a rename on one side cannot silently stop the other
         // from ever matching - which would re-attach the view on every single navigation.
         assertTrue(BrowserFrameStall.BEACON_SCRIPT.contains("__bossFrameBeacon"))
@@ -67,14 +82,34 @@ class BrowserFrameStallTest {
             BrowserFrameStall.BEACON_SCRIPT.contains("'${BrowserFrameStall.BEACON_PAINTED}'"),
             "the script must assign the exact value isStalled compares against",
         )
+        assertTrue(
+            BrowserFrameStall.BEACON_SCRIPT.contains("'${BrowserFrameStall.BEACON_UNPAINTED}'"),
+            "the script must seed the exact value isStalled treats as stalled",
+        )
+        // The typeof guard is what makes arming once-per-document rather than once-per-call, and
+        // that is what lets a second reading confirm the first instead of restarting the clock.
+        assertTrue(
+            BrowserFrameStall.BEACON_SCRIPT.contains("typeof window.__bossFrameBeacon === 'undefined'"),
+            "re-arming on every call would make every reading the first one, which is always unpainted",
+        )
     }
 
     @Test
-    fun `both waits are non-trivial`() {
-        // A first check that fires immediately would call every page stalled, since no page has
-        // painted at commit time.
-        assertTrue(BrowserFrameStall.FIRST_CHECK_MS >= 500)
-        assertTrue(BrowserFrameStall.CONFIRM_MS >= 500)
-        assertEquals(1600L, BrowserFrameStall.FIRST_CHECK_MS + BrowserFrameStall.CONFIRM_MS)
+    fun `the waits leave room for a page to paint`() {
+        // An arm delay of zero would be harmless, but a zero read gap would judge the page in the
+        // same tick it was armed in, when no page has painted yet.
+        assertTrue(BrowserFrameStall.ARM_DELAY_MS >= 500)
+        assertTrue(BrowserFrameStall.READ_GAP_MS >= 500)
+        assertTrue(BrowserFrameStall.PROBE_TIMEOUT_MS > 0)
+    }
+
+    @Test
+    fun `the repair is bounded, but only by how often it fails`() {
+        // Unbounded, any condition that reliably reads unpainted becomes a flicker on every
+        // navigation - worse than the blank being fixed. See EngineWedgeDetector for the sibling.
+        assertTrue(BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES in 1..10)
+        // The rate limit is what bounds a tight navigation loop, and it applies whether or not the
+        // repair is working - so it, not the give-up counter, has to be non-trivial.
+        assertTrue(BrowserFrameStall.REATTACH_COOLDOWN_MS >= 1_000)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.browser
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -10,9 +11,27 @@ import kotlin.test.assertTrue
  * Extracted from `BrowserHandleImpl` precisely so these cases can be asserted without a live
  * JxBrowser view, and with the clock supplied rather than read - the cooldown boundary is not
  * testable otherwise.
+ *
+ * The real sequence per repair is `claim` -> [FrameStallPolicy.recordAttemptPending] -> (only on
+ * an *observed* recovery) [FrameStallPolicy.recordRecovered], and these tests follow it. The
+ * pessimistic booking is the point: anything that ends the job before the confirmation has to
+ * leave the attempt counted.
  */
 class FrameStallPolicyTest {
     private fun policy() = FrameStallPolicy(maxIneffective = 3, cooldownMs = 10_000L)
+
+    /** A repair that was performed and then failed, or whose outcome never arrived. */
+    private fun FrameStallPolicy.failedRepairAt(now: Long) {
+        claim(now)
+        recordAttemptPending()
+    }
+
+    /** A repair that was performed and observed to restore painting. */
+    private fun FrameStallPolicy.goodRepairAt(now: Long) {
+        claim(now)
+        recordAttemptPending()
+        recordRecovered()
+    }
 
     @Test
     fun `the first claim is granted`() {
@@ -42,48 +61,64 @@ class FrameStallPolicyTest {
         val p = policy()
         var now = 0L
         repeat(3) {
-            assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now), "attempt at $now")
-            p.recordOutcome(recovered = false)
+            p.failedRepairAt(now)
             now += 10_000L
         }
         assertEquals(3, p.ineffectiveInARow)
-        // First refusal is the one the caller logs; every later one stays silent, so a tab that
-        // keeps navigating does not repeat the give-up line forever.
+        assertTrue(p.hasGivenUp)
+        // The first refusal is the one the caller logs; later ones stay silent, so a tab that keeps
+        // navigating does not repeat the give-up line forever.
         assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
         assertEquals(FrameStallPolicy.Decision.GIVEN_UP, p.claim(now + 10_000L))
         assertEquals(FrameStallPolicy.Decision.GIVEN_UP, p.claim(now + 100_000L))
     }
 
     @Test
+    fun `an attempt whose outcome never arrives still counts against the cap`() {
+        // The gap the pessimistic booking closes. recordRecovered is only reachable from an
+        // observed recovery, so a job superseded by a fresh commit, ended by the view leaving
+        // composition, or handed a probe that never answers, confirms nothing. If the attempt were
+        // booked only at confirmation time, a tab that reliably reads unpainted and re-navigates
+        // inside that window would re-attach every cooldown forever and never reach the cap.
+        val p = policy()
+        var now = 0L
+        repeat(3) {
+            assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now))
+            p.recordAttemptPending() // and then the job ends - no confirmation ever runs
+            now += 10_000L
+        }
+        assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
+    }
+
+    @Test
     fun `a repair that works resets the run, so a repeatedly-repairable tab is never abandoned`() {
-        // The regression this exists for: an earlier lifetime cap abandoned the 4th and 5th
+        // The regression this design exists for: an earlier lifetime cap abandoned the 4th and 5th
         // click-through on one tab while the repair was recovering the page 3 times out of 3.
         val p = policy()
         var now = 0L
         repeat(10) {
             assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now), "attempt at $now")
-            p.recordOutcome(recovered = true)
+            p.recordAttemptPending()
+            p.recordRecovered()
             now += 10_000L
         }
         assertEquals(10, p.attempts)
         assertEquals(0, p.ineffectiveInARow)
+        assertFalse(p.hasGivenUp)
     }
 
     @Test
     fun `two failures then a success clears the run`() {
         val p = policy()
         var now = 0L
-        p.claim(now)
-        p.recordOutcome(recovered = false)
+        p.failedRepairAt(now)
         now += 10_000L
-        p.claim(now)
-        p.recordOutcome(recovered = false)
+        p.failedRepairAt(now)
         assertEquals(2, p.ineffectiveInARow)
         now += 10_000L
-        p.claim(now)
-        p.recordOutcome(recovered = true)
+        p.goodRepairAt(now)
         assertEquals(0, p.ineffectiveInARow)
-        // Still granted well past what would have been the cap.
+        // Still granted well past what would otherwise have been the cap.
         now += 10_000L
         assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now))
     }
@@ -96,13 +131,13 @@ class FrameStallPolicyTest {
         val p = policy()
         var now = 0L
         repeat(2) {
-            p.claim(now)
-            p.recordOutcome(recovered = false)
+            p.failedRepairAt(now)
             now += 10_000L
         }
         assertEquals(2, p.ineffectiveInARow)
         p.recordHealthyNavigation()
         assertEquals(0, p.ineffectiveInARow)
+        assertFalse(p.hasGivenUp)
     }
 
     @Test
@@ -110,21 +145,20 @@ class FrameStallPolicyTest {
         val p = policy()
         var now = 0L
         repeat(3) {
-            p.claim(now)
-            p.recordOutcome(recovered = false)
+            p.failedRepairAt(now)
             now += 10_000L
         }
         assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
         p.recordHealthyNavigation()
         now += 10_000L
         assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now))
-        // Fails three more times: the operator gets a fresh line rather than permanent silence.
+        p.recordAttemptPending()
+        // Two more failures reach the cap again, and the operator gets a fresh line rather than
+        // permanent silence.
         repeat(2) {
-            p.recordOutcome(recovered = false)
             now += 10_000L
-            p.claim(now)
+            p.failedRepairAt(now)
         }
-        p.recordOutcome(recovered = false)
         now += 10_000L
         assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
@@ -1,0 +1,149 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The part of the frame-stall repair that decides whether a user ever sees a flicker loop.
+ *
+ * Extracted from `BrowserHandleImpl` precisely so these cases can be asserted without a live
+ * JxBrowser view, and with the clock supplied rather than read - the cooldown boundary is not
+ * testable otherwise.
+ */
+class FrameStallPolicyTest {
+    private fun policy() = FrameStallPolicy(maxIneffective = 3, cooldownMs = 10_000L)
+
+    @Test
+    fun `the first claim is granted`() {
+        assertEquals(FrameStallPolicy.Decision.REATTACH, policy().claim(0L))
+    }
+
+    @Test
+    fun `a second claim inside the cooldown is denied, and allowed on the boundary`() {
+        val p = policy()
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(1_000L))
+        assertEquals(FrameStallPolicy.Decision.COOLING_DOWN, p.claim(1_000L + 9_999L))
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(1_000L + 10_000L))
+    }
+
+    @Test
+    fun `a denied claim does not restart the cooldown`() {
+        // If a refusal moved the clock forward, a tab navigating faster than the cooldown would
+        // never be repaired again - each attempt pushing the window out ahead of itself.
+        val p = policy()
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(0L))
+        assertEquals(FrameStallPolicy.Decision.COOLING_DOWN, p.claim(9_000L))
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(10_000L))
+    }
+
+    @Test
+    fun `the cap trips after N ineffective repairs in a row and reports once`() {
+        val p = policy()
+        var now = 0L
+        repeat(3) {
+            assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now), "attempt at $now")
+            p.recordOutcome(recovered = false)
+            now += 10_000L
+        }
+        assertEquals(3, p.ineffectiveInARow)
+        // First refusal is the one the caller logs; every later one stays silent, so a tab that
+        // keeps navigating does not repeat the give-up line forever.
+        assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
+        assertEquals(FrameStallPolicy.Decision.GIVEN_UP, p.claim(now + 10_000L))
+        assertEquals(FrameStallPolicy.Decision.GIVEN_UP, p.claim(now + 100_000L))
+    }
+
+    @Test
+    fun `a repair that works resets the run, so a repeatedly-repairable tab is never abandoned`() {
+        // The regression this exists for: an earlier lifetime cap abandoned the 4th and 5th
+        // click-through on one tab while the repair was recovering the page 3 times out of 3.
+        val p = policy()
+        var now = 0L
+        repeat(10) {
+            assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now), "attempt at $now")
+            p.recordOutcome(recovered = true)
+            now += 10_000L
+        }
+        assertEquals(10, p.attempts)
+        assertEquals(0, p.ineffectiveInARow)
+    }
+
+    @Test
+    fun `two failures then a success clears the run`() {
+        val p = policy()
+        var now = 0L
+        p.claim(now)
+        p.recordOutcome(recovered = false)
+        now += 10_000L
+        p.claim(now)
+        p.recordOutcome(recovered = false)
+        assertEquals(2, p.ineffectiveInARow)
+        now += 10_000L
+        p.claim(now)
+        p.recordOutcome(recovered = true)
+        assertEquals(0, p.ineffectiveInARow)
+        // Still granted well past what would have been the cap.
+        now += 10_000L
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now))
+    }
+
+    @Test
+    fun `a healthy navigation decays the run`() {
+        // "Consecutive" must be counted against evidence the tab is broken, not against wall time:
+        // three ineffective attempts spread over hours of healthy browsing should not retire the
+        // watchdog for that tab.
+        val p = policy()
+        var now = 0L
+        repeat(2) {
+            p.claim(now)
+            p.recordOutcome(recovered = false)
+            now += 10_000L
+        }
+        assertEquals(2, p.ineffectiveInARow)
+        p.recordHealthyNavigation()
+        assertEquals(0, p.ineffectiveInARow)
+    }
+
+    @Test
+    fun `a give-up can be reported again after the tab recovers`() {
+        val p = policy()
+        var now = 0L
+        repeat(3) {
+            p.claim(now)
+            p.recordOutcome(recovered = false)
+            now += 10_000L
+        }
+        assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
+        p.recordHealthyNavigation()
+        now += 10_000L
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now))
+        // Fails three more times: the operator gets a fresh line rather than permanent silence.
+        repeat(2) {
+            p.recordOutcome(recovered = false)
+            now += 10_000L
+            p.claim(now)
+        }
+        p.recordOutcome(recovered = false)
+        now += 10_000L
+        assertEquals(FrameStallPolicy.Decision.GIVE_UP_NOW, p.claim(now))
+    }
+
+    @Test
+    fun `attempts counts only granted claims`() {
+        val p = policy()
+        p.claim(0L)
+        p.claim(1L)
+        p.claim(2L)
+        assertEquals(1, p.attempts)
+    }
+
+    @Test
+    fun `the shipped defaults are sane`() {
+        val shipped = FrameStallPolicy()
+        assertEquals(FrameStallPolicy.Decision.REATTACH, shipped.claim(0L))
+        assertEquals(FrameStallPolicy.Decision.COOLING_DOWN, shipped.claim(1L))
+        assertTrue(BrowserFrameStall.REATTACH_COOLDOWN_MS >= 1_000)
+        assertTrue(BrowserFrameStall.MAX_INEFFECTIVE_REATTACHES in 1..10)
+    }
+}


### PR DESCRIPTION
## The bug

Clicking Google's **AI Mode** tab left the browser pane blank, and it stayed blank. The landing URL is the one that tab link always builds, `...&udm=50&aep=1`. Measured on the click path: **0 of 5 navigations painted**, against **5 of 5** for the same queries without the click.

The document was never the problem. It loads completely and stays interactive - DOM complete, layout correct, `setTimeout` and `setInterval` firing, microtasks resolving, JS evaluating normally. What never happens is a frame: `requestAnimationFrame` does not fire once, and painting a fresh background colour into `body` changes nothing on screen.

## What this is not

Each eliminated by measurement, not reasoning, because the plausible suspects here are all wrong and each costs a rebuild to re-test:

- **Not raster, not Skia Graphite, not the GPU path.** It reproduces identically on a build reporting `Canvas/Compositing/Rasterization: Software only` and `Skia Graphite: Disabled`.
- **Not CSS.** Forcing every element opaque leaves the pane blank, and the nav row sitting at effective opacity 1 is as unpainted as the animated content.
- **Not filters, masks or animations.** Removing each in turn changes nothing, and a local page exercising the same SVG filters, blurs, conic-gradient masks and entry animations renders fine.
- **Not view transitions, a prerender, a render-blocking resource, or a renderer process swap.** Response headers are identical to the variant that works.

## Why re-attaching is the fix

Switching to another tab and back restores frame production immediately and permanently (0 rAF callbacks before, 850 after). Nothing about the document changes across that switch - under `HARDWARE_ACCELERATED` the surface is even retained. What changes is that the view leaves and re-enters composition, so the native view is attached again. That makes this a presentation-side stall, and re-attaching is the same repair a user already performs by hand.

## The change

After a main-frame commit a beacon is armed, and two subsequent readings that both say "no frame" re-attach the view by bumping a `key()` around `BrowserView`. The `BrowserViewState` is deliberately **not** rebuilt, because the manual repair this imitates does not rebuild it either.

Deliberately narrow, since it is a recovery for a fault inside the JxBrowser widget rather than a cure:

- only http(s) main-frame commits are watched, so `about:blank`, `chrome://` and the dashboard's empty states never arm a probe
- only under `HARDWARE_ACCELERATED`; `OFF_SCREEN` exports frames as a bitmap and has never shown this
- only while the view is actually composed, since Chromium serves no frames to a hidden one (ref-counted, so a tab dragged between windows does not silently disable it)
- a **failed** beacon read counts as "not stalled" - treating a raced or timed-out round-trip as a stall would flicker healthy pages
- the blocking `executeJavaScript` runs on a dedicated daemon thread with a bounded wait, never on the EDT
- one probe in flight at a time, so a redirect chain judges only the document that finally sticks
- rate-limited by a cooldown, and stopped after repeated re-attaches that fail to restore painting (`FrameStallPolicy`)

## Verification

Against the same click path that produced 0/5: **5/5 painted, 5 re-attaches, 5 recovered, 0 give-ups**, with the watchdog firing only on the AI Mode commits and never on the plain searches or `example.com`. Run in a dev instance built from this branch, driven over MCP, with paint state read via a rAF counter (a painting page gives roughly 420 callbacks over 3s, a blanked one exactly 0). Re-verified after each round of review changes, since timing, threading and the visibility gate all moved.

`FrameStallPolicyTest` covers the cap, the cooldown boundary, a denial not restarting the window, success resetting the run, and the give-up logging once - with the clock injected. `BrowserFrameStallTest` covers which URLs are watched and that a null reading is not a stall. Neither covers the re-attach itself, which needs a live view; the test KDoc says so.

## Known limits

- It is a recovery, not a cure. The underlying fault is inside the JxBrowser/Chromium widget and is not fixed here.
- The repair costs `ARM_DELAY_MS + 2 x READ_GAP_MS` = **2500ms minimum** before the re-attach, plus probe round-trips, so an affected page shows blank for about two and a half seconds before snapping in.
- A `key()` bump rebuilds the AWT view, so it can drop keyboard focus and IME composition state in that tab. On a genuinely blank page there is nothing to lose, which is the case this targets - but on a false positive against a page someone is typing into, the cost is more than cosmetic. That is why every gate above fails towards doing nothing.
- One extra daemon thread per handle that actually probes, alongside the context-menu one. The per-handle isolation is the point: a wedged probe must not queue behind a wedged context-menu lookup.
- Related, not fixed here: `ensureCoBrowseInjectCallback` claims the browser's single `InjectJsCallback` slot with a direct `browser.set` instead of going through `BrowserInjectDispatcher`, which is what stops this feature from arming its beacon at document start. Worth its own issue.

