### PR TITLE
Frame-stall follow-ups: cancel leak, deferred cooldown, same-document commits

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
@@ -31,6 +31,17 @@ import com.teamdev.jxbrowser.engine.RenderingMode
  * deliberately a recovery and not a cure: it detects a document that committed but never drew, and
  * performs the tab-switch repair on the user's behalf.
  *
+ * **Known limit: only a new document is covered.** The beacon is armed once per document and
+ * latches at [BEACON_PAINTED] for that document's life, so it answers "has this document ever
+ * painted", not "is it painting now". Two consequences, both deliberate. Same-document
+ * navigations (pushState, fragment) are skipped entirely at the call site, because probing one
+ * would read the flag the original load left behind and clear a legitimate ineffective run on
+ * stale evidence. And a stall that *begins* after a document has already painted is invisible -
+ * if Google ever serves the AI Mode transition client-side rather than as a fresh commit, this
+ * stops firing, silently. Catching that would need a liveness beacon (a rolling rAF timestamp
+ * compared against wall time) rather than a latch, which is a different and more expensive
+ * design than the one the measured failure called for.
+ *
  * **Known and accepted: the page can influence the verdict.** The flag lives on `window`, so a
  * page could pin it to `"0"` (forcing a re-attach per navigation, costing flicker) or to `"1"`
  * (suppressing the repair, leaving itself blank). This is the same exposure AGENTS.md already
@@ -244,6 +255,23 @@ internal class FrameStallPolicy(
                 Decision.REATTACH
             }
         }
+    }
+
+    /**
+     * How much of the cooldown is left at [nowMs], or 0 when a claim would be granted now.
+     *
+     * Exists so a stall arriving inside the cooldown can be **deferred rather than dropped**. The
+     * cooldown bounds how often the view is rebuilt; it is not a decision that a blank page stays
+     * blank. The decision point is `ARM_DELAY_MS + 2 * READ_GAP_MS` after a commit and the
+     * cooldown is four times that, so two stalling commits close together used to leave the second
+     * one blank with nothing logged - the same "no signal at all" this whole feature exists to
+     * remove, and on the page it targets, which is one people iterate on. Waiting out the
+     * remainder and claiming once respects the rate limit and still repairs the page.
+     */
+    @Synchronized
+    fun remainingCooldownMs(nowMs: Long): Long {
+        val last = lastReattachAt ?: return 0L
+        return (cooldownMs - (nowMs - last)).coerceAtLeast(0L)
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFrameStall.kt
@@ -117,8 +117,12 @@ internal object BrowserFrameStall {
     fun isStalled(beaconReading: String?): Boolean = beaconReading == BEACON_UNPAINTED
 
     /**
-     * What a post-repair reading says about the re-attach: true painting, false still blank, null
-     * unknown.
+     * What a beacon reading says: true painting, false still blank, null unknown.
+     *
+     * Used for **every** read whose answer feeds the ineffective run - the post-repair
+     * confirmation and the "did it paint unaided" reads - because all of them can be wrong in the
+     * same way. [isStalled] stays the right predicate for the narrower question of whether to
+     * touch the view at all, where an unknown must read as "leave it alone".
      *
      * **Three states, not two, and [isStalled] must not be reused here.** For the *decision* to
      * re-attach, null correctly means "leave it alone". For the *outcome*, `!isStalled(null)`
@@ -256,6 +260,44 @@ internal class FrameStallPolicy(
             }
         }
     }
+
+    /** What the caller should do about a stall it has just confirmed. */
+    sealed interface Claim {
+        /** Granted; the attempt is already recorded. */
+        object Now : Claim
+
+        /** Refused for now, but [waitMs] from now it would be granted. */
+        data class After(
+            val waitMs: Long,
+        ) : Claim
+
+        /** Refused for good. [firstRefusal] is true exactly once, for the log. */
+        data class Refused(
+            val firstRefusal: Boolean,
+        ) : Claim
+    }
+
+    /**
+     * [claim], answered in the form the caller actually needs.
+     *
+     * **One synchronized call, deliberately.** Asking `claim` and then `remainingCooldownMs`
+     * separately is two decisions about a clock that moved in between, and it conflates two
+     * different refusals: [claim] tests the give-up cap *before* the cooldown, so a retired tab
+     * refuses while `lastReattachAt` is still recent, and a caller reading the leftover cooldown
+     * would deferentially wait out a tab it has already abandoned - logging "leaving this tab
+     * alone" and "deferred until the cooldown expires" about the same decision, then possibly
+     * un-retiring it. Returning the reason with the wait makes that unrepresentable, and it
+     * removes the boundary race where the remainder reaches 0 between the two reads and a
+     * grantable repair is dropped.
+     */
+    @Synchronized
+    fun claimOrDefer(nowMs: Long): Claim =
+        when (claim(nowMs)) {
+            Decision.REATTACH -> Claim.Now
+            Decision.COOLING_DOWN -> Claim.After(remainingCooldownMs(nowMs))
+            Decision.GIVE_UP_NOW -> Claim.Refused(firstRefusal = true)
+            Decision.GIVEN_UP -> Claim.Refused(firstRefusal = false)
+        }
 
     /**
      * How much of the cooldown is left at [nowMs], or 0 when a claim would be granted now.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -611,14 +611,26 @@ internal class BrowserHandleImpl(
                     browser.mainFrame().orElse(null)?.executeJavaScript<String?>(BrowserFrameStall.BEACON_SCRIPT)
                 }.getOrNull()
             }
-        val reading = withTimeoutOrNull(BrowserFrameStall.PROBE_TIMEOUT_MS) { probe.await() }
-        // The probe is a child of the scope, not of this coroutine, so neither the timeout above
+        // The probe is a child of the scope, not of this coroutine, so neither the timeout below
         // nor a supersede cancels it. Left alone, one still queued behind a blocked probe on the
-        // single-thread executor would run later against whatever document is current by then.
-        // A queued coroutine honours this immediately; one already inside executeJavaScript is
-        // unaffected either way, which is the parked-thread cost frameProbeExecutor documents.
-        if (reading == null) probe.cancel()
-        return reading
+        // single-thread executor would run later against whatever document is current by then -
+        // arming THAT document's beacon ahead of its own ARM_DELAY_MS, so its first real reading
+        // is no longer the reading the constants describe.
+        //
+        // In a finally, not after the call. `withTimeoutOrNull` swallows only its own
+        // TimeoutCancellationException: when the enclosing job is cancelled instead - the
+        // supersede at the end of scheduleFrameStallCheck, or dispose - `probe.await()` rethrows
+        // that CancellationException and unwinds straight past any cleanup placed after it. The
+        // earlier `if (reading == null) probe.cancel()` therefore covered the timeout and missed
+        // both cancellation paths, which are the ones the paragraph above is about.
+        //
+        // A queued coroutine honours the cancel immediately; one already inside executeJavaScript
+        // is unaffected either way, which is the parked-thread cost frameProbeExecutor documents.
+        return try {
+            withTimeoutOrNull(BrowserFrameStall.PROBE_TIMEOUT_MS) { probe.await() }
+        } finally {
+            if (!probe.isCompleted) probe.cancel()
+        }
     }
 
     /**
@@ -634,9 +646,12 @@ internal class BrowserHandleImpl(
      * probing is the only way a retired tab can ever come back. Giving up means "stop re-attaching",
      * not "stop looking".
      */
-    private fun claimReattachSlot(): Boolean {
-        // Monotonic, not wall clock: an NTP step must not stretch or shorten the cooldown.
-        val decision = frameStallPolicy.claim(System.nanoTime() / 1_000_000L)
+
+    /** Monotonic, not wall clock: an NTP step must not stretch or shorten the cooldown. */
+    private fun monotonicNowMs(): Long = System.nanoTime() / 1_000_000L
+
+    private fun claimReattachSlot(): FrameStallPolicy.Decision {
+        val decision = frameStallPolicy.claim(monotonicNowMs())
         if (decision == FrameStallPolicy.Decision.GIVE_UP_NOW) {
             logger.warn(
                 LogCategory.BROWSER,
@@ -647,7 +662,57 @@ internal class BrowserHandleImpl(
                 ),
             )
         }
-        return decision == FrameStallPolicy.Decision.REATTACH
+        return decision
+    }
+
+    /**
+     * Claim a re-attach slot, waiting out the cooldown once rather than abandoning the page.
+     *
+     * A stall detected inside the cooldown used to end the job silently, so a follow-up query
+     * within about 7.5s of a repaired one sat blank with nothing in the log to explain it. The
+     * rate limit is still honoured - this waits for the remainder instead of shortening it - and
+     * only one deferral is attempted, so a tab navigating in a tight loop cannot queue them up.
+     */
+    private suspend fun claimReattachSlotWaiting(): Boolean {
+        if (claimReattachSlot() == FrameStallPolicy.Decision.REATTACH) return true
+        // A refusal with nothing left on the clock is a give-up, not a cooldown: nothing to wait
+        // out, and claimReattachSlot has already logged it.
+        val remaining = frameStallPolicy.remainingCooldownMs(monotonicNowMs())
+        return remaining > 0L && claimAfterCooldown(remaining)
+    }
+
+    /**
+     * Wait out [remainingMs] of cooldown, then re-judge and claim once.
+     *
+     * Split from its caller only to keep each side within the return-count limit; the reason it
+     * re-judges rather than claiming straight away is that the wait is long enough for the page to
+     * have started painting on its own, or for the view to be hidden or the handle disposed.
+     */
+    private suspend fun claimAfterCooldown(remainingMs: Long): Boolean {
+        logger.debug(
+            LogCategory.BROWSER,
+            "Frame-stall repair deferred until the cooldown expires",
+            mapOf("remainingMs" to remainingMs.toString()),
+        )
+        delay(remainingMs)
+        val stillWorthRepairing =
+            when {
+                !viewComposed -> {
+                    false
+                }
+
+                BrowserFrameStall.isStalled(readFrameBeacon()) -> {
+                    true
+                }
+
+                else -> {
+                    // Painted while we waited, so the tab is fine and any earlier ineffective run
+                    // should decay just as it would on any unaided paint.
+                    frameStallPolicy.recordHealthyNavigation()
+                    false
+                }
+            }
+        return stillWorthRepairing && claimReattachSlot() == FrameStallPolicy.Decision.REATTACH
     }
 
     /**
@@ -697,7 +762,7 @@ internal class BrowserHandleImpl(
                     }
                 }
 
-                if (!claimReattachSlot()) return@launch
+                if (!claimReattachSlotWaiting()) return@launch
                 // Booked as ineffective before the repair, upgraded only by an observed recovery.
                 // Everything that can end this job before the confirmation - a fresh commit
                 // superseding it, the view leaving composition, a probe that never answers - would
@@ -788,7 +853,13 @@ internal class BrowserHandleImpl(
                 // incorrectly updating the URL bar in plugins
                 if (event.isInMainFrame) {
                     val url = event.url()
-                    scheduleFrameStallCheck(url)
+                    // Same-document navigations (pushState, fragment) keep the document, and the
+                    // beacon is armed once per document and latches at painted. Probing one reads
+                    // the "1" the ORIGINAL load left behind, which is not evidence about this
+                    // navigation at all - and it reaches recordHealthyNavigation, clearing a
+                    // legitimate ineffective run on a stale reading. See BrowserFrameStall for the
+                    // mirror case this leaves open.
+                    if (!event.isSameDocument) scheduleFrameStallCheck(url)
                     navigationListeners.forEach { listener ->
                         try {
                             listener(url)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -633,26 +633,27 @@ internal class BrowserHandleImpl(
         }
     }
 
-    /**
-     * Whether a re-attach is allowed right now, and record it if so.
-     *
-     * Bounded like `EngineWedgeDetector`'s recycle: past the cap the handle degrades to the
-     * pre-existing behaviour (the user switches tabs themselves) rather than flickering forever.
-     */
-
-    /**
-     * Note that a handle which has given up still probes on every commit. That reads like waste and
-     * is not: [FrameStallPolicy.recordHealthyNavigation] is only reachable from a reading, so
-     * probing is the only way a retired tab can ever come back. Giving up means "stop re-attaching",
-     * not "stop looking".
-     */
-
     /** Monotonic, not wall clock: an NTP step must not stretch or shorten the cooldown. */
     private fun monotonicNowMs(): Long = System.nanoTime() / 1_000_000L
 
-    private fun claimReattachSlot(): FrameStallPolicy.Decision {
-        val decision = frameStallPolicy.claim(monotonicNowMs())
-        if (decision == FrameStallPolicy.Decision.GIVE_UP_NOW) {
+    /**
+     * Ask whether a re-attach is allowed, recording the attempt when it is.
+     *
+     * Answers with the *reason* rather than a boolean, because the two refusals are not
+     * interchangeable: a cooldown is worth waiting out and a give-up is not. See
+     * [FrameStallPolicy.claimOrDefer] for why deciding both in one place matters.
+     *
+     * Bounded like `EngineWedgeDetector`'s recycle: past the cap the handle degrades to the
+     * pre-existing behaviour (the user switches tabs themselves) rather than flickering forever.
+     *
+     * A handle which has given up still probes on every commit. That reads like waste and is not:
+     * [FrameStallPolicy.recordHealthyNavigation] is only reachable from a reading, so probing is
+     * the only way a retired tab can ever come back. Giving up means "stop re-attaching", not
+     * "stop looking".
+     */
+    private fun claimReattachSlot(): FrameStallPolicy.Claim {
+        val claim = frameStallPolicy.claimOrDefer(monotonicNowMs())
+        if (claim is FrameStallPolicy.Claim.Refused && claim.firstRefusal) {
             logger.warn(
                 LogCategory.BROWSER,
                 "Re-attaching stopped helping - leaving this tab alone",
@@ -662,7 +663,27 @@ internal class BrowserHandleImpl(
                 ),
             )
         }
-        return decision
+        return claim
+    }
+
+    /**
+     * Record a page that painted without help, and say so if this tab had been given up on.
+     *
+     * Shared by the decision loop and the deferred retry so the revival line cannot go missing on
+     * one of them - a log that says a tab was abandoned and never says it came back is the exact
+     * asymmetry the line exists to prevent.
+     */
+    private fun notePaintedUnaided() {
+        // Read before the reset, since the reset is what clears it.
+        val wasRetired = frameStallPolicy.hasGivenUp
+        frameStallPolicy.recordHealthyNavigation()
+        if (wasRetired) {
+            logger.info(
+                LogCategory.BROWSER,
+                "Tab painted unaided - frame-stall watchdog active again",
+                mapOf("attemptsTotal" to frameStallPolicy.attempts.toString()),
+            )
+        }
     }
 
     /**
@@ -672,47 +693,56 @@ internal class BrowserHandleImpl(
      * within about 7.5s of a repaired one sat blank with nothing in the log to explain it. The
      * rate limit is still honoured - this waits for the remainder instead of shortening it - and
      * only one deferral is attempted, so a tab navigating in a tight loop cannot queue them up.
-     */
-    private suspend fun claimReattachSlotWaiting(): Boolean {
-        if (claimReattachSlot() == FrameStallPolicy.Decision.REATTACH) return true
-        // A refusal with nothing left on the clock is a give-up, not a cooldown: nothing to wait
-        // out, and claimReattachSlot has already logged it.
-        val remaining = frameStallPolicy.remainingCooldownMs(monotonicNowMs())
-        return remaining > 0L && claimAfterCooldown(remaining)
-    }
-
-    /**
-     * Wait out [remainingMs] of cooldown, then re-judge and claim once.
      *
-     * Split from its caller only to keep each side within the return-count limit; the reason it
-     * re-judges rather than claiming straight away is that the wait is long enough for the page to
-     * have started painting on its own, or for the view to be hidden or the handle disposed.
+     * Deferring costs the user the wait: worst case the page stays blank for the 2500ms decision
+     * plus the remaining cooldown, so up to about 12.5s before it snaps in. That is the deliberate
+     * price of not rebuilding the view more often than the rate limit allows.
+     *
+     * Only a cooldown is waited out. A give-up is refused immediately, which is what keeps a
+     * retired tab from being deferred and then silently un-retired by the re-judge below.
      */
+    private suspend fun claimReattachSlotWaiting(): Boolean =
+        when (val claim = claimReattachSlot()) {
+            is FrameStallPolicy.Claim.Now -> true
+            is FrameStallPolicy.Claim.After -> claimAfterCooldown(claim.waitMs)
+            is FrameStallPolicy.Claim.Refused -> false
+        }
+
     private suspend fun claimAfterCooldown(remainingMs: Long): Boolean {
-        logger.debug(
+        // INFO, not DEBUG: the default level is INFO, so a DEBUG line here would leave a page
+        // blank for up to another 10s with nothing in a shipped log to say why - the same silence
+        // this change set out to remove.
+        logger.info(
             LogCategory.BROWSER,
             "Frame-stall repair deferred until the cooldown expires",
             mapOf("remainingMs" to remainingMs.toString()),
         )
         delay(remainingMs)
+        // Re-judged rather than claimed blind: the wait is long enough for the page to have
+        // started painting on its own, or for the view to be hidden or the handle disposed.
+        //
+        // Tri-state, because isStalled(null) is false and an unanswered probe would otherwise be
+        // credited as "painted while we waited" - clearing the ineffective run in exactly the
+        // wedged-renderer case the cap exists for, and doing it on the population most likely to
+        // stop answering, since this path is only reached for a tab already known stalled.
+        if (!viewComposed) return false
         val stillWorthRepairing =
-            when {
-                !viewComposed -> {
-                    false
-                }
-
-                BrowserFrameStall.isStalled(readFrameBeacon()) -> {
+            when (BrowserFrameStall.repairOutcome(readFrameBeacon())) {
+                false -> {
                     true
                 }
 
-                else -> {
-                    // Painted while we waited, so the tab is fine and any earlier ineffective run
-                    // should decay just as it would on any unaided paint.
-                    frameStallPolicy.recordHealthyNavigation()
+                true -> {
+                    notePaintedUnaided()
+                    false
+                }
+
+                // Unknown: no evidence either way, so leave the ineffective run untouched.
+                null -> {
                     false
                 }
             }
-        return stillWorthRepairing && claimReattachSlot() == FrameStallPolicy.Decision.REATTACH
+        return stillWorthRepairing && claimReattachSlot() is FrameStallPolicy.Claim.Now
     }
 
     /**
@@ -743,22 +773,27 @@ internal class BrowserHandleImpl(
                 repeat(2) {
                     delay(BrowserFrameStall.READ_GAP_MS)
                     if (!viewComposed) return@launch
-                    if (!BrowserFrameStall.isStalled(readFrameBeacon())) {
-                        // Painted unaided, so this tab is evidently fine - let that decay any
-                        // earlier ineffective attempts rather than holding them against it.
-                        // Read before the reset, since the reset is what clears it.
-                        val wasRetired = frameStallPolicy.hasGivenUp
-                        frameStallPolicy.recordHealthyNavigation()
-                        if (wasRetired) {
-                            // The counterpart to the give-up line, so a log that says a tab was
-                            // abandoned also says when it came back.
-                            logger.info(
-                                LogCategory.BROWSER,
-                                "Tab painted unaided - frame-stall watchdog active again",
-                                mapOf("attemptsTotal" to frameStallPolicy.attempts.toString()),
-                            )
+                    // Tri-state, not isStalled: that reads null as "not stalled", so an
+                    // unanswered probe would be credited as a page painting unaided and would
+                    // clear a legitimate ineffective run on no evidence at all.
+                    when (BrowserFrameStall.repairOutcome(readFrameBeacon())) {
+                        true -> {
+                            // Painted unaided, so this tab is evidently fine - let that decay any
+                            // earlier ineffective attempts rather than holding them against it.
+                            notePaintedUnaided()
+                            return@launch
                         }
-                        return@launch
+
+                        // Unknown: not evidence of a stall, and not evidence of health either, so
+                        // stop without touching the run.
+                        null -> {
+                            return@launch
+                        }
+
+                        // Still blank; keep going and take the second reading.
+                        false -> {
+                            Unit
+                        }
                     }
                 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
@@ -164,6 +164,40 @@ class FrameStallPolicyTest {
     }
 
     @Test
+    fun `remaining cooldown counts down and reaches zero on the boundary`() {
+        // Drives the deferred retry: a stall found inside the cooldown waits exactly this long
+        // rather than being dropped, so the number has to be the real remainder - too short and
+        // the re-claim is refused again, too long and the page stays blank past the rate limit.
+        val p = policy()
+        assertEquals(0L, p.remainingCooldownMs(0L), "nothing claimed yet, so nothing to wait for")
+        p.claim(1_000L)
+        assertEquals(10_000L, p.remainingCooldownMs(1_000L))
+        assertEquals(1L, p.remainingCooldownMs(10_999L))
+        assertEquals(0L, p.remainingCooldownMs(11_000L))
+    }
+
+    @Test
+    fun `remaining cooldown never goes negative`() {
+        // The caller delays by this value; a negative would throw rather than proceed.
+        val p = policy()
+        p.claim(0L)
+        assertEquals(0L, p.remainingCooldownMs(60_000L))
+    }
+
+    @Test
+    fun `waiting out the remaining cooldown makes the next claim succeed`() {
+        // The deferred-retry contract, end to end on the policy: refused now, granted after
+        // exactly remainingCooldownMs has passed.
+        val p = policy()
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(0L))
+        val now = 3_000L
+        assertEquals(FrameStallPolicy.Decision.COOLING_DOWN, p.claim(now))
+        val wait = p.remainingCooldownMs(now)
+        assertEquals(7_000L, wait)
+        assertEquals(FrameStallPolicy.Decision.REATTACH, p.claim(now + wait))
+    }
+
+    @Test
     fun `attempts counts only granted claims`() {
         val p = policy()
         p.claim(0L)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FrameStallPolicyTest.kt
@@ -198,6 +198,44 @@ class FrameStallPolicyTest {
     }
 
     @Test
+    fun `claimOrDefer grants, defers a cooldown, and refuses a give-up`() {
+        val p = policy()
+        assertEquals(FrameStallPolicy.Claim.Now, p.claimOrDefer(0L))
+        assertEquals(FrameStallPolicy.Claim.After(7_000L), p.claimOrDefer(3_000L))
+        assertEquals(FrameStallPolicy.Claim.Now, p.claimOrDefer(10_000L))
+    }
+
+    @Test
+    fun `a tab that has given up is refused outright, never deferred`() {
+        // The bug this exists for: claim() tests the cap BEFORE the cooldown, so a retired tab
+        // refuses while lastReattachAt is still recent. A caller that asked for the decision and
+        // the leftover cooldown separately would wait out a tab it had just abandoned - logging
+        // "leaving this tab alone" and "deferred until the cooldown expires" about the same
+        // decision, and then possibly un-retiring it when the re-judge found it painting.
+        val p = policy()
+        var now = 0L
+        repeat(3) {
+            assertEquals(FrameStallPolicy.Claim.Now, p.claimOrDefer(now))
+            p.recordAttemptPending()
+            now += 10_000L
+        }
+        // Retired, and only 2.5s since the last re-attach - so there IS cooldown left to read.
+        val soonAfter = now - 7_500L
+        assertTrue(p.remainingCooldownMs(soonAfter) > 0, "precondition: cooldown time remains")
+        assertEquals(FrameStallPolicy.Claim.Refused(firstRefusal = true), p.claimOrDefer(soonAfter))
+        assertEquals(FrameStallPolicy.Claim.Refused(firstRefusal = false), p.claimOrDefer(soonAfter + 1))
+    }
+
+    @Test
+    fun `the deferred wait is exactly what makes the next claim succeed`() {
+        val p = policy()
+        assertEquals(FrameStallPolicy.Claim.Now, p.claimOrDefer(0L))
+        val deferred = p.claimOrDefer(4_000L)
+        assertTrue(deferred is FrameStallPolicy.Claim.After)
+        assertEquals(FrameStallPolicy.Claim.Now, p.claimOrDefer(4_000L + deferred.waitMs))
+    }
+
+    @Test
     fun `attempts counts only granted claims`() {
         val p = policy()
         p.claim(0L)


### PR DESCRIPTION
Follow-up to #183. The last review round landed three findings after that PR had already merged; this closes them.

## 1. The probe cancel only covered the timeout path - the one case its comment did not claim

`withTimeoutOrNull` swallows only its own `TimeoutCancellationException`. When the **enclosing** job was cancelled instead - the supersede at the end of `scheduleFrameStallCheck`, or `dispose` - `probe.await()` rethrew that `CancellationException` and unwound straight past the `if (reading == null) probe.cancel()` that followed it. Those two cancellation paths are exactly what the comment above it described, so the guard covered the case it was not written for and missed the two it was.

Concretely: commit A arms a probe that blocks on the single-thread executor, commit B supersedes A's job, and A's probe later runs against B's document - arming B's beacon ahead of B's own `ARM_DELAY_MS`, so B's first real reading is no longer the reading the constants describe.

Moved into a `finally`, which covers the timeout case too, so the separate `if` goes away.

## 2. A stall inside the cooldown was left blank and unlogged

The decision point is `ARM_DELAY_MS + 2 * READ_GAP_MS` = 2500ms after a commit; the cooldown is 10s. Two stalling commits less than about 7.5s apart left the second unrepaired, and the job simply returned - `claimReattachSlot` logged only `GIVE_UP_NOW`, never `COOLING_DOWN`. AI Mode is a page people iterate on, so a follow-up query within that window put the user back in the original bug with nothing in the log to explain it, which is the same "no signal at all" state this feature exists to remove.

`FrameStallPolicy.remainingCooldownMs` now lets the job wait out the remainder and claim once. That honours the rate limit rather than shortening it, and only one deferral is attempted so a tab navigating in a tight loop cannot queue them up. It re-judges after the wait rather than claiming blind, since by then the page may have started painting on its own, or the view may be hidden or the handle disposed.

## 3. Same-document navigations are no longer probed

The beacon arms once per document and latches at painted, so probing a `pushState` or fragment navigation read the `"1"` the **original** load left behind. That is not evidence about that navigation, and it reached `recordHealthyNavigation()` and cleared a legitimate ineffective run on a stale reading. `NavigationFinished.isSameDocument` exists, so this is a one-line gate rather than a caveat.

What the gate leaves open is now written down rather than implied: **a stall that begins after a document has already painted is invisible**, so if Google ever serves the AI Mode transition client-side this stops firing, silently. Catching that needs a liveness beacon (a rolling rAF timestamp compared against wall time) rather than a latch, which is a different and more expensive design than the measured failure called for.

## Verification

Both paths, live, against a dev build of this branch:

- **Ordinary click path**: 5/5 painted, 5 re-attaches, 5 confirmed painting, 0 ineffective, 0 give-ups.
- **The new deferral**, observed in the log rather than inferred: first repair at `23:00:42.320`; the second stall decided at `23:00:49.257` and logged `Frame-stall repair deferred until the cooldown expires {remainingMs=3063}`; re-attach at `23:00:52.322`, which is the decision plus exactly that 3.063s and also first-repair plus 10.0s - the cooldown boundary. Page painting afterwards. Under the previous code that claim would have been refused and the page left blank.

  Correcting an earlier claim in this PR: my first attempt to verify this measured only the spacing between two re-attaches and called it proof. It was not - the gap was my test script's own pacing, and the deferral was never entered. It only fires when the second decision point lands inside the cooldown, which needs the two commits closer together than that test had them.

Three new unit tests cover `remainingCooldownMs`: the countdown and its zero boundary, the negative clamp (the caller `delay`s on this value), and the end-to-end refused-then-granted contract the deferral depends on.

`ktlintCheck` and `detekt` pass.

