### PR TITLE
Home screen follow-ups: recent files deleted on an absent volume, and three silent failures

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -730,13 +730,6 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                 }
             }.launchIn(this)
 
-        // Handle plugin activation events
-        DashboardEventBus.activatePluginEvents
-            .filter { event -> event.sourceWindowId == windowId }
-            .onEach { event ->
-                state.draggablePanelComponent.activatePlugin(event.pluginId)
-            }.launchIn(this)
-
         // Handle settings window events from the home screen.
         DashboardEventBus.showSettingsEvents
             .filter { event -> event.sourceWindowId == windowId }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/DashboardEventBus.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/DashboardEventBus.kt
@@ -42,11 +42,6 @@ data class DashboardApplySplitTemplateEvent(
     val sourceWindowId: String,
 )
 
-data class DashboardActivatePluginEvent(
-    val pluginId: String,
-    val sourceWindowId: String,
-)
-
 /**
  * Open a tab by the [ai.rever.boss.plugin.api.TabTypeId] a plugin registered it under.
  *
@@ -141,10 +136,6 @@ object DashboardEventBus {
     private val _applySplitTemplateEvents = MutableSharedFlow<DashboardApplySplitTemplateEvent>(extraBufferCapacity = 10)
     val applySplitTemplateEvents: SharedFlow<DashboardApplySplitTemplateEvent> = _applySplitTemplateEvents.asSharedFlow()
 
-    // Plugin activation
-    private val _activatePluginEvents = MutableSharedFlow<DashboardActivatePluginEvent>(extraBufferCapacity = 10)
-    val activatePluginEvents: SharedFlow<DashboardActivatePluginEvent> = _activatePluginEvents.asSharedFlow()
-
     // Open a plugin-registered tab type by id
     private val _openTabTypeEvents = MutableSharedFlow<DashboardOpenTabTypeEvent>(extraBufferCapacity = 10)
     val openTabTypeEvents: SharedFlow<DashboardOpenTabTypeEvent> = _openTabTypeEvents.asSharedFlow()
@@ -213,15 +204,6 @@ object DashboardEventBus {
         val event = DashboardApplySplitTemplateEvent(template, sourceWindowId)
         _applySplitTemplateEvents.emit(event)
         ipcBridge?.forward("DashboardApplySplitTemplateEvent", event, sourceWindowId)
-    }
-
-    suspend fun activatePlugin(
-        pluginId: String,
-        sourceWindowId: String,
-    ) {
-        val event = DashboardActivatePluginEvent(pluginId, sourceWindowId)
-        _activatePluginEvents.emit(event)
-        ipcBridge?.forward("DashboardActivatePluginEvent", event, sourceWindowId)
     }
 
     suspend fun openTabType(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeToolCatalog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeToolCatalog.kt
@@ -50,7 +50,6 @@ data class HomePanelInput(
 data class HomeStorePluginInput(
     val pluginId: String,
     val displayName: String,
-    val version: String,
     /**
      * `plugins.icon_url`, passed through verbatim.
      *

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -321,6 +321,20 @@ class DynamicPluginManager(
         /** Whether any live manager has [pluginId] loaded. */
         fun isPluginKnown(pluginId: String): Boolean = activeManagers().any { it.getPluginInfo(pluginId) != null }
 
+        /**
+         * Any manager that is still live, for a **process-wide** caller that must not capture one
+         * window's.
+         *
+         * Exists for `HomeCatalogAccess`: its store installer is registered once for the process
+         * but loads a jar into a manager, and capturing the first window's meant that closing that
+         * window left every other window's Install tile targeting a disposed manager - the install
+         * would report success having loaded into something nothing renders. Resolving here at
+         * install time keeps it pointed at something alive.
+         *
+         * Null in a headless or fully torn-down process, where there is nothing to install into.
+         */
+        fun anyActiveManager(): DynamicPluginManager? = activeManagers().firstOrNull()
+
         /** Where [pluginId] was loaded from, per the first live manager that knows it. */
         fun jarPathOf(pluginId: String): String? =
             activeManagers()
@@ -2146,6 +2160,14 @@ class DynamicPluginManager(
                 closeTabsAcrossWindows = closeTabsAcrossWindows,
             )
         }
+
+        // Deregister before cancelling, so nothing can pick this manager as a live one after it
+        // has unloaded everything. Previously this relied on the WeakReference being collected,
+        // which leaves a disposed manager in `activeManagers()` for an unbounded time - and its
+        // callers all assume "live": `isPluginKnown` and `jarPathOf` would answer from it, the api
+        // hot swap would try to reload into it, and a process-wide holder that resolves a manager
+        // lazily (HomeCatalogAccess's installer) would hand it an install that lands nowhere.
+        liveManagers.removeIf { it.get() === this || it.get() == null }
 
         // Cancel scope
         managerScope.cancel()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentBrowserPagesManager.kt
@@ -442,7 +442,10 @@ object RecentBrowserPagesManager {
         if (key in promoKeys) {
             _dismissedSuggestions.update { it + key }
         }
-        scheduleSave()
+        // Immediately, not debounced: this is a user-initiated dismissal, and losing it to a quit
+        // within the 5s window means the card returns and they dismiss it again. `removeMatchingPages`
+        // already reasons about exactly this.
+        scope.launch { saveImmediately() }
     }
 
     /**
@@ -500,6 +503,16 @@ object RecentBrowserPagesManager {
     /**
      * Clear all recent pages.
      */
+
+    /**
+     * Empty the strip: forget the recorded pages and dismiss every suggested site.
+     *
+     * **Permanent, and worth knowing.** The dismissals persist, so after one Clear the Recent pages
+     * section stays empty until a real page is recorded, and there is no UI to bring the suggestions
+     * back short of editing `~/.boss/recent-browser-pages.json`. That is the reading of "Clear" this
+     * chooses deliberately - the alternative left seventeen undismissable promo cards behind - but it
+     * is a property, not an accident.
+     */
     fun clearAll() {
         _recentPages.value = emptyList()
         // Dismiss the padding suggestions too, so "Clear" clears the strip the user is looking
@@ -509,7 +522,7 @@ object RecentBrowserPagesManager {
         // Unioned, not replaced: `removePage` also records real pages it dismissed, and
         // overwriting the set would discard those and let them return as padding later.
         _dismissedSuggestions.update { it + promoKeys }
-        scheduleSave()
+        scope.launch { saveImmediately() }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentFilesManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/dashboard/RecentFilesManager.kt
@@ -60,8 +60,32 @@ object RecentFilesManager {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var saveJob: Job? = null
 
+    /**
+     * Every recorded file, including ones not currently on disk. **This is what is persisted.**
+     *
+     * Split from [recentFiles] because the displayed list is filtered by `File.exists()`, and that
+     * is false for an unmounted volume or a disconnected share - normal at login, which is when
+     * the prune runs. Persisting the filtered list would turn "not here right now" into permanent
+     * loss: the first `recordFileOpen` after launch calls `scheduleSave()`, which serialises
+     * whatever this manager holds, so hiding and saving cannot be the same list.
+     */
+    private val _allFiles = MutableStateFlow<List<RecentFile>>(emptyList())
+
     private val _recentFiles = MutableStateFlow<List<RecentFile>>(emptyList())
+
+    /** The displayed list: [_allFiles] minus anything not on disk right now. */
     val recentFiles: StateFlow<List<RecentFile>> = _recentFiles.asStateFlow()
+
+    /**
+     * Replace the recorded list and re-derive the displayed one.
+     *
+     * Every mutation goes through here so the two can never drift - the defect being avoided is a
+     * caller updating the display and the save then writing the display back.
+     */
+    private fun setFiles(files: List<RecentFile>) {
+        _allFiles.value = files
+        _recentFiles.value = visibleFiles(files) { fileExists(it) }
+    }
 
     init {
         scope.launch {
@@ -80,18 +104,12 @@ object RecentFilesManager {
                 if (settingsFile.exists()) {
                     val content = settingsFile.readText()
                     val data = json.decodeFromString<RecentFilesData>(content)
-                    // Hide files that are no longer on disk, so a deleted or moved one stops
-                    // opening as an empty editor - fileExists existed for exactly this and had
-                    // no callers. Already on Dispatchers.IO, so the stat calls belong here.
-                    //
-                    // **Filtered in memory, deliberately not persisted.** `File.exists()` is also
-                    // false for an unmounted volume, a disconnected share, or a container mount
-                    // that has not come up yet - all normal at login, which is exactly when this
-                    // runs. Writing the pruned list back would turn "not here right now" into
-                    // permanent loss. The entry stays in the file and reappears when the mount
-                    // does; the only cost is re-checking on the next launch.
-                    val present = data.files.filter { fileExists(it.path) }
-                    _recentFiles.value = present
+                    // Hidden, not pruned: a file that is not on disk stops being offered (it
+                    // would open an empty editor - fileExists existed for exactly this and had no
+                    // callers) but stays in the recorded list, so an unmounted volume coming back
+                    // brings its entries with it. See _allFiles.
+                    setFiles(data.files)
+                    val present = _recentFiles.value
                     recentFilesLogger.debug(
                         LogCategory.FILE,
                         "Loaded recent files",
@@ -123,7 +141,8 @@ object RecentFilesManager {
         withContext(Dispatchers.IO) {
             try {
                 settingsFile.parentFile?.mkdirs()
-                val data = RecentFilesData(files = _recentFiles.value)
+                // The recorded list, never the filtered view; see _allFiles.
+                val data = RecentFilesData(files = _allFiles.value)
                 val content = json.encodeToString(RecentFilesData.serializer(), data)
                 settingsFile.writeText(content)
             } catch (e: Exception) {
@@ -154,12 +173,14 @@ object RecentFilesManager {
                 )
 
             // Remove existing entry for this path and add to front
-            val currentFiles = _recentFiles.value.toMutableList()
+            // Over the recorded list, not the displayed one, so opening a file does not drop
+            // entries that are merely on an absent volume.
+            val currentFiles = _allFiles.value.toMutableList()
             currentFiles.removeAll { it.path == filePath }
             currentFiles.add(0, newFile)
 
             // Trim to max size
-            _recentFiles.value = currentFiles.take(MAX_FILES)
+            setFiles(currentFiles.take(MAX_FILES))
             scheduleSave()
         }
     }
@@ -169,7 +190,7 @@ object RecentFilesManager {
      */
     fun removeFile(filePath: String) {
         scope.launch {
-            _recentFiles.value = _recentFiles.value.filter { it.path != filePath }
+            setFiles(_allFiles.value.filter { it.path != filePath })
             scheduleSave()
         }
     }
@@ -179,7 +200,7 @@ object RecentFilesManager {
      */
     fun clearAll() {
         scope.launch {
-            _recentFiles.value = emptyList()
+            setFiles(emptyList())
             scheduleSave()
         }
     }
@@ -189,3 +210,17 @@ object RecentFilesManager {
      */
     fun fileExists(filePath: String): Boolean = File(filePath).exists()
 }
+
+/**
+ * The displayed subset of [all]: entries whose file is present according to [exists].
+ *
+ * Pure and separate so the hide-versus-prune rule is testable without driving the singleton's file
+ * I/O. The other half of that rule - that the **recorded** list is what gets persisted - is
+ * structural rather than tested: `saveImmediately` serialises `_allFiles`, and `setFiles` is the
+ * only writer of either flow. If a future change makes `saveImmediately` read `_recentFiles`, an
+ * absent volume becomes permanent deletion again and nothing here will catch it.
+ */
+internal fun visibleFiles(
+    all: List<RecentFile>,
+    exists: (path: String) -> Boolean,
+): List<RecentFile> = all.filter { exists(it.path) }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/home/PluginIconLoader.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/home/PluginIconLoader.desktop.kt
@@ -12,6 +12,7 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -21,6 +22,11 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.imageio.ImageIO
 
 private val logger = BossLogger.forComponent("PluginIconLoader")
+
+/** A cache entry, so a *resolved absence* can be stored - ConcurrentHashMap rejects null values. */
+private class CachedIcon(
+    val painter: Painter?,
+)
 
 /**
  * Fetches and decodes plugin store icons. Shape follows `HighQualityFaviconService`.
@@ -57,10 +63,12 @@ private object PluginIcons {
      * eviction and invalidation for an icon that can change server-side at any time. A miss costs
      * one small request.
      *
-     * The value is nullable-wrapped so a *failure* is cached too - otherwise every recomposition
-     * would retry an unreachable host.
+     * Keyed on the URL with a **nullable** painter as the value, so a failure caches too -
+     * otherwise every recomposition would retry an unreachable host. `ConcurrentHashMap` cannot
+     * store a null value, hence `Optional`-style wrapping via a one-element holder rather than a
+     * `Result`, which only ever held `success` and read as though failures were `failure`.
      */
-    private val cache = ConcurrentHashMap<String, Result<Painter?>>()
+    private val cache = ConcurrentHashMap<String, CachedIcon>()
 
     private val fetchSemaphore = Semaphore(MAX_CONCURRENT_FETCHES)
 
@@ -82,10 +90,20 @@ private object PluginIcons {
         // The common case: `icon_url` is blank for every row in the store today, so this returns
         // before touching the network and the tile renders the plugin's initials.
         if (iconUrl.isBlank()) return null
-        cache[iconUrl]?.let { return it.getOrNull() }
+        cache[iconUrl]?.let { return it.painter }
+
+        val attempt = runCatching { fetch(iconUrl) }
+
+        // Cancellation is not a fetch failure, and must not be cached as one. `fetch` suspends, so
+        // runCatching also catches CancellationException - and the LaunchedEffect that calls this
+        // is cancelled routinely, whenever a tile leaves composition on a filter change or a
+        // reflow. Absorbing it here would write a permanent "no icon" for a perfectly reachable
+        // URL, so a scroll could lose an icon for the rest of the session. It also breaks
+        // structured concurrency: the cancellation has to reach the caller.
+        attempt.exceptionOrNull()?.let { if (it is CancellationException) throw it }
 
         val painter =
-            runCatching { fetch(iconUrl) }
+            attempt
                 .onFailure { error ->
                     logger.debug(
                         LogCategory.NETWORK,
@@ -96,7 +114,7 @@ private object PluginIcons {
 
         // Cached either way, including null: a plugin whose icon 404s must not be re-requested on
         // every recomposition of the grid.
-        cache[iconUrl] = Result.success(painter)
+        cache[iconUrl] = CachedIcon(painter)
         return painter
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -50,10 +50,17 @@ actual object PluginLoaderDelegateSetup {
         // the other process-wide wiring rather than from `PluginLoaderDelegateImpl`'s constructor,
         // where a process-global set up as a side effect of constructing an object was easy to
         // miss. First-wins is enforced inside `initialize`, matching the `== null` guards below.
+        //
+        // The installer resolves a manager per install rather than capturing this window's.
+        // `register` runs per window, so capturing would mean closing that one window left every
+        // other window's Install tile loading into a disposed manager - reporting success having
+        // put the plugin somewhere nothing renders.
         HomeCatalogAccess.initialize(
             StoreHomeCatalogProvider(
                 repository = { PluginStoreSetup.remoteRepository },
-                installer = MissingDependencyReporter.installerFor(dynamicPluginManager),
+                installer = {
+                    DynamicPluginManager.anyActiveManager()?.let { MissingDependencyReporter.installerFor(it) }
+                },
             ),
         )
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreHomeCatalogProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreHomeCatalogProvider.kt
@@ -10,6 +10,7 @@ import ai.rever.boss.plugin.updater.satisfiesVersionFloor
 import ai.rever.boss.utils.AppVersion
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CancellationException
 
 /**
  * Answers the home screen's two store questions: what could be installed, and install it.
@@ -26,12 +27,16 @@ import ai.rever.boss.utils.logging.LogCategory
  *
  * @param repository the remote store, null when it never initialised (offline first run, or
  *   absent store credentials) - discovery is then simply empty
- * @param installer the shared store installer, reached through its interface so this class does
- *   not also own how a jar lands on disk
+ * @param installer resolves the shared store installer **per call**, not once at construction.
+ *   Late-bound because the installer loads a jar into a `DynamicPluginManager`, there is one per
+ *   window, and this provider is registered once for the process: capturing the first window's
+ *   meant that closing that window left every Install tile targeting a disposed manager, where the
+ *   install reports success having loaded into something nothing renders. Null when no manager is
+ *   live, which is the honest answer in a torn-down process.
  */
 class StoreHomeCatalogProvider(
     private val repository: () -> PluginRepository?,
-    private val installer: MissingDependencyInstaller,
+    private val installer: () -> MissingDependencyInstaller?,
     private val hostBossVersion: () -> String = { AppVersion.currentVersionString() },
     private val hostApiVersion: () -> String = { System.getProperty("boss.api.version") ?: "" },
     private val isIpcInstallable: (String) -> Boolean = { IpcCompatibility.isInstallable(it) },
@@ -72,6 +77,12 @@ class StoreHomeCatalogProvider(
 
         val store = repository() ?: return emptyList()
         val listing = runCatching { store.listPlugins().getOrThrow() }
+        // Cancellation is not a store failure. This runs in a LaunchedEffect that is cancelled
+        // whenever the screen leaves composition, and `runCatching` around a suspending call also
+        // catches CancellationException - so without this a routine cancellation is logged as the
+        // store having failed, which is misleading in a support log, and swallowing it breaks
+        // structured concurrency.
+        listing.exceptionOrNull()?.let { if (it is CancellationException) throw it }
         listing.exceptionOrNull()?.let { error ->
             logger.warn(
                 LogCategory.SYSTEM,
@@ -90,13 +101,18 @@ class StoreHomeCatalogProvider(
             .also { cached = it }
     }
 
-    override suspend fun install(pluginId: String): Result<Unit> = installer.install(pluginId)
+    override suspend fun install(pluginId: String): Result<Unit> {
+        val target =
+            installer() ?: return Result.failure(
+                IllegalStateException("No window is available to install into. Try again in a moment."),
+            )
+        return target.install(pluginId)
+    }
 
     private fun toInput(row: PluginInfo): HomeStorePluginInput =
         HomeStorePluginInput(
             pluginId = row.pluginId,
             displayName = row.displayName,
-            version = row.version,
             // Straight through from `plugins.icon_url`. The host holds no icon table for
             // not-yet-installed plugins: this column is the source, and a blank one renders as the
             // plugin's initials. Populating the column is all it takes for real icons to appear -

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/HomeToolCatalogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/HomeToolCatalogTest.kt
@@ -48,7 +48,6 @@ class HomeToolCatalogTest {
     ) = HomeStorePluginInput(
         pluginId = pluginId,
         displayName = displayName,
-        version = "1.0.0",
         iconUrl = iconUrl,
         requiresAdmin = requiresAdmin,
         isCompatible = compatible,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/dashboard/RecentFileVisibilityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/dashboard/RecentFileVisibilityTest.kt
@@ -1,0 +1,66 @@
+package ai.rever.boss.dashboard
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A recent file that is not on disk right now is **hidden, not forgotten**.
+ *
+ * Two bugs in sequence made this worth pinning. First, nothing filtered at all, so a deleted file
+ * stayed on the home screen and opened an empty editor. Then the fix pruned the list and persisted
+ * it - and `File.exists()` is false for an unmounted volume or a disconnected share, which is normal
+ * at login, exactly when the load runs. So recent files on a network share were permanently deleted
+ * by the act of opening one local file, while the KDoc claimed the opposite.
+ *
+ * The recorded list and the displayed list are now separate, and only the recorded one is written.
+ */
+class RecentFileVisibilityTest {
+    private fun file(path: String) = RecentFile(path = path, name = path.substringAfterLast('/'), lastOpened = 0L)
+
+    private val onDisk = file("/local/present.kt")
+    private val absent = file("/Volumes/share/away.kt")
+
+    @Test
+    fun `an absent file is hidden from the displayed list`() {
+        val visible = visibleFiles(listOf(onDisk, absent)) { it == onDisk.path }
+
+        assertEquals(listOf(onDisk), visible)
+    }
+
+    @Test
+    fun `hiding does not remove the entry from the list it was given`() {
+        // The recorded list is the input and is untouched: this is what gets persisted, so an entry
+        // on an absent volume survives to reappear when the volume returns.
+        val all = listOf(onDisk, absent)
+
+        visibleFiles(all) { it == onDisk.path }
+
+        assertTrue(absent in all, "visibleFiles must not mutate or drop from the recorded list")
+        assertEquals(2, all.size)
+    }
+
+    @Test
+    fun `everything present means nothing hidden`() {
+        val all = listOf(onDisk, absent)
+
+        assertEquals(all, visibleFiles(all) { true })
+    }
+
+    @Test
+    fun `nothing present means an empty display over an intact record`() {
+        val all = listOf(onDisk, absent)
+
+        assertTrue(visibleFiles(all) { false }.isEmpty())
+        assertEquals(2, all.size)
+    }
+
+    @Test
+    fun `order is preserved, since the list is ordered by recency`() {
+        val a = file("/a.kt")
+        val b = file("/b.kt")
+        val c = file("/c.kt")
+
+        assertEquals(listOf(a, c), visibleFiles(listOf(a, b, c)) { it != b.path })
+    }
+}


### PR DESCRIPTION
Follow-ups to #185, which merged at `d32af913` while the third review round was still being addressed. These are the fixes from that round; the first one is data loss and is live in `main` now.

## `RecentFilesManager` deletes recent files on an absent volume

#185 filtered files that are not on disk out of the displayed list, so a deleted file stops opening an empty editor, and carried a comment promising the filter was memory-only:

> **Filtered in memory, deliberately not persisted.** [...] The entry stays in the file and reappears when the mount does.

It does not. `saveImmediately` serialises whatever `_recentFiles` holds, and `recordFileOpen` / `removeFile` / `clearAll` all call `scheduleSave()`. So the first file opened after launch rewrites `recent-files.json` from the filtered list.

`File.exists()` is false for an unmounted volume, a disconnected share, or a container mount that has not come up yet - all normal at login, which is exactly when the load runs. **Failure:** recent files include three paths on a network share, the share is not mounted at login, the user opens one local file, the three entries are permanently gone.

Recorded and displayed are now separate flows. `_allFiles` is what gets persisted, `recentFiles` is `visibleFiles(_allFiles)`, and `setFiles` is the only writer of either. `visibleFiles` is pure and tested.

## The store installer captured one window's plugin manager

`PluginLoaderDelegateSetup.register` runs per window and `HomeCatalogAccess` keeps the first provider, whose installer closed over that window's `DynamicPluginManager`. Closing that window calls `disposeWindow()`, which unloads every plugin and cancels the manager's scope - so every other window's Install tile then loaded into a dead manager and reported success having put the plugin where nothing renders. The KDoc anticipated the multi-window case but not the closed-window one, which is worse.

The installer now resolves per install via `DynamicPluginManager.anyActiveManager()`.

**That needed one adjacent fix worth reviewing on its own merits:** `dispose` cancelled the manager but never removed it from `liveManagers`, relying on the `WeakReference` being collected, so a disposed manager stayed in `activeManagers()` for an unbounded time. Every existing caller assumes "live" - `isPluginKnown` and `jarPathOf` would answer from it, and the api hot swap would try to reload into it. Deregistering on dispose is a fix beyond this feature.

## `runCatching` around suspending work swallowed cancellation, then cached it

`PluginIconLoader.load` cached its result either way, and `fetch` suspends, so `runCatching` also caught `CancellationException`. The `LaunchedEffect` behind a tile is cancelled routinely - a filter change, a reflow, a remount - and each one wrote a permanent "no icon" for a perfectly reachable URL, so a scroll could lose an icon for the session. It also broke structured concurrency.

Cancellation is rethrown before anything is cached. The same shape in `StoreHomeCatalogProvider.discoverable` no longer logs a cancelled fetch as a store failure.

## `DashboardEventBus.activatePlugin` was a dead emitter

#185 deleted `onActivatePlugin` from the screen, leaving the flow, the emit function and the handler with nothing calling them - the same "flow nothing reaches" state that PR set out to remove, one layer along. No IPC consumer either, so all three are deleted.

## Smaller

- `HomeStorePluginInput.version` became unread when `Install.version` went. Dropped, since its neighbour's KDoc calls exactly that the dead-field pattern.
- `PluginIcons.cache` was typed `Result<Painter?>` but only ever stored `Result.success`, reading as though failures were `failure`. A small holder says what it means: `ConcurrentHashMap` cannot store null, and wrapping an absence was all it was for.
- Dismissals save immediately rather than through the 5s debounce, so a dismissal followed by a quit is not lost. `removeMatchingPages` already reasoned about this for the same shape of action.
- `clearAll`'s permanence is stated in its KDoc as a property rather than implied. It is deliberate - the alternative left seventeen undismissable promo cards - but "no way back short of editing the json" should be written down.

## Verification

Cherry-picked onto the merged `main` (`644dff01`) and applied with no conflicts. `./gradlew build` (all modules, all tests), `ktlintCheck` and `detekt` all pass on that base.

`RecentFileVisibilityTest` covers the hide-versus-prune rule and names both bugs in sequence. It also says plainly which half is **not** tested: that the recorded list is what gets persisted is structural - `saveImmediately` reads `_allFiles` and `setFiles` is the only writer - so if a future change points `saveImmediately` at `_recentFiles`, an absent volume becomes permanent deletion again and no test will catch it.

## Not done here, with reasons

- **`newWindow()` does not carry the current project.** Parity with the card it replaces; changing it is a behaviour decision, not a fix.
- **Accessibility labelling** of the new tiles and chips matches surrounding house style. Worth one pass over the app rather than piecemeal here.
- **`HomeActionRoutingTest` reads a source file by relative path** to assert every bus flow has a handler. A tripwire, not a contract: it depends on Gradle's default working directory and would pass on a commented-out handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
