### PR TITLE
fix(crash): publish contained reports atomically

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashHandler.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
 import ai.rever.boss.plugin.sandbox.ui.PluginRecoveryQuarantine
 import ai.rever.boss.utils.AppVersion
+import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
@@ -110,10 +111,17 @@ object CrashHandler {
     @Volatile
     internal var containedReportDirOverride: File? = null
 
+    /** Pauses a test after the temp file is complete but before it is published. */
+    @Volatile
+    internal var beforeContainedReportPublishForTest: ((temp: File, target: File) -> Unit)? = null
+
     private fun containedReportDir(): File = containedReportDirOverride ?: BossDirectories.resolve(CONTAINED_REPORT_DIR)
 
     /** Lets a test start from a clean dedupe. */
-    internal fun resetContainedStateForTest() = containedSignatures.clear()
+    internal fun resetContainedStateForTest() {
+        containedSignatures.clear()
+        beforeContainedReportPublishForTest = null
+    }
 
     /**
      * Single thread for writing contained reports.
@@ -375,30 +383,40 @@ object CrashHandler {
             .substringBefore('-')
             .toLongOrNull() ?: 0L
 
-    /**
-     * Create [file] owner-only and *then* write [text] into it.
-     *
-     * `writeText` creates at the umask — typically 0644 — and fills the file before
-     * any chmod can run, so tightening afterwards leaves a window in which the
-     * whole report is world-readable at a predictable path. The permissions have to
-     * be attached at creation instead. Falls back to create-then-restrict where
-     * POSIX attributes are unavailable.
-     */
+    /** Write [text] owner-only, then atomically publish it at [file]. */
     private fun writeOwnerOnly(
         file: File,
         text: String,
     ) {
+        val temp = createOwnerOnlyTempFile(file)
+        try {
+            temp.writeText(text)
+            beforeContainedReportPublishForTest?.invoke(temp, file)
+            file.atomicMoveFrom(temp)
+        } finally {
+            // No-op after a successful move; removes a partial temp file on failure.
+            temp.delete()
+        }
+    }
+
+    /** Create a unique owner-only temp file beside [target], so its move can be atomic. */
+    private fun createOwnerOnlyTempFile(target: File): File {
         val createdWithPerms =
             runCatching {
                 java.nio.file.Files
-                    .deleteIfExists(file.toPath())
-                java.nio.file.Files
-                    .createFile(file.toPath(), posixAttribute("rw-------"))
-            }.isSuccess
-        file.writeText(text)
-        // Only needed where creation could not carry the permissions; that path keeps
-        // the narrow exposure window, and is best effort by nature.
-        if (!createdWithPerms) restrictToOwner(file, directory = false)
+                    .createTempFile(
+                        target.parentFile.toPath(),
+                        ".${target.name}.",
+                        ".tmp",
+                        posixAttribute("rw-------"),
+                    ).toFile()
+            }.getOrNull()
+        if (createdWithPerms != null) return createdWithPerms
+
+        // Non-POSIX filesystem: restrict the temp before any report content is written.
+        return File.createTempFile(".${target.name}.", ".tmp", target.parentFile).also {
+            restrictToOwner(it, directory = false)
+        }
     }
 
     private fun posixAttribute(mode: String) =

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/ContainedCrashReportTest.kt
@@ -2,6 +2,8 @@ package ai.rever.boss.crash
 
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -48,7 +50,10 @@ class ContainedCrashReportTest {
         dir.deleteRecursively()
     }
 
-    private fun reports(): List<File> = dir.listFiles()?.toList().orEmpty()
+    private fun reports(): List<File> =
+        dir.listFiles { file -> file.name.startsWith("contained-") && file.name.endsWith(".txt") }?.toList().orEmpty()
+
+    private fun tempFiles(): List<File> = dir.listFiles { file -> file.name.endsWith(".tmp") }?.toList().orEmpty()
 
     /**
      * A fault with a signature of its own.
@@ -77,6 +82,34 @@ class ContainedCrashReportTest {
         assertTrue(text.contains("contained render fault"), "the file should say what it is")
         assertTrue(text.contains("plugin:"), "pluginId is the most useful field on this path")
         assertTrue(text.contains("contained-report-test write"), "the original message should survive")
+    }
+
+    @Test
+    fun `a contained report is published only after its content is complete`() {
+        val readyToPublish = CountDownLatch(1)
+        val allowPublish = CountDownLatch(1)
+        CrashHandler.beforeContainedReportPublishForTest = { _, _ ->
+            readyToPublish.countDown()
+            check(allowPublish.await(5, TimeUnit.SECONDS)) { "timed out waiting to publish the report" }
+        }
+
+        CrashHandler.recordContained(uniqueThrowable("atomic-publish"))
+        try {
+            assertTrue(readyToPublish.await(5, TimeUnit.SECONDS), "the writer never reached the publish point")
+            assertTrue(reports().isEmpty(), "the final report must not be visible before the atomic move")
+
+            val temp = tempFiles().single()
+            assertTrue(
+                temp.readText().contains("contained-report-test atomic-publish"),
+                "the temp file must be complete",
+            )
+        } finally {
+            allowPublish.countDown()
+        }
+
+        awaitFiles(1)
+        assertTrue(reports().single().readText().contains("contained-report-test atomic-publish"))
+        assertTrue(tempFiles().isEmpty(), "the temp file must be removed after publication")
     }
 
     @Test


### PR DESCRIPTION
# Pull Request

## Description

Write contained crash reports to an owner-only sibling temporary file and publish them with an atomic replacement only after the content is complete. This prevents readers from observing a partially written report at the final path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding missing tests or correcting existing tests)

## Version Impact

- [x] No version change needed

## Testing Checklist

### Local Testing

- [x] I have tested this change locally on my development machine
- [ ] All existing tests pass with my changes
- [x] I have added a deterministic regression test
- [x] I have verified the fix works as intended

### Platform Testing

- [ ] macOS
- [x] Windows
- [ ] Linux

### Build Verification

- [x] The affected desktop sources and tests compile successfully
- [x] No new build warnings introduced
- [ ] Distribution packages can be created successfully

## Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] The non-obvious test synchronization is documented
- [x] My changes generate no new warnings or errors

## CI/CD Integration

- [x] This PR will trigger the appropriate CI/CD workflows
- [x] I understand that all status checks must pass before merging
- [x] No version-management changes are required

## Screenshots/Media

Not applicable. This change has no UI impact.

## Related Issues

Fixes #105

## Additional Context

### Motivation and Context

The report was previously created at its final path and filled in place. Even with owner-only permissions, another reader could observe incomplete content while the write was in progress.

### Implementation Details

- Create a unique temporary file in the report directory.
- Apply owner-only permissions before writing report content.
- Reuse `atomicMoveFrom` to replace the final path after the write completes.
- Remove temporary files on failure.
- Add a latch-controlled test that pauses immediately before publication and verifies the final path is absent, the temporary content is complete, and no temporary file remains after publication.

### Breaking Changes

None.

### Future Considerations

Cross-platform CI will exercise the POSIX and Windows permission paths.

## Review Focus Areas

- [x] Logic and Algorithm
- [x] Security
- [x] Platform Compatibility

## Pre-merge Checklist

- [x] Code has been rebased on latest main branch
- [x] Commit message is clear and descriptive
- [x] PR title accurately describes the change
- [x] Ready for review

## Verification

- `:composeApp:desktopTest --tests ai.rever.boss.crash.ContainedCrashReportTest`
- `:composeApp:desktopTest --tests ai.rever.boss.utils.AtomicFileWriteTest`
- `:composeApp:ktlintCheck`
- `:composeApp:detekt`
- `git diff --check`
