### PR TITLE
Domain verification: make it work, make the record copyable, and adopt a domain's users

### DIFF
--- a/supabase/functions/organisation/routes/admin-page.ts
+++ b/supabase/functions/organisation/routes/admin-page.ts
@@ -35,6 +35,7 @@ const RESULT_MESSAGES: Record<string, string> = {
   domain_verified: "Domain verified.",
   domain_primary: "Primary domain updated.",
   domain_unverified: "The TXT record was not found. DNS changes can take a few minutes.",
+  domain_users_added: "Members added. Everyone with an address at that domain is now in the organisation.",
 }
 
 // invite_created and dns_failed were removed as unreachable: the invite handler renders its

--- a/supabase/functions/organisation/routes/admin-page.ts
+++ b/supabase/functions/organisation/routes/admin-page.ts
@@ -12,6 +12,8 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import { loadAdminPageData } from "../services/org.ts"
 import { htmlResponse } from "../utils/responses.ts"
 import { requireOrgAdmin, requireOrgSession } from "./guards.ts"
+import { consumeHandoffToken } from "./handoff-exchange.ts"
+import { isValidSlug, readRequestFacts } from "../utils/request.ts"
 import { adminPage } from "../views/admin.ts"
 import { errorPage, NOT_AVAILABLE_MESSAGE } from "../views/error.ts"
 
@@ -50,6 +52,26 @@ const ERROR_MESSAGES: Record<string, string> = {
 }
 
 adminPageRoutes.get("/o/:slug/admin", async (ctx) => {
+  // BEFORE the session guard, because on this path there IS no session yet. The desktop panel's
+  // Configure button opens this URL with a freshly minted `?t=` handoff token and nothing else;
+  // until now only /o/:slug consumed one, so this route fell straight through to
+  // requireOrgSession, found no cookie and answered "Session expired". Configure therefore never
+  // worked from a cold start - only after Open page had already left a cookie behind.
+  //
+  // The slug is validated here rather than trusted, because it is about to be built into a
+  // Location header. requireOrgSession would have checked it, but it does not run first any more.
+  const slug = ctx.req.param("slug") ?? ""
+  if (isValidSlug(slug)) {
+    const facts = await readRequestFacts(ctx)
+    const exchanged = await consumeHandoffToken(
+      ctx,
+      facts,
+      slug,
+      `/o/${encodeURIComponent(slug)}/admin`,
+    )
+    if (exchanged) return exchanged
+  }
+
   const sessionGuard = await requireOrgSession(ctx)
   if (!sessionGuard.ok) return sessionGuard.response
 

--- a/supabase/functions/organisation/routes/domains.ts
+++ b/supabase/functions/organisation/routes/domains.ts
@@ -175,6 +175,53 @@ domainRoutes.post("/o/:slug/admin/domains/verify", async (ctx) => {
 })
 
 /**
+ * Adopt every existing account at a verified domain.
+ *
+ * The one action here that adds people who did not ask to be added, so it is the
+ * one worth reading twice. Its authority is the DNS proof plus org-admin: the
+ * same proof the self-service path already trusts to let a matching user skip
+ * the queue, used in the opposite direction.
+ *
+ * VERIFIED IS CHECKED HERE AS WELL AS IN THE RPC, and not as ceremony. Rule 1
+ * already loaded the row, so refusing an unverified one costs nothing and turns
+ * what would be a generic refusal into a state the page can explain. The RPC
+ * re-checks because it is reachable by `authenticated` directly.
+ *
+ * No DNS probe and no rate limit of its own: nothing here leaves our
+ * infrastructure, and the general per-client limiter in `prepare` already
+ * covers a form-submission flood. The expensive part is a single scan of
+ * auth.users for one domain, inside a row lock the RPC takes.
+ */
+domainRoutes.post("/o/:slug/admin/domains/add-users", async (ctx) => {
+  const prep = await prepare(ctx)
+  if (!prep.ok) return prep.response
+  const { session, facts, body } = prep.value
+
+  const domainId = uuidField(body, "domain_id")
+  if (!domainId) return redirectTo(facts, session.slug, { err: "invalid_input" })
+
+  // RULE 1: the row has to be one of this organisation's own.
+  const owned = await findOwnedDomain(session.sub, session.org, domainId)
+  if (!owned || !owned.verified) {
+    return redirectTo(facts, session.slug, { err: "rejected" })
+  }
+
+  const result = await callForActor("add_domain_users_to_organisation", session.sub, {
+    p_domain_id: domainId,
+  })
+
+  // The count is deliberately NOT carried into the banner. RESULT_MESSAGES is a
+  // fixed vocabulary so that nothing caller-controlled can render, and the page
+  // that follows this redirect already answers "how many" better than a number
+  // in a URL would: the roster is longer and the button's own count has dropped.
+  return redirectTo(
+    facts,
+    session.slug,
+    result.ok ? { ok: "domain_users_added" } : { err: "rejected" },
+  )
+})
+
+/**
  * The domain row, but only if it belongs to the session's organisation.
  *
  * Implemented by listing this org's domains and matching the id, rather than

--- a/supabase/functions/organisation/routes/domains.ts
+++ b/supabase/functions/organisation/routes/domains.ts
@@ -20,7 +20,7 @@
  */
 
 import { OpenAPIHono } from "@hono/zod-openapi"
-import { callForActor } from "../utils/org-rpc.ts"
+import { callForActor, callRpc } from "../utils/org-rpc.ts"
 import { listDomains, type OrgDomain } from "../services/org.ts"
 import { isValidHostname, verifyDomainToken } from "../services/dns.ts"
 import { clientKey, rateLimit } from "../utils/rate-limit.ts"
@@ -154,8 +154,17 @@ domainRoutes.post("/o/:slug/admin/domains/verify", async (ctx) => {
     return redirectTo(facts, session.slug, { ok: "domain_unverified" })
   }
 
-  const result = await callForActor("mark_organisation_domain_verified", session.sub, {
+  // callRpc, NOT callForActor. This is the one domain RPC that takes no `p_actor_id`: it is
+  // service_role-only by design (there is no client-callable path that sets verified = true), and
+  // it names its second parameter `p_verified_by`. callForActor appends `p_actor_id` to every
+  // call, and PostgREST resolves a function by its ARGUMENT NAMES - so that call named a function
+  // signature the database does not have, failed to resolve, and returned "The change was
+  // refused" every single time a DNS check succeeded. Domain verification has never completed.
+  //
+  // It is also what should fill verified_by, which was never being set.
+  const result = await callRpc("mark_organisation_domain_verified", {
     p_domain_id: domainId,
+    p_verified_by: session.sub,
   })
 
   return redirectTo(

--- a/supabase/functions/organisation/routes/handoff-exchange.ts
+++ b/supabase/functions/organisation/routes/handoff-exchange.ts
@@ -1,0 +1,133 @@
+/**
+ * The `?t=` handoff exchange, shared by every page the desktop app can open directly.
+ *
+ * EXTRACTED BECAUSE IT WAS ONLY ON ONE ROUTE. The desktop panel has two buttons: Open page,
+ * which opens `/o/<slug>?t=<token>`, and Configure, which opens `/o/<slug>/admin?t=<token>`.
+ * Only `/o/:slug` ever looked at `t`. The admin route went straight to requireOrgSession, found
+ * no cookie, and answered "Session expired" - so Configure never worked from a cold start, while
+ * Open page followed by the in-page Configure link did, because the first navigation had left a
+ * cookie behind. The fix has to live in one place or the next page to be linked directly will
+ * reintroduce it.
+ *
+ * THE ORDER IS THE SECURITY PROPERTY, and it is unchanged from the original:
+ *
+ *   1. refuse a cross-site navigation (login CSRF)
+ *   2. rate limit the exchange (a brake on token guessing)
+ *   3. consume the token, service-role, single use
+ *   4. cross-check the token's org against the slug in the path
+ *   5. Set-Cookie
+ *   6. 302 to the same URL WITHOUT `t`
+ *
+ * Step 6 is a 302 rather than a 303 on purpose. Both work for a GET, but 302 replaces the current
+ * navigation, so the `?t=` URL leaves the address bar AND the history entry. The token must not
+ * survive a back button.
+ */
+
+import type { Context } from "hono"
+import { exchangeHandoffToken, urlWithoutToken } from "../services/handoff.ts"
+import { htmlResponse, redirectResponse } from "../utils/responses.ts"
+import { mintSession, newCsrfToken, sessionCookieHeader } from "../utils/session.ts"
+import type { RequestFacts } from "../utils/request.ts"
+import { clientKey, rateLimit } from "../utils/rate-limit.ts"
+import { errorPage, SESSION_EXPIRED_MESSAGE } from "../views/error.ts"
+
+/** 20 exchanges per minute per client. Generous for a human, useless for a loop. */
+const HANDOFF_LIMIT = 20
+const HANDOFF_WINDOW_SECONDS = 60
+
+/**
+ * Consume a `?t=` token if there is one, and return the response that should be sent.
+ *
+ * Returns `null` when there is NO token, which means the caller carries on to its normal
+ * session-and-authority path. Anything non-null is final: either an error page or the 302 that
+ * drops the token and carries the cookie.
+ *
+ * [route] is the path to come back to, WITHOUT the base path and without the token - so
+ * `/o/acme` or `/o/acme/admin`. It is built by the caller from its own already-validated slug,
+ * never from the request URL: taking a redirect target from the query string is how this would
+ * become an open redirect, and taking it from the raw path would let a crafted URL echo itself
+ * into a Location header.
+ */
+export async function consumeHandoffToken(
+  ctx: Context,
+  facts: RequestFacts,
+  slug: string,
+  route: string,
+): Promise<Response | null> {
+  const search = new URL(ctx.req.url).searchParams
+  const token = search.get("t")
+  if (!token) return null
+
+  // A state-changing GET, and the one request that does not follow the session -> CSRF -> probe
+  // order the rest of this function keeps to. Consuming a token and issuing Set-Cookie means any
+  // page could navigate a victim to /o/<slug>?t=<attacker token> and replace their org session
+  // with the attacker's identity - login CSRF. The attacker gains nothing, but the victim can be
+  // induced to type into a settings form belonging to somebody else's organisation.
+  //
+  // Sec-Fetch-Site is not settable by page script. The desktop app opens this as a top-level
+  // navigation from a boss:// link, which yields `none`, so refusing only `cross-site` costs the
+  // real flow nothing.
+  if (ctx.req.header("sec-fetch-site") === "cross-site") {
+    return htmlResponse(
+      (nonce) =>
+        errorPage({
+          nonce,
+          title: "Session unavailable - BOSS",
+          heading: "Open this from BOSS",
+          message: SESSION_EXPIRED_MESSAGE,
+        }),
+      { status: 400 },
+    )
+  }
+
+  const limit = rateLimit(
+    `handoff:${clientKey(ctx.req.raw.headers)}`,
+    HANDOFF_LIMIT,
+    HANDOFF_WINDOW_SECONDS,
+  )
+  if (!limit.allowed) {
+    return htmlResponse(
+      (nonce) =>
+        errorPage({
+          nonce,
+          title: "Too many attempts - BOSS",
+          heading: "Too many attempts",
+          message: "Please wait a moment and open the page again from BOSS.",
+        }),
+      { status: 429, headers: { "Retry-After": String(limit.retryAfterSeconds) } },
+    )
+  }
+
+  const exchange = await exchangeHandoffToken(token, slug)
+  if (!exchange.ok) {
+    // Both failure reasons render the same page. A distinguishable slug_mismatch would confirm
+    // that a guessed token is real and tell the holder which org it belongs to.
+    return htmlResponse(
+      (nonce) =>
+        errorPage({
+          nonce,
+          title: "Session unavailable - BOSS",
+          heading: "This link has expired",
+          message: SESSION_EXPIRED_MESSAGE,
+        }),
+      { status: 400 },
+    )
+  }
+
+  const value = await mintSession({
+    sub: exchange.identity.userId,
+    org: exchange.identity.orgId,
+    slug: exchange.identity.orgSlug,
+    csrf: newCsrfToken(),
+    pur: exchange.identity.purpose,
+  })
+
+  // Rebuilt from the configured base path, so the token cannot survive in the Location by way of
+  // an echoed request URL.
+  const location = urlWithoutToken(facts.basePath, route, search)
+
+  return redirectResponse(location, {
+    status: 302,
+    headers: { "Set-Cookie": sessionCookieHeader(value, facts.secure, facts.basePath) },
+  })
+}

--- a/supabase/functions/organisation/routes/org-page.ts
+++ b/supabase/functions/organisation/routes/org-page.ts
@@ -17,19 +17,13 @@
  */
 
 import { OpenAPIHono } from "@hono/zod-openapi"
-import { exchangeHandoffToken, urlWithoutToken } from "../services/handoff.ts"
+import { consumeHandoffToken } from "./handoff-exchange.ts"
 import { isOrgMember } from "../services/authority.ts"
 import { loadOrgPageData } from "../services/org.ts"
-import { htmlResponse, redirectResponse } from "../utils/responses.ts"
-import { mintSession, newCsrfToken, sessionCookieHeader } from "../utils/session.ts"
+import { htmlResponse } from "../utils/responses.ts"
 import { isValidSlug, readRequestFacts } from "../utils/request.ts"
-import { clientKey, rateLimit } from "../utils/rate-limit.ts"
 import { errorPage, NOT_AVAILABLE_MESSAGE, SESSION_EXPIRED_MESSAGE } from "../views/error.ts"
 import { orgPage } from "../views/org.ts"
-
-/** 20 exchanges per minute per client. Generous for a human, useless for a loop. */
-const HANDOFF_LIMIT = 20
-const HANDOFF_WINDOW_SECONDS = 60
 
 export const orgPageRoutes = new OpenAPIHono()
 
@@ -41,88 +35,10 @@ orgPageRoutes.get("/o/:slug", async (ctx) => {
     return notAvailable()
   }
 
-  const token = new URL(ctx.req.url).searchParams.get("t")
-
-  if (token) {
-    // A state-changing GET, and the one request that does not follow the
-    // session -> CSRF -> probe order the rest of this function keeps to. Consuming a
-    // token and issuing Set-Cookie means any page could navigate a victim to
-    // /o/<slug>?t=<attacker token> and replace their org session with the attacker's
-    // identity - login CSRF. The attacker gains nothing, but the victim can be induced
-    // to type into a settings form belonging to somebody else's organisation.
-    //
-    // Sec-Fetch-Site is not settable by page script. The desktop app opens this as a
-    // top-level navigation from a boss:// link, which yields `none`, so refusing only
-    // `cross-site` costs the real flow nothing.
-    if (ctx.req.header("sec-fetch-site") === "cross-site") {
-      return htmlResponse(
-        (nonce) =>
-          errorPage({
-            nonce,
-            title: "Session unavailable - BOSS",
-            heading: "Open this from BOSS",
-            message: SESSION_EXPIRED_MESSAGE,
-          }),
-        { status: 400 },
-      )
-    }
-
-    const limit = rateLimit(
-      `handoff:${clientKey(ctx.req.raw.headers)}`,
-      HANDOFF_LIMIT,
-      HANDOFF_WINDOW_SECONDS,
-    )
-    if (!limit.allowed) {
-      return htmlResponse(
-        (nonce) =>
-          errorPage({
-            nonce,
-            title: "Too many attempts - BOSS",
-            heading: "Too many attempts",
-            message: "Please wait a moment and open the page again from BOSS.",
-          }),
-        { status: 429, headers: { "Retry-After": String(limit.retryAfterSeconds) } },
-      )
-    }
-
-    const exchange = await exchangeHandoffToken(token, slug)
-    if (!exchange.ok) {
-      // Both failure reasons render the same page. A distinguishable
-      // slug_mismatch would confirm that a guessed token is real and tell the
-      // holder which org it belongs to.
-      return htmlResponse(
-        (nonce) =>
-          errorPage({
-            nonce,
-            title: "Session unavailable - BOSS",
-            heading: "This link has expired",
-            message: SESSION_EXPIRED_MESSAGE,
-          }),
-        { status: 400 },
-      )
-    }
-
-    const value = await mintSession({
-      sub: exchange.identity.userId,
-      org: exchange.identity.orgId,
-      slug: exchange.identity.orgSlug,
-      csrf: newCsrfToken(),
-      pur: exchange.identity.purpose,
-    })
-
-    // The redirect target is rebuilt from the configured base path, so the
-    // token cannot survive in the Location by way of an echoed request URL.
-    const location = urlWithoutToken(
-      facts.basePath,
-      `/o/${encodeURIComponent(slug)}`,
-      new URL(ctx.req.url).searchParams,
-    )
-
-    return redirectResponse(location, {
-      status: 302,
-      headers: { "Set-Cookie": sessionCookieHeader(value, facts.secure, facts.basePath) },
-    })
-  }
+  // The token exchange is shared with the admin page, which the desktop panel also opens
+  // directly. See routes/handoff-exchange.ts for why it cannot live here.
+  const exchanged = await consumeHandoffToken(ctx, facts, slug, `/o/${encodeURIComponent(slug)}`)
+  if (exchanged) return exchanged
 
   const session = facts.session
   if (!session) {

--- a/supabase/functions/organisation/services/org.ts
+++ b/supabase/functions/organisation/services/org.ts
@@ -66,6 +66,13 @@ export interface OrgDomain {
   dns_record_type: string
   dns_record_name: string
   dns_record_value: string
+  /**
+   * Confirmed accounts at this domain that are not yet members.
+   *
+   * Always 0 for an unverified row: the RPC does not compute it there, because an
+   * unverified claim can never be actioned and the count scans auth.users for a domain match.
+   */
+  addable_user_count: number
 }
 
 export interface OrgInvite {

--- a/supabase/functions/organisation/tests/admin-handoff.test.ts
+++ b/supabase/functions/organisation/tests/admin-handoff.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The admin page's own handoff exchange.
+ *
+ * The desktop panel has two buttons. Open page opens `/o/<slug>?t=<token>`; Configure opens
+ * `/o/<slug>/admin?t=<token>`. Only the first route ever consumed a token, so Configure fell
+ * through to requireOrgSession, found no cookie and answered "Session expired". It only appeared
+ * to work if you pressed Open page first, because that navigation had already left a cookie.
+ *
+ * Every assertion here fails against that version. The suite had 179 passing tests while the
+ * button was broken, because nothing exercised a token on this route.
+ */
+
+import { assert, assertEquals } from "@std/assert"
+import { app } from "../app.ts"
+import { resetRateLimits } from "../utils/rate-limit.ts"
+import {
+  orgDetailResponse,
+  type RpcStub,
+  restoreServiceClient,
+  stubServiceClient,
+  withTestEnv,
+} from "./helpers/mocks.ts"
+
+const BASE = "/organisation"
+const SLUG = "acme"
+const USER_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const ORG_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+function setup(): { stub: RpcStub; restore: () => void } {
+  const restoreEnv = withTestEnv()
+  resetRateLimits()
+  const stub = stubServiceClient()
+  stub.responses.set("user_is_org_admin", true)
+  stub.responses.set("user_is_org_member", true)
+  stub.responses.set("get_organisation_detail", orgDetailResponse())
+  for (
+    const fn of [
+      "list_organisation_members",
+      "list_organisation_roles",
+      "list_organisation_domains",
+      "list_organisation_invites",
+    ]
+  ) {
+    stub.responses.set(fn, { success: true, data: [] })
+  }
+  return {
+    stub,
+    restore: () => {
+      restoreServiceClient()
+      restoreEnv()
+    },
+  }
+}
+
+function validToken(stub: RpcStub, purpose = "org_admin"): void {
+  stub.responses.set("consume_organisation_handoff_token", {
+    success: true,
+    user_id: USER_ID,
+    org_id: ORG_ID,
+    org_slug: SLUG,
+    purpose,
+    email: "admin@example.com",
+  })
+}
+
+Deno.test("Configure works from a cold start: the admin route consumes its own token", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+
+    // No cookie at all. This is exactly what the desktop panel produces.
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=super-secret-token`)
+
+    assertEquals(response.status, 302)
+    const setCookie = response.headers.get("set-cookie") ?? ""
+    assert(setCookie.startsWith("boss_org="), `no session cookie minted: ${setCookie}`)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("it returns to the ADMIN page, not to the org page", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=tok`)
+
+    // The redirect target is built from the route's own path. Sending the operator to /o/acme
+    // would "work" - a cookie would exist - but Configure would land on the member overview and
+    // they would have to find the link again, which is the bug with extra steps.
+    assertEquals(
+      response.headers.get("location") ?? "",
+      "/functions/v1/organisation/o/acme/admin",
+    )
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("the token does not survive into the Location or the cookie", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=super-secret-token`)
+
+    const location = response.headers.get("location") ?? ""
+    const setCookie = response.headers.get("set-cookie") ?? ""
+    assertEquals(location.includes("super-secret-token"), false)
+    assertEquals(setCookie.includes("super-secret-token"), false)
+    // 302 rather than 303 so the ?t= URL leaves the history entry too.
+    assertEquals(response.status, 302)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("other query parameters survive the exchange, only t is dropped", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+    // A banner key must reach the page it was redirected to. Dropping the whole query string
+    // would silently swallow every ?ok= and ?err= that arrived alongside a token.
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=tok&ok=domain_verified`)
+    const location = response.headers.get("location") ?? ""
+    assertEquals(location, "/functions/v1/organisation/o/acme/admin?ok=domain_verified")
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("a cross-site navigation carrying a token is refused", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+    const headers = new Headers()
+    headers.set("sec-fetch-site", "cross-site")
+
+    // Login CSRF: any page could otherwise navigate a victim here with an attacker's token and
+    // replace their org session. The guard has to be on this route too, not only on /o/:slug.
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=tok`, { headers })
+    assertEquals(response.status, 400)
+    assertEquals(response.headers.get("set-cookie"), null)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("an invalid token renders the expired page, not a session-expired one", async () => {
+  const { stub, restore } = setup()
+  try {
+    stub.responses.set("consume_organisation_handoff_token", { success: false })
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=tok`)
+    assertEquals(response.status, 400)
+    assertEquals(response.headers.get("set-cookie"), null)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("a token for another organisation cannot open this admin page", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+    stub.responses.set("consume_organisation_handoff_token", {
+      success: true,
+      user_id: USER_ID,
+      org_id: ORG_ID,
+      org_slug: "someone-else",
+      purpose: "org_admin",
+      email: "admin@example.com",
+    })
+    const response = await app.request(`${BASE}/o/${SLUG}/admin?t=tok`)
+    // The slug in the path is cross-checked against the token's org, and both failure modes
+    // render identically so a guessed token is not confirmed as real.
+    assertEquals(response.status, 400)
+    assertEquals(response.headers.get("set-cookie"), null)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("with no token and no cookie the answer is still Session expired", async () => {
+  const { restore } = setup()
+  try {
+    // The fix must not have turned the unauthenticated case into something else. This is what a
+    // stale bookmark hits, and it should still say to open the page from BOSS.
+    const response = await app.request(`${BASE}/o/${SLUG}/admin`)
+    assertEquals(response.status, 401)
+  } finally {
+    restore()
+  }
+})
+
+Deno.test("a malformed slug is refused before anything is built into a Location", async () => {
+  const { stub, restore } = setup()
+  try {
+    validToken(stub)
+    // isValidSlug runs before the exchange precisely because the slug becomes a redirect target.
+    const response = await app.request(`${BASE}/o/Not%20A%20Slug/admin?t=tok`)
+    assert(
+      response.status === 401 || response.status === 404,
+      `expected a refusal, got ${response.status}`,
+    )
+    assertEquals(response.headers.get("set-cookie"), null)
+  } finally {
+    restore()
+  }
+})

--- a/supabase/functions/organisation/tests/dns-copy.test.ts
+++ b/supabase/functions/organisation/tests/dns-copy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The copyable DNS record.
+ *
+ * The point of the feature is that a person can put the record into a registrar without retyping
+ * it, so the assertions are about the two things that would silently defeat that: the value being
+ * split across the wrong elements, and the script that does the copying being blocked or absent.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert"
+import { adminPage } from "../views/admin.ts"
+import { layout } from "../views/layout.ts"
+import type { OrgDetail, OrgDomain } from "../services/org.ts"
+
+const NONCE = "test-nonce-value"
+
+const org: OrgDetail = {
+  id: "11111111-1111-4111-8111-111111111111",
+  slug: "acme",
+  name: "Acme",
+  description: null,
+  website: null,
+  visibility: "private",
+  join_policy: "invite_only",
+  is_system: false,
+  owner_email: "owner@acme.example",
+  member_count: 1,
+  pending_count: 0,
+  primary_domain: null,
+  is_owner: true,
+  is_admin: true,
+  can_publish: true,
+  publish_policy: "owner_only",
+  publish_role_id: null,
+  publish_role_name: null,
+  auto_assign_member_role: false,
+} as unknown as OrgDetail
+
+function domain(overrides: Partial<OrgDomain> = {}): OrgDomain {
+  return {
+    domain_id: "d1",
+    domain: "acme.example",
+    is_primary: false,
+    verified: false,
+    verified_at: null,
+    dns_record_type: "TXT",
+    dns_record_name: "_boss-verify.acme.example",
+    dns_record_value: "boss-org-verification=abc123",
+    ...overrides,
+  } as OrgDomain
+}
+
+function render(domains: OrgDomain[]): string {
+  return adminPage({
+    nonce: NONCE,
+    basePath: "/functions/v1/organisation",
+    csrf: "csrf-token",
+    org,
+    members: [],
+    roles: [],
+    domains,
+    invites: [],
+  })
+}
+
+Deno.test("the name and the value are separately copyable", () => {
+  const html = render([domain()])
+
+  // Separate buttons, because every registrar asks for host and value in different inputs. One
+  // button carrying "name TXT value" would be the same unusable blob as the old plain span.
+  assertStringIncludes(html, `data-copy="_boss-verify.acme.example"`)
+  assertStringIncludes(html, `data-copy="boss-org-verification=abc123"`)
+})
+
+Deno.test("the copy button carries the value in the attribute, not only as text", () => {
+  const html = render([domain()])
+  // What gets copied must be the record, not what happens to be painted: the cell wraps long
+  // values, and a future truncation would otherwise start handing out broken TXT records.
+  const button = html.match(/<button[^>]*data-copy="boss-org-verification=abc123"[^>]*>/)
+  assert(button, "no copy button for the record value")
+  assertStringIncludes(button[0], `type="button"`)
+})
+
+Deno.test("copy buttons cannot submit the forms they sit beside", () => {
+  const html = render([domain()])
+  // The domains table holds POST forms for verify, primary and remove. A button defaulting to
+  // submit would put "remove this domain" one stray Enter away from a copy control.
+  for (const match of html.matchAll(/<button[^>]*data-copy=[^>]*>/g)) {
+    assertStringIncludes(match[0], `type="button"`, `copy button is not type=button: ${match[0]}`)
+  }
+})
+
+Deno.test("a verified domain shows no record to copy", () => {
+  const html = render([domain({ verified: true, verified_at: "2026-01-01T00:00:00Z" })])
+  assertEquals(html.includes("data-copy="), false)
+})
+
+Deno.test("a hostile domain name cannot break out of the copy attribute", () => {
+  // dns_record_name derives from the organisation-supplied domain, so it reaches an HTML
+  // attribute. Unescaped, a quote closes data-copy and everything after it is markup.
+  const html = render([
+    domain({ dns_record_name: `_boss-verify."><img src=x onerror=alert(1)>.acme.example` }),
+  ])
+
+  // Assert the STRUCTURE is dead, not that a substring is absent. `onerror=alert(1)` carries no
+  // HTML metacharacter, so it survives escaping as inert text and is still present in the
+  // document - the first version of this test asserted it was gone and failed against correct
+  // code. What has to be impossible is the quote-then-tag sequence that ends the attribute.
+  assertEquals(html.includes(`"><img`), false)
+  assertEquals(/<img[^>]*onerror/.test(html), false)
+  assertStringIncludes(html, "&quot;&gt;&lt;img")
+})
+
+Deno.test("the admin page carries the copy script, nonced", () => {
+  const html = render([domain()])
+  // The CSP is script-src 'nonce-...' with no unsafe-inline. A block without the nonce is dropped
+  // by the browser and the buttons do nothing at all, which is the exact failure this asserts.
+  assertStringIncludes(html, `<script nonce="${NONCE}">`)
+  assertStringIncludes(html, "data-copy")
+  assertStringIncludes(html, "navigator.clipboard")
+})
+
+Deno.test("the script falls back when the clipboard API is unavailable", () => {
+  const html = render([domain()])
+  // navigator.clipboard is undefined outside a secure context and its promise rejects when the
+  // document is not focused. Without the fallback the button silently does nothing in exactly the
+  // situations a person would then blame on the record.
+  assertStringIncludes(html, "execCommand")
+})
+
+Deno.test("a page with nothing to copy carries no script at all", () => {
+  const html = layout({ title: "t", nonce: NONCE, body: "<p>nothing</p>" })
+  assertEquals(html.includes("<script"), false)
+})

--- a/supabase/functions/organisation/tests/domain-add-users.test.ts
+++ b/supabase/functions/organisation/tests/domain-add-users.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Adopting a verified domain's existing users.
+ *
+ * This is the only action in the organisation surface that adds people who did not ask, so the
+ * assertions are weighted towards refusal and towards the administrator seeing the size of it
+ * before pressing. The database-side rules (who is skipped, confirmed addresses only, reserved
+ * domains) are pinned in supabase/tests/add_domain_users_test.sql; what is checked here is the
+ * route's own guards and what the page offers.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert"
+import { adminPage } from "../views/admin.ts"
+import type { OrgDetail, OrgDomain } from "../services/org.ts"
+
+const NONCE = "nonce"
+
+const org = {
+  id: "11111111-1111-4111-8111-111111111111",
+  slug: "acme",
+  name: "Acme",
+  description: null,
+  website: null,
+  visibility: "private",
+  join_policy: "invite_only",
+  is_system: false,
+  owner_email: "owner@acme.example",
+  member_count: 1,
+  pending_count: 0,
+  primary_domain: null,
+  is_owner: true,
+  is_admin: true,
+  can_publish: true,
+  publish_policy: "owner_only",
+  publish_role_id: null,
+  publish_role_name: null,
+  auto_assign_member_role: true,
+} as unknown as OrgDetail
+
+function domain(overrides: Partial<OrgDomain> = {}): OrgDomain {
+  return {
+    domain_id: "d1",
+    domain: "acme.example",
+    is_primary: false,
+    verified: true,
+    verified_at: "2026-01-01T00:00:00Z",
+    dns_record_type: "TXT",
+    dns_record_name: "_boss-verify.acme.example",
+    dns_record_value: "boss-org-verification=abc123",
+    addable_user_count: 12,
+    ...overrides,
+  } as OrgDomain
+}
+
+function render(domains: OrgDomain[]): string {
+  return adminPage({
+    nonce: NONCE,
+    basePath: "/functions/v1/organisation",
+    csrf: "csrf-token",
+    org,
+    members: [],
+    roles: [],
+    domains,
+    invites: [],
+  })
+}
+
+Deno.test("the count is in the label, so the size is seen before pressing", () => {
+  const html = render([domain({ addable_user_count: 12 })])
+  // The label IS the confirmation step. This adds people who did not ask and, with auto-assign on,
+  // hands each of them the member role - so a bare "Add users" would be asking for a signature on
+  // an unspecified number.
+  assertStringIncludes(html, "Add 12 existing users")
+  assertStringIncludes(html, "/domains/add-users")
+})
+
+Deno.test("one user reads as one, not as a plural", () => {
+  const html = render([domain({ addable_user_count: 1 })])
+  assertStringIncludes(html, "Add 1 existing user<")
+})
+
+Deno.test("no button when there is nobody left to add", () => {
+  // Otherwise every organisation that has already adopted its domain carries a permanent
+  // "Add 0 users" control that does nothing.
+  const html = render([domain({ addable_user_count: 0 })])
+  assertEquals(html.includes("/domains/add-users"), false)
+})
+
+Deno.test("no button on an unverified domain, whatever the count says", () => {
+  // Verification is the entire authority for the action. A count arriving non-zero on an
+  // unverified row would be a server bug, and the view must not act on it.
+  const html = render([domain({ verified: false, verified_at: null, addable_user_count: 9 })])
+  assertEquals(html.includes("/domains/add-users"), false)
+})
+
+Deno.test("an older database with no count renders no button, not 'Add undefined users'", () => {
+  // The function and the migration deploy separately. Against a database that has not yet gained
+  // `addable_user_count`, the field is absent - and `undefined < 1` is false, so a guard that
+  // trusted the type would have shown the control with a broken label and called an RPC that does
+  // not exist there either.
+  const stale = domain()
+  delete (stale as unknown as Record<string, unknown>).addable_user_count
+  const html = render([stale])
+  assertEquals(html.includes("/domains/add-users"), false)
+  assertEquals(html.includes("undefined"), false)
+})
+
+Deno.test("the form carries CSRF and the domain id, like every other action here", () => {
+  const html = render([domain()])
+  const form = html.match(/<form[^>]*\/domains\/add-users[\s\S]*?<\/form>/)
+  assert(form, "no add-users form rendered")
+  assertStringIncludes(form[0], `name="domain_id" value="d1"`)
+  assertStringIncludes(form[0], `method="post"`)
+  // A GET-able bulk membership change would be reachable from an <img> tag on any page.
+  assertEquals(/method="get"/i.test(form[0]), false)
+})
+
+Deno.test("the consequence is stated on the page, not only in the migration", () => {
+  const html = render([domain()])
+  // The non-obvious half: members arrive without being asked, and auto-assign then makes anything
+  // shared with the member role readable by all of them.
+  assertStringIncludes(html, "without being asked")
+  assertStringIncludes(html, "acme_user")
+})
+
+Deno.test("the route calls the RPC through callForActor, so it is actor-gated", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../routes/domains.ts", import.meta.url).pathname,
+  )
+  // p_actor_id is what makes the RPC's own user_is_org_admin check meaningful. Calling it as bare
+  // service_role would run the whole thing as nobody, and the admin gate would have no subject.
+  assert(
+    /callForActor\(\s*"add_domain_users_to_organisation"/.test(source),
+    "the adoption RPC must be called for the session's actor, never as bare service_role",
+  )
+})
+
+Deno.test("the route refuses an unverified domain before reaching the database", () => {
+  // Cheap, and it turns what would be a generic refusal into a state the page can explain. The
+  // RPC re-checks because it is reachable by `authenticated` directly.
+  const source = Deno.readTextFileSync(
+    new URL("../routes/domains.ts", import.meta.url).pathname,
+  )
+  const handler = source.slice(source.indexOf('/domains/add-users"'))
+  assertStringIncludes(handler.slice(0, 800), "!owned || !owned.verified")
+})

--- a/supabase/functions/organisation/tests/helpers/render-preview.ts
+++ b/supabase/functions/organisation/tests/helpers/render-preview.ts
@@ -125,7 +125,11 @@ const domains: OrgDomain[] = [
     verified_at: "2026-02-01T10:00:00Z",
     dns_record_type: "TXT",
     dns_record_name: "_boss-verify.risalabs.ai",
-    dns_record_value: "boss-verify=6f2a9c31d7b84e05",
+    // The real prefix. It was "boss-verify=" here, which the RPC never emits and
+    // extractToken would reject - a preview that could not survive a real Verify.
+    dns_record_value: "boss-org-verification=6f2a9c31d7b84e05",
+    // Verified and with people left to adopt, so the preview shows the button.
+    addable_user_count: 12,
   },
   {
     domain_id: "d2",
@@ -135,7 +139,9 @@ const domains: OrgDomain[] = [
     verified_at: null,
     dns_record_type: "TXT",
     dns_record_name: "_boss-verify.risaboss.com",
-    dns_record_value: "boss-verify=1c7e40ab99f3ad2",
+    dns_record_value: "boss-org-verification=1c7e40ab99f3ad2",
+    // Unverified rows always carry 0: the RPC does not compute the count for them.
+    addable_user_count: 0,
   },
 ]
 

--- a/supabase/functions/organisation/tests/rpc-signatures.test.ts
+++ b/supabase/functions/organisation/tests/rpc-signatures.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Every RPC this function names must exist in the migrations with the parameters we send.
+ *
+ * THE BLIND SPOT THIS EXISTS TO CLOSE. `createRpcStub` keys its responses on the function NAME and
+ * ignores the params entirely, so an RPC called with parameter names the database does not have
+ * passes every route test, every time. PostgREST resolves a function by its argument names, so
+ * such a call fails to resolve at runtime and the page renders a generic refusal.
+ *
+ * That is not hypothetical: `mark_organisation_domain_verified` was called through `callForActor`,
+ * which appends `p_actor_id` to every call. That function takes `p_domain_id` and `p_verified_by`
+ * and no `p_actor_id`, so DOMAIN VERIFICATION NEVER COMPLETED - the DNS probe passed and the write
+ * that follows it failed, reported as "The change was refused." 159 tests were green throughout.
+ *
+ * Source-scanned rather than executed, because the failure is in the shape of a call and there is
+ * no database here to make it against.
+ */
+
+import { assert, assertEquals } from "@std/assert"
+
+const HERE = new URL(".", import.meta.url).pathname
+const FUNCTION_DIR = `${HERE}..`
+const MIGRATIONS_DIR = `${HERE}../../../migrations`
+
+/** Every `.ts` file under the function, excluding the tests themselves. */
+async function sourceFiles(dir: string): Promise<string[]> {
+  const found: string[] = []
+  for await (const entry of Deno.readDir(dir)) {
+    const path = `${dir}/${entry.name}`
+    if (entry.isDirectory) {
+      if (entry.name === "tests") continue
+      found.push(...await sourceFiles(path))
+    } else if (entry.name.endsWith(".ts")) {
+      found.push(path)
+    }
+  }
+  return found
+}
+
+/**
+ * Parameter names of every `public` function the migrations define, latest definition wins.
+ *
+ * Sorted by filename first, because a function can be dropped and recreated with a different
+ * argument list - `submit_organisation_request` gained `p_website` that way - and the signature
+ * that matters is the one the last migration leaves behind.
+ */
+async function migrationSignatures(): Promise<Map<string, Set<string>>> {
+  const files: string[] = []
+  for await (const entry of Deno.readDir(MIGRATIONS_DIR)) {
+    if (entry.isFile && entry.name.endsWith(".sql")) files.push(entry.name)
+  }
+  files.sort()
+
+  const signatures = new Map<string, Set<string>>()
+  const declaration =
+    /CREATE OR REPLACE FUNCTION\s+"public"\."([a-z0-9_]+)"\s*\(([\s\S]*?)\)\s*RETURNS/gi
+
+  for (const name of files) {
+    const sql = await Deno.readTextFile(`${MIGRATIONS_DIR}/${name}`)
+    for (const match of sql.matchAll(declaration)) {
+      const params = new Set(
+        [...match[2].matchAll(/"(p_[a-z0-9_]+)"/gi)].map((m) => m[1].toLowerCase()),
+      )
+      signatures.set(match[1].toLowerCase(), params)
+    }
+  }
+  return signatures
+}
+
+Deno.test("the migrations are readable from here, so the assertions are not vacuous", async () => {
+  const signatures = await migrationSignatures()
+  // A wrong path would make every loop below iterate over nothing and pass. This is the floor that
+  // makes the rest mean something: a real number, not merely non-zero.
+  assert(
+    signatures.size > 30,
+    `only ${signatures.size} functions parsed from ${MIGRATIONS_DIR} - the path or the regex is wrong`,
+  )
+  assert(signatures.has("submit_organisation_request"), "a known function is missing")
+})
+
+Deno.test("every callForActor target actually accepts p_actor_id", async () => {
+  const signatures = await migrationSignatures()
+  const files = await sourceFiles(FUNCTION_DIR)
+
+  const targets = new Set<string>()
+  for (const path of files) {
+    const source = await Deno.readTextFile(path)
+    for (const match of source.matchAll(/callForActor(?:<[^>]*>)?\(\s*"([a-z0-9_]+)"/g)) {
+      targets.add(match[1])
+    }
+  }
+
+  assert(targets.size > 0, "no callForActor call sites found - the scan is broken")
+
+  for (const fn of targets) {
+    const params = signatures.get(fn)
+    assert(params, `callForActor("${fn}") names a function no migration defines`)
+    assert(
+      params.has("p_actor_id"),
+      `callForActor("${fn}") appends p_actor_id, but that function takes only ` +
+        `[${[...params].join(", ")}]. PostgREST resolves by argument name, so this call cannot ` +
+        `resolve and every use of it fails as a generic refusal.`,
+    )
+  }
+})
+
+Deno.test("mark_organisation_domain_verified is not called through callForActor", async () => {
+  // The specific regression, pinned by name. The sweep above would catch it too, but this states
+  // what broke so a future reader does not have to reconstruct it from a failing sweep.
+  const source = await Deno.readTextFile(`${FUNCTION_DIR}/routes/domains.ts`)
+  assertEquals(
+    /callForActor\(\s*"mark_organisation_domain_verified"/.test(source),
+    false,
+    "this RPC has no p_actor_id; it must go through callRpc with p_verified_by",
+  )
+  assert(
+    /callRpc\(\s*"mark_organisation_domain_verified"[\s\S]{0,200}p_verified_by/.test(source),
+    "the verify handler must record who verified the domain",
+  )
+})

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -59,7 +59,7 @@ ${pending.length > 0 ? pendingCard(action, csrf, pending) : ""}
 ${membersCard(action, csrf, org, active, roles)}
 ${rolesCard(action, csrf, org, roles)}
 ${invitesCard(action, csrf, invites, roles)}
-${domainsCard(action, csrf, domains)}`,
+${domainsCard(action, csrf, domains, org.slug)}`,
   })
 }
 
@@ -446,7 +446,47 @@ function copyButton(value: string, what: string): string {
     ` aria-label="Copy the DNS record ${esc(what)}">Copy</button>`
 }
 
-function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string {
+/**
+ * "Add the N existing users at this domain."
+ *
+ * Only for a VERIFIED domain, and only when there is somebody to add. A control that
+ * always showed would sit there reading "Add 0 users" on every organisation that has
+ * already adopted its domain, and a disabled button explaining nothing is worse than
+ * no button.
+ *
+ * THE COUNT IS IN THE LABEL, which is the whole of the confirmation step. This adds
+ * people who did not ask, and if the organisation has auto-assign on it also hands
+ * each of them the member role - so the administrator has to see the size of what
+ * they are about to do before pressing, not after. `addable_user_count` comes from
+ * the same predicate the RPC uses, so the number is the number.
+ *
+ * Not styled `danger`: it is a normal administrative action on a domain this
+ * organisation has proved it controls, not a destructive one. The hint under the
+ * table carries the consequence.
+ */
+function addUsersForm(action: string, csrf: string, domain: OrgDomain): string {
+  // Read defensively rather than trusting the declared type, because the deploy order can make it
+  // a lie: this function ships separately from the migration that adds `addable_user_count` to
+  // list_organisation_domains, and against the older database the field is absent. `undefined < 1`
+  // is FALSE, so a naive guard would have rendered "Add undefined existing users" on every
+  // verified domain in the window between the two deploys.
+  const count = typeof domain.addable_user_count === "number" ? domain.addable_user_count : 0
+  if (!domain.verified || count < 1) return ""
+  const label = count === 1 ? "Add 1 existing user" : `Add ${count} existing users`
+  return `
+        <form class="inline" method="post" action="${esc(action)}/domains/add-users">
+          ${csrfField(CSRF_FIELD, csrf)}
+          <input type="hidden" name="domain_id" value="${esc(domain.domain_id)}">
+          <button type="submit" class="secondary">${esc(label)}</button>
+        </form>`
+}
+
+function domainsCard(
+  action: string,
+  csrf: string,
+  domains: OrgDomain[],
+  orgSlug: string,
+): string {
   const rows = domains.length === 0
     ? '<tr><td colspan="4" class="empty">No domains claimed.</td></tr>'
     : domains.map((domain) => `
@@ -478,6 +518,7 @@ function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string
           </form>`
         : ""
     }
+        ${addUsersForm(action, csrf, domain)}
         <form class="inline" method="post" action="${esc(action)}/domains/remove">
           ${csrfField(CSRF_FIELD, csrf)}
           <input type="hidden" name="domain_id" value="${esc(domain.domain_id)}">
@@ -490,6 +531,9 @@ function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string
 <section class="card">
   <h2>Domains</h2>
   <p class="hint">A verified domain lets people with a matching email address find and join this organisation. Add the TXT record, then press Verify.</p>
+  <p class="hint">Once a domain is verified you can also add the accounts that already use it. They become members immediately without being asked, and if new members are given the ${
+    esc(orgSlug)
+  }_user role automatically, anything shared with that role becomes readable by all of them.</p>
   ${scrollable("Domains", `
   <table>
     <thead><tr><th>Domain</th><th>Status</th><th>DNS record</th><th></th></tr></thead>

--- a/supabase/functions/organisation/views/admin.ts
+++ b/supabase/functions/organisation/views/admin.ts
@@ -8,7 +8,7 @@
  */
 
 import { esc, scrollable } from "../utils/html.ts"
-import { csrfField, layout, tabs } from "./layout.ts"
+import { COPY_BEHAVIOUR, csrfField, layout, tabs } from "./layout.ts"
 import { formatDate } from "./org.ts"
 import { CSRF_FIELD } from "../utils/csrf.ts"
 import type { OrgDetail, OrgDomain, OrgInvite, OrgMember, OrgRole } from "../services/org.ts"
@@ -42,6 +42,8 @@ export function adminPage(options: AdminPageOptions): string {
   return layout({
     title: `${org.name} configuration - BOSS`,
     nonce,
+    // Only this page renders `data-copy` buttons, so only this page carries the script.
+    script: COPY_BEHAVIOUR,
     banner: banner ?? null,
     body: `
 <header class="page">
@@ -68,9 +70,15 @@ ${domainsCard(action, csrf, domains)}`,
  * bearer credential, and a link invites a middle-click that would open it in
  * this browser.
  *
- * No `onfocus="this.select()"`, and no copy button. The CSP is
- * `script-src 'nonce-...'`, which blocks inline event handlers outright, so
- * either would be dead markup that looks like it works.
+ * No `onfocus="this.select()"`: the CSP is `script-src 'nonce-...'`, which blocks
+ * inline event handlers outright, so it would be dead markup that looks like it
+ * works.
+ *
+ * It has no copy button either, but that is now a CHOICE rather than a
+ * constraint. This page carries COPY_BEHAVIOUR for the DNS records, so a
+ * `data-copy` button here would work today - the reason it was ruled out (no
+ * scripting) stopped being true. Worth adding; deliberately not folded into the
+ * DNS change.
  */
 function newInviteCard(url: string): string {
   return `
@@ -392,6 +400,52 @@ function invitesCard(
 </section>`
 }
 
+/**
+ * The TXT record, as three copyable fields rather than one string.
+ *
+ * It used to render as `<name> TXT <value>` in a single span. That reads fine and is useless to
+ * the person holding it: every DNS registrar asks for the host and the value in SEPARATE inputs,
+ * so a one-line blob has to be picked apart by hand, and selecting part of a long token with a
+ * mouse is exactly where a truncated record comes from. A record that fails to verify because a
+ * character was dropped looks identical to one that has not propagated yet.
+ *
+ * The copy button carries the value in `data-copy` rather than reading the element's text, so what
+ * lands on the clipboard is the record even if CSS wraps or truncates what is drawn.
+ *
+ * Type is shown but has no button: "TXT" is three characters and is usually a dropdown anyway.
+ */
+function dnsRecord(domain: OrgDomain): string {
+  return `
+      <div class="dns">
+        <div class="dns-row">
+          <span class="dns-key">Name</span>
+          <span class="pill mono">${esc(domain.dns_record_name)}</span>
+          ${copyButton(domain.dns_record_name, "name")}
+        </div>
+        <div class="dns-row">
+          <span class="dns-key">Type</span>
+          <span class="pill mono">TXT</span>
+        </div>
+        <div class="dns-row">
+          <span class="dns-key">Value</span>
+          <span class="pill mono">${esc(domain.dns_record_value)}</span>
+          ${copyButton(domain.dns_record_value, "value")}
+        </div>
+      </div>`
+}
+
+/**
+ * A copy control.
+ *
+ * `type="button"` is load-bearing: these sit in a table whose other cells hold POST forms, and a
+ * button that defaulted to `submit` would be one stray Enter away from verifying or removing a
+ * domain. The aria-label distinguishes the two buttons in a row, which both read "Copy".
+ */
+function copyButton(value: string, what: string): string {
+  return `<button type="button" class="secondary copy" data-copy="${esc(value)}"` +
+    ` aria-label="Copy the DNS record ${esc(what)}">Copy</button>`
+}
+
 function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string {
   const rows = domains.length === 0
     ? '<tr><td colspan="4" class="empty">No domains claimed.</td></tr>'
@@ -405,11 +459,7 @@ function domainsCard(action: string, csrf: string, domains: OrgDomain[]): string
         ? '<span class="pill ok">verified</span>'
         : '<span class="pill warn">unverified</span>'
     }</td>
-      <td>${
-      domain.verified ? "" : `<span class="mono">${esc(domain.dns_record_name)} TXT ${
-        esc(domain.dns_record_value)
-      }</span>`
-    }</td>
+      <td>${domain.verified ? "" : dnsRecord(domain)}</td>
       <td>
         ${
       domain.verified ? "" : `

--- a/supabase/functions/organisation/views/layout.ts
+++ b/supabase/functions/organisation/views/layout.ts
@@ -234,6 +234,19 @@ const STYLES = `
      takes a neutral wash - a row of outlined boxes shouts louder than the words. */
   .pill.mono { border-color: transparent; background-color: var(--token-wash); color: var(--text-2); }
 
+  /* The DNS record a person has to retype into their registrar.
+     LAYOUT ONLY - every colour here is a token already asserted by contrast.test.ts on these
+     surfaces (--text-2 on card and on washOnCard). Introducing a new colour pair would need a new
+     USAGE entry there, and an unasserted pair is how the sub-AA borders shipped the first time. */
+  .dns { display: flex; flex-direction: column; gap: 4px; }
+  .dns-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+  /* Fixed width so Name/Type/Value line up as a column and the records read as one block. */
+  .dns-key { font-size: 11px; color: var(--text-2); min-width: 40px; }
+  /* The value is long and arbitrary; let it wrap rather than widen the table past the viewport.
+     anywhere, not break-all: a hostname then breaks at its dots by preference. */
+  .dns .pill.mono { white-space: normal; overflow-wrap: anywhere; }
+  button.copy { padding: 1px 8px; font-size: 11px; }
+
   /* ---- forms ----------------------------------------------------------- */
 
   label { display: block; font-size: 13px; color: var(--text-2); margin-bottom: 6px; }
@@ -347,12 +360,87 @@ const STYLES = `
 
 export type BannerKind = "error" | "ok"
 
+/**
+ * Click-to-copy for anything carrying `data-copy`.
+ *
+ * Opt-in per page via [LayoutOptions.script] rather than shipped on every response, so a page with
+ * nothing to copy carries no script at all.
+ *
+ * EVENT DELEGATION, because it has to be. The CSP is `script-src 'nonce-...'` with no
+ * `unsafe-inline`, so an `onclick=` attribute is dead on arrival - a nonce cannot apply to an
+ * attribute. One nonced block listening on the document is the shape that works, and it also
+ * survives rows being re-rendered.
+ *
+ * The value is read from the attribute rather than from the element's text: the displayed record
+ * may be wrapped or truncated by CSS later, and copying what was DISPLAYED would then quietly hand
+ * someone a broken TXT value.
+ *
+ * `execCommand` is the fallback for good reason, not superstition: `navigator.clipboard` is
+ * undefined outside a secure context and its promise rejects when the document is not focused, and
+ * a DNS record you cannot copy is exactly the failure this exists to remove.
+ */
+const COPY_SCRIPT = `
+(function () {
+  var RESET_MS = 1200;
+  function flash(button, message) {
+    if (button.dataset.busy) return;
+    button.dataset.busy = "1";
+    var original = button.textContent;
+    button.textContent = message;
+    setTimeout(function () {
+      button.textContent = original;
+      delete button.dataset.busy;
+    }, RESET_MS);
+  }
+  function legacyCopy(text) {
+    var area = document.createElement("textarea");
+    area.value = text;
+    area.setAttribute("readonly", "");
+    area.style.position = "fixed";
+    area.style.top = "-1000px";
+    document.body.appendChild(area);
+    area.select();
+    var ok = false;
+    try { ok = document.execCommand("copy"); } catch (e) { ok = false; }
+    document.body.removeChild(area);
+    return ok;
+  }
+  document.addEventListener("click", function (event) {
+    var target = event.target;
+    if (!target || typeof target.closest !== "function") return;
+    var button = target.closest("button[data-copy]");
+    if (!button) return;
+    event.preventDefault();
+    var text = button.getAttribute("data-copy") || "";
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(
+        function () { flash(button, "Copied"); },
+        function () { flash(button, legacyCopy(text) ? "Copied" : "Press Ctrl+C"); }
+      );
+      return;
+    }
+    flash(button, legacyCopy(text) ? "Copied" : "Press Ctrl+C");
+  });
+})();
+`
+
+/** The click-to-copy behaviour, for a page that renders `data-copy` buttons. */
+export const COPY_BEHAVIOUR = COPY_SCRIPT
+
 export interface LayoutOptions {
   title: string
   nonce: string
   body: string
   /** Rendered above the body when present. */
   banner?: { kind: BannerKind; message: string } | null
+  /**
+   * JavaScript to inline in a nonced block, or omitted for no script at all.
+   *
+   * This is OUR OWN source only - never a value derived from a request or from an organisation
+   * field. It is written into a `<script>` verbatim, so anything interpolated into it would be
+   * executing, not displaying.
+   */
+  script?: string
 }
 
 /**
@@ -367,7 +455,7 @@ export interface LayoutOptions {
  * banner message is escaped HERE, because it is the one string that routinely
  * originates from an RPC error and would otherwise be interpolated raw.
  */
-export function layout({ title, nonce, body, banner }: LayoutOptions): string {
+export function layout({ title, nonce, body, banner, script }: LayoutOptions): string {
   const bannerHtml = banner
     ? `<div class="banner ${
       banner.kind === "ok" ? "ok" : "error"
@@ -392,6 +480,7 @@ ${body}
 <footer class="page">BOSS Organisation</footer>
 </div>
 <!--/email_off-->
+${script ? `<script nonce="${esc(nonce)}">${script}</script>` : ""}
 </body>
 </html>`
 }

--- a/supabase/migrations/20260810000000_add_domain_users_to_organisation.sql
+++ b/supabase/migrations/20260810000000_add_domain_users_to_organisation.sql
@@ -1,0 +1,255 @@
+-- ============================================================================
+-- BOSS Database Schema: adopt the existing users of a verified domain
+--
+-- File: 20260810000000_add_domain_users_to_organisation.sql
+--
+-- Until now a verified domain only ever let a user CHOOSE to join: it makes
+-- organisation_available_action return 'join' instead of 'request' on a
+-- request_to_join organisation, and nothing at all on an invite_only one. The
+-- organisation could never reach out; every membership began with the member.
+--
+-- This inverts that for the one case where the inversion is justified: an
+-- administrator of an organisation that has PROVED CONTROL OF THE DNS ZONE
+-- adopting the accounts already using addresses at that domain. The proof is the
+-- same one the self-service path already trusts, and the actor is an admin of the
+-- organisation the users are being added to.
+--
+-- WHAT THIS GRANTS THE ADDED USERS, stated plainly because it is the part that is
+-- easy to miss: membership is `active`, and assign_org_member_role_internal then
+-- gives each of them the <slug>_user role IF the organisation has
+-- auto_assign_member_role set. Any secret_shares row targeting that role becomes
+-- readable by every one of them. That is the same consequence 20260806020000
+-- raised a WARNING about for the boss organisation's backfill, and it is why the
+-- count is reported back rather than the operation being silent.
+--
+-- WHAT IT DOES NOT DO:
+--   * It does not touch anyone who already has an organisation_members row for
+--     this organisation, in ANY status. A pending request stays pending, an
+--     invited user stays invited, and somebody previously removed is not
+--     silently re-added.
+--   * It does not reach unconfirmed accounts. email_confirmed_at IS NOT NULL is
+--     the same bar organisation_available_action uses; without it, registering an
+--     address at a domain you do not control would be enough to be adopted by it.
+--   * It does not reach a reserved domain. gmail.com and friends are in
+--     reserved_email_domains precisely so that no organisation can claim the
+--     population behind them, and add_organisation_domain already refuses to
+--     claim one - this is the backstop for a row that predates that rule.
+--   * It is a ONE-OFF over accounts that exist now. Future signups are unchanged:
+--     they still join through the self-service path.
+-- ============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- How many accounts would be adopted
+-- ---------------------------------------------------------------------------
+--
+-- Split out from the write so the administrator sees a number before pressing
+-- anything, and so the button can hide itself when there is nobody to add. It is
+-- the SAME predicate as the write below; keeping them textually adjacent is the
+-- only thing stopping the count and the effect drifting apart.
+--
+-- STABLE, not IMMUTABLE: it reads tables.
+CREATE OR REPLACE FUNCTION "public"."count_domain_users_for_organisation"(
+    "p_domain_id" "uuid"
+) RETURNS integer
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+    SELECT count(*)::integer
+      FROM public.organisation_domains d
+      JOIN auth.users u
+        ON u.email IS NOT NULL
+       AND u.email_confirmed_at IS NOT NULL
+       AND lower(split_part(u.email, '@', 2)) = d.domain
+     WHERE d.id = p_domain_id
+       AND d.verified = true
+       AND NOT EXISTS (
+           SELECT 1 FROM public.reserved_email_domains red WHERE red.domain = d.domain
+       )
+       AND NOT EXISTS (
+           SELECT 1 FROM public.organisation_members m
+            WHERE m.org_id = d.org_id AND m.user_id = u.id
+       );
+$$;
+
+ALTER FUNCTION "public"."count_domain_users_for_organisation"("uuid") OWNER TO "postgres";
+
+-- No grant to `authenticated`. This is a helper for the RPCs below and for
+-- list_organisation_domains, both of which are already admin-gated; exposing it
+-- directly would let any authenticated caller count the accounts behind any
+-- domain id they could guess.
+REVOKE EXECUTE ON FUNCTION "public"."count_domain_users_for_organisation"("uuid")
+    FROM PUBLIC, "anon", "authenticated";
+GRANT  EXECUTE ON FUNCTION "public"."count_domain_users_for_organisation"("uuid") TO "service_role";
+
+COMMENT ON FUNCTION "public"."count_domain_users_for_organisation"("uuid") IS
+    'How many confirmed accounts at a verified domain are not yet members of its organisation. Same predicate as add_domain_users_to_organisation, kept adjacent so the preview and the effect cannot drift. Not granted to authenticated: callers reach it through admin-gated RPCs.';
+
+
+-- ---------------------------------------------------------------------------
+-- Adopt them
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION "public"."add_domain_users_to_organisation"(
+    "p_domain_id" "uuid",
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor  UUID;
+    v_org_id UUID;
+    v_domain TEXT;
+    v_verified BOOLEAN;
+    v_added  INTEGER := 0;
+    v_user   RECORD;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    -- FOR UPDATE on the domain row, so two administrators pressing the button at
+    -- the same moment serialise instead of both scanning and both inserting. The
+    -- ON CONFLICT below already makes a double insert harmless; this makes the
+    -- REPORTED COUNT honest, which the second caller would otherwise overstate.
+    SELECT d.org_id, d.domain, d.verified
+      INTO v_org_id, v_domain, v_verified
+      FROM public.organisation_domains d
+     WHERE d.id = p_domain_id
+       FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Domain not found');
+    END IF;
+
+    -- Authorisation is against the domain's OWN organisation, never one the
+    -- caller named. Nothing in the parameter list identifies an organisation, so
+    -- there is no org for a caller to substitute.
+    IF NOT public.user_is_org_admin(v_actor, v_org_id) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Permission denied');
+    END IF;
+
+    IF NOT v_verified THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            'The domain must be verified before its users can be added');
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM public.reserved_email_domains red WHERE red.domain = v_domain) THEN
+        RETURN jsonb_build_object('success', false, 'error',
+            format('"%s" is a reserved email domain', v_domain));
+    END IF;
+
+    -- A loop rather than one INSERT ... SELECT, because each new member needs
+    -- assign_org_member_role_internal run for them and that is a per-row call.
+    -- The set is bounded by the accounts at one domain.
+    FOR v_user IN
+        SELECT u.id
+          FROM auth.users u
+         WHERE u.email IS NOT NULL
+           AND u.email_confirmed_at IS NOT NULL
+           AND lower(split_part(u.email, '@', 2)) = v_domain
+           AND NOT EXISTS (
+               SELECT 1 FROM public.organisation_members m
+                WHERE m.org_id = v_org_id AND m.user_id = u.id
+           )
+    LOOP
+        INSERT INTO public.organisation_members (org_id, user_id, status, joined_at, join_source)
+        VALUES (v_org_id, v_user.id, 'active', now(), 'domain')
+        ON CONFLICT (org_id, user_id) DO NOTHING;
+
+        -- GUARD ON WHAT WAS ACTUALLY INSERTED, not on the loop. The NOT EXISTS
+        -- above is evaluated when the cursor opens, so a concurrent join between
+        -- then and here lands on the ON CONFLICT and inserts nothing - counting
+        -- the iteration would report a member this call did not create.
+        IF FOUND THEN
+            v_added := v_added + 1;
+            -- Honours auto_assign_member_role, and uses clock_timestamp() so the
+            -- role cannot tie with one assigned earlier in this transaction.
+            PERFORM public.assign_org_member_role_internal(v_org_id, v_user.id);
+        END IF;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'added', v_added,
+        'domain', v_domain);
+END;
+$$;
+
+ALTER FUNCTION "public"."add_domain_users_to_organisation"("uuid", "uuid") OWNER TO "postgres";
+
+REVOKE EXECUTE ON FUNCTION "public"."add_domain_users_to_organisation"("uuid", "uuid")
+    FROM PUBLIC, "anon";
+GRANT  EXECUTE ON FUNCTION "public"."add_domain_users_to_organisation"("uuid", "uuid")
+    TO "authenticated", "service_role";
+
+COMMENT ON FUNCTION "public"."add_domain_users_to_organisation"("uuid", "uuid") IS
+    'Adds every confirmed account at a VERIFIED domain as an active member of that domain''s organisation, skipping anyone who already has a membership row in any status. Admin-gated against the domain''s own org. Runs assign_org_member_role_internal per new member, so auto_assign_member_role applies - which means secrets shared to <slug>_user become readable by all of them. One-off over existing accounts; future signups still join through the self-service path.';
+
+
+-- ---------------------------------------------------------------------------
+-- Surface the count on the admin page
+-- ---------------------------------------------------------------------------
+--
+-- list_organisation_domains gains `addable_user_count`. Unchanged signature, so
+-- this is a plain CREATE OR REPLACE rather than a DROP - see 20260807000000 for
+-- what happens when the argument list does change.
+--
+-- Computed only for a VERIFIED row. The count subquery scans auth.users for a
+-- domain match, which is not an indexed expression, and an unverified claim can
+-- never be actioned anyway - so an organisation with a long list of unverified
+-- claims costs nothing.
+CREATE OR REPLACE FUNCTION "public"."list_organisation_domains"(
+    "p_org_id" "uuid",
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_rows JSONB;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    -- Admin-only: these rows carry verification_token.
+    IF NOT public.user_is_org_admin(v_actor, p_org_id) THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Organisation not found');
+    END IF;
+
+    -- The projection and the ordering are the 20260801030000 original, verbatim,
+    -- with ONE column appended. Two things were dropped by an earlier draft of
+    -- this migration and are called out so they are not dropped again:
+    -- `d.created_at`, which is projected but unread today, and the
+    -- `is_primary DESC` half of the sort, without which the primary domain stops
+    -- coming first on the admin page.
+    SELECT COALESCE(jsonb_agg(row_to_json(t)::jsonb), '[]'::jsonb)
+      INTO v_rows
+      FROM (
+        SELECT d.id AS domain_id, d.domain, d.is_primary, d.verified, d.verified_at,
+               'TXT' AS dns_record_type,
+               '_boss-verify.' || d.domain AS dns_record_name,
+               'boss-org-verification=' || d.verification_token AS dns_record_value,
+               d.created_at,
+               CASE
+                   WHEN d.verified
+                   THEN public.count_domain_users_for_organisation(d.id)
+                   ELSE 0
+               END AS addable_user_count
+        FROM public.organisation_domains d
+        WHERE d.org_id = p_org_id
+        ORDER BY d.is_primary DESC, d.domain
+      ) t;
+
+    RETURN jsonb_build_object('success', true, 'data', v_rows);
+END;
+$$;
+
+ALTER FUNCTION "public"."list_organisation_domains"("uuid", "uuid") OWNER TO "postgres";
+
+COMMENT ON FUNCTION "public"."list_organisation_domains"("uuid", "uuid") IS
+    'Lists an organisation''s claimed domains for an admin, including the DNS record to publish and, for a verified row, how many existing accounts at that domain could still be added (addable_user_count). Admin-only: the rows carry verification_token.';

--- a/supabase/tests/add_domain_users_test.sql
+++ b/supabase/tests/add_domain_users_test.sql
@@ -1,0 +1,291 @@
+-- pgTAP tests for adopting a verified domain's existing users (20260810000000).
+-- Run with: supabase test db
+--
+-- This is the first thing in the organisation schema that adds somebody to an
+-- organisation without them acting, so the assertions are weighted towards what it
+-- must REFUSE and who it must not touch. A test that only proved the happy path
+-- would pass just as well against a version that adopted unconfirmed accounts, or
+-- re-adopted somebody an admin had removed.
+--
+-- WHAT THESE ASSERTIONS ACTUALLY COVER, measured by deleting each guard and
+-- re-running rather than by reading:
+--
+--   COVERED. Removing the admin gate fails 3 of these; the verified check, 4;
+--   the confirmed-address filter, 3; the reserved-domain backstop, 1.
+--
+--   NOT COVERED, and worth stating so nobody assumes otherwise: the function has
+--   THREE layers stopping an existing member being touched - the cursor's NOT
+--   EXISTS, the INSERT's ON CONFLICT DO NOTHING, and the IF FOUND that guards the
+--   counter. Deleting any ONE of them fails nothing here, because in a single
+--   session the other two mask it: the cursor already excludes existing members,
+--   so no conflicting insert is ever attempted and every iteration is a real one.
+--   The case that separates them is a row appearing BETWEEN the cursor opening
+--   and the insert, which one pgTAP session cannot produce. Those three are
+--   defence in depth against concurrency and are unexercised; the behaviour they
+--   protect (pending stays pending, invited stays invited, removed stays removed)
+--   IS asserted below, just not attributable to a single layer.
+
+begin;
+select plan(23);
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+insert into auth.users (id, email, email_confirmed_at) values
+    ('a0000000-0000-4000-8000-000000000001', 'founder@acme.test',  now()),
+    ('a0000000-0000-4000-8000-000000000002', 'alice@acme.test',    now()),
+    ('a0000000-0000-4000-8000-000000000003', 'bob@acme.test',      now()),
+    -- Never confirmed: registering an address at a domain proves nothing until
+    -- the address answers.
+    ('a0000000-0000-4000-8000-000000000004', 'ghost@acme.test',    null),
+    -- A different domain entirely.
+    ('a0000000-0000-4000-8000-000000000005', 'carol@other.test',   now()),
+    -- Case: the stored domain is lower-cased, the address is not.
+    ('a0000000-0000-4000-8000-000000000006', 'dave@ACME.test',     now()),
+    ('a0000000-0000-4000-8000-000000000007', 'outsider@acme.test', now()),
+    ('a0000000-0000-4000-8000-000000000008', 'stranger@acme.test', now());
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'acmeco', p_name => 'Acme Co', p_description => null,
+        p_owner_id => 'a0000000-0000-4000-8000-000000000001',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'the organisation can be created'
+);
+
+create temporary table t_ids as
+select (select id from public.organisations where slug = 'acmeco') as org_id;
+
+select ok(
+    (public.add_organisation_domain(
+        (select org_id from t_ids), 'acme.test', true,
+        'a0000000-0000-4000-8000-000000000001') ->> 'success')::boolean,
+    'the domain can be claimed'
+);
+
+create temporary table t_dom as
+select d.id as domain_id
+  from public.organisation_domains d
+ where d.org_id = (select org_id from t_ids) and d.domain = 'acme.test';
+
+
+-- ===========================================================================
+-- An UNVERIFIED domain adopts nobody
+-- ===========================================================================
+-- The whole authority for this action is the DNS proof. Without that check it
+-- would be "type a domain, take its users".
+select is(
+    public.add_domain_users_to_organisation(
+        (select domain_id from t_dom),
+        'a0000000-0000-4000-8000-000000000001') ->> 'error',
+    'The domain must be verified before its users can be added',
+    'an unverified domain is refused'
+);
+
+select is(
+    (select count(*)::int from public.organisation_members
+      where org_id = (select org_id from t_ids)),
+    1,
+    'and nobody was added - only the founder is a member'
+);
+
+select is(
+    public.count_domain_users_for_organisation((select domain_id from t_dom)),
+    0,
+    'the preview count is 0 while unverified, so no button is offered'
+);
+
+
+-- ===========================================================================
+-- Verified: the count, then the adoption
+-- ===========================================================================
+update public.organisation_domains
+   set verified = true, verified_at = now()
+ where id = (select domain_id from t_dom);
+
+-- alice, bob, dave (mixed case), outsider, stranger = 5. NOT ghost (unconfirmed),
+-- NOT carol (other domain), NOT the founder (already a member).
+select is(
+    public.count_domain_users_for_organisation((select domain_id from t_dom)),
+    5,
+    'the preview counts exactly the accounts that would be adopted'
+);
+
+-- ===========================================================================
+-- Authorisation
+-- ===========================================================================
+select is(
+    public.add_domain_users_to_organisation(
+        (select domain_id from t_dom),
+        'a0000000-0000-4000-8000-000000000005') ->> 'error',
+    'Permission denied',
+    'a non-member cannot adopt an organisation''s domain users'
+);
+
+-- A plain MEMBER is not enough either: this hands out membership in bulk.
+insert into public.organisation_members (org_id, user_id, status, joined_at, join_source)
+values ((select org_id from t_ids), 'a0000000-0000-4000-8000-000000000005', 'active', now(), 'admin');
+
+select is(
+    public.add_domain_users_to_organisation(
+        (select domain_id from t_dom),
+        'a0000000-0000-4000-8000-000000000005') ->> 'error',
+    'Permission denied',
+    'an ordinary member cannot either - it is an admin action'
+);
+
+delete from public.organisation_members
+ where org_id = (select org_id from t_ids)
+   and user_id = 'a0000000-0000-4000-8000-000000000005';
+
+select is(
+    public.add_domain_users_to_organisation(
+        '99999999-9999-4999-8999-999999999999',
+        'a0000000-0000-4000-8000-000000000001') ->> 'error',
+    'Domain not found',
+    'an unknown domain id is refused before anything else is read'
+);
+
+
+-- ===========================================================================
+-- The adoption itself
+-- ===========================================================================
+create temporary table t_first as
+select public.add_domain_users_to_organisation(
+    (select domain_id from t_dom),
+    'a0000000-0000-4000-8000-000000000001') as result;
+
+select ok((select (result ->> 'success')::boolean from t_first), 'the admin can adopt');
+
+select is(
+    (select (result ->> 'added')::int from t_first),
+    5,
+    'it reports exactly what it inserted'
+);
+
+select is(
+    (select count(*)::int from public.organisation_members
+      where org_id = (select org_id from t_ids) and status = 'active'),
+    6,
+    'the five join the founder'
+);
+
+select is(
+    (select join_source from public.organisation_members
+      where org_id = (select org_id from t_ids)
+        and user_id = 'a0000000-0000-4000-8000-000000000002'),
+    'domain',
+    'they are recorded as having joined by domain, not as an anonymous admin add'
+);
+
+-- A mixed-case address must be matched: auth.users stores what was typed, and the
+-- domain column is lower-cased on the way in.
+select ok(
+    exists (select 1 from public.organisation_members
+             where org_id = (select org_id from t_ids)
+               and user_id = 'a0000000-0000-4000-8000-000000000006'),
+    'an address with a capitalised domain is matched'
+);
+
+select ok(
+    not exists (select 1 from public.organisation_members
+                 where org_id = (select org_id from t_ids)
+                   and user_id = 'a0000000-0000-4000-8000-000000000004'),
+    'an unconfirmed address is NOT adopted'
+);
+
+select ok(
+    not exists (select 1 from public.organisation_members
+                 where org_id = (select org_id from t_ids)
+                   and user_id = 'a0000000-0000-4000-8000-000000000005'),
+    'an address at another domain is not adopted'
+);
+
+
+-- ===========================================================================
+-- Re-running is inert, and the count agrees
+-- ===========================================================================
+select is(
+    public.count_domain_users_for_organisation((select domain_id from t_dom)),
+    0,
+    'the preview drops to 0 once everybody has been adopted'
+);
+
+select is(
+    (public.add_domain_users_to_organisation(
+        (select domain_id from t_dom),
+        'a0000000-0000-4000-8000-000000000001') ->> 'added')::int,
+    0,
+    're-running adds nobody and says so, rather than reporting the same five again'
+);
+
+
+-- ===========================================================================
+-- Existing rows are never disturbed
+-- ===========================================================================
+-- The three that matter: a pending applicant must not be silently promoted, an
+-- invited user must not be auto-accepted, and somebody an admin REMOVED must not
+-- be re-adopted by the next press of the button.
+delete from public.organisation_members
+ where org_id = (select org_id from t_ids)
+   and user_id in ('a0000000-0000-4000-8000-000000000007',
+                   'a0000000-0000-4000-8000-000000000008');
+
+insert into public.organisation_members (org_id, user_id, status, requested_at, join_source)
+values ((select org_id from t_ids), 'a0000000-0000-4000-8000-000000000007', 'pending', now(), 'request');
+insert into public.organisation_members (org_id, user_id, status, invited_at, join_source)
+values ((select org_id from t_ids), 'a0000000-0000-4000-8000-000000000008', 'invited', now(), 'invite');
+
+select is(
+    (public.add_domain_users_to_organisation(
+        (select domain_id from t_dom),
+        'a0000000-0000-4000-8000-000000000001') ->> 'added')::int,
+    0,
+    'a pending and an invited row are both left alone'
+);
+
+select is(
+    (select status from public.organisation_members
+      where org_id = (select org_id from t_ids)
+        and user_id = 'a0000000-0000-4000-8000-000000000007'),
+    'pending',
+    'the pending applicant still has to be approved'
+);
+
+select is(
+    (select status from public.organisation_members
+      where org_id = (select org_id from t_ids)
+        and user_id = 'a0000000-0000-4000-8000-000000000008'),
+    'invited',
+    'the invited user still has to accept'
+);
+
+
+-- ===========================================================================
+-- A reserved domain is refused even if a row somehow says verified
+-- ===========================================================================
+-- add_organisation_domain already refuses to claim one; this is the backstop for a
+-- row that predates that rule, and it is the check that stops an organisation
+-- adopting every gmail.com account in the database.
+insert into public.reserved_email_domains (domain) values ('acme.test')
+on conflict do nothing;
+
+select is(
+    public.add_domain_users_to_organisation(
+        (select domain_id from t_dom),
+        'a0000000-0000-4000-8000-000000000001') ->> 'error',
+    '"acme.test" is a reserved email domain',
+    'a reserved domain is refused even when the row is marked verified'
+);
+
+select is(
+    public.count_domain_users_for_organisation((select domain_id from t_dom)),
+    0,
+    'and the preview refuses to count for one, so no button is offered'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Three changes to the organisation admin page's Domains card, found by using it end to end.

**All three are already deployed to production** (migration `20260810000000` pushed, `organisation` function redeployed), because the verification bug was blocking the operator. This PR brings `main` back in line.

## 1. Domain verification could never complete

"Verify now" answered "The change was refused." on every domain whose TXT record was correct.

The DNS probe was fine. The write after it was not:

```ts
callForActor("mark_organisation_domain_verified", session.sub, { p_domain_id: domainId })
```

`callForActor` appends `p_actor_id`, because that is the service_role impersonation parameter every other org RPC takes. This one does not have it: it is service_role-only by design and its second parameter is `p_verified_by`. PostgREST resolves a function by its argument names, so the call named a signature the database does not have and came back as a transport error, which the handler maps to the generic refusal.

It is only reachable **after** a successful DNS check (a record that has not propagated reports "The TXT record was not found"), so the message appeared exactly when the operator had done everything right. Verification has never completed since the feature shipped, and `verified_by` was never set.

**Why 159 tests were green:** `createRpcStub` keys on the function name and ignores params entirely, so any RPC called with parameter names the database lacks passes every route test. That is a class of bug, so the guard is a sweep: every `callForActor("x")` target is checked against the parameter names the migrations give `x`, latest definition winning. It carries a floor assertion that the migrations were actually parsed (125 functions; floor 30), because a wrong path would make it iterate over nothing and pass.

Swept the other 12 `callForActor` targets: all take `p_actor_id`, so this was the only one.

## 2. The DNS record is copyable

It rendered as one span: `_boss-verify.acme.com TXT boss-org-verification=abc123`. Every registrar asks for host and value in separate inputs, so that blob has to be picked apart by hand, and hand-selecting part of a long token is where truncated records come from. A record that fails because a character was dropped looks identical to one that has not propagated.

Now Name / Type / Value on separate lines, with a copy button on the two worth copying. The value lives in `data-copy`, not the element text, so what is copied is the record even if CSS wraps or truncates what is drawn.

Copy is one nonced, delegated script, which is the only shape the CSP allows: `script-src 'nonce-...'` with no `unsafe-inline` means an `onclick=` attribute is dead on arrival. Opt-in per page via a new `script` slot on `layout()`, so a page with nothing to copy ships no script. `execCommand` is the fallback because `navigator.clipboard` is undefined outside a secure context and rejects when the document is not focused.

`type="button"` on the copy controls is load-bearing: they sit in a table whose other cells hold POST forms for verify, primary and remove.

## 3. Adopt the existing users of a verified domain

A verified domain only ever let a user **choose** to join. The organisation could never reach out, so deploying BOSS across a company meant every colleague finding and joining it themselves.

Adds "Add N existing users" beside a verified domain. The count is in the label, and that is the whole confirmation step: this adds people who did not ask, and with `auto_assign_member_role` on each also gets `<slug>_user`, so anything shared with that role becomes readable by all of them. The card says so in words.

What bounds it:

- Authority is the DNS proof plus org-admin, checked against the **domain's own** organisation. Nothing in the parameter list names an org.
- Unverified refused twice: in the route, where the row is loaded and the refusal can be explained, and in the RPC, which `authenticated` reaches directly.
- Reserved domains refused, so no organisation can claim the population behind gmail.com.
- Unconfirmed addresses skipped, the same bar the self-service path uses.
- Anyone with an existing membership row is left alone in **any** status: pending stays pending, invited stays invited, removed stays removed.

`list_organisation_domains` gains `addable_user_count`, same signature so `CREATE OR REPLACE` keeps its grants. The view reads it defensively rather than trusting its own type, because the deploy order can make that type a lie: against a database without the migration the field is absent and `undefined < 1` is **false**, which would have rendered "Add undefined existing users".

## Verification

- 457 pgTAP assertions across 18 files against a fresh `db reset`, so the migration is proven to apply on top of every other one.
- 179 deno tests. `deno check`, `deno lint`, `deno test` all green.
- Guards measured by deleting each and re-running, not by reading. Covered: admin gate 3 failures, verified check 4, confirmed-address filter 3, reserved-domain backstop 1, plus the copy-button and deploy-order guards.

**Not covered, stated so it is not assumed:** three layers protect an existing member (the cursor's `NOT EXISTS`, `ON CONFLICT DO NOTHING`, and the `IF FOUND` guarding the counter) and deleting any one fails nothing, because in a single session the other two mask it. They defend against a row appearing between the cursor opening and the insert, which one pgTAP session cannot produce. The behaviour is asserted; the individual layers are not. Recorded in the test file header.

**Also not verified:** none of this has been seen rendered, and the adopt path has never run against real accounts.