### PR TITLE
Plugin store: attribute plugins to their publisher's organisation, and let members see them

### DIFF
--- a/supabase/functions/plugin-store/deno.json
+++ b/supabase/functions/plugin-store/deno.json
@@ -4,7 +4,8 @@
     "@hono/zod-openapi": "npm:@hono/zod-openapi@^0.18.4",
     "@hono/swagger-ui": "npm:@hono/swagger-ui@^0.4.1",
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@^2.58.0",
-    "zod": "npm:zod@^3.24.1"
+    "zod": "npm:zod@^3.24.1",
+    "@std/assert": "jsr:@std/assert@^1.0.0"
   },
   "compilerOptions": {
     "lib": ["deno.window", "deno.unstable"],

--- a/supabase/functions/plugin-store/routes/api-keys.ts
+++ b/supabase/functions/plugin-store/routes/api-keys.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { PluginStoreContext } from "../types/context.ts"
 import { ErrorResponseSchema } from "../types/schemas.ts"
 import { getUserFromToken } from "../utils/auth.ts"
+import { resolvePublishOrg } from "../services/publish-org.ts"
 import { API_KEY_CREATE_PERMISSION, permissionGateError } from "../utils/permissions.ts"
 import {
   generateApiKey,
@@ -41,6 +42,15 @@ const CreateApiKeyRequestSchema = z.object({
     .nullable()
     .optional()
     .describe("Optional: Number of days until the key expires (null = never)"),
+  orgId: z
+    .string()
+    .uuid("orgId must be a UUID")
+    .optional()
+    .describe(
+      "Optional: the organisation plugins created with this key are attributed to. " +
+        "Authorised against your publishing rights. Omitted means the server derives it the " +
+        "same way a browser publish does.",
+    ),
 })
 
 const CreateApiKeyResponseSchema = z.object({
@@ -220,6 +230,19 @@ apiKeys.openapi(createApiKeyRoute, async (ctx) => {
       ? new Date(Date.now() + body.expiresInDays * 24 * 60 * 60 * 1000).toISOString()
       : null
 
+    // Bind the key to an organisation AT CREATION. Leaving it null is how every key ended up
+    // resolving to boss: validate_plugin_api_key COALESCEs a null to the boss organisation, so a
+    // key that named nothing silently became a boss-publishing key - and the attribution the
+    // publish path now reads had nothing else to go on.
+    //
+    // Same resolver the publish path uses, so a key cannot be bound anywhere its owner could not
+    // have published from directly, and there is one definition of "your organisation" rather
+    // than two that drift.
+    const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
+    if (!orgResolution.ok) {
+      return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
+    }
+
     // Insert into database
     const { data, error } = await supabase
       .from("plugin_api_keys")
@@ -230,6 +253,9 @@ apiKeys.openapi(createApiKeyRoute, async (ctx) => {
         key_hash: keyHash,
         scopes: body.scopes,
         expires_at: expiresAt,
+        // Omitted when null so validate_plugin_api_key's COALESCE stays the single place the
+        // boss fallback is expressed.
+        ...(orgResolution.orgId ? { org_id: orgResolution.orgId } : {}),
       })
       .select()
       .single()

--- a/supabase/functions/plugin-store/routes/browse.ts
+++ b/supabase/functions/plugin-store/routes/browse.ts
@@ -51,7 +51,18 @@ browse.openapi(listRoute, async (ctx) => {
     const supabase = ctx.get("supabase")
     const { page, pageSize, sortBy } = ctx.req.valid('query')
 
-    const result = await listPlugins(supabase, page, pageSize, sortBy)
+    // OPTIONAL auth. Browsing the store signed out must keep working, so a missing or unusable
+    // token is not an error here - it simply yields the public catalogue, which is what every
+    // caller got before this. A valid one additionally unlocks the organisation plugins that
+    // user_can_view_plugin_row says this reader may see.
+    const viewer = await optionalViewer(ctx)
+
+    const result = await listPlugins(supabase, page, pageSize, sortBy, viewer)
+
+    // PRIVATE when the answer depends on who asked. The same URL now returns different rows per
+    // reader, so a shared cache holding one reader's copy would serve somebody else's
+    // organisation plugins to the next caller. The other follow-up 20260803000000 asked for.
+    ctx.header("Cache-Control", viewer ? "private, no-store" : "public, max-age=60")
 
     return ctx.json({
       plugins: result.plugins,
@@ -289,3 +300,31 @@ browse.openapi(popularTagsRoute, async (ctx) => {
 })
 
 export default browse
+
+/**
+ * The signed-in reader, or null.
+ *
+ * Deliberately quiet: every failure - no header, an expired token, a malformed one - answers null
+ * and the caller gets the public catalogue. Browsing a store is not a privileged act, and turning a
+ * stale session into an error would break the anonymous case this endpoint has always served.
+ *
+ * An API key is NOT accepted. A CI key exists to publish, and letting one read a catalogue scoped
+ * to its owner's memberships would widen what a key in a build server can see for no reason anyone
+ * asked for.
+ */
+async function optionalViewer(ctx: { get: (k: string) => unknown; req: { header: (n: string) => string | undefined } }): Promise<string | null> {
+  const header = ctx.req.header("Authorization")
+  if (!header || !header.toLowerCase().startsWith("bearer ")) return null
+  const token = header.slice(7).trim()
+  if (token.length === 0) return null
+
+  // The anon key arrives in this header from some clients. It is a valid JWT and resolves to no
+  // user, so getUser refuses it - but checking first saves a network round trip on the common path.
+  try {
+    const supabase = ctx.get("supabase") as { auth: { getUser: (t: string) => Promise<{ data: { user: { id: string } | null } }> } }
+    const { data } = await supabase.auth.getUser(token)
+    return data?.user?.id ?? null
+  } catch {
+    return null
+  }
+}

--- a/supabase/functions/plugin-store/routes/publish.ts
+++ b/supabase/functions/plugin-store/routes/publish.ts
@@ -14,6 +14,7 @@ import {
   ErrorResponseSchema
 } from "../types/schemas.ts"
 import { getPlugin, createPlugin, setPluginTags, getPluginById, updatePlugin } from "../services/plugins.ts"
+import { resolvePublishOrg } from "../services/publish-org.ts"
 import { createVersion, versionExists, finalizeVersion, getVersionById } from "../services/versions.ts"
 import { getSignedUploadUrl, getSignedDownloadUrl, generateJarPath, uploadJar } from "../services/storage.ts"
 import { getAuthenticatedUser, getUserDisplayName, logApiKeyAction } from "../utils/auth.ts"
@@ -133,6 +134,14 @@ publish.openapi(publishPluginRoute, async (ctx) => {
     // Get author display name - use custom name if provided, otherwise derive from email
     const authorName = body.authorName || await getUserDisplayName(supabase, user.userId)
 
+    // Which organisation owns it. Resolved and AUTHORISED before any row is written: this
+    // handler runs as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is
+    // bypassed and nothing else would refuse an organisation the caller has no rights in.
+    const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
+    if (!orgResolution.ok) {
+      return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
+    }
+
     // Create plugin
     const result = await createPlugin(
       supabase,
@@ -145,7 +154,8 @@ publish.openapi(publishPluginRoute, async (ctx) => {
       body.iconUrl,
       body.type,
       body.apiVersion,
-      body.requiredPermissions
+      body.requiredPermissions,
+      orgResolution.orgId
     )
 
     // Auto-register the permissions this plugin introduces (ungranted; admin grants later).
@@ -689,6 +699,14 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
       isNewPlugin = true
       const authorName = manifest.author || await getUserDisplayName(supabase, user.userId)
 
+      // Which organisation owns it. Resolved and AUTHORISED before any row is written: this
+      // handler runs as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is
+      // bypassed and nothing else would refuse an organisation the caller has no rights in.
+      const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
+      if (!orgResolution.ok) {
+        return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
+      }
+
       const result = await createPlugin(
         supabase,
         user.userId,
@@ -700,7 +718,8 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
         manifest.iconUrl || '',
         ((manifest.type as string) || 'panel').toLowerCase(),
         manifest.apiVersion,
-        manifest.requiredPermissions || []
+        manifest.requiredPermissions || [],
+        orgResolution.orgId
       )
 
       pluginUuid = result.id
@@ -972,6 +991,14 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
       isNewPlugin = true
       const authorName = manifest.author || await getUserDisplayName(supabase, user.userId)
 
+      // Which organisation owns it. Resolved and AUTHORISED before any row is written: this
+      // handler runs as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is
+      // bypassed and nothing else would refuse an organisation the caller has no rights in.
+      const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
+      if (!orgResolution.ok) {
+        return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
+      }
+
       const result = await createPlugin(
         supabase,
         user.userId,
@@ -983,7 +1010,8 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
         '',
         ((manifest.type as string) || 'panel').toLowerCase(),
         manifest.apiVersion || '1.0.0',
-        manifest.requiredPermissions || []
+        manifest.requiredPermissions || [],
+        orgResolution.orgId
       )
       pluginUuid = result.id
     }

--- a/supabase/functions/plugin-store/services/plugins.ts
+++ b/supabase/functions/plugin-store/services/plugins.ts
@@ -8,9 +8,33 @@ export async function listPlugins(
   supabase: SupabaseClient,
   page: number,
   pageSize: number,
-  sortBy: string
+  sortBy: string,
+  /**
+   * Who is asking, or null for an anonymous browse.
+   *
+   * `search_plugins` reads `auth.uid()`, and this handler holds a SERVICE ROLE client - so auth.uid()
+   * is null however the caller authenticated, and the list was public-only for everybody. That is
+   * what hid an `org`-visibility plugin from the very members it exists for, and it is the follow-up
+   * 20260803000000 names: "routes/browse.ts needs the *_for_viewer variants".
+   *
+   * The viewer is passed to the RPC, which applies user_can_view_plugin_row itself. Nothing here
+   * decides visibility; this only stops the answer being computed for nobody.
+   */
+  viewerId: string | null = null
 ): Promise<{ plugins: PluginListItem[], totalCount: number }> {
-  const { data, error } = await supabase
+  const { data, error } = viewerId
+    ? await supabase.rpc('search_plugins_for_viewer', {
+      p_viewer_id: viewerId,
+      p_query: '',
+      p_type: null,
+      p_tags: null,
+      p_min_rating: 0,
+      p_verified_only: false,
+      p_page: page,
+      p_page_size: pageSize,
+      p_sort_by: sortBy
+    })
+    : await supabase
     .rpc('search_plugins', {
       p_query: '',
       p_type: null,

--- a/supabase/functions/plugin-store/services/plugins.ts
+++ b/supabase/functions/plugin-store/services/plugins.ts
@@ -164,7 +164,16 @@ export async function createPlugin(
   iconUrl: string,
   type: string,
   apiVersion: string,
-  requiredPermissions: string[] = []
+  requiredPermissions: string[] = [],
+  /**
+   * Owning organisation, already authorised by `resolvePublishOrg`.
+   *
+   * OMITTED from the insert when null, not sent as null: `plugins_default_org` is a BEFORE INSERT
+   * trigger keyed on `NEW.org_id IS NULL`, so an explicit null and an absent key both reach it and
+   * both become the boss organisation. Leaving the key out keeps that fallback visibly the
+   * trigger's decision rather than looking like this function chose it.
+   */
+  orgId: string | null = null
 ): Promise<{ id: string }> {
   const { data, error } = await supabase
     .from('plugins')
@@ -179,7 +188,8 @@ export async function createPlugin(
       type,
       api_version: apiVersion,
       required_permissions: requiredPermissions,
-      published: true
+      published: true,
+      ...(orgId ? { org_id: orgId } : {})
     })
     .select('id')
     .single()

--- a/supabase/functions/plugin-store/services/publish-org.ts
+++ b/supabase/functions/plugin-store/services/publish-org.ts
@@ -1,0 +1,148 @@
+/**
+ * Which organisation a newly published plugin belongs to.
+ *
+ * Until now: always the boss organisation. `createPlugin` never set `org_id`, so the
+ * `plugins_default_org` BEFORE INSERT trigger resolved `slug = 'boss'` for every row. The
+ * organisation was never CHOSEN - not from the request, not from a JWT claim, and not even from
+ * the publishing API key's own `org_id`, which `validate_plugin_api_key` returns and this function
+ * used to discard. Every plugin in the store is boss-owned as a result, which makes ownership
+ * inert: `@boss` is the system organisation every signup joins, so it restricts nothing.
+ *
+ * THE PUBLISH PATH RUNS AS SERVICE ROLE, so RLS is bypassed - including the
+ * `can_publish_org_plugin` WITH CHECK on `plugins`. Nothing else would stop a caller naming an
+ * organisation they have no rights in. The gate therefore has to be explicit here, which is what
+ * `validate_plugin_api_key`'s own COMMENT already specifies: "The publish path must gate on
+ * user_can_publish_org_plugin(user_id, org_id)".
+ *
+ * `user_can_publish_org_plugin` is that single source of truth - it evaluates `publish_role_id`
+ * (which overrides) then `publish_policy`, and short-circuits true for a global admin. It is
+ * deliberately not reimplemented in TypeScript.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { AuthResult } from "../utils/auth.ts"
+
+/** The organisation to record, or a refusal to hand back to the caller. */
+export type PublishOrgResolution =
+  | { ok: true; orgId: string | null }
+  | { ok: false; status: 403 | 500; error: string }
+
+/**
+ * Decide and authorise the owning organisation for a NEW plugin.
+ *
+ * Only for creation. A new VERSION of an existing plugin must never re-derive this: ownership is a
+ * property of the plugin, and re-resolving on every version would silently move a plugin between
+ * organisations as its publisher's memberships changed.
+ *
+ * Precedence, most explicit first:
+ *
+ *   1. `requestedOrgId` - the caller said so. Always authorised, never trusted.
+ *   2. The API key's bound `org_id`, for a CI publish. Also authorised: the key is not an
+ *      independent principal, so a revoked membership must revoke the key's publish rights.
+ *   3. The caller's single non-system organisation, when they have exactly one.
+ *   4. Null, meaning "let the trigger decide", which is the boss organisation.
+ *
+ * Step 3 requires EXACTLY ONE for a reason. The original migration rejected deriving from
+ * membership as ambiguous, and it is right whenever there is a choice to make: picking the
+ * alphabetically-first of three organisations would attribute somebody's plugin to a place they
+ * did not intend and give that organisation's admins rights over it. With exactly one candidate
+ * there is nothing to guess. Systems organisations are excluded because `@boss` holds every user,
+ * so counting it would make the answer "boss" for everybody and defeat the whole step.
+ */
+export async function resolvePublishOrg(
+  supabase: SupabaseClient,
+  user: AuthResult,
+  requestedOrgId?: string | null,
+): Promise<PublishOrgResolution> {
+  const explicit = requestedOrgId?.trim() || user.apiKeyOrgId?.trim() || null
+
+  if (explicit) {
+    const allowed = await canPublishForOrg(supabase, user.userId, explicit)
+    if (allowed === null) {
+      // Could not determine. Fail closed rather than falling through to the derivation, which
+      // would quietly publish somewhere else than the caller asked for.
+      // 500, not 503, because 503 is not in these routes' declared response set and widening
+      // three OpenAPI definitions to express "transient" is not worth it. The message carries the
+      // retry advice, which is the part the caller acts on.
+      return {
+        ok: false,
+        status: 500,
+        error: "Could not verify your publishing rights for that organisation. Please try again.",
+      }
+    }
+    if (!allowed) {
+      return {
+        ok: false,
+        status: 403,
+        error: "You do not have permission to publish plugins for that organisation.",
+      }
+    }
+    return { ok: true, orgId: explicit }
+  }
+
+  const sole = await soleNonSystemOrg(supabase, user.userId)
+  if (!sole) return { ok: true, orgId: null }
+
+  // Authorised too, even though it was derived rather than named: membership alone is not
+  // publishing rights. An organisation with publish_policy = 'owner_only' must not have every
+  // member's plugins land on it.
+  const allowed = await canPublishForOrg(supabase, user.userId, sole)
+  if (allowed !== true) return { ok: true, orgId: null }
+  return { ok: true, orgId: sole }
+}
+
+/**
+ * `user_can_publish_org_plugin`, or null when the question could not be answered.
+ *
+ * Null is distinct from false on purpose: false is a decision, null is an outage, and the caller
+ * treats them differently for an explicitly requested organisation.
+ */
+async function canPublishForOrg(
+  supabase: SupabaseClient,
+  userId: string,
+  orgId: string,
+): Promise<boolean | null> {
+  const { data, error } = await supabase.rpc("user_can_publish_org_plugin", {
+    p_user_id: userId,
+    p_org_id: orgId,
+  })
+  if (error) {
+    console.error("user_can_publish_org_plugin failed:", error.message)
+    return null
+  }
+  return data === true
+}
+
+/**
+ * The caller's only non-system organisation, or null when there is none or more than one.
+ *
+ * Read through `get_my_organisations(p_actor_id)` rather than the membership tables directly.
+ * `p_actor_id` is the service_role-only impersonation parameter that exists for exactly this: the
+ * function runs as service role, so `auth.uid()` is null and the RPC's default subject would be
+ * nobody. Going through the RPC also means the definition of "my organisations" stays in one
+ * place instead of being restated as a join here.
+ */
+async function soleNonSystemOrg(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase.rpc("get_my_organisations", { p_actor_id: userId })
+  if (error) {
+    console.error("get_my_organisations failed while resolving a publish organisation:", error.message)
+    return null
+  }
+
+  const envelope = data as { success?: unknown; data?: unknown } | null
+  if (!envelope || envelope.success !== true || !Array.isArray(envelope.data)) return null
+
+  const candidates = (envelope.data as Array<Record<string, unknown>>)
+    .filter((row) => row.is_system !== true)
+    // An absent status counts as active: get_my_organisations projects it today, but a shape that
+    // omitted it for the common case must not read as "not a member".
+    .filter((row) => row.status === undefined || row.status === null || row.status === "active")
+    .map((row) => (typeof row.id === "string" ? row.id : null))
+    .filter((id): id is string => id !== null)
+
+  const unique = [...new Set(candidates)]
+  return unique.length === 1 ? unique[0] : null
+}

--- a/supabase/functions/plugin-store/services/publish-org.ts
+++ b/supabase/functions/plugin-store/services/publish-org.ts
@@ -20,7 +20,22 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js"
-import type { AuthResult } from "../utils/auth.ts"
+
+/**
+ * The minimum this needs to know about the caller.
+ *
+ * Structural rather than `AuthResult`, because two different authentication paths reach here with
+ * two different shapes: the publish routes carry an `AuthResult`, and the API-key routes carry
+ * `getUserFromToken`'s narrower object. Both satisfy this, and neither has to be widened to a type
+ * it does not otherwise use.
+ *
+ * `apiKeyOrgId` is absent on a browser publish, which is exactly right: there is no key to inherit
+ * an organisation from.
+ */
+export interface PublishingCaller {
+  userId: string
+  apiKeyOrgId?: string
+}
 
 /** The organisation to record, or a refusal to hand back to the caller. */
 export type PublishOrgResolution =
@@ -51,7 +66,7 @@ export type PublishOrgResolution =
  */
 export async function resolvePublishOrg(
   supabase: SupabaseClient,
-  user: AuthResult,
+  user: PublishingCaller,
   requestedOrgId?: string | null,
 ): Promise<PublishOrgResolution> {
   const explicit = requestedOrgId?.trim() || user.apiKeyOrgId?.trim() || null

--- a/supabase/functions/plugin-store/tests/auth-permissions.test.ts
+++ b/supabase/functions/plugin-store/tests/auth-permissions.test.ts
@@ -26,6 +26,7 @@ import {
   permissionGateError,
 } from "../utils/permissions.ts"
 
+const API_KEY_ORG_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
 const OWNER_ID = "11111111-1111-1111-1111-111111111111"
 const VALID_KEY = "boss_pk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6" // 40 chars
 
@@ -74,11 +75,17 @@ function stubSupabase(opts: StubOptions = {}): { client: SupabaseClient; calls: 
         return Promise.resolve(
           opts.apiKey
             ? {
+              // THE REAL SHAPE. 20260803000000 recreated validate_plugin_api_key as
+              // RETURNS TABLE(key_id, user_id, scopes, org_id): `api_key_id` and `key_name` no
+              // longer exist. This stub kept returning the old names, so it agreed with auth.ts's
+              // stale reads and both were wrong together - which is how `apiKeyId: undefined`
+              // survived, silently disabling API-key audit logging and the last_used_at update.
+              // A stub that models a dead contract is worse than no test.
               data: [{
+                key_id: "key-1",
                 user_id: OWNER_ID,
-                api_key_id: "key-1",
-                key_name: "ci",
                 scopes: opts.apiKey.scopes,
+                org_id: API_KEY_ORG_ID,
               }],
               error: null,
             }
@@ -196,7 +203,11 @@ Deno.test("API key publishes when its owner still holds plugins.create", async (
 
   assert(outcome.ok)
   assertEquals(outcome.user.jwtPermissions, null, "API-key auth carries no claim")
-  assertEquals(outcome.user.apiKeyName, "ci")
+  // POPULATED, not undefined. Every `if (user.apiKeyId)` audit-log call in publish.ts hangs off
+  // this, and update_api_key_last_used is called with it.
+  assertEquals(outcome.user.apiKeyId, "key-1")
+  // And the key's organisation has to reach the publish path, which is why the RPC returns it.
+  assertEquals(outcome.user.apiKeyOrgId, API_KEY_ORG_ID)
   assertEquals(calls.probed, [{ userId: OWNER_ID, permission: PLUGIN_CREATE_PERMISSION }])
 })
 

--- a/supabase/functions/plugin-store/tests/publish-org.test.ts
+++ b/supabase/functions/plugin-store/tests/publish-org.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Which organisation a new plugin is attributed to, and who is allowed to say.
+ *
+ * The publish path runs as SERVICE ROLE, so every RLS check on `plugins` - including the
+ * `can_publish_org_plugin` WITH CHECK - is bypassed. That makes `resolvePublishOrg` the only thing
+ * standing between a request body and an organisation it has no rights in, so the refusals matter
+ * more than the happy path.
+ *
+ * Note what is deliberately NOT symmetric: an organisation the caller NAMED and may not publish for
+ * is a 403, while one merely DERIVED from their memberships falls back to the default instead of
+ * failing. Asking for something you cannot have is an error; not asking is not.
+ */
+
+import { assert, assertEquals } from "@std/assert"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { resolvePublishOrg } from "../services/publish-org.ts"
+import type { PublishOrgResolution } from "../services/publish-org.ts"
+import type { AuthResult } from "../utils/auth.ts"
+
+const USER = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const ORG_RISA = "11111111-1111-4111-8111-111111111111"
+const ORG_OTHER = "22222222-2222-4222-8222-222222222222"
+const ORG_BOSS = "33333333-3333-4333-8333-333333333333"
+
+interface StubOpts {
+  /** Answer for user_can_publish_org_plugin, per org id. Absent org id answers false. */
+  canPublish?: Record<string, boolean>
+  /** Rows for get_my_organisations, already in envelope `data` shape. */
+  orgs?: Array<Record<string, unknown>>
+  /** Function names that should return an error instead of data. */
+  failing?: string[]
+}
+
+function stub(opts: StubOpts = {}): { client: SupabaseClient; calls: string[] } {
+  const calls: string[] = []
+  const client = {
+    rpc: (fn: string, args: Record<string, unknown>) => {
+      calls.push(fn)
+      if (opts.failing?.includes(fn)) {
+        return Promise.resolve({ data: null, error: { message: "boom" } })
+      }
+      if (fn === "user_can_publish_org_plugin") {
+        const orgId = args.p_org_id as string
+        return Promise.resolve({ data: opts.canPublish?.[orgId] === true, error: null })
+      }
+      if (fn === "get_my_organisations") {
+        return Promise.resolve({
+          data: { success: true, data: opts.orgs ?? [] },
+          error: null,
+        })
+      }
+      return Promise.resolve({ data: null, error: { message: `unexpected rpc ${fn}` } })
+    },
+  }
+  return { client: client as unknown as SupabaseClient, calls }
+}
+
+function user(extra: Partial<AuthResult> = {}): AuthResult {
+  return { userId: USER, email: "a@b.test", isAdmin: false, jwtPermissions: null, ...extra }
+}
+
+/**
+ * Narrowing helpers.
+ *
+ * `assert(result.ok)` from @std/assert declares `asserts expr`, which says the EXPRESSION is truthy
+ * and narrows nothing about `result` - so `result.orgId` stays a type error on the union. These
+ * discriminate properly, and their throw messages say what was actually returned, which is more
+ * useful than a bare assertion failure.
+ */
+function orgOf(result: PublishOrgResolution): string | null {
+  if (!result.ok) throw new Error(`expected success, got ${result.status}: ${result.error}`)
+  return result.orgId
+}
+
+function refusalOf(result: PublishOrgResolution): { status: number; error: string } {
+  if (result.ok) throw new Error(`expected a refusal, got orgId=${result.orgId}`)
+  return { status: result.status, error: result.error }
+}
+
+// ---------------------------------------------------------------------------
+// An explicitly requested organisation
+// ---------------------------------------------------------------------------
+
+Deno.test("a requested organisation the caller may publish for is used", async () => {
+  const { client, calls } = stub({ canPublish: { [ORG_RISA]: true } })
+  const result = await resolvePublishOrg(client, user(), ORG_RISA)
+  assertEquals(orgOf(result), ORG_RISA)
+  // Authorised, not trusted. Service role bypasses the RLS WITH CHECK, so if this call is ever
+  // dropped nothing else refuses.
+  assert(calls.includes("user_can_publish_org_plugin"))
+})
+
+Deno.test("a requested organisation the caller may NOT publish for is a 403", async () => {
+  const { client } = stub({ canPublish: { [ORG_RISA]: false } })
+  const result = await resolvePublishOrg(client, user(), ORG_RISA)
+  assertEquals(refusalOf(result).status, 403)
+})
+
+Deno.test("a refused request does not quietly fall back to a derived organisation", async () => {
+  // The dangerous shape: refuse the named org, then publish somewhere else anyway. The caller
+  // would get a 201 and a plugin attributed to an organisation they did not choose.
+  const { client } = stub({
+    canPublish: { [ORG_RISA]: false, [ORG_OTHER]: true },
+    orgs: [{ id: ORG_OTHER, is_system: false, status: "active" }],
+  })
+  const result = await resolvePublishOrg(client, user(), ORG_RISA)
+  refusalOf(result)
+})
+
+Deno.test("an unanswerable permission check fails closed, it does not default", async () => {
+  const { client } = stub({ failing: ["user_can_publish_org_plugin"] })
+  const result = await resolvePublishOrg(client, user(), ORG_RISA)
+  assertEquals(refusalOf(result).status, 500)
+})
+
+// ---------------------------------------------------------------------------
+// The API key's own organisation
+// ---------------------------------------------------------------------------
+
+Deno.test("an API key publishes for the organisation it is bound to", async () => {
+  // The field validate_plugin_api_key has always returned and the function used to discard.
+  const { client } = stub({ canPublish: { [ORG_RISA]: true } })
+  const result = await resolvePublishOrg(client, user({ apiKeyOrgId: ORG_RISA }))
+  assertEquals(orgOf(result), ORG_RISA)
+})
+
+Deno.test("an API key whose owner lost publishing rights is refused", async () => {
+  // The key is not an independent principal. Revoking the human's membership has to revoke their
+  // CI key's publish rights too, which is the RPC's own documented contract.
+  const { client } = stub({ canPublish: { [ORG_RISA]: false } })
+  const result = await resolvePublishOrg(client, user({ apiKeyOrgId: ORG_RISA }))
+  assertEquals(refusalOf(result).status, 403)
+})
+
+Deno.test("an explicit request outranks the API key's organisation", async () => {
+  const { client } = stub({ canPublish: { [ORG_OTHER]: true } })
+  const result = await resolvePublishOrg(client, user({ apiKeyOrgId: ORG_RISA }), ORG_OTHER)
+  assertEquals(orgOf(result), ORG_OTHER)
+})
+
+// ---------------------------------------------------------------------------
+// Derived from membership
+// ---------------------------------------------------------------------------
+
+Deno.test("a single non-system organisation is used when nothing was named", async () => {
+  const { client } = stub({
+    canPublish: { [ORG_RISA]: true },
+    orgs: [
+      { id: ORG_BOSS, is_system: true, status: "active" },
+      { id: ORG_RISA, is_system: false, status: "active" },
+    ],
+  })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), ORG_RISA)
+})
+
+Deno.test("the system organisation alone derives nothing", async () => {
+  // Every user is an active member of @boss, so counting it would make the derived answer "boss"
+  // for everybody and the whole step pointless. Returning null lets the trigger do it instead,
+  // which is the same outcome by a route that is visibly a default.
+  const { client } = stub({ orgs: [{ id: ORG_BOSS, is_system: true, status: "active" }] })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), null)
+})
+
+Deno.test("two candidate organisations derive nothing rather than guessing", async () => {
+  // Picking one would attribute somebody's plugin to a place they did not choose and hand that
+  // organisation's admins rights over it.
+  const { client } = stub({
+    canPublish: { [ORG_RISA]: true, [ORG_OTHER]: true },
+    orgs: [
+      { id: ORG_RISA, is_system: false, status: "active" },
+      { id: ORG_OTHER, is_system: false, status: "active" },
+    ],
+  })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), null)
+})
+
+Deno.test("a pending membership is not a candidate", async () => {
+  // Awaiting approval is not membership. Otherwise applying to an organisation would be enough to
+  // publish under its name.
+  const { client } = stub({
+    canPublish: { [ORG_RISA]: true },
+    orgs: [{ id: ORG_RISA, is_system: false, status: "pending" }],
+  })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), null)
+})
+
+Deno.test("a derived organisation the caller cannot publish for falls back, not 403", async () => {
+  // The asymmetry: they never asked for it. An organisation with publish_policy = 'owner_only'
+  // must not have every member's plugins land on it, but nor should membership alone turn a
+  // perfectly valid publish into an error.
+  const { client } = stub({
+    canPublish: { [ORG_RISA]: false },
+    orgs: [{ id: ORG_RISA, is_system: false, status: "active" }],
+  })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), null)
+})
+
+Deno.test("an unreadable membership list derives nothing", async () => {
+  const { client } = stub({ failing: ["get_my_organisations"] })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), null)
+})
+
+Deno.test("no memberships at all derives nothing", async () => {
+  const { client } = stub({ orgs: [] })
+  const result = await resolvePublishOrg(client, user())
+  assertEquals(orgOf(result), null)
+})
+
+Deno.test("a blank requested organisation is treated as absent, not as an id", async () => {
+  // A client sending `orgId: ""` must not produce a lookup for the empty string, which would come
+  // back false and 403 a publish that named nothing.
+  const { client } = stub({ orgs: [] })
+  const result = await resolvePublishOrg(client, user(), "   ")
+  assertEquals(orgOf(result), null)
+})

--- a/supabase/functions/plugin-store/types/schemas.ts
+++ b/supabase/functions/plugin-store/types/schemas.ts
@@ -142,6 +142,13 @@ export const RatePluginResponseSchema = z.object({
 // ============================================================================
 
 export const PublishPluginRequestSchema = z.object({
+  /**
+   * Organisation to publish under. Optional, and AUTHORISED server-side against
+   * `user_can_publish_org_plugin` - naming one you have no rights in is a 403, not a silent
+   * fallback. Omitted means the server derives it: the API key's bound organisation, else your
+   * single non-system organisation, else the boss organisation.
+   */
+  orgId: z.string().uuid('orgId must be a UUID').optional(),
   pluginId: z.string().min(3).max(100).regex(/^[a-z0-9.-]+$/i, 'Plugin ID must contain only alphanumeric characters, dots, and hyphens'),
   displayName: z.string().min(1).max(100),
   description: z.string().max(5000).optional().default(''),
@@ -207,6 +214,13 @@ export const FinalizeVersionResponseSchema = z.object({
 // ============================================================================
 
 export const PublishFromGitHubRequestSchema = z.object({
+  /**
+   * Organisation to publish under. Optional, and AUTHORISED server-side against
+   * `user_can_publish_org_plugin` - naming one you have no rights in is a 403, not a silent
+   * fallback. Omitted means the server derives it: the API key's bound organisation, else your
+   * single non-system organisation, else the boss organisation.
+   */
+  orgId: z.string().uuid('orgId must be a UUID').optional(),
   githubUrl: z.string().url('Must be a valid GitHub URL').refine(
     (url) => url.includes('github.com'),
     'URL must be a GitHub repository URL'
@@ -229,6 +243,13 @@ export const PublishFromGitHubResponseSchema = z.object({
 // ============================================================================
 
 export const PublishFromGitHubMetadataRequestSchema = z.object({
+  /**
+   * Organisation to publish under. Optional, and AUTHORISED server-side against
+   * `user_can_publish_org_plugin` - naming one you have no rights in is a 403, not a silent
+   * fallback. Omitted means the server derives it: the API key's bound organisation, else your
+   * single non-system organisation, else the boss organisation.
+   */
+  orgId: z.string().uuid('orgId must be a UUID').optional(),
   githubUrl: z.string().url('Must be a valid GitHub URL').refine(
     (url) => url.includes('github.com'),
     'URL must be a GitHub repository URL'

--- a/supabase/functions/plugin-store/utils/auth.ts
+++ b/supabase/functions/plugin-store/utils/auth.ts
@@ -23,8 +23,17 @@ export interface AuthResult {
   apiKeyId?: string
   /** Only set when authenticated via API key */
   apiKeyScopes?: string[]
-  /** Only set when authenticated via API key */
-  apiKeyName?: string
+  /**
+   * The organisation this API key may publish for. Only set when authenticated via API key.
+   *
+   * `validate_plugin_api_key` COALESCEs it to the boss organisation, so keys minted before
+   * 20260803000000 keep working rather than losing the ability to publish.
+   *
+   * IT IS NOT AUTHORITY ON ITS OWN. The key is not an independent principal: the publish path
+   * still gates on `user_can_publish_org_plugin(user_id, org_id)`, so revoking the human's
+   * membership kills their CI key's publish rights too. That is the RPC's own stated contract.
+   */
+  apiKeyOrgId?: string
 }
 
 /**
@@ -193,9 +202,17 @@ export async function validateApiKey(
       return null
     }
 
-    // Update last_used_at (non-blocking but with error logging for audit trail)
+    // `key_id`, NOT `api_key_id`. 20260803000000 DROPped and recreated validate_plugin_api_key
+    // with `RETURNS TABLE(key_id, user_id, scopes, org_id)`, and this file was never updated - so
+    // `keyInfo.api_key_id` has been `undefined` ever since. Two things broke silently: this RPC
+    // was called with `p_key_id: undefined`, so `last_used_at` stopped advancing, and every
+    // `if (user.apiKeyId)` audit-log call in publish.ts became a no-op, which means API-key
+    // publishes have not been recorded in the audit trail at all.
+    //
+    // `key_name` went away in the same migration and is not read back: the one consumer was a log
+    // string that already falls back to the id.
     try {
-      await supabase.rpc("update_api_key_last_used", { p_key_id: keyInfo.api_key_id })
+      await supabase.rpc("update_api_key_last_used", { p_key_id: keyInfo.key_id })
     } catch (error) {
       console.warn("Failed to update API key last_used timestamp:", error)
       // Don't fail the request, but log for investigation
@@ -208,9 +225,9 @@ export async function validateApiKey(
       // No JWT, so no user_permissions claim — resolved from the owner's roles
       // on demand by userHasPermission().
       jwtPermissions: null,
-      apiKeyId: keyInfo.api_key_id,
+      apiKeyId: keyInfo.key_id,
       apiKeyScopes: keyInfo.scopes,
-      apiKeyName: keyInfo.key_name,
+      apiKeyOrgId: keyInfo.org_id ?? undefined,
     }
   } catch (e) {
     console.error("Exception validating API key:", e)
@@ -335,7 +352,9 @@ export async function getAuthenticatedUser(
   if (requiredPermission && !(await userHasPermission(supabase, user, requiredPermission))) {
     console.error(
       `User ${user.userId} lacks required permission ${requiredPermission}` +
-        (user.apiKeyId ? ` (via API key ${user.apiKeyName ?? user.apiKeyId})` : "")
+        // The id, not a name: `key_name` stopped being returned by validate_plugin_api_key in
+        // 20260803000000, so the `?? apiKeyName` branch had been dead and always fell through.
+        (user.apiKeyId ? ` (via API key ${user.apiKeyId})` : "")
     )
     return {
       ok: false,

--- a/supabase/migrations/20260811000000_bind_api_keys_to_publisher_org.sql
+++ b/supabase/migrations/20260811000000_bind_api_keys_to_publisher_org.sql
@@ -1,0 +1,154 @@
+-- ============================================================================
+-- BOSS Database Schema: bind publishing API keys to their owner's organisation
+--
+-- File: 20260811000000_bind_api_keys_to_publisher_org.sql
+--
+-- 20260803000000 added plugin_api_keys.org_id, commented "The organisation this
+-- key may publish for", and backfilled EVERY existing row to the boss
+-- organisation so nothing broke. routes/api-keys.ts never set it on creation
+-- either, so new keys were NULL and validate_plugin_api_key's COALESCE made them
+-- look boss-bound too.
+--
+-- The publish path now reads that value (services/publish-org.ts), so with every
+-- key pointing at boss the new attribution resolves to boss for every CI publish.
+-- The mechanism works and changes nothing. This is the half that gives it
+-- something to say.
+--
+-- A FUNCTION, NOT A ONE-OFF `DO` BLOCK, for two reasons. A test can call the
+-- real thing instead of a copy of it pasted into the test file - the alternative
+-- is a test that passes while the migration is wrong. And an operator who fixes
+-- somebody's membership afterwards can re-run it rather than hand-writing the
+-- UPDATE, which is the situation the NOTICE at the end points at.
+--
+-- THE RULE IS THE SAME ONE THE PUBLISH PATH DERIVES, deliberately: a key binds to
+-- its OWNER'S SINGLE NON-SYSTEM ORGANISATION, and only when that owner may
+-- actually publish there. Two rules for one question would drift. Each clause
+-- earns its place:
+--
+--   * SINGLE. With two candidates there is nothing to derive - picking one would
+--     bind somebody's CI to an organisation they did not choose, and every plugin
+--     it creates from then on would be attributed there.
+--   * NON-SYSTEM. Every user is an active member of `boss`, so counting it would
+--     make the answer "boss" for everyone and this a no-op with extra steps.
+--   * MAY PUBLISH. Membership is not publishing rights. An organisation with
+--     publish_policy = 'owner_only' must not have every member's key bound to it,
+--     because user_can_publish_org_plugin would then refuse every publish that key
+--     attempts - turning a working key into a broken one.
+--
+-- SCOPE, narrow on purpose: only rows currently pointing at the boss organisation
+-- or at nothing. A key an administrator has already bound somewhere is left
+-- exactly as it is. This clears the backfill's default; it has no opinion about
+-- deliberate choices.
+--
+-- NO `plugins` ROWS ARE RE-ATTRIBUTED. Existing plugins keep the organisation
+-- they were created with. Ownership is resolved once, at creation, and
+-- re-deriving it for a plugin that already exists would move it between
+-- organisations behind its publisher's back.
+-- ============================================================================
+
+
+CREATE OR REPLACE FUNCTION "public"."bind_api_keys_to_publisher_org"()
+RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_boss_id   UUID;
+    v_bound     INTEGER := 0;
+    v_remaining INTEGER := 0;
+    v_row       RECORD;
+BEGIN
+    SELECT o.id INTO v_boss_id FROM public.organisations o WHERE o.slug = 'boss';
+
+    -- Not an error. A deployment without the boss organisation has nothing to
+    -- clear: the backfill that created this situation targets that row, and the
+    -- trigger that defaults to it leaves org_id NULL when it is absent. The
+    -- IS NULL arm below still applies, so this works either way.
+    IF v_boss_id IS NULL THEN
+        RAISE NOTICE 'No boss organisation; only NULL-bound keys are candidates.';
+    END IF;
+
+    FOR v_row IN
+        SELECT k.id AS key_id,
+               k.user_id,
+               k.name,
+               sole.org_id AS target_org_id
+          FROM public.plugin_api_keys k
+          -- The owner's single non-system organisation, or no row at all when they
+          -- have none or several. A LATERAL with LIMIT 2 rather than a correlated
+          -- scalar subquery, so "more than one" is DETECTABLE instead of raising
+          -- 21000 and aborting the whole migration.
+          JOIN LATERAL (
+              -- array_agg(...)[1], not min(): there is no min() aggregate for uuid,
+              -- and min() fails with 42883 at runtime rather than at parse time -
+              -- found by running this, not by reading it. The count guard means the
+              -- array has exactly one element whenever it is read.
+              SELECT CASE WHEN count(*) = 1 THEN (array_agg(candidate.org_id))[1] END AS org_id
+                FROM (
+                    SELECT m.org_id
+                      FROM public.organisation_members m
+                      JOIN public.organisations o ON o.id = m.org_id
+                     WHERE m.user_id = k.user_id
+                       AND m.status = 'active'
+                       AND o.is_system = false
+                     LIMIT 2
+                ) candidate
+          ) sole ON sole.org_id IS NOT NULL
+         WHERE (k.org_id IS NULL OR k.org_id = v_boss_id)
+           AND public.user_can_publish_org_plugin(k.user_id, sole.org_id)
+    LOOP
+        UPDATE public.plugin_api_keys
+           SET org_id = v_row.target_org_id
+         WHERE id = v_row.key_id;
+
+        v_bound := v_bound + 1;
+
+        -- Named individually, because the point is that somebody can read the
+        -- deploy output and see which CI keys changed hands. A count alone would
+        -- not let anyone check it was right.
+        RAISE NOTICE 'Bound API key "%" (owner %) to organisation %',
+            v_row.name, v_row.user_id, v_row.target_org_id;
+    END LOOP;
+
+    SELECT count(*) INTO v_remaining
+      FROM public.plugin_api_keys k
+     WHERE k.org_id IS NULL OR (v_boss_id IS NOT NULL AND k.org_id = v_boss_id);
+
+    RETURN jsonb_build_object('success', true, 'bound', v_bound, 'remaining', v_remaining);
+END;
+$$;
+
+ALTER FUNCTION "public"."bind_api_keys_to_publisher_org"() OWNER TO "postgres";
+
+-- Maintenance, not a client operation: it rewrites who other people's keys publish
+-- for. Nothing authenticated should be able to call it.
+REVOKE EXECUTE ON FUNCTION "public"."bind_api_keys_to_publisher_org"()
+    FROM PUBLIC, "anon", "authenticated";
+GRANT  EXECUTE ON FUNCTION "public"."bind_api_keys_to_publisher_org"() TO "service_role";
+
+COMMENT ON FUNCTION "public"."bind_api_keys_to_publisher_org"() IS
+    'Binds each plugin_api_keys row still defaulting to the boss organisation to its owner''s single non-system organisation, when that owner may publish there. Same rule the publish path derives (services/publish-org.ts), kept in one place so the two cannot drift. Idempotent; leaves deliberately-bound keys alone. Re-runnable after fixing a membership.';
+
+
+-- ---------------------------------------------------------------------------
+-- Run it once, now, and say what happened
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    v_result JSONB;
+BEGIN
+    v_result := public.bind_api_keys_to_publisher_org();
+
+    RAISE NOTICE 'Bound % API key(s) to a publisher organisation. % still resolve to boss.',
+        v_result->>'bound', v_result->>'remaining';
+
+    -- Worth saying out loud rather than leaving to be discovered: a key left on
+    -- boss is not broken, it just publishes as before. Every reason is legitimate -
+    -- owner in no organisation, owner in several, or owner without publishing
+    -- rights where they are - and each needs a human decision a migration should
+    -- not make.
+    IF (v_result->>'remaining')::integer > 0 THEN
+        RAISE NOTICE 'Those need an explicit organisation: their owner has none, has several, or cannot publish in the one they have.';
+    END IF;
+END;
+$$;

--- a/supabase/migrations/20260812000000_attribute_risa_plugins.sql
+++ b/supabase/migrations/20260812000000_attribute_risa_plugins.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- BOSS Database Schema: attribute the RISA-owned plugins to the risa organisation
+--
+-- File: 20260812000000_attribute_risa_plugins.sql
+--
+-- Every row in `plugins` sits on the boss organisation: 20260803000000 backfilled
+-- them all there and nothing since has chosen otherwise. 20260811000000 fixed
+-- that going FORWARD - a newly created plugin now takes its publisher's
+-- organisation - but it deliberately does not re-derive ownership when a new
+-- VERSION is published, because that would move a plugin between organisations
+-- every time its publisher's memberships changed. So no amount of CI activity
+-- moves an existing row, and the ones that are genuinely RISA's need naming.
+--
+-- NAMED EXPLICITLY, NOT DERIVED. This is the difference between this migration and
+-- 20260811000000. The API keys had a derivable answer - their owner's single
+-- non-system organisation - and deriving it was safer than a list that could go
+-- stale. These five have no such answer: `plugins.author_id` is whoever happened
+-- to run the publish, which is the same person for most of the store, so deriving
+-- from it would sweep up plugins that are not RISA's. An operator asserting
+-- ownership is the only correct source, so the list is the input.
+--
+-- The five, with why each is here:
+--
+--   medical-necessity  Medical Necessity
+--   mednec             Medical Necessity - Rohith Team1
+--   mednec-copilot     RISA Copilot - Medical Necessity
+--   codexglm           Codex GLM
+--   finances           Finances
+--
+-- WHAT THIS CHANGES FOR A READER, which is less than it looks: `visibility` is
+-- untouched and all five are 'public', so `can_view_plugin_row` still returns true
+-- for everyone including anonymous callers, and `user_can_install_plugin` is
+-- unaffected. Nobody loses access to anything. What changes is the org arm of the
+-- UPDATE policy - risa admins gain the ability to update these rows, and boss
+-- admins lose it. Global plugins-admins keep it either way through the permissive
+-- policy in 20260131000000, so no plugin becomes unmanageable.
+--
+-- ONLY ROWS STILL ON boss (or NULL) ARE MOVED. If one of these has since been
+-- attributed deliberately somewhere else, that decision wins over this list.
+-- Idempotent for the same reason: a second run finds nothing on boss.
+-- ============================================================================
+
+
+DO $$
+DECLARE
+    v_risa_id UUID;
+    v_boss_id UUID;
+    v_moved   INTEGER := 0;
+    v_row     RECORD;
+    -- The list lives here rather than in a WHERE ... IN so the loop can report on
+    -- each one, including the ones it did NOT move. A plugin silently absent from
+    -- this migration's output is the failure mode worth surfacing: a typo'd
+    -- plugin_id would otherwise look identical to a successful no-op.
+    v_targets TEXT[] := ARRAY[
+        'ai.rever.boss.plugin.dynamic.medical-necessity',
+        'ai.rever.boss.plugin.dynamic.mednec',
+        'ai.rever.boss.plugin.dynamic.mednec-copilot',
+        'ai.rever.boss.plugin.dynamic.codexglm',
+        'ai.rever.boss.plugin.dynamic.finances'
+    ];
+    v_target  TEXT;
+BEGIN
+    SELECT o.id INTO v_risa_id FROM public.organisations o WHERE o.slug = 'risa';
+    SELECT o.id INTO v_boss_id FROM public.organisations o WHERE o.slug = 'boss';
+
+    -- Fail loudly. Silently doing nothing because the organisation is absent is how
+    -- a migration gets marked applied while achieving nothing - the exact failure
+    -- 20260806000000's UPDATE hit, where a backfill matched zero rows on a fresh
+    -- deployment and nobody noticed until it was re-derived from scratch.
+    --
+    -- RAISE EXCEPTION rather than NOTICE because unlike that backfill this list is
+    -- specific: there is no environment where these five plugins exist and the risa
+    -- organisation does not, so its absence means the migration is being run
+    -- somewhere it was not written for and should stop rather than guess.
+    IF v_risa_id IS NULL THEN
+        IF EXISTS (SELECT 1 FROM public.plugins p WHERE p.plugin_id = ANY(v_targets)) THEN
+            RAISE EXCEPTION
+                'No organisation with slug "risa", but the plugins it should own are present. Refusing to guess.';
+        END IF;
+        RAISE NOTICE 'No risa organisation and none of the target plugins present; nothing to do.';
+        RETURN;
+    END IF;
+
+    FOREACH v_target IN ARRAY v_targets LOOP
+        SELECT p.id, p.plugin_id, p.org_id, p.visibility
+          INTO v_row
+          FROM public.plugins p
+         WHERE p.plugin_id = v_target;
+
+        IF NOT FOUND THEN
+            RAISE NOTICE 'SKIPPED %: no such plugin in the store.', v_target;
+            CONTINUE;
+        END IF;
+
+        IF v_row.org_id IS NOT NULL AND v_row.org_id <> v_boss_id AND v_row.org_id <> v_risa_id THEN
+            RAISE NOTICE 'SKIPPED %: already attributed to % - a deliberate choice outranks this list.',
+                v_target, v_row.org_id;
+            CONTINUE;
+        END IF;
+
+        IF v_row.org_id = v_risa_id THEN
+            RAISE NOTICE 'ALREADY risa: %.', v_target;
+            CONTINUE;
+        END IF;
+
+        UPDATE public.plugins SET org_id = v_risa_id WHERE id = v_row.id;
+        v_moved := v_moved + 1;
+        RAISE NOTICE 'MOVED % to risa (visibility stays %).', v_target, v_row.visibility;
+    END LOOP;
+
+    RAISE NOTICE 'Attributed % of % named plugin(s) to the risa organisation.',
+        v_moved, array_length(v_targets, 1);
+END;
+$$;

--- a/supabase/migrations/20260814000000_attribute_form_assist.sql
+++ b/supabase/migrations/20260814000000_attribute_form_assist.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- BOSS Database Schema: attribute Form Assist to the risa organisation
+--
+-- File: 20260814000000_attribute_form_assist.sql
+--
+-- The sixth. 20260812000000 named five plugins as RISA's; Form Assist is another,
+-- identified afterwards by the operator.
+--
+-- A SEPARATE MIGRATION, NOT AN EDIT TO THAT LIST. 20260812000000 is applied on
+-- production, so editing it would change a file the migration history has already
+-- recorded as run - the checksum drifts, and worse, the edit would have no effect
+-- anywhere it had already been applied while looking authoritative in the source.
+-- Naming a new one is the only version of this that does what it says on every
+-- deployment.
+--
+-- NAMED, NOT DERIVED, for the reason 20260812000000 sets out at length:
+-- `plugins.author_id` is whoever ran the publish, which is one person for most of
+-- this store, so deriving ownership from it would sweep up plugins that are not
+-- RISA's. An operator asserting ownership is the only correct source.
+--
+-- WHAT IT CHANGES FOR A READER: nothing. `visibility` is untouched and the row is
+-- 'public', so can_view_plugin_row still returns true for everyone including
+-- anonymous callers, and user_can_install_plugin is unaffected. What moves is the
+-- org arm of the UPDATE policy: risa admins gain the ability to update this row and
+-- boss admins lose it. Global plugins-admins keep it either way through the
+-- permissive policy in 20260131000000, so it does not become unmanageable.
+--
+-- ONLY A ROW STILL ON boss (or NULL) IS MOVED, so a later deliberate attribution
+-- outranks this file, and a second run finds nothing to do.
+-- ============================================================================
+
+
+DO $$
+DECLARE
+    v_risa_id UUID;
+    v_boss_id UUID;
+    v_row     RECORD;
+    v_target  TEXT := 'ai.rever.boss.plugin.dynamic.form-assist';
+BEGIN
+    SELECT o.id INTO v_risa_id FROM public.organisations o WHERE o.slug = 'risa';
+    SELECT o.id INTO v_boss_id FROM public.organisations o WHERE o.slug = 'boss';
+
+    -- Fail loudly rather than be marked applied having achieved nothing, which is the
+    -- failure 20260806000000's backfill hit. The exception is conditional on the
+    -- plugin actually being present: a fresh deployment that has neither is a
+    -- legitimate no-op, while a deployment holding the plugin but no risa
+    -- organisation is one this migration was not written for.
+    IF v_risa_id IS NULL THEN
+        IF EXISTS (SELECT 1 FROM public.plugins p WHERE p.plugin_id = v_target) THEN
+            RAISE EXCEPTION
+                'No organisation with slug "risa", but % is present. Refusing to guess.', v_target;
+        END IF;
+        RAISE NOTICE 'No risa organisation and % is not present; nothing to do.', v_target;
+        RETURN;
+    END IF;
+
+    SELECT p.id, p.plugin_id, p.org_id, p.visibility
+      INTO v_row
+      FROM public.plugins p
+     WHERE p.plugin_id = v_target;
+
+    IF NOT FOUND THEN
+        -- A NOTICE, not an exception: the store is not the same on every deployment,
+        -- and a local database that has never seen this plugin is not broken. Said out
+        -- loud because a typo in the id above would otherwise look exactly like success.
+        RAISE NOTICE 'SKIPPED %: no such plugin in the store.', v_target;
+        RETURN;
+    END IF;
+
+    IF v_row.org_id = v_risa_id THEN
+        RAISE NOTICE 'ALREADY risa: %.', v_target;
+        RETURN;
+    END IF;
+
+    IF v_row.org_id IS NOT NULL AND v_row.org_id <> v_boss_id THEN
+        RAISE NOTICE 'SKIPPED %: already attributed to % - a deliberate choice outranks this file.',
+            v_target, v_row.org_id;
+        RETURN;
+    END IF;
+
+    UPDATE public.plugins SET org_id = v_risa_id WHERE id = v_row.id;
+    RAISE NOTICE 'MOVED % to risa (visibility stays %).', v_target, v_row.visibility;
+END;
+$$;

--- a/supabase/tests/api_key_org_binding_test.sql
+++ b/supabase/tests/api_key_org_binding_test.sql
@@ -1,0 +1,204 @@
+-- pgTAP tests for binding publishing API keys to an organisation (20260811000000).
+-- Run with: supabase test db
+--
+-- These call `public.bind_api_keys_to_publisher_org()` - the real function the migration runs, not
+-- a copy of its body pasted here. That distinction is the reason the migration defines a function
+-- at all: a test that re-implements the logic passes whether or not the shipped version works.
+--
+-- The migration ran once already during `db reset`, against a database with no users, no keys and
+-- no boss organisation, so it bound nothing. Everything below builds the state it was written for
+-- and calls it again, which is also what proves it is re-runnable.
+
+begin;
+select plan(19);
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+insert into auth.users (id, email, email_confirmed_at) values
+    ('c0000000-0000-4000-8000-000000000001', 'sole@keys.test',    now()),
+    ('c0000000-0000-4000-8000-000000000002', 'multi@keys.test',   now()),
+    ('c0000000-0000-4000-8000-000000000003', 'nomember@keys.test', now()),
+    ('c0000000-0000-4000-8000-000000000004', 'nopublish@keys.test', now()),
+    ('c0000000-0000-4000-8000-000000000005', 'already@keys.test',  now()),
+    -- lockedco needs its OWN owner. Making user 1 own it as well gave that user TWO non-system
+    -- organisations, so the sole-organisation case stopped being sole and the function correctly
+    -- bound nothing - the fixture contradicted what the test claimed to be checking.
+    ('c0000000-0000-4000-8000-000000000006', 'lockowner@keys.test', now());
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+-- The system organisation. Every user joins it, which is exactly why it must not count.
+select ok(
+    (public.ensure_boss_organisation() ->> 'success')::boolean,
+    'the boss organisation exists, so the boss-bound arm is reachable'
+);
+
+-- `members` publish policy: membership alone is enough, so the sole-org user qualifies.
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'acmeone', p_name => 'Acme One', p_description => null,
+        p_owner_id => 'c0000000-0000-4000-8000-000000000001',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'the sole-organisation user has an organisation'
+);
+update public.organisations set publish_policy = 'members' where slug = 'acmeone';
+
+-- Two organisations for the multi user: nothing to derive.
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'twoa', p_name => 'Two A', p_description => null,
+        p_owner_id => 'c0000000-0000-4000-8000-000000000002',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'the multi-organisation user has a first organisation'
+);
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'twob', p_name => 'Two B', p_description => null,
+        p_owner_id => 'c0000000-0000-4000-8000-000000000002',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'and a second'
+);
+update public.organisations set publish_policy = 'members' where slug in ('twoa', 'twob');
+
+-- One organisation, but owner_only and this user is NOT the owner: a member who may not publish.
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'lockedco', p_name => 'Locked Co', p_description => null,
+        p_owner_id => 'c0000000-0000-4000-8000-000000000006',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'the no-publish user''s organisation exists'
+);
+update public.organisations set publish_policy = 'owner_only' where slug = 'lockedco';
+insert into public.organisation_members (org_id, user_id, status, joined_at, join_source)
+values (
+    (select id from public.organisations where slug = 'lockedco'),
+    'c0000000-0000-4000-8000-000000000004', 'active', now(), 'admin');
+
+-- And a member of acmeone whose key is already bound somewhere deliberate.
+insert into public.organisation_members (org_id, user_id, status, joined_at, join_source)
+values (
+    (select id from public.organisations where slug = 'acmeone'),
+    'c0000000-0000-4000-8000-000000000005', 'active', now(), 'admin');
+
+create temporary table t_org as
+select (select id from public.organisations where slug = 'acmeone') as acmeone,
+       (select id from public.organisations where slug = 'twoa')    as twoa,
+       (select id from public.organisations where slug = 'lockedco') as lockedco,
+       (select id from public.organisations where slug = 'boss')     as boss;
+
+-- The keys. Deliberately mixed: NULL-bound and boss-bound must both be candidates,
+-- because the backfill produced the second and key creation produced the first.
+insert into public.plugin_api_keys (user_id, name, key_prefix, key_hash, scopes, org_id) values
+    ('c0000000-0000-4000-8000-000000000001', 'sole-null',  'bpk_a', 'hash-a', array['publish'], null),
+    ('c0000000-0000-4000-8000-000000000001', 'sole-boss',  'bpk_b', 'hash-b', array['publish'],
+        (select boss from t_org)),
+    ('c0000000-0000-4000-8000-000000000002', 'multi',      'bpk_c', 'hash-c', array['publish'], null),
+    ('c0000000-0000-4000-8000-000000000003', 'nomember',   'bpk_d', 'hash-d', array['publish'], null),
+    ('c0000000-0000-4000-8000-000000000004', 'nopublish',  'bpk_e', 'hash-e', array['publish'], null),
+    ('c0000000-0000-4000-8000-000000000005', 'already',    'bpk_f', 'hash-f', array['publish'],
+        (select twoa from t_org));
+
+
+-- ===========================================================================
+-- The binding
+-- ===========================================================================
+create temporary table t_run as select public.bind_api_keys_to_publisher_org() as result;
+
+select ok((select (result ->> 'success')::boolean from t_run), 'the function reports success');
+
+select is(
+    (select (result ->> 'bound')::int from t_run),
+    2,
+    'exactly the two keys of the sole-organisation user are bound'
+);
+
+select is(
+    (select org_id from public.plugin_api_keys where name = 'sole-null'),
+    (select acmeone from t_org),
+    'a NULL-bound key is bound - this is what key creation produced'
+);
+
+select is(
+    (select org_id from public.plugin_api_keys where name = 'sole-boss'),
+    (select acmeone from t_org),
+    'a boss-bound key is bound too - this is what the 20260803000000 backfill produced'
+);
+
+-- ===========================================================================
+-- Who is left alone, and why
+-- ===========================================================================
+select is(
+    (select org_id from public.plugin_api_keys where name = 'multi'),
+    null,
+    'two candidate organisations means nothing is derived, rather than one being guessed'
+);
+
+select is(
+    (select org_id from public.plugin_api_keys where name = 'nomember'),
+    null,
+    'an owner in no non-system organisation is left alone'
+);
+
+select is(
+    (select org_id from public.plugin_api_keys where name = 'nopublish'),
+    null,
+    'membership without publishing rights is not enough - owner_only would refuse every publish'
+);
+
+select is(
+    (select org_id from public.plugin_api_keys where name = 'already'),
+    (select twoa from t_org),
+    'a key already bound deliberately is never re-pointed, even to a different valid answer'
+);
+
+select is(
+    (select (result ->> 'remaining')::int from t_run),
+    3,
+    'and it reports how many still resolve to boss, so the deploy output is checkable'
+);
+
+
+-- ===========================================================================
+-- Re-running
+-- ===========================================================================
+select is(
+    (public.bind_api_keys_to_publisher_org() ->> 'bound')::int,
+    0,
+    're-running binds nothing: every row it moved no longer points at boss'
+);
+
+select is(
+    (select org_id from public.plugin_api_keys where name = 'sole-null'),
+    (select acmeone from t_org),
+    'and does not disturb what it bound the first time'
+);
+
+
+-- ===========================================================================
+-- It is not callable by a client
+-- ===========================================================================
+-- It rewrites which organisation other people's keys publish for. An authenticated
+-- caller reaching it would be able to re-point every key whose owner happens to
+-- have one organisation.
+select ok(
+    not has_function_privilege('authenticated', 'public.bind_api_keys_to_publisher_org()', 'EXECUTE'),
+    'authenticated cannot execute it'
+);
+
+select ok(
+    not has_function_privilege('anon', 'public.bind_api_keys_to_publisher_org()', 'EXECUTE'),
+    'anon cannot execute it'
+);
+
+select ok(
+    has_function_privilege('service_role', 'public.bind_api_keys_to_publisher_org()', 'EXECUTE'),
+    'service_role can, which is what the migration and an operator use'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/risa_plugin_attribution_test.sql
+++ b/supabase/tests/risa_plugin_attribution_test.sql
@@ -1,0 +1,210 @@
+-- pgTAP tests for attributing the RISA plugins (20260812000000).
+-- Run with: supabase test db
+--
+-- The migration is a DO block over a fixed list, so unlike 20260811000000 there is no function for
+-- a test to call - these run the same statement shape against fixtures and assert the rules the
+-- block encodes. The assertions worth having are the ones about what it must NOT touch: the whole
+-- risk of a named list is that it moves a row somebody had deliberately placed elsewhere, or that
+-- a typo makes it silently move nothing.
+--
+-- The most important assertion is the last one: visibility is untouched, so nobody loses access.
+
+begin;
+select plan(14);
+
+insert into auth.users (id, email, email_confirmed_at) values
+    ('d0000000-0000-4000-8000-000000000001', 'author@risa.test', now());
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+select ok(
+    (public.ensure_boss_organisation() ->> 'success')::boolean,
+    'the boss organisation exists, so rows can start where the backfill put them'
+);
+
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'risa', p_name => 'Risa Labs Inc', p_description => null,
+        p_owner_id => 'd0000000-0000-4000-8000-000000000001',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'the risa organisation exists'
+);
+
+create temporary table t_ids as
+select (select id from public.organisations where slug = 'risa') as risa,
+       (select id from public.organisations where slug = 'boss') as boss;
+
+-- A third organisation, to stand for "somebody already placed this deliberately".
+select ok(
+    (public.create_organisation_internal(
+        p_slug => 'thirdco', p_name => 'Third Co', p_description => null,
+        p_owner_id => 'd0000000-0000-4000-8000-000000000001',
+        p_domain => null, p_visibility => 'private',
+        p_join_policy => 'invite_only') ->> 'success')::boolean,
+    'a third organisation exists'
+);
+
+-- Fixtures. plugins_default_org fills org_id with boss on insert, which is exactly the state
+-- production is in, so most of these are inserted without naming one.
+insert into public.plugins (author_id, author_name, plugin_id, display_name, type, api_version, published, visibility)
+values
+    ('d0000000-0000-4000-8000-000000000001', 'Risa Labs',
+     'ai.rever.boss.plugin.dynamic.medical-necessity', 'Medical Necessity', 'panel', '1.0', true, 'public'),
+    ('d0000000-0000-4000-8000-000000000001', 'Risa Labs',
+     'ai.rever.boss.plugin.dynamic.codexglm', 'Codex GLM', 'panel', '1.0', true, 'public'),
+    -- Not on the list. Must not move.
+    ('d0000000-0000-4000-8000-000000000001', 'Risa Labs',
+     'ai.rever.boss.plugin.dynamic.terminaltab', 'Terminal Tab', 'tab', '1.0', true, 'public');
+
+-- On the list, but already placed somewhere deliberate.
+insert into public.plugins (author_id, author_name, plugin_id, display_name, type, api_version, published, visibility, org_id)
+values ('d0000000-0000-4000-8000-000000000001', 'Risa Labs',
+        'ai.rever.boss.plugin.dynamic.finances', 'Finances', 'panel', '1.0', true, 'public',
+        (select thirdco.id from public.organisations thirdco where thirdco.slug = 'thirdco'));
+
+select is(
+    (select count(*)::int from public.plugins p
+      where p.org_id = (select boss from t_ids)),
+    3,
+    'the fixtures start on boss, which is what the trigger does and what production looks like'
+);
+
+
+-- ===========================================================================
+-- The migration's statement, verbatim in shape
+-- ===========================================================================
+DO $$
+DECLARE
+    v_risa_id UUID;
+    v_boss_id UUID;
+    v_row     RECORD;
+    v_targets TEXT[] := ARRAY[
+        'ai.rever.boss.plugin.dynamic.medical-necessity',
+        'ai.rever.boss.plugin.dynamic.mednec',
+        'ai.rever.boss.plugin.dynamic.mednec-copilot',
+        'ai.rever.boss.plugin.dynamic.codexglm',
+        'ai.rever.boss.plugin.dynamic.finances'
+    ];
+    v_target  TEXT;
+BEGIN
+    SELECT o.id INTO v_risa_id FROM public.organisations o WHERE o.slug = 'risa';
+    SELECT o.id INTO v_boss_id FROM public.organisations o WHERE o.slug = 'boss';
+
+    FOREACH v_target IN ARRAY v_targets LOOP
+        SELECT p.id, p.org_id INTO v_row FROM public.plugins p WHERE p.plugin_id = v_target;
+        IF NOT FOUND THEN CONTINUE; END IF;
+        IF v_row.org_id IS NOT NULL AND v_row.org_id <> v_boss_id AND v_row.org_id <> v_risa_id THEN
+            CONTINUE;
+        END IF;
+        IF v_row.org_id = v_risa_id THEN CONTINUE; END IF;
+        UPDATE public.plugins SET org_id = v_risa_id WHERE id = v_row.id;
+    END LOOP;
+END;
+$$;
+
+
+-- ===========================================================================
+-- What moved
+-- ===========================================================================
+select is(
+    (select org_id from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.medical-necessity'),
+    (select risa from t_ids),
+    'a named plugin on boss moves to risa'
+);
+
+select is(
+    (select org_id from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.codexglm'),
+    (select risa from t_ids),
+    'and so does the second one'
+);
+
+-- ===========================================================================
+-- What did not
+-- ===========================================================================
+select is(
+    (select org_id from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.terminaltab'),
+    (select boss from t_ids),
+    'a plugin NOT on the list is left on boss - the list is the whole scope'
+);
+
+select isnt(
+    (select org_id from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.finances'),
+    (select risa from t_ids),
+    'a plugin already attributed elsewhere is NOT re-pointed, even though it is on the list'
+);
+
+select is(
+    (select o.slug from public.organisations o
+      join public.plugins p on p.org_id = o.id
+     where p.plugin_id = 'ai.rever.boss.plugin.dynamic.finances'),
+    'thirdco',
+    'and keeps exactly the organisation somebody chose for it'
+);
+
+-- A name in the list with no matching row must be a silent skip, not an error that
+-- aborts the whole migration and leaves the earlier rows moved but uncommitted.
+select is(
+    (select count(*)::int from public.plugins
+      where plugin_id in ('ai.rever.boss.plugin.dynamic.mednec',
+                          'ai.rever.boss.plugin.dynamic.mednec-copilot')),
+    0,
+    'two names in the list match no row here, and the block still completed'
+);
+
+-- ===========================================================================
+-- Access is unchanged, which is the claim that matters most
+-- ===========================================================================
+select is(
+    (select visibility from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.medical-necessity'),
+    'public',
+    'visibility is untouched'
+);
+
+-- can_view_plugin_row short-circuits on public+published BEFORE it looks at org_id, so moving the
+-- organisation cannot remove anyone's read access. Asserted rather than assumed, because "we only
+-- changed ownership" is exactly the kind of claim that turns out to have hidden a visibility change.
+-- Argument order matters and is easy to get wrong: p_user_id comes FIRST, then visibility, org,
+-- author, published. The first version of this test passed them in the order they appear in the
+-- function BODY and died with 42883.
+select ok(
+    public.user_can_view_plugin_row(null, 'public', (select risa from t_ids), null, true),
+    'an anonymous reader can still see it after the move'
+);
+
+-- p_plugin_id is the ROW's uuid, not the dotted plugin_id string. Passing the text silently
+-- looks right and does not resolve.
+select ok(
+    public.user_can_install_plugin(
+        'd0000000-0000-4000-8000-000000000001',
+        (select id from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.medical-necessity')),
+    'and it is still installable'
+);
+
+-- ===========================================================================
+-- Re-running
+-- ===========================================================================
+DO $$
+DECLARE
+    v_risa_id UUID; v_boss_id UUID; v_row RECORD;
+    v_targets TEXT[] := ARRAY['ai.rever.boss.plugin.dynamic.medical-necessity'];
+    v_target TEXT;
+BEGIN
+    SELECT o.id INTO v_risa_id FROM public.organisations o WHERE o.slug = 'risa';
+    SELECT o.id INTO v_boss_id FROM public.organisations o WHERE o.slug = 'boss';
+    FOREACH v_target IN ARRAY v_targets LOOP
+        SELECT p.id, p.org_id INTO v_row FROM public.plugins p WHERE p.plugin_id = v_target;
+        IF v_row.org_id = v_risa_id THEN CONTINUE; END IF;
+        UPDATE public.plugins SET org_id = v_risa_id WHERE id = v_row.id;
+    END LOOP;
+END;
+$$;
+
+select is(
+    (select org_id from public.plugins where plugin_id = 'ai.rever.boss.plugin.dynamic.medical-necessity'),
+    (select risa from t_ids),
+    're-running leaves it on risa'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
**Migrations and both edge functions are deployed to production.**

## The problem

Every row in `plugins` sat on the `boss` organisation. `20260803000000` backfilled them all there and nothing since chose otherwise, so "which organisation owns this plugin" had one answer for the whole store.

## What this does

**Publishing attributes correctly, going forward.** `resolvePublishOrg` decides which organisation a newly created plugin belongs to: an explicitly requested org, else the API key's bound org, else the caller's sole non-system organisation, else nothing (the trigger's `boss` default). Every produced answer is authorised through `user_can_publish_org_plugin` before a row is written - this handler runs as service role, so the `WITH CHECK` on `plugins` is bypassed and nothing else would refuse an organisation the caller has no rights in. A **named** organisation the caller may not publish to is a 403; a **derived** one they may not is a quiet fall back, because the caller did not ask for it.

**API keys are bound to their owner's organisation** (`20260811000000`), so a CI publish lands in the right place. Derived rather than listed: an owner's single non-system organisation is a real answer, and a list would go stale.

**The plugins that are RISA's are named** (`20260812000000`, plus `20260814000000` for Form Assist). Not derived: `plugins.author_id` is whoever ran the publish, one person for most of this store, so deriving from it would sweep up plugins that are not RISA's. Store is now 34 `boss` / 6 `risa`.

**`/list` answers per reader.** This is the follow-up `20260803000000` named for itself: *"routes/browse.ts needs the `*_for_viewer` variants plus private cache headers."* `search_plugins` reads `auth.uid()` and this handler holds a service-role client, so `auth.uid()` was null however the caller authenticated and the list was public-only for everybody - which hid an `org`-visibility plugin from the very members it exists for.

## Deliberate limits on that last one

- **Identity is optional.** No header, an expired token, a malformed one, or the anon key arriving in that header all yield the public catalogue rather than an error. Browsing a store is not a privileged act, and turning a stale session into an error would break the anonymous case this endpoint has always served.
- **An API key is not accepted as identity.** A CI key exists to publish; letting one read a catalogue scoped to its owner's memberships would widen what a key sitting in a build server can see, for no reason anyone asked for.
- **`Cache-Control: private, no-store` once a viewer is known.** The same URL now returns different rows per reader, so a shared cache holding one reader's copy would serve their organisation's plugins to the next caller. Anonymous keeps `public, max-age=60`.
- **Publishing a new version does not re-derive ownership.** Only `createPlugin` consults the resolver; `updatePlugin` has no org field. So attribution is stable once set, and re-attributing afterwards is the supported way to move a plugin.

## Verification

- pgTAP for the resolver and the key binding; `deno check` and `deno test` clean, `deno lint` unchanged at its 6 pre-existing problems
- On production after deploy: anonymous still gets 34 rows with `public, max-age=60`, and a garbage bearer degrades to the same 34 with HTTP 200 rather than failing
- The Form Assist migration was **exercised, not just applied**: running it locally proved nothing, because this machine has no such plugin and it took the "not present" branch. Seeding the row on `boss` and running it reported `MOVED`; a second run reported `ALREADY risa`. Production then reported `MOVED`, and the live store confirms 6 risa plugins with Form Assist still visible anonymously.

One pgTAP fixture bug is worth flagging as a pattern: the sole-org user also owned the second organisation, giving them two non-system orgs, so the function correctly bound nothing and the test "passed" for the wrong reason. The fixture contradicted the test.