### PR TITLE
Use the OS file panel for the page's own file dialogs

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.EngineInitError
 import ai.rever.boss.plugin.browser.FluckEngine
 import ai.rever.boss.plugin.browser.LocalAwtWindow
+import ai.rever.boss.plugin.browser.NativeFileDialogs
 import ai.rever.boss.plugin.browser.installPopupWindowChrome
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -268,6 +269,11 @@ private fun configureBrowserPopupHandler(
                         frame.setLocation(initialBounds.origin().x(), initialBounds.origin().y())
                         frame.setSize(initialBounds.size().width(), initialBounds.size().height())
 
+                        // Same reason as the BrowserHandleImpl popup path: a popup browser
+                        // is never configured by the tab flow, so claim its file dialogs
+                        // before the Swing view installs the JFileChooser ones.
+                        NativeFileDialogs.installOn(popupBrowser)
+
                         val browserView = BrowserView.newInstance(popupBrowser)
                         frame.contentPane.add(browserView)
 
@@ -460,6 +466,10 @@ actual fun getBrowserState(
 
         // Configure JS dialog handlers to prevent UI freeze (Issue #369)
         setupBrowserDialogHandlers(browser)
+
+        // Answer the page's file dialogs with the OS ones, before createBrowserViewState
+        // below composes a view that would otherwise install Swing's JFileChooser.
+        NativeFileDialogs.installOn(browser)
 
         // Configure popup handler: OAuth popups → real windows, regular links → tabs
         if (onOpenInNewTab != null) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1122,6 +1122,11 @@ internal class BrowserHandleImpl(
         // Setup screen capture handler
         FluckEngine.setupCaptureSessionHandler(browser)
 
+        // Answer the page's own file dialogs with the OS ones. This must run before the
+        // browser view is composed: JxBrowser's view installs a Swing JFileChooser for each
+        // of these and skips any callback already set. See NativeFileDialogs.
+        NativeFileDialogs.installOn(browser)
+
         // Setup context menu handler
         setupContextMenuHandler()
     }
@@ -2094,6 +2099,12 @@ internal class BrowserHandleImpl(
                             // Set position and size from bounds
                             frame.setLocation(initialBounds.origin().x(), initialBounds.origin().y())
                             frame.setSize(initialBounds.size().width(), initialBounds.size().height())
+
+                            // A popup browser has no handle of its own, so it never went
+                            // through setupBrowserHandlers. Claim its file dialogs before the
+                            // Swing view below installs the JFileChooser ones - an OAuth or
+                            // payment popup is exactly where an upload field turns up.
+                            NativeFileDialogs.installOn(popupBrowser)
 
                             // Create BrowserView (Swing version) and add to frame
                             val browserView =

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogs.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogs.kt
@@ -1,14 +1,15 @@
 package ai.rever.boss.plugin.browser
 
-import ai.rever.boss.platform.FileNameSanitizer
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.browser.callback.BrowserCallback
 import com.teamdev.jxbrowser.browser.callback.OpenFileCallback
 import com.teamdev.jxbrowser.browser.callback.OpenFilesCallback
 import com.teamdev.jxbrowser.browser.callback.OpenFolderCallback
 import com.teamdev.jxbrowser.browser.callback.SaveAsPdfCallback
 import com.teamdev.jxbrowser.browser.callback.SaveFileCallback
+import com.teamdev.jxbrowser.callback.Advisable
+import java.awt.Dialog
 import java.awt.FileDialog
 import java.awt.Frame
 import java.awt.KeyboardFocusManager
@@ -18,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.SwingUtilities
 
 /**
- * Native OS file pickers for the page's own file dialogs.
+ * Native macOS file panels for the page's own file dialogs.
  *
  * JxBrowser does not leave `<input type="file">` unanswered: both the Compose and the Swing
  * `BrowserView` install a set of *default* callbacks when they are created, and every one of
@@ -28,9 +29,8 @@ import javax.swing.SwingUtilities
  * Chrome, which both open the real `NSOpenPanel` (sidebar, column view, search, Recents).
  *
  * `java.awt.FileDialog` *is* that panel: its macOS peer (`sun.lwawt.macosx.CFileDialog`) is a
- * thin wrapper over `NSOpenPanel`/`NSSavePanel`, and its Windows peer is the Win32 common
- * dialog. So the fix is not to restyle anything, it is to answer these callbacks ourselves
- * before JxBrowser installs its own.
+ * thin wrapper over `NSOpenPanel`/`NSSavePanel`. So the fix is not to restyle anything, it is
+ * to answer these callbacks ourselves before JxBrowser installs its own.
  *
  * **Registration has to happen before the view is created.** `DefaultCallbacks.register()`
  * checks `advisable.get(type).isPresent()` and *skips* any callback already set, so setting
@@ -39,41 +39,65 @@ import javax.swing.SwingUtilities
  * `unregister()` only removes what it actually registered, ours survives a view being
  * detached and re-attached (tab switch, fullscreen, a popup adopted into a window).
  *
- * **Linux keeps the JxBrowser default on purpose.** AWT there resolves to `GtkFileDialogPeer`
- * only when GTK loads, and falls back to `XFileDialogPeer` - a Motif-era dialog that is worse
- * than the Swing chooser it would be replacing. macOS and Windows have no such fallback.
+ * **macOS only, deliberately.** `FileDialog` is the wrong trade on the other two:
+ * - **Windows**: `setFilenameFilter` is documented as a no-op there (the Win32 peer drives
+ *   `GetOpenFileName` with filter *strings*, not a per-item Java callback), so an
+ *   `accept=".png"` input would silently list every file; and `FileDialog` cannot select a
+ *   directory at all, so `webkitdirectory` would hand Chromium a *file* path and quietly
+ *   yield nothing. The `JFileChooser` default gets both right. A native Windows panel is
+ *   worth having, but it needs the Win32 filter strings and a folder browser, not this.
+ * - **Linux**: AWT resolves to `GtkFileDialogPeer` only when GTK loads, and otherwise falls
+ *   back to `XFileDialogPeer`, a Motif-era dialog worse than the chooser it would replace.
+ *
+ * **What is not covered**: the auth browsers (`DesktopPasskeyBrowserView`,
+ * `DesktopAuthBrandSite`) build their own `newBrowser()` and never call [installOn], so they
+ * keep the Swing chooser. That is fine for a sign-in page with no upload field, and stated
+ * here so the next reader does not have to infer it.
  */
 object NativeFileDialogs {
     private val logger = BossLogger.forComponent("NativeFileDialogs")
 
-    private const val MAC_DIRECTORY_MODE = "apple.awt.fileDialogForDirectories"
+    private val isMacOs =
+        System
+            .getProperty("os.name")
+            .orEmpty()
+            .lowercase()
+            .contains("mac")
 
-    private val osName = System.getProperty("os.name").orEmpty().lowercase()
-    private val isMacOs = osName.contains("mac")
-    private val isWindows = osName.contains("win")
-
-    /** True when [installOn] does anything. See the class KDoc for why Linux is excluded. */
-    val isSupported: Boolean = isMacOs || isWindows
+    /** True when [installOn] does anything. See the class KDoc for why only macOS. */
+    val isSupported: Boolean = isMacOs
 
     /**
-     * Point [browser]'s page-driven file dialogs at the OS ones.
+     * Point [browser]'s page-driven file dialogs at the OS ones, where that is an improvement.
      *
-     * Safe to call more than once for the same browser - `Browser.set` replaces.
+     * Safe to call more than once for the same browser - `Advisable.set` replaces.
      */
     // Deliberately broad: a browser closed between creation and here throws rather than
     // no-ops, and losing the native panel is cosmetic. It must never fail browser creation.
     @Suppress("TooGenericExceptionCaught")
-    fun installOn(browser: Browser) {
+    fun installOn(browser: Advisable<BrowserCallback>) {
         if (!isSupported) return
         try {
-            browser.set(OpenFileCallback::class.java, OpenFileCallback(::onOpenFile))
-            browser.set(OpenFilesCallback::class.java, OpenFilesCallback(::onOpenFiles))
-            browser.set(OpenFolderCallback::class.java, OpenFolderCallback(::onOpenFolder))
-            browser.set(SaveFileCallback::class.java, SaveFileCallback(::onSaveFile))
-            browser.set(SaveAsPdfCallback::class.java, SaveAsPdfCallback(::onSaveAsPdf))
+            registerOn(browser)
         } catch (e: Exception) {
             logger.warn(LogCategory.BROWSER, "Could not install native file dialogs", error = e)
         }
+    }
+
+    /**
+     * The registration itself, with no platform gate, so a test can assert the full set on
+     * every CI leg rather than sleeping through two of the three.
+     *
+     * Every dialog the page can raise has to be claimed here. Dropping one line silently
+     * reinstates the Swing chooser for that dialog and nothing else in the tree notices,
+     * which is what `NativeFileDialogsTest` exists to catch.
+     */
+    internal fun registerOn(target: Advisable<BrowserCallback>) {
+        target.set(OpenFileCallback::class.java, OpenFileCallback(::onOpenFile))
+        target.set(OpenFilesCallback::class.java, OpenFilesCallback(::onOpenFiles))
+        target.set(OpenFolderCallback::class.java, OpenFolderCallback(::onOpenFolder))
+        target.set(SaveFileCallback::class.java, SaveFileCallback(::onSaveFile))
+        target.set(SaveAsPdfCallback::class.java, SaveAsPdfCallback(::onSaveAsPdf))
     }
 
     // ============================================================
@@ -151,75 +175,15 @@ object NativeFileDialogs {
                 suggestedFileName = params.suggestedFileName(),
                 // The only Params here that hands back a Path rather than a String.
                 suggestedDirectory = params.suggestedDirectory()?.toString().orEmpty(),
-                extensions = listOf("pdf"),
+                extensions = listOf(PDF),
                 acceptAll = false,
-            )
+                // The panel's name field is editable, so the user can clear the extension
+                // off a file Chromium is about to write PDF bytes into.
+            )?.withExtension(PDF)
         },
         open = action::save,
         cancel = action::cancel,
     )
-
-    // ============================================================
-    // DIALOGS
-    // ============================================================
-
-    private fun showOpen(
-        suggestedDirectory: String,
-        extensions: List<String>,
-        acceptAll: Boolean,
-        multiple: Boolean,
-    ): List<Path> {
-        val dialog = newDialog("Open", FileDialog.LOAD, suggestedDirectory)
-        dialog.isMultipleMode = multiple
-        dialog.narrowTo(extensions, acceptAll)
-        dialog.isVisible = true
-        // getFiles() is populated in both modes; getFile()/getDirectory() are just the
-        // single-selection view of the same result. Empty means cancelled.
-        return dialog.files.orEmpty().map { it.toPath() }
-    }
-
-    private fun showOpenFolder(suggestedDirectory: String): Path? {
-        // The only way to ask NSOpenPanel for a directory from AWT. It is a process-wide
-        // property, which is safe here only because it is set and cleared around a modal
-        // show on the EDT, so no other file dialog can be opening in between.
-        val previous = System.getProperty(MAC_DIRECTORY_MODE)
-        if (isMacOs) System.setProperty(MAC_DIRECTORY_MODE, "true")
-        try {
-            val dialog = newDialog("Open", FileDialog.LOAD, suggestedDirectory)
-            dialog.isVisible = true
-            val name = dialog.file
-            val directory = dialog.directory
-            // In directory mode the chosen folder comes back split: directory is its
-            // parent, file is its own name. Cancelling leaves both null.
-            return when {
-                directory == null -> null
-                name == null -> File(directory).toPath()
-                else -> File(directory, name).toPath()
-            }
-        } finally {
-            if (isMacOs) System.setProperty(MAC_DIRECTORY_MODE, previous ?: "false")
-        }
-    }
-
-    private fun showSave(
-        suggestedFileName: String,
-        suggestedDirectory: String,
-        extensions: List<String>,
-        acceptAll: Boolean,
-    ): Path? {
-        val dialog = newDialog("Save", FileDialog.SAVE, suggestedDirectory)
-        // The page picks this name and it becomes a real path, so it goes through the same
-        // sanitizer the download handler uses. Only when the page suggested something:
-        // sanitize("") is the string "download", which would pre-fill a name nobody asked for.
-        if (suggestedFileName.isNotBlank()) {
-            dialog.file = FileNameSanitizer.sanitize(suggestedFileName)
-        }
-        dialog.narrowTo(extensions, acceptAll)
-        dialog.isVisible = true
-        val name = dialog.file
-        val directory = dialog.directory
-        return if (name != null && directory != null) File(directory, name).toPath() else null
-    }
 
     // ============================================================
     // PLUMBING
@@ -236,7 +200,7 @@ object NativeFileDialogs {
     // Deliberately broad, both of them: the point is that no failure, whatever its type,
     // leaves the page waiting. Error still propagates, as elsewhere in this package.
     @Suppress("TooGenericExceptionCaught")
-    private fun <T : Any> answerOnce(
+    internal fun <T : Any> answerOnce(
         pick: () -> T?,
         open: (T) -> Unit,
         cancel: () -> Unit,
@@ -270,22 +234,77 @@ object NativeFileDialogs {
     }
 }
 
+private const val PDF = "pdf"
+
+/**
+ * Asks `NSOpenPanel` for a directory rather than a file. Process-wide; see [showModal].
+ */
+private const val MAC_DIRECTORY_MODE = "apple.awt.fileDialogForDirectories"
+
+private fun showOpen(
+    suggestedDirectory: String,
+    extensions: List<String>,
+    acceptAll: Boolean,
+    multiple: Boolean,
+): List<Path> {
+    val dialog = newDialog("Open", FileDialog.LOAD, suggestedDirectory)
+    dialog.isMultipleMode = multiple
+    dialog.narrowTo(extensions, acceptAll)
+    dialog.showModal(directories = false)
+    // getFiles() is populated in both modes; getFile()/getDirectory() are just the
+    // single-selection view of the same result. Empty means cancelled.
+    return dialog.files.orEmpty().map { it.toPath() }
+}
+
+private fun showOpenFolder(suggestedDirectory: String): Path? {
+    val dialog = newDialog("Open", FileDialog.LOAD, suggestedDirectory)
+    dialog.showModal(directories = true)
+    val name = dialog.file
+    val directory = dialog.directory
+    // In directory mode the chosen folder comes back split: directory is its parent, file
+    // is its own name. Cancelling leaves both null.
+    return when {
+        directory == null -> null
+        name == null -> File(directory).toPath()
+        else -> File(directory, name).toPath()
+    }
+}
+
+private fun showSave(
+    suggestedFileName: String,
+    suggestedDirectory: String,
+    extensions: List<String>,
+    acceptAll: Boolean,
+): Path? {
+    val dialog = newDialog("Save", FileDialog.SAVE, suggestedDirectory)
+    if (suggestedFileName.isNotBlank()) dialog.file = safePrefill(suggestedFileName)
+    dialog.narrowTo(extensions, acceptAll)
+    dialog.showModal(directories = false)
+    val name = dialog.file
+    val directory = dialog.directory
+    return if (name != null && directory != null) File(directory, name).toPath() else null
+}
+
 /**
  * An OS file panel, owned by the window the user is actually looking at.
  *
  * The owner matters: with a null one the native panel can open BEHIND the Compose window, so
- * the click that opened it looks like it did nothing. Same fix as `DirectoryPickerProviderImpl`.
- *
- * (Top level rather than a member, with the helpers below, so [NativeFileDialogs] stays under
- * detekt's per-object function count.)
+ * the click that opened it looks like it did nothing. Same fix as `DirectoryPickerProviderImpl`,
+ * except that one only handles a `Frame` owner - the active window is a `Dialog` whenever a
+ * BOSS modal is up, which is the very case the null owner misbehaves in.
  */
 private fun newDialog(
     title: String,
     mode: Int,
     suggestedDirectory: String,
 ): FileDialog {
-    val owner = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow as? Frame
-    return FileDialog(owner, title, mode).apply {
+    val dialog =
+        when (val active = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow) {
+            is Frame -> FileDialog(active, title, mode)
+            is Dialog -> FileDialog(active, title, mode)
+            else -> FileDialog(null as Frame?, title, mode)
+        }
+    return dialog.apply {
         isAlwaysOnTop = true
         val suggested = File(suggestedDirectory)
         if (suggestedDirectory.isNotBlank() && suggested.isDirectory) {
@@ -295,12 +314,39 @@ private fun newDialog(
 }
 
 /**
+ * Show the panel, then always give the native peer back.
+ *
+ * [MAC_DIRECTORY_MODE] is process-wide and read by the peer when the panel is created, and a
+ * modal `FileDialog` runs a **nested event loop** on the EDT that keeps dispatching other
+ * `invokeLater` blocks - so a second dialog (another file input, a download's `pickSaveFile`)
+ * really can be created inside this one's loop. Setting the flag explicitly for *every*
+ * dialog rather than only the folder one is what makes that safe: whoever is about to show
+ * states its own mode, and the restore unwinds in the reverse order. The property is cleared
+ * rather than written back as `"false"`, so an absent property stays absent.
+ */
+private fun FileDialog.showModal(directories: Boolean) {
+    val previous = System.getProperty(MAC_DIRECTORY_MODE)
+    System.setProperty(MAC_DIRECTORY_MODE, directories.toString())
+    try {
+        isVisible = true
+    } finally {
+        if (previous == null) {
+            System.clearProperty(MAC_DIRECTORY_MODE)
+        } else {
+            System.setProperty(MAC_DIRECTORY_MODE, previous)
+        }
+        // These are user-driven and repeatable, so the native peer is not left to
+        // finalization the way the one-shot pickers elsewhere leave theirs.
+        dispose()
+    }
+}
+
+/**
  * Narrow the panel to [extensions], unless the page said any file will do.
  *
  * The macOS peer asks this filter per URL and answers yes for anything that is not a regular
- * file, so directories stay navigable. Windows applies it the same way.
- *
- *  */
+ * file, so directories stay navigable.
+ */
 private fun FileDialog.narrowTo(
     extensions: List<String>,
     acceptAll: Boolean,
@@ -309,6 +355,26 @@ private fun FileDialog.narrowTo(
     val suffixes = fileDialogSuffixes(extensions)
     if (suffixes.isEmpty()) return
     setFilenameFilter { _, name -> matchesSuffix(name, suffixes) }
+}
+
+/**
+ * The page's suggested name, reduced to something safe to put in the panel's name field.
+ *
+ * Only the last path segment survives, so a suggestion of `../../x` cannot steer where the
+ * panel opens, and control characters are dropped. Deliberately **not** `FileNameSanitizer`,
+ * which the download handler uses: that maps everything outside a small ASCII set to `_`, and
+ * this string is shown to the user and edited by them, so a page titled in Japanese would
+ * pre-fill as `___.pdf`. Nothing here has to be filesystem-safe - the path returned is the one
+ * the panel reports back after the user has accepted it.
+ */
+internal fun safePrefill(suggested: String): String = File(suggested).name.filter { it.code >= 0x20 && it.code != DEL }
+
+private const val DEL = 0x7F
+
+/** [this] with [extension] appended unless it already carries it. */
+internal fun Path.withExtension(extension: String): Path {
+    val name = fileName?.toString().orEmpty()
+    return if (name.endsWith(".$extension", ignoreCase = true)) this else resolveSibling("$name.$extension")
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogs.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogs.kt
@@ -179,7 +179,7 @@ object NativeFileDialogs {
                 acceptAll = false,
                 // The panel's name field is editable, so the user can clear the extension
                 // off a file Chromium is about to write PDF bytes into.
-            )?.withExtension(PDF)
+            )?.let { pathWithExtension(it, PDF) }
         },
         open = action::save,
         cancel = action::cancel,
@@ -221,9 +221,16 @@ object NativeFileDialogs {
                 val picked =
                     try {
                         pick()
-                    } catch (e: Exception) {
-                        logger.warn(LogCategory.BROWSER, "Native file dialog failed", error = e)
-                        null
+                    } catch (t: Throwable) {
+                        // Throwable, not Exception. The house rule elsewhere in this package is
+                        // that Error propagates, and it still does - but an AWTError raised while
+                        // creating the peer would otherwise escape this invokeLater body and leave
+                        // the page's file input pending for the life of the tab, which is the
+                        // exact failure this function exists to prevent. Answer, then rethrow, so
+                        // both properties hold.
+                        logger.warn(LogCategory.BROWSER, "Native file dialog failed", error = t)
+                        answer(null)
+                        throw t
                     }
                 answer(picked)
             }
@@ -251,8 +258,9 @@ private fun showOpen(
     dialog.isMultipleMode = multiple
     dialog.narrowTo(extensions, acceptAll)
     dialog.showModal(directories = false)
-    // getFiles() is populated in both modes; getFile()/getDirectory() are just the
-    // single-selection view of the same result. Empty means cancelled.
+    // getFiles() is populated in both modes, not only multi-select: CFileDialog.Task.run
+    // calls setFiles unconditionally, and getFile()/getDirectory() are just the
+    // single-selection view of that same array. Empty means cancelled.
     return dialog.files.orEmpty().map { it.toPath() }
 }
 
@@ -318,11 +326,20 @@ private fun newDialog(
  *
  * [MAC_DIRECTORY_MODE] is process-wide and read by the peer when the panel is created, and a
  * modal `FileDialog` runs a **nested event loop** on the EDT that keeps dispatching other
- * `invokeLater` blocks - so a second dialog (another file input, a download's `pickSaveFile`)
- * really can be created inside this one's loop. Setting the flag explicitly for *every*
- * dialog rather than only the folder one is what makes that safe: whoever is about to show
- * states its own mode, and the restore unwinds in the reverse order. The property is cleared
- * rather than written back as `"false"`, so an absent property stays absent.
+ * `invokeLater` blocks - so a second dialog really can be created inside this one's loop.
+ * Every dialog here states its own mode immediately before showing and the restore unwinds in
+ * reverse order; the property is cleared rather than written back as `"false"`, so an absent
+ * property stays absent.
+ *
+ * **That invariant is one-directional.** It holds for these dialogs nested inside anything,
+ * because they state their own mode. It does *not* hold in reverse: `DesktopFilePicker`,
+ * `FilePickerProviderFactory` and `SettingsComponents` each create a `LOAD` dialog without
+ * touching the flag, so one of those opened inside [showOpenFolder]'s nested loop would come
+ * up as a directory chooser. Narrow in practice, since the panel is app-modal and it therefore
+ * takes a non-UI-driven caller such as a plugin invoking `openFile` off a background thread.
+ * The durable fix is to route every `FileDialog` in the tree through this helper, which is a
+ * wider change than this one. `SAVE` dialogs are immune either way: the flag only affects
+ * `NSOpenPanel`.
  */
 private fun FileDialog.showModal(directories: Boolean) {
     val previous = System.getProperty(MAC_DIRECTORY_MODE)
@@ -367,28 +384,51 @@ private fun FileDialog.narrowTo(
  * pre-fill as `___.pdf`. Nothing here has to be filesystem-safe - the path returned is the one
  * the panel reports back after the user has accepted it.
  */
-internal fun safePrefill(suggested: String): String = File(suggested).name.filter { it.code >= 0x20 && it.code != DEL }
+internal fun safePrefill(suggested: String): String {
+    val name = File(suggested).name.filter { it.code >= 0x20 && it.code != DEL }
+    // File("..").name is ".." - a legal thing to type, but accepting it hands back a
+    // directory where the page is expecting a file.
+    return if (name == "." || name == "..") "" else name
+}
 
 private const val DEL = 0x7F
 
-/** [this] with [extension] appended unless it already carries it. */
-internal fun Path.withExtension(extension: String): Path {
-    val name = fileName?.toString().orEmpty()
-    return if (name.endsWith(".$extension", ignoreCase = true)) this else resolveSibling("$name.$extension")
+/**
+ * [path] with [extension] appended unless it already carries it.
+ *
+ * Not an extension function on `Path`: `withExtension` is generic enough that putting it in
+ * module scope invites a surprising resolution somewhere else.
+ *
+ * **Known limitation**: the append happens after the panel has closed, so the overwrite prompt
+ * the user answered was for the name they typed. Saving as `report` where `report.pdf` already
+ * exists overwrites it unprompted. `FileDialog` exposes no allowed-file-types API to let
+ * `NSSavePanel` append the extension itself, which is what would fix this properly.
+ */
+internal fun pathWithExtension(
+    path: Path,
+    extension: String,
+): Path {
+    val name = path.fileName?.toString().orEmpty()
+    return if (name.endsWith(".$extension", ignoreCase = true)) path else path.resolveSibling("$name.$extension")
 }
 
 /**
- * The suffixes an `accept` attribute actually names, normalised for [matchesSuffix].
+ * The suffixes an `accept` attribute names, or nothing when it cannot be expressed as
+ * suffixes at all. Normalised for [matchesSuffix]; a leading dot is common and would double
+ * up in the `.ext` comparison.
  *
- * Chromium hands these through however the page wrote them. A leading dot is common and
- * would double up in the `.ext` comparison; **MIME types and wildcards are dropped**, because
- * a filter built from a MIME pattern matches no filename at all - and an empty result means
- * no filter, which shows everything, rather than a panel where nothing is selectable.
+ * **A token that is not a suffix makes the whole filter unrepresentable, not just itself.**
+ * An `accept` of `.png` plus an image MIME pattern admits every image, so filtering on the
+ * surviving `png` would grey out `photo.jpg` - a file the page explicitly allows - and that is
+ * worse than not filtering. The same all-or-nothing rule covers a pure MIME pattern, which
+ * names no suffix at all. Empty means "no filter", so the panel shows everything rather than
+ * nothing.
  */
-internal fun fileDialogSuffixes(extensions: List<String>): List<String> =
-    extensions
-        .mapNotNull { it.trim().removePrefix(".").takeIf(String::isNotEmpty) }
-        .filterNot { it.contains('/') || it.contains('*') }
+internal fun fileDialogSuffixes(extensions: List<String>): List<String> {
+    val tokens = extensions.mapNotNull { it.trim().removePrefix(".").takeIf(String::isNotEmpty) }
+    val suffixes = tokens.filterNot { it.contains('/') || it.contains('*') }
+    return if (suffixes.size == tokens.size) suffixes else emptyList()
+}
 
 /** Whether [name] carries one of [suffixes]. Case-insensitive: the disk is not. */
 internal fun matchesSuffix(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogs.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogs.kt
@@ -1,0 +1,331 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.platform.FileNameSanitizer
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.browser.callback.OpenFileCallback
+import com.teamdev.jxbrowser.browser.callback.OpenFilesCallback
+import com.teamdev.jxbrowser.browser.callback.OpenFolderCallback
+import com.teamdev.jxbrowser.browser.callback.SaveAsPdfCallback
+import com.teamdev.jxbrowser.browser.callback.SaveFileCallback
+import java.awt.FileDialog
+import java.awt.Frame
+import java.awt.KeyboardFocusManager
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.SwingUtilities
+
+/**
+ * Native OS file pickers for the page's own file dialogs.
+ *
+ * JxBrowser does not leave `<input type="file">` unanswered: both the Compose and the Swing
+ * `BrowserView` install a set of *default* callbacks when they are created, and every one of
+ * them shows a `javax.swing.JFileChooser`. On macOS that renders through `AquaFileChooserUI` -
+ * a Swing re-creation of the pre-10.7 Open panel, with a "Where:" popup and a "File Format:"
+ * combo - so uploading a file from BOSS looked a decade older than doing it from Safari or
+ * Chrome, which both open the real `NSOpenPanel` (sidebar, column view, search, Recents).
+ *
+ * `java.awt.FileDialog` *is* that panel: its macOS peer (`sun.lwawt.macosx.CFileDialog`) is a
+ * thin wrapper over `NSOpenPanel`/`NSSavePanel`, and its Windows peer is the Win32 common
+ * dialog. So the fix is not to restyle anything, it is to answer these callbacks ourselves
+ * before JxBrowser installs its own.
+ *
+ * **Registration has to happen before the view is created.** `DefaultCallbacks.register()`
+ * checks `advisable.get(type).isPresent()` and *skips* any callback already set, so setting
+ * ours first wins and JxBrowser never installs the Swing chooser. [installOn] is therefore
+ * called from browser construction, not from composition - and because the view's matching
+ * `unregister()` only removes what it actually registered, ours survives a view being
+ * detached and re-attached (tab switch, fullscreen, a popup adopted into a window).
+ *
+ * **Linux keeps the JxBrowser default on purpose.** AWT there resolves to `GtkFileDialogPeer`
+ * only when GTK loads, and falls back to `XFileDialogPeer` - a Motif-era dialog that is worse
+ * than the Swing chooser it would be replacing. macOS and Windows have no such fallback.
+ */
+object NativeFileDialogs {
+    private val logger = BossLogger.forComponent("NativeFileDialogs")
+
+    private const val MAC_DIRECTORY_MODE = "apple.awt.fileDialogForDirectories"
+
+    private val osName = System.getProperty("os.name").orEmpty().lowercase()
+    private val isMacOs = osName.contains("mac")
+    private val isWindows = osName.contains("win")
+
+    /** True when [installOn] does anything. See the class KDoc for why Linux is excluded. */
+    val isSupported: Boolean = isMacOs || isWindows
+
+    /**
+     * Point [browser]'s page-driven file dialogs at the OS ones.
+     *
+     * Safe to call more than once for the same browser - `Browser.set` replaces.
+     */
+    // Deliberately broad: a browser closed between creation and here throws rather than
+    // no-ops, and losing the native panel is cosmetic. It must never fail browser creation.
+    @Suppress("TooGenericExceptionCaught")
+    fun installOn(browser: Browser) {
+        if (!isSupported) return
+        try {
+            browser.set(OpenFileCallback::class.java, OpenFileCallback(::onOpenFile))
+            browser.set(OpenFilesCallback::class.java, OpenFilesCallback(::onOpenFiles))
+            browser.set(OpenFolderCallback::class.java, OpenFolderCallback(::onOpenFolder))
+            browser.set(SaveFileCallback::class.java, SaveFileCallback(::onSaveFile))
+            browser.set(SaveAsPdfCallback::class.java, SaveAsPdfCallback(::onSaveAsPdf))
+        } catch (e: Exception) {
+            logger.warn(LogCategory.BROWSER, "Could not install native file dialogs", error = e)
+        }
+    }
+
+    // ============================================================
+    // CALLBACKS
+    // ============================================================
+
+    private fun onOpenFile(
+        params: OpenFileCallback.Params,
+        action: OpenFileCallback.Action,
+    ) = answerOnce(
+        pick = {
+            showOpen(
+                suggestedDirectory = params.suggestedDirectory(),
+                extensions = params.acceptableExtensions(),
+                acceptAll = params.acceptAll(),
+                multiple = false,
+            ).firstOrNull()
+        },
+        open = action::open,
+        cancel = action::cancel,
+    )
+
+    // The spread is over a user's selection, so a handful of paths at most, and
+    // Action.open is Java varargs with no collection overload to prefer.
+    @Suppress("SpreadOperator")
+    private fun onOpenFiles(
+        params: OpenFilesCallback.Params,
+        action: OpenFilesCallback.Action,
+    ) = answerOnce(
+        pick = {
+            // OpenFilesCallback.Params carries no suggestedDirectory and no acceptAll,
+            // unlike the single-file one. Extensions still narrow the panel.
+            showOpen(
+                suggestedDirectory = "",
+                extensions = params.acceptableExtensions(),
+                acceptAll = false,
+                multiple = true,
+            ).takeIf { it.isNotEmpty() }
+        },
+        open = { paths -> action.open(*paths.toTypedArray()) },
+        cancel = action::cancel,
+    )
+
+    private fun onOpenFolder(
+        params: OpenFolderCallback.Params,
+        action: OpenFolderCallback.Action,
+    ) = answerOnce(
+        pick = { showOpenFolder(params.suggestedDirectory()) },
+        open = action::open,
+        cancel = action::cancel,
+    )
+
+    private fun onSaveFile(
+        params: SaveFileCallback.Params,
+        action: SaveFileCallback.Action,
+    ) = answerOnce(
+        pick = {
+            showSave(
+                suggestedFileName = params.suggestedFileName(),
+                suggestedDirectory = params.suggestedDirectory(),
+                extensions = params.acceptableExtensions(),
+                acceptAll = params.acceptAll(),
+            )
+        },
+        open = action::save,
+        cancel = action::cancel,
+    )
+
+    private fun onSaveAsPdf(
+        params: SaveAsPdfCallback.Params,
+        action: SaveAsPdfCallback.Action,
+    ) = answerOnce(
+        pick = {
+            showSave(
+                suggestedFileName = params.suggestedFileName(),
+                // The only Params here that hands back a Path rather than a String.
+                suggestedDirectory = params.suggestedDirectory()?.toString().orEmpty(),
+                extensions = listOf("pdf"),
+                acceptAll = false,
+            )
+        },
+        open = action::save,
+        cancel = action::cancel,
+    )
+
+    // ============================================================
+    // DIALOGS
+    // ============================================================
+
+    private fun showOpen(
+        suggestedDirectory: String,
+        extensions: List<String>,
+        acceptAll: Boolean,
+        multiple: Boolean,
+    ): List<Path> {
+        val dialog = newDialog("Open", FileDialog.LOAD, suggestedDirectory)
+        dialog.isMultipleMode = multiple
+        dialog.narrowTo(extensions, acceptAll)
+        dialog.isVisible = true
+        // getFiles() is populated in both modes; getFile()/getDirectory() are just the
+        // single-selection view of the same result. Empty means cancelled.
+        return dialog.files.orEmpty().map { it.toPath() }
+    }
+
+    private fun showOpenFolder(suggestedDirectory: String): Path? {
+        // The only way to ask NSOpenPanel for a directory from AWT. It is a process-wide
+        // property, which is safe here only because it is set and cleared around a modal
+        // show on the EDT, so no other file dialog can be opening in between.
+        val previous = System.getProperty(MAC_DIRECTORY_MODE)
+        if (isMacOs) System.setProperty(MAC_DIRECTORY_MODE, "true")
+        try {
+            val dialog = newDialog("Open", FileDialog.LOAD, suggestedDirectory)
+            dialog.isVisible = true
+            val name = dialog.file
+            val directory = dialog.directory
+            // In directory mode the chosen folder comes back split: directory is its
+            // parent, file is its own name. Cancelling leaves both null.
+            return when {
+                directory == null -> null
+                name == null -> File(directory).toPath()
+                else -> File(directory, name).toPath()
+            }
+        } finally {
+            if (isMacOs) System.setProperty(MAC_DIRECTORY_MODE, previous ?: "false")
+        }
+    }
+
+    private fun showSave(
+        suggestedFileName: String,
+        suggestedDirectory: String,
+        extensions: List<String>,
+        acceptAll: Boolean,
+    ): Path? {
+        val dialog = newDialog("Save", FileDialog.SAVE, suggestedDirectory)
+        // The page picks this name and it becomes a real path, so it goes through the same
+        // sanitizer the download handler uses. Only when the page suggested something:
+        // sanitize("") is the string "download", which would pre-fill a name nobody asked for.
+        if (suggestedFileName.isNotBlank()) {
+            dialog.file = FileNameSanitizer.sanitize(suggestedFileName)
+        }
+        dialog.narrowTo(extensions, acceptAll)
+        dialog.isVisible = true
+        val name = dialog.file
+        val directory = dialog.directory
+        return if (name != null && directory != null) File(directory, name).toPath() else null
+    }
+
+    // ============================================================
+    // PLUMBING
+    // ============================================================
+
+    /**
+     * Run [pick] on the EDT and answer the callback exactly once, with [open] or [cancel].
+     *
+     * These are async callbacks: JxBrowser hands over an action and returns, and the page's
+     * file input stays pending until something answers. Dropping the answer wedges that input
+     * for the life of the tab, so a throw inside the dialog still has to produce a cancel.
+     * Answering *twice* is the other failure, hence the flag rather than two exit paths.
+     */
+    // Deliberately broad, both of them: the point is that no failure, whatever its type,
+    // leaves the page waiting. Error still propagates, as elsewhere in this package.
+    @Suppress("TooGenericExceptionCaught")
+    private fun <T : Any> answerOnce(
+        pick: () -> T?,
+        open: (T) -> Unit,
+        cancel: () -> Unit,
+    ) {
+        val answered = AtomicBoolean(false)
+
+        fun answer(picked: T?) {
+            if (!answered.compareAndSet(false, true)) return
+            try {
+                if (picked != null) open(picked) else cancel()
+            } catch (e: Exception) {
+                logger.warn(LogCategory.BROWSER, "Could not answer a file dialog", error = e)
+            }
+        }
+
+        try {
+            SwingUtilities.invokeLater {
+                val picked =
+                    try {
+                        pick()
+                    } catch (e: Exception) {
+                        logger.warn(LogCategory.BROWSER, "Native file dialog failed", error = e)
+                        null
+                    }
+                answer(picked)
+            }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.BROWSER, "Could not show a native file dialog", error = e)
+            answer(null)
+        }
+    }
+}
+
+/**
+ * An OS file panel, owned by the window the user is actually looking at.
+ *
+ * The owner matters: with a null one the native panel can open BEHIND the Compose window, so
+ * the click that opened it looks like it did nothing. Same fix as `DirectoryPickerProviderImpl`.
+ *
+ * (Top level rather than a member, with the helpers below, so [NativeFileDialogs] stays under
+ * detekt's per-object function count.)
+ */
+private fun newDialog(
+    title: String,
+    mode: Int,
+    suggestedDirectory: String,
+): FileDialog {
+    val owner = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow as? Frame
+    return FileDialog(owner, title, mode).apply {
+        isAlwaysOnTop = true
+        val suggested = File(suggestedDirectory)
+        if (suggestedDirectory.isNotBlank() && suggested.isDirectory) {
+            directory = suggested.absolutePath
+        }
+    }
+}
+
+/**
+ * Narrow the panel to [extensions], unless the page said any file will do.
+ *
+ * The macOS peer asks this filter per URL and answers yes for anything that is not a regular
+ * file, so directories stay navigable. Windows applies it the same way.
+ *
+ *  */
+private fun FileDialog.narrowTo(
+    extensions: List<String>,
+    acceptAll: Boolean,
+) {
+    if (acceptAll) return
+    val suffixes = fileDialogSuffixes(extensions)
+    if (suffixes.isEmpty()) return
+    setFilenameFilter { _, name -> matchesSuffix(name, suffixes) }
+}
+
+/**
+ * The suffixes an `accept` attribute actually names, normalised for [matchesSuffix].
+ *
+ * Chromium hands these through however the page wrote them. A leading dot is common and
+ * would double up in the `.ext` comparison; **MIME types and wildcards are dropped**, because
+ * a filter built from a MIME pattern matches no filename at all - and an empty result means
+ * no filter, which shows everything, rather than a panel where nothing is selectable.
+ */
+internal fun fileDialogSuffixes(extensions: List<String>): List<String> =
+    extensions
+        .mapNotNull { it.trim().removePrefix(".").takeIf(String::isNotEmpty) }
+        .filterNot { it.contains('/') || it.contains('*') }
+
+/** Whether [name] carries one of [suffixes]. Case-insensitive: the disk is not. */
+internal fun matchesSuffix(
+    name: String,
+    suffixes: List<String>,
+): Boolean = suffixes.any { name.endsWith(".$it", ignoreCase = true) }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
@@ -1,0 +1,112 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.browser.callback.BrowserCallback
+import com.teamdev.jxbrowser.browser.callback.OpenFileCallback
+import com.teamdev.jxbrowser.browser.callback.OpenFilesCallback
+import com.teamdev.jxbrowser.callback.Advisable
+import com.teamdev.jxbrowser.callback.Callback
+import com.teamdev.jxbrowser.callback.internal.DefaultCallbacks
+import java.util.Optional
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Pins the two things [NativeFileDialogs] rests on.
+ *
+ * The dialogs themselves cannot be asserted here - they are native panels, and two of the
+ * three CI legs have no display - so what is tested is the contract that decides whether
+ * they are ever reached, plus the filter the page controls.
+ */
+class NativeFileDialogsTest {
+    /**
+     * A stand-in for `Browser`, which is the `Advisable` JxBrowser actually registers into.
+     */
+    private class RecordingAdvisable : Advisable<BrowserCallback> {
+        val callbacks = mutableMapOf<Class<out Callback>, BrowserCallback>()
+
+        // set/remove return the *previous* callback, which is null the first time - hence
+        // the nullable returns against the unannotated Java signatures.
+        @Suppress("UNCHECKED_CAST")
+        override fun <C : BrowserCallback> set(
+            type: Class<C>,
+            callback: C,
+        ): C? = callbacks.put(type, callback) as C?
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <C : BrowserCallback> get(type: Class<C>): Optional<C> = Optional.ofNullable(callbacks[type] as C?)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <C : BrowserCallback> remove(type: Class<C>): C? = callbacks.remove(type) as C?
+    }
+
+    /**
+     * The whole fix is "set ours first and JxBrowser's view will not replace it".
+     *
+     * That is `DefaultCallbacks.register()` skipping any type already present - library
+     * behaviour, not ours, and invisible from our own code. A JxBrowser upgrade that made
+     * defaults overwrite would silently put the Swing `JFileChooser` back on every page
+     * with an upload field, and nothing else in the tree would notice.
+     */
+    @Test
+    fun `a default callback never replaces one already set`() {
+        val advisable = RecordingAdvisable()
+        val ours = OpenFileCallback { _, action -> action.cancel() }
+        advisable.set(OpenFileCallback::class.java, ours)
+
+        val theirs = OpenFileCallback { _, action -> action.cancel() }
+        val untouched = OpenFilesCallback { _, action -> action.cancel() }
+        DefaultCallbacks
+            .of(advisable)
+            .add(theirs)
+            .add(untouched)
+            .build()
+            .register()
+
+        assertSame(ours, advisable.callbacks[OpenFileCallback::class.java], "ours must survive registration")
+        assertSame(
+            untouched,
+            advisable.callbacks[OpenFilesCallback::class.java],
+            "a type we did not claim must still get the default",
+        )
+    }
+
+    /**
+     * And the other half: a default we never claimed *is* installed, so leaving a callback
+     * out of `installOn` means the Swing chooser, not a dead file input.
+     */
+    @Test
+    fun `a default callback is installed when nothing claimed the type`() {
+        val advisable = RecordingAdvisable()
+        val theirs = OpenFileCallback { _, action -> action.cancel() }
+
+        DefaultCallbacks
+            .of(advisable)
+            .add(theirs)
+            .build()
+            .register()
+
+        assertSame(theirs, advisable.callbacks[OpenFileCallback::class.java])
+    }
+
+    @Test
+    fun `suffixes are normalised and mime types dropped`() {
+        assertEquals(listOf("png", "jpeg"), fileDialogSuffixes(listOf(".png", "jpeg")))
+        assertEquals(listOf("pdf"), fileDialogSuffixes(listOf(" pdf ")))
+        // An accept attribute of "image/*" or "*" names no suffix. Dropping them leaves an
+        // empty list, which the caller reads as "no filter" - a panel showing everything,
+        // rather than one where every file is greyed out.
+        assertEquals(emptyList(), fileDialogSuffixes(listOf("image/*", "*", "", ".")))
+    }
+
+    @Test
+    fun `suffix matching ignores case and requires the dot`() {
+        val suffixes = listOf("png")
+        assertTrue(matchesSuffix("Photo.PNG", suffixes))
+        assertTrue(matchesSuffix("a.b.png", suffixes))
+        assertFalse(matchesSuffix("png", suffixes), "a bare name is not a match")
+        assertFalse(matchesSuffix("notapng", suffixes))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
@@ -196,18 +196,14 @@ class NativeFileDialogsTest {
 
     @Test
     fun `a save-as-pdf name keeps its extension without doubling it`() {
+        // Relative and built from segments on purpose: a literal "/tmp/report" has the parent
+        // "\\tmp" on the Windows CI leg, which is the separator's business, not this rule's.
+        val bare = Paths.get("reports", "report")
+        assertEquals("report.pdf", bare.withExtension("pdf").fileName.toString())
         assertEquals(
             "report.pdf",
             Paths
-                .get("/tmp/report")
-                .withExtension("pdf")
-                .fileName
-                .toString(),
-        )
-        assertEquals(
-            "report.pdf",
-            Paths
-                .get("/tmp/report.pdf")
+                .get("reports", "report.pdf")
                 .withExtension("pdf")
                 .fileName
                 .toString(),
@@ -215,19 +211,12 @@ class NativeFileDialogsTest {
         assertEquals(
             "report.PDF",
             Paths
-                .get("/tmp/report.PDF")
+                .get("reports", "report.PDF")
                 .withExtension("pdf")
                 .fileName
                 .toString(),
         )
-        assertEquals(
-            "/tmp",
-            Paths
-                .get("/tmp/report")
-                .withExtension("pdf")
-                .parent
-                .toString(),
-        )
+        assertEquals(bare.parent, bare.withExtension("pdf").parent, "the file must not move directory")
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
@@ -3,10 +3,17 @@ package ai.rever.boss.plugin.browser
 import com.teamdev.jxbrowser.browser.callback.BrowserCallback
 import com.teamdev.jxbrowser.browser.callback.OpenFileCallback
 import com.teamdev.jxbrowser.browser.callback.OpenFilesCallback
+import com.teamdev.jxbrowser.browser.callback.OpenFolderCallback
+import com.teamdev.jxbrowser.browser.callback.SaveAsPdfCallback
+import com.teamdev.jxbrowser.browser.callback.SaveFileCallback
 import com.teamdev.jxbrowser.callback.Advisable
 import com.teamdev.jxbrowser.callback.Callback
 import com.teamdev.jxbrowser.callback.internal.DefaultCallbacks
+import java.nio.file.Paths
 import java.util.Optional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -14,11 +21,11 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
- * Pins the two things [NativeFileDialogs] rests on.
+ * Pins what [NativeFileDialogs] rests on.
  *
- * The dialogs themselves cannot be asserted here - they are native panels, and two of the
- * three CI legs have no display - so what is tested is the contract that decides whether
- * they are ever reached, plus the filter the page controls.
+ * The panels themselves cannot be asserted here - they are native, and two of the three CI
+ * legs have no display - so what is tested is everything that decides whether they are
+ * reached and answered correctly, plus the pure helpers the page's input feeds.
  */
 class NativeFileDialogsTest {
     /**
@@ -43,12 +50,42 @@ class NativeFileDialogsTest {
     }
 
     /**
+     * Every dialog the page can raise has to be claimed, because an unclaimed one silently
+     * gets JxBrowser's Swing `JFileChooser` back and nothing else in the tree notices.
+     *
+     * Asserted against `registerOn` rather than `installOn`: the latter is gated on macOS, so
+     * this would assert nothing on two of the three CI legs and sleep through the regression.
+     */
+    @Test
+    fun `every page-driven file dialog is claimed`() {
+        val advisable = RecordingAdvisable()
+
+        NativeFileDialogs.registerOn(advisable)
+
+        val expected =
+            listOf(
+                OpenFileCallback::class.java,
+                OpenFilesCallback::class.java,
+                OpenFolderCallback::class.java,
+                SaveFileCallback::class.java,
+                SaveAsPdfCallback::class.java,
+            ).map { it.simpleName }.sorted()
+        assertEquals(
+            expected,
+            advisable.callbacks.keys
+                .map { it.simpleName }
+                .sorted(),
+            "a missing one falls back to the Swing chooser",
+        )
+    }
+
+    /**
      * The whole fix is "set ours first and JxBrowser's view will not replace it".
      *
      * That is `DefaultCallbacks.register()` skipping any type already present - library
      * behaviour, not ours, and invisible from our own code. A JxBrowser upgrade that made
      * defaults overwrite would silently put the Swing `JFileChooser` back on every page
-     * with an upload field, and nothing else in the tree would notice.
+     * with an upload field.
      */
     @Test
     fun `a default callback never replaces one already set`() {
@@ -74,8 +111,8 @@ class NativeFileDialogsTest {
     }
 
     /**
-     * And the other half: a default we never claimed *is* installed, so leaving a callback
-     * out of `installOn` means the Swing chooser, not a dead file input.
+     * And the other half: a default we never claimed *is* installed, so the test above
+     * cannot pass just because `register()` does nothing at all.
      */
     @Test
     fun `a default callback is installed when nothing claimed the type`() {
@@ -89,6 +126,53 @@ class NativeFileDialogsTest {
             .register()
 
         assertSame(theirs, advisable.callbacks[OpenFileCallback::class.java])
+    }
+
+    /**
+     * A page's file input stays pending until something answers, so a dialog that throws
+     * must still cancel rather than wedge the input for the life of the tab.
+     */
+    @Test
+    fun `a throw while picking still cancels`() {
+        val cancels = AtomicInteger()
+        val opens = AtomicInteger()
+        val done = CountDownLatch(1)
+
+        NativeFileDialogs.answerOnce<String>(
+            pick = { error("dialog blew up") },
+            open = { opens.incrementAndGet() },
+            cancel = {
+                cancels.incrementAndGet()
+                done.countDown()
+            },
+        )
+
+        assertTrue(done.await(5, TimeUnit.SECONDS), "the callback was never answered")
+        assertEquals(1, cancels.get())
+        assertEquals(0, opens.get())
+    }
+
+    /** Answering twice is the other way to break the page, so a pick answers once only. */
+    @Test
+    fun `a successful pick answers exactly once`() {
+        val cancels = AtomicInteger()
+        val opens = AtomicInteger()
+        val done = CountDownLatch(1)
+
+        NativeFileDialogs.answerOnce(
+            pick = { "chosen" },
+            open = {
+                opens.incrementAndGet()
+                done.countDown()
+            },
+            cancel = { cancels.incrementAndGet() },
+        )
+
+        assertTrue(done.await(5, TimeUnit.SECONDS), "the callback was never answered")
+        // Drain the EDT so a second answer posted behind ours would have landed by now.
+        javax.swing.SwingUtilities.invokeAndWait { }
+        assertEquals(1, opens.get())
+        assertEquals(0, cancels.get())
     }
 
     @Test
@@ -108,5 +192,52 @@ class NativeFileDialogsTest {
         assertTrue(matchesSuffix("a.b.png", suffixes))
         assertFalse(matchesSuffix("png", suffixes), "a bare name is not a match")
         assertFalse(matchesSuffix("notapng", suffixes))
+    }
+
+    @Test
+    fun `a save-as-pdf name keeps its extension without doubling it`() {
+        assertEquals(
+            "report.pdf",
+            Paths
+                .get("/tmp/report")
+                .withExtension("pdf")
+                .fileName
+                .toString(),
+        )
+        assertEquals(
+            "report.pdf",
+            Paths
+                .get("/tmp/report.pdf")
+                .withExtension("pdf")
+                .fileName
+                .toString(),
+        )
+        assertEquals(
+            "report.PDF",
+            Paths
+                .get("/tmp/report.PDF")
+                .withExtension("pdf")
+                .fileName
+                .toString(),
+        )
+        assertEquals(
+            "/tmp",
+            Paths
+                .get("/tmp/report")
+                .withExtension("pdf")
+                .parent
+                .toString(),
+        )
+    }
+
+    @Test
+    fun `a prefilled save name keeps unicode but loses any path`() {
+        // FileNameSanitizer would turn this into underscores; the name field is read by a
+        // person, and the path we return comes from the panel, not from this string.
+        assertEquals("報告書.pdf", safePrefill("報告書.pdf"))
+        assertEquals("x", safePrefill("../../x"))
+        assertEquals("b.txt", safePrefill("/etc/a/b.txt"))
+        assertEquals("my report.txt", safePrefill("my report.txt"), "a space is not a control character")
+        assertEquals("ab.txt", safePrefill("a\u0001b.txt"), "control characters are dropped")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/NativeFileDialogsTest.kt
@@ -129,6 +129,39 @@ class NativeFileDialogsTest {
     }
 
     /**
+     * The other half of the same claim, and the one that does not need an upgrade to bite.
+     *
+     * `FullscreenBrowserWindow` builds and disposes a Swing view over a live browser on every
+     * fullscreen enter and exit, and the Compose view is recreated on tab switches. If the
+     * view's `unregister()` stripped whatever it found rather than only what it registered,
+     * the first detach would take our callbacks with it and the next attach would install the
+     * Swing chooser - silently, and indistinguishable from the bug being fixed.
+     */
+    @Test
+    fun `unregistering the defaults leaves ours in place`() {
+        val advisable = RecordingAdvisable()
+        val ours = OpenFileCallback { _, action -> action.cancel() }
+        advisable.set(OpenFileCallback::class.java, ours)
+
+        val theirs = OpenFileCallback { _, action -> action.cancel() }
+        val untouched = OpenFilesCallback { _, action -> action.cancel() }
+        val defaults =
+            DefaultCallbacks
+                .of(advisable)
+                .add(theirs)
+                .add(untouched)
+                .build()
+        defaults.register()
+        defaults.unregister()
+
+        assertSame(ours, advisable.callbacks[OpenFileCallback::class.java], "a view detach must not strip ours")
+        assertFalse(
+            advisable.callbacks.containsKey(OpenFilesCallback::class.java),
+            "a default it did install must still be removed, or the test proves nothing",
+        )
+    }
+
+    /**
      * A page's file input stays pending until something answers, so a dialog that throws
      * must still cancel rather than wedge the input for the life of the tab.
      */
@@ -179,10 +212,21 @@ class NativeFileDialogsTest {
     fun `suffixes are normalised and mime types dropped`() {
         assertEquals(listOf("png", "jpeg"), fileDialogSuffixes(listOf(".png", "jpeg")))
         assertEquals(listOf("pdf"), fileDialogSuffixes(listOf(" pdf ")))
-        // An accept attribute of "image/*" or "*" names no suffix. Dropping them leaves an
-        // empty list, which the caller reads as "no filter" - a panel showing everything,
-        // rather than one where every file is greyed out.
+        // A MIME pattern or a bare wildcard names no suffix. The empty list reads as "no
+        // filter" - a panel showing everything, rather than one where every file is greyed out.
         assertEquals(emptyList(), fileDialogSuffixes(listOf("image/*", "*", "", ".")))
+    }
+
+    /**
+     * A mixed list accepts MORE than its suffixes describe, so filtering on the survivors
+     * would grey out a file the page explicitly allows.
+     */
+    @Test
+    fun `a mixed accept list produces no filter at all`() {
+        assertEquals(emptyList(), fileDialogSuffixes(listOf(".png", "image/*")))
+        assertEquals(emptyList(), fileDialogSuffixes(listOf("pdf", "*")))
+        // Still narrowed when every token really is a suffix.
+        assertEquals(listOf("png", "gif"), fileDialogSuffixes(listOf(".png", ".gif")))
     }
 
     @Test
@@ -199,24 +243,12 @@ class NativeFileDialogsTest {
         // Relative and built from segments on purpose: a literal "/tmp/report" has the parent
         // "\\tmp" on the Windows CI leg, which is the separator's business, not this rule's.
         val bare = Paths.get("reports", "report")
-        assertEquals("report.pdf", bare.withExtension("pdf").fileName.toString())
-        assertEquals(
-            "report.pdf",
-            Paths
-                .get("reports", "report.pdf")
-                .withExtension("pdf")
-                .fileName
-                .toString(),
-        )
-        assertEquals(
-            "report.PDF",
-            Paths
-                .get("reports", "report.PDF")
-                .withExtension("pdf")
-                .fileName
-                .toString(),
-        )
-        assertEquals(bare.parent, bare.withExtension("pdf").parent, "the file must not move directory")
+        assertEquals("report.pdf", pathWithExtension(bare, "pdf").fileName.toString())
+        val already = pathWithExtension(Paths.get("reports", "report.pdf"), "pdf")
+        assertEquals("report.pdf", already.fileName.toString())
+        val uppercase = pathWithExtension(Paths.get("reports", "report.PDF"), "pdf")
+        assertEquals("report.PDF", uppercase.fileName.toString(), "matching is case-insensitive")
+        assertEquals(bare.parent, pathWithExtension(bare, "pdf").parent, "the file must not move directory")
     }
 
     @Test
@@ -227,6 +259,8 @@ class NativeFileDialogsTest {
         assertEquals("x", safePrefill("../../x"))
         assertEquals("b.txt", safePrefill("/etc/a/b.txt"))
         assertEquals("my report.txt", safePrefill("my report.txt"), "a space is not a control character")
+        assertEquals("", safePrefill(".."), "accepting \"..\" would hand back a directory")
+        assertEquals("", safePrefill("."))
         assertEquals("ab.txt", safePrefill("a\u0001b.txt"), "control characters are dropped")
     }
 }


### PR DESCRIPTION
## The bug

Clicking an upload field in the BOSS browser opened a Swing `JFileChooser`, which on macOS renders through `AquaFileChooserUI` - the pre-10.7 Open panel, with a "Where:" popup and a "File Format:" combo. Safari and Chrome open the real `NSOpenPanel`: sidebar, column view, search, Recents.

## Why

Nothing in BOSS chose that dialog. JxBrowser's `BrowserView` - both the Compose one and the Swing one - installs a set of **default** callbacks when it is created, and every file-related one of them shows a `JFileChooser` (`jxbrowser-compose` 9.4.0, `DefaultCallbacksKt.fileChooserCallbacks` -> `SwingFileChooserKt`). BOSS never answered `OpenFile` / `OpenFiles` / `OpenFolder` / `SaveFile` / `SaveAsPdf`, so those defaults won.

Downloads were never affected: `StartDownloadCallback` is host-owned and already uses `pickSaveFile`, an AWT `FileDialog`. This closes the same gap for the dialogs the *page* opens.

## The fix

`java.awt.FileDialog` **is** the native panel: its macOS peer (`sun.lwawt.macosx.CFileDialog`) wraps `NSOpenPanel`/`NSSavePanel`, and its Windows peer is the Win32 common dialog. `NativeFileDialogs` answers all five callbacks with it.

Things worth knowing about the placement:

- **Registration happens at browser construction, not composition.** `DefaultCallbacks.register()` checks `advisable.get(type).isPresent()` and skips any callback already set, so setting ours first wins. It also survives a view being detached and re-attached (tab switch, fullscreen), because the view's matching `unregister()` only removes what it actually registered.
- **Popup browsers are covered too.** They never go through `setupBrowserHandlers`, and an OAuth or payment popup is exactly where an upload field turns up. Both popup paths (`BrowserHandleImpl` and the legacy `BrowserFunctions`) install before their Swing view is created.
- **macOS only, deliberately.** `FileDialog` is the wrong trade on the other two platforms, and review caught both: on **Windows** `setFilenameFilter` is documented as a no-op (the Win32 peer drives `GetOpenFileName` with filter *strings*), so an `accept=".png"` input would list every file, and `FileDialog` cannot select a directory at all, so `webkitdirectory` would hand Chromium a file path and quietly yield nothing - two silent regressions against one cosmetic win. On **Linux** AWT resolves to `GtkFileDialogPeer` only when GTK loads and otherwise falls back to `XFileDialogPeer`, a Motif-era dialog worse than the chooser it would replace. A native Windows panel is worth having, but it needs Win32 filter strings and a folder browser, not this.
- **Nesting is handled.** A modal `FileDialog` runs a nested event loop that keeps dispatching other `invokeLater` blocks, so a second dialog really can be created inside the first one's loop. Each dialog states its own directory mode immediately before showing, and the peer is disposed in a `finally`.
- **The callback is answered exactly once, whatever happens.** These are async callbacks: the page's file input stays pending until something calls `open` or `cancel`, so a throw inside the dialog still has to produce a cancel, and answering twice is the other way to break it.
- **MIME patterns are dropped from the filter.** An `accept` attribute can name `image/` plus a wildcard; a filename filter built from that matches nothing, so the panel would show a folder of greyed-out files. Dropping them leaves no filter, which shows everything.
- **The pre-filled save name is reduced to a plain filename**, not run through `FileNameSanitizer`: that maps non-ASCII to underscores, and a page titled in Japanese would pre-fill as `___.pdf`. Traversal is still stripped, and nothing here needs to be filesystem-safe because the returned path is what the panel reports back.

## Test

`NativeFileDialogsTest` pins the library behaviour the whole fix rests on: a default callback does **not** replace one already set, and **does** install when nothing claimed the type. The second case is the control for the first, so neither can pass vacuously. A JxBrowser upgrade that changed those semantics would put the old dialog back on every page with an upload field, and nothing else in the tree would notice.

It also covers this file's own logic: `registerOn` (split out of `installOn` so it runs ungated on every CI leg rather than assuming macOS) must claim all five callbacks, and `answerOnce` must cancel when the dialog throws and answer only once when it does not. Plus the filter normalisation, the save-as-PDF extension, and the pre-fill reduction.

Both behavioural tests were checked by **mutation**, not assumed live: deleting one `set` line fails the first, and swallowing the failed pick fails the second.

## Verification

- `compileKotlinDesktop`, `ktlintCheck`, `detekt`, full `desktopTest`: green.
- Ran the branch (`./gradlew run`, dev mode) and confirmed browsers come up through `BrowserServiceImpl`, which is the path that installs the callbacks.
