### PR TITLE
Stop downloads overwriting each other, and open files dropped on the main panel

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.components.window_panel.components.main_window_panels.BossM
 import ai.rever.boss.components.window_panel.components.main_window_panels.BossTabsComponent
 import ai.rever.boss.components.window_panel.components.main_window_panels.createBossAppContext
 import ai.rever.boss.icons.FileIcons
+import ai.rever.boss.platform.bossFileDropTarget
 import ai.rever.boss.plugin.api.Panel
 import ai.rever.boss.plugin.api.TabIcon
 import ai.rever.boss.plugin.api.TabInfo
@@ -23,6 +24,7 @@ import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.project.DefaultWorkingDirectory
 import ai.rever.boss.topofmind.ActiveTab
+import ai.rever.boss.utils.extractFileName
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.window.WindowProjectStateRegistry
@@ -1539,7 +1541,18 @@ fun SplitViewPanel(
     tabDragComponent: TabDraggableComponent? = null,
     onTabDropResult: (TabDropResult) -> Unit = {},
 ) {
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                // Dropping a file on the main panel opens it, routed by extension exactly as a
+                // click in the sidebar would be. Attached here rather than per-panel so the
+                // whole main area is a target, and it accepts the plain OS file flavour, so a
+                // drag out of Finder works the same as one out of a BOSS sidebar.
+                .bossFileDropTarget { paths ->
+                    paths.forEach { splitViewState.openFileInActivePanel(it, it.extractFileName()) }
+                },
+    ) {
         RenderSplitNode(
             node = splitViewState.rootNode,
             splitViewState = splitViewState,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileDropTarget.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/platform/FileDropTarget.kt
@@ -1,0 +1,15 @@
+package ai.rever.boss.platform
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Accept files dropped onto this composable, from anywhere the OS can drag from.
+ *
+ * The transfer is a plain `java.awt.datatransfer.DataFlavor.javaFileListFlavor`, which is what
+ * Finder, Explorer and every other desktop app publishes when dragging a file. That is
+ * deliberate: it means the same drop target serves a drag out of Finder and a drag out of a
+ * BOSS sidebar, with no BOSS-specific transfer type for a plugin to have to know about.
+ *
+ * [onFilesDropped] receives absolute paths and runs on the UI thread.
+ */
+expect fun Modifier.bossFileDropTarget(onFilesDropped: (List<String>) -> Unit): Modifier

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileDropTarget.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileDropTarget.desktop.kt
@@ -3,7 +3,9 @@ package ai.rever.boss.platform
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -11,57 +13,93 @@ import androidx.compose.ui.draganddrop.DragAndDropEvent
 import androidx.compose.ui.draganddrop.DragAndDropTarget
 import androidx.compose.ui.draganddrop.awtTransferable
 import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
 import java.io.File
 
 private val logger = BossLogger.forComponent("FileDropTarget")
 
+/**
+ * Most files one drop will open.
+ *
+ * A select-all in Finder is a single gesture, and every opened file costs a tab (and, for
+ * code, an LSP session). The remainder is logged rather than silently discarded.
+ */
+internal const val MAX_FILES_PER_DROP = 20
+
 actual fun Modifier.bossFileDropTarget(onFilesDropped: (List<String>) -> Unit): Modifier =
     composed {
+        // Read through a state holder so the target itself never has to be rebuilt. Keying
+        // remember() on the lambda would reallocate and re-register the target on every
+        // recomposition where the call site's lambda is not inferred stable.
+        val current by rememberUpdatedState(onFilesDropped)
         val target =
-            remember(onFilesDropped) {
+            remember {
                 object : DragAndDropTarget {
                     override fun onDrop(event: DragAndDropEvent): Boolean {
-                        val paths = event.filePaths()
+                        val paths = event.transferableOrNull().filePathsOrEmpty()
                         if (paths.isEmpty()) return false
-                        onFilesDropped(paths)
+                        current(paths)
                         return true
                     }
                 }
             }
         dragAndDropTarget(
-            // Answered for every drag that crosses this composable, including drags of BOSS's
-            // own tabs, so it has to be cheap and it has to say no to anything that is not a
-            // file. Returning true here is what makes onDrop reachable at all.
-            shouldStartDragAndDrop = { event -> event.carriesFiles() },
+            // Answered for every platform drag crossing this composable, so it stays cheap and
+            // only inspects the advertised flavours. (BOSS's own tab drags are pointer-input
+            // based, not platform drag-and-drop, so they never reach this at all.)
+            shouldStartDragAndDrop = { event -> event.transferableOrNull().carriesFiles() },
             target = target,
         )
     }
 
-/** Whether [this] is an OS file drag, without deserialising the payload. */
 @OptIn(ExperimentalComposeUiApi::class)
-private fun DragAndDropEvent.carriesFiles(): Boolean =
+private fun DragAndDropEvent.transferableOrNull(): Transferable? = runCatching { awtTransferable }.getOrNull()
+
+/** Whether [this] is an OS file drag, without deserialising the payload. */
+internal fun Transferable?.carriesFiles(): Boolean =
     runCatching {
-        awtTransferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)
+        this?.isDataFlavorSupported(DataFlavor.javaFileListFlavor) == true
     }.getOrDefault(false)
 
 /**
- * The dropped files as absolute paths, or empty if the payload is not readable.
+ * The dropped **files** as absolute paths, capped at [MAX_FILES_PER_DROP].
  *
- * `getTransferData` reaches across to the source application and is documented to throw, so a
- * malformed or already-revoked drag must not take the UI thread down with it - a failed drop
- * is a no-op, not a crash.
+ * Directories are dropped on the floor. Finder and Explorer hand a folder over through the
+ * same flavour as a file, and the caller routes by extension - so a folder would reach the
+ * code editor as though it were a source file. Ignoring it keeps the promise that a drop and
+ * a click agree; opening a workspace from a drop is a bigger behaviour than this should
+ * invent on its own.
+ *
+ * Never throws. `getTransferData` reaches into the source application and is documented to, so
+ * a malformed or already-revoked drag has to be a no-op rather than an exception on the UI
+ * thread. The cast is deliberately loose for the same reason: `as? List<File>` only proves it
+ * is a `List`, so a `List<String>` from a misbehaving source raises `ClassCastException`
+ * inside the map, which this same catch owns.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Suppress("TooGenericExceptionCaught") // A drag source is another process; any failure is a no-op.
-private fun DragAndDropEvent.filePaths(): List<String> =
+internal fun Transferable?.filePathsOrEmpty(): List<String> =
     try {
-        val transferable = awtTransferable
-        if (!transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+        if (this == null || !isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
             emptyList()
         } else {
             @Suppress("UNCHECKED_CAST")
-            val files = transferable.getTransferData(DataFlavor.javaFileListFlavor) as? List<File>
-            files.orEmpty().map { it.absolutePath }
+            val entries = (getTransferData(DataFlavor.javaFileListFlavor) as? List<File>).orEmpty()
+            val files = entries.filterNot { it.isDirectory }
+            if (entries.size > files.size) {
+                logger.info(
+                    LogCategory.FILE,
+                    "Ignored directories in a file drop",
+                    mapOf("count" to entries.size - files.size),
+                )
+            }
+            if (files.size > MAX_FILES_PER_DROP) {
+                logger.warn(
+                    LogCategory.FILE,
+                    "Too many files in one drop - opening the first $MAX_FILES_PER_DROP",
+                    mapOf("dropped" to files.size),
+                )
+            }
+            files.take(MAX_FILES_PER_DROP).map { it.absolutePath }
         }
     } catch (e: Exception) {
         logger.warn(LogCategory.FILE, "Could not read a dropped file list", error = e)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileDropTarget.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileDropTarget.desktop.kt
@@ -1,0 +1,69 @@
+package ai.rever.boss.platform
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.awtTransferable
+import java.awt.datatransfer.DataFlavor
+import java.io.File
+
+private val logger = BossLogger.forComponent("FileDropTarget")
+
+actual fun Modifier.bossFileDropTarget(onFilesDropped: (List<String>) -> Unit): Modifier =
+    composed {
+        val target =
+            remember(onFilesDropped) {
+                object : DragAndDropTarget {
+                    override fun onDrop(event: DragAndDropEvent): Boolean {
+                        val paths = event.filePaths()
+                        if (paths.isEmpty()) return false
+                        onFilesDropped(paths)
+                        return true
+                    }
+                }
+            }
+        dragAndDropTarget(
+            // Answered for every drag that crosses this composable, including drags of BOSS's
+            // own tabs, so it has to be cheap and it has to say no to anything that is not a
+            // file. Returning true here is what makes onDrop reachable at all.
+            shouldStartDragAndDrop = { event -> event.carriesFiles() },
+            target = target,
+        )
+    }
+
+/** Whether [this] is an OS file drag, without deserialising the payload. */
+@OptIn(ExperimentalComposeUiApi::class)
+private fun DragAndDropEvent.carriesFiles(): Boolean =
+    runCatching {
+        awtTransferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)
+    }.getOrDefault(false)
+
+/**
+ * The dropped files as absolute paths, or empty if the payload is not readable.
+ *
+ * `getTransferData` reaches across to the source application and is documented to throw, so a
+ * malformed or already-revoked drag must not take the UI thread down with it - a failed drop
+ * is a no-op, not a crash.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Suppress("TooGenericExceptionCaught") // A drag source is another process; any failure is a no-op.
+private fun DragAndDropEvent.filePaths(): List<String> =
+    try {
+        val transferable = awtTransferable
+        if (!transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+            emptyList()
+        } else {
+            @Suppress("UNCHECKED_CAST")
+            val files = transferable.getTransferData(DataFlavor.javaFileListFlavor) as? List<File>
+            files.orEmpty().map { it.absolutePath }
+        }
+    } catch (e: Exception) {
+        logger.warn(LogCategory.FILE, "Could not read a dropped file list", error = e)
+        emptyList()
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
@@ -88,8 +88,27 @@ object FileSystemUtils {
     }
 
     /**
-     * Generates a unique file path by appending (1), (2), etc. if file already exists.
+     * Paths handed out by [generateUniqueFilePath] whose file does not exist yet.
+     *
+     * "Is the name free?" cannot be answered by [File.exists] alone. A download's file is not
+     * created until bytes arrive, so two downloads of `report.pdf` started before either lands
+     * both saw a free name and both resolved to the same path - the second silently truncating
+     * the first. A claimed path is treated as taken until [releaseFilePath] is called, which
+     * the download's terminal handlers do.
+     */
+    private val claimedPaths =
+        java.util.concurrent.ConcurrentHashMap
+            .newKeySet<String>()
+
+    /** Highest `(n)` suffix tried before falling back to a name that cannot collide. */
+    private const val MAX_COLLISION_SUFFIX = 1000
+
+    /**
+     * Generates a unique file path by appending (1), (2), etc. if the name is taken.
      * Example: "file.txt" -> "file (1).txt" -> "file (2).txt"
+     *
+     * The returned path is **claimed** until [releaseFilePath] is called for it, so a caller
+     * that has not written its file yet still blocks a concurrent caller from the same name.
      *
      * @param directory Directory where file will be saved
      * @param fileName Original file name
@@ -106,30 +125,59 @@ object FileSystemUtils {
             dir.mkdirs()
         }
 
-        var file = File(dir, fileName)
+        val original = File(dir, fileName)
+        val extension = original.extension
+        val stem = original.nameWithoutExtension
 
-        // If no collision, return original path
-        if (!file.exists()) {
-            return file.absolutePath
+        fun suffixed(suffix: String): File {
+            val name = if (extension.isEmpty()) "$stem ($suffix)" else "$stem ($suffix).$extension"
+            return File(dir, name)
         }
 
-        // Handle collision with incrementing counter
-        val extension = file.extension
-        val nameWithoutExtension = file.nameWithoutExtension
-        var counter = 1
+        val claimed =
+            if (claim(original)) {
+                original
+            } else {
+                (1 until MAX_COLLISION_SUFFIX)
+                    .asSequence()
+                    .map { suffixed(it.toString()) }
+                    .firstOrNull { claim(it) }
+                    ?: run {
+                        // A thousand collisions is not a real directory, but the old loop
+                        // *returned the colliding path* once it gave up, overwriting the very
+                        // file the counter exists to protect. Fall back to a name nothing else
+                        // holds instead.
+                        logger.warn(
+                            LogCategory.FILE,
+                            "Exhausted numbered suffixes for a download name - using a unique suffix",
+                            mapOf("fileName" to fileName),
+                        )
+                        suffixed(System.nanoTime().toString(radix = 16)).also { claim(it) }
+                    }
+            }
+        return claimed.absolutePath
+    }
 
-        do {
-            val newName =
-                if (extension.isNotEmpty()) {
-                    "$nameWithoutExtension ($counter).$extension"
-                } else {
-                    "$nameWithoutExtension ($counter)"
-                }
-            file = File(dir, newName)
-            counter++
-        } while (file.exists() && counter < 1000) // Prevent infinite loop
+    /** Take [file]'s path if nothing holds it and it is not already on disk. */
+    private fun claim(file: File): Boolean {
+        val path = file.absolutePath
+        // add() before exists() so two threads cannot both pass the exists() check; the loser
+        // gives the path back and moves on to the next suffix.
+        if (!claimedPaths.add(path)) return false
+        val free = !file.exists()
+        if (!free) claimedPaths.remove(path)
+        return free
+    }
 
-        return file.absolutePath
+    /**
+     * Give back a path claimed by [generateUniqueFilePath].
+     *
+     * Call this once the file exists (so [File.exists] takes over) or once the transfer that
+     * claimed it has failed. Not calling it leaks one string per download for the life of the
+     * process and pushes a later download of the same name onto a suffix it did not need.
+     */
+    fun releaseFilePath(path: String) {
+        claimedPaths.remove(path)
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/platform/FileSystemUtils.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.revealInFileManager
 import java.io.File
 import java.io.IOException
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 private val logger = BossLogger.forComponent("FileSystemUtils")
 
@@ -88,35 +90,56 @@ object FileSystemUtils {
     }
 
     /**
-     * Paths handed out by [generateUniqueFilePath] whose file does not exist yet.
+     * Paths handed out by [generateUniqueFilePath] whose file does not exist yet, by owner.
      *
      * "Is the name free?" cannot be answered by [File.exists] alone. A download's file is not
      * created until bytes arrive, so two downloads of `report.pdf` started before either lands
      * both saw a free name and both resolved to the same path - the second silently truncating
-     * the first. A claimed path is treated as taken until [releaseFilePath] is called, which
-     * the download's terminal handlers do.
+     * the first.
+     *
+     * **Keyed by owner, not just by path.** A bare `release(path)` let one download free
+     * another's claim: the save-dialog path returns whatever the user typed, which can be a
+     * path the auto path already claimed, and that download's terminal handler would then
+     * release a claim it never took. So a claim records who holds it and only that holder can
+     * give it back.
+     *
+     * Entries are advisory and self-healing. Nothing guarantees a terminal event - the engine
+     * can be disposed mid-download, and `action.download()` itself can throw after the claim -
+     * so a claim whose file still does not exist after [STALE_CLAIM_MS] is treated as
+     * abandoned. Without that, one lost release pushes every later download of that name onto
+     * a numbered suffix for the life of the process, with nothing on disk to explain why: the
+     * exact confusion this whole mechanism exists to remove.
      */
-    private val claimedPaths =
-        java.util.concurrent.ConcurrentHashMap
-            .newKeySet<String>()
+    private val claimedPaths = ConcurrentHashMap<String, Claim>()
 
-    /** Highest `(n)` suffix tried before falling back to a name that cannot collide. */
-    private const val MAX_COLLISION_SUFFIX = 1000
+    private data class Claim(
+        val owner: String,
+        val takenAtMs: Long,
+    )
+
+    /** How long a claim with no file behind it is honoured before it is treated as abandoned. */
+    private const val STALE_CLAIM_MS = 10 * 60 * 1000L
+
+    /** Number of `(n)` suffixes tried before falling back to a name that cannot collide. */
+    private const val MAX_COLLISION_SUFFIX = 999
 
     /**
      * Generates a unique file path by appending (1), (2), etc. if the name is taken.
      * Example: "file.txt" -> "file (1).txt" -> "file (2).txt"
      *
-     * The returned path is **claimed** until [releaseFilePath] is called for it, so a caller
-     * that has not written its file yet still blocks a concurrent caller from the same name.
+     * The returned path is **claimed for [owner]** until [releaseFilePath] is called with the
+     * same owner, so a caller that has not written its file yet still blocks a concurrent
+     * caller from the same name.
      *
      * @param directory Directory where file will be saved
      * @param fileName Original file name
+     * @param owner Identifies the caller, so only it can release the claim
      * @return Absolute path to a unique file (may be the original if no collision)
      */
     fun generateUniqueFilePath(
         directory: String,
         fileName: String,
+        owner: String,
     ): String {
         val dir = File(directory)
 
@@ -135,49 +158,79 @@ object FileSystemUtils {
         }
 
         val claimed =
-            if (claim(original)) {
+            if (claim(original, owner)) {
                 original
             } else {
-                (1 until MAX_COLLISION_SUFFIX)
+                (1..MAX_COLLISION_SUFFIX)
                     .asSequence()
                     .map { suffixed(it.toString()) }
-                    .firstOrNull { claim(it) }
+                    .firstOrNull { claim(it, owner) }
                     ?: run {
-                        // A thousand collisions is not a real directory, but the old loop
-                        // *returned the colliding path* once it gave up, overwriting the very
-                        // file the counter exists to protect. Fall back to a name nothing else
-                        // holds instead.
+                        // The old loop *returned the colliding path* once it gave up,
+                        // overwriting the very file the counter exists to protect. Retry until
+                        // a claim actually succeeds rather than assuming one will: a random
+                        // name that happens to be taken, returned unclaimed, is that bug again.
                         logger.warn(
                             LogCategory.FILE,
                             "Exhausted numbered suffixes for a download name - using a unique suffix",
                             mapOf("fileName" to fileName),
                         )
-                        suffixed(System.nanoTime().toString(radix = 16)).also { claim(it) }
+                        generateSequence { suffixed(UUID.randomUUID().toString()) }
+                            .first { claim(it, owner) }
                     }
             }
         return claimed.absolutePath
     }
 
-    /** Take [file]'s path if nothing holds it and it is not already on disk. */
-    private fun claim(file: File): Boolean {
-        val path = file.absolutePath
-        // add() before exists() so two threads cannot both pass the exists() check; the loser
-        // gives the path back and moves on to the next suffix.
-        if (!claimedPaths.add(path)) return false
-        val free = !file.exists()
-        if (!free) claimedPaths.remove(path)
-        return free
+    /**
+     * Take [file]'s path for [owner] if nothing live holds it and it is not already on disk.
+     *
+     * The key is case-folded, because APFS and NTFS are case-insensitive by default: without
+     * it `report.pdf` and `Report.pdf` are one file but two claims, and a server-supplied
+     * `Content-Disposition` makes that trivial to arrange.
+     */
+    private fun claim(
+        file: File,
+        owner: String,
+    ): Boolean {
+        val key = claimKey(file)
+        val now = System.currentTimeMillis()
+        val mine = Claim(owner, now)
+        var taken = false
+        // Resolve against the map first, so two threads cannot both pass the exists() check.
+        claimedPaths.compute(key) { _, current ->
+            val abandoned = current != null && now - current.takenAtMs > STALE_CLAIM_MS && !file.exists()
+            if (current == null || abandoned) {
+                taken = true
+                mine
+            } else {
+                current
+            }
+        }
+        if (taken && file.exists()) {
+            // A file appeared at the name between the map write and here. Give it straight
+            // back rather than handing out a path whose contents the caller would destroy.
+            claimedPaths.remove(key, mine)
+            taken = false
+        }
+        return taken
     }
+
+    private fun claimKey(file: File): String = file.absolutePath.lowercase()
 
     /**
      * Give back a path claimed by [generateUniqueFilePath].
      *
-     * Call this once the file exists (so [File.exists] takes over) or once the transfer that
-     * claimed it has failed. Not calling it leaks one string per download for the life of the
-     * process and pushes a later download of the same name onto a suffix it did not need.
+     * A no-op unless [owner] is the holder, so a download releasing its own path cannot free
+     * one that belongs to another. Call it once the file exists (so [File.exists] takes over)
+     * or once the transfer has failed.
      */
-    fun releaseFilePath(path: String) {
-        claimedPaths.remove(path)
+    fun releaseFilePath(
+        path: String,
+        owner: String,
+    ) {
+        val key = claimKey(File(path))
+        claimedPaths.computeIfPresent(key) { _, current -> if (current.owner == owner) null else current }
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -2945,8 +2945,17 @@ object FluckEngine {
                     }
 
                 if (savePath != null) {
+                    // The name the file is actually written under. generateUniqueFilePath may
+                    // have appended " (1)", and the save dialog lets the user type anything at
+                    // all, so sanitizedFileName is only ever a *request*. Recording that instead
+                    // left the Downloads panel showing "report.pdf" for a file on disk called
+                    // "report (1).pdf" - and Rename, Reveal and Open all read from the panel.
+                    val savedFileName = java.io.File(savePath).name
                     // Ensure parent directory exists
                     if (!FileSystemUtils.ensureParentDirectoryExists(savePath)) {
+                        // Bailing before setupDownloadEventListeners means none of the three
+                        // terminal handlers will run, so the claim is released here or never.
+                        FileSystemUtils.releaseFilePath(savePath)
                         action.cancel()
                         return@StartDownloadCallback
                     }
@@ -2975,7 +2984,7 @@ object FluckEngine {
                         downloadManager.addDownload(
                             DownloadItem(
                                 id = downloadId,
-                                fileName = sanitizedFileName,
+                                fileName = savedFileName,
                                 destinationPath = savePath,
                                 url = target.url(),
                                 mimeType = target.mimeType().toString(),
@@ -3068,6 +3077,8 @@ object FluckEngine {
                 // Remove from tracking maps
                 activeDownloadUrls.remove(url)
                 activeDownloads.remove(downloadId)
+                // The file exists now, so exists() guards the name from here on.
+                FileSystemUtils.releaseFilePath(destinationPath)
             }
         }
 
@@ -3084,6 +3095,9 @@ object FluckEngine {
                 // Remove from tracking maps
                 activeDownloadUrls.remove(url)
                 activeDownloads.remove(downloadId)
+                // Nothing was written, so the name goes back to the pool rather than
+                // pushing the next download of it onto a suffix it does not need.
+                FileSystemUtils.releaseFilePath(destinationPath)
             }
         }
 
@@ -3095,6 +3109,7 @@ object FluckEngine {
                 // Remove from tracking maps
                 activeDownloadUrls.remove(url)
                 activeDownloads.remove(downloadId)
+                FileSystemUtils.releaseFilePath(destinationPath)
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -2922,6 +2922,10 @@ object FluckEngine {
                 // Check if Shift key is pressed (force save dialog)
                 val forceDialog = isShiftPressed()
 
+                // Generated up here because it owns the path claim below, and a claim has to
+                // name its holder so that no other download can release it.
+                val downloadId = UUID.randomUUID().toString()
+
                 // Determine save location based on settings
                 val savePath =
                     when {
@@ -2940,7 +2944,7 @@ object FluckEngine {
                             val directory =
                                 downloadSettings.lastUsedDirectory
                                     ?: downloadSettings.defaultDownloadDirectory
-                            FileSystemUtils.generateUniqueFilePath(directory, sanitizedFileName)
+                            FileSystemUtils.generateUniqueFilePath(directory, sanitizedFileName, owner = downloadId)
                         }
                     }
 
@@ -2955,7 +2959,7 @@ object FluckEngine {
                     if (!FileSystemUtils.ensureParentDirectoryExists(savePath)) {
                         // Bailing before setupDownloadEventListeners means none of the three
                         // terminal handlers will run, so the claim is released here or never.
-                        FileSystemUtils.releaseFilePath(savePath)
+                        FileSystemUtils.releaseFilePath(savePath, owner = downloadId)
                         action.cancel()
                         return@StartDownloadCallback
                     }
@@ -2975,9 +2979,6 @@ object FluckEngine {
                     if (parentDir != null) {
                         downloadSettings = downloadSettings.copy(lastUsedDirectory = parentDir)
                     }
-
-                    // Generate unique download ID
-                    val downloadId = UUID.randomUUID().toString()
 
                     // Add download to manager immediately and open Downloads panel
                     CoroutineScope(Dispatchers.Default).launch {
@@ -3078,7 +3079,7 @@ object FluckEngine {
                 activeDownloadUrls.remove(url)
                 activeDownloads.remove(downloadId)
                 // The file exists now, so exists() guards the name from here on.
-                FileSystemUtils.releaseFilePath(destinationPath)
+                FileSystemUtils.releaseFilePath(destinationPath, owner = downloadId)
             }
         }
 
@@ -3097,7 +3098,7 @@ object FluckEngine {
                 activeDownloads.remove(downloadId)
                 // Nothing was written, so the name goes back to the pool rather than
                 // pushing the next download of it onto a suffix it does not need.
-                FileSystemUtils.releaseFilePath(destinationPath)
+                FileSystemUtils.releaseFilePath(destinationPath, owner = downloadId)
             }
         }
 
@@ -3109,7 +3110,7 @@ object FluckEngine {
                 // Remove from tracking maps
                 activeDownloadUrls.remove(url)
                 activeDownloads.remove(downloadId)
-                FileSystemUtils.releaseFilePath(destinationPath)
+                FileSystemUtils.releaseFilePath(destinationPath, owner = downloadId)
             }
         }
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/DroppedFileListTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/DroppedFileListTest.kt
@@ -1,0 +1,119 @@
+package ai.rever.boss.platform
+
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The payload side of the drop target, which needs no window server.
+ *
+ * The modifier itself does - a real drag comes from the OS - but reading a `Transferable` is
+ * ordinary code, and it is where the failure modes live: a drag source is another process, so
+ * every one of these is something a misbehaving or already-finished source can hand over.
+ */
+class DroppedFileListTest {
+    private val temps = mutableListOf<File>()
+
+    private fun tempDir(): File = createTempDirectory("dropped").toFile().also { temps += it }
+
+    @AfterTest
+    fun cleanup() {
+        temps.forEach { it.deleteRecursively() }
+    }
+
+    private val fileFlavor: DataFlavor = DataFlavor.javaFileListFlavor
+
+    private inner class FakeTransferable(
+        private val supported: Boolean,
+        private val data: (() -> Any?)? = null,
+    ) : Transferable {
+        override fun getTransferDataFlavors(): Array<DataFlavor> = if (supported) arrayOf(fileFlavor) else emptyArray()
+
+        override fun isDataFlavorSupported(flavor: DataFlavor): Boolean = supported && flavor == fileFlavor
+
+        override fun getTransferData(flavor: DataFlavor): Any? {
+            if (!supported) throw UnsupportedFlavorException(flavor)
+            return data?.invoke()
+        }
+    }
+
+    private fun files(entries: List<File>) = FakeTransferable(supported = true, data = { entries })
+
+    private fun files(vararg entries: File) = files(entries.toList())
+
+    @Test
+    fun `a null or non-file transferable carries nothing`() {
+        assertFalse(null.carriesFiles())
+        assertFalse(FakeTransferable(supported = false).carriesFiles())
+        assertEquals(emptyList(), null.filePathsOrEmpty())
+        assertEquals(emptyList(), FakeTransferable(supported = false).filePathsOrEmpty())
+    }
+
+    @Test
+    fun `files come back as absolute paths`() {
+        val dir = tempDir()
+        val a = File(dir, "a.txt").apply { writeText("a") }
+        val b = File(dir, "b.kt").apply { writeText("b") }
+
+        assertTrue(files(a, b).carriesFiles())
+        assertEquals(listOf(a.absolutePath, b.absolutePath), files(a, b).filePathsOrEmpty())
+    }
+
+    /**
+     * The finding this exists for: Finder hands a folder over through the same flavour, and
+     * the caller routes by extension, so a folder would have opened as a source file.
+     */
+    @Test
+    fun `directories are dropped from the list`() {
+        val dir = tempDir()
+        val file = File(dir, "keep.txt").apply { writeText("x") }
+        val folder = File(dir, "a-folder").apply { mkdirs() }
+
+        assertEquals(listOf(file.absolutePath), files(file, folder).filePathsOrEmpty())
+    }
+
+    @Test
+    fun `a folder-only drop opens nothing`() {
+        val dir = tempDir()
+        val folder = File(dir, "only").apply { mkdirs() }
+        assertEquals(emptyList(), files(folder).filePathsOrEmpty())
+    }
+
+    /** One select-all in Finder should not open a tab, and an LSP session, per file. */
+    @Test
+    fun `a huge drop is capped`() {
+        val dir = tempDir()
+        val many = (1..MAX_FILES_PER_DROP + 5).map { File(dir, "f$it.txt").apply { writeText("x") } }
+        assertEquals(MAX_FILES_PER_DROP, files(many).filePathsOrEmpty().size)
+    }
+
+    /** `getTransferData` reaches into the source process and is documented to throw. */
+    @Test
+    fun `a throwing source is a no-op, not a crash`() {
+        val exploding = FakeTransferable(supported = true, data = { error("source went away") })
+        assertEquals(emptyList(), exploding.filePathsOrEmpty())
+    }
+
+    /**
+     * `as? List<File>` only proves it is a `List`, so the wrong element type reaches the map
+     * and raises ClassCastException there. Behaviour is already correct; this pins it rather
+     * than leaving the next reader to trace the erasure.
+     */
+    @Test
+    fun `a list of the wrong element type is a no-op`() {
+        val wrong = FakeTransferable(supported = true, data = { listOf("not-a-file") })
+        assertEquals(emptyList(), wrong.filePathsOrEmpty())
+    }
+
+    @Test
+    fun `null data is a no-op`() {
+        assertEquals(emptyList(), FakeTransferable(supported = true, data = { null }).filePathsOrEmpty())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/UniqueFilePathTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/UniqueFilePathTest.kt
@@ -1,0 +1,137 @@
+package ai.rever.boss.platform
+
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the rule that stops one download destroying another's file.
+ *
+ * This had no test at all, which is how three of the four bugs below survived: the counter
+ * returned a colliding path once it gave up, two downloads racing the same name both got it,
+ * and a released name was never reusable because nothing released it.
+ */
+class UniqueFilePathTest {
+    private val temps = mutableListOf<File>()
+
+    private fun tempDir(): File = createTempDirectory("unique-path").toFile().also { temps += it }
+
+    @AfterTest
+    fun cleanup() {
+        temps.forEach { it.deleteRecursively() }
+    }
+
+    private fun release(vararg paths: String) = paths.forEach { FileSystemUtils.releaseFilePath(it) }
+
+    @Test
+    fun `a free name is returned unchanged`() {
+        val dir = tempDir()
+        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "report.pdf")
+        assertEquals(File(dir, "report.pdf").absolutePath, path)
+        release(path)
+    }
+
+    @Test
+    fun `an existing file pushes the name to a numbered suffix`() {
+        val dir = tempDir()
+        File(dir, "report.pdf").writeText("first")
+
+        val second = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "report.pdf")
+        assertEquals("report (1).pdf", File(second).name)
+        File(second).writeText("second")
+
+        val third = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "report.pdf")
+        assertEquals("report (2).pdf", File(third).name)
+        release(second, third)
+
+        assertEquals("first", File(dir, "report.pdf").readText(), "the original must be untouched")
+    }
+
+    @Test
+    fun `an extensionless name still gets a suffix`() {
+        val dir = tempDir()
+        File(dir, "LICENSE").writeText("x")
+        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "LICENSE")
+        assertEquals("LICENSE (1)", File(path).name)
+        release(path)
+    }
+
+    /**
+     * The bug the claim mechanism exists for. A download's file does not appear until bytes
+     * arrive, so `exists()` says "free" to every caller until the first write lands.
+     */
+    @Test
+    fun `two callers racing one name do not get the same path`() {
+        val dir = tempDir()
+        val threads = 8
+        val start = CountDownLatch(1)
+        val pool = Executors.newFixedThreadPool(threads)
+        try {
+            val results =
+                (1..threads)
+                    .map {
+                        pool.submit<String> {
+                            start.await(5, TimeUnit.SECONDS)
+                            FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "race.bin")
+                        }
+                    }.also { start.countDown() }
+                    .map { it.get(10, TimeUnit.SECONDS) }
+
+            assertEquals(threads, results.toSet().size, "every caller must get its own path")
+            results.forEach(FileSystemUtils::releaseFilePath)
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    /** A claim is a reservation, not a lease: releasing it puts the name back in the pool. */
+    @Test
+    fun `a released name is handed out again`() {
+        val dir = tempDir()
+        val first = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "note.txt")
+        val second = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "note.txt")
+        assertNotEquals(first, second, "the unreleased claim must still block")
+
+        release(first, second)
+        val reused = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "note.txt")
+        assertEquals(first, reused, "nothing holds the name and no file exists, so it is free")
+        release(reused)
+    }
+
+    /**
+     * The old loop stopped at 1000 and returned the *colliding* path, so a directory that
+     * pathological overwrote the file the counter exists to protect. The fallback name only
+     * has to not collide.
+     */
+    @Test
+    fun `exhausting the numbered suffixes never returns an existing file`() {
+        val dir = tempDir()
+        File(dir, "x.dat").writeText("keep")
+        for (i in 1 until 1000) {
+            File(dir, "x ($i).dat").writeText("keep")
+        }
+
+        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "x.dat")
+
+        assertTrue(File(path).parentFile.absolutePath == dir.absolutePath, "must stay in the directory")
+        assertTrue(!File(path).exists(), "an occupied path would be overwritten by the caller")
+        assertTrue(File(path).name.endsWith(".dat"), "the extension must survive the fallback")
+        release(path)
+    }
+
+    @Test
+    fun `a missing directory is created rather than failing`() {
+        val dir = File(tempDir(), "nested/deeper")
+        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "a.txt")
+        assertTrue(dir.isDirectory, "the directory should have been created")
+        assertEquals(File(dir, "a.txt").absolutePath, path)
+        release(path)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/UniqueFilePathTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/platform/UniqueFilePathTest.kt
@@ -19,6 +19,11 @@ import kotlin.test.assertTrue
  * and a released name was never reusable because nothing released it.
  */
 class UniqueFilePathTest {
+    private companion object {
+        const val OWNER = "download-a"
+        const val OTHER_OWNER = "download-b"
+    }
+
     private val temps = mutableListOf<File>()
 
     private fun tempDir(): File = createTempDirectory("unique-path").toFile().also { temps += it }
@@ -28,12 +33,25 @@ class UniqueFilePathTest {
         temps.forEach { it.deleteRecursively() }
     }
 
-    private fun release(vararg paths: String) = paths.forEach { FileSystemUtils.releaseFilePath(it) }
+    private fun unique(
+        dir: File,
+        name: String,
+        owner: String = OWNER,
+    ): String = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, name, owner)
+
+    private fun release(
+        path: String,
+        owner: String = OWNER,
+    ) = FileSystemUtils.releaseFilePath(path, owner)
+
+    // Named apart from release() on purpose: as an overload, release(a, b) silently bound
+    // b as the *owner* rather than releasing both, and the release then did nothing.
+    private fun releaseAll(vararg paths: String) = paths.forEach { release(it) }
 
     @Test
     fun `a free name is returned unchanged`() {
         val dir = tempDir()
-        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "report.pdf")
+        val path = unique(dir, "report.pdf")
         assertEquals(File(dir, "report.pdf").absolutePath, path)
         release(path)
     }
@@ -43,13 +61,13 @@ class UniqueFilePathTest {
         val dir = tempDir()
         File(dir, "report.pdf").writeText("first")
 
-        val second = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "report.pdf")
+        val second = unique(dir, "report.pdf")
         assertEquals("report (1).pdf", File(second).name)
         File(second).writeText("second")
 
-        val third = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "report.pdf")
+        val third = unique(dir, "report.pdf")
         assertEquals("report (2).pdf", File(third).name)
-        release(second, third)
+        releaseAll(second, third)
 
         assertEquals("first", File(dir, "report.pdf").readText(), "the original must be untouched")
     }
@@ -58,7 +76,7 @@ class UniqueFilePathTest {
     fun `an extensionless name still gets a suffix`() {
         val dir = tempDir()
         File(dir, "LICENSE").writeText("x")
-        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "LICENSE")
+        val path = unique(dir, "LICENSE")
         assertEquals("LICENSE (1)", File(path).name)
         release(path)
     }
@@ -79,13 +97,14 @@ class UniqueFilePathTest {
                     .map {
                         pool.submit<String> {
                             start.await(5, TimeUnit.SECONDS)
-                            FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "race.bin")
+                            // A distinct owner each, which is the real shape: one per download.
+                            unique(dir, "race.bin", "dl-$it")
                         }
                     }.also { start.countDown() }
                     .map { it.get(10, TimeUnit.SECONDS) }
 
             assertEquals(threads, results.toSet().size, "every caller must get its own path")
-            results.forEach(FileSystemUtils::releaseFilePath)
+            results.forEachIndexed { i, path -> release(path, "dl-${i + 1}") }
         } finally {
             pool.shutdownNow()
         }
@@ -95,12 +114,12 @@ class UniqueFilePathTest {
     @Test
     fun `a released name is handed out again`() {
         val dir = tempDir()
-        val first = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "note.txt")
-        val second = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "note.txt")
+        val first = unique(dir, "note.txt")
+        val second = unique(dir, "note.txt")
         assertNotEquals(first, second, "the unreleased claim must still block")
 
-        release(first, second)
-        val reused = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "note.txt")
+        releaseAll(first, second)
+        val reused = unique(dir, "note.txt")
         assertEquals(first, reused, "nothing holds the name and no file exists, so it is free")
         release(reused)
     }
@@ -114,11 +133,11 @@ class UniqueFilePathTest {
     fun `exhausting the numbered suffixes never returns an existing file`() {
         val dir = tempDir()
         File(dir, "x.dat").writeText("keep")
-        for (i in 1 until 1000) {
-            File(dir, "x ($i).dat").writeText("keep")
+        for (i in 1..999) {
+            File(dir, "x ($i).dat").createNewFile()
         }
 
-        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "x.dat")
+        val path = unique(dir, "x.dat")
 
         assertTrue(File(path).parentFile.absolutePath == dir.absolutePath, "must stay in the directory")
         assertTrue(!File(path).exists(), "an occupied path would be overwritten by the caller")
@@ -126,10 +145,40 @@ class UniqueFilePathTest {
         release(path)
     }
 
+    /**
+     * The claim is owned. Without that, the save-dialog path - which returns whatever name
+     * the user typed, and never claims it - would release a claim the auto path was holding,
+     * and a third download could then take a path still being written to.
+     */
+    @Test
+    fun `one download cannot release another's claim`() {
+        val dir = tempDir()
+        val mine = unique(dir, "shared.bin")
+
+        release(mine, OTHER_OWNER)
+
+        val next = unique(dir, "shared.bin", OTHER_OWNER)
+        assertNotEquals(mine, next, "a stranger's release must not free the claim")
+
+        release(mine)
+        release(next, OTHER_OWNER)
+    }
+
+    /** APFS and NTFS are case-insensitive, so these two names are one file. */
+    @Test
+    fun `claims are case-insensitive`() {
+        val dir = tempDir()
+        val lower = unique(dir, "Report.PDF")
+        val upper = unique(dir, "report.pdf", OTHER_OWNER)
+        assertNotEquals(lower.lowercase(), upper.lowercase(), "case alone must not look like a free name")
+        release(lower)
+        release(upper, OTHER_OWNER)
+    }
+
     @Test
     fun `a missing directory is created rather than failing`() {
         val dir = File(tempDir(), "nested/deeper")
-        val path = FileSystemUtils.generateUniqueFilePath(dir.absolutePath, "a.txt")
+        val path = unique(dir, "a.txt")
         assertTrue(dir.isDirectory, "the directory should have been created")
         assertEquals(File(dir, "a.txt").absolutePath, path)
         release(path)


### PR DESCRIPTION
Step 1 of the downloads/drag work. This is the half that needs no API change, so it can land while `boss-plugin-api` catches up.

## Downloads were overwriting each other

Three defects behind "it replaced my existing file". `FileSystemUtils` had **no test at all**, which is how they survived.

**The panel showed a name the disk did not have.** `generateUniqueFilePath` may append ` (1)`, and the save dialog lets the user type anything, so the suggested name is only ever a *request* - but the request is what got recorded on the `DownloadItem`. A file written as `report (1).pdf` was listed as `report.pdf`, and Reveal, Open, and anything else reading the panel followed the label rather than the file. This one alone is enough to make a correct dedup look like an overwrite.

**Two downloads of one name raced.** A download's file does not exist until bytes arrive, so `exists()` answered "free" to both callers and the second truncated the first. A path is now *claimed* when handed out and released at a terminal state. All four exits release: finished, interrupted, cancelled, and the parent-directory failure that returns before the listeners are even registered.

**The counter overwrote the file it exists to protect.** `while (file.exists() && counter < 1000)` leaves the loop with the path *still occupied* once it gives up, and that path was returned and written to. It now falls back to a suffix nothing can hold.

The save-dialog path is deliberately unchanged: there the user picked the name and answered the panel's own overwrite prompt, so replacing the file is what they asked for.

## Files dropped on the main panel open

Routed by extension through the same `openFileInActivePanel` a sidebar click uses - images and PDFs to the browser, `.ipynb` to the notebook tab when that plugin is registered, everything else to the editor. No new routing rules, so a drop and a click cannot disagree.

The transfer type is plain `DataFlavor.javaFileListFlavor`, not something BOSS-specific. That is deliberate: **this target already accepts a drag out of Finder or Explorer today**, and it will accept one out of a BOSS sidebar once the plugin-side drag source lands, with no transfer type a plugin has to know about.

Attached to `SplitViewPanel`'s root box so the whole main area is a target. `shouldStartDragAndDrop` is answered for every drag crossing the composable, including BOSS's own tab drags, so it only inspects flavours and never deserialises. Reading the payload is wrapped, because `getTransferData` reaches into another process and is documented to throw - a failed drop must be a no-op, not an exception on the UI thread.

## Tests

`UniqueFilePathTest` is new, covering the free name, the numbered suffix, extensionless names, directory creation, the concurrency race (8 threads on one name), claim release, and suffix exhaustion.

Mutation-checked rather than assumed live: reverting `claim()` to a bare `exists()` fails the race test, and returning the colliding path on exhaustion fails the exhaustion test.

The drop target has no unit test - it needs a real drag from the window server, and two of the three CI legs have no display. It is the thin edge over `openFileInActivePanel`, which is exercised by the existing paths.

## Still to come

Separate PRs, in forced order: `boss-plugin-api` (a `renameDownload` verb and a file drag-source modifier) → host implementation of rename → the downloads plugin (rename UI, drag source) → the codebase plugin (drag source).
