### PR TITLE
Stop a recycled browser engine leaving live browsers and processes behind

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1749,10 +1749,25 @@ internal class BrowserHandleImpl(
         }
     }
 
+    /**
+     * Generation first, and `isClosed` last and guarded, because the two are not equally
+     * trustworthy.
+     *
+     * `Browser.isClosed` only reports what this side has been *told*. Closing an engine whose
+     * IPC has already died leaves its browsers unmarked - the notification has no channel to
+     * arrive on - so a browser belonging to a closed engine keeps answering `false` while every
+     * call through it throws ObjectClosedException. The generation is decided locally by
+     * [FluckEngine] and cannot lie in that direction, so it is the load-bearing clause.
+     *
+     * Guarded, because this is read from `if (isValid)` at the top of nearly every method here:
+     * a throw out of the getter would escape those methods into plugin code, which is the exact
+     * failure it exists to prevent.
+     */
     override val isValid: Boolean
         get() =
-            !disposed.get() && !browser.isClosed &&
-                FluckEngine.currentEngineGeneration == engineGeneration
+            !disposed.get() &&
+                FluckEngine.currentEngineGeneration == engineGeneration &&
+                runCatching { !browser.isClosed }.getOrDefault(false)
 
     override suspend fun loadUrl(url: String) {
         if (!isValid) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -141,6 +141,14 @@ private sealed interface CreationOutcome {
 
     object EngineFailure : CreationOutcome
 
+    /**
+     * The engine was replaced while this creation was in flight, so the browser it produced
+     * belongs to a closed engine. Distinct from [EngineFailure] because it is evidence about
+     * the *previous* engine, which has already been dealt with: feeding it to the wedge
+     * detector would count one wedge twice and could recycle a healthy replacement.
+     */
+    object StaleGeneration : CreationOutcome
+
     object OtherFailure : CreationOutcome
 }
 
@@ -465,9 +473,20 @@ object BrowserServiceImpl : BrowserService {
                 WedgeRecovery.recordSuccess()
                 return outcome.handle
             }
-            // Only an engine-level failure is worth recycling for, and only while the detector
-            // agrees; anything else is this request's own problem and fails as it always did.
-            if (outcome !is CreationOutcome.EngineFailure || !WedgeRecovery.recycleIfWedged()) break
+            val retry =
+                when (outcome) {
+                    // A creation the recycle invalidated retries straight onto the replacement:
+                    // the engine it needed already exists, so there is nothing to repair first.
+                    is CreationOutcome.StaleGeneration -> true
+
+                    // Only an engine-level failure is worth recycling for, and only while the
+                    // detector agrees; anything else is this request's own problem and fails as
+                    // it always did.
+                    is CreationOutcome.EngineFailure -> WedgeRecovery.recycleIfWedged()
+
+                    else -> false
+                }
+            if (!retry) break
         }
         return null
     }
@@ -485,8 +504,13 @@ object BrowserServiceImpl : BrowserService {
         // engine-level failure from a handle-construction one. Profile seeding below sits
         // inside the same outer try but must NOT be attributed to the engine.
         var engineCallFailed = false
+        // Set when the engine was recycled while this creation was in flight, so the caller
+        // retries against the replacement instead of accusing it of a failure it did not have.
+        var engineRecycled = false
         return try {
-            val engine = FluckEngine.engine
+            // Read as one step: the generation that is current when this browser is created is
+            // the only one it can honestly claim. See FluckEngine.engineWithGeneration.
+            val (engine, generation) = FluckEngine.engineWithGeneration()
 
             // Optionally run on an isolated managed profile (ephemeral or named),
             // seeding auth into it first. Null = the engine default profile (tabs).
@@ -513,10 +537,26 @@ object BrowserServiceImpl : BrowserService {
                     throw e
                 }
 
+            // newBrowser() is time-boxed at 20s and a recycle triggered by another caller's
+            // failure lands inside that window routinely. This browser belongs to the engine
+            // that was current when it was created; if that engine has since been replaced it
+            // is already closed, and every use of it from here on throws ObjectClosedException
+            // at whoever calls — a plugin crash, not a browser error. Discard it and retry.
+            //
+            // Checked before touching the browser at all, since settings() would be the first
+            // such call. Ordered after creation for a reason: a check on the way in cannot see
+            // a recycle that has not happened yet, which is the whole failure mode.
+            if (FluckEngine.currentEngineGeneration != generation) {
+                engineRecycled = true
+                // Best-effort: against a closed engine this is a no-op or a dead-IPC failure,
+                // but the browser is unreachable from any dispose path once we throw, and a
+                // recycle that closed cleanly leaves a live renderer to reclaim here.
+                runCatching { browser.close() }
+                error("Engine was recycled during browser creation (generation $generation is stale)")
+            }
+
             // Enable swipe navigation for touchscreen devices
             browser.settings().enableOverscrollHistoryNavigation()
-
-            val generation = FluckEngine.currentEngineGeneration
 
             // If a popup handed off a POST body for this URL (form-submit target="_blank"),
             // consume it and replay on first navigation. Explicit config wins if set.
@@ -583,7 +623,17 @@ object BrowserServiceImpl : BrowserService {
 
             CreationOutcome.Created(handle)
         } catch (e: Exception) {
-            logger.error(LogCategory.BROWSER, "Failed to create browser", error = e)
+            // A recycle landing mid-creation is expected and self-correcting - the retry above
+            // opens the tab on the replacement - so it is not reported as a failure.
+            if (engineRecycled) {
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Discarding browser from a recycled engine - retrying",
+                    mapOf("url" to config.url),
+                )
+            } else {
+                logger.error(LogCategory.BROWSER, "Failed to create browser", error = e)
+            }
             // A throw after newBrowser() (overscroll / popup-replay / handle ctor / meta
             // persist) is caught only here; without releasing, a NAMED profile's fence
             // stays locked for the process lifetime (deadlock) and an EPHEMERAL profile
@@ -596,7 +646,11 @@ object BrowserServiceImpl : BrowserService {
                 }
                 managed?.let { releaseManaged(it) }
             }
-            if (engineCallFailed) CreationOutcome.EngineFailure else CreationOutcome.OtherFailure
+            when {
+                engineRecycled -> CreationOutcome.StaleGeneration
+                engineCallFailed -> CreationOutcome.EngineFailure
+                else -> CreationOutcome.OtherFailure
+            }
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -34,6 +34,7 @@ import com.teamdev.jxbrowser.permission.callback.RequestPermissionCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,6 +46,8 @@ import java.awt.Toolkit
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -861,6 +864,32 @@ object FluckEngine {
     /** How long [recycleWedgedEngine] waits for a wedged engine to close before force-killing it. */
     private const val ENGINE_CLOSE_TIMEOUT_MS = 5_000L
 
+    /**
+     * How long a replacement engine's boot waits for the engine it replaces to let go of the
+     * profile directory. Covers [ENGINE_CLOSE_TIMEOUT_MS] plus the force-kill that follows it.
+     */
+    private const val ENGINE_DRAIN_TIMEOUT_MS = 10_000L
+
+    /** How long the force-kill waits for a doomed Chromium process to actually exit. */
+    private const val PROCESS_EXIT_TIMEOUT_MS = 3_000L
+
+    /** Poll interval while waiting for doomed Chromium processes to exit. */
+    private const val PROCESS_EXIT_POLL_MS = 100L
+
+    /**
+     * Gate that holds a replacement engine's boot until the engine it replaces has really let go
+     * of the profile directory.
+     *
+     * Chromium takes an exclusive lock on `--user-data-dir`. [recycleWedgedEngine] bumps the
+     * generation first, so every live handle reports itself stale and every tab comes straight
+     * back through the [engine] getter - observed at ~400ms, long before the doomed process is
+     * gone. Without this gate that boot loses the race to the lock, and
+     * [createEngineWithProfile] quietly falls back to a throwaway `browser-profile-<millis>`
+     * directory: the user is signed out of every site they were signed into, and the session
+     * they had is stranded in a directory nothing will read again.
+     */
+    @Volatile private var recycleDrain: CountDownLatch? = null
+
     // Set by BrowserServiceImpl once its wedge detector has spent its recycle budget: the
     // engine still refuses to create browsers and we have stopped trying to repair it.
     // Read by isEngineHealthy(), which otherwise cannot see a wedge (isClosed stays false).
@@ -898,6 +927,21 @@ object FluckEngine {
             }
 
     /**
+     * The engine together with the generation it belongs to, read as one atomic step.
+     *
+     * Reading the two separately is a bug the type system will not catch. Browser creation is
+     * time-boxed at 20s, and a recycle triggered by *another* caller's failure lands inside that
+     * window routinely — so a caller that reads the generation after creating its browser stamps
+     * a browser belonging to the closed engine with the *replacement's* generation. That handle
+     * then reports `isValid == true` forever (the generation matches, and the browser's own
+     * `isClosed` never flips because the notification would have to arrive over the IPC channel
+     * that just died), so nothing invalidates it and no tab recovers, until the first call
+     * through it throws ObjectClosedException — which is a crash inside whichever plugin made
+     * the call, not a recoverable browser error.
+     */
+    fun engineWithGeneration(): Pair<Engine, Long> = synchronized(engineLock) { engine to _engineGeneration }
+
+    /**
      * Force-replace an engine that is alive but can no longer create browsers.
      *
      * The [engine] getter above self-heals only when JxBrowser reports the engine closed. A
@@ -911,20 +955,28 @@ object FluckEngine {
      * @return true if an engine was dropped, false if there was nothing cached to recycle.
      */
     suspend fun recycleWedgedEngine(reason: String): Boolean {
-        val doomed =
-            synchronized(engineLock) {
-                // Exactly the mutations the getter performs when it finds a closed engine:
-                // drop the cached instance, clear the retry budget, and bump the generation
-                // so every live BrowserHandle reports itself invalid and its tab reloads onto
-                // the replacement (BrowserHandleImpl.isValid / Fluck.kt's generation effect).
-                _engine?.also {
-                    _engine = null
-                    initializationError = null
-                    attemptCount = 0
-                    _engineGeneration++
-                    _engineGenerationFlow.value = _engineGeneration
-                }
-            } ?: return false
+        val drain = CountDownLatch(1)
+        val doomed: Engine
+        val doomedProcesses: List<ProcessHandle>
+        synchronized(engineLock) {
+            val cached = _engine ?: return false
+            // Snapshot the doomed engine's Chromium processes HERE: under the lock, while
+            // _engine still points at it and before the generation bump. No replacement can
+            // exist yet, so every Chromium child of this JVM belongs to the engine being
+            // dropped. A moment later that is no longer true and the list would be unsafe.
+            doomed = cached
+            doomedProcesses = chromiumEngineProcesses()
+            recycleDrain = drain
+            // Exactly the mutations the getter performs when it finds a closed engine:
+            // drop the cached instance, clear the retry budget, and bump the generation
+            // so every live BrowserHandle reports itself invalid and its tab reloads onto
+            // the replacement (BrowserHandleImpl.isValid / Fluck.kt's generation effect).
+            _engine = null
+            initializationError = null
+            attemptCount = 0
+            _engineGeneration++
+            _engineGenerationFlow.value = _engineGeneration
+        }
 
         logger.warn(
             LogCategory.BROWSER,
@@ -932,38 +984,147 @@ object FluckEngine {
             mapOf(
                 "reason" to reason,
                 "newGeneration" to _engineGeneration,
+                "chromiumProcesses" to doomedProcesses.size,
             ),
         )
 
-        // close() runs OUTSIDE engineLock and on its own scope, for three reasons: a wedged
-        // engine can block in there for as long as its dead IPC takes to give up; the getter
-        // needs the lock to boot the replacement; and join() gives the timeout a real
-        // suspension point to fire on — wrapping the blocking close() directly in
-        // withTimeoutOrNull would never interrupt it.
-        val closeJob = CoroutineScope(Dispatchers.IO).launch { runCatching { doomed.close() } }
-        val closedInTime = withTimeoutOrNull(ENGINE_CLOSE_TIMEOUT_MS) { closeJob.join() } != null
+        try {
+            // close() runs OUTSIDE engineLock and on its own scope, for three reasons: a wedged
+            // engine can block in there for as long as its dead IPC takes to give up; the getter
+            // needs the lock to boot the replacement; and await() gives the timeout a real
+            // suspension point to fire on — wrapping the blocking close() directly in
+            // withTimeoutOrNull would never interrupt it.
+            val closeJob = CoroutineScope(Dispatchers.IO).async { runCatching { doomed.close() } }
+            val closeResult = withTimeoutOrNull(ENGINE_CLOSE_TIMEOUT_MS) { closeJob.await() }
 
-        if (!closedInTime) {
-            // Chromium holds an exclusive lock on --user-data-dir, so the replacement cannot
-            // boot while the old process lingers. destroyForcibly() inside the cleanup below
-            // is what actually frees it — a stopped or wedged process ignores SIGTERM.
-            logger.warn(
-                LogCategory.BROWSER,
-                "Wedged engine did not close in time - force-killing its Chromium processes",
-                mapOf("timeoutMs" to ENGINE_CLOSE_TIMEOUT_MS),
-            )
-            withContext(Dispatchers.IO) {
-                runCatching { killStaleChromiumProcesses() }
-                    .onFailure {
-                        logger.warn(
-                            LogCategory.BROWSER,
-                            "Force-kill of wedged Chromium processes failed - engine boot may fail",
-                            error = it,
-                        )
-                    }
+            // Whether close() *returned* says nothing about whether Chromium is gone, and the
+            // difference is the whole bug this branch was written for. Against a wedged engine
+            // close() fails fast with a dead-IPC error rather than hanging, so a timeout-only
+            // test read that instant failure as success and skipped the kill entirely: the
+            // process tree lived on, kept holding the profile lock (sending the replacement to
+            // a throwaway temp profile, i.e. signing the user out everywhere) and kept playing
+            // whatever audio it had. Ask the OS instead.
+            val survivors = doomedProcesses.filter { runCatching { it.isAlive }.getOrDefault(false) }
+            if (survivors.isNotEmpty()) {
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Wedged engine left Chromium processes alive - killing them",
+                    mapOf(
+                        "closeOutcome" to closeOutcomeLabel(closeResult),
+                        "processes" to survivors.size,
+                        "pids" to survivors.joinToString(",") { it.pid().toString() },
+                    ),
+                )
+                withContext(Dispatchers.IO) { killEngineProcesses(survivors) }
             }
+        } finally {
+            // Releases the replacement engine's boot (see [recycleDrain]). In a finally so a
+            // failure in here cannot leave every later boot waiting out the full timeout.
+            drain.countDown()
         }
         return true
+    }
+
+    /** How [recycleWedgedEngine]'s close attempt ended, for the log line that reports survivors. */
+    private fun closeOutcomeLabel(result: Result<Unit>?): String =
+        when {
+            result == null -> "timed-out"
+            result.isSuccess -> "returned"
+            else -> "threw: ${result.exceptionOrNull()?.message ?: "unknown"}"
+        }
+
+    /**
+     * The Chromium process trees this JVM has spawned, for a targeted kill.
+     *
+     * [killStaleChromiumProcesses] cannot serve this: it deliberately skips any process whose
+     * parent is this one, so that a sweep can never kill the *live* engine. The engine being
+     * recycled is precisely such a child, which is why a wedged engine used to survive the
+     * force-kill path and go on holding the profile lock for the rest of the session.
+     *
+     * Safety here comes from *when* this is called rather than from what it excludes: under
+     * engineLock, before the generation bump, when the only engine that can own a Chromium
+     * child is the one being dropped.
+     */
+    private fun chromiumEngineProcesses(): List<ProcessHandle> =
+        runCatching {
+            val brandedDir = BossDirectories.resolve("boss-chromium").absolutePath
+            val legacyDir = BossDirectories.resolve("jxbrowser-chromium").absolutePath
+            ProcessHandle
+                .current()
+                .children()
+                .filter { child ->
+                    val command = runCatching { child.info().command().orElse("") }.getOrDefault("")
+                    command.startsWith(brandedDir) || command.startsWith(legacyDir)
+                }.toList()
+        }.getOrElse {
+            logger.warn(LogCategory.BROWSER, "Could not enumerate Chromium processes for recycle", error = it)
+            emptyList()
+        }
+
+    /**
+     * Terminate the given engine processes and everything they spawned.
+     *
+     * Descendants are collected BEFORE the parent is signalled: killing the browser process
+     * reparents its helpers to pid 1, and an orphan can no longer be reached from here. The
+     * audio helper is one of those, which is what keeps a video audible after its tab is gone.
+     *
+     * Not covered: `chrome_crashpad_handler`, which JxBrowser reparents to pid 1 at startup, so
+     * it is neither a child nor a descendant of anything we hold. It is ~10MB, holds no lock,
+     * and [killStaleChromiumProcesses] already sweeps orphaned crashpad handlers on startup.
+     */
+    internal suspend fun killEngineProcesses(processes: List<ProcessHandle>) {
+        val tree =
+            processes.flatMap { engineProcess ->
+                runCatching { engineProcess.descendants().toList() }.getOrDefault(emptyList()) + engineProcess
+            }
+        tree.forEach { runCatching { it.destroy() } }
+        awaitProcessExit(tree)
+
+        // SIGTERM is advisory, and a wedged (or SIGSTOPped) Chromium ignores it. SIGKILL is
+        // what actually frees the --user-data-dir lock the replacement needs.
+        val stubborn = tree.filter { runCatching { it.isAlive }.getOrDefault(false) }
+        if (stubborn.isNotEmpty()) {
+            stubborn.forEach { runCatching { it.destroyForcibly() } }
+            awaitProcessExit(stubborn)
+        }
+
+        val remaining = tree.count { runCatching { it.isAlive }.getOrDefault(false) }
+        if (remaining > 0) {
+            logger.warn(
+                LogCategory.BROWSER,
+                "Chromium processes survived SIGKILL - replacement engine may fall back to a temp profile",
+                mapOf("remaining" to remaining),
+            )
+        }
+    }
+
+    internal suspend fun awaitProcessExit(processes: List<ProcessHandle>) {
+        val deadline = System.currentTimeMillis() + PROCESS_EXIT_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline &&
+            processes.any { runCatching { it.isAlive }.getOrDefault(false) }
+        ) {
+            delay(PROCESS_EXIT_POLL_MS)
+        }
+    }
+
+    /**
+     * Hold a boot until an engine being recycled has released the profile directory.
+     *
+     * Called from [initializeEngine], which runs under engineLock — deliberately, since the
+     * point is that no engine boots while the old one is draining. [recycleWedgedEngine] takes
+     * that lock only for its opening snapshot, before this can be reached, so waiting here
+     * cannot deadlock the recycle that is going to release it.
+     */
+    private fun awaitRecycleDrain() {
+        val drain = recycleDrain ?: return
+        if (drain.count == 0L) return
+        if (!drain.await(ENGINE_DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            logger.warn(
+                LogCategory.BROWSER,
+                "Recycled engine still draining - booting anyway, profile directory may still be locked",
+                mapOf("timeoutMs" to ENGINE_DRAIN_TIMEOUT_MS),
+            )
+        }
     }
 
     // ---- RPA profile helpers (used by BrowserServiceImpl's managed profiles) ----
@@ -1243,6 +1404,10 @@ object FluckEngine {
 
     private fun initializeEngine(): Engine {
         attemptCount++
+
+        // Nothing below can boot while the engine this one replaces is still holding the
+        // profile directory open. See [recycleDrain] for what that costs when it is skipped.
+        awaitRecycleDrain()
 
         // NOTE: screen-recording permission is intentionally NOT requested here.
         // Asking at engine startup is an unexplained, abrupt OS prompt. It is now

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineProcessKillTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineProcessKillTest.kt
@@ -1,0 +1,76 @@
+package ai.rever.boss.plugin.browser
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards the force-kill half of [FluckEngine.recycleWedgedEngine] against the two ways it
+ * silently did nothing in production.
+ *
+ * A wedged engine's Chromium tree outlived every recycle: its `close()` failed fast on dead IPC
+ * (so a timeout-only test read it as success), and the generic sweeper skips anything parented to
+ * this process, which every engine we spawn is. The tree kept the profile lock - sending the
+ * replacement engine to a throwaway temp profile, which signs the user out of every site - and
+ * kept its audio helper playing the video from a tab that had already been closed.
+ *
+ * Real processes rather than mocks, because both failures were about what the OS does, not about
+ * what the code believes: a helper that has been reparented cannot be found from its old parent,
+ * and SIGTERM is a request a stopped or wedged process is free to ignore.
+ */
+class FluckEngineProcessKillTest {
+    @Test
+    fun `kills the whole tree, including a child that outlives its parent`() =
+        runBlocking {
+            // The shell backgrounds a sleep and then sleeps itself: two processes, and the
+            // grandchild is exactly the shape of Chromium's audio helper - it is reparented to
+            // pid 1 the moment its parent dies, after which nothing can reach it from here.
+            val parent = ProcessBuilder("/bin/sh", "-c", "sleep 120 & sleep 120").start()
+            val parentHandle = parent.toHandle()
+            val children = waitForDescendants(parentHandle, expected = 2)
+
+            FluckEngine.killEngineProcesses(listOf(parentHandle))
+
+            assertFalse(parentHandle.isAlive, "engine process survived the kill")
+            children.forEach { child ->
+                assertFalse(child.isAlive, "descendant ${child.pid()} survived the kill")
+            }
+        }
+
+    @Test
+    fun `escalates to SIGKILL for a process that ignores SIGTERM`() =
+        runBlocking {
+            // A wedged Chromium is precisely this: alive, signalled, and unmoved. destroy() is a
+            // request; only destroyForcibly() frees the --user-data-dir lock.
+            val stubborn = ProcessBuilder("/bin/sh", "-c", "trap '' TERM; sleep 120").start()
+            val handle = stubborn.toHandle()
+            assertTrue(handle.isAlive, "test process did not start")
+
+            FluckEngine.killEngineProcesses(listOf(handle))
+
+            assertFalse(handle.isAlive, "process ignoring SIGTERM was never force-killed")
+        }
+
+    /**
+     * The shell forks its children asynchronously, so the tree is not complete the instant
+     * `start()` returns. Polls rather than sleeping a fixed amount, since a short sleep that is
+     * occasionally too short would make this test assert the kill of an empty list and pass.
+     */
+    private fun waitForDescendants(
+        parent: ProcessHandle,
+        expected: Int,
+    ): List<ProcessHandle> {
+        val deadline = System.currentTimeMillis() + 5_000
+        var found = parent.descendants().toList()
+        while (found.size < expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50)
+            found = parent.descendants().toList()
+        }
+        assertTrue(
+            found.size >= expected,
+            "expected at least $expected descendants to kill, found ${found.size} - the test would prove nothing",
+        )
+        return found
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineProcessKillTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/FluckEngineProcessKillTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin.browser
 
 import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -20,9 +21,16 @@ import kotlin.test.assertTrue
  * and SIGTERM is a request a stopped or wedged process is free to ignore.
  */
 class FluckEngineProcessKillTest {
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
     @Test
     fun `kills the whole tree, including a child that outlives its parent`() =
         runBlocking {
+            // Reparenting to pid 1 is what makes ordering matter, and it is a POSIX rule: on
+            // Windows an orphan keeps its recorded parent id and `destroy()` is TerminateProcess
+            // either way. There is no /bin/sh to build the tree with there either.
+            assumeTrue(!isWindows, "Orphan reparenting is POSIX behaviour")
+
             // The shell backgrounds a sleep and then sleeps itself: two processes, and the
             // grandchild is exactly the shape of Chromium's audio helper - it is reparented to
             // pid 1 the moment its parent dies, after which nothing can reach it from here.
@@ -41,6 +49,10 @@ class FluckEngineProcessKillTest {
     @Test
     fun `escalates to SIGKILL for a process that ignores SIGTERM`() =
         runBlocking {
+            // Nothing to escalate from on Windows: destroy() and destroyForcibly() are both
+            // TerminateProcess, which cannot be trapped or ignored.
+            assumeTrue(!isWindows, "SIGTERM is advisory only on POSIX")
+
             // A wedged Chromium is precisely this: alive, signalled, and unmoved. destroy() is a
             // request; only destroyForcibly() frees the --user-data-dir lock.
             val stubborn = ProcessBuilder("/bin/sh", "-c", "trap '' TERM; sleep 120").start()


### PR DESCRIPTION
On 17 Aug a user pressed Enter in the URL bar and lost all 13 open browser tabs, while an
invisible Chromium went on playing audio from one of them for the next hour. One incident, four
defects, all on the engine-recycle path.

## What the logs showed

```
18:45:00  FluckEngine: Recycling wedged browser engine {auto-recycle #1, newGeneration=1}
19:09:05  PluginCrashInterceptor: plugin crash {fluckbrowser, ObjectClosedException}
            at FluckBrowserTabComponentKt$...invokeSuspend(FluckBrowserTabComponent.kt:2331)
19:09:15  BossMainWindowPanel: Closed tabs for disabled plugin {typeId=fluck, count=10 + 3}
          [FluckBrowser] Browser dispose failed: Failed to receive the response.   (x4)
19:09:37  FluckEngine: Recycling wedged browser engine {auto-recycle #2, newGeneration=2}
19:09:38  UserDataDirectoryAlreadyInUseException: /Users/…/.boss/browser-profile
```

No `Wedged engine did not close in time` line anywhere - the force-kill never ran. Fifty minutes
later the generation-1 process tree was still up: 12 processes, ~3.5 GB, including
`audio.mojom.AudioService`, serving tabs that had been closed since 19:09.

## The four defects

**A browser could be stamped with a generation it does not belong to.** `attemptCreateBrowser`
read the engine first and the generation **last**, with a 20s time-boxed `newBrowser()` in
between - the exact window a recycle fires in, since the recycle is triggered by these creations
failing. A browser made by the old engine then claimed the new generation, so `isValid` answered
true forever: the generation matched, and `Browser.isClosed` stays false for a browser whose
engine died with its IPC channel, because the notification that would flip it has no channel left
to arrive on. Nothing invalidated the handle, no tab recovered, and the first call through it
threw `ObjectClosedException` at whichever plugin made it - 24 minutes after the engine died.
Both values are now read in one step (`FluckEngine.engineWithGeneration`), and a browser whose
engine moved on mid-creation is discarded and retried.

**A `close()` that failed counted as a `close()` that worked.** The force-kill ran only when
`close()` failed to *return* within 5s, but a wedged engine's `close()` throws immediately on dead
IPC and `runCatching` swallowed it - so the kill was skipped precisely when it was needed. What
matters is whether Chromium is gone, so that is now what is asked, of the OS rather than of the
return value.

**The kill could not have killed it anyway.** `killStaleChromiumProcesses` skips any process
parented to this JVM, deliberately, so a sweep can never take out the live engine - and the engine
being recycled is exactly such a child. The doomed processes are now snapshotted under
`engineLock` **before** the generation bump, when no replacement can exist yet, and that list is
killed directly: descendants first (killing the parent reparents them to pid 1, where nothing can
reach them - the audio helper is one of those), and SIGKILL after SIGTERM, which a wedged process
is free to ignore.

**And the replacement booted into the wreckage.** Tabs came back through the engine getter ~400ms
after the generation bump, long before the old process let go of `--user-data-dir`, so engine
creation hit `UserDataDirectoryAlreadyInUseException` and fell back to a throwaway
`browser-profile-<millis>` directory - signing the user out of every site they were signed into,
with the real session data stranded in a directory nothing reads again. A boot now waits, bounded,
on a drain latch for the engine it replaces.

`isValid` is also reordered to match what each clause is worth: the generation is decided locally
and cannot lie in this direction, `isClosed` only reports what this side has been told, and the
`isClosed` read is guarded because a throw out of a property read at the top of ~30 methods would
escape into plugin code.

## Tests

`FluckEngineProcessKillTest` drives real process trees, because both failures were about what the
OS does rather than what the code believes:

- a shell that backgrounds a child, to prove descendants are collected before the parent is
  signalled (afterwards they are reparented and unreachable). It polls for the tree to exist so it
  cannot pass by asserting the kill of an empty list.
- a process with `trap '' TERM`, to prove the SIGKILL escalation happens. Verified out of band
  that such a process does survive `kill -TERM`, so the test is not vacuous.

`./gradlew :composeApp:desktopTest --tests "ai.rever.boss.plugin.browser.*"`, `ktlintCheck` and
`detekt` are green.

The plugin half of this incident - the unguarded `loadUrl` in a bare `launch` that turned one dead
handle into a whole-plugin teardown - is
risa-labs-inc/boss-plugin-fluck-browser#25.