### PR TITLE
Name which Supabase client a realtime log line came from

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/NamedSupabaseLogging.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/NamedSupabaseLogging.kt
@@ -30,7 +30,6 @@ class NamedSupabaseLogging(
     private val name: String,
     private val minimum: LogLevel,
 ) : SupabaseLoggingProcessor {
-
     private val logger = BossLogger.forComponent("Supabase")
 
     override fun isEnabled(level: LogLevel): Boolean = level.ordinal >= minimum.ordinal
@@ -46,14 +45,14 @@ class NamedSupabaseLogging(
         // it rather than parse it back out of the message.
         val fields = mapOf<String, Any?>("client" to name, "tag" to tag)
         val text = "[$name] $message"
+        // The library is chatty at debug, so that level stays opt-in via BOSS_LOG_LEVEL
+        // rather than being paid for on every run.
         when (level) {
             LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields, error = throwable)
             LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields, error = throwable)
             LogLevel.INFO -> logger.info(LogCategory.NETWORK, text, fields)
-            // The library is chatty here, so this stays at debug: opt in with BOSS_LOG_LEVEL
-            // rather than paying for it on every run.
             LogLevel.DEBUG -> logger.debug(LogCategory.NETWORK, text, fields)
-            LogLevel.NONE -> {}
+            LogLevel.NONE -> Unit
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/NamedSupabaseLogging.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/NamedSupabaseLogging.kt
@@ -43,13 +43,24 @@ class NamedSupabaseLogging(
         if (!isEnabled(level)) return
         // The name goes in the structured fields as well as the text, so a log search can group by
         // it rather than parse it back out of the message.
-        val fields = mapOf<String, Any?>("client" to name, "tag" to tag)
+        //
+        // The throwable is NOT handed to the logger. BossLogger writes `error.message` and a
+        // stack trace to the log file, and what arrives here is whatever supabase-kt chose to
+        // log: a RestException carries the PostgREST error body, which can echo column values.
+        // sanitizeSupabaseFailure would not help, as it rewrites only SerializationException.
+        // The type is the diagnostic half worth keeping; the library's own text is in `message`.
+        val fields =
+            mapOf<String, Any?>(
+                "client" to name,
+                "tag" to tag,
+                "errorType" to throwable?.let { it::class.simpleName },
+            )
         val text = "[$name] $message"
         // The library is chatty at debug, so that level stays opt-in via BOSS_LOG_LEVEL
         // rather than being paid for on every run.
         when (level) {
-            LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields, error = throwable)
-            LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields, error = throwable)
+            LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields)
+            LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields)
             LogLevel.INFO -> logger.info(LogCategory.NETWORK, text, fields)
             LogLevel.DEBUG -> logger.debug(LogCategory.NETWORK, text, fields)
             LogLevel.NONE -> Unit

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseClientLogging.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseClientLogging.kt
@@ -1,0 +1,59 @@
+package ai.rever.boss.services.supabase
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import io.github.jan.supabase.logging.LogLevel
+import io.github.jan.supabase.logging.SupabaseLoggingProcessor
+
+/**
+ * Names which Supabase client a library log line came from, and routes it through BossLogger.
+ *
+ * WHY THIS EXISTS. supabase-kt writes its own diagnostics with a fixed `(Supabase-Realtime)` tag
+ * and nothing identifying the client. This app runs THREE Supabase clients against the same
+ * project - the main one in SupabaseConfig, the app-update watcher and the plugin-store watcher -
+ * and an installed plugin may run more (the Toolbox does). So a line like
+ *
+ *     Warn: (Supabase-Realtime) Heartbeat timeout. Trying to reconnect in 7s
+ *
+ * says a socket is flapping without saying whose. With several clients the lines interleave, so
+ * even the timing is unattributable: pairing a "Connected" with the next "Heartbeat timeout"
+ * assumes both came from one client, and that assumption is how an investigation into exactly this
+ * message spent its time on the wrong component before proving otherwise.
+ *
+ * It also stops these lines bypassing BossLogger. They went straight to stdout, so they carried no
+ * category, were not in our format, and never reached a log file.
+ *
+ * [name] is the client's ROLE rather than its class: what a reader needs from a flapping socket is
+ * which feature is affected.
+ */
+class NamedSupabaseLogging(
+    private val name: String,
+    private val minimum: LogLevel,
+) : SupabaseLoggingProcessor {
+
+    private val logger = BossLogger.forComponent("Supabase")
+
+    override fun isEnabled(level: LogLevel): Boolean = level.ordinal >= minimum.ordinal
+
+    override fun processLog(
+        level: LogLevel,
+        tag: String,
+        throwable: Throwable?,
+        message: String,
+    ) {
+        if (!isEnabled(level)) return
+        // The name goes in the structured fields as well as the text, so a log search can group by
+        // it rather than parse it back out of the message.
+        val fields = mapOf<String, Any?>("client" to name, "tag" to tag)
+        val text = "[$name] $message"
+        when (level) {
+            LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields, error = throwable)
+            LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields, error = throwable)
+            LogLevel.INFO -> logger.info(LogCategory.NETWORK, text, fields)
+            // The library is chatty here, so this stays at debug: opt in with BOSS_LOG_LEVEL
+            // rather than paying for it on every run.
+            LogLevel.DEBUG -> logger.debug(LogCategory.NETWORK, text, fields)
+            LogLevel.NONE -> {}
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/supabase/SupabaseConfig.kt
@@ -64,6 +64,7 @@ object SupabaseConfig {
                         autoLoadFromStorage = true
                     }
                     install(Postgrest)
+                    defaultLoggingFactory = { level -> NamedSupabaseLogging("main", level) }
                     install(Realtime) {
                         // Increase heartbeat interval to prevent premature timeout disconnects.
                         // Default is 10s with 30s timeout — on slower networks or under load

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/AppUpdateRealtimeService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/AppUpdateRealtimeService.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.updater
 
 import ai.rever.boss.config.UpdateSourceConfig
+import ai.rever.boss.services.supabase.NamedSupabaseLogging
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import io.github.jan.supabase.SupabaseClient
@@ -74,6 +75,7 @@ class AppUpdateRealtimeService(
 
             client =
                 createSupabaseClient(supabaseUrl = fullUrl, supabaseKey = anonKey) {
+                    defaultLoggingFactory = { level -> NamedSupabaseLogging("app-update", level) }
                     install(Realtime) {
                         // Match SupabaseConfig heartbeat settings to avoid "Heartbeat
                         // timeout" websocket crashes in Ktor.

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreRealtimeService.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreRealtimeService.kt
@@ -1,11 +1,11 @@
 package ai.rever.boss.plugin.repository.remote
 
 import ai.rever.boss.plugin.logging.BossLogger
-import io.github.jan.supabase.logging.LogLevel
-import io.github.jan.supabase.logging.SupabaseLoggingProcessor
 import ai.rever.boss.plugin.logging.LogCategory
 import ai.rever.boss.plugin.repository.PluginInfo
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.logging.LogLevel
+import io.github.jan.supabase.logging.SupabaseLoggingProcessor
 import io.github.jan.supabase.realtime.PostgresAction
 import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
@@ -311,7 +311,6 @@ class PluginStoreRealtimeService {
 private class StoreSupabaseLogging(
     private val minimum: LogLevel,
 ) : SupabaseLoggingProcessor {
-
     private val logger = BossLogger.forComponent("Supabase")
 
     override fun isEnabled(level: LogLevel): Boolean = level.ordinal >= minimum.ordinal
@@ -330,7 +329,7 @@ private class StoreSupabaseLogging(
             LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields, error = throwable)
             LogLevel.INFO -> logger.info(LogCategory.NETWORK, text, fields)
             LogLevel.DEBUG -> logger.debug(LogCategory.NETWORK, text, fields)
-            LogLevel.NONE -> {}
+            LogLevel.NONE -> Unit
         }
     }
 }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreRealtimeService.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreRealtimeService.kt
@@ -322,11 +322,21 @@ private class StoreSupabaseLogging(
         message: String,
     ) {
         if (!isEnabled(level)) return
-        val fields = mapOf<String, Any?>("client" to "plugin-store", "tag" to tag)
+        // The throwable is NOT handed to the logger. BossLogger writes `error.message` and a
+        // stack trace to the log file, and what arrives here is whatever supabase-kt chose to
+        // log: a RestException carries the PostgREST error body, which can echo column values.
+        // sanitizeSupabaseFailure would not help, as it rewrites only SerializationException.
+        // The type is the diagnostic half worth keeping; the library's own text is in `message`.
+        val fields =
+            mapOf<String, Any?>(
+                "client" to "plugin-store",
+                "tag" to tag,
+                "errorType" to throwable?.let { it::class.simpleName },
+            )
         val text = "[plugin-store] $message"
         when (level) {
-            LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields, error = throwable)
-            LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields, error = throwable)
+            LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields)
+            LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields)
             LogLevel.INFO -> logger.info(LogCategory.NETWORK, text, fields)
             LogLevel.DEBUG -> logger.debug(LogCategory.NETWORK, text, fields)
             LogLevel.NONE -> Unit

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreRealtimeService.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/PluginStoreRealtimeService.kt
@@ -1,6 +1,8 @@
 package ai.rever.boss.plugin.repository.remote
 
 import ai.rever.boss.plugin.logging.BossLogger
+import io.github.jan.supabase.logging.LogLevel
+import io.github.jan.supabase.logging.SupabaseLoggingProcessor
 import ai.rever.boss.plugin.logging.LogCategory
 import ai.rever.boss.plugin.repository.PluginInfo
 import io.github.jan.supabase.createSupabaseClient
@@ -117,6 +119,7 @@ class PluginStoreRealtimeService {
                     supabaseUrl = baseUrl,
                     supabaseKey = anonKey,
                 ) {
+                    defaultLoggingFactory = { level -> StoreSupabaseLogging(level) }
                     install(Realtime) {
                         // Match main SupabaseConfig heartbeat settings to prevent
                         // "Heartbeat timeout" crashes in Ktor websocket
@@ -289,5 +292,45 @@ class PluginStoreRealtimeService {
     fun dispose() {
         stop()
         scope.cancel()
+    }
+}
+
+/**
+ * Names this client's supabase-kt log lines so they can be told apart from the app's other two.
+ *
+ * A near-copy of composeApp's NamedSupabaseLogging, and deliberately not shared: that one is
+ * commonMain in a module this one does not depend on (composeApp depends on plugin-repository, not
+ * the reverse), and this file is desktopMain, so there is no source set both can reach without
+ * inventing a module for forty lines.
+ *
+ * The reason either exists: supabase-kt tags every line `(Supabase-Realtime)` and nothing more, so
+ * with three clients in one process a flapping socket cannot be attributed to a feature - the
+ * lines interleave, and pairing a "Connected" with the next "Heartbeat timeout" quietly assumes
+ * they came from the same client.
+ */
+private class StoreSupabaseLogging(
+    private val minimum: LogLevel,
+) : SupabaseLoggingProcessor {
+
+    private val logger = BossLogger.forComponent("Supabase")
+
+    override fun isEnabled(level: LogLevel): Boolean = level.ordinal >= minimum.ordinal
+
+    override fun processLog(
+        level: LogLevel,
+        tag: String,
+        throwable: Throwable?,
+        message: String,
+    ) {
+        if (!isEnabled(level)) return
+        val fields = mapOf<String, Any?>("client" to "plugin-store", "tag" to tag)
+        val text = "[plugin-store] $message"
+        when (level) {
+            LogLevel.ERROR -> logger.error(LogCategory.NETWORK, text, fields, error = throwable)
+            LogLevel.WARNING -> logger.warn(LogCategory.NETWORK, text, fields, error = throwable)
+            LogLevel.INFO -> logger.info(LogCategory.NETWORK, text, fields)
+            LogLevel.DEBUG -> logger.debug(LogCategory.NETWORK, text, fields)
+            LogLevel.NONE -> {}
+        }
     }
 }


### PR DESCRIPTION
## Why

Chasing a reconnect loop, the log said this once a minute and nothing more:

```
Warn: (Supabase-Realtime) Heartbeat timeout. Trying to reconnect in 7s
```

supabase-kt tags every line `(Supabase-Realtime)` and identifies no client. This app runs **three** of them against the same project - the main client, the app-update watcher and the plugin-store watcher - and an installed plugin may run more (the Toolbox does). So the message says a socket is flapping without saying whose.

Worse, because the lines interleave, even the **timing** is unattributable: pairing a "Connected" with the next "Heartbeat timeout" quietly assumes both came from the same client. Acting on that assumption is how the investigation spent its first stretch on the Toolbox, which turned out to be entirely healthy.

## What this does

Each client installs a logging processor that names it, so the same line reads `[app-update] Heartbeat timeout...`, with the name also in the structured fields so logs can be grouped by it.

It also stops these lines bypassing `BossLogger`. They went straight to stdout: no category, not in our format, never reaching a log file.

## What this does NOT do

**It does not fix the loop.** It makes the next run say which client to fix. I would rather ship the instrumentation than guess at a fix - see below for what is already ruled out.

## What the investigation established

- **The server and network are fine.** A raw WebSocket to the same `api.risaboss.com` realtime endpoint with the same anon key: channel joined, subscribed to Postgres, **17/17 heartbeats acked over 260 seconds**, socket still open. That run was deliberately longer than Cloudflare's ~100s idle limit, because the loop's period is ~105s and a shorter probe would have proved nothing.
- **The Toolbox is not the culprit.** Instrumenting its client showed it `CONNECTED` throughout two full loop cycles underneath it.
- **It is one of the three host clients.** All three have `heartbeatInterval = 30s` compiled into the running 9.4.13 build - checked in the app bundle's bytecode, not in source.
- **Leading suspect: the main client.** It is the only one with `install(Auth)`, so a user JWT rides its socket, and `SystemPluginManifestService` subscribes a channel on it. The other two use the anon key, exactly like the healthy probe. That is a suspicion, not a conclusion.

## Two near-identical copies, deliberately

`plugin-repository` cannot see `composeApp` (the dependency runs the other way), and composeApp's copy is commonMain while that service is desktopMain - so no source set reaches both without inventing a module for forty lines.

## Next step

The running app is a packaged release, so this instrumentation is not in it. A dev build names the offending client on the next loop cycle, and the fix becomes targeted rather than guessed. I deliberately did not blind-fix by raising heartbeat intervals: the server acks in 40ms, so a longer interval would only make the client notice later.