### PR TITLE
Ignore the .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,9 @@ firebase-debug.log
 # Python bytecode from running scripts/*.py locally. Churns per interpreter version.
 __pycache__/
 *.pyc
+
+# Git worktrees. Every repo in this workspace keeps its feature checkouts under
+# .worktrees/, so the directory shows up as untracked in `git status` on every branch.
+# Ignored rather than tracked: what lives here is per-developer and per-task, and a stray
+# entry in `git status` is how a real untracked file gets overlooked.
+.worktrees/


### PR DESCRIPTION
Every repo in this workspace keeps its feature checkouts under `.worktrees/`, so the directory shows up as untracked in `git status` on every branch, in every checkout, forever.

It matters slightly beyond tidiness: a permanent entry in `git status` is how a *real* untracked file gets overlooked - a new source file that was never `git add`ed looks exactly like the noise you have learned to skip past. That happened during this session's work.

Ignored rather than tracked because what lives there is per-developer and per-task.

Verified rather than assumed: `git check-ignore -v` reports `.gitignore:114:.worktrees/` matching a probe file, and `git status` is clean with the directory present.

Safe to merge here: BossConsole's `release.yml` is `workflow_dispatch` only, so a push to main runs `build.yml` and nothing ships.

**The same change in the two plugin repos is deliberately NOT merged yet** (branches pushed, `chore/ignore-worktrees-dir` in `boss-plugin-organisation` and `boss-plugin-plugin-manager`). A push to a plugin's main calls the shared `plugin-release.yml`, whose docs-only gate covers `.md`, `.txt`, `docs/`, `LICENSE` and `NOTICE` - **not** `.gitignore`. Merging there alone would bump the version, recreate the GitHub release and publish to the Plugin Store, offering every BOSS user an update that changes nothing runnable. Either bundle those with the next substantive change, or add `.gitignore` to that gate in `BossConsole-Releases` first.