### PR TITLE
Actually skip the lint gates in the per-OS build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,8 +180,14 @@ jobs:
           echo "🔨 Building application for ${{ matrix.os }}"
           # detekt and ktlintCheck are authoritative in the code-quality job;
           # skip the redundant per-OS runs the plugins wire into check
-          # (3x waste + confusing signal)
-          ./gradlew build -x detekt -x ktlintCheck --stacktrace
+          # (3x waste + confusing signal).
+          #
+          # -PskipLint rather than `-x`: ktlint wires a ktlint<SourceSet>Check
+          # task into `check` for every source set, so `-x ktlintCheck` dropped
+          # only the umbrella task and left 351 ktlint tasks running per OS,
+          # which is how a formatting slip failed this job instead of (just)
+          # code-quality.
+          ./gradlew build -PskipLint --stacktrace
         env:
           # boss-plugin-api-core resolution from GitHub Packages (settings/composeApp repos)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,17 @@ plugins {
 // ktlint: formatting gate (`ktlintCheck`, wired into `check`; `ktlintFormat`
 // to fix). The format-the-world PR normalized the whole tree, so any failure
 // is a new violation — run `./gradlew ktlintFormat` and recommit.
+//
+// -PskipLint turns both gates off for a build that is not the gate. CI uses it
+// in the per-OS build jobs, which only need to prove the code compiles and the
+// tests pass; the dedicated code-quality job stays authoritative for lint.
+// Excluding the tasks on the command line is not equivalent: `-x detekt` works,
+// but ktlint wires a ktlint<SourceSet>Check task into `check` for every source
+// set in every module, so `-x ktlintCheck` drops only the umbrella and leaves
+// all of them scheduled.
 // ---------------------------------------------------------------------------
+val skipLint = providers.gradleProperty("skipLint").isPresent
+
 allprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
@@ -50,6 +60,14 @@ allprojects {
         // The format-the-world PR normalized every module; ktlintCheck is part
         // of `check` and NEW formatting violations fail the build.
         ignoreFailures.set(false)
+    }
+
+    if (skipLint) {
+        tasks
+            .matching {
+                it.name.contains("ktlint", ignoreCase = true) ||
+                    it.name.contains("detekt", ignoreCase = true)
+            }.configureEach { enabled = false }
     }
 }
 


### PR DESCRIPTION
## Why

The build job runs this, with a comment saying it skips the redundant per-OS lint runs:

```
./gradlew build -x detekt -x ktlintCheck --stacktrace
```

It does not. `-x detekt` works, but ktlint wires a `ktlint<SourceSet>Check` task into `check` for every source set in every module, so excluding the umbrella `ktlintCheck` leaves all of them scheduled. A dry run of that exact command still lists **351 ktlint tasks**, on each of the three OSes.

Two consequences, both of which the original comment was written to prevent:

- the "3x waste" was never actually removed
- a formatting slip fails `build-test` too, not just `code-quality`. On #201 it failed macOS and fail-fast then cancelled ubuntu and windows, so one lint error read as a broken build on three platforms.

## What this does

Replaces the exclusions with a `-PskipLint` property that disables both plugins' tasks outright, matching the repo's existing `-PskipGitCheck` convention. The `code-quality` job keeps running `detekt ktlintCheck` unflagged and remains the authoritative gate; local `./gradlew build` is unchanged.

## Verification

`--dry-run` is useless here, because it lists disabled tasks exactly like enabled ones. Verified instead against a deliberately misformatted probe file (bad import order plus a blank line opening the class body):

| check | expected | result |
|---|---|---|
| `:composeApp:ktlintCommonMainSourceSetCheck` (no flag) | fails on the probe | exit 1, both violations reported |
| `:composeApp:ktlintCommonMainSourceSetCheck -PskipLint` | disabled | `SKIPPED`, exit 0 |
| `:composeApp:detekt -PskipLint` | disabled | `SKIPPED`, exit 0 |
| `:composeApp:ktlintCheck` (what code-quality runs) | still catches it | exit 1 |
| `:server:build -PskipLint` end to end | builds despite the violation | `BUILD SUCCESSFUL` |

The probe file was removed before committing; the diff is only the two files.