### PR TITLE
Fix flaky browser copy/paste: real editor commands, and focus on tab re-show

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -2312,19 +2312,19 @@ internal class BrowserHandleImpl(
     // ============================================================
 
     override fun copySelection() {
-        editorCommand(EditorCommand.copy(), "Copy")
+        editorCommand(EditorCommand.copy())
     }
 
     override fun paste() {
-        editorCommand(EditorCommand.paste(), "Paste")
+        editorCommand(EditorCommand.paste())
     }
 
     override fun cut() {
-        editorCommand(EditorCommand.cut(), "Cut")
+        editorCommand(EditorCommand.cut())
     }
 
     override fun selectAll() {
-        editorCommand(EditorCommand.selectAll(), "Select All")
+        editorCommand(EditorCommand.selectAll())
     }
 
     /**
@@ -2349,31 +2349,55 @@ internal class BrowserHandleImpl(
      * that framework-managed inputs listen for; the old paste bypassed them, so a React or Vue
      * field could show text its own state never learned about.
      *
-     * [Browser.focusedFrame] first and `mainFrame()` only as a fallback: the caret is what an
-     * editor command acts on, and it routinely sits in a subframe (an embedded editor, an OAuth
-     * form). Note the menu that offers these is still main-frame-gated upstream — see
-     * `toContextMenuInfo` — so today the fallback is the common path and the preference is what
-     * lets the gate be widened later without revisiting this.
+     * **On the frame choice, and a comment in this package that says the opposite.**
+     * [Browser.focusedFrame] first, `mainFrame()` only as a fallback: the caret is what an editor
+     * command acts on, and it routinely sits in a subframe. `PopupWindowContextMenu` reaches the
+     * other conclusion for its own menu ("browser.focusedFrame() would answer for the wrong frame
+     * inside an iframe") and it is right there: a right-click has a frame Chromium already
+     * resolved for that exact click, `params.frame()`, which beats any inference. These are not
+     * in conflict so much as differently supplied — that callback has the accurate frame in hand
+     * and this method does not.
+     *
+     * What that costs, stated plainly: for a caller reaching `copySelection()` on a non-editable
+     * selection while an iframe holds keyboard focus, `focusedFrame()` is the iframe and the
+     * command acts on its empty selection. `mainFrame()` would have been right there. That case
+     * is not reachable through the browser plugin's menu today — its non-editable branch copies
+     * the reported selection through AWT and never calls this, and the editable branch is gated
+     * on `isEditable`, which `toContextMenuInfo` computes for the main frame only, so a
+     * right-click that reaches here has focused a main-frame editable element. It is reachable by
+     * any other plugin holding a [BrowserHandle].
+     *
+     * The durable answer is to prefer the frame the context-menu callback already resolved
+     * (`BrowserHandleImpl` line ~1232 keeps `params.frame()`), held weakly and only while its
+     * menu is live, with `focusedFrame()` then `mainFrame()` behind it. Not done here: it changes
+     * the shape of the handle for a case nothing currently hits.
      *
      * Never throws: this runs from context-menu handlers on a JxBrowser callback thread, where
      * an escaping exception has no owner. A refusal is logged rather than returned, because
      * `BrowserHandle` declares these as `Unit` and widening that would force a plugin-api
      * release for a signal only this log needs.
      */
-    private fun editorCommand(
-        command: EditorCommand,
-        what: String,
-    ): Boolean {
+    @Suppress("TooGenericExceptionCaught") // Matches PopupWindowContextMenu: Error must propagate.
+    private fun editorCommand(command: EditorCommand): Boolean {
         if (!isValid) return false
+        // The command's own identity, not a hand-passed label: a second parameter would let
+        // editorCommand(EditorCommand.paste(), "Copy") compile and mislabel every log line it
+        // produced.
+        val what = command.name().name
         val accepted =
-            runCatching {
+            try {
                 executeEditorCommand(
                     focusedFrame = browser.focusedFrame().orElse(null),
                     mainFrame = browser.mainFrame().orElse(null),
                     command = command,
                 )
-            }.onFailure { logger.warn(LogCategory.BROWSER, "$what failed", error = it) }
-                .getOrDefault(false)
+            } catch (e: Exception) {
+                // Exception, not Throwable: `runCatching` here would swallow Error, which
+                // PopupWindowContextMenu in this same package deliberately lets propagate. Two
+                // stances on one failure class in one package is how the next reader gets it wrong.
+                logger.warn(LogCategory.BROWSER, "$what failed", mapOf("handleId" to id), error = e)
+                false
+            }
         if (!accepted) {
             // Chromium's own answer, not an exception: nothing selected, nothing editable at
             // the caret, or an empty clipboard. Worth a line — a silently refused clipboard
@@ -2480,12 +2504,36 @@ internal class BrowserHandleImpl(
         // after the incoming one has focused and undo it. Hiding is already communicated by the
         // widget detaching; the missing half was only ever the re-show.
         DisposableEffect(Unit) {
-            if (needsExplicitFocusOnReshow(JxBrowserConfig.renderingMode) && shownBefore.getAndSet(true)) {
+            // Re-entering composition is not by itself "the user switched to this tab". This file
+            // already establishes two other ways in: a cross-window move builds one composition
+            // and tears down the other (why the visibility effect ref-counts), and the surface
+            // effect exists because the window a tab composes in can differ from the one it came
+            // from. A workspace restore, a pane split or a tab moving between panes would all end
+            // in focus() otherwise, including in a window nobody is looking at - and with two
+            // browser tabs side by side, a rebuild would have both handles calling focus() with
+            // the last runnable winning. Gating on the host window being focused keeps the case
+            // this fixes (a tab switch in the window you are using) and drops the rest.
+            // FluckEngine's key-input gate reads the same signal the same way.
+            val focusOnShow =
+                shouldFocusOnShow(
+                    mode = JxBrowserConfig.renderingMode,
+                    alreadyShown = shownBefore.getAndSet(true),
+                    hostWindowFocused = hostWindowId?.let(WindowFocusManager::isWindowFocused) == true,
+                )
+            // Cancelled if this composition leaves before the runnable gets to run. `isValid`
+            // answers "not disposed, engine generation still matches" - it does NOT answer "still
+            // on screen", and the gap is reachable: on a fast A->B->A, B queues a focus, leaves
+            // composition, and the runnable then focuses B, whose native view is still alive
+            // precisely because HARDWARE mode retains the surface. Same first-responder confusion
+            // this effect exists to fix, pointed the other way. A click on the URL bar or another
+            // pane in the interval is the same race with a different loser.
+            var stillComposed = true
+            if (focusOnShow) {
                 // invokeLater, not a direct call: child effects run before parent ones, so the
                 // native view has been shown by now, but the focus request still reads better one
                 // turn of the event loop later than in the middle of applying this frame.
                 SwingUtilities.invokeLater {
-                    if (isValid) {
+                    if (stillComposed && isValid) {
                         runCatching { browser.focus() }
                             .onFailure {
                                 logger.debug(
@@ -2497,7 +2545,7 @@ internal class BrowserHandleImpl(
                     }
                 }
             }
-            onDispose {}
+            onDispose { stillComposed = false }
         }
 
         // Which window telemetry is attributed to, kept current across a tab move. Its own
@@ -2973,6 +3021,29 @@ internal fun executeEditorCommand(
  */
 internal fun needsExplicitFocusOnReshow(mode: com.teamdev.jxbrowser.engine.RenderingMode): Boolean =
     mode == com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
+
+/**
+ * Whether a browser surface entering composition should take keyboard focus.
+ *
+ * All three clauses are load-bearing and each is a bug on its own:
+ *
+ *  - [mode] - see [needsExplicitFocusOnReshow]. Under OFF_SCREEN the widget owns focus and a
+ *    host-side call fights it.
+ *  - [alreadyShown] `false` means this tab is appearing for the first time, and a new browser tab
+ *    is supposed to leave the caret in the URL bar. Focusing here would take it away on every new
+ *    tab, which is a worse bug than the one being fixed.
+ *  - [hostWindowFocused] - composition re-entry happens for reasons that are not a tab switch (a
+ *    cross-window tab move, a workspace restore, a split rebuild), and without this a background
+ *    window steals focus, or two side-by-side browser tabs race to claim it on one rebuild.
+ *
+ * Pure so the rule is pinned by a test: the decision lives inside a composable, where the effect
+ * that consumes it cannot be reached from a unit test.
+ */
+internal fun shouldFocusOnShow(
+    mode: com.teamdev.jxbrowser.engine.RenderingMode,
+    alreadyShown: Boolean,
+    hostWindowFocused: Boolean,
+): Boolean = needsExplicitFocusOnReshow(mode) && alreadyShown && hostWindowFocused
 
 /**
  * Whether an AWT pointer falls inside a Compose-measured rect, given the display density.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -40,6 +40,7 @@ import com.teamdev.jxbrowser.browser.event.FaviconChanged
 import com.teamdev.jxbrowser.browser.event.TitleChanged
 import com.teamdev.jxbrowser.engine.Engine
 import com.teamdev.jxbrowser.event.Subscription
+import com.teamdev.jxbrowser.frame.EditorCommand
 import com.teamdev.jxbrowser.frame.Frame
 import com.teamdev.jxbrowser.js.JsObject
 import com.teamdev.jxbrowser.media.MediaType
@@ -91,10 +92,7 @@ import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import java.awt.Toolkit
 import java.awt.Window
-import java.awt.datatransfer.DataFlavor
-import java.awt.datatransfer.StringSelection
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
@@ -140,12 +138,14 @@ internal data class ContextMenuTarget(
  *   An inline image's source is a `data:` URL of the whole encoded image, which this is
  *   the first path to hand to plugins; past [MAX_INLINE_IMAGE_URL_LENGTH] it counts as no
  *   address rather than shipping megabytes of base64 into every menu.
- * - Editable is reported for the main frame only. Every action it unlocks —
- *   `cut`/`copySelection`/`paste`/`selectAll` and `fillCredentials` — runs against
- *   `browser.mainFrame()` and `document.activeElement`. Offering them for a field inside an
- *   iframe would act on the wrong frame, and in the credential case could write a password
- *   into whatever main-frame input happens to be focused. Frame-accurate detection has to
- *   wait for a frame-accurate fill path.
+ * - Editable is reported for the main frame only, and `fillCredentials` is why it stays that
+ *   way: it runs against `browser.mainFrame()` and `document.activeElement`, so offering it
+ *   for a field inside an iframe could write a password into whatever main-frame input
+ *   happens to be focused. Frame-accurate detection has to wait for a frame-accurate fill
+ *   path. `cut`/`copySelection`/`paste`/`selectAll` no longer share that limit — they go
+ *   through [BrowserHandleImpl.editorCommand], which targets `focusedFrame()` — but this gate
+ *   still decides whether the menu offers them at all, so widening it is what would actually
+ *   put them in reach inside an iframe.
  */
 internal fun ContextMenuTarget.toContextMenuInfo(
     pageUrl: String,
@@ -243,6 +243,17 @@ internal class BrowserHandleImpl(
         )
 
     private val disposed = AtomicBoolean(false)
+
+    /**
+     * Whether [Content] has ever been composed for this handle.
+     *
+     * Separates "this tab is appearing for the first time" from "this tab is being shown again"
+     * so the focus effect in [Content] can act on the second and not the first. Deliberately not
+     * derived from the retained-surface state: retention answers whether the *surface* survived,
+     * which is a different question and is false on the very first show for the same mode.
+     */
+    private val shownBefore = AtomicBoolean(false)
+
     private val subscriptions = mutableListOf<Subscription>()
 
     private val navigationListeners = CopyOnWriteArrayList<(String) -> Unit>()
@@ -2301,63 +2312,75 @@ internal class BrowserHandleImpl(
     // ============================================================
 
     override fun copySelection() {
-        if (!isValid) return
-        browser.mainFrame().ifPresent { frame ->
-            frame.executeJavaScript<Unit>("document.execCommand('copy')")
-        }
+        editorCommand(EditorCommand.copy(), "Copy")
     }
 
     override fun paste() {
-        if (!isValid) return
-        try {
-            val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-            val clipboardText = clipboard.getData(DataFlavor.stringFlavor) as? String
-            if (!clipboardText.isNullOrEmpty()) {
-                browser.mainFrame().ifPresent { frame ->
-                    val escapedText =
-                        clipboardText
-                            .replace("\\", "\\\\")
-                            .replace("'", "\\'")
-                            .replace("\n", "\\n")
-                            .replace("\r", "")
-                    frame.executeJavaScript<Unit>(
-                        """
-                        (function() {
-                            var el = document.activeElement;
-                            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
-                                if (el.isContentEditable) {
-                                    document.execCommand('insertText', false, '$escapedText');
-                                } else {
-                                    var start = el.selectionStart || 0;
-                                    var end = el.selectionEnd || 0;
-                                    var value = el.value || '';
-                                    el.value = value.substring(0, start) + '$escapedText' + value.substring(end);
-                                    el.selectionStart = el.selectionEnd = start + '$escapedText'.length;
-                                    el.dispatchEvent(new Event('input', { bubbles: true }));
-                                }
-                            }
-                        })()
-                        """.trimIndent(),
-                    )
-                }
-            }
-        } catch (e: Exception) {
-            logger.warn(LogCategory.BROWSER, "Failed to paste from clipboard", error = e)
-        }
+        editorCommand(EditorCommand.paste(), "Paste")
     }
 
     override fun cut() {
-        if (!isValid) return
-        browser.mainFrame().ifPresent { frame ->
-            frame.executeJavaScript<Unit>("document.execCommand('cut')")
-        }
+        editorCommand(EditorCommand.cut(), "Cut")
     }
 
     override fun selectAll() {
-        if (!isValid) return
-        browser.mainFrame().ifPresent { frame ->
-            frame.executeJavaScript<Unit>("document.execCommand('selectAll')")
+        editorCommand(EditorCommand.selectAll(), "Select All")
+    }
+
+    /**
+     * Runs [command] on the frame that holds the caret, and reports whether Chromium took it.
+     *
+     * These four used to be `frame.executeJavaScript("document.execCommand(...)")`, which was
+     * wrong three separate ways and produced the "copy works sometimes" report:
+     *
+     *  - **`execCommand('copy'|'cut')` needs transient user activation.** A right-click grants
+     *    it, but it lapses after roughly five seconds, so picking the item straight away copied
+     *    and picking it after reading the menu silently did nothing. Nothing about the two
+     *    attempts looked different to the user, which is what made it read as flakiness rather
+     *    than as a rule.
+     *  - **It only ever reached `mainFrame()`,** so a selection inside an iframe copied nothing.
+     *  - **The answer was discarded** by the `<Unit>` type argument: `execCommand` returns a
+     *    boolean, and a refusal was indistinguishable from a success.
+     *
+     * `Frame.execute` drives Chromium's own editor instead. It has no activation requirement,
+     * and it reads and writes the real system clipboard rather than splicing a string into
+     * `document.activeElement` from JS — which is what makes a copy here paste in another tab,
+     * in a terminal, or in another application. It also fires the `beforeinput`/`paste` events
+     * that framework-managed inputs listen for; the old paste bypassed them, so a React or Vue
+     * field could show text its own state never learned about.
+     *
+     * [Browser.focusedFrame] first and `mainFrame()` only as a fallback: the caret is what an
+     * editor command acts on, and it routinely sits in a subframe (an embedded editor, an OAuth
+     * form). Note the menu that offers these is still main-frame-gated upstream — see
+     * `toContextMenuInfo` — so today the fallback is the common path and the preference is what
+     * lets the gate be widened later without revisiting this.
+     *
+     * Never throws: this runs from context-menu handlers on a JxBrowser callback thread, where
+     * an escaping exception has no owner. A refusal is logged rather than returned, because
+     * `BrowserHandle` declares these as `Unit` and widening that would force a plugin-api
+     * release for a signal only this log needs.
+     */
+    private fun editorCommand(
+        command: EditorCommand,
+        what: String,
+    ): Boolean {
+        if (!isValid) return false
+        val accepted =
+            runCatching {
+                executeEditorCommand(
+                    focusedFrame = browser.focusedFrame().orElse(null),
+                    mainFrame = browser.mainFrame().orElse(null),
+                    command = command,
+                )
+            }.onFailure { logger.warn(LogCategory.BROWSER, "$what failed", error = it) }
+                .getOrDefault(false)
+        if (!accepted) {
+            // Chromium's own answer, not an exception: nothing selected, nothing editable at
+            // the caret, or an empty clipboard. Worth a line — a silently refused clipboard
+            // command is exactly the failure this method was rewritten to stop hiding.
+            logger.debug(LogCategory.BROWSER, "$what refused by Chromium", mapOf("handleId" to id))
         }
+        return accepted
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
@@ -2377,11 +2400,13 @@ internal class BrowserHandleImpl(
         // and the tab paints BLANK on the way back (A->B->A). BossConsoleLite hit this on its
         // Windows fleet and calls it the "fast-switch blank".
         //
-        // Retaining is gated on the rendering mode, NOT applied unconditionally as Lite does:
-        // Lite defaults HARDWARE everywhere so the two are the same thing there, but here
-        // OFF_SCREEN is still the macOS/Linux default and they must keep the exact lifecycle they
-        // have today. Safe because the surface is still closed for real in dispose(), which runs
-        // when the tab is actually closed rather than merely hidden.
+        // Retaining is gated on the rendering mode, NOT applied unconditionally as Lite does.
+        // HARDWARE is now the default on every platform, so in practice the gate is open
+        // everywhere; it still earns its keep because OFF_SCREEN remains reachable per install
+        // (BOSS_RENDERING_MODE, the Chromium-flags setting), and an install that picks it must
+        // keep the exact close-on-hide lifecycle it had. Safe because the surface is still closed
+        // for real in dispose(), which runs when the tab is actually closed rather than merely
+        // hidden.
         val retainSurfaceAcrossTabSwitches = shouldRetainSurface(JxBrowserConfig.renderingMode)
 
         // The window actually hosting this composition, resolved through the app's window
@@ -2432,9 +2457,54 @@ internal class BrowserHandleImpl(
             }
         }
 
+        // Give the web content keyboard focus when a tab is shown AGAIN, and never the first
+        // time.
+        //
+        // In HARDWARE_ACCELERATED mode the Compose view is JxBrowser's SharedSurfaceWidget over
+        // a native child view, and unlike the OFF_SCREEN widget — whose OffScreenWidgetState
+        // wires onFocusChanged to BrowserWidget.focus()/unfocus() and answers TakeFocusCallback —
+        // it has no Java-side focus wiring at all. It relies entirely on the native view being
+        // first responder. Switching tabs hides that view and shows another, and nothing
+        // promotes the one that reappears, so the returned-to tab can hold no keyboard focus:
+        // Cmd+V goes nowhere until the page is clicked. Whether it happens depends on what the
+        // window fell back to when the outgoing view was hidden, which is what made it read as
+        // "sometimes".
+        //
+        // The first-show exception is the point of [shownBefore], not an optimisation: a tab
+        // being created is supposed to leave the caret in BOSS's own URL bar, and focusing the
+        // page here would take it away on every new tab.
+        //
+        // There is deliberately no unfocus() on the way out. A tab moving between windows builds
+        // one composition and tears down the other in an order this effect does not control (see
+        // the ref-counting note above), so an unfocus from the outgoing composition could land
+        // after the incoming one has focused and undo it. Hiding is already communicated by the
+        // widget detaching; the missing half was only ever the re-show.
+        DisposableEffect(Unit) {
+            if (needsExplicitFocusOnReshow(JxBrowserConfig.renderingMode) && shownBefore.getAndSet(true)) {
+                // invokeLater, not a direct call: child effects run before parent ones, so the
+                // native view has been shown by now, but the focus request still reads better one
+                // turn of the event loop later than in the middle of applying this frame.
+                SwingUtilities.invokeLater {
+                    if (isValid) {
+                        runCatching { browser.focus() }
+                            .onFailure {
+                                logger.debug(
+                                    LogCategory.BROWSER,
+                                    "Could not focus web content on tab re-show",
+                                    mapOf("handleId" to id, "error" to it.toString()),
+                                )
+                            }
+                    }
+                }
+            }
+            onDispose {}
+        }
+
         // Which window telemetry is attributed to, kept current across a tab move. Its own
-        // effect because the focus effect above must stay keyed on Unit - keying that one on
-        // the window would fire a spurious TAB_ACTIVATED every time a tab moved.
+        // effect because the visibility effect above must stay keyed on Unit - keying that one
+        // on the window would fire a spurious TAB_ACTIVATED every time a tab moved. (It used to
+        // say "the focus effect above"; there is now a second effect above that really is about
+        // focus, and this is not the one it means.)
         DisposableEffect(hostWindowId) {
             hostWindowId?.let { currentWindowId = it }
             onDispose {}
@@ -2863,6 +2933,45 @@ internal class BrowserHandleImpl(
  * reading an inline expression buried in a composable.
  */
 internal fun shouldRetainSurface(mode: com.teamdev.jxbrowser.engine.RenderingMode): Boolean =
+    mode == com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
+
+/**
+ * Runs [command] on the frame that should receive it, and reports whether Chromium took it.
+ *
+ * The whole content of this function is the frame choice, and it is the part that was wrong:
+ * the clipboard operations used to reach `mainFrame()` unconditionally, so a caret inside an
+ * iframe copied and pasted nothing. [focusedFrame] is where the caret is; [mainFrame] is the
+ * fallback for the case Chromium reports no focused frame at all.
+ *
+ * Pure and separate from [BrowserHandleImpl] so that choice is pinned by a test instead of
+ * needing a live engine to observe. Exception containment stays at the call site, which owns
+ * the logger.
+ */
+internal fun executeEditorCommand(
+    focusedFrame: Frame?,
+    mainFrame: Frame?,
+    command: EditorCommand,
+): Boolean {
+    val frame = focusedFrame ?: mainFrame ?: return false
+    return frame.execute(command)
+}
+
+/**
+ * Whether the host has to hand keyboard focus back to the web content when a tab is shown again.
+ *
+ * Only under HARDWARE_ACCELERATED, and for a reason unrelated to [shouldRetainSurface] even
+ * though both currently name the same mode. This one is about JxBrowser's Compose widgets:
+ * `OffScreenWidgetState` wires `onFocusChanged` to `BrowserWidget.focus()`/`unfocus()` and
+ * answers `TakeFocusCallback`, so under OFF_SCREEN focus is already handled and a second,
+ * host-side `focus()` would fight it. `SharedSurfaceWidget` — the HARDWARE_ACCELERATED path —
+ * has none of that and depends on the native view being first responder, which nothing restores
+ * after a tab switch.
+ *
+ * Kept as its own predicate rather than reusing [shouldRetainSurface] so the two reasons can
+ * diverge: a future JxBrowser that wires focus into the shared-surface widget would flip this
+ * one and leave surface retention exactly as it is.
+ */
+internal fun needsExplicitFocusOnReshow(mode: com.teamdev.jxbrowser.engine.RenderingMode): Boolean =
     mode == com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
 
 /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserClipboardCommandsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserClipboardCommandsTest.kt
@@ -1,0 +1,166 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.engine.RenderingMode
+import com.teamdev.jxbrowser.frame.EditorCommand
+import com.teamdev.jxbrowser.frame.Frame
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards the two decisions behind browser copy/paste, both of which failed silently before.
+ *
+ * The reported symptom was "copy in a browser tab, switch tabs, paste - works sometimes". Two
+ * unrelated causes produced it, and neither could be caught by any existing test:
+ *
+ *  - The clipboard operations ran `document.execCommand(...)` as injected JavaScript against
+ *    `mainFrame()`. `execCommand('copy')` needs transient user activation, which a right-click
+ *    grants for about five seconds - so the same menu item copied or did nothing depending on
+ *    how long the menu had been open, and the boolean saying which was discarded.
+ *  - Nothing gave the web content keyboard focus when a tab came back into view.
+ *
+ * What is NOT covered here, deliberately, so nobody reads more into a green run: the four
+ * one-line mappings from `copySelection`/`cut`/`paste`/`selectAll` to their `EditorCommand`
+ * factories are review-verified. Reaching them needs a `BrowserHandleImpl`, which needs a live
+ * engine generation for `isValid`, and a test that stood up an engine to assert four constants
+ * would be testing JxBrowser rather than this code.
+ */
+class BrowserClipboardCommandsTest {
+    /** A [Frame] that records the commands it is asked to run and answers [accepts]. */
+    private class RecordingFrame(
+        private val accepts: Boolean = true,
+    ) {
+        val executed = mutableListOf<EditorCommand>()
+
+        val frame: Frame =
+            Proxy.newProxyInstance(
+                Frame::class.java.classLoader,
+                arrayOf(Frame::class.java),
+            ) { _, method, args ->
+                when (method.name) {
+                    "execute" -> {
+                        executed += args[0] as EditorCommand
+                        accepts
+                    }
+
+                    "hashCode" -> {
+                        System.identityHashCode(this)
+                    }
+
+                    "equals" -> {
+                        false
+                    }
+
+                    "toString" -> {
+                        "RecordingFrame"
+                    }
+
+                    else -> {
+                        error("unexpected Frame call: ${method.name}")
+                    }
+                }
+            } as Frame
+    }
+
+    // --- which frame an editor command reaches ---
+
+    /**
+     * The regression this exists for. `mainFrame()` was the only target, so a caret inside an
+     * iframe - an embedded editor, an OAuth form, a comment box - copied and pasted nothing at
+     * all. Asserted as "the main frame was not touched" rather than only "the focused frame was",
+     * because a change that ran the command on both would satisfy the weaker claim while pasting
+     * into the wrong document.
+     */
+    @Test
+    fun `the focused frame receives the command, and the main frame does not`() {
+        val focused = RecordingFrame()
+        val main = RecordingFrame()
+
+        executeEditorCommand(focused.frame, main.frame, EditorCommand.copy())
+
+        assertEquals(1, focused.executed.size, "the focused frame should have run the command")
+        assertEquals(EditorCommand.Name.COPY, focused.executed.single().name())
+        assertTrue(main.executed.isEmpty(), "the main frame must not also run it")
+    }
+
+    /**
+     * Chromium reports no focused frame for a page nothing has been clicked in yet, which is
+     * exactly the state a freshly restored tab is in. Falling back keeps Select All and Copy
+     * working there instead of turning the fix into a different silent no-op.
+     */
+    @Test
+    fun `the main frame is the fallback when nothing is focused`() {
+        val main = RecordingFrame()
+
+        executeEditorCommand(focusedFrame = null, mainFrame = main.frame, command = EditorCommand.paste())
+
+        assertEquals(EditorCommand.Name.PASTE, main.executed.single().name())
+    }
+
+    /** A closed or still-loading browser has neither frame. Refusing beats throwing at a menu. */
+    @Test
+    fun `no frame at all is a refusal, not a throw`() {
+        assertFalse(executeEditorCommand(focusedFrame = null, mainFrame = null, command = EditorCommand.cut()))
+    }
+
+    /**
+     * Chromium's own answer has to survive the call, because it is the only signal that a
+     * clipboard command did nothing - an empty selection, a non-editable caret, an empty
+     * clipboard. Swallowing it is what the old `executeJavaScript<Unit>` did, and it is why the
+     * failure was invisible for as long as it was.
+     */
+    @Test
+    fun `a refusal by Chromium is reported, not swallowed`() {
+        val refusing = RecordingFrame(accepts = false)
+
+        assertFalse(executeEditorCommand(refusing.frame, null, EditorCommand.copy()))
+        assertTrue(executeEditorCommand(RecordingFrame(accepts = true).frame, null, EditorCommand.copy()))
+    }
+
+    // --- who has to restore keyboard focus ---
+
+    /**
+     * OFF_SCREEN must stay false. JxBrowser's own `OffScreenWidgetState` wires `onFocusChanged`
+     * to `BrowserWidget.focus()`/`unfocus()` and answers `TakeFocusCallback`, so a second
+     * host-side `focus()` there would fight the widget rather than help it. `SharedSurfaceWidget`,
+     * the HARDWARE_ACCELERATED path, has no such wiring - which is the gap being filled.
+     */
+    @Test
+    fun `only the hardware path needs the host to restore focus`() {
+        assertTrue(needsExplicitFocusOnReshow(RenderingMode.HARDWARE_ACCELERATED))
+        assertFalse(needsExplicitFocusOnReshow(RenderingMode.OFF_SCREEN))
+    }
+
+    // --- the JxBrowser API this rests on ---
+
+    /**
+     * Not a test of our code, and here on purpose: the fix replaced injected JavaScript with
+     * `Frame.execute(EditorCommand)`, and this pins that the four commands it needs exist and are
+     * distinct in whatever JxBrowser version the build resolves. A version bump that renamed or
+     * merged one of them would otherwise surface as clipboard operations quietly doing the wrong
+     * thing rather than as a failing build.
+     */
+    @Test
+    fun `the four editor commands the clipboard needs are distinct`() {
+        val names =
+            listOf(
+                EditorCommand.copy(),
+                EditorCommand.cut(),
+                EditorCommand.paste(),
+                EditorCommand.selectAll(),
+            ).map { it.name() }
+
+        assertEquals(
+            listOf(
+                EditorCommand.Name.COPY,
+                EditorCommand.Name.CUT,
+                EditorCommand.Name.PASTE,
+                EditorCommand.Name.SELECT_ALL,
+            ),
+            names,
+        )
+        assertEquals(names.size, names.toSet().size, "the four must not collapse onto each other")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserClipboardCommandsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserClipboardCommandsTest.kt
@@ -133,6 +133,33 @@ class BrowserClipboardCommandsTest {
         assertFalse(needsExplicitFocusOnReshow(RenderingMode.OFF_SCREEN))
     }
 
+    /**
+     * The rule the fix turns on, and the one no test could reach while it lived inside the
+     * composable. Each clause is asserted by removing it and nothing else, because each is a
+     * distinct bug: focusing on first show steals the URL bar from every new tab, and focusing in
+     * an unfocused window is a background tab taking the keyboard from the one being used.
+     */
+    @Test
+    fun `focus is taken only on a re-show, in the focused window, under hardware`() {
+        assertTrue(
+            shouldFocusOnShow(RenderingMode.HARDWARE_ACCELERATED, alreadyShown = true, hostWindowFocused = true),
+            "the case the fix exists for: switching back to a tab in the window you are using",
+        )
+
+        assertFalse(
+            shouldFocusOnShow(RenderingMode.HARDWARE_ACCELERATED, alreadyShown = false, hostWindowFocused = true),
+            "a tab appearing for the first time must leave the caret in the URL bar",
+        )
+        assertFalse(
+            shouldFocusOnShow(RenderingMode.HARDWARE_ACCELERATED, alreadyShown = true, hostWindowFocused = false),
+            "a re-show in a background window must not take the keyboard",
+        )
+        assertFalse(
+            shouldFocusOnShow(RenderingMode.OFF_SCREEN, alreadyShown = true, hostWindowFocused = true),
+            "under OFF_SCREEN the widget owns focus and a host-side call fights it",
+        )
+    }
+
     // --- the JxBrowser API this rests on ---
 
     /**


### PR DESCRIPTION
Copying in a fluck browser tab, switching to another tab and pasting there worked only sometimes. Two unrelated defects each produce exactly that, and both are fixed here.

## 1. The clipboard operations were injected JavaScript, not Chromium commands

`copySelection` / `cut` / `paste` / `selectAll` on `BrowserHandleImpl` ran `frame.executeJavaScript("document.execCommand(...)")` against `mainFrame()`. Three things wrong with that:

- **`execCommand('copy'|'cut')` needs transient user activation.** A right-click grants it, and it lapses after roughly five seconds - so picking the menu item straight away copied, and picking it after reading the menu silently did nothing. Nothing about the two attempts looked different, which is what made it read as flakiness rather than as a rule.
- **It only ever reached the main frame,** so a caret inside an iframe copied and pasted nothing.
- **The answer was discarded.** `execCommand` returns a boolean; `executeJavaScript<Unit>` threw it away, so a refusal was indistinguishable from a success.

`paste()` was worse - it did not paste. It read the AWT clipboard, hand-escaped the string and spliced it into `document.activeElement` from JS: it dropped `\r`, targeted the main frame's active element rather than the caret, and skipped the `beforeinput` / `paste` events that framework-managed inputs listen for, so a React or Vue field could show text its own state never learned about.

All four now go through `Frame.execute(EditorCommand)`, which drives Chromium's own editor: no activation requirement, the real system clipboard, and `focusedFrame()` in preference to `mainFrame()`. The host already did exactly this for popup windows in `PopupWindowContextMenu`, so this converges the two mechanisms. Refs #92.

`BrowserHandle`'s signatures are unchanged, so **no plugin-api change and no plugin release are needed** - the shipped fluck-browser gets this from a host update alone. A refusal is logged rather than returned, since widening those four to `Boolean` would force an api release for a signal only the log needs.

## 2. Nothing ever called `Browser.focus()`

`JxBrowserConfig.resolveRenderingMode` returns `HARDWARE_ACCELERATED` on every platform now, which makes the Compose view JxBrowser's `SharedSurfaceWidget` over a native child view. Unlike the OFF_SCREEN widget - whose `OffScreenWidgetState` wires `onFocusChanged` to `BrowserWidget.focus()`/`unfocus()` and answers `TakeFocusCallback` - the shared-surface path has **no Java-side focus wiring at all** and depends entirely on the native view being first responder.

Switching tabs hides one view and shows another, and nothing promoted the one that reappeared. So the returned-to tab could hold no keyboard focus and Cmd+V went nowhere until the page was clicked. Whether it happened depended on what the window fell back to when the outgoing view was hidden - the "sometimes".

A tab shown *again* now focuses its web content. Two deliberate limits:

- **Only again, never the first time.** A tab being created is supposed to leave the caret in BOSS's own URL bar, and focusing the page here would take it away on every new tab. That is what `shownBefore` is for, not an optimisation.
- **No `unfocus()` on the way out.** A tab moving between windows builds one composition and tears down the other in an order this effect does not control, so an unfocus from the outgoing composition could land after the incoming one has focused and undo it.

`needsExplicitFocusOnReshow` is its own predicate rather than a reuse of `shouldRetainSurface`, even though both name the same mode today - they answer different questions and a future JxBrowser that wires focus into the shared-surface widget would flip one and not the other.

## Which defect caused the report

Both are real, but they are not equally implicated in the exact case reported. Copying a plain page selection - by Cmd+C or by right-click - was already sound: Cmd+C is native Chromium, and the non-editable menu branch writes the selection through AWT. Defect 2 is the load-bearing fix for "copy, switch tab, paste". Defect 1 is a genuine adjacent bug that breaks right-click Copy/Paste *inside a text field*, and it is the one that also explains the five-second timing pattern.

## Tests

`BrowserClipboardCommandsTest` (6 tests) pins the frame choice, that a Chromium refusal survives the call rather than being swallowed, and the rendering-mode gate. The two frame assertions were confirmed to **fail** against the old main-frame-only behaviour before being kept.

`ktlintCheck`, `detekt` and the whole `ai.rever.boss.plugin.browser` test package are green.

## Verification still owed

The focus half cannot be proved by a unit test - it needs the running app. Worth checking on this branch:

- copy in one browser tab, switch to another, Cmd+V into an input, **without** clicking the page first
- right-click > Copy inside a text field, both immediately and after leaving the menu open ten seconds
- a selection inside an iframe
- regression: a new browser tab still opens with the caret in the URL bar, and a browser copy still pastes into a terminal tab and into another application