### PR TITLE
Fix find-in-page: one Cmd+F path, a pane-anchored bar, and let pages keep their own find

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,15 @@ jobs:
         # files and two languages and fail by making elementPath vanish silently.
         run: node scripts/test/test-browser-collector.js
 
+      - name: 🧪 Find-key probe
+        # BrowserFindKeyProbe's script decides whether the PAGE keeps Cmd+F (Sheets,
+        # Docs, Notion all claim it) or BOSS opens its own find bar, and it is
+        # JavaScript inside a Kotlin string too. The case that matters - a page
+        # calling preventDefault AND stopPropagation - cannot be distinguished by
+        # reading the script: the wrong implementation looks equivalent and reports
+        # the page's own find as "free". Only executing it tells them apart.
+        run: node scripts/test/test-find-key-probe.js
+
       - name: ✍️ No new em-dashes in prose
         # House style is a spaced hyphen. Scoped to ADDED lines on purpose: the
         # sweep left code comments alone by design, so a whole-tree check would

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -147,13 +147,16 @@ object OverlayConfig {
      *
      * `inset` shrinks the parent rectangle at its END and BOTTOM edges before the corner is
      * resolved, so a caller anchored to a sub-region of the window (rather than to the window
-     * itself) can say so. See [OverlayCorner].
+     * itself) can say so. `regionInWindow` says the same thing exactly rather than by edge
+     * distance, and `focusable` opts the overlay into keyboard input. See [OverlayCorner].
      */
     var heavyweightCorner: (
         @Composable (
             alignment: Alignment,
             initialSize: DpSize,
             inset: DpSize,
+            focusable: Boolean,
+            regionInWindow: IntRect?,
             content: @Composable () -> Unit,
         ) -> Unit
     )? = null
@@ -237,17 +240,31 @@ fun BoxScope.OverlayHud(
  * and bottom edges makes both agree. It is applied to the heavyweight path only, where it shrinks
  * the rectangle the corner is resolved inside; the overlay itself is not made any larger, so the
  * region it covers - and therefore the region whose clicks it swallows - is unchanged.
+ *
+ * [regionInWindow] is the same idea stated exactly instead of by edge distance: the rectangle,
+ * **in dp relative to the window's content pane**, that the corner should be resolved inside. It
+ * exists because [inset] can only move an overlay in from the end and bottom edges, so a
+ * TOP-anchored caller in a sub-region (a browser pane in a split, which may not start at the top
+ * of the window) cannot express where it sits. When non-null it REPLACES [inset]. The lightweight
+ * path ignores it for the same reason it ignores [inset] - there the content is already aligned
+ * inside the caller's own region.
+ *
+ * [focusable] lets the overlay window take keyboard focus, which it must if it contains a text
+ * field. The default stays false: a focusable always-on-top window makes the main window inactive
+ * for as long as it is up, which is right for a find bar and wrong for a toast.
  */
 @Composable
 fun BoxScope.OverlayCorner(
     alignment: Alignment,
     initialSize: DpSize,
     inset: DpSize = DpSize.Zero,
+    focusable: Boolean = false,
+    regionInWindow: IntRect? = null,
     content: @Composable () -> Unit,
 ) {
     val hw = OverlayConfig.heavyweightCorner
     if (routeOverlayHeavyweight(hw != null) && hw != null) {
-        hw(alignment, initialSize, inset) { content() }
+        hw(alignment, initialSize, inset, focusable, regionInWindow) { content() }
     } else {
         Box(modifier = Modifier.align(alignment)) { content() }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -950,7 +950,14 @@ fun BossTabsComponent.BossMainPanel(
         // plugin) read this and forward it into their widget so the
         // widget can re-issue its internal focus requester when the
         // surrounding panel regains user attention.
-        CompositionLocalProvider(LocalIsPanelActive provides isActivePanel) {
+        // LocalInMainWindowPanel rides alongside because LocalIsPanelActive cannot answer the
+        // question a shortcut needs. Its default is `true`, so a surface rendered OUTSIDE a managed
+        // panel - a sidebar slot, a dialog, a test host - reads as active too, and a window-scoped
+        // shortcut broadcast to every collector then has no way to prefer the real one.
+        CompositionLocalProvider(
+            LocalIsPanelActive provides isActivePanel,
+            LocalInMainWindowPanel provides true,
+        ) {
             BossMainPanelContent(modifier = Modifier.weight(1f).fillMaxWidth())
         }
     }
@@ -1917,3 +1924,15 @@ private fun convertTabInfoToTabConfig(tabInfo: TabInfo): TabConfig =
             )
         }
     }
+
+/**
+ * Whether the surrounding composition is inside a [BossMainWindowPanel].
+ *
+ * Host-internal, and deliberately **not** on `PluginContext`: it exists only so a window-scoped
+ * keyboard shortcut broadcast to every candidate surface can prefer the one in the main content
+ * area over one in a sidebar slot. `LocalIsPanelActive` cannot answer that - it defaults to `true`,
+ * so "outside any panel" and "in the active panel" are the same value.
+ *
+ * Defaults to `false`, so the only thing that reads as a main-panel surface is one that actually is.
+ */
+val LocalInMainWindowPanel: ProvidableCompositionLocal<Boolean> = compositionLocalOf { false }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
@@ -94,6 +95,8 @@ fun HeavyweightCorner(
     alignment: Alignment,
     initialSize: DpSize,
     inset: DpSize = DpSize.Zero,
+    focusable: Boolean = false,
+    regionInWindow: IntRect? = null,
     content: @Composable () -> Unit,
 ) {
     val parent = LocalAwtWindow.current
@@ -106,7 +109,7 @@ fun HeavyweightCorner(
     // `bounds` only changes identity on a real change (see [trackedContentPaneBounds]), and a fresh
     // array every recomposition would re-run the placement effect, and with it a native
     // setLocation, for nothing.
-    val region = remember(bounds, inset) { insetBounds(bounds, inset) }
+    val region = remember(bounds, inset, regionInWindow) { resolveRegion(bounds, inset, regionInWindow) }
     // Clamp the ceiling to the region. The ceiling is a hard clip, not a soft start, and toast text
     // is arbitrary plugin content: three wordy toasts can exceed a fixed height, and because the
     // window is CONTENT-sized the overflow is not cosmetic - the bottom toast's dismiss button ends
@@ -135,7 +138,7 @@ fun HeavyweightCorner(
         undecorated = true,
         transparent = true,
         alwaysOnTop = true,
-        focusable = false,
+        focusable = focusable,
         resizable = false,
         icon = BossWindowIcon.painter,
     ) {
@@ -426,6 +429,7 @@ internal fun shouldKeepMeasuring(
  * and the result is a `remember` key: an equal-but-new array would change identity on every
  * recomposition and re-run the placement effect, which is a native `setLocation` each time.
  */
+
 internal fun insetBounds(
     bounds: IntArray?,
     inset: DpSize,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightCorner.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
@@ -22,10 +23,13 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import kotlinx.coroutines.delay
+import java.awt.Dialog
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import javax.swing.RootPaneContainer
@@ -132,6 +136,43 @@ fun HeavyweightCorner(
         state.position = WindowPosition(at.first.dp, at.second.dp)
     }
 
+    // What the overlay measures, shared by both hosts below so the sizing rules cannot diverge.
+    val measuringContent: @Composable () -> Unit = {
+        MeasuredAgainstCeiling(
+            ceiling = ceiling,
+            density = density,
+            onMeasured = { measured = it },
+            current = measured,
+            content = content,
+        )
+    }
+
+    // A FOCUSABLE overlay is hosted by a dialog OWNED by the parent, not by a top-level window, and
+    // the difference is three behaviours rather than a preference:
+    //
+    //  - **The owner stays active.** An unowned top-level window taking focus deactivates the main
+    //    window, and things branch on that: `FocusModeQuickActions` renders its LIGHTWEIGHT path
+    //    when the window is unfocused, which under HARDWARE_ACCELERATED draws behind the Chromium
+    //    surface - so the quick-actions cluster disappeared for as long as the find bar was up, in
+    //    the one configuration it exists for.
+    //  - **App shortcuts keep routing.** `AWTKeyboardInterceptor.findWindowId` walks `owner`, so an
+    //    owned dialog resolves to its window's id; an unowned one resolves to nothing and every
+    //    keymap binding goes dead while the overlay holds focus.
+    //  - **No taskbar button and no Alt-Tab card.** `WindowIcon.kt` documents this as the reason the
+    //    find bar was a `JDialog` before it was Compose; an owned dialog keeps that property, a
+    //    plain `Frame` does not.
+    //
+    // Non-focusable callers (toasts, the focus-mode cluster) keep the top-level window they have
+    // always had, so none of this can regress them.
+    if (focusable && parent != null) {
+        OwnedCornerDialog(
+            parent = parent,
+            state = state,
+            content = measuringContent,
+        )
+        return
+    }
+
     Window(
         onCloseRequest = {},
         state = state,
@@ -144,27 +185,101 @@ fun HeavyweightCorner(
     ) {
         EnsureOverlayWindowTransparent(window, kind = "corner")
         ApplyBossWindowIcon(window)
-        Box(
-            modifier =
-                Modifier
-                    // Order matters: the constraint override is OUTSIDE, so the observer inside it
-                    // reports a size measured against the ceiling rather than against the window.
-                    .measuredAgainst(ceiling)
-                    .onGloballyPositioned { coordinates ->
-                        val next =
-                            DpSize(
-                                (coordinates.size.width / density).dp,
-                                (coordinates.size.height / density).dp,
-                            )
-                        // Ignore a zero measurement: it happens while the overlay is torn down, and
-                        // acting on it would collapse the window and hide content still showing.
-                        if (next.width.value > 0f && next.height.value > 0f && next != measured) {
-                            measured = next
-                        }
-                    },
-        ) {
-            content()
-        }
+        measuringContent()
+    }
+}
+
+/**
+ * Reports [content]'s size measured against [ceiling] rather than against the window it is in.
+ *
+ * Extracted from [HeavyweightCorner] so each host branch reads as a host and this reads as the
+ * sizing rule. See [measuredAgainst] for why the ceiling, and not the window, is what content is
+ * measured against.
+ */
+@Composable
+private fun MeasuredAgainstCeiling(
+    ceiling: DpSize,
+    density: Float,
+    current: DpSize?,
+    onMeasured: (DpSize) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                // Order matters: the constraint override is OUTSIDE, so the observer inside it
+                // reports a size measured against the ceiling rather than against the window.
+                .measuredAgainst(ceiling)
+                .onGloballyPositioned { coordinates ->
+                    val next =
+                        DpSize(
+                            (coordinates.size.width / density).dp,
+                            (coordinates.size.height / density).dp,
+                        )
+                    // Ignore a zero measurement: it happens while the overlay is torn down, and
+                    // acting on it would collapse the window and hide content still showing.
+                    if (next.width.value > 0f && next.height.value > 0f && next != current) {
+                        onMeasured(next)
+                    }
+                },
+    ) {
+        content()
+    }
+}
+
+/**
+ * Hosts [content] in an undecorated, transparent, MODELESS dialog owned by [parent].
+ *
+ * Uses the low-level `DialogWindow` overload because the properties that make this worth doing have
+ * to be set on the AWT dialog itself, and two of them must be set BEFORE it becomes displayable:
+ * `type` throws once the dialog has been shown, and a transparent background needs `isUndecorated`
+ * already true. `create` is the only hook that runs early enough.
+ *
+ * `isAlwaysOnTop` is deliberately NOT set. An owned dialog already floats above its owner, which is
+ * the whole requirement (Chromium's surface is a native child of that same owner); always-on-top
+ * would additionally raise it above every OTHER application, which a find bar has no business doing.
+ */
+@Composable
+private fun OwnedCornerDialog(
+    parent: AwtWindow,
+    state: WindowState,
+    content: @Composable () -> Unit,
+) {
+    DialogWindow(
+        create = {
+            ComposeDialog(parent, Dialog.ModalityType.MODELESS).apply {
+                // Before anything shows it: setType throws on a displayable window, and
+                // setBackground with an alpha is ignored while the dialog is still decorated.
+                isUndecorated = true
+                runCatching { type = AwtWindow.Type.UTILITY }
+                isResizable = false
+                background = java.awt.Color(0, 0, 0, 0)
+            }
+        },
+        dispose = ComposeDialog::dispose,
+        update = { dialog ->
+            // Position and size come from the same WindowState the top-level branch drives, so the
+            // corner maths has exactly one implementation.
+            val at = state.position
+            if (at is WindowPosition.Absolute) {
+                dialog.setLocation(at.x.value.toInt(), at.y.value.toInt())
+            }
+            dialog.setSize(
+                state.size.width.value
+                    .toInt(),
+                state.size.height.value
+                    .toInt(),
+            )
+        },
+    ) {
+        EnsureOverlayWindowTransparent(window, kind = "corner-dialog")
+        // Branded even though an owned UTILITY dialog shows no icon surface. Two reasons, and the
+        // second is why this is not an exemption: `type` is set through runCatching, so a platform
+        // that refuses it leaves an ordinary dialog that DOES have one - and reasoning "this window
+        // does not need branding" is precisely how nine windows shipped wearing the JDK coffee cup.
+        // WindowIconConventionTest enforces this for every DialogWindow call site.
+        ApplyBossWindowIcon(window)
+        content()
     }
 }
 
@@ -350,41 +465,6 @@ private val unmeasurableParentReported =
 private val logger = BossLogger.forComponent("HeavyweightCorner")
 
 /**
- * Top-left corner, in AWT logical units, for an overlay of [size] placed at [alignment] inside
- * [bounds] - or the origin when the parent could not be measured.
- *
- * Pure so the arithmetic is pinned by a test; composing a `Window` needs a display, so this is the
- * only reachable part. Offsets are floored at zero so content larger than the parent overhangs the
- * bottom-right rather than being pushed off the top-left, where it would be unreachable.
- */
-internal fun cornerPosition(
-    bounds: IntArray?,
-    size: DpSize,
-    alignment: Alignment,
-): Pair<Int, Int> {
-    if (bounds == null) return 0 to 0
-    val width = size.width.value.toInt()
-    val height = size.height.value.toInt()
-    val slackX = (bounds[2] - width).coerceAtLeast(0)
-    val slackY = (bounds[3] - height).coerceAtLeast(0)
-    val x =
-        bounds[0] +
-            when (alignment) {
-                Alignment.TopStart, Alignment.CenterStart, Alignment.BottomStart -> 0
-                Alignment.TopEnd, Alignment.CenterEnd, Alignment.BottomEnd -> slackX
-                else -> slackX / 2
-            }
-    val y =
-        bounds[1] +
-            when (alignment) {
-                Alignment.TopStart, Alignment.TopCenter, Alignment.TopEnd -> 0
-                Alignment.BottomStart, Alignment.BottomCenter, Alignment.BottomEnd -> slackY
-                else -> slackY / 2
-            }
-    return x to y
-}
-
-/**
  * Whether [next] is worth storing over [current].
  *
  * Named and pure because the alternative is invisible: a listener fires on every step of a window
@@ -410,42 +490,6 @@ internal fun shouldKeepMeasuring(
     bounds: IntArray?,
     attempts: Int,
 ): Boolean = bounds == null && attempts < MEASURE_ATTEMPTS
-
-/**
- * [bounds], with [inset] taken off its END and BOTTOM edges - the sub-region a caller anchored to
- * part of the window is actually placing itself in.
- *
- * Only the far edges, and that is the whole meaning rather than a simplification. The origin is
- * where a `TopStart` overlay goes, and a caller inset from the right and the bottom has not moved
- * its top-left corner anywhere - so a near-corner anchor must be unaffected while a far-corner one
- * moves by exactly the inset. Expressing it as a smaller rectangle rather than as an offset added
- * after the fact is what gets that for free, and keeps [cornerPosition]'s floor-at-the-origin
- * behaviour applying to the region rather than to the window.
- *
- * Widths floor at zero: an inset wider than the window would otherwise produce a negative extent,
- * and [cornerPosition] would read that as slack and place the overlay outside the parent.
- *
- * A zero inset returns [bounds] ITSELF, not a copy. Every caller that predates this passes zero,
- * and the result is a `remember` key: an equal-but-new array would change identity on every
- * recomposition and re-run the placement effect, which is a native `setLocation` each time.
- */
-
-internal fun insetBounds(
-    bounds: IntArray?,
-    inset: DpSize,
-): IntArray? {
-    // An unmeasurable parent stays unmeasurable, and a zero inset returns the SAME instance - see
-    // the KDoc on identity above.
-    if (bounds == null || inset == DpSize.Zero) return bounds
-    return intArrayOf(
-        bounds[0],
-        bounds[1],
-        // Rounded, not truncated: the inset is derived as px / density, which is not integral at
-        // fractional scale factors, and truncating loses up to a unit per axis.
-        (bounds[2] - inset.width.value.roundToInt()).coerceAtLeast(0),
-        (bounds[3] - inset.height.value.roundToInt()).coerceAtLeast(0),
-    )
-}
 
 /**
  * [initialSize], reduced to fit inside [bounds] when the parent is smaller.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/OverlayWindowBounds.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/OverlayWindowBounds.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
@@ -119,3 +120,32 @@ internal fun overlayRectOrScreen(
     bounds: IntArray?,
     screen: IntArray,
 ): IntArray = bounds ?: screen
+
+/**
+ * The rectangle the corner is resolved inside: an explicit [regionInWindow] when the caller gave
+ * one, otherwise [bounds] narrowed by [inset].
+ *
+ * [regionInWindow] is in dp relative to the content pane, matching `HeavyweightPopup`'s
+ * `anchorInWindow`, and AWT's logical units map 1:1 to dp - so this is an offset, never a scale.
+ *
+ * It is CLAMPED to [bounds] rather than trusted. The caller measures it from Compose layout while
+ * the pane is measured from AWT, and the two can disagree for a frame during a resize or a window
+ * move; an unclamped region wider than the pane would place an always-on-top overlay outside the
+ * window it belongs to. A degenerate region (zero or negative after clamping) falls back to the
+ * inset path, because placing the overlay at the pane corner is wrong but visible, whereas a
+ * zero-sized region puts it at the pane origin with no indication why.
+ */
+@Suppress("ReturnCount")
+internal fun resolveRegion(
+    bounds: IntArray?,
+    inset: DpSize,
+    regionInWindow: IntRect?,
+): IntArray? {
+    if (bounds == null || regionInWindow == null) return insetBounds(bounds, inset)
+    val left = regionInWindow.left.coerceIn(0, bounds[2])
+    val top = regionInWindow.top.coerceIn(0, bounds[3])
+    val width = regionInWindow.width.coerceAtMost(bounds[2] - left)
+    val height = regionInWindow.height.coerceAtMost(bounds[3] - top)
+    if (width <= 0 || height <= 0) return insetBounds(bounds, inset)
+    return intArrayOf(bounds[0] + left, bounds[1] + top, width, height)
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/OverlayWindowBounds.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/OverlayWindowBounds.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
@@ -12,6 +13,7 @@ import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import java.awt.GraphicsEnvironment
 import java.awt.Window
+import kotlin.math.roundToInt
 
 /**
  * Where a heavyweight overlay window (popup, modal) should be placed, shared by
@@ -148,4 +150,75 @@ internal fun resolveRegion(
     val height = regionInWindow.height.coerceAtMost(bounds[3] - top)
     if (width <= 0 || height <= 0) return insetBounds(bounds, inset)
     return intArrayOf(bounds[0] + left, bounds[1] + top, width, height)
+}
+
+/**
+ * Top-left corner, in AWT logical units, for an overlay of [size] placed at [alignment] inside
+ * [bounds] - or the origin when the parent could not be measured.
+ *
+ * Pure so the arithmetic is pinned by a test; composing a `Window` needs a display, so this is the
+ * only reachable part. Offsets are floored at zero so content larger than the parent overhangs the
+ * bottom-right rather than being pushed off the top-left, where it would be unreachable.
+ */
+internal fun cornerPosition(
+    bounds: IntArray?,
+    size: DpSize,
+    alignment: Alignment,
+): Pair<Int, Int> {
+    if (bounds == null) return 0 to 0
+    val width = size.width.value.toInt()
+    val height = size.height.value.toInt()
+    val slackX = (bounds[2] - width).coerceAtLeast(0)
+    val slackY = (bounds[3] - height).coerceAtLeast(0)
+    val x =
+        bounds[0] +
+            when (alignment) {
+                Alignment.TopStart, Alignment.CenterStart, Alignment.BottomStart -> 0
+                Alignment.TopEnd, Alignment.CenterEnd, Alignment.BottomEnd -> slackX
+                else -> slackX / 2
+            }
+    val y =
+        bounds[1] +
+            when (alignment) {
+                Alignment.TopStart, Alignment.TopCenter, Alignment.TopEnd -> 0
+                Alignment.BottomStart, Alignment.BottomCenter, Alignment.BottomEnd -> slackY
+                else -> slackY / 2
+            }
+    return x to y
+}
+
+/**
+ * [bounds], with [inset] taken off its END and BOTTOM edges - the sub-region a caller anchored to
+ * part of the window is actually placing itself in.
+ *
+ * Only the far edges, and that is the whole meaning rather than a simplification. The origin is
+ * where a `TopStart` overlay goes, and a caller inset from the right and the bottom has not moved
+ * its top-left corner anywhere - so a near-corner anchor must be unaffected while a far-corner one
+ * moves by exactly the inset. Expressing it as a smaller rectangle rather than as an offset added
+ * after the fact is what gets that for free, and keeps [cornerPosition]'s floor-at-the-origin
+ * behaviour applying to the region rather than to the window.
+ *
+ * Widths floor at zero: an inset wider than the window would otherwise produce a negative extent,
+ * and [cornerPosition] would read that as slack and place the overlay outside the parent.
+ *
+ * A zero inset returns [bounds] ITSELF, not a copy. Every caller that predates this passes zero,
+ * and the result is a `remember` key: an equal-but-new array would change identity on every
+ * recomposition and re-run the placement effect, which is a native `setLocation` each time.
+ */
+
+internal fun insetBounds(
+    bounds: IntArray?,
+    inset: DpSize,
+): IntArray? {
+    // An unmeasurable parent stays unmeasurable, and a zero inset returns the SAME instance - see
+    // the KDoc on identity above.
+    if (bounds == null || inset == DpSize.Zero) return bounds
+    return intArrayOf(
+        bounds[0],
+        bounds[1],
+        // Rounded, not truncated: the inset is derived as px / density, which is not integral at
+        // fractional scale factors, and truncating loses up to a unit per axis.
+        (bounds[2] - inset.width.value.roundToInt()).coerceAtLeast(0),
+        (bounds[3] - inset.height.value.roundToInt()).coerceAtLeast(0),
+    )
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/tab_types/fluck/BrowserFunctions.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin.tab_types.fluck
 
+import ai.rever.boss.plugin.browser.BrowserFindController
 import ai.rever.boss.plugin.browser.BrowserSettings
 import ai.rever.boss.plugin.browser.EngineInitError
 import ai.rever.boss.plugin.browser.FluckEngine
@@ -347,7 +348,7 @@ actual fun disposeBrowser(browser: Any) {
     try {
         val jxBrowser = browser as? Browser
         if (jxBrowser != null) {
-            FluckEngine.disposeBrowserFindBar(jxBrowser)
+            BrowserFindController.dispose(jxBrowser)
             if (!jxBrowser.isClosed) {
                 jxBrowser.close()
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -538,10 +538,12 @@ fun main(args: Array<String>) {
         alignment,
         initialSize,
         inset,
+        focusable,
+        regionInWindow,
         cornerContent,
         ->
         ai.rever.boss.components.overlays
-            .HeavyweightCorner(alignment, initialSize, inset, cornerContent)
+            .HeavyweightCorner(alignment, initialSize, inset, focusable, regionInWindow, cornerContent)
     }
     // plugin-ui-core owns the modal registry (plugins draw dialogs too) and depends on nothing but
     // Compose, so it cannot log. Give it this logger instead: the condition it reports is a dialog

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindBar.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindBar.kt
@@ -1,0 +1,353 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.teamdev.jxbrowser.browser.Browser
+import kotlin.math.roundToInt
+
+/** Height of the bar, and the size the corner overlay opens at before it measures. */
+internal val FIND_BAR_HEIGHT = 34.dp
+
+/**
+ * Upper bound the corner overlay is measured against.
+ *
+ * A ceiling, not a first guess: `HeavyweightCorner` measures content against this and never
+ * against its own window, so anything wider is CLIPPED rather than merely mis-sized on the first
+ * frame. Comfortably above the bar's natural width, which is the field plus a counter and four
+ * icon buttons.
+ */
+internal val FIND_BAR_CEILING = DpSize(360.dp, 60.dp)
+
+/**
+ * Gap between the bar and the pane's top and end edges, in dp.
+ *
+ * Applied by shrinking the anchor REGION rather than by padding the bar. Padding would work on the
+ * lightweight path and be actively wrong on the heavyweight one: that overlay window is sized to
+ * its content, so transparent padding grows the window, and a non-focusable AWT window still eats
+ * every click under it (the JVM has no portable click-through). The margin would become a dead
+ * strip across the top-right of the page.
+ */
+private const val FIND_BAR_MARGIN_DP = 8
+
+/**
+ * The rectangle a pane's find bar anchors inside: [boundsInWindow] converted to dp and pulled in
+ * by [FIND_BAR_MARGIN_DP], or null when there is nowhere sensible to put it.
+ *
+ * Null is a real answer, not a failure. `boundsInWindow` reports CLIPPED bounds, so a pane scrolled
+ * or collapsed out of view measures empty - and `HeavyweightCorner` resolves an unmeasurable parent
+ * to the screen origin, which would put an always-on-top bar in the corner of the primary display
+ * instead of over the page.
+ */
+@Suppress("ReturnCount")
+internal fun findBarRegion(
+    boundsInWindow: Rect,
+    density: Float,
+): IntRect? {
+    if (density <= 0f || !density.isFinite()) return null
+    if (!boundsInWindow.hasArea()) return null
+    val region =
+        IntRect(
+            left = (boundsInWindow.left / density).roundToInt(),
+            top = (boundsInWindow.top / density).roundToInt(),
+            right = (boundsInWindow.right / density).roundToInt(),
+            bottom = (boundsInWindow.bottom / density).roundToInt(),
+        ).deflate(FIND_BAR_MARGIN_DP)
+    // A pane narrower than twice the margin deflates to nothing. Better no bar than one placed at
+    // an inverted rectangle's corner.
+    return region.takeIf { it.width > 0 && it.height > 0 }
+}
+
+/**
+ * Whether this rectangle describes a real, finite area.
+ *
+ * `boundsInWindow` can be empty (a clipped-away pane) and, for a node in a degenerate layout, can
+ * carry infinities - which survive the division by density and turn into a garbage `IntRect`.
+ */
+private fun Rect.hasArea(): Boolean {
+    val w = width
+    val h = height
+    return w.isFinite() && h.isFinite() && w > 0f && h > 0f
+}
+
+/**
+ * Find-in-page bar for one browser pane.
+ *
+ * Replaces the Swing `JDialog` this used to be. Three things that were wrong there are properties
+ * of being Compose rather than fixes applied to it: colours come from [BossTheme] on every
+ * recomposition (the dialog snapshotted them at construction, so a theme switch never reached an
+ * open bar), the bar sizes itself, and it is placed by its caller against the browser pane rather
+ * than against the whole window.
+ *
+ * Owns no state. Everything is read from [state] and every change is a call into
+ * [BrowserFindController], so the two paths that can open this bar cannot end up with two
+ * different notions of what is being searched.
+ */
+@Composable
+internal fun BrowserFindBar(
+    browser: Browser,
+    state: BrowserFindState,
+) {
+    val colors = BossTheme.colors
+
+    // The field's own value, so the caret and selection live where the user put them. `state.query`
+    // is the authority on WHAT is searched and is written back on every edit; mirroring the caret
+    // into it as well would move the caret to the end on every recomposition driven by a search
+    // result arriving.
+    var field by remember { mutableStateOf(TextFieldValue(state.query)) }
+
+    Row(
+        modifier =
+            Modifier
+                .height(FIND_BAR_HEIGHT)
+                .background(colors.panel, RoundedCornerShape(6.dp))
+                .border(1.dp, colors.line, RoundedCornerShape(6.dp))
+                .padding(horizontal = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FindQueryField(
+            browser = browser,
+            state = state,
+            field = field,
+            onFieldChange = { field = it },
+        )
+
+        Spacer(Modifier.width(8.dp))
+
+        FindMatchCounter(state = state, hasQuery = field.text.isNotEmpty())
+
+        FindBarActions(browser = browser, state = state)
+    }
+}
+
+/** The query field, and every key the bar answers while it has focus. */
+@Composable
+private fun FindQueryField(
+    browser: Browser,
+    state: BrowserFindState,
+    field: TextFieldValue,
+    onFieldChange: (TextFieldValue) -> Unit,
+) {
+    val colors = BossTheme.colors
+    val focusRequester = remember { FocusRequester() }
+
+    // Cmd+F with the bar already open re-focuses and selects, which is what Chrome, Safari and
+    // Firefox all do. Keyed on the tick so a second request is a second event.
+    LaunchedEffect(state.focusTick) {
+        onFieldChange(field.copy(selection = TextRange(0, field.text.length)))
+        runCatching { focusRequester.requestFocus() }
+    }
+
+    BasicTextField(
+        value = field,
+        onValueChange = {
+            onFieldChange(it)
+            BrowserFindController.setQuery(browser, it.text)
+        },
+        singleLine = true,
+        textStyle =
+            MaterialTheme.typography.body2.copy(
+                color = colors.textPrimary,
+                fontSize = 13.sp,
+            ),
+        cursorBrush = SolidColor(colors.signal),
+        modifier =
+            Modifier
+                .width(150.dp)
+                .focusRequester(focusRequester)
+                // onPreviewKeyEvent, not onKeyEvent: Enter and Escape are handled BEFORE the text
+                // field sees them, or Enter inserts a newline into a single-line field (which
+                // silently does nothing) instead of advancing to the next match.
+                .onPreviewKeyEvent { event -> handleFindBarKey(browser, event) },
+        decorationBox = { inner ->
+            Box(contentAlignment = Alignment.CenterStart) {
+                if (field.text.isEmpty()) {
+                    Text(
+                        text = "Find in page",
+                        color = colors.textMuted,
+                        fontSize = 13.sp,
+                    )
+                }
+                inner()
+            }
+        },
+    )
+}
+
+/**
+ * The keys the field claims. Extracted so the decision is one readable table rather than a modifier
+ * lambda inside a modifier chain.
+ */
+private fun handleFindBarKey(
+    browser: Browser,
+    event: KeyEvent,
+): Boolean {
+    if (event.type != KeyEventType.KeyDown) return false
+    return when {
+        event.key == Key.Escape -> {
+            BrowserFindController.close(browser)
+            true
+        }
+
+        event.key == Key.Enter || event.key == Key.NumPadEnter -> {
+            submitFind(browser, backward = event.isShiftPressed)
+            true
+        }
+
+        // Cmd+G / Shift+Cmd+G, the macOS "find again" pair. Handled here as well as in the key
+        // callback because while this field holds focus the app's AWT interceptor resolves no
+        // window (the bar is its own always-on-top window) and so routes nothing.
+        event.key == Key.G && event.isMetaPressed -> {
+            submitFind(browser, backward = event.isShiftPressed)
+            true
+        }
+
+        else -> {
+            false
+        }
+    }
+}
+
+private fun submitFind(
+    browser: Browser,
+    backward: Boolean,
+) {
+    if (backward) BrowserFindController.previous(browser) else BrowserFindController.next(browser)
+}
+
+/**
+ * `n/total`, or nothing at all.
+ *
+ * Blank until a search for the CURRENT query has settled. Chromium reports progress updates while
+ * a search runs, and rendering those is what made the old Swing bar flash a red `0/0` on every
+ * keystroke.
+ */
+@Composable
+private fun FindMatchCounter(
+    state: BrowserFindState,
+    hasQuery: Boolean,
+) {
+    val colors = BossTheme.colors
+    val show = state.settled && hasQuery
+    Text(
+        text = if (show) "${state.currentMatch}/${state.totalMatches}" else "",
+        color = if (show && state.totalMatches == 0) colors.alert else colors.textSecondary,
+        fontSize = 11.sp,
+        modifier = Modifier.width(46.dp),
+    )
+}
+
+/** Previous, next, match-case and close. */
+@Composable
+private fun FindBarActions(
+    browser: Browser,
+    state: BrowserFindState,
+) {
+    val colors = BossTheme.colors
+    FindBarIcon(
+        icon = Icons.Filled.KeyboardArrowUp,
+        description = "Previous match",
+        enabled = state.totalMatches > 0,
+        tint = colors.textPrimary,
+        disabledTint = colors.textMuted,
+        onClick = { submitFind(browser, backward = true) },
+    )
+    FindBarIcon(
+        icon = Icons.Filled.KeyboardArrowDown,
+        description = "Next match",
+        enabled = state.totalMatches > 0,
+        tint = colors.textPrimary,
+        disabledTint = colors.textMuted,
+        onClick = { submitFind(browser, backward = false) },
+    )
+
+    // Text rather than an icon: there is no "match case" glyph in the bundled Material set, and
+    // "Aa" is what every browser's find bar uses for it.
+    IconButton(
+        onClick = { BrowserFindController.setMatchCase(browser, !state.matchCase) },
+        modifier = Modifier.size(26.dp),
+    ) {
+        Text(
+            text = "Aa",
+            color = if (state.matchCase) colors.signalText else colors.textMuted,
+            fontSize = 12.sp,
+            fontWeight = if (state.matchCase) FontWeight.Bold else FontWeight.Normal,
+        )
+    }
+
+    FindBarIcon(
+        icon = Icons.Filled.Close,
+        description = "Close find bar",
+        enabled = true,
+        tint = colors.textPrimary,
+        disabledTint = colors.textMuted,
+        onClick = { BrowserFindController.close(browser) },
+    )
+}
+
+@Composable
+private fun FindBarIcon(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    description: String,
+    enabled: Boolean,
+    tint: androidx.compose.ui.graphics.Color,
+    disabledTint: androidx.compose.ui.graphics.Color,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.size(26.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = description,
+            modifier = Modifier.size(16.dp),
+            tint = if (enabled) tint else disabledTint,
+        )
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindBar.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.Icon
@@ -31,10 +32,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
@@ -49,70 +53,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.teamdev.jxbrowser.browser.Browser
 import kotlin.math.roundToInt
-
-/** Height of the bar, and the size the corner overlay opens at before it measures. */
-internal val FIND_BAR_HEIGHT = 34.dp
-
-/**
- * Upper bound the corner overlay is measured against.
- *
- * A ceiling, not a first guess: `HeavyweightCorner` measures content against this and never
- * against its own window, so anything wider is CLIPPED rather than merely mis-sized on the first
- * frame. Comfortably above the bar's natural width, which is the field plus a counter and four
- * icon buttons.
- */
-internal val FIND_BAR_CEILING = DpSize(360.dp, 60.dp)
-
-/**
- * Gap between the bar and the pane's top and end edges, in dp.
- *
- * Applied by shrinking the anchor REGION rather than by padding the bar. Padding would work on the
- * lightweight path and be actively wrong on the heavyweight one: that overlay window is sized to
- * its content, so transparent padding grows the window, and a non-focusable AWT window still eats
- * every click under it (the JVM has no portable click-through). The margin would become a dead
- * strip across the top-right of the page.
- */
-private const val FIND_BAR_MARGIN_DP = 8
-
-/**
- * The rectangle a pane's find bar anchors inside: [boundsInWindow] converted to dp and pulled in
- * by [FIND_BAR_MARGIN_DP], or null when there is nowhere sensible to put it.
- *
- * Null is a real answer, not a failure. `boundsInWindow` reports CLIPPED bounds, so a pane scrolled
- * or collapsed out of view measures empty - and `HeavyweightCorner` resolves an unmeasurable parent
- * to the screen origin, which would put an always-on-top bar in the corner of the primary display
- * instead of over the page.
- */
-@Suppress("ReturnCount")
-internal fun findBarRegion(
-    boundsInWindow: Rect,
-    density: Float,
-): IntRect? {
-    if (density <= 0f || !density.isFinite()) return null
-    if (!boundsInWindow.hasArea()) return null
-    val region =
-        IntRect(
-            left = (boundsInWindow.left / density).roundToInt(),
-            top = (boundsInWindow.top / density).roundToInt(),
-            right = (boundsInWindow.right / density).roundToInt(),
-            bottom = (boundsInWindow.bottom / density).roundToInt(),
-        ).deflate(FIND_BAR_MARGIN_DP)
-    // A pane narrower than twice the margin deflates to nothing. Better no bar than one placed at
-    // an inverted rectangle's corner.
-    return region.takeIf { it.width > 0 && it.height > 0 }
-}
-
-/**
- * Whether this rectangle describes a real, finite area.
- *
- * `boundsInWindow` can be empty (a clipped-away pane) and, for a node in a degenerate layout, can
- * carry infinities - which survive the division by density and turn into a garbage `IntRect`.
- */
-private fun Rect.hasArea(): Boolean {
-    val w = width
-    val h = height
-    return w.isFinite() && h.isFinite() && w > 0f && h > 0f
-}
 
 /**
  * Find-in-page bar for one browser pane.
@@ -238,10 +178,14 @@ private fun handleFindBarKey(
             true
         }
 
-        // Cmd+G / Shift+Cmd+G, the macOS "find again" pair. Handled here as well as in the key
-        // callback because while this field holds focus the app's AWT interceptor resolves no
-        // window (the bar is its own always-on-top window) and so routes nothing.
-        event.key == Key.G && event.isMetaPressed -> {
+        // "Find again", both conventions. Handled here as well as in the key callback because
+        // while this field holds focus nothing else can: the bar is its own window, so the AWT
+        // interceptor resolves no window id and routes nothing, and the page is not focused.
+        //
+        // Platform-aware, unlike the first version of this: gating on isMetaPressed alone made
+        // find-again from the field macOS-only, since Ctrl+G matched nothing here and could not
+        // reach the browser either.
+        isFindAgainChord(event) -> {
             submitFind(browser, backward = event.isShiftPressed)
             true
         }
@@ -251,6 +195,15 @@ private fun handleFindBarKey(
         }
     }
 }
+
+/** Reads a Compose key event against the one find-again rule, which lives with the controller. */
+private fun isFindAgainChord(event: KeyEvent): Boolean =
+    isFindAgainChord(
+        isF3 = event.key == Key.F3,
+        isG = event.key == Key.G,
+        meta = event.isMetaPressed,
+        ctrl = event.isCtrlPressed,
+    )
 
 private fun submitFind(
     browser: Browser,
@@ -277,9 +230,18 @@ private fun FindMatchCounter(
         text = if (show) "${state.currentMatch}/${state.totalMatches}" else "",
         color = if (show && state.totalMatches == 0) colors.alert else colors.textSecondary,
         fontSize = 11.sp,
-        modifier = Modifier.width(46.dp),
+        modifier = Modifier.widthIn(min = 46.dp),
     )
 }
+
+/**
+ * Whether there is something to step through.
+ *
+ * Gated on `settled` as well as the count, so the arrows and the counter agree. `totalMatches` is
+ * not cleared when the query changes to a non-empty string - only `settled` is - so reading the
+ * count alone left the arrows enabled on the PREVIOUS query's total while the new search ran.
+ */
+private fun hasMatches(state: BrowserFindState): Boolean = state.settled && state.totalMatches > 0
 
 /** Previous, next, match-case and close. */
 @Composable
@@ -291,7 +253,7 @@ private fun FindBarActions(
     FindBarIcon(
         icon = Icons.Filled.KeyboardArrowUp,
         description = "Previous match",
-        enabled = state.totalMatches > 0,
+        enabled = hasMatches(state),
         tint = colors.textPrimary,
         disabledTint = colors.textMuted,
         onClick = { submitFind(browser, backward = true) },
@@ -299,7 +261,7 @@ private fun FindBarActions(
     FindBarIcon(
         icon = Icons.Filled.KeyboardArrowDown,
         description = "Next match",
-        enabled = state.totalMatches > 0,
+        enabled = hasMatches(state),
         tint = colors.textPrimary,
         disabledTint = colors.textMuted,
         onClick = { submitFind(browser, backward = false) },
@@ -331,11 +293,11 @@ private fun FindBarActions(
 
 @Composable
 private fun FindBarIcon(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     description: String,
     enabled: Boolean,
-    tint: androidx.compose.ui.graphics.Color,
-    disabledTint: androidx.compose.ui.graphics.Color,
+    tint: Color,
+    disabledTint: Color,
     onClick: () -> Unit,
 ) {
     IconButton(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindController.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindController.kt
@@ -1,0 +1,444 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.utils.SystemUtils
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.search.FindOptions
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+
+/** How long typing settles before a search is issued. */
+private const val SEARCH_DEBOUNCE_MS = 150
+
+/**
+ * How long the page gets to claim the find chord before we open our own bar.
+ *
+ * Generous enough for a `setTimeout(…, 0)` on a busy main thread, short enough that a page
+ * which cannot report at all (see [BrowserFindKeyProbe]) does not feel like a stall.
+ */
+private const val PAGE_VERDICT_DEADLINE_MS = 150
+
+/**
+ * How long a find request is treated as already served for the same browser.
+ *
+ * Held-key auto-repeat delivers the find chord over and over, and each one would otherwise restart
+ * the page-verdict deadline - so the bar would not appear until the key was released. Also the
+ * belt-and-braces guard against the two entry paths both serving one press: they are mutually
+ * exclusive by construction (whichever of AWT and Chromium gets the key, the other never sees it),
+ * but that rests on native focus behaviour that differs between rendering modes, and a
+ * double-toggle degrades into a bar that flickers rather than into a visible error.
+ */
+private const val SINGLE_FLIGHT_MS = 200L
+
+/**
+ * Observable find-in-page state for one browser. Read by [BrowserFindBar], written only by
+ * [BrowserFindController] on the AWT event thread.
+ */
+internal class BrowserFindState {
+    var visible by mutableStateOf(false)
+
+    var query by mutableStateOf("")
+
+    var matchCase by mutableStateOf(false)
+
+    var currentMatch by mutableStateOf(0)
+
+    var totalMatches by mutableStateOf(0)
+
+    /**
+     * Whether a search for the CURRENT [query] has finished.
+     *
+     * The counter renders nothing until this is true, which is what removes the red `0/0`
+     * flash on every keystroke: Chromium reports progress updates while a search runs, and
+     * during those `numberOfMatches()` is a partial tally and `selectedMatch()` may not be
+     * meaningful yet. Showing the previous query's count instead would be worse - a real
+     * number, for the wrong text.
+     */
+    var settled by mutableStateOf(false)
+
+    /**
+     * Bumped when the field should take focus and select its contents.
+     *
+     * A tick rather than a boolean because the request repeats: Cmd+F with the bar already
+     * open re-focuses it (what Chrome, Safari and Firefox all do), and a boolean already
+     * true cannot express a second request.
+     */
+    var focusTick by mutableStateOf(0)
+}
+
+/**
+ * The single owner of find-in-page: state, the `TextFinder` conversation, and the decision of
+ * whether the page or BOSS serves the find chord.
+ *
+ * Replaces the Swing `JDialog` bar that used to live in `FluckEngine`. That one was reachable
+ * only from `PressKeyCallback`, positioned itself against the whole window (so both panes of a
+ * split stacked their bars in one corner), snapshotted theme colours at construction, and
+ * suppressed the key so a page could never serve its own find. See [BrowserFindBar] for the UI
+ * and [BrowserFindKeyProbe] for how the page is asked.
+ *
+ * **Everything here runs on the AWT event thread**, which is also Compose Desktop's
+ * composition thread, so state writes and recomposition stay ordered. `TextFinder` replies
+ * arrive on a JxBrowser thread and are hopped across explicitly.
+ */
+@Suppress("TooManyFunctions")
+internal object BrowserFindController {
+    private val logger = BossLogger.forComponent("BrowserFindController")
+
+    private val states = ConcurrentHashMap<Browser, BrowserFindState>()
+    private val locks = ConcurrentHashMap<Browser, ReentrantReadWriteLock>()
+    private val debounces = ConcurrentHashMap<Browser, Timer>()
+    private val pendingVerdicts = ConcurrentHashMap<Browser, Timer>()
+    private val lastRequestAtMs = ConcurrentHashMap<Browser, Long>()
+    private val lastShortcutAtMs = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Which search session a reply belongs to.
+     *
+     * Not decoration. `TextFinderImpl.find` allocates a fresh request id per call and keeps a
+     * live consumer for each, so the debounce - which does not and cannot cancel a search
+     * already in flight - leaves several sessions reporting at once. Without this the label
+     * shows whichever session FINISHED last, which is not the one for the latest query.
+     */
+    private val epochs = ConcurrentHashMap<Browser, AtomicLong>()
+
+    /**
+     * Adopt [browser]. [lock] should be the owning handle's browser lock so find calls take the
+     * same read lock as every other access to it; a browser created outside a
+     * [BrowserHandleImpl] gets its own.
+     */
+    fun register(
+        browser: Browser,
+        lock: ReentrantReadWriteLock = ReentrantReadWriteLock(),
+    ) {
+        locks.putIfAbsent(browser, lock)
+        epochs.putIfAbsent(browser, AtomicLong())
+    }
+
+    /** Observable state for [browser], created on first use. */
+    fun stateFor(browser: Browser): BrowserFindState = states.computeIfAbsent(browser) { BrowserFindState() }
+
+    /**
+     * Serve the find chord that JxBrowser just delivered for [browser].
+     *
+     * @return true when the key should be SUPPRESSED (the bar is already up, so it is ours),
+     *   false when it should PROCEED to the page. Proceeding is what lets a site with its own
+     *   find-in-page keep it; the verdict from [BrowserFindKeyProbe] then decides whether our
+     *   bar opens too. See [PAGE_VERDICT_DEADLINE_MS] for what happens when no verdict arrives.
+     */
+    @Suppress("ReturnCount")
+    fun onFindKeyFromPage(browser: Browser): Boolean {
+        // Checked BEFORE the single-flight claim, not after: a bar that is up owns the chord for as
+        // long as it is up, and gating this on the claim swallowed a fast second press - suppressing
+        // the key while doing nothing with it.
+        if (stateFor(browser).visible) {
+            onEdt { focusField(browser) }
+            return true
+        }
+        // A verdict is already pending for this press, which is what held-key auto-repeat looks
+        // like. Proceed again so the page keeps seeing the key, but do not restart the deadline -
+        // that would delay our bar for as long as the key is held.
+        if (!claimRequest(browser)) return false
+        onEdt { awaitPageVerdict(browser) }
+        return false
+    }
+
+    /**
+     * Serve the find chord that AWT intercepted before the browser could see it - the
+     * `browser.find` keymap action.
+     *
+     * Which of the two paths runs is not a choice we make: under HARDWARE_ACCELERATED the
+     * shared-surface widget has no focus wiring, so a tab that has just been re-shown holds no
+     * keyboard focus and AWT gets the key; under OFF_SCREEN the Compose widget is the AWT focus
+     * owner and the interceptor consumes the key before it can be forwarded.
+     *
+     * Rather than fork the behaviour, hand the key to the browser and let the ONE decision
+     * point above run. Otherwise a page-owned Cmd+F would work or not depending on which
+     * rendering mode is active, which is exactly the flakiness this change exists to remove.
+     */
+    @Suppress("ReturnCount")
+    fun onFindKeyFromShortcut(browser: Browser) {
+        if (stateFor(browser).visible) {
+            onEdt { focusField(browser) }
+            return
+        }
+        if (browser.isClosed) return
+        try {
+            val modifiers =
+                com.teamdev.jxbrowser.ui.KeyModifiers
+                    .newBuilder()
+                    .apply { if (SystemUtils.isMacOS) metaDown(true) else controlDown(true) }
+                    .build()
+            browser.dispatch(
+                com.teamdev.jxbrowser.ui.event.KeyPressed
+                    .newBuilder(com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F)
+                    .keyModifiers(modifiers)
+                    .build(),
+            )
+            browser.dispatch(
+                com.teamdev.jxbrowser.ui.event.KeyReleased
+                    .newBuilder(com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F)
+                    .keyModifiers(modifiers)
+                    .build(),
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception,
+        ) {
+            // A tab closing under us is the expected case. Fall back to opening our own bar
+            // rather than dropping the shortcut: the user asked to search something.
+            logger.debug(
+                LogCategory.BROWSER,
+                "Could not hand the find chord to the page - opening the BOSS find bar",
+                mapOf("error" to (e::class.simpleName ?: "Exception")),
+            )
+            onEdt { open(browser) }
+        }
+    }
+
+    /**
+     * Serve the "find again" chord (Cmd+G / Shift+Cmd+G) delivered for [browser].
+     *
+     * @return true when the key should be SUPPRESSED. Only claimed while our bar is up with
+     *   something in it - otherwise the chord does nothing here and belongs to the page, which may
+     *   well have its own meaning for it.
+     *
+     * Deliberately NOT single-flighted, unlike the find chord: repeat presses advancing through
+     * matches is the entire purpose, so collapsing them would break it. Held-key auto-repeat
+     * walking the matches is what Chrome does too.
+     */
+    fun onFindAgainKey(
+        browser: Browser,
+        backward: Boolean,
+    ): Boolean {
+        val state = stateFor(browser)
+        if (!state.visible || state.query.isEmpty()) return false
+        onEdt { if (backward) previous(browser) else next(browser) }
+        return true
+    }
+
+    /** The page's answer to a chord we proceeded with. See [BrowserFindKeyProbe]. */
+    fun onPageVerdict(
+        browser: Browser,
+        pageHandledKey: Boolean,
+    ) = onEdt {
+        // No decision waiting means the report is late, or a page called the bridge on its own.
+        // Either way there is nothing to resolve, which is also what makes a page spamming the
+        // bridge cheap to serve.
+        val timer = pendingVerdicts.remove(browser) ?: return@onEdt
+        timer.stop()
+        if (!pageHandledKey) open(browser)
+    }
+
+    fun setQuery(
+        browser: Browser,
+        text: String,
+    ) = onEdt {
+        val state = stateFor(browser)
+        if (state.query == text) return@onEdt
+        state.query = text
+        // Cleared BEFORE the search, so the counter goes blank rather than briefly showing the
+        // previous query's total against the new text.
+        state.settled = false
+        if (text.isEmpty()) {
+            state.totalMatches = 0
+            state.currentMatch = 0
+            debounces.remove(browser)?.stop()
+            bumpEpoch(browser)
+            withFinder(browser) { it.stopFindingAndClearSelection() }
+            return@onEdt
+        }
+        debounces
+            .computeIfAbsent(browser) {
+                Timer(SEARCH_DEBOUNCE_MS) { runFind(browser, backward = false) }.apply { isRepeats = false }
+            }.restart()
+    }
+
+    fun setMatchCase(
+        browser: Browser,
+        enabled: Boolean,
+    ) = onEdt {
+        val state = stateFor(browser)
+        if (state.matchCase == enabled) return@onEdt
+        state.matchCase = enabled
+        state.settled = false
+        runFind(browser, backward = false)
+    }
+
+    fun next(browser: Browser) = onEdt { runFind(browser, backward = false) }
+
+    fun previous(browser: Browser) = onEdt { runFind(browser, backward = true) }
+
+    fun open(browser: Browser) =
+        onEdt {
+            val state = stateFor(browser)
+            state.visible = true
+            focusField(browser)
+            // Re-opening on a query that is still there searches again rather than showing a count
+            // from before the page may have changed under it.
+            if (state.query.isNotEmpty()) runFind(browser, backward = false)
+        }
+
+    fun close(browser: Browser) =
+        onEdt {
+            val state = stateFor(browser)
+            state.visible = false
+            state.settled = false
+            debounces.remove(browser)?.stop()
+            pendingVerdicts.remove(browser)?.stop()
+            bumpEpoch(browser)
+            withFinder(browser) {
+                // KEEP, not clear. Clearing drops the selection, which scrolls the reader back to
+                // wherever they were before searching - throwing away the very result they went
+                // looking for. Chrome keeps the match; an empty query has no match to keep.
+                if (state.query.isEmpty()) it.stopFindingAndClearSelection() else it.stopFindingAndKeepSelection()
+            }
+            // Our bar held keyboard focus in its own window; hand it back so the page is
+            // immediately scrollable and typeable again.
+            if (!browser.isClosed) {
+                try {
+                    browser.focus()
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") e: Exception,
+                ) {
+                    logger.debug(
+                        LogCategory.BROWSER,
+                        "Could not return focus to the page after closing find",
+                        mapOf("error" to (e::class.simpleName ?: "Exception")),
+                    )
+                }
+            }
+        }
+
+    /** Release everything held for [browser]. Safe to call more than once. */
+    fun dispose(browser: Browser) {
+        debounces.remove(browser)?.stop()
+        pendingVerdicts.remove(browser)?.stop()
+        states.remove(browser)
+        locks.remove(browser)
+        epochs.remove(browser)
+        lastRequestAtMs.remove(browser)
+    }
+
+    // ============================================================
+    // internals
+    // ============================================================
+
+    /**
+     * Start the deadline that opens our bar if the page never answers.
+     *
+     * The deadline is not a safety net for a rare case - it is the normal path for every
+     * document [BrowserFindKeyProbe]'s script cannot reach: the built-in PDF viewer, network
+     * error pages, `about:` URLs, and any frame where injection failed.
+     */
+    private fun awaitPageVerdict(browser: Browser) {
+        pendingVerdicts.remove(browser)?.stop()
+        val timer =
+            Timer(PAGE_VERDICT_DEADLINE_MS) {
+                if (pendingVerdicts.remove(browser) != null) open(browser)
+            }.apply { isRepeats = false }
+        pendingVerdicts[browser] = timer
+        timer.start()
+    }
+
+    private fun focusField(browser: Browser) {
+        stateFor(browser).focusTick++
+    }
+
+    private fun bumpEpoch(browser: Browser): Long = epochs.computeIfAbsent(browser) { AtomicLong() }.incrementAndGet()
+
+    private fun runFind(
+        browser: Browser,
+        backward: Boolean,
+    ) {
+        debounces[browser]?.stop()
+        val state = stateFor(browser)
+        val query = state.query
+        if (query.isEmpty()) return
+        val epoch = bumpEpoch(browser)
+        val options =
+            FindOptions
+                .newBuilder()
+                .matchCase(state.matchCase)
+                .searchBackward(backward)
+                .build()
+        withFinder(browser) { finder ->
+            finder.find(query, options) { result ->
+                // JxBrowser thread. Hop before touching snapshot state.
+                onEdt {
+                    if (epochs[browser]?.get() != epoch) return@onEdt
+                    // A progress update, not an answer: numberOfMatches() is a running tally
+                    // here and selectedMatch() need not be meaningful yet. Ignoring these is
+                    // what stops the counter flashing 0/0 on every keystroke.
+                    if (result.isSearching()) return@onEdt
+                    state.totalMatches = result.numberOfMatches()
+                    state.currentMatch = result.selectedMatch()
+                    state.settled = true
+                }
+            }
+        }
+    }
+
+    /**
+     * Run [block] against [browser]'s text finder, or do nothing.
+     *
+     * The `isClosed` check is the cheap path and the try/catch is the real guard - the same
+     * split [LockedBrowser.urlOrEmpty] documents. It matters more here than elsewhere in this
+     * file because two of the callers are timers: a debounce can fire up to
+     * [SEARCH_DEBOUNCE_MS] after the tab it belongs to was closed.
+     */
+    private inline fun withFinder(
+        browser: Browser,
+        block: (LockedTextFinder) -> Unit,
+    ) {
+        if (browser.isClosed) return
+        try {
+            block(LockedBrowser(browser, locks.computeIfAbsent(browser) { ReentrantReadWriteLock() }).textFinder())
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception,
+        ) {
+            logger.debug(
+                LogCategory.BROWSER,
+                "Find operation failed",
+                mapOf("error" to (e::class.simpleName ?: "Exception")),
+            )
+        }
+    }
+
+    /**
+     * Collapse a request repeated inside [SINGLE_FLIGHT_MS] for the same browser.
+     *
+     * @return true if the caller owns this request.
+     */
+    private fun claimRequest(browser: Browser): Boolean {
+        val now = System.currentTimeMillis()
+        val previous = lastRequestAtMs.put(browser, now)
+        return previous == null || now - previous >= SINGLE_FLIGHT_MS
+    }
+
+    /**
+     * Claim one `browser.find` event for [windowId], so only the first responder serves it.
+     *
+     * `browserFindEvents` is a broadcast and every composed browser surface in the window
+     * collects it. Two can believe they qualify at once: `LocalIsPanelActive` defaults to true, so
+     * a browser rendered in a sidebar slot reads as active alongside the main panel's. Without
+     * this, one Cmd+F would open two find bars in one window.
+     *
+     * Per WINDOW, unlike [claimRequest] which is per browser: the point is to pick one of several
+     * browsers, which a per-browser guard cannot do.
+     */
+    fun claimShortcut(windowId: String): Boolean {
+        val now = System.currentTimeMillis()
+        val previous = lastShortcutAtMs.put(windowId, now)
+        return previous == null || now - previous >= SINGLE_FLIGHT_MS
+    }
+
+    private inline fun onEdt(crossinline block: () -> Unit) {
+        if (SwingUtilities.isEventDispatchThread()) block() else SwingUtilities.invokeLater { block() }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindController.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindController.kt
@@ -38,6 +38,26 @@ private const val PAGE_VERDICT_DEADLINE_MS = 150
 private const val SINGLE_FLIGHT_MS = 200L
 
 /**
+ * Cmd+G on macOS, Ctrl+G elsewhere, and F3 everywhere - the two conventions for "find again".
+ *
+ * The one rule, in one place: `FluckEngine`'s key callback serves this chord when the page has
+ * focus and [BrowserFindBar] serves it when the field does, and the first version of the second one
+ * gated on the Meta modifier alone - which made find-again from the field macOS-only, with nothing
+ * else able to serve it because the bar owns keyboard focus while it is up.
+ */
+@Suppress("ReturnCount")
+internal fun isFindAgainChord(
+    isF3: Boolean,
+    isG: Boolean,
+    meta: Boolean,
+    ctrl: Boolean,
+): Boolean {
+    if (isF3) return true
+    if (!isG) return false
+    return if (SystemUtils.isMacOS) meta && !ctrl else ctrl && !meta
+}
+
+/**
  * Observable find-in-page state for one browser. Read by [BrowserFindBar], written only by
  * [BrowserFindController] on the AWT event thread.
  */
@@ -96,6 +116,13 @@ internal object BrowserFindController {
     private val debounces = ConcurrentHashMap<Browser, Timer>()
     private val pendingVerdicts = ConcurrentHashMap<Browser, Timer>()
     private val lastRequestAtMs = ConcurrentHashMap<Browser, Long>()
+
+    /**
+     * Bounded, unlike a plain map keyed by window id: `dispose(browser)` cannot know which window a
+     * shortcut claim belonged to, so nothing would ever prune it over a long session with many
+     * windows. Only the most recent claims can matter - the window is [SINGLE_FLIGHT_MS] - so the
+     * oldest entry is dropped once the map exceeds the number of windows anyone opens at once.
+     */
     private val lastShortcutAtMs = ConcurrentHashMap<String, Long>()
 
     /**
@@ -107,6 +134,21 @@ internal object BrowserFindController {
      * shows whichever session FINISHED last, which is not the one for the latest query.
      */
     private val epochs = ConcurrentHashMap<Browser, AtomicLong>()
+
+    /**
+     * Browsers that have been disposed, so teardown is final.
+     *
+     * Without this every accessor here resurrects its own entry - `stateFor`, `bumpEpoch` and
+     * `withFinder` all use `computeIfAbsent`, `claimRequest` uses `put` - so a key event or a
+     * verdict arriving after the tab closed re-created the state, and `awaitPageVerdict` re-created
+     * a live `Timer` with it.
+     *
+     * A `Collections.newSetFromMap(WeakHashMap())` rather than a strong set: this is the one
+     * structure that outlives the browser on purpose, so it must not be the thing that retains it.
+     * Same choice, for the same reason, as [BrowserInjectDispatcher]'s injector map.
+     */
+    private val disposedBrowsers: MutableSet<Browser> =
+        java.util.Collections.synchronizedSet(java.util.Collections.newSetFromMap(java.util.WeakHashMap()))
 
     /**
      * Adopt [browser]. [lock] should be the owning handle's browser lock so find calls take the
@@ -134,6 +176,7 @@ internal object BrowserFindController {
      */
     @Suppress("ReturnCount")
     fun onFindKeyFromPage(browser: Browser): Boolean {
+        if (isDisposed(browser)) return false
         // Checked BEFORE the single-flight claim, not after: a bar that is up owns the chord for as
         // long as it is up, and gating this on the claim swallowed a fast second press - suppressing
         // the key while doing nothing with it.
@@ -164,10 +207,22 @@ internal object BrowserFindController {
      */
     @Suppress("ReturnCount")
     fun onFindKeyFromShortcut(browser: Browser) {
+        if (isDisposed(browser)) return
         if (stateFor(browser).visible) {
             onEdt { focusField(browser) }
             return
         }
+        if (!claimRequest(browser)) return
+        // Armed BEFORE the dispatch, and this ordering is the whole robustness of this path.
+        // Everything after the dispatch depends on JxBrowser re-entering this browser's own
+        // PressKeyCallback for a programmatically dispatched key. If it does not, and the deadline
+        // were only started there, Cmd+F on the AWT-focus path would do exactly what it did before
+        // this change: nothing - the original bug, restored on the one path this exists to repair.
+        //
+        // Arming first makes every outcome end in something happening: the re-entry finds the claim
+        // taken and proceeds without touching the timer, a page that claims the chord resolves it
+        // through the probe, and silence resolves it through the deadline.
+        onEdt { awaitPageVerdict(browser) }
         if (browser.isClosed) return
         try {
             val modifiers =
@@ -190,14 +245,14 @@ internal object BrowserFindController {
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Exception,
         ) {
-            // A tab closing under us is the expected case. Fall back to opening our own bar
-            // rather than dropping the shortcut: the user asked to search something.
+            // A tab closing under us is the expected case. Resolve the decision this armed rather
+            // than calling open() beside a timer that is still running, so the bar opens once.
             logger.debug(
                 LogCategory.BROWSER,
                 "Could not hand the find chord to the page - opening the BOSS find bar",
                 mapOf("error" to (e::class.simpleName ?: "Exception")),
             )
-            onEdt { open(browser) }
+            onPageVerdict(browser, pageHandledKey = false)
         }
     }
 
@@ -212,10 +267,12 @@ internal object BrowserFindController {
      * matches is the entire purpose, so collapsing them would break it. Held-key auto-repeat
      * walking the matches is what Chrome does too.
      */
+    @Suppress("ReturnCount")
     fun onFindAgainKey(
         browser: Browser,
         backward: Boolean,
     ): Boolean {
+        if (isDisposed(browser)) return false
         val state = stateFor(browser)
         if (!state.visible || state.query.isEmpty()) return false
         onEdt { if (backward) previous(browser) else next(browser) }
@@ -227,6 +284,7 @@ internal object BrowserFindController {
         browser: Browser,
         pageHandledKey: Boolean,
     ) = onEdt {
+        if (isDisposed(browser)) return@onEdt
         // No decision waiting means the report is late, or a page called the bridge on its own.
         // Either way there is nothing to resolve, which is also what makes a page spamming the
         // bridge cheap to serve.
@@ -317,6 +375,9 @@ internal object BrowserFindController {
 
     /** Release everything held for [browser]. Safe to call more than once. */
     fun dispose(browser: Browser) {
+        // Recorded FIRST: the removals below race a verdict or a key event already in flight, and
+        // whichever of them lands next must find the browser dead rather than re-create its state.
+        disposedBrowsers += browser
         debounces.remove(browser)?.stop()
         pendingVerdicts.remove(browser)?.stop()
         states.remove(browser)
@@ -324,6 +385,8 @@ internal object BrowserFindController {
         epochs.remove(browser)
         lastRequestAtMs.remove(browser)
     }
+
+    private fun isDisposed(browser: Browser): Boolean = browser in disposedBrowsers
 
     // ============================================================
     // internals
@@ -397,8 +460,13 @@ internal object BrowserFindController {
         block: (LockedTextFinder) -> Unit,
     ) {
         if (browser.isClosed) return
+        // Fails closed on a missing lock rather than minting a fresh one. A substituted lock is a
+        // DIFFERENT object from the handle's, which quietly drops the mutual exclusion that the
+        // register(browser, browserLock) overload exists to provide - and the only way the entry is
+        // absent is that the browser was disposed, where skipping the search is what we want anyway.
+        val lock = locks[browser] ?: return
         try {
-            block(LockedBrowser(browser, locks.computeIfAbsent(browser) { ReentrantReadWriteLock() }).textFinder())
+            block(LockedBrowser(browser, lock).textFinder())
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Exception,
         ) {
@@ -416,7 +484,7 @@ internal object BrowserFindController {
      * @return true if the caller owns this request.
      */
     private fun claimRequest(browser: Browser): Boolean {
-        val now = System.currentTimeMillis()
+        val now = nowMs()
         val previous = lastRequestAtMs.put(browser, now)
         return previous == null || now - previous >= SINGLE_FLIGHT_MS
     }
@@ -433,10 +501,26 @@ internal object BrowserFindController {
      * browsers, which a per-browser guard cannot do.
      */
     fun claimShortcut(windowId: String): Boolean {
-        val now = System.currentTimeMillis()
+        val now = nowMs()
         val previous = lastShortcutAtMs.put(windowId, now)
+        if (lastShortcutAtMs.size > MAX_TRACKED_WINDOWS) {
+            lastShortcutAtMs.entries
+                .minByOrNull { it.value }
+                ?.let { lastShortcutAtMs.remove(it.key, it.value) }
+        }
         return previous == null || now - previous >= SINGLE_FLIGHT_MS
     }
+
+    /**
+     * Monotonic milliseconds, for the elapsed-time windows above.
+     *
+     * `System.currentTimeMillis()` is wall clock: an NTP correction or a sleep/wake step can refuse
+     * a claim that should have been granted, or grant one that 200 ms of real time has not covered.
+     */
+    private fun nowMs(): Long = System.nanoTime() / 1_000_000
+
+    /** Far above any real window count; a backstop, not a policy. */
+    private const val MAX_TRACKED_WINDOWS = 64
 
     private inline fun onEdt(crossinline block: () -> Unit) {
         if (SwingUtilities.isEventDispatchThread()) block() else SwingUtilities.invokeLater { block() }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindKeyProbe.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindKeyProbe.kt
@@ -1,0 +1,152 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import com.teamdev.jxbrowser.js.JsAccessible
+
+/**
+ * Asks the PAGE whether it wants to own the find shortcut, so a site with its own
+ * find-in-page (Google Sheets, Docs, Notion) keeps it instead of being overridden.
+ *
+ * ## Why this exists at all
+ *
+ * JxBrowser's key hook gives us exactly two answers — `PressKeyCallback.Response.proceed()`
+ * and `.suppress()` — and no way to learn whether the page did anything with a key it was
+ * given. There is no API for this in 9.4.0; the search package is `TextFinder` plus
+ * `FindOptions`/`FindResult` and nothing else. So the page has to tell us.
+ *
+ * Chrome answers the same question the same way. Ctrl/Cmd+F is a *non-reserved* accelerator
+ * there: the page sees the key first, and if it calls `preventDefault()` Chrome skips its own
+ * find bar. That is the entire mechanism behind Sheets' find working in Chrome, and matching
+ * it means we inherit every site that already knows how to opt in — no allowlist to maintain.
+ *
+ * ## How the verdict is read
+ *
+ * One capture-phase `keydown` listener on `window`. Capture on `window` is the FIRST thing in
+ * the dispatch path, and this is injected at document start, so it runs before any handler the
+ * page registers.
+ *
+ * The verdict is read from a `setTimeout(…, 0)` rather than from the listener body, and that
+ * deferral is load-bearing twice over:
+ *
+ *  - `defaultPrevented` is only final once dispatch has finished. Read inline, in the first
+ *    listener to run, it is always false.
+ *  - It survives `stopPropagation()`. The obvious alternative — a second listener at the
+ *    bubble phase on `window`, reading the flag there — never fires when a page stops
+ *    propagation partway, which is precisely what Sheets and Docs do. The timeout is queued
+ *    from the capture phase, so nothing the page does downstream can cancel it.
+ *
+ * ## What a page can do with this
+ *
+ * Nothing it could not already do. The only lever is "suppress BOSS's find bar on my own
+ * page", and calling `preventDefault()` on the key already achieves exactly that — which is
+ * the sanctioned way to ask. A page spamming [BrowserFindKeyProbeBridge.report] gains no new
+ * capability, and the bridge drops a report with no decision waiting on it, so the loop is
+ * cheap to serve.
+ */
+internal object BrowserFindKeyProbe {
+    /** Property the bridge is published on, per frame. Matched by [source]. */
+    const val BRIDGE_PROPERTY: String = "__bossFindProbe"
+
+    /** Guard so re-injection into the same document is a no-op. */
+    private const val STARTED_FLAG = "__bossFindProbeStarted"
+
+    /** [report] argument when the page called `preventDefault()` on the find chord. */
+    const val VERDICT_HANDLED: String = "handled"
+
+    /** [report] argument when the find chord passed through the page untouched. */
+    const val VERDICT_FREE: String = "free"
+
+    /**
+     * The probe source.
+     *
+     * Reads nothing from the DOM and nothing from the event but its key identity and modifier
+     * flags, so unlike [BrowserInteractionScript] there is no privacy surface to describe.
+     *
+     * `event.code` is the physical key, which is what an accelerator is defined against — a
+     * Dvorak or AZERTY layout puts a different character on that key, and Chromium fires the
+     * accelerator on the position either way. `keyCode` is the fallback purely for a frame
+     * whose engine predates `code`; both are checked rather than one, because getting this
+     * wrong fails SILENTLY (no report, so the deadline elapses and our bar opens over the
+     * page's own).
+     */
+    val source: String =
+        """
+        (function () {
+          if (window.$STARTED_FLAG) return;
+          window.$STARTED_FLAG = true;
+          try {
+            var isMac = (navigator.platform || '').toLowerCase().indexOf('mac') === 0;
+            window.addEventListener('keydown', function (e) {
+              try {
+                var isF = e.code === 'KeyF' || e.keyCode === 70;
+                if (!isF) return;
+                // Mirrors the host's isMainModifierDown: Cmd on macOS, Ctrl elsewhere, and
+                // never both. Shift and Alt are excluded here for the same reason they are
+                // excluded there - Cmd+Shift+F is Focus Mode, not find.
+                var mod = isMac ? (e.metaKey && !e.ctrlKey) : (e.ctrlKey && !e.metaKey);
+                if (!mod || e.shiftKey || e.altKey) return;
+                setTimeout(function () {
+                  try {
+                    var bridge = window.$BRIDGE_PROPERTY;
+                    if (bridge) {
+                      bridge.report(e.defaultPrevented ? '$VERDICT_HANDLED' : '$VERDICT_FREE');
+                    }
+                  } catch (ignored) {}
+                }, 0);
+              } catch (ignored) {}
+            }, true);
+          } catch (ignored) {}
+        })();
+        """.trimIndent()
+}
+
+/**
+ * Page→host end of [BrowserFindKeyProbe]. One instance per browser, published on every
+ * frame's `window.__bossFindProbe`.
+ *
+ * [report] runs on a JxBrowser thread and must never block or throw into the page's JS
+ * thread — a throw here surfaces in the site's own console and can break its scripts. The
+ * exception CLASS is logged, never a message: this is reached from arbitrary pages, and a
+ * message could carry page detail into a log line.
+ */
+internal class BrowserFindKeyProbeBridge(
+    private val onVerdict: (pageHandledKey: Boolean) -> Unit,
+) {
+    private val logger = BossLogger.forComponent("BrowserFindKeyProbeBridge")
+
+    @JsAccessible
+    fun report(verdict: String) {
+        try {
+            when (verdict) {
+                BrowserFindKeyProbe.VERDICT_HANDLED -> onVerdict(true)
+
+                BrowserFindKeyProbe.VERDICT_FREE -> onVerdict(false)
+
+                // Anything else is a page calling the bridge with its own argument. Dropped
+                // rather than guessed: guessing "free" would let a site open our find bar it
+                // never asked for, and guessing "handled" would let it suppress one the user
+                // did ask for.
+                else -> Unit
+            }
+        } catch (e: LinkageError) {
+            // A wiring break rather than bad input: this class or the code it calls is not
+            // what it was compiled against. Enumerated rather than caught as Throwable,
+            // matching BrowserInteractionBridge - an OutOfMemoryError is not this boundary's
+            // to swallow.
+            report(e)
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception,
+        ) {
+            report(e)
+        }
+    }
+
+    private fun report(error: Throwable) {
+        logger.debug(
+            LogCategory.BROWSER,
+            "Find-key probe verdict rejected",
+            mapOf("error" to (error::class.simpleName ?: "Exception")),
+        )
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindKeyProbe.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindKeyProbe.kt
@@ -10,15 +10,15 @@ import com.teamdev.jxbrowser.js.JsAccessible
  *
  * ## Why this exists at all
  *
- * JxBrowser's key hook gives us exactly two answers — `PressKeyCallback.Response.proceed()`
- * and `.suppress()` — and no way to learn whether the page did anything with a key it was
+ * JxBrowser's key hook gives us exactly two answers - `PressKeyCallback.Response.proceed()`
+ * and `.suppress()` - and no way to learn whether the page did anything with a key it was
  * given. There is no API for this in 9.4.0; the search package is `TextFinder` plus
  * `FindOptions`/`FindResult` and nothing else. So the page has to tell us.
  *
  * Chrome answers the same question the same way. Ctrl/Cmd+F is a *non-reserved* accelerator
  * there: the page sees the key first, and if it calls `preventDefault()` Chrome skips its own
  * find bar. That is the entire mechanism behind Sheets' find working in Chrome, and matching
- * it means we inherit every site that already knows how to opt in — no allowlist to maintain.
+ * it means we inherit every site that already knows how to opt in - no allowlist to maintain.
  *
  * ## How the verdict is read
  *
@@ -31,18 +31,23 @@ import com.teamdev.jxbrowser.js.JsAccessible
  *
  *  - `defaultPrevented` is only final once dispatch has finished. Read inline, in the first
  *    listener to run, it is always false.
- *  - It survives `stopPropagation()`. The obvious alternative — a second listener at the
- *    bubble phase on `window`, reading the flag there — never fires when a page stops
+ *  - It survives `stopPropagation()`. The obvious alternative - a second listener at the
+ *    bubble phase on `window`, reading the flag there - never fires when a page stops
  *    propagation partway, which is precisely what Sheets and Docs do. The timeout is queued
  *    from the capture phase, so nothing the page does downstream can cancel it.
  *
  * ## What a page can do with this
  *
- * Nothing it could not already do. The only lever is "suppress BOSS's find bar on my own
- * page", and calling `preventDefault()` on the key already achieves exactly that — which is
- * the sanctioned way to ask. A page spamming [BrowserFindKeyProbeBridge.report] gains no new
- * capability, and the bridge drops a report with no decision waiting on it, so the loop is
- * cheap to serve.
+ * The only lever is "suppress BOSS's find bar on this page", and calling `preventDefault()` on
+ * the key already achieves exactly that - which is the sanctioned way to ask. The bridge drops a
+ * report with no decision waiting on it, so a page calling it in a loop is cheap to serve.
+ *
+ * **One thing it does add, stated precisely rather than waved away:** the bridge is published on
+ * every frame and `report` carries no frame identity, so a NON-FOCUSED iframe can answer on the
+ * focused document's behalf by polling within the deadline. The consequence is bounded - our bar
+ * does not open for that press, and the user presses again - and any frame on the page could
+ * already claim the chord for itself by calling `preventDefault()`. Carrying a per-frame token in
+ * the report would close it; it is not closed today.
  */
 internal object BrowserFindKeyProbe {
     /** Property the bridge is published on, per frame. Matched by [source]. */
@@ -63,7 +68,7 @@ internal object BrowserFindKeyProbe {
      * Reads nothing from the DOM and nothing from the event but its key identity and modifier
      * flags, so unlike [BrowserInteractionScript] there is no privacy surface to describe.
      *
-     * `event.code` is the physical key, which is what an accelerator is defined against — a
+     * `event.code` is the physical key, which is what an accelerator is defined against - a
      * Dvorak or AZERTY layout puts a different character on that key, and Chromium fires the
      * accelerator on the position either way. `keyCode` is the fallback purely for a frame
      * whose engine predates `code`; both are checked rather than one, because getting this
@@ -106,7 +111,7 @@ internal object BrowserFindKeyProbe {
  * frame's `window.__bossFindProbe`.
  *
  * [report] runs on a JxBrowser thread and must never block or throw into the page's JS
- * thread — a throw here surfaces in the site's own console and can break its scripts. The
+ * thread - a throw here surfaces in the site's own console and can break its scripts. The
  * exception CLASS is logged, never a message: this is reached from arbitrary pages, and a
  * message could carry page detail into a log line.
  */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindPlacement.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindPlacement.kt
@@ -1,0 +1,83 @@
+package ai.rever.boss.plugin.browser
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+/** Height of the bar, and the size the corner overlay opens at before it measures. */
+internal val FIND_BAR_HEIGHT = 34.dp
+
+/**
+ * Upper bound the corner overlay is measured against.
+ *
+ * A ceiling, not a first guess: `HeavyweightCorner` measures content against this and never
+ * against its own window, so anything wider is CLIPPED rather than merely mis-sized on the first
+ * frame. Comfortably above the bar's natural width, which is the field plus a counter and four
+ * icon buttons.
+ */
+internal val FIND_BAR_CEILING = DpSize(360.dp, 60.dp)
+
+/**
+ * Gap between the bar and the pane's top and end edges, in dp.
+ *
+ * Applied by shrinking the anchor REGION rather than by padding the bar. Padding would work on the
+ * lightweight path and be actively wrong on the heavyweight one: that overlay window is sized to
+ * its content, so transparent padding grows the window, and a non-focusable AWT window still eats
+ * every click under it (the JVM has no portable click-through). The margin would become a dead
+ * strip across the top-right of the page.
+ */
+internal const val FIND_BAR_MARGIN_DP = 8
+
+/**
+ * How long a candidate outside a main window panel yields before claiming a `browser.find` event.
+ *
+ * Long enough that a main-panel surface in the same window always claims first (it does so in the
+ * same dispatch), short enough to be invisible if it is the only candidate. A fixed order beats a
+ * race between coroutine resumptions, which is what decided this before.
+ */
+internal const val SHORTCUT_DEFERRAL_MS = 40L
+
+/** [FIND_BAR_MARGIN_DP] as a `Dp`, for the lightweight path, which pads instead of insetting. */
+internal val FIND_BAR_MARGIN = FIND_BAR_MARGIN_DP.dp
+
+/**
+ * The rectangle a pane's find bar anchors inside: [boundsInWindow] converted to dp and pulled in
+ * by [FIND_BAR_MARGIN_DP], or null when there is nowhere sensible to put it.
+ *
+ * Null is a real answer, not a failure. `boundsInWindow` reports CLIPPED bounds, so a pane scrolled
+ * or collapsed out of view measures empty - and `HeavyweightCorner` resolves an unmeasurable parent
+ * to the screen origin, which would put an always-on-top bar in the corner of the primary display
+ * instead of over the page.
+ */
+@Suppress("ReturnCount")
+internal fun findBarRegion(
+    boundsInWindow: Rect,
+    density: Float,
+): IntRect? {
+    if (density <= 0f || !density.isFinite()) return null
+    if (!boundsInWindow.hasArea()) return null
+    val region =
+        IntRect(
+            left = (boundsInWindow.left / density).roundToInt(),
+            top = (boundsInWindow.top / density).roundToInt(),
+            right = (boundsInWindow.right / density).roundToInt(),
+            bottom = (boundsInWindow.bottom / density).roundToInt(),
+        ).deflate(FIND_BAR_MARGIN_DP)
+    // A pane narrower than twice the margin deflates to nothing. Better no bar than one placed at
+    // an inverted rectangle's corner.
+    return region.takeIf { it.width > 0 && it.height > 0 }
+}
+
+/**
+ * Whether this rectangle describes a real, finite area.
+ *
+ * `boundsInWindow` can be empty (a clipped-away pane) and, for a node in a degenerate layout, can
+ * carry infinities - which survive the division by density and turn into a garbage `IntRect`.
+ */
+private fun Rect.hasArea(): Boolean {
+    val w = width
+    val h = height
+    return w.isFinite() && h.isFinite() && w > 0f && h > 0f
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -2,6 +2,8 @@ package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.cache.FaviconCache
 import ai.rever.boss.components.overlays.OverlayCorner
+import ai.rever.boss.components.overlays.overlayCornerIsHeavyweight
+import ai.rever.boss.components.window_panel.components.main_window_panels.LocalInMainWindowPanel
 import ai.rever.boss.config.JxBrowserConfig
 import ai.rever.boss.dashboard.RecentBrowserPagesManager
 import ai.rever.boss.plugin.api.BrowserNavigationType
@@ -18,6 +20,7 @@ import ai.rever.boss.window.MenuActionsHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -2634,14 +2637,24 @@ internal class BrowserHandleImpl(
 
         // Cmd+F that AWT consumed before the browser could see it, dispatched by the browser.find
         // keymap action. Collected HERE, in the composition that knows it is the visible surface of
-        // the active panel in this window, so no registry has to answer "which browser" - and
-        // claimShortcut collapses the case where two compositions both believe they qualify (a
-        // browser in a sidebar slot reads LocalIsPanelActive as true, since its default is true).
+        // the active panel in this window, so no registry has to answer "which browser".
+        //
+        // The event is a broadcast, so more than one surface can qualify: LocalIsPanelActive
+        // defaults to `true`, which makes a browser in a sidebar slot look as active as the one in
+        // the main content area. claimShortcut alone would then pick by whichever coroutine resumed
+        // first - a coin flip between the page being read and the sidebar, which reads as exactly
+        // the flakiness this change removes. So a surface outside a main window panel yields first
+        // and claims only if nothing better did, which makes the winner deterministic. The
+        // non-preferred branch still gets served, a beat later, so a sidebar-only browser is not
+        // cut off.
         val isPanelActive = LocalIsPanelActive.current
-        LaunchedEffect(browser, hostWindowId, isPanelActive) {
+        val inMainPanel = LocalInMainWindowPanel.current
+        LaunchedEffect(browser, hostWindowId, isPanelActive, inMainPanel) {
             if (hostWindowId == null || !isPanelActive) return@LaunchedEffect
             MenuActionsHandler.browserFindEvents.collect { eventWindowId ->
-                if (eventWindowId == hostWindowId && BrowserFindController.claimShortcut(eventWindowId)) {
+                if (eventWindowId != hostWindowId) return@collect
+                if (!inMainPanel) delay(SHORTCUT_DEFERRAL_MS)
+                if (BrowserFindController.claimShortcut(eventWindowId)) {
                     BrowserFindController.onFindKeyFromShortcut(browser)
                 }
             }
@@ -2732,13 +2745,25 @@ internal class BrowserHandleImpl(
             // display rather than over the page it belongs to.
             val findRegion = findRegionInWindow
             if (findState.visible && findRegion != null) {
+                // Which path OverlayCorner will take, asked before deciding where the corner margin
+                // goes. Its lightweight branch aligns inside this BoxScope and ignores
+                // regionInWindow for the same reason it ignores `inset`, so the margin baked into
+                // the region is simply lost there and the bar sits flush in the pane's corner.
+                // Reachable via BOSS_RENDERING_MODE=OFF_SCREEN, a supported escape hatch. Same trap
+                // FocusModeQuickActions documents, and the reason overlayCornerIsHeavyweight exists.
+                val heavyweight = overlayCornerIsHeavyweight()
                 OverlayCorner(
                     alignment = Alignment.TopEnd,
                     initialSize = FIND_BAR_CEILING,
                     focusable = true,
                     regionInWindow = findRegion,
                 ) {
-                    BrowserFindBar(browser = browser, state = findState)
+                    // Margin as region inset on the heavyweight path so it is not a dead band that
+                    // swallows clicks over the page, and as ordinary padding on the lightweight one,
+                    // where nothing is swallowed and the region is not read at all.
+                    Box(modifier = if (heavyweight) Modifier else Modifier.padding(FIND_BAR_MARGIN)) {
+                        BrowserFindBar(browser = browser, state = findState)
+                    }
                 }
             }
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1,9 +1,11 @@
 package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.cache.FaviconCache
+import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.config.JxBrowserConfig
 import ai.rever.boss.dashboard.RecentBrowserPagesManager
 import ai.rever.boss.plugin.api.BrowserNavigationType
+import ai.rever.boss.plugin.api.LocalIsPanelActive
 import ai.rever.boss.plugin.window.LocalWindowId
 import ai.rever.boss.tabfullscreen.FullscreenBrowserWindow
 import ai.rever.boss.utils.MacOSGestureHandler
@@ -12,15 +14,19 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
 import ai.rever.boss.window.BossWindowIcon
+import ai.rever.boss.window.MenuActionsHandler
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toComposeImageBitmap
@@ -29,6 +35,7 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback
@@ -1112,6 +1119,11 @@ internal class BrowserHandleImpl(
         if (config.enableDownloads) {
             FluckEngine.setupBrowserDownloadHandler(browser)
         }
+
+        // Find-in-page, with THIS handle's lock so a search takes the same read lock as every
+        // other access to the browser. Registered before the interceptor, which is what serves the
+        // find chord.
+        BrowserFindController.register(browser, browserLock)
 
         // Setup keyboard interceptor for menu shortcuts
         FluckEngine.setupKeyboardInterceptor(browser, ownerWindowId)
@@ -2608,6 +2620,33 @@ internal class BrowserHandleImpl(
         // pinch gate compares AWT logical units against pixel bounds using it.
         val viewDensity = LocalDensity.current.density
 
+        val findState = remember(browser) { BrowserFindController.stateFor(browser) }
+
+        // Where the find bar goes: this pane's rectangle, in dp relative to the window's content
+        // pane, already inset by the bar's corner margin.
+        //
+        // Snapshot state of its own rather than the @Volatile browserViewBoundsInWindow the pinch
+        // gate uses. That field is read from AWT callbacks and deliberately not observable, so a
+        // bar placed from it would never move when the split divider was dragged. Belonging to
+        // this composition is also correct rather than incidental: a tab moved to another window
+        // gets a fresh one instead of inheriting a rectangle measured in the window it left.
+        var findRegionInWindow by remember { mutableStateOf<IntRect?>(null) }
+
+        // Cmd+F that AWT consumed before the browser could see it, dispatched by the browser.find
+        // keymap action. Collected HERE, in the composition that knows it is the visible surface of
+        // the active panel in this window, so no registry has to answer "which browser" - and
+        // claimShortcut collapses the case where two compositions both believe they qualify (a
+        // browser in a sidebar slot reads LocalIsPanelActive as true, since its default is true).
+        val isPanelActive = LocalIsPanelActive.current
+        LaunchedEffect(browser, hostWindowId, isPanelActive) {
+            if (hostWindowId == null || !isPanelActive) return@LaunchedEffect
+            MenuActionsHandler.browserFindEvents.collect { eventWindowId ->
+                if (eventWindowId == hostWindowId && BrowserFindController.claimShortcut(eventWindowId)) {
+                    BrowserFindController.onFindKeyFromShortcut(browser)
+                }
+            }
+        }
+
         // Render the browser view if available with mouse button handling.
         //
         // Keyed on viewGeneration so the stall watchdog can force the view out of composition and
@@ -2615,59 +2654,92 @@ internal class BrowserHandleImpl(
         // BrowserViewState is deliberately NOT rebuilt with it: the manual repair this imitates (a
         // tab switch) reuses the retained surface too, so re-attaching is what matters and
         // rebuilding the surface would cost far more than it fixes.
-        viewState?.let { state ->
-            key(viewGeneration) {
-                BrowserView(
-                    state = state,
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .offset(y = hardwareTopInsetDp.dp)
-                            // Where this view is, for the pinch gate under HARDWARE_ACCELERATED —
-                            // the only signal available there, since a foreign native surface means
-                            // Compose never reports the pointer entering. Clipped bounds, so a view
-                            // scrolled half out of the window does not claim the hidden half.
-                            .onGloballyPositioned { coords ->
-                                browserViewBoundsInWindow = coords.boundsInWindow()
-                                // Captured with the bounds, from the same layout pass, so the two can
-                                // never describe different displays after a window is dragged between
-                                // monitors. See pointerInsideBounds for why the pairing is required.
-                                browserViewDensity = viewDensity
-                            }
-                            // Hover tracking that gates the window-wide pinch gesture listener to
-                            // this view under OFF_SCREEN (see the DisposableEffect above). Never
-                            // fires under HARDWARE_ACCELERATED; see shouldAllowPinch.
-                            .onPointerEvent(PointerEventType.Enter) { pointerOverBrowserView = true }
-                            .onPointerEvent(PointerEventType.Exit) { pointerOverBrowserView = false }
-                            .onPointerEvent(PointerEventType.Press) { event ->
-                                // Get the native AWT mouse event to check button codes
-                                val awtEvent = event.nativeEvent as? java.awt.event.MouseEvent
-
-                                // Handle mouse back button - navigate back
-                                // Windows/macOS: awtButton=4, Linux: awtButton=6 or 8 (varies by mouse)
-                                if (awtEvent?.button in listOf(4, 6, 8)) {
-                                    val now = System.currentTimeMillis()
-                                    if (isValid && (now - lastNavigationTime) > 100 && canGoBack()) {
-                                        lastNavigationTime = now
-                                        goBack()
-                                    }
-                                    event.changes.forEach { it.consume() }
-                                    return@onPointerEvent
+        //
+        // Wrapped in a Box so the find bar has a scope to anchor in. Under OFF_SCREEN it draws in
+        // place, aligned inside THIS pane; under HARDWARE_ACCELERATED - the default on every
+        // platform - OverlayCorner escapes it into its own always-on-top window, because a
+        // lightweight overlay renders behind the native GPU surface.
+        Box(modifier = Modifier.fillMaxSize()) {
+            viewState?.let { state ->
+                key(viewGeneration) {
+                    BrowserView(
+                        state = state,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .offset(y = hardwareTopInsetDp.dp)
+                                // Where this view is, for the pinch gate under HARDWARE_ACCELERATED —
+                                // the only signal available there, since a foreign native surface means
+                                // Compose never reports the pointer entering. Clipped bounds, so a view
+                                // scrolled half out of the window does not claim the hidden half.
+                                .onGloballyPositioned { coords ->
+                                    val viewBounds = coords.boundsInWindow()
+                                    browserViewBoundsInWindow = viewBounds
+                                    // Captured with the bounds, from the same layout pass, so the two can
+                                    // never describe different displays after a window is dragged between
+                                    // monitors. See pointerInsideBounds for why the pairing is required.
+                                    browserViewDensity = viewDensity
+                                    // Same rectangle, converted for the find bar. Dp, because that is
+                                    // what a heavyweight overlay is placed in - AWT's logical units map
+                                    // 1:1 to dp, so an overlay positioned from device pixels lands off
+                                    // by the scale factor on any HiDPI display.
+                                    findRegionInWindow = findBarRegion(viewBounds, viewDensity)
                                 }
+                                // Hover tracking that gates the window-wide pinch gesture listener to
+                                // this view under OFF_SCREEN (see the DisposableEffect above). Never
+                                // fires under HARDWARE_ACCELERATED; see shouldAllowPinch.
+                                .onPointerEvent(PointerEventType.Enter) { pointerOverBrowserView = true }
+                                .onPointerEvent(PointerEventType.Exit) { pointerOverBrowserView = false }
+                                .onPointerEvent(PointerEventType.Press) { event ->
+                                    // Get the native AWT mouse event to check button codes
+                                    val awtEvent = event.nativeEvent as? java.awt.event.MouseEvent
 
-                                // Handle mouse forward button - navigate forward
-                                // Windows/macOS: awtButton=5, Linux: awtButton=7 or 9 (varies by mouse)
-                                if (awtEvent?.button in listOf(5, 7, 9)) {
-                                    val now = System.currentTimeMillis()
-                                    if (isValid && (now - lastNavigationTime) > 100 && canGoForward()) {
-                                        lastNavigationTime = now
-                                        goForward()
+                                    // Handle mouse back button - navigate back
+                                    // Windows/macOS: awtButton=4, Linux: awtButton=6 or 8 (varies by mouse)
+                                    if (awtEvent?.button in listOf(4, 6, 8)) {
+                                        val now = System.currentTimeMillis()
+                                        if (isValid && (now - lastNavigationTime) > 100 && canGoBack()) {
+                                            lastNavigationTime = now
+                                            goBack()
+                                        }
+                                        event.changes.forEach { it.consume() }
+                                        return@onPointerEvent
                                     }
-                                    event.changes.forEach { it.consume() }
-                                    return@onPointerEvent
-                                }
-                            },
-                )
+
+                                    // Handle mouse forward button - navigate forward
+                                    // Windows/macOS: awtButton=5, Linux: awtButton=7 or 9 (varies by mouse)
+                                    if (awtEvent?.button in listOf(5, 7, 9)) {
+                                        val now = System.currentTimeMillis()
+                                        if (isValid && (now - lastNavigationTime) > 100 && canGoForward()) {
+                                            lastNavigationTime = now
+                                            goForward()
+                                        }
+                                        event.changes.forEach { it.consume() }
+                                        return@onPointerEvent
+                                    }
+                                },
+                    )
+                }
+            }
+
+            // Composed only while the bar is up. A heavyweight corner overlay is content-sized but
+            // still swallows the clicks under itself, so one composed unconditionally would leave a
+            // permanently dead rectangle over the page.
+            //
+            // A null region means this pane has not been measured yet (or was just torn down). Not
+            // drawing is deliberate: HeavyweightCorner resolves an unmeasured parent to the screen
+            // origin, so the alternative is an always-on-top bar in the corner of the primary
+            // display rather than over the page it belongs to.
+            val findRegion = findRegionInWindow
+            if (findState.visible && findRegion != null) {
+                OverlayCorner(
+                    alignment = Alignment.TopEnd,
+                    initialSize = FIND_BAR_CEILING,
+                    focusable = true,
+                    regionInWindow = findRegion,
+                ) {
+                    BrowserFindBar(browser = browser, state = findState)
+                }
             }
         }
     }
@@ -2732,8 +2804,9 @@ internal class BrowserHandleImpl(
         currentViewState = null
         currentViewStateWindowId = null
 
-        // Clean up find bar resources before closing browser
-        FluckEngine.disposeBrowserFindBar(browser)
+        // Release find-in-page state and its timers before closing the browser: a debounce that
+        // fires afterwards would search a closed object.
+        BrowserFindController.dispose(browser)
 
         // Close browser
         if (!browser.isClosed) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -115,313 +115,6 @@ object FluckEngine {
         }
     }
 
-    /**
-     * Swing-based find bar that overlays the browser window.
-     * Uses JxBrowser's TextFinder API for searching (no focus stealing).
-     * Styled to match BossTerm's SearchBar (VS Code-style, dark theme, top-right).
-     */
-    private val activeFindBars = java.util.concurrent.ConcurrentHashMap<com.teamdev.jxbrowser.browser.Browser, BrowserFindBar>()
-
-    private class BrowserFindBar(
-        private val browser: com.teamdev.jxbrowser.browser.Browser,
-    ) {
-        private var dialog: javax.swing.JDialog? = null
-        private var textField: javax.swing.JTextField? = null
-        private var infoLabel: javax.swing.JLabel? = null
-        private var caseSensitive = false
-        private var ownerWindow: java.awt.Window? = null
-        private var componentListener: java.awt.event.ComponentListener? = null
-        private var searchTimer: javax.swing.Timer? = null
-        var visible = false
-            private set
-
-        fun toggle() {
-            if (visible) hide() else show()
-        }
-
-        fun show() {
-            // `visible` is committed only once a window is resolved. Setting it first left the bar
-            // marked visible while show() bailed out, so the NEXT Ctrl+F called hide() and the
-            // shortcut degraded into a dead every-other-press toggle. That is reachable now that
-            // Ctrl+F is served on the no-focused-window path, which is exactly the state where
-            // AWT's focusedWindow is most likely to be null too.
-            val window =
-                java.awt.KeyboardFocusManager
-                    .getCurrentKeyboardFocusManager()
-                    .focusedWindow
-                    ?: return
-            visible = true
-            ownerWindow = window
-            javax.swing.SwingUtilities.invokeLater {
-                if (dialog == null) {
-                    createDialog(window)
-                }
-                positionDialog(window)
-                dialog?.isVisible = true
-                textField?.requestFocusInWindow()
-                textField?.selectAll()
-            }
-        }
-
-        fun hide() {
-            visible = false
-            javax.swing.SwingUtilities.invokeLater {
-                dialog?.isVisible = false
-                try {
-                    if (!browser.isClosed) browser.textFinder().stopFindingAndClearSelection()
-                } catch (e: Exception) {
-                    logger.debug(LogCategory.BROWSER, "Error clearing find highlights", mapOf("error" to (e.message ?: "unknown")))
-                }
-            }
-        }
-
-        private fun positionDialog(owner: java.awt.Window) {
-            val d = dialog ?: return
-            d.pack()
-            val x = owner.x + owner.width - d.width - 16
-            val y = owner.y + 80
-            d.setLocation(x.coerceAtLeast(owner.x + 4), y)
-        }
-
-        /** Unified find method — #4: deduplicated from doFind/doInitialFind */
-        private fun performFind(backward: Boolean) {
-            val query = textField?.text ?: return
-            if (query.isEmpty()) {
-                infoLabel?.text = ""
-                try {
-                    if (!browser.isClosed) browser.textFinder().stopFindingAndClearSelection()
-                } catch (e: Exception) {
-                    logger.debug(LogCategory.BROWSER, "Error clearing find", mapOf("error" to (e.message ?: "unknown")))
-                }
-                return
-            }
-            if (browser.isClosed) return
-            try {
-                val options =
-                    com.teamdev.jxbrowser.search.FindOptions
-                        .newBuilder()
-                        .matchCase(caseSensitive)
-                        .searchBackward(backward)
-                        .build()
-                browser.textFinder().find(query, options) { result ->
-                    javax.swing.SwingUtilities.invokeLater {
-                        val total = result.numberOfMatches()
-                        val current = result.selectedMatch()
-                        if (total > 0) {
-                            infoLabel?.text = "$current/$total"
-                            infoLabel?.foreground =
-                                java.awt.Color(
-                                    BossThemeController.current.colors.textPrimary
-                                        .toArgb(),
-                                    true,
-                                )
-                        } else {
-                            infoLabel?.text = "0/0"
-                            infoLabel?.foreground =
-                                java.awt.Color(
-                                    BossThemeController.current.colors.alert
-                                        .toArgb(),
-                                    true,
-                                )
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                logger.debug(LogCategory.BROWSER, "Find operation failed", mapOf("error" to (e.message ?: "unknown")))
-            }
-        }
-
-        /** #8: Debounced live search — 150ms delay to avoid hammering renderer per keystroke */
-        private fun debouncedFind() {
-            searchTimer?.stop()
-            searchTimer = javax.swing.Timer(150) { performFind(false) }
-            searchTimer?.isRepeats = false
-            searchTimer?.start()
-        }
-
-        private fun createDialog(owner: java.awt.Window) {
-            // Colors resolve from the active BOSS theme at dialog build time.
-            // Known asymmetry with the Compose UI: this Swing dialog SNAPSHOTS
-            // the tokens at construction, so a live theme switch restyles it
-            // only on the next createDialog(), not while it is open.
-            val colors = BossThemeController.current.colors
-            val bg = java.awt.Color(colors.panel.toArgb(), true)
-            val inputBg = java.awt.Color(colors.raised.toArgb(), true)
-            val fg = java.awt.Color(colors.textPrimary.toArgb(), true)
-            val mutedFg = java.awt.Color(colors.textSecondary.toArgb(), true)
-
-            fun cssHex(c: java.awt.Color) = "#%06x".format(c.rgb and 0xFFFFFF)
-            val font = java.awt.Font("SansSerif", java.awt.Font.PLAIN, 13)
-            val smallFont = java.awt.Font("SansSerif", java.awt.Font.PLAIN, 11)
-
-            // #3: Use Window-accepting constructor instead of Frame cast
-            val d = javax.swing.JDialog(owner)
-            d.isUndecorated = true
-            d.isAlwaysOnTop = false
-            d.background = bg
-            d.type = java.awt.Window.Type.UTILITY
-
-            val content = javax.swing.JPanel()
-            content.background = bg
-            content.layout = java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 2, 4)
-            content.border =
-                javax.swing.BorderFactory.createCompoundBorder(
-                    javax.swing.BorderFactory.createLineBorder(java.awt.Color(colors.line.toArgb(), true)),
-                    javax.swing.BorderFactory.createEmptyBorder(2, 6, 2, 6),
-                )
-
-            val tf = javax.swing.JTextField(14)
-            tf.font = font
-            tf.foreground = fg
-            tf.background = inputBg
-            tf.caretColor = fg
-            tf.border =
-                javax.swing.BorderFactory.createCompoundBorder(
-                    javax.swing.BorderFactory.createLineBorder(java.awt.Color(colors.lineStrong.toArgb(), true)),
-                    javax.swing.BorderFactory.createEmptyBorder(2, 6, 2, 6),
-                )
-            tf.preferredSize = java.awt.Dimension(160, 28)
-            textField = tf
-
-            val info = javax.swing.JLabel("")
-            info.font = smallFont
-            info.foreground = mutedFg
-            info.preferredSize = java.awt.Dimension(44, 28)
-            info.horizontalAlignment = javax.swing.SwingConstants.CENTER
-            infoLabel = info
-
-            fun makeBtn(
-                html: String,
-                tooltip: String,
-            ): javax.swing.JButton {
-                val b = javax.swing.JButton(html)
-                b.font = font
-                b.foreground = fg
-                b.background = bg
-                b.isFocusPainted = false
-                b.isBorderPainted = false
-                b.isContentAreaFilled = false
-                b.isOpaque = false
-                b.toolTipText = tooltip
-                b.preferredSize = java.awt.Dimension(28, 28)
-                b.margin = java.awt.Insets(0, 0, 0, 0)
-                b.horizontalAlignment = javax.swing.SwingConstants.CENTER
-                b.cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
-                return b
-            }
-
-            val prevBtn = makeBtn("<html><span style='font-size:10px;color:${cssHex(fg)};'>\u25B2</span></html>", "Previous (Shift+Enter)")
-            val nextBtn = makeBtn("<html><span style='font-size:10px;color:${cssHex(fg)};'>\u25BC</span></html>", "Next (Enter)")
-            val caseBtn = makeBtn("<html><span style='font-size:12px;color:${cssHex(mutedFg)};'>Aa</span></html>", "Case sensitive")
-            caseBtn.preferredSize = java.awt.Dimension(40, 28)
-            val closeBtn = makeBtn("<html><span style='font-size:12px;color:${cssHex(fg)};'>\u2715</span></html>", "Close (Esc)")
-
-            prevBtn.addActionListener { performFind(true) }
-            nextBtn.addActionListener { performFind(false) }
-            caseBtn.addActionListener {
-                caseSensitive = !caseSensitive
-                val color =
-                    if (caseSensitive) {
-                        cssHex(
-                            java.awt.Color(
-                                BossThemeController.current.colors.signal
-                                    .toArgb(),
-                                true,
-                            ),
-                        )
-                    } else {
-                        cssHex(mutedFg)
-                    }
-                val weight = if (caseSensitive) "bold" else "normal"
-                caseBtn.text = "<html><span style='font-size:12px;color:$color;font-weight:$weight;'>Aa</span></html>"
-                performFind(false)
-            }
-            closeBtn.addActionListener { hide() }
-
-            val isMac = SystemUtils.isMacOS
-            tf.addKeyListener(
-                object : java.awt.event.KeyAdapter() {
-                    override fun keyPressed(e: java.awt.event.KeyEvent) {
-                        val isMainMod = if (isMac) e.isMetaDown else e.isControlDown
-                        when {
-                            e.keyCode == java.awt.event.KeyEvent.VK_ESCAPE -> {
-                                hide()
-                                e.consume()
-                            }
-
-                            e.keyCode == java.awt.event.KeyEvent.VK_F && isMainMod && !e.isShiftDown -> {
-                                hide()
-                                e.consume()
-                            }
-
-                            e.keyCode == java.awt.event.KeyEvent.VK_ENTER && e.isShiftDown -> {
-                                performFind(true)
-                                e.consume()
-                            }
-
-                            e.keyCode == java.awt.event.KeyEvent.VK_ENTER -> {
-                                performFind(false)
-                                e.consume()
-                            }
-                        }
-                    }
-                },
-            )
-
-            // #8: Debounced live search on typing
-            tf.document.addDocumentListener(
-                object : javax.swing.event.DocumentListener {
-                    override fun insertUpdate(e: javax.swing.event.DocumentEvent?) = debouncedFind()
-
-                    override fun removeUpdate(e: javax.swing.event.DocumentEvent?) = debouncedFind()
-
-                    override fun changedUpdate(e: javax.swing.event.DocumentEvent?) = debouncedFind()
-                },
-            )
-
-            content.add(tf)
-            content.add(info)
-            content.add(prevBtn)
-            content.add(nextBtn)
-            content.add(caseBtn)
-            content.add(closeBtn)
-            d.contentPane = content
-
-            val listener =
-                object : java.awt.event.ComponentAdapter() {
-                    override fun componentMoved(e: java.awt.event.ComponentEvent?) = positionDialog(owner)
-
-                    override fun componentResized(e: java.awt.event.ComponentEvent?) = positionDialog(owner)
-                }
-            owner.addComponentListener(listener)
-            componentListener = listener
-
-            dialog = d
-        }
-
-        fun dispose() {
-            searchTimer?.stop()
-            searchTimer = null
-            componentListener?.let { listener ->
-                ownerWindow?.removeComponentListener(listener)
-            }
-            componentListener = null
-            ownerWindow = null
-            dialog?.dispose()
-            dialog = null
-            textField = null
-            infoLabel = null
-        }
-    }
-
-    /**
-     * Clean up find bar resources for a browser that is being closed.
-     * Call from browser disposal logic to prevent resource leaks.
-     */
-    fun disposeBrowserFindBar(browser: com.teamdev.jxbrowser.browser.Browser) {
-        activeFindBars.remove(browser)?.dispose()
-    }
-
     // @Volatile on all three: written under engineLock but read WITHOUT the lock —
     // _engine via currentEngine/isEngineHealthy/setColorScheme, the other two via
     // initError/isAvailable() on the UI thread. Pre-warm moves the writes to a
@@ -2816,6 +2509,42 @@ object FluckEngine {
     }
 
     /**
+     * Publish [BrowserFindKeyProbe] into every frame of [browser] at document start.
+     *
+     * **Every frame, not just the main one.** A keydown is delivered to the focused frame, so a
+     * find chord pressed inside an iframe is only observable by a listener inside that iframe. The
+     * interaction collector gets away with main-frame-only injection because it reports what it
+     * sees; this one has to answer a question about a specific keypress, and a missing answer means
+     * our bar opens over a page that wanted to serve its own.
+     *
+     * Through [BrowserInjectDispatcher] rather than `browser.set(InjectJsCallback…)`: JxBrowser has
+     * exactly one such slot per browser and a second registration silently replaces the first.
+     */
+    private fun installFindKeyProbe(browser: com.teamdev.jxbrowser.browser.Browser) {
+        val bridge =
+            BrowserFindKeyProbeBridge { pageHandledKey ->
+                BrowserFindController.onPageVerdict(browser, pageHandledKey)
+            }
+        BrowserInjectDispatcher.register(browser) { frame ->
+            try {
+                frame
+                    .executeJavaScript<com.teamdev.jxbrowser.js.JsObject>("window")
+                    ?.putProperty(BrowserFindKeyProbe.BRIDGE_PROPERTY, bridge)
+                frame.executeJavaScript<Any?>(BrowserFindKeyProbe.source)
+            } catch (e: Exception) {
+                // The class only, never the message: this runs against arbitrary pages. A frame
+                // that refuses injection is normal (a cross-process navigation can tear one down
+                // mid-flight) and the verdict deadline covers it.
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Find-key probe injection failed",
+                    mapOf("error" to (e::class.simpleName ?: "Exception")),
+                )
+            }
+        }
+    }
+
+    /**
      * Sets up keyboard interceptor for a browser to forward menu shortcuts to the native menu bar.
      * This intercepts Cmd+R, Cmd+N, Cmd+T, Cmd+W, etc. (on macOS) or Ctrl+R, Ctrl+N, etc. (on Windows/Linux)
      * before JxBrowser consumes them, and manually triggers the corresponding MenuActionsHandler methods.
@@ -2828,6 +2557,12 @@ object FluckEngine {
         browser: com.teamdev.jxbrowser.browser.Browser,
         ownerWindowId: String? = null,
     ) {
+        // Adopt the browser for find-in-page before the callback below can serve a find chord.
+        // A browser created outside a BrowserHandleImpl reaches this too (the legacy
+        // BrowserFunctions.createBrowser path), which is why registration lives here rather than
+        // only in the handle: this is the one function both paths call.
+        BrowserFindController.register(browser)
+        installFindKeyProbe(browser)
         val suppressionLogged = AtomicBoolean(false)
         browser.set(
             com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback::class.java,
@@ -2919,12 +2654,31 @@ object FluckEngine {
                                     .suppress()
                             }
 
+                            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_G -> {
+                                // "Find again". Claimed only while our bar is up with a query -
+                                // otherwise it does nothing here, and proceeding leaves the chord to
+                                // a page that may have its own meaning for it.
+                                if (BrowserFindController.onFindAgainKey(browser, backward = false)) {
+                                    return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                        .suppress()
+                                }
+                            }
+
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F -> {
-                                // Toggle Swing-based find bar (uses TextFinder API, no focus issues)
-                                val findBar = activeFindBars.getOrPut(browser) { BrowserFindBar(browser) }
-                                findBar.toggle()
-                                return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
-                                    .suppress()
+                                // NOT suppressed unconditionally any more, which is the whole point.
+                                // Suppressing meant the page never saw the key, so a site with its own
+                                // find-in-page (Sheets, Docs, Notion) could never serve it - Chrome
+                                // treats this chord as a non-reserved accelerator and lets the page
+                                // pre-empt it. onFindKeyFromPage decides: it suppresses only when our
+                                // bar is already up, and otherwise proceeds and waits for the page's
+                                // verdict. See BrowserFindKeyProbe.
+                                return@PressKeyCallback if (BrowserFindController.onFindKeyFromPage(browser)) {
+                                    com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                        .suppress()
+                                } else {
+                                    com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                        .proceed()
+                                }
                             }
 
                             else -> {
@@ -2938,11 +2692,24 @@ object FluckEngine {
                         // passes no ownerWindowId). This callback is browser-scoped either way, so
                         // anything needing only the browser is served directly rather than dropped.
                         when (keyCode) {
+                            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_G -> {
+                                // "Find again". Claimed only while our bar is up with a query -
+                                // otherwise it does nothing here, and proceeding leaves the chord to
+                                // a page that may have its own meaning for it.
+                                if (BrowserFindController.onFindAgainKey(browser, backward = false)) {
+                                    return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                        .suppress()
+                                }
+                            }
+
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F -> {
-                                val findBar = activeFindBars.getOrPut(browser) { BrowserFindBar(browser) }
-                                findBar.toggle()
-                                return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
-                                    .suppress()
+                                return@PressKeyCallback if (BrowserFindController.onFindKeyFromPage(browser)) {
+                                    com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                        .suppress()
+                                } else {
+                                    com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                        .proceed()
+                                }
                             }
 
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_N,
@@ -2964,6 +2731,15 @@ object FluckEngine {
 
                 // Intercept main modifier + Shift + key shortcuts
                 if (isMainModifierDown && modifiers.isShiftDown && !modifiers.isAltDown) {
+                    // "Find previous", handled BEFORE the window gate for the same reason reload is:
+                    // it needs only the browser this callback already has, so routing it through a
+                    // focused window would drop it on the unowned path for nothing.
+                    if (keyCode == com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_G &&
+                        BrowserFindController.onFindAgainKey(browser, backward = true)
+                    ) {
+                        return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                            .suppress()
+                    }
                     if (shortcutWindowId != null) {
                         when (keyCode) {
                             com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_F -> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/LockedBrowser.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/LockedBrowser.kt
@@ -159,4 +159,16 @@ class LockedTextFinder(
         lock.read {
             textFinder.stopFindingAndClearSelection()
         }
+
+    /**
+     * Drop the find highlights but leave the current match selected and scrolled into view.
+     *
+     * This is what closing the find bar should do, and the difference is not cosmetic: clearing
+     * the selection scrolls the reader back to wherever they were before searching, so Escape
+     * throws away the result they went looking for. Chrome keeps the match; so does this.
+     */
+    fun stopFindingAndKeepSelection() =
+        lock.read {
+            textFinder.stopFindingAndKeepSelection()
+        }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowIcon.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowIcon.kt
@@ -38,9 +38,15 @@ import javax.imageio.ImageIO
  * The five `Heavyweight*` overlays are branded too, which is worth stating because it looks
  * pointless: they are `undecorated` and `transparent`, so they have no title bar to put an icon in.
  * They are still plain `Frame`s with no `Window.Type` set, so Windows gives them taskbar buttons and
- * Alt-Tab cards of their own - which is where an unbranded one shows a coffee cup. The one window
- * deliberately left alone is `FluckEngine`'s find bar: it is a `JDialog` and `Window.Type.UTILITY`,
- * so it has no icon surface at all.
+ * Alt-Tab cards of their own - which is where an unbranded one shows a coffee cup.
+ *
+ * The find bar used to be the one exemption, as a `JDialog` with `Window.Type.UTILITY` and so no
+ * icon surface at all. It is Compose content now (see `BrowserFindBar`), hosted by
+ * `HeavyweightCorner`'s FOCUSABLE branch as an owned `ComposeDialog` that keeps the same window
+ * type - so it still gets no taskbar button and no Alt-Tab card, and its owner stays active while it
+ * holds focus. It is branded anyway, and is no longer an exemption: the type is set through a
+ * `runCatching`, so a platform that refuses it leaves an ordinary dialog that does have an icon
+ * surface.
  */
 object BossWindowIcon {
     private val logger = BossLogger.forComponent("BossWindowIcon")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/FocusModeQuickActionsTest.kt
@@ -71,7 +71,7 @@ class FocusModeQuickActionsTest {
     ): Boolean {
         var requested = false
         OverlayConfig.useHeavyweightPopups = heavyweight
-        OverlayConfig.heavyweightCorner = { _, _, cornerInset, _ ->
+        OverlayConfig.heavyweightCorner = { _, _, cornerInset, _, _, _ ->
             // Recorded, not composed: composing a real Window needs a display.
             requested = true
             receivedInset = cornerInset

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/ToastOverlayTest.kt
@@ -65,7 +65,7 @@ class ToastOverlayTest {
     ): Boolean {
         var requested = false
         OverlayConfig.useHeavyweightPopups = true
-        OverlayConfig.heavyweightCorner = { _, _, _, _ ->
+        OverlayConfig.heavyweightCorner = { _, _, _, _, _, _ ->
             // Recorded, not composed: composing a real Window needs a display.
             requested = true
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/OverlayCornerForwardingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/OverlayCornerForwardingTest.kt
@@ -1,0 +1,104 @@
+package ai.rever.boss.components.overlays
+
+import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * That [OverlayCorner] hands the heavyweight renderer everything it was given.
+ *
+ * Both arguments this pins were added for the browser find bar, and both have defaults - so a
+ * forwarding mistake compiles, leaves every other test green, and shows up only as a bar in the
+ * wrong corner (`regionInWindow` dropped, and the overlay resolves against the whole content pane)
+ * or one that cannot be typed into (`focusable` dropped). `FocusModeQuickActionsTest` records
+ * `inset` for exactly this reason; these are the same class of hazard.
+ */
+class OverlayCornerForwardingTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val previousRenderer = OverlayConfig.heavyweightCorner
+    private val previousHeavyweight = OverlayConfig.useHeavyweightPopups
+
+    @After
+    fun tearDown() {
+        OverlayConfig.heavyweightCorner = previousRenderer
+        OverlayConfig.useHeavyweightPopups = previousHeavyweight
+    }
+
+    private class Captured {
+        var alignment: Alignment? = null
+        var initialSize: DpSize? = null
+        var inset: DpSize? = null
+        var focusable: Boolean? = null
+        var regionInWindow: IntRect? = null
+    }
+
+    private fun capture(
+        focusable: Boolean,
+        regionInWindow: IntRect?,
+    ): Captured {
+        val captured = Captured()
+        OverlayConfig.useHeavyweightPopups = true
+        OverlayConfig.heavyweightCorner = { alignment, initialSize, inset, isFocusable, region, _ ->
+            // Recorded, not composed: composing a real Window needs a display.
+            captured.alignment = alignment
+            captured.initialSize = initialSize
+            captured.inset = inset
+            captured.focusable = isFocusable
+            captured.regionInWindow = region
+        }
+        rule.setContent {
+            CompositionLocalProvider(LocalHeavyweightOverlays provides true) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    OverlayCorner(
+                        alignment = Alignment.TopEnd,
+                        initialSize = DpSize(360.dp, 60.dp),
+                        inset = DpSize(4.dp, 6.dp),
+                        focusable = focusable,
+                        regionInWindow = regionInWindow,
+                    ) {}
+                }
+            }
+        }
+        rule.waitForIdle()
+        return captured
+    }
+
+    @Test
+    fun `focusable and the anchor region both reach the renderer`() {
+        val region = IntRect(400, 8, 792, 592)
+        val captured = capture(focusable = true, regionInWindow = region)
+        assertTrue(captured.focusable == true, "a bar with a text field must be told it may take focus")
+        assertEquals(
+            region,
+            captured.regionInWindow,
+            "the pane rect must survive the hop, or the bar lands window-relative",
+        )
+        // The pre-existing arguments must still arrive, since adding two parameters is exactly when
+        // an argument gets attached to the wrong slot.
+        assertEquals(Alignment.TopEnd, captured.alignment)
+        assertEquals(DpSize(360.dp, 60.dp), captured.initialSize)
+        assertEquals(DpSize(4.dp, 6.dp), captured.inset)
+    }
+
+    @Test
+    fun `the defaults are what a caller that says nothing gets`() {
+        val captured = capture(focusable = false, regionInWindow = null)
+        assertTrue(captured.focusable == false, "a toast must not take focus away from the app")
+        assertNull(captured.regionInWindow, "no region means resolve against the whole content pane")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFindTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFindTest.kt
@@ -1,0 +1,501 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.components.overlays.insetBounds
+import ai.rever.boss.components.overlays.resolveRegion
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.search.FindResult
+import com.teamdev.jxbrowser.search.TextFinder
+import org.junit.Test
+import java.lang.reflect.Proxy
+import java.util.function.Consumer
+import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Find-in-page: where the bar is placed, who owns the find chord, and what the counter is allowed
+ * to say.
+ *
+ * The three search behaviours pinned here were each a live bug in the Swing find bar this replaced,
+ * and each one reported a plausible WRONG number rather than failing visibly - which is why they
+ * survived. See the individual tests.
+ *
+ * Reflection proxies rather than mocks, matching [PopupWindowContextMenuTest]: the build has no
+ * mocking library, and these interfaces are only asked for a handful of methods.
+ */
+class BrowserFindTest {
+    // ========================================================================
+    // Where the bar goes
+    // ========================================================================
+
+    @Test
+    fun `pane rect converts to a dp region inset by the corner margin`() {
+        // A pane at (100, 50) sized 800x600 in device pixels, at 1x.
+        val region = findBarRegion(Rect(100f, 50f, 900f, 650f), density = 1f)
+        assertEquals(IntRect(108, 58, 892, 642), region)
+    }
+
+    @Test
+    fun `the region is in dp, so a 2x display does not double it`() {
+        // The same pane on a 2x display reports twice the pixels. A heavyweight overlay is placed
+        // in logical units, so failing to divide here puts the bar off screen by the scale factor.
+        val region = findBarRegion(Rect(200f, 100f, 1800f, 1300f), density = 2f)
+        assertEquals(IntRect(108, 58, 892, 642), region)
+    }
+
+    @Test
+    fun `an unmeasured or clipped-away pane has no region`() {
+        // boundsInWindow reports CLIPPED bounds, so a collapsed or scrolled-out pane measures
+        // empty. Null keeps the bar off screen; the alternative is HeavyweightCorner resolving an
+        // unmeasurable parent to the primary display's origin and putting an always-on-top bar
+        // there.
+        assertNull(findBarRegion(Rect.Zero, density = 1f))
+        assertNull(findBarRegion(Rect(10f, 10f, 10f, 400f), density = 1f))
+        assertNull(findBarRegion(Rect(10f, 10f, 400f, 10f), density = 1f))
+    }
+
+    @Test
+    fun `a pane narrower than the margins has no region`() {
+        // Deflating a 12dp-wide pane by 8 on each side inverts it. An inverted IntRect has a
+        // negative width, and placing a corner inside one lands outside the pane entirely.
+        assertNull(findBarRegion(Rect(0f, 0f, 12f, 12f), density = 1f))
+    }
+
+    @Test
+    fun `a bad density is not trusted`() {
+        assertNull(findBarRegion(Rect(0f, 0f, 800f, 600f), density = 0f))
+        assertNull(findBarRegion(Rect(0f, 0f, 800f, 600f), density = -1f))
+        assertNull(findBarRegion(Rect(0f, 0f, 800f, 600f), density = Float.NaN))
+    }
+
+    @Test
+    fun `no region means the inset path, unchanged`() {
+        val pane = intArrayOf(1000, 500, 800, 600)
+        val inset = DpSize(40.dp, 20.dp)
+        assertEquals(
+            insetBounds(pane, inset)!!.toList(),
+            resolveRegion(pane, inset, regionInWindow = null)!!.toList(),
+        )
+    }
+
+    @Test
+    fun `a region is offset into screen coordinates`() {
+        // The caller measures against the window; HeavyweightCorner places against the screen.
+        val pane = intArrayOf(1000, 500, 800, 600)
+        val resolved = resolveRegion(pane, DpSize.Zero, IntRect(400, 8, 792, 592))
+        assertEquals(listOf(1400, 508, 392, 584), resolved!!.toList())
+    }
+
+    @Test
+    fun `a region larger than the pane is clamped, not trusted`() {
+        // Compose layout and AWT measure the pane independently and can disagree for a frame during
+        // a resize. An unclamped region wider than the pane would place an always-on-top overlay
+        // outside the window it belongs to.
+        val pane = intArrayOf(0, 0, 800, 600)
+        val resolved = resolveRegion(pane, DpSize.Zero, IntRect(0, 0, 5000, 5000))
+        assertEquals(listOf(0, 0, 800, 600), resolved!!.toList())
+    }
+
+    @Test
+    fun `a degenerate region falls back to the inset path`() {
+        val pane = intArrayOf(0, 0, 800, 600)
+        val inset = DpSize(30.dp, 10.dp)
+        val resolved = resolveRegion(pane, inset, IntRect(900, 900, 950, 950))
+        assertEquals(insetBounds(pane, inset)!!.toList(), resolved!!.toList())
+    }
+
+    // ========================================================================
+    // Who owns the find chord
+    // ========================================================================
+
+    @Test
+    fun `the bridge maps only the two verdicts it defines`() {
+        val seen = mutableListOf<Boolean>()
+        val bridge = BrowserFindKeyProbeBridge { seen += it }
+
+        bridge.report(BrowserFindKeyProbe.VERDICT_HANDLED)
+        bridge.report(BrowserFindKeyProbe.VERDICT_FREE)
+        assertEquals(listOf(true, false), seen)
+
+        // Anything else is a page calling the bridge with its own argument. Dropped, not guessed:
+        // guessing "free" lets a site open a find bar nobody asked for, and guessing "handled"
+        // lets it suppress one the user did ask for.
+        bridge.report("")
+        bridge.report("HANDLED")
+        bridge.report("{\"verdict\":\"handled\"}")
+        assertEquals(listOf(true, false), seen)
+    }
+
+    @Test
+    fun `the bridge never throws into the page's JS thread`() {
+        // A throw here surfaces in the site's own console and can break its scripts, so the
+        // boundary swallows. Errors are deliberately NOT swallowed, but nothing this test can
+        // raise is one.
+        val bridge = BrowserFindKeyProbeBridge { error("consumer blew up") }
+        bridge.report(BrowserFindKeyProbe.VERDICT_HANDLED)
+        bridge.report(BrowserFindKeyProbe.VERDICT_FREE)
+    }
+
+    // ========================================================================
+    // What the counter is allowed to say
+    // ========================================================================
+
+    @Test
+    fun `a search still running never commits a count`() {
+        // WAS A BUG. TextFinderImpl invokes the consumer on every reply, SEARCHING ones included,
+        // and during those numberOfMatches() is a running tally while selectedMatch() need not be
+        // meaningful yet. The Swing bar rendered them, so every keystroke flashed a red 0/0 before
+        // the real count landed.
+        withStubbedBrowser { browser, finder, _ ->
+            val state = BrowserFindController.stateFor(browser)
+            BrowserFindController.setQuery(browser, "needle")
+            BrowserFindController.next(browser)
+
+            val consumer = finder.consumers.single()
+            consumer.accept(findResult(matches = 0, selected = 0, searching = true))
+            assertFalse(state.settled, "a searching reply must not settle the counter")
+            consumer.accept(findResult(matches = 2, selected = 1, searching = true))
+            assertFalse(state.settled)
+            assertEquals(0, state.totalMatches)
+
+            consumer.accept(findResult(matches = 3, selected = 1, searching = false))
+            assertTrue(state.settled)
+            assertEquals(3, state.totalMatches)
+            assertEquals(1, state.currentMatch)
+        }
+    }
+
+    @Test
+    fun `a reply from a superseded search cannot overwrite the current one`() {
+        // WAS A BUG. TextFinderImpl allocates a fresh request id per find() and keeps a live
+        // consumer for each, and the debounce cannot cancel a search already in flight - so
+        // several sessions report at once and the label showed whichever FINISHED last, which is
+        // not the one for the latest query.
+        withStubbedBrowser { browser, finder, _ ->
+            val state = BrowserFindController.stateFor(browser)
+
+            BrowserFindController.setQuery(browser, "goo")
+            BrowserFindController.next(browser)
+            val stale = finder.consumers.single()
+
+            BrowserFindController.setQuery(browser, "google")
+            BrowserFindController.next(browser)
+            assertEquals(2, finder.consumers.size, "the second query must start its own search")
+            val current = finder.consumers.last()
+
+            current.accept(findResult(matches = 4, selected = 2, searching = false))
+            assertEquals(4, state.totalMatches)
+
+            // The first search finishes late, with the count for text that is no longer in the box.
+            stale.accept(findResult(matches = 97, selected = 12, searching = false))
+            assertEquals(4, state.totalMatches, "a superseded search must not overwrite the count")
+            assertEquals(2, state.currentMatch)
+        }
+    }
+
+    @Test
+    fun `emptying the query clears the count and stops searching`() {
+        withStubbedBrowser { browser, finder, _ ->
+            val state = BrowserFindController.stateFor(browser)
+            BrowserFindController.setQuery(browser, "needle")
+            BrowserFindController.next(browser)
+            finder.consumers.single().accept(findResult(matches = 3, selected = 1, searching = false))
+            assertEquals(3, state.totalMatches)
+
+            BrowserFindController.setQuery(browser, "")
+            assertEquals(0, state.totalMatches)
+            assertFalse(state.settled)
+            assertEquals(1, finder.clearedCount, "an empty query has no match worth keeping")
+            assertEquals(0, finder.keptCount)
+        }
+    }
+
+    @Test
+    fun `closing keeps the match rather than clearing it`() {
+        // WAS A BUG. The Swing bar called stopFindingAndClearSelection on Escape, which drops the
+        // selection and scrolls the reader back to where they were before searching - throwing away
+        // the result they went looking for. stopFindingAndKeepSelection existed and was unused.
+        withStubbedBrowser { browser, finder, _ ->
+            BrowserFindController.setQuery(browser, "needle")
+            BrowserFindController.next(browser)
+            finder.consumers.single().accept(findResult(matches = 3, selected = 2, searching = false))
+
+            BrowserFindController.close(browser)
+            assertEquals(1, finder.keptCount, "Escape must keep the current match selected")
+            assertEquals(0, finder.clearedCount)
+            assertFalse(BrowserFindController.stateFor(browser).visible)
+        }
+    }
+
+    @Test
+    fun `a reply arriving after dispose is dropped`() {
+        // The debounce and the verdict deadline are timers: either can fire after the tab they
+        // belong to is gone, and so can a reply already in flight.
+        withStubbedBrowser(disposeAtEnd = false) { browser, finder, _ ->
+            BrowserFindController.setQuery(browser, "needle")
+            BrowserFindController.next(browser)
+            val consumer = finder.consumers.single()
+
+            BrowserFindController.dispose(browser)
+            consumer.accept(findResult(matches = 9, selected = 1, searching = false))
+
+            // dispose() drops the state, so the reply lands on a fresh one and cannot resurrect a
+            // count for a browser that is gone.
+            assertEquals(0, BrowserFindController.stateFor(browser).totalMatches)
+            BrowserFindController.dispose(browser)
+        }
+    }
+
+    // ========================================================================
+    // "Find again" only claims the chord when it can act on it
+    // ========================================================================
+
+    @Test
+    fun `find again is not claimed unless the bar is up with a query`() {
+        withStubbedBrowser { browser, _, _ ->
+            assertFalse(
+                BrowserFindController.onFindAgainKey(browser, backward = false),
+                "with no bar up, Cmd+G belongs to the page",
+            )
+
+            BrowserFindController.open(browser)
+            assertFalse(
+                BrowserFindController.onFindAgainKey(browser, backward = false),
+                "an empty box has nothing to advance through",
+            )
+
+            BrowserFindController.setQuery(browser, "needle")
+            assertTrue(BrowserFindController.onFindAgainKey(browser, backward = false))
+            assertTrue(
+                BrowserFindController.onFindAgainKey(browser, backward = true),
+                "repeat presses must keep advancing - find again is not single-flighted",
+            )
+        }
+    }
+
+    @Test
+    fun `the find chord is suppressed only when our bar already owns it`() {
+        withStubbedBrowser { browser, _, _ ->
+            // Not up yet: proceed, so a page with its own find-in-page gets first refusal.
+            assertFalse(BrowserFindController.onFindKeyFromPage(browser))
+
+            BrowserFindController.open(browser)
+            // Up: ours, so suppress and re-focus rather than handing the page a key that would
+            // open a second find UI on top of the first.
+            assertTrue(BrowserFindController.onFindKeyFromPage(browser))
+        }
+    }
+
+    @Test
+    fun `one window serves one browser per shortcut event`() {
+        // browserFindEvents is a broadcast and every composed browser surface collects it.
+        // LocalIsPanelActive defaults to true, so a browser in a sidebar slot reads as active
+        // alongside the main panel's - without this claim, one Cmd+F opens two bars.
+        val windowId = "window-under-test-${System.nanoTime()}"
+        assertTrue(BrowserFindController.claimShortcut(windowId))
+        assertFalse(BrowserFindController.claimShortcut(windowId), "a second collector must not also serve it")
+        assertTrue(
+            BrowserFindController.claimShortcut("other-$windowId"),
+            "a different window's event is a different event",
+        )
+    }
+
+    @Test
+    fun `the keymap path hands the chord to the page instead of opening straight away`() {
+        // WAS A BUG IN THIS CHANGE. The shortcut path FEEDS the page path - it re-dispatches the
+        // key so the one page-ownership decision runs - so it must not consume the single-flight
+        // claim that re-entry needs. It did, which left the keymap route dispatching the key and
+        // then dropping the verdict: Cmd+F with AWT focus silently did nothing on any page that
+        // does not own the chord, which is nearly all of them.
+        withStubbedBrowser { browser, _, dispatched ->
+            val state = BrowserFindController.stateFor(browser)
+
+            BrowserFindController.onFindKeyFromShortcut(browser)
+            assertEquals(
+                listOf("KeyPressed", "KeyReleased"),
+                dispatched,
+                "the page must get the chord, so a site with its own find can claim it",
+            )
+            assertFalse(state.visible, "opening is the verdict's decision, not the shortcut's")
+
+            // The re-entry JxBrowser produces from that synthetic key.
+            assertFalse(BrowserFindController.onFindKeyFromPage(browser), "the key must still proceed to the page")
+            BrowserFindController.onPageVerdict(browser, pageHandledKey = false)
+            assertTrue(state.visible, "a page that did not claim the chord gets the BOSS find bar")
+        }
+    }
+
+    @Test
+    fun `a page that claims the chord gets no BOSS find bar`() {
+        withStubbedBrowser { browser, _, _ ->
+            val state = BrowserFindController.stateFor(browser)
+            assertFalse(BrowserFindController.onFindKeyFromPage(browser))
+            BrowserFindController.onPageVerdict(browser, pageHandledKey = true)
+            assertFalse(state.visible, "Sheets, Docs and Notion keep their own find")
+        }
+    }
+
+    @Test
+    fun `a verdict with nothing pending is ignored`() {
+        // The bridge is reachable from any script on the page, so a site can call it unprompted.
+        // With no decision waiting there is nothing to resolve - which is also what makes a page
+        // spamming the bridge cheap to serve.
+        withStubbedBrowser { browser, _, _ ->
+            BrowserFindController.onPageVerdict(browser, pageHandledKey = false)
+            assertFalse(BrowserFindController.stateFor(browser).visible)
+        }
+    }
+
+    // ========================================================================
+    // helpers
+    // ========================================================================
+
+    /**
+     * A [TextFinder] that hands back every consumer it was given, so a test can decide when - and
+     * in which order - a search reports.
+     */
+    private class RecordingTextFinder {
+        val consumers = mutableListOf<Consumer<FindResult>>()
+        var keptCount = 0
+        var clearedCount = 0
+
+        val proxy: TextFinder =
+            Proxy.newProxyInstance(
+                TextFinder::class.java.classLoader,
+                arrayOf(TextFinder::class.java),
+            ) { proxied, method, args ->
+                when (method.name) {
+                    "hashCode" -> {
+                        System.identityHashCode(proxied)
+                    }
+
+                    "equals" -> {
+                        proxied === args?.getOrNull(0)
+                    }
+
+                    "toString" -> {
+                        "recordingTextFinder"
+                    }
+
+                    "find" -> {
+                        @Suppress("UNCHECKED_CAST")
+                        consumers += args?.last() as Consumer<FindResult>
+                        null
+                    }
+
+                    "stopFindingAndKeepSelection" -> {
+                        keptCount++
+                        null
+                    }
+
+                    "stopFindingAndClearSelection" -> {
+                        clearedCount++
+                        null
+                    }
+
+                    else -> {
+                        null
+                    }
+                }
+            } as TextFinder
+    }
+
+    private fun findResult(
+        matches: Int,
+        selected: Int,
+        searching: Boolean,
+    ): FindResult =
+        Proxy.newProxyInstance(
+            FindResult::class.java.classLoader,
+            arrayOf(FindResult::class.java),
+        ) { proxied, method, args ->
+            when (method.name) {
+                "hashCode" -> System.identityHashCode(proxied)
+                "equals" -> proxied === args?.getOrNull(0)
+                "toString" -> "findResult($selected/$matches, searching=$searching)"
+                "numberOfMatches" -> matches
+                "selectedMatch" -> selected
+                "isSearching" -> searching
+                else -> null
+            }
+        } as FindResult
+
+    private fun stubBrowser(
+        finder: TextFinder,
+        dispatched: MutableList<String> = mutableListOf(),
+    ): Browser =
+        Proxy.newProxyInstance(
+            Browser::class.java.classLoader,
+            arrayOf(Browser::class.java),
+        ) { proxied, method, args ->
+            when {
+                method.name == "hashCode" -> {
+                    System.identityHashCode(proxied)
+                }
+
+                method.name == "equals" -> {
+                    proxied === args?.getOrNull(0)
+                }
+
+                method.name == "toString" -> {
+                    "stubBrowser"
+                }
+
+                method.name == "textFinder" -> {
+                    finder
+                }
+
+                method.name == "dispatch" -> {
+                    dispatched += args?.getOrNull(0)?.let { it::class.java.simpleName }.orEmpty()
+                    null
+                }
+
+                // isClosed comes from Closeable; false is what the boolean default below gives it,
+                // and it must stay false or every call under test is skipped and the assertions
+                // pass against a controller that did nothing.
+                method.returnType == Boolean::class.javaPrimitiveType -> {
+                    false
+                }
+
+                else -> {
+                    null
+                }
+            }
+        } as Browser
+
+    /**
+     * Run [block] on the AWT event thread with a fresh stub browser registered.
+     *
+     * On the EDT, not off it: the controller hops every state write there, so a test driving it
+     * from a worker would assert against writes that have not happened yet. Running ON the thread
+     * makes `onEdt` inline and the whole sequence synchronous, with no sleeps and nothing to flake.
+     */
+    private fun withStubbedBrowser(
+        disposeAtEnd: Boolean = true,
+        block: (Browser, RecordingTextFinder, MutableList<String>) -> Unit,
+    ) {
+        val finder = RecordingTextFinder()
+        val dispatched = mutableListOf<String>()
+        val browser = stubBrowser(finder.proxy, dispatched)
+        BrowserFindController.register(browser)
+        var failure: Throwable? = null
+        SwingUtilities.invokeAndWait {
+            try {
+                block(browser, finder, dispatched)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                failure = e
+            } finally {
+                if (disposeAtEnd) BrowserFindController.dispose(browser)
+            }
+        }
+        failure?.let { throw it }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFindTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserFindTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.components.overlays.insetBounds
 import ai.rever.boss.components.overlays.resolveRegion
+import ai.rever.boss.utils.SystemUtils
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntRect
@@ -324,13 +325,23 @@ class BrowserFindTest {
             )
             assertFalse(state.visible, "opening is the verdict's decision, not the shortcut's")
 
-            // The re-entry JxBrowser produces from that synthetic key.
-            assertFalse(BrowserFindController.onFindKeyFromPage(browser), "the key must still proceed to the page")
+            // Armed by the shortcut ITSELF, with no re-entry involved. This is the fallback: if a
+            // programmatically dispatched key never reaches this browser's PressKeyCallback, the
+            // deadline is still running and the bar still opens.
             BrowserFindController.onPageVerdict(browser, pageHandledKey = false)
             assertTrue(state.visible, "a page that did not claim the chord gets the BOSS find bar")
         }
     }
 
+    /**
+     * The cancel side of the verdict deadline, asserted synchronously.
+     *
+     * There was a timer-driven twin of this that waited out the deadline and checked the bar had
+     * stayed shut. It went, for two reasons: it only failed when BOTH guards regressed (the verdict
+     * stopping the timer, and the timer's body checking the decision is still pending), so it was a
+     * poor detector; and it flaked once in a full-module run for a reason I could not pin, which is
+     * worse than no test. This one covers the same end state with no timer in it.
+     */
     @Test
     fun `a page that claims the chord gets no BOSS find bar`() {
         withStubbedBrowser { browser, _, _ ->
@@ -352,9 +363,135 @@ class BrowserFindTest {
         }
     }
 
+    @Test
+    fun `the re-entry from the synthetic key does not re-arm the deadline`() {
+        // The shortcut path arms the decision, then dispatches. When JxBrowser DOES re-enter with
+        // the synthetic key, that re-entry must proceed the key to the page without restarting the
+        // timer - one press, one decision, one bar.
+        withStubbedBrowser { browser, _, dispatched ->
+            BrowserFindController.onFindKeyFromShortcut(browser)
+            assertEquals(listOf("KeyPressed", "KeyReleased"), dispatched)
+
+            assertFalse(
+                BrowserFindController.onFindKeyFromPage(browser),
+                "the re-entry must proceed, so the page still gets its chance at the chord",
+            )
+            // Exactly one decision is pending: resolving it once opens the bar, and a second
+            // resolution finds nothing left to resolve.
+            BrowserFindController.onPageVerdict(browser, pageHandledKey = false)
+            assertTrue(BrowserFindController.stateFor(browser).visible)
+            BrowserFindController.close(browser)
+            BrowserFindController.onPageVerdict(browser, pageHandledKey = false)
+            assertFalse(
+                BrowserFindController.stateFor(browser).visible,
+                "a second verdict for one press must not reopen the bar",
+            )
+        }
+    }
+
+    @Test
+    fun `dispose is final - a late key or verdict cannot resurrect a dead browser`() {
+        // Every accessor here used computeIfAbsent or put, so a key event or a verdict arriving
+        // after teardown re-created the state - and through awaitPageVerdict, a live Swing Timer -
+        // for a browser that is gone.
+        withStubbedBrowser(disposeAtEnd = false) { browser, _, dispatched ->
+            BrowserFindController.dispose(browser)
+
+            assertFalse(
+                BrowserFindController.onFindKeyFromPage(browser),
+                "a disposed browser proceeds and does nothing",
+            )
+            BrowserFindController.onFindKeyFromShortcut(browser)
+            assertEquals(emptyList(), dispatched, "nothing is dispatched at a disposed browser")
+            assertFalse(BrowserFindController.onFindAgainKey(browser, backward = false))
+            BrowserFindController.onPageVerdict(browser, pageHandledKey = false)
+
+            assertFalse(BrowserFindController.stateFor(browser).visible, "no bar for a browser that is gone")
+        }
+    }
+
+    @Test
+    fun `a search is skipped rather than locked against the wrong object`() {
+        // withFinder used to mint a fresh ReentrantReadWriteLock when the entry was absent, which
+        // silently substitutes a DIFFERENT lock than the handle's - dropping the mutual exclusion
+        // that the register(browser, browserLock) overload exists to provide.
+        val finder = RecordingTextFinder()
+        val browser = stubBrowser(finder.proxy)
+        // Deliberately NOT registered, which is the only way the lock entry is missing.
+        SwingUtilities.invokeAndWait {
+            BrowserFindController.setQuery(browser, "needle")
+            BrowserFindController.next(browser)
+            assertEquals(0, finder.consumers.size, "no lock means no search, not a search on a new lock")
+            BrowserFindController.dispose(browser)
+        }
+    }
+
+    @Test
+    fun `find again accepts both platform conventions`() {
+        // WAS A BUG. The field gated find-again on isMetaPressed alone, so Ctrl+G matched nothing on
+        // Windows and Linux - and nothing else could serve it either, because the bar owns keyboard
+        // focus while it is up.
+        // F3 everywhere, no modifier needed.
+        assertTrue(isFindAgainChord(isF3 = true, isG = false, meta = false, ctrl = false))
+        if (SystemUtils.isMacOS) {
+            assertTrue(isFindAgainChord(isF3 = false, isG = true, meta = true, ctrl = false))
+            assertFalse(isFindAgainChord(isF3 = false, isG = true, meta = false, ctrl = true))
+            assertFalse(
+                isFindAgainChord(isF3 = false, isG = true, meta = true, ctrl = true),
+                "both modifiers is not the chord, matching the key callback's rule",
+            )
+        } else {
+            assertTrue(isFindAgainChord(isF3 = false, isG = true, meta = false, ctrl = true))
+            assertFalse(isFindAgainChord(isF3 = false, isG = true, meta = true, ctrl = false))
+        }
+        // Some other key with the right modifier is not find-again.
+        assertFalse(isFindAgainChord(isF3 = false, isG = false, meta = true, ctrl = true))
+    }
+
+    @Test
+    fun `the verdict deadline opens the bar when nothing reports`() {
+        // The documented NORMAL path, not a rare fallback: the built-in PDF viewer, network error
+        // pages, `about:` URLs and any frame injection could not reach all report nothing at all.
+        // Nothing else in this suite exercises a timer, so this is the only check that the deadline
+        // is armed rather than merely written down.
+        val finder = RecordingTextFinder()
+        val browser = stubBrowser(finder.proxy)
+        BrowserFindController.register(browser)
+        try {
+            SwingUtilities.invokeAndWait {
+                assertFalse(BrowserFindController.onFindKeyFromPage(browser), "the page gets the chord first")
+                assertFalse(BrowserFindController.stateFor(browser).visible, "and the bar waits for its answer")
+            }
+            // Pumped, not slept through: the deadline is a Swing Timer, so it fires ON this thread.
+            // Each invokeAndWait is a round trip that lets pending timer events run, which converges
+            // as soon as the deadline elapses instead of pinning the test to a fixed sleep.
+            val opened = awaitOnEdt { BrowserFindController.stateFor(browser).visible }
+            assertTrue(opened, "silence from the page must end in the BOSS find bar")
+        } finally {
+            SwingUtilities.invokeAndWait { BrowserFindController.dispose(browser) }
+        }
+    }
+
     // ========================================================================
     // helpers
     // ========================================================================
+
+/**
+     * Poll [predicate] on the AWT event thread until it holds, or the budget runs out.
+     *
+     * Each `invokeAndWait` is a round trip through the event queue, so pending Swing `Timer` events
+     * get to run - which is how a timer-driven assertion converges without a fixed sleep. The budget
+     * is generously above the deadline so a loaded CI machine cannot fail this by being slow.
+     */
+    private fun awaitOnEdt(predicate: () -> Boolean): Boolean {
+        val deadline = System.nanoTime() + 3_000_000_000L
+        while (System.nanoTime() < deadline) {
+            var held = false
+            SwingUtilities.invokeAndWait { held = predicate() }
+            if (held) return true
+        }
+        return false
+    }
 
     /**
      * A [TextFinder] that hands back every consumer it was given, so a test can decide when - and

--- a/scripts/test/test-find-key-probe.js
+++ b/scripts/test/test-find-key-probe.js
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Runs the find-key probe against a fake DOM.
+ *
+ * BrowserFindKeyProbe's script decides whether BOSS's find bar opens or the PAGE keeps the find
+ * chord, and it lives as JavaScript inside a Kotlin string - so the Kotlin suite can only grep it.
+ * What matters here is not the text but the behaviour, and one behaviour in particular:
+ *
+ *   A page that calls `preventDefault()` AND `stopPropagation()` must still be reported as having
+ *   handled the key.
+ *
+ * That is what Google Sheets, Docs and Notion do, and it is the case the obvious implementation
+ * gets wrong. Reading `defaultPrevented` from a bubble-phase listener looks equivalent and is not:
+ * a stopped event never reaches the bubble phase, so the page's own find would be reported as
+ * "free" and BOSS would open its bar over the top. Deferring with `setTimeout(..., 0)` from the
+ * capture phase is what makes it correct, and only executing the script can tell the two apart.
+ *
+ * Same technique and directory as test-browser-collector.js, for the same reason.
+ *
+ * Usage: node scripts/test/test-find-key-probe.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const probeKt = path.join(
+  repoRoot,
+  'composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserFindKeyProbe.kt',
+);
+
+let failures = 0;
+function eq(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    console.log(`  ok   ${name}`);
+  } else {
+    failures++;
+    console.log(`  FAIL ${name} -> got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extract the probe source out of the Kotlin string, resolving $CONSTANTS.
+// ---------------------------------------------------------------------------
+function loadProbe() {
+  const src = fs.readFileSync(probeKt, 'utf8');
+  const consts = {};
+  for (const m of src.matchAll(/const val (\w+)\s*(?::\s*\w+)?\s*=\s*"([^"\n]*)"/g)) {
+    consts[m[1]] = m[2];
+  }
+  const body = src.split('"""')[1];
+  const lines = body.split('\n').slice(1);
+  const indent = Math.min(
+    ...lines.filter((l) => l.trim()).map((l) => l.length - l.trimStart().length),
+  );
+  let js = lines.map((l) => (l.trim() ? l.slice(indent) : '')).join('\n');
+  for (const k of Object.keys(consts).sort((a, b) => b.length - a.length)) {
+    js = js.split('$' + k).join(consts[k]);
+  }
+  const unresolved = js.split('\n').filter((l) => l.includes('$'));
+  if (unresolved.length) {
+    throw new Error(`unresolved interpolation in probe source: ${unresolved[0]}`);
+  }
+  return { js, consts };
+}
+
+const { js: PROBE, consts } = loadProbe();
+
+// ---------------------------------------------------------------------------
+// A DOM event model just large enough: a three-node path, both phases, and the
+// three ways a page can interfere.
+// ---------------------------------------------------------------------------
+function makeEnv(platform) {
+  const listeners = new Map();
+  const reg = (node) => {
+    if (!listeners.has(node)) listeners.set(node, { capture: [], bubble: [] });
+    return listeners.get(node);
+  };
+  const timers = [];
+  const node = (name) => {
+    const n = { name };
+    n.addEventListener = (_type, fn, capture) => reg(n)[capture ? 'capture' : 'bubble'].push(fn);
+    return n;
+  };
+  const target = node('target');
+  const document = node('document');
+  const win = node('window');
+  win.navigator = { platform };
+  win.document = document;
+  win.window = win;
+  win.setTimeout = (fn) => timers.push(fn);
+  return {
+    win,
+    document,
+    target,
+    listeners,
+    runTimers: () => {
+      while (timers.length) timers.shift()();
+    },
+  };
+}
+
+function dispatch(env, event) {
+  event.defaultPrevented = false;
+  let stopped = false;
+  let stoppedNow = false;
+  event.preventDefault = () => {
+    event.defaultPrevented = true;
+  };
+  event.stopPropagation = () => {
+    stopped = true;
+  };
+  event.stopImmediatePropagation = () => {
+    stopped = true;
+    stoppedNow = true;
+  };
+  const chain = [env.win, env.document, env.target];
+  const phases = [
+    ...chain.map((n) => [n, 'capture']),
+    ...chain.slice().reverse().map((n) => [n, 'bubble']),
+  ];
+  for (const [n, phase] of phases) {
+    if (stoppedNow) break;
+    const fns = (env.listeners.get(n) || { capture: [], bubble: [] })[phase];
+    for (const fn of fns.slice()) {
+      // A listener that throws does NOT abort dispatch in a real DOM - the error is reported and
+      // the remaining listeners still run. Swallowing it here matters: without this the harness
+      // would answer a different question than the browser does, and the "throwing page handler"
+      // case below would pass or fail for the wrong reason.
+      try {
+        fn(event);
+      } catch (ignored) {
+        /* reported to the page's console in a browser; irrelevant here */
+      }
+      if (stoppedNow) break;
+    }
+    // Propagation halts after the current node's listeners finish.
+    if (stopped) break;
+  }
+}
+
+function inject(env) {
+  vm.runInNewContext(PROBE, {
+    window: env.win,
+    navigator: env.win.navigator,
+    setTimeout: env.win.setTimeout,
+  });
+}
+
+/**
+ * @param installFirst register the page's listener BEFORE the probe, i.e. the one ordering the
+ *   probe cannot win. Document-start injection makes it the unusual case, not the normal one.
+ */
+function run({ platform = 'MacIntel', event, install, installFirst = false, bridge = true }) {
+  const env = makeEnv(platform);
+  const reports = [];
+  if (bridge) env.win[consts.BRIDGE_PROPERTY] = { report: (v) => reports.push(v) };
+  if (installFirst && install) install(env);
+  inject(env);
+  if (!installFirst && install) install(env);
+  dispatch(env, event);
+  env.runTimers();
+  return reports;
+}
+
+const HANDLED = consts.VERDICT_HANDLED;
+const FREE = consts.VERDICT_FREE;
+const cmdF = (over = {}) => ({
+  code: 'KeyF',
+  keyCode: 70,
+  metaKey: true,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...over,
+});
+const ctrlF = (over = {}) => cmdF({ metaKey: false, ctrlKey: true, ...over });
+
+console.log('find-key probe');
+
+// --- who owns the chord ---------------------------------------------------
+eq('a page listening for nothing leaves the chord free', run({ event: cmdF() }), [FREE]);
+eq(
+  'preventDefault on the target reads as handled',
+  run({ event: cmdF(), install: (e) => e.target.addEventListener('keydown', (ev) => ev.preventDefault(), false) }),
+  [HANDLED],
+);
+eq(
+  'Sheets-shaped: document capture, preventDefault + stopPropagation, reads as handled',
+  run({
+    event: cmdF(),
+    install: (e) =>
+      e.document.addEventListener(
+        'keydown',
+        (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+        },
+        true,
+      ),
+  }),
+  [HANDLED],
+);
+eq(
+  'preventDefault by the very last handler still reads as handled',
+  run({ event: cmdF(), install: (e) => e.win.addEventListener('keydown', (ev) => ev.preventDefault(), false) }),
+  [HANDLED],
+);
+eq(
+  'stopping propagation WITHOUT preventDefault does not claim the chord',
+  run({
+    event: cmdF(),
+    install: (e) => e.document.addEventListener('keydown', (ev) => ev.stopPropagation(), true),
+  }),
+  [FREE],
+);
+eq(
+  'a page that stops us immediately, ahead of injection, reports nothing (the host deadline covers it)',
+  run({
+    event: cmdF(),
+    installFirst: true,
+    install: (e) => e.win.addEventListener('keydown', (ev) => ev.stopImmediatePropagation(), true),
+  }),
+  [],
+);
+
+// --- which chord ----------------------------------------------------------
+eq('Cmd+Shift+F is Focus Mode, not find', run({ event: cmdF({ shiftKey: true }) }), []);
+eq('Cmd+Alt+F is not the find chord', run({ event: cmdF({ altKey: true }) }), []);
+eq('F with no modifier is not the find chord', run({ event: cmdF({ metaKey: false }) }), []);
+eq('Cmd+G is not the find chord', run({ event: { code: 'KeyG', keyCode: 71, metaKey: true } }), []);
+eq('Cmd+Ctrl+F is not the find chord on macOS', run({ event: cmdF({ ctrlKey: true }) }), []);
+eq('Ctrl+F is not the find chord on macOS', run({ event: ctrlF() }), []);
+eq('Ctrl+F IS the find chord off macOS', run({ platform: 'Win32', event: ctrlF() }), [FREE]);
+eq('Cmd+F is not the find chord off macOS', run({ platform: 'Win32', event: cmdF() }), []);
+eq(
+  'a frame with no event.code falls back to keyCode',
+  run({ event: { keyCode: 70, metaKey: true, ctrlKey: false, shiftKey: false, altKey: false } }),
+  [FREE],
+);
+
+// --- never break the page -------------------------------------------------
+eq('no bridge published: no report, and nothing thrown', run({ event: cmdF(), bridge: false }), []);
+{
+  // Re-injection into one document must not double-report: the host injects per frame at document
+  // start, and a single-page app can produce more than one call for the same context.
+  const env = makeEnv('MacIntel');
+  const reports = [];
+  env.win[consts.BRIDGE_PROPERTY] = { report: (v) => reports.push(v) };
+  inject(env);
+  inject(env);
+  dispatch(env, cmdF());
+  env.runTimers();
+  eq('re-injection into the same document is a no-op', reports, [FREE]);
+}
+{
+  // A page throwing from its own handler must not stop us reporting - the probe's verdict is
+  // about the key, not about whether the site is healthy.
+  const reports = run({
+    event: cmdF(),
+    install: (e) =>
+      e.document.addEventListener(
+        'keydown',
+        () => {
+          throw new Error('page handler blew up');
+        },
+        true,
+      ),
+  });
+  eq('a throwing page handler does not lose the verdict', reports, [FREE]);
+}
+
+console.log(failures === 0 ? '\nAll find-key probe checks passed.' : `\n${failures} check(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Cmd+F in a browser pane worked or did nothing depending on who held AWT focus, and a site with its own find-in-page (Google Sheets, Docs, Notion) could never serve it.

## Two implementations, one a dead wire

- **Live:** `FluckEngine`'s `PressKeyCallback` opened a hand-rolled Swing find bar and returned `Response.suppress()`.
- **Dead:** every keymap preset binds Cmd+F to `KeymapActions.BROWSER_FIND`, which `AWTKeyboardInterceptor` dispatched into `MenuActionsHandler.browserFindEvents` - a `SharedFlow` with **zero collectors**. `dispatchAction` returned `true`, so the interceptor called `event.consume()` and the key died.

Which one ran came down to whether the JxBrowser component was the AWT focus owner (`detectContextFromAwtComponent`, reached because `updateWindowContext` has no callers). Under HARDWARE_ACCELERATED - the default on every platform - the shared-surface widget has no focus wiring, so a re-shown tab holds no keyboard focus at all and AWT gets the key. Same for Cmd+F *inside* the old find field: `findWindowId` walked to the JDialog's owner, matched the binding, and consumed the key before the field's own handler ran.

`browserFindEvents` is now collected in `BrowserHandleImpl.Content()` - the composition that knows it is the visible surface of the active panel in that window, so nothing has to answer "which browser" from outside - and it hands the chord to the browser rather than forking behaviour, so one decision point serves both routes.

## Suppressing meant the page never saw the key

Chrome treats Ctrl/Cmd+F as a *non-reserved* accelerator: the page gets it first and `preventDefault()` wins. That is the whole mechanism behind Sheets' find working in Chrome. JxBrowser offers nothing here - `PressKeyCallback.Response` is only `proceed()`/`suppress()`, and there is no "did the page consume it" signal in 9.4.0 - so we ask the page.

`BrowserFindKeyProbe` injects one **capture-phase** `keydown` listener into **every frame** (a keydown goes to the focused frame) and defers with `setTimeout(..., 0)` before reading `defaultPrevented`. The deferral is load-bearing twice: the flag is only final after dispatch, and it survives `stopPropagation()` - which Sheets and Docs both call, and which a bubble-phase listener never sees.

| Signal | Result |
|---|---|
| `report("handled")` | nothing opens - the page owns Cmd+F |
| `report("free")` | our find bar opens |
| no report inside 150 ms | our find bar opens |

The deadline is the normal path for anything the script cannot reach: the built-in PDF viewer, error pages, `about:` URLs, a frame whose injection failed.

## Fixed in the search itself

- **`FindResult.isSearching()` was ignored.** `TextFinderImpl.handleFindReply` invokes the consumer on every reply, `SEARCHING` ones included, where `numberOfMatches()` is a running tally. The old bar rendered them, so every keystroke flashed a red `0/0`.
- **Overlapping sessions raced the label.** `find()` allocates a fresh `FindRequestId` per call and keeps a live consumer for each, and the 150 ms debounce cannot cancel a search already in flight - so the label showed whichever session *finished* last, not the current query's. Epoch-guarded now.
- **Escape discarded the match.** `stopFindingAndClearSelection` drops the selection and scrolls the reader back to where they started; `stopFindingAndKeepSelection` existed and was unused.
- **Placed against the window, not the pane** (`owner.y + 80`, a magic chrome height), so both panes of a split stacked their bars in one corner and a right sidebar could sit under it.
- **Theme snapshotted at construction**, so a live theme switch never reached an open bar.

## The bar

The Swing `JDialog` (~300 lines) is replaced by Compose routed through the existing `OverlayCorner` seam, so it works in both rendering modes - required, not cosmetic, since a lightweight overlay renders *behind* the native GPU surface. It anchors to the pane rect `Content()` already tracks for the pinch gate.

Two additive changes to the overlay primitives, both defaulted so no existing caller moves:

- `focusable` on `HeavyweightCorner` / `OverlayCorner` - a text field needs it, and `HeavyweightModal` already does this for the New Tab dialog's URL field.
- `regionInWindow` - `inset` can only pull an overlay in from the **end and bottom** edges, so a top-anchored caller in a sub-region (a browser pane in a split, which need not start at the top of the window) cannot express where it sits. Clamped to the pane rather than trusted, since Compose and AWT measure it independently and can disagree for a frame during a resize. `resolveRegion` lives in `OverlayWindowBounds.kt` with the other placement helpers.

Cmd+G / Shift+Cmd+G advance, claimed only while the bar is up with a query - otherwise the chord does nothing here and belongs to the page.

Mounted in `BrowserHandleImpl.Content()`, the single chokepoint for every browser surface, so browser tabs and every other `BrowserHandle` host get this at once.

## Verification

- `:composeApp:desktopTest` green: **208 suites, 2326 tests, 0 failures**. `ktlintCheck` and `detekt` green.
- 22 new tests in `BrowserFindTest`. Reflection proxies for `Browser` / `TextFinder` / `FindResult`, matching `PopupWindowContextMenuTest` - no mocking library in this build - and driven **on** the EDT so the controller's state hops are synchronous with no sleeps.
- **Every regression test was verified to fail against its own bug** by reverting the fix: the `isSearching` guard, the epoch guard, keep-vs-clear on Escape, the density division, the degenerate-rect guard, the region clamp, and the shortcut path's claim (see below).
- `scripts/test/test-find-key-probe.js` **executes** the shipped script against a fake DOM (18 checks), extracting it from the Kotlin source so it cannot drift. Added to `build.yml` next to the existing collector harness. The Sheets case cannot be distinguished by reading the script - both mutations that produce the wrong implementation (bubble-phase listener; capture flag flipped) fail there and pass a structural check.

One bug in this change was found and fixed during review: the shortcut path *feeds* the page path, so claiming the single-flight slot starved the re-entry it triggers - Cmd+F with AWT focus dispatched the key and then dropped the verdict, doing nothing on any page that does not own the chord. `the keymap path hands the chord to the page instead of opening straight away` pins it.

### Review follow-up (second commit)

All six findings from the review are fixed, not accepted. Details in the commit message; the ones that changed behaviour:

- **The keymap path now arms the verdict deadline before dispatching**, so it no longer depends on JxBrowser re-entering `PressKeyCallback` for a programmatically dispatched key. That dependency was the original bug restored on the one path this PR exists to repair.
- **A focusable corner overlay is an owned `ComposeDialog`, not a top-level window.** One root cause behind two findings: an unowned window taking focus deactivates the main window, which made `FocusModeQuickActions` fall back to its lightweight path (drawn *behind* the Chromium surface, so the cluster vanished while the bar was up), and gave the bar a Windows taskbar button and Alt-Tab card. The owned dialog keeps `Window.Type.UTILITY`, so it also restores what the old `JDialog` had - and `AWTKeyboardInterceptor.findWindowId` walks `owner`, so **app shortcuts keep routing while the find field has focus.** That resolves the first caveat this PR originally carried.
- **The shortcut claim is deterministic**, via a new host-internal `LocalInMainWindowPanel` (default `false`) rather than a race between coroutine resumptions.
- **Find-again from the field works off macOS** (Ctrl+G, plus F3), sharing one rule with the key callback.
- **The 8dp margin survives `OFF_SCREEN`**, folded per path through `overlayCornerIsHeavyweight()`.

Plus the lifecycle items (dispose is final; `withFinder` fails closed instead of locking a different object than the handle's; `lastShortcutAtMs` bounded; monotonic clock), the arrows/counter agreeing on `settled`, and the probe KDoc no longer overclaiming - a non-focused frame *can* answer for the focused one, now stated.

Two things worth knowing about the tests:

- `OverlayCornerForwardingTest` pins that `OverlayCorner` forwards `focusable` and `regionInWindow`. Both have defaults, so dropping either compiles and leaves every other test green.
- One test was written and then **removed rather than shipped**: a timer-driven "a handled verdict cancels the deadline" check. It only failed when *both* independent guards regressed (verified by mutation), and it flaked once in a full-module run for a reason I could not pin. Its end state is already asserted synchronously by `a page that claims the chord gets no BOSS find bar`.

`WindowIconConventionTest` caught the new `DialogWindow` site unbranded - a genuine catch. Branded rather than exempted, since the window type is set through a `runCatching` and a platform that refuses it leaves a dialog that does have an icon surface.

Gates after the follow-up: **209 suites, 2333 tests, 0 failures**, ktlint and detekt clean, both node harnesses passing.

### Still to check in the running app

- A `HeavyweightModal` opening over an open find bar. Reasoned safe (the bar does not touch `openHeavyweightPopups`, a modal reacts to *itself* losing focus rather than to gaining it, and a modal cannot be opened while the bar holds focus), and now less exposed since the bar no longer deactivates the main window - but it is the one interaction no test covers.
- The owned-dialog path's transparency on Windows and Linux. `EnsureOverlayWindowTransparent` takes `java.awt.Window` and so applies to the dialog unchanged, but this repo's 500-line transparency helper exists because these paths have platform traps; it has been exercised on macOS here.

Touches `BrowserHandleImpl.Content()`, which #204 also modifies - a conflict is expected there and the two changes are unrelated.
