### PR TITLE
Ask what removing a project means, and offer to trash the folder

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.components.buttons.QuickActionHints
 import ai.rever.boss.components.dialogs.CommitDialog
 import ai.rever.boss.components.dialogs.ProjectOpenModeDialog
 import ai.rever.boss.components.dialogs.ProjectSelectionDialog
+import ai.rever.boss.components.dialogs.RemoveProjectDialog
 import ai.rever.boss.components.events.PanelEventBus
 import ai.rever.boss.components.events.TerminalLinkEventBus
 import ai.rever.boss.components.model.BossDraggableComponent
@@ -24,6 +25,7 @@ import ai.rever.boss.git.GitStashInfo
 import ai.rever.boss.platform.rememberDirectoryPicker
 import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.project.removeProjectAndReport
 import ai.rever.boss.services.supabase.AuthService
 import ai.rever.boss.utils.extractFileName
 import ai.rever.boss.window.LocalWindowGitState
@@ -141,6 +143,7 @@ fun BossDraggableComponent.getProjectSelectContextMenuItems(
     showNewProjectDialog: () -> Unit,
     showCloneProjectDialog: () -> Unit,
     onProjectSelected: (Project) -> Unit,
+    onRemoveProject: (Project) -> Unit,
 ): List<ContextMenuItem> {
     val recentProjects by ProjectState.recentProjects.collectAsState()
 
@@ -153,7 +156,9 @@ fun BossDraggableComponent.getProjectSelectContextMenuItems(
                     icon = Icons.Outlined.Folder,
                     trailingIcon = Icons.Outlined.Close,
                     trailingIconColor = androidx.compose.ui.graphics.Color.Gray,
-                    onTrailingClick = { ProjectState.removeRecentProject(project.path) },
+                    // Asks, like the home screen's card cross. Both crosses mean the same
+                    // thing, so both go through RemoveProjectDialog.
+                    onTrailingClick = { onRemoveProject(project) },
                     onClick = { onProjectSelected(project) },
                 )
             },
@@ -425,6 +430,7 @@ fun BossDraggableComponent.BossTopLeftBar(
     var showProjectDialog by remember { mutableStateOf(false) }
     var projectToOpen by remember { mutableStateOf<Project?>(null) }
     var deletedProjectName by remember { mutableStateOf<String?>(null) }
+    var projectToRemove by remember { mutableStateOf<Project?>(null) }
 
     // Window-specific git state - each window maintains independent git state
     // This fixes the issue where opening a new window with no project would hide git UI in all windows
@@ -511,9 +517,23 @@ fun BossDraggableComponent.BossTopLeftBar(
                 showNewProjectDialog = { onNewProject?.invoke() },
                 showCloneProjectDialog = { onCloneProject?.invoke() },
                 onProjectSelected = { project -> handleProjectSelection(project) },
+                onRemoveProject = { project -> projectToRemove = project },
             ),
         hintText = if (selectedProject.path.isEmpty()) "Click to open a project" else "Current Project: ${selectedProject.path}",
     )
+
+    // "Remove this project?" - the trailing cross on a recent-projects menu row.
+    projectToRemove?.let { project ->
+        RemoveProjectDialog(
+            project = project,
+            isOpenHere = project.path == selectedProject.path,
+            onDismiss = { projectToRemove = null },
+            onConfirm = { removalScope ->
+                projectToRemove = null
+                scope.launch { removeProjectAndReport(project, removalScope) }
+            },
+        )
+    }
 
     // Deleted project dialog
     deletedProjectName?.let { projectName ->

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/RemoveProjectDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/RemoveProjectDialog.kt
@@ -1,0 +1,181 @@
+package ai.rever.boss.components.dialogs
+
+import ai.rever.boss.plugin.ui.BossAlertDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.project.ProjectRemovalScope
+import ai.rever.boss.project.trashRefusal
+import ai.rever.boss.window.Project
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.Checkbox
+import androidx.compose.material.CheckboxDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/** Keeps the dialog from collapsing to the width of a short project name. */
+private val DIALOG_MIN_WIDTH = 380.dp
+
+/**
+ * Asks what "remove this project" should mean before doing it.
+ *
+ * The cross on a project card used to call `removeRecentProject` straight away. That is
+ * the right *default* - it forgets an entry and touches nothing - but it left no way to
+ * get rid of a project properly, so the folder stayed behind on disk with no affordance
+ * for it anywhere in BOSS.
+ *
+ * So: one confirm, two scopes. Forgetting is the unchecked default and is what the button
+ * does if someone just presses through. The folder deletion is an explicit opt-in that
+ * restates itself in the button label and turns it red, because it is the only thing BOSS
+ * does to a directory the user has not otherwise asked it to touch.
+ *
+ * It moves the folder to the Trash - never an unlink - so a wrong click is recoverable
+ * outside BOSS. [trashRefusal] decides whether that is possible at all and says why not;
+ * an unavailable Trash disables the checkbox rather than quietly downgrading to a delete.
+ */
+@Composable
+fun RemoveProjectDialog(
+    project: Project,
+    isOpenHere: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (ProjectRemovalScope) -> Unit,
+) {
+    // Read once per dialog: the answer depends on the filesystem, and re-reading it on
+    // every recomposition would stat the disk from the composition thread.
+    val refusal = remember(project.path) { trashRefusal(project.path) }
+    var alsoTrash by remember(project.path) { mutableStateOf(false) }
+    val canTrash = refusal == null
+
+    BossAlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Remove ${project.name}?") },
+        text = {
+            DialogBody(
+                project = project,
+                isOpenHere = isOpenHere,
+                refusal = refusal,
+                alsoTrash = alsoTrash && canTrash,
+                canTrash = canTrash,
+                onAlsoTrashChange = { alsoTrash = it },
+            )
+        },
+        confirmButton = {
+            val trashing = alsoTrash && canTrash
+            TextButton(
+                onClick = {
+                    onConfirm(
+                        if (trashing) ProjectRemovalScope.RECENTS_AND_FOLDER else ProjectRemovalScope.RECENTS_ONLY,
+                    )
+                },
+            ) {
+                // The label restates the destructive half rather than staying "Remove",
+                // so the button and the checkbox cannot disagree about what is about to
+                // happen.
+                Text(
+                    text = if (trashing) "Remove and Trash Folder" else "Remove",
+                    color = if (trashing) BossTheme.colors.alert else BossTheme.colors.signalText,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel", color = BossTheme.colors.textMuted)
+            }
+        },
+    )
+}
+
+@Composable
+private fun DialogBody(
+    project: Project,
+    isOpenHere: Boolean,
+    refusal: String?,
+    alsoTrash: Boolean,
+    canTrash: Boolean,
+    onAlsoTrashChange: (Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier.widthIn(min = DIALOG_MIN_WIDTH),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text =
+                "This takes it off your recent projects. " +
+                    "The folder stays where it is unless you say otherwise.",
+            color = BossTheme.colors.textSecondary,
+            fontSize = 12.sp,
+        )
+
+        Text(
+            text = project.path,
+            color = BossTheme.colors.textMuted,
+            fontSize = 11.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        TrashOption(
+            checked = alsoTrash,
+            enabled = canTrash,
+            onCheckedChange = onAlsoTrashChange,
+        )
+
+        refusal?.let {
+            Text(text = it, color = BossTheme.colors.textMuted, fontSize = 11.sp)
+        }
+
+        if (isOpenHere) {
+            // Worth saying, because it is the one case where the button does less than it
+            // looks like it does: the window keeps whatever tabs the project opened.
+            Text(
+                text =
+                    "This project is open in this window. " +
+                        "Removing it does not close what is already open.",
+                color = BossTheme.colors.warn,
+                fontSize = 11.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrashOption(
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(enabled = enabled) { onCheckedChange(!checked) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+            colors = CheckboxDefaults.colors(checkedColor = BossTheme.colors.alert),
+        )
+        Text(
+            text = "Also move the folder to the Trash",
+            color = if (enabled) BossTheme.colors.textPrimary else BossTheme.colors.textMuted,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeProjectDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeProjectDialogs.kt
@@ -1,0 +1,69 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.components.dialogs.ProjectOpenModeDialog
+import ai.rever.boss.components.dialogs.RemoveProjectDialog
+import ai.rever.boss.project.ProjectRemovalScope
+import ai.rever.boss.window.Project
+import ai.rever.boss.window.WindowOperations
+import androidx.compose.runtime.Composable
+
+/**
+ * The two dialogs a project card can raise, kept out of [HomeScreen] so its body stays a
+ * readable list of sections.
+ */
+@Composable
+internal fun HomeProjectDialogs(
+    projectToOpen: Project?,
+    projectToRemove: Project?,
+    openProjectPath: String,
+    onOpenHere: (Project) -> Unit,
+    onOpenDone: () -> Unit,
+    onRemoveDone: () -> Unit,
+    onRemove: (Project, ProjectRemovalScope) -> Unit,
+) {
+    projectToOpen?.let { project ->
+        OpenModeDialog(project = project, onOpenHere = onOpenHere, onDone = onOpenDone)
+    }
+
+    projectToRemove?.let { project ->
+        RemoveProjectDialog(
+            project = project,
+            isOpenHere = project.path == openProjectPath,
+            onDismiss = onRemoveDone,
+            onConfirm = { removalScope ->
+                onRemoveDone()
+                onRemove(project, removalScope)
+            },
+        )
+    }
+}
+
+/**
+ * Asks which window a recent project should open in.
+ *
+ * Extracted mostly to keep [HomeScreen] readable, but the new-window branch is the interesting
+ * part: it must create the window *with* the project.
+ */
+@Composable
+private fun OpenModeDialog(
+    project: Project,
+    onOpenHere: (Project) -> Unit,
+    onDone: () -> Unit,
+) {
+    ProjectOpenModeDialog(
+        project = project,
+        onDismiss = onDone,
+        onOpenInCurrentWindow = { chosen ->
+            onOpenHere(chosen)
+            onDone()
+        },
+        onOpenInNewWindow = { chosen ->
+            // createNewWindowWithProject, not createNewWindow() then select. Project state is PER
+            // WINDOW, so selecting after creating applied the project to the window the user
+            // clicked in and left the new one empty. The two other callers of this flow
+            // (BossTopBar, BossAppDialogs) already use this API.
+            WindowOperations.createNewWindowWithProject(chosen)
+            onDone()
+        },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
@@ -5,7 +5,6 @@ import ai.rever.boss.components.dashboard.cards.FileCard
 import ai.rever.boss.components.dashboard.cards.ProjectCard
 import ai.rever.boss.components.dashboard.cards.SplitTemplateCard
 import ai.rever.boss.components.dashboard.sections.DashboardSection
-import ai.rever.boss.components.dialogs.ProjectOpenModeDialog
 import ai.rever.boss.components.plugin.panels.left_top.ProjectState
 import ai.rever.boss.dashboard.RecentBrowserPage
 import ai.rever.boss.dashboard.RecentBrowserPagesManager
@@ -19,9 +18,10 @@ import ai.rever.boss.keymap.model.KeymapActions
 import ai.rever.boss.keymap.model.shortcutLabelFor
 import ai.rever.boss.plugin.scrollbar.verticalScrollWithScrollbar
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.project.ProjectRemovalScope
+import ai.rever.boss.project.removeProjectAndReport
 import ai.rever.boss.window.LocalWindowProjectState
 import ai.rever.boss.window.Project
-import ai.rever.boss.window.WindowOperations
 import ai.rever.boss.window.selectProjectInWindow
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
@@ -38,9 +38,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
 
 /**
  * The BOSS home screen: what you were working on, everything you can do, and what else exists.
@@ -77,7 +79,9 @@ fun HomeScreen(modifier: Modifier = Modifier) {
     val splitTemplates by SplitTemplatesManager.allTemplates.collectAsState()
 
     var projectToOpen by remember { mutableStateOf<Project?>(null) }
+    var projectToRemove by remember { mutableStateOf<Project?>(null) }
     val scrollState = rememberScrollState()
+    val scope = rememberCoroutineScope()
 
     Box(modifier = modifier.fillMaxSize().background(BossTheme.colors.panel)) {
         Column(
@@ -99,6 +103,7 @@ fun HomeScreen(modifier: Modifier = Modifier) {
                 actions = actions,
                 onAskWhichWindow = { projectToOpen = it },
                 onOpenHere = { selectProjectInWindow(windowProjectState, it) },
+                onAskToRemove = { projectToRemove = it },
             )
 
             RecentPagesSection(suggestions = suggestions, actions = actions)
@@ -111,42 +116,14 @@ fun HomeScreen(modifier: Modifier = Modifier) {
         }
     }
 
-    projectToOpen?.let { project ->
-        OpenModeDialog(
-            project = project,
-            onOpenHere = { selectProjectInWindow(windowProjectState, it) },
-            onDone = { projectToOpen = null },
-        )
-    }
-}
-
-/**
- * Asks which window a recent project should open in.
- *
- * Extracted mostly to keep [HomeScreen] readable, but the new-window branch is the interesting
- * part: it must create the window *with* the project.
- */
-@Composable
-private fun OpenModeDialog(
-    project: Project,
-    onOpenHere: (Project) -> Unit,
-    onDone: () -> Unit,
-) {
-    ProjectOpenModeDialog(
-        project = project,
-        onDismiss = onDone,
-        onOpenInCurrentWindow = { chosen ->
-            onOpenHere(chosen)
-            onDone()
-        },
-        onOpenInNewWindow = { chosen ->
-            // createNewWindowWithProject, not createNewWindow() then select. Project state is PER
-            // WINDOW, so selecting after creating applied the project to the window the user
-            // clicked in and left the new one empty. The two other callers of this flow
-            // (BossTopBar, BossAppDialogs) already use this API.
-            WindowOperations.createNewWindowWithProject(chosen)
-            onDone()
-        },
+    HomeProjectDialogs(
+        projectToOpen = projectToOpen,
+        projectToRemove = projectToRemove,
+        openProjectPath = selectedProject.path,
+        onOpenHere = { selectProjectInWindow(windowProjectState, it) },
+        onOpenDone = { projectToOpen = null },
+        onRemoveDone = { projectToRemove = null },
+        onRemove = { project, removalScope -> scope.launch { removeProjectAndReport(project, removalScope) } },
     )
 }
 
@@ -165,6 +142,7 @@ private fun JumpBackInSection(
     actions: HomeActions,
     onAskWhichWindow: (Project) -> Unit,
     onOpenHere: (Project) -> Unit,
+    onAskToRemove: (Project) -> Unit,
 ) {
     if (recentProjects.isEmpty()) return
     DashboardSection(
@@ -178,7 +156,9 @@ private fun JumpBackInSection(
                     project = project,
                     // Only ask which window when this one already holds a project.
                     onClick = { if (windowHoldsProject) onAskWhichWindow(project) else onOpenHere(project) },
-                    onRemove = { ProjectState.removeRecentProject(project.path) },
+                    // Asks rather than removing. The cross used to forget the project on
+                    // the click, with no undo and no way to get rid of the folder.
+                    onRemove = { onAskToRemove(project) },
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/project/ProjectRemoval.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/project/ProjectRemoval.kt
@@ -1,0 +1,214 @@
+package ai.rever.boss.project
+
+import ai.rever.boss.components.bars.horizontal.StatusMessageManager
+import ai.rever.boss.components.plugin.panels.left_top.ProjectState
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.Project
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Desktop
+import java.io.File
+
+private val logger = BossLogger.forComponent("ProjectRemoval")
+
+/** Whether removing a recent project also disposes of the folder it points at. */
+enum class ProjectRemovalScope {
+    /** Forget the project. The folder stays exactly where it is. */
+    RECENTS_ONLY,
+
+    /** Forget the project and move its folder to the Trash. */
+    RECENTS_AND_FOLDER,
+}
+
+/**
+ * What a removal actually did, so the caller can say so.
+ *
+ * The list entry always goes - that is what the button says it does. The folder is the
+ * part that can fail, and it fails in ways the user needs told about rather than
+ * discovering later that a folder they asked to delete is still on disk.
+ */
+sealed interface ProjectRemovalResult {
+    /** Forgotten, and the folder went to the Trash if it was asked for. */
+    data class Removed(
+        val trashed: Boolean,
+    ) : ProjectRemovalResult
+
+    /** Forgotten, but the folder is still there. [reason] is written for the user. */
+    data class FolderKept(
+        val reason: String,
+    ) : ProjectRemovalResult
+}
+
+/**
+ * Why [path] must not be moved to the Trash, or null when it may be.
+ *
+ * Both kinds of refusal - "this system cannot" and "not this folder" - come back through
+ * one function because they land in the same place: the checkbox that offers the folder
+ * deletion is disabled and shows this text. Two entry points would mean a caller could
+ * check one and forget the other, and the cost of forgetting is a deleted directory.
+ */
+fun trashRefusal(path: String): String? {
+    if (!isTrashAvailable()) return NO_TRASH
+    return pathTrashRefusal(path)
+}
+
+/**
+ * The half of [trashRefusal] that only looks at the path.
+ *
+ * Split out because the other half asks AWT whether this desktop has a Trash, and a
+ * headless JVM - which is how the tests run, and how CI runs everything - answers no. With
+ * one function the guards below would be unreachable from a test, which is the wrong thing
+ * to leave untested: they are what stands between a checkbox and someone's home directory.
+ *
+ * Deliberately blunt. A recent-projects entry is whatever directory someone once pointed
+ * BOSS at, `$HOME` included if they did that.
+ */
+internal fun pathTrashRefusal(path: String): String? {
+    if (path.isBlank()) return "This project has no folder on disk."
+    val folder = canonicalOrNull(path)
+    return if (folder == null) {
+        "That folder cannot be read."
+    } else {
+        PATH_GUARDS.firstNotNullOfOrNull { guard -> guard.reason.takeIf { guard.refuses(folder) } }
+    }
+}
+
+private class PathGuard(
+    val reason: String,
+    val refuses: (File) -> Boolean,
+)
+
+/**
+ * Ordered so the message matches what the user is most likely looking at: the two that
+ * explain a folder that is not there come before the two that explain one BOSS will not
+ * touch.
+ */
+private val PATH_GUARDS =
+    listOf(
+        PathGuard("That folder is already gone.") { !it.exists() },
+        PathGuard("That path is not a folder.") { !it.isDirectory },
+        PathGuard("That is a filesystem root.") { it.parentFile == null },
+        PathGuard("That is your home folder.") { it == HOME_FOLDER },
+    )
+
+/**
+ * Canonical, so `~/projects/..` and a symlink pointing at `$HOME` both reach the guards
+ * that refuse them. A path that cannot be resolved at all is refused rather than guessed at.
+ */
+private fun canonicalOrNull(path: String): File? =
+    try {
+        File(path).canonicalFile
+    } catch (e: java.io.IOException) {
+        logger.warn(LogCategory.FILE, "Could not canonicalise a project path", mapOf("path" to path), error = e)
+        null
+    }
+
+/** Resolved once: it costs a syscall and cannot change while the process runs. */
+private val HOME_FOLDER: File? by lazy {
+    System.getProperty("user.home")?.let { runCatching { File(it).canonicalFile }.getOrNull() }
+}
+
+/**
+ * Forget [project], and move its folder to the Trash when [scope] says so.
+ *
+ * The forget happens either way, including when the folder could not be trashed: the user
+ * pressed a button that says Remove, and leaving the entry behind because a *second*,
+ * optional part failed would be a worse surprise than the entry going. The result says
+ * which of the two happened.
+ *
+ * Moving to the Trash rather than deleting is the whole point of the folder option. There
+ * is no path through this file that unlinks anything - a mistake has to stay recoverable
+ * from the user's own Trash.
+ */
+suspend fun removeProject(
+    project: Project,
+    scope: ProjectRemovalScope,
+): ProjectRemovalResult {
+    val askedForFolder = scope == ProjectRemovalScope.RECENTS_AND_FOLDER
+    val failure = if (askedForFolder) moveFolderToTrash(project.path) else null
+
+    ProjectState.removeRecentProject(project.path)
+
+    return when {
+        failure != null -> ProjectRemovalResult.FolderKept(failure)
+        else -> ProjectRemovalResult.Removed(trashed = askedForFolder)
+    }
+}
+
+/** Returns null on success, or the reason the folder is still on disk. */
+private suspend fun moveFolderToTrash(path: String): String? {
+    trashRefusal(path)?.let { return it }
+
+    return withContext(Dispatchers.IO) {
+        try {
+            // Re-resolved inside the IO block rather than passed in: the refusal above was
+            // checked when the dialog opened, and the folder can have gone since.
+            val moved = Desktop.getDesktop().moveToTrash(File(path))
+            if (moved) {
+                logger.info(LogCategory.FILE, "Moved a project folder to the Trash", mapOf("path" to path))
+                null
+            } else {
+                logger.warn(LogCategory.FILE, "The system refused to trash a project folder", mapOf("path" to path))
+                "The system would not move that folder to the Trash."
+            }
+        } catch (e: SecurityException) {
+            logger.warn(LogCategory.FILE, "Not permitted to trash a project folder", mapOf("path" to path), error = e)
+            "BOSS is not permitted to move that folder."
+        } catch (e: IllegalArgumentException) {
+            // What moveToTrash throws for a path that has gone between the check and here.
+            logger.warn(
+                LogCategory.FILE,
+                "A project folder vanished before it could be trashed",
+                mapOf("path" to path),
+                error = e,
+            )
+            "That folder is already gone."
+        } catch (e: UnsupportedOperationException) {
+            logger.warn(LogCategory.FILE, "This platform cannot trash files", mapOf("path" to path), error = e)
+            NO_TRASH
+        }
+    }
+}
+
+/**
+ * Whether this desktop can move a file to the Trash at all.
+ *
+ * `Desktop.getDesktop()` throws in a headless JVM, which is how the test JVM runs, so the
+ * headless check has to come first rather than being wrapped in a try.
+ */
+private const val NO_TRASH = "This system has no Trash that BOSS can move folders to."
+
+private fun isTrashAvailable(): Boolean =
+    Desktop.isDesktopSupported() &&
+        Desktop.getDesktop().isSupported(Desktop.Action.MOVE_TO_TRASH)
+
+/** What to tell the user. Pure, so the wording is pinned by a test rather than by reading it. */
+fun ProjectRemovalResult.describe(project: Project): String =
+    when (this) {
+        is ProjectRemovalResult.Removed -> {
+            if (trashed) {
+                "Removed ${project.name} and moved its folder to the Trash"
+            } else {
+                "Removed ${project.name} from BOSS"
+            }
+        }
+
+        // Both halves, in that order: the entry did go, and the folder did not. Reporting
+        // only the failure would read as though nothing happened.
+        is ProjectRemovalResult.FolderKept -> {
+            "Removed ${project.name} from BOSS, but the folder is still there. $reason"
+        }
+    }
+
+/**
+ * [removeProject] plus the toast, so the two mount points of the remove dialog - the home
+ * screen's project cards and the top bar's project menu - cannot report it differently.
+ */
+suspend fun removeProjectAndReport(
+    project: Project,
+    scope: ProjectRemovalScope,
+) {
+    val result = removeProject(project, scope)
+    StatusMessageManager.showMessage(result.describe(project))
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/project/ProjectRemovalTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/project/ProjectRemovalTest.kt
@@ -1,0 +1,138 @@
+package ai.rever.boss.project
+
+import ai.rever.boss.window.Project
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The guards standing between a checkbox and someone's files.
+ *
+ * The cross on a project card used to call `removeRecentProject` and nothing else. It now
+ * offers to move the folder to the Trash as well, which is the only thing BOSS does to a
+ * directory the user has not otherwise pointed it at - so the question "which paths must
+ * this refuse" is worth holding down rather than reading once.
+ *
+ * These exercise [pathTrashRefusal], not [trashRefusal]: the latter asks AWT whether this
+ * desktop has a Trash at all, and a headless JVM says no, which would make every case
+ * below pass for the wrong reason.
+ */
+class ProjectRemovalTest {
+    private val temps = mutableListOf<File>()
+
+    @AfterTest
+    fun cleanup() {
+        temps.forEach { it.deleteRecursively() }
+    }
+
+    private fun tempDir(): File =
+        File.createTempFile("project-removal", "").let { file ->
+            file.delete()
+            file.mkdirs()
+            temps += file
+            file
+        }
+
+    @Test
+    fun `an ordinary project folder may be trashed`() {
+        assertNull(pathTrashRefusal(tempDir().absolutePath))
+    }
+
+    @Test
+    fun `a blank path is refused`() {
+        assertNotNull(pathTrashRefusal(""))
+        assertNotNull(pathTrashRefusal("   "))
+    }
+
+    @Test
+    fun `a folder that is already gone is refused`() {
+        val gone = File(tempDir(), "never-existed")
+        assertNotNull(pathTrashRefusal(gone.absolutePath))
+    }
+
+    /** A recent-projects entry is a directory. A file there means something else is wrong. */
+    @Test
+    fun `a plain file is refused`() {
+        val file = File(tempDir(), "notes.txt").apply { writeText("x") }
+        assertNotNull(pathTrashRefusal(file.absolutePath))
+    }
+
+    @Test
+    fun `the home folder is refused`() {
+        val home = System.getProperty("user.home")
+        assertNotNull(pathTrashRefusal(home), "the home directory must never be trashable")
+    }
+
+    /**
+     * The guard is on the canonical path, so the ways of naming `$HOME` without spelling it
+     * are caught too. A `..` walk is the one someone actually reaches by accident.
+     */
+    @Test
+    fun `a path that resolves to the home folder is refused`() {
+        val home = File(System.getProperty("user.home"))
+        val roundabout = File(home, "..").resolve(home.name).path
+        assertNotNull(pathTrashRefusal(roundabout))
+    }
+
+    @Test
+    fun `a filesystem root is refused`() {
+        File.listRoots().forEach { root ->
+            assertNotNull(pathTrashRefusal(root.path), "root ${root.path} must never be trashable")
+        }
+    }
+
+    /**
+     * The reason is shown to the user under a disabled checkbox, so it has to read as a
+     * sentence rather than as an enum name.
+     */
+    @Test
+    fun `every refusal is a readable sentence`() {
+        val refusals =
+            listOfNotNull(
+                pathTrashRefusal(""),
+                pathTrashRefusal(File(tempDir(), "gone").absolutePath),
+                pathTrashRefusal(System.getProperty("user.home")),
+            )
+        assertEquals(3, refusals.size)
+        refusals.forEach { reason ->
+            assertTrue(reason.endsWith("."), "not a sentence: $reason")
+            assertTrue(reason.first().isUpperCase(), "not a sentence: $reason")
+        }
+    }
+
+    private val project = Project(name = "Boss", path = "/tmp/boss", lastOpened = 0L)
+
+    @Test
+    fun `forgetting a project says only that`() {
+        assertEquals(
+            "Removed Boss from BOSS",
+            ProjectRemovalResult.Removed(trashed = false).describe(project),
+        )
+    }
+
+    @Test
+    fun `trashing the folder says so too`() {
+        assertEquals(
+            "Removed Boss and moved its folder to the Trash",
+            ProjectRemovalResult.Removed(trashed = true).describe(project),
+        )
+    }
+
+    /**
+     * The half-done case, and the reason the result type is not a Boolean: the entry went
+     * and the folder did not, and a message reporting only the failure would read as though
+     * nothing had happened at all.
+     */
+    @Test
+    fun `a kept folder reports both halves`() {
+        val message =
+            ProjectRemovalResult.FolderKept("That folder is already gone.").describe(project)
+        assertTrue(message.contains("Removed Boss from BOSS"), message)
+        assertTrue(message.contains("still there"), message)
+        assertTrue(message.contains("That folder is already gone."), message)
+    }
+}


### PR DESCRIPTION
The cross on a project card called `removeRecentProject` on the click. No confirmation, no undo - and no way to get rid of the folder it pointed at, so a project you actually wanted gone left its directory behind with no affordance for it anywhere in BOSS.

## One confirm, two scopes

Both crosses now open `RemoveProjectDialog`: the card on the home screen, and the trailing X on a recent project in the top bar's project menu. They mean the same thing, so they go through the same dialog.

- **Forgetting is the unchecked default.** Pressing through does exactly what the cross did before.
- **"Also move the folder to the Trash" is an explicit opt-in.** The confirm button restates it (`Remove and Trash Folder`) and turns red, so the button and the checkbox cannot disagree about what is about to happen.
- **Trash, never unlink.** There is no path through `ProjectRemoval.kt` that deletes anything - a wrong click has to stay recoverable from the user's own Trash.

## What it refuses

`trashRefusal` disables the checkbox and says why, rather than failing at the point of no return:

| Case | Reason shown |
|---|---|
| No `Desktop.Action.MOVE_TO_TRASH` on this desktop | This system has no Trash that BOSS can move folders to. |
| Entry whose folder has gone | That folder is already gone. |
| Path is a file, not a directory | That path is not a folder. |
| Filesystem root | That is a filesystem root. |
| The user's home directory | That is your home folder. |

The root and home guards run on the **canonical** path, so a `..` walk or a symlink pointing at `$HOME` is caught too. A recent-projects entry is whatever directory someone once pointed BOSS at, `$HOME` included if they did that, and "move your home directory to the Trash" must not be two clicks away behind a checkbox.

An unavailable Trash disables the option; it never quietly downgrades to a delete.

## The half-done case

The list entry is forgotten **even when the folder could not be trashed** - the button says Remove, and leaving the entry behind because a second, optional part failed is a worse surprise than the entry going. `ProjectRemovalResult` carries which of the two happened so the toast reports both halves ("Removed X from BOSS, but the folder is still there. ...") rather than only the failure, which would read as though nothing had happened.

## Testing

`:composeApp:desktopTest`, `ktlintCheck` and `detekt` pass.

`ProjectRemovalTest` (11 tests) covers every guard plus the three result wordings. The path guards are split into `pathTrashRefusal` specifically so they are reachable: the capability half asks AWT, which answers no in a headless JVM, and with one function every case below it would have passed for the wrong reason.

**The tests were checked against their own bug**: deleting the home-directory guard fails three of them (`the home folder is refused`, `a path that resolves to the home folder is refused`, `every refusal is a readable sentence`); restoring it passes.

## Deliberately out of scope

- **Removing a project that is open does not close its tabs.** The dialog says so in amber instead. Auto-closing is a bigger decision than a cross implies.
- **`ProjectDataProvider.removeRecentProject` is unchanged.** It is the programmatic plugin-facing path, not a cross, and a dialog does not belong on it.
- **The auto-removal in `handleProjectSelection`** - which drops an entry whose folder has vanished - is untouched. Nothing was asked for there and nothing is.
