### PR TITLE
Ask before unloading a plugin others depend on, and restart them after

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -15,6 +15,8 @@ import ai.rever.boss.components.dialogs.TerminalLinkOpenDialog
 import ai.rever.boss.components.dialogs.TopOfMindDialog
 import ai.rever.boss.components.events.FileEventBus
 import ai.rever.boss.components.events.PanelEventBus
+import ai.rever.boss.components.plugin.DependentRestartDeclinedException
+import ai.rever.boss.components.plugin.DependentRestartDialog
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MissingDependencyDialog
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
@@ -99,10 +101,26 @@ internal fun BossAppDialogs(state: BossAppState) {
                     coroutineScope.launch {
                         StatusMessageManager.showMessage("Updating ${prompt.displayName}…")
                         val r = PluginUpdateBridge.performUpdate(prompt.pluginId, mgr)
-                        if (r.isSuccess) {
-                            StatusMessageManager.showMessage("Updated ${prompt.displayName} to v${r.getOrNull()}")
-                        } else {
-                            StatusMessageManager.showMessage("Update failed: ${r.exceptionOrNull()?.message}")
+                        val cause = r.exceptionOrNull()
+                        when {
+                            r.isSuccess -> {
+                                StatusMessageManager.showMessage(
+                                    "Updated ${prompt.displayName} to v${r.getOrNull()}",
+                                )
+                            }
+
+                            // Declining the dependent-restart prompt is an answer, not a fault:
+                            // nothing downloaded, nothing unloaded. "Update failed" would read
+                            // as something having gone wrong with a choice the user just made.
+                            cause is DependentRestartDeclinedException -> {
+                                StatusMessageManager.showMessage(
+                                    "${prompt.displayName} was left on v${prompt.currentVersion}",
+                                )
+                            }
+
+                            else -> {
+                                StatusMessageManager.showMessage("Update failed: ${cause?.message}")
+                            }
                         }
                     }
                 }
@@ -158,14 +176,25 @@ internal fun BossAppDialogs(state: BossAppState) {
                                     prompt.storeSourceUrl,
                                     mgr,
                                 )
-                            if (r.isSuccess) {
-                                StatusMessageManager.showMessage(
-                                    "${prompt.displayName} is now on the store version v${r.getOrNull()}",
-                                )
-                            } else {
-                                StatusMessageManager.showMessage(
-                                    "Could not install the store version: ${r.exceptionOrNull()?.message}",
-                                )
+                            val cause = r.exceptionOrNull()
+                            when {
+                                r.isSuccess -> {
+                                    StatusMessageManager.showMessage(
+                                        "${prompt.displayName} is now on the store version v${r.getOrNull()}",
+                                    )
+                                }
+
+                                cause is DependentRestartDeclinedException -> {
+                                    StatusMessageManager.showMessage(
+                                        "${prompt.displayName} was left on ${prompt.runningVersion}",
+                                    )
+                                }
+
+                                else -> {
+                                    StatusMessageManager.showMessage(
+                                        "Could not install the store version: ${cause?.message}",
+                                    )
+                                }
                             }
                         }
                     }
@@ -203,6 +232,10 @@ internal fun BossAppDialogs(state: BossAppState) {
                             }
                             PanelComponentStoreRegistry.resetPanels(prompt.panelIds)
                             StatusMessageManager.showMessage("Uninstalled ${prompt.displayName}")
+                        } else if (result.exceptionOrNull() is DependentRestartDeclinedException) {
+                            // Cancel on the dependent-restart prompt. The plugin is still
+                            // installed and still running, which is what was asked for.
+                            StatusMessageManager.showMessage("${prompt.displayName} was left installed")
                         } else {
                             StatusMessageManager.showMessage(
                                 "Could not uninstall ${prompt.displayName}: ${result.exceptionOrNull()?.message}",
@@ -609,6 +642,23 @@ internal fun BossAppDialogs(state: BossAppState) {
                 )
                 state.pendingTerminalLinkUrl = ""
                 state.pendingTerminalSourceId = null
+            },
+        )
+    }
+
+    // An unload is waiting on this answer: other plugins depend on the one being updated or
+    // removed. Both handlers complete the prompt's `answer` before clearing the field - the
+    // collector's finally block is only a backstop for a window closing mid-dialog.
+    state.pendingDependentRestart?.let { prompt ->
+        DependentRestartDialog(
+            prompt = prompt,
+            onDismiss = {
+                prompt.answer.complete(false)
+                state.pendingDependentRestart = null
+            },
+            onConfirm = {
+                prompt.answer.complete(true)
+                state.pendingDependentRestart = null
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.components.events.TerminalEventBus
 import ai.rever.boss.components.events.TerminalLinkEventBus
 import ai.rever.boss.components.events.URLEventBus
 import ai.rever.boss.components.events.WorkspaceEventBus
+import ai.rever.boss.components.plugin.DependentRestartEventBus
 import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.resolveRegisteredPanelId
@@ -232,6 +233,30 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                 // though a prompt already received here and not yet shown does go with it.
                 snapshotFlow { state.pendingMissingPluginDependency }.first { it == null }
             }
+    }
+
+    // An unload is waiting on a person: other plugins depend on the one being updated or
+    // removed, and confirming restarts them. Unlike the prompt above, this one is BLOCKING an
+    // operation - the unload suspends on `prompt.answer` - so every exit from here has to
+    // complete that deferred, including the one where this effect is cancelled with a dialog
+    // still up. Without the try/finally, closing the window mid-dialog would leave the caller
+    // waiting out the bus's five-minute timeout.
+    LaunchedEffect(windowId) {
+        try {
+            DependentRestartEventBus.restartPrompts
+                .collect { prompt ->
+                    state.pendingDependentRestart = prompt
+                    // Back-pressure exactly as above: a second unload's question waits in the
+                    // channel rather than replacing a dialog someone is reading.
+                    snapshotFlow { state.pendingDependentRestart }.first { it == null }
+                    // The dialog's own handlers answer; this is the backstop for a prompt
+                    // cleared without one, which would otherwise hang the unload.
+                    prompt.answer.complete(false)
+                }
+        } finally {
+            state.pendingDependentRestart?.answer?.complete(false)
+            state.pendingDependentRestart = null
+        }
     }
 
     // Listen for terminal link click events (Issue #346)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.model.TabDraggableComponent
 import ai.rever.boss.components.plugin.AvailablePluginUpdate
 import ai.rever.boss.components.plugin.DefaultPlugin
+import ai.rever.boss.components.plugin.DependentRestartPrompt
 import ai.rever.boss.components.plugin.MissingDependencyPrompt
 import ai.rever.boss.components.plugin.PluginUninstallPrompt
 import ai.rever.boss.components.plugin.StoreVersionPrompt
@@ -116,6 +117,16 @@ internal class BossAppState(
         mutableStateOf<MissingDependencyPrompt?>(null)
     var installingMissingDependency by mutableStateOf(false)
     var missingDependencyError by mutableStateOf<String?>(null)
+
+    /**
+     * Plugins that would be restarted by an unload the user has not answered yet.
+     *
+     * The unload is suspended on this prompt's own `answer`, so leaving it null-but-unanswered
+     * strands the caller until [ai.rever.boss.components.plugin.DependentRestartBus]'s timeout.
+     * Every path that clears this field must complete the deferred first.
+     */
+    var pendingDependentRestart by
+        mutableStateOf<DependentRestartPrompt?>(null)
 
     // A terminal command that arrived from outside this BOSS invocation and is
     // waiting for the operator to confirm it. Null whenever nothing is pending.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DependentRestartDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DependentRestartDialog.kt
@@ -1,0 +1,209 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginUnloadIntent
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * Asks whether the plugins that depend on one being updated or removed may be restarted.
+ *
+ * A dialog rather than the shared [ai.rever.boss.components.dialogs.ConfirmationDialog] because
+ * the answer turns on *which* plugins those are: "3 plugins depend on this" is not something a
+ * person can decide about, and the whole point of asking is that the update used to be refused
+ * with the names known only to the host log.
+ *
+ * The list is scrollable and height-capped. There is no upper bound on how many plugins can
+ * declare one dependency, and a dialog that grew past the window would put its buttons offscreen.
+ *
+ * @param prompt the plugin being unloaded, why, and everything that depends on it
+ * @param onDismiss the user declined; the caller leaves the plugin loaded
+ * @param onConfirm the user agreed; the caller forces the unload and restarts the dependents
+ */
+@Composable
+fun DependentRestartDialog(
+    prompt: DependentRestartPrompt,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    BossDialog(
+        onDismissRequest = onDismiss,
+        properties =
+            DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .width(440.dp)
+                    .onKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+                            onDismiss()
+                            true
+                        } else {
+                            false
+                        }
+                    },
+            shape = RoundedCornerShape(8.dp),
+            backgroundColor = BossTheme.colors.panel,
+            elevation = 8.dp,
+        ) {
+            DependentRestartBody(prompt = prompt, onDismiss = onDismiss, onConfirm = onConfirm)
+        }
+    }
+}
+
+@Composable
+private fun DependentRestartBody(
+    prompt: DependentRestartPrompt,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Column(modifier = Modifier.padding(20.dp)) {
+        Text(
+            text = DependentRestartCopy.title(prompt.intent),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = BossTheme.colors.textPrimary,
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            // The target's display name comes from its manifest, so it is clamped for the same
+            // reason MissingDependencyDialog clamps its own: a crafted name must not be able to
+            // grow the dialog or run on into text that reads like our copy.
+            text = DependentRestartCopy.message(prompt.intent, prompt.targetDisplayName, prompt.dependents),
+            fontSize = 13.sp,
+            color = BossTheme.colors.textSecondary,
+            maxLines = 5,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(modifier = Modifier.height(14.dp))
+
+        LazyColumn(
+            modifier = Modifier.heightIn(max = 220.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            items(prompt.dependents, key = { dependent -> dependent.pluginId }) { dependent ->
+                DependentRow(
+                    dependent = dependent,
+                    openInstances = prompt.openInstancesOf(dependent),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            TextButton(
+                onClick = onDismiss,
+                colors = ButtonDefaults.textButtonColors(contentColor = BossTheme.colors.textSecondary),
+            ) {
+                Text("Cancel")
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Button(
+                onClick = onConfirm,
+                colors =
+                    ButtonDefaults.buttonColors(
+                        // Removing is the destructive one: a dependent loses what it needs and no
+                        // newer version arrives to replace it. Updating restarts things that come
+                        // straight back, so it gets the ordinary signal colour.
+                        backgroundColor =
+                            if (prompt.intent == PluginUnloadIntent.REMOVE) {
+                                BossTheme.colors.alert
+                            } else {
+                                BossTheme.colors.signal
+                            },
+                        contentColor = BossTheme.colors.onSignal,
+                    ),
+            ) {
+                Text(DependentRestartCopy.confirmLabel(prompt.intent))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DependentRow(
+    dependent: DependentPlugin,
+    openInstances: Int,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = dependent.displayName,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = BossTheme.colors.textPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                // Optional dependents are in this list too, and saying so is what stops the
+                // dialog reading as a warning about plugins that are all about to break.
+                text = if (dependent.optional) "Optional" else "Required",
+                fontSize = 11.sp,
+                color = BossTheme.colors.textMuted,
+            )
+        }
+        Text(
+            // What confirming costs, in the only unit the user has: tabs they have open. Silent
+            // when nothing is open, so the common case does not carry a "0 open tabs" line.
+            text =
+                if (openInstances > 0) {
+                    val tabs = if (openInstances == 1) "tab" else "tabs"
+                    "${dependent.pluginId} - $openInstances open $tabs will close"
+                } else {
+                    dependent.pluginId
+                },
+            fontSize = 11.sp,
+            color = BossTheme.colors.textMuted,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DependentRestartPrompt.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DependentRestartPrompt.kt
@@ -1,0 +1,488 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginUnloadIntent
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A pending question: "these plugins depend on the one you are about to unload - restart them?"
+ *
+ * Carries its own answer, which makes it unlike [MissingDependencyPrompt]: that one reports
+ * something and moves on, this one blocks an unload until a person decides. The unload path is
+ * suspending all the way from `PluginManagerAPIImpl.updatePlugin`, so waiting here is waiting in
+ * the Toolbox's own coroutine, not on any UI thread.
+ *
+ * @param targetPluginId the plugin being unloaded
+ * @param dependents everything loaded that declares a dependency on it, optional included
+ * @param openInstances open tabs per dependent plugin id, so the dialog can say what closes
+ */
+data class DependentRestartPrompt(
+    val targetPluginId: String,
+    val targetDisplayName: String,
+    val intent: PluginUnloadIntent,
+    val dependents: List<DependentPlugin>,
+    val openInstances: Map<String, Int> = emptyMap(),
+    val answer: CompletableDeferred<Boolean> = CompletableDeferred(),
+) {
+    /** Open tabs of [dependent] that confirming would close, or 0 when nothing is open. */
+    fun openInstancesOf(dependent: DependentPlugin): Int = openInstances[dependent.pluginId] ?: 0
+}
+
+/**
+ * Carries a dependent-restart question from an unload to whichever window can ask it.
+ *
+ * The same delivery reasoning as [PluginDependencyBus]: a `Channel`, not a `SharedFlow`, so
+ * exactly one window asks. Here it matters more than there, because a broadcast would let two
+ * windows answer the same question and the second answer would arrive after the unload had
+ * already run.
+ *
+ * A class with a singleton subclass so a test can hold its own bus; the shared buffer otherwise
+ * carries prompts between tests.
+ */
+open class DependentRestartBus {
+    private val logger = BossLogger.forComponent("DependentRestartBus")
+
+    /**
+     * Buffered like the missing-dependency bus, so reporting never suspends the unload path and
+     * a second question queues rather than replacing the first.
+     */
+    private val prompts = Channel<DependentRestartPrompt>(capacity = 4)
+
+    val restartPrompts = prompts.receiveAsFlow()
+
+    /**
+     * Asks, and returns what the user answered.
+     *
+     * **Every failure mode answers `false`, never a hang.** The caller is mid-unload with the
+     * plugin still loaded, so "we could not ask" and "the user said no" want the same outcome -
+     * which is also exactly today's behaviour, a refusal. The three:
+     *
+     * - **no dependents**: nothing to ask about, so `true` without a dialog. A plugin with no
+     *   dependents must not see any change in its update flow.
+     * - **nobody to ask**: `trySend` fails when no window has collected yet or the buffer is
+     *   full. Logged, because a question that never appears is indistinguishable from a feature
+     *   that does not exist.
+     * - **never answered**: the window can close with the dialog open, which drops the collector
+     *   and with it the only thing that would complete the deferred. [ANSWER_TIMEOUT_MS] bounds
+     *   that; without it the Toolbox's update coroutine would wait for the life of the process.
+     */
+    suspend fun ask(prompt: DependentRestartPrompt): Boolean =
+        when {
+            prompt.dependents.isEmpty() -> {
+                true
+            }
+
+            prompts.trySend(prompt).isFailure -> {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Dropped a dependent-restart prompt; refusing the unload",
+                    mapOf(
+                        "pluginId" to prompt.targetPluginId,
+                        "dependents" to prompt.dependents.joinToString(", ") { it.pluginId },
+                    ),
+                )
+                false
+            }
+
+            else -> {
+                awaitAnswer(prompt)
+            }
+        }
+
+    private suspend fun awaitAnswer(prompt: DependentRestartPrompt): Boolean {
+        val answered = withTimeoutOrNull(ANSWER_TIMEOUT_MS) { prompt.answer.await() }
+        if (answered == null) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Dependent-restart prompt went unanswered; refusing the unload",
+                mapOf("pluginId" to prompt.targetPluginId),
+            )
+        }
+        return answered ?: false
+    }
+
+    companion object {
+        /**
+         * Long enough to be a person deciding, short enough that a dropped dialog does not pin
+         * the caller's coroutine for the life of the process.
+         */
+        const val ANSWER_TIMEOUT_MS = 5 * 60 * 1000L
+    }
+}
+
+/** The bus the host actually uses. */
+object DependentRestartEventBus : DependentRestartBus()
+
+/**
+ * The user declined the dependent-restart prompt.
+ *
+ * A distinct type so the caller can word it as a cancellation. Reported through
+ * `Result.failure` because the update did not happen, but "Update failed" is the wrong sentence
+ * for an answer the user gave on purpose.
+ */
+class DependentRestartDeclinedException(
+    val pluginId: String,
+) : Exception("Cancelled: $pluginId was left as it is")
+
+/**
+ * Asks about [pluginId]'s dependents and, on confirmation, arranges for them to be restarted.
+ *
+ * For the host's own update paths, which pass `force = true` to `uninstallPlugin` and so never
+ * meet the veto in `checkCanUnload`. They had the opposite bug to the Toolbox's: they always
+ * succeeded, and left every dependent running against a classloader that had closed. The prompt
+ * is the same one the delegate raises, so a person sees one dialog whichever button started the
+ * update.
+ *
+ * Returns true when there was nothing to ask or the user agreed. The pending restarts are
+ * recorded here, and flushed by `installPlugin` when the new version registers.
+ */
+suspend fun confirmDependentRestart(
+    pluginId: String,
+    displayName: String,
+    intent: PluginUnloadIntent,
+    manager: DynamicPluginManager,
+): Boolean {
+    val dependents = manager.dependentsOf(pluginId)
+    if (dependents.isEmpty()) return true
+    val confirmed =
+        DependentRestartEventBus.ask(
+            DependentRestartCoordinator.promptFor(
+                targetPluginId = pluginId,
+                targetDisplayName = displayName,
+                intent = intent,
+                dependents = dependents,
+            ),
+        )
+    if (confirmed) {
+        DependentRestartCoordinator.record(pluginId, dependents.map { it.pluginId })
+    }
+    return confirmed
+}
+
+/**
+ * Owns restarting the plugins that depend on one being updated or removed.
+ *
+ * Separate from `DynamicPluginManager`'s companion, which is already the process-wide home of
+ * every plugin hook there is: putting three more functions and two more hooks there made a
+ * crowded object crowded enough for detekt to say so, and none of this is about managing
+ * plugins in a window. It is one arrangement - who gets restarted, and when - so it lives in
+ * one place, next to the question that creates it.
+ */
+object DependentRestartCoordinator {
+    private val logger = BossLogger.forComponent("DependentRestartCoordinator")
+
+    /**
+     * Runs restarts decoupled from whoever triggered them.
+     *
+     * The trigger is usually the plugin being updated, or the Toolbox that started the update;
+     * either can be torn down by the very restart this schedules. Mirrors
+     * `DynamicPluginManager.swapScope`, which exists for the same reason.
+     */
+    private val restartScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    /**
+     * Closes ONE plugin's open tabs and reloads it, so it re-resolves everything it holds - the
+     * delegate's `resetPluginInstances`, reachable from commonMain.
+     *
+     * A plain reload would not do: the dependent's open tabs were composed against the old
+     * classloader, which is why `resetPluginInstances` closes them on the EDT first.
+     *
+     * Set once by the desktop layer; null in headless/test contexts, where nothing is open and
+     * nothing needs restarting.
+     */
+    @Volatile
+    var restartPlugin: (suspend (pluginId: String) -> Unit)? = null
+
+    /**
+     * How many tabs/panels a plugin currently has open, so the prompt can say what closing them
+     * costs. Counting them walks the split-view registries, which is desktop work.
+     */
+    @Volatile
+    var instanceCount: ((pluginId: String) -> Int)? = null
+
+    /**
+     * How long [record] waits before restarting dependents whose plugin never came back.
+     *
+     * A `var` purely so a test does not have to wait a real minute; nothing in the host writes
+     * it. The timer runs on a plain scope rather than a virtual-time one because it must survive
+     * the caller, which is the whole point of it.
+     */
+    internal var restartDeadlineMs: Long = PendingDependentRestarts.EXPIRY_MS
+
+    /** A prompt with each dependent's open-tab count filled in. */
+    fun promptFor(
+        targetPluginId: String,
+        targetDisplayName: String,
+        intent: PluginUnloadIntent,
+        dependents: List<DependentPlugin>,
+    ): DependentRestartPrompt {
+        val counter = instanceCount
+        return DependentRestartPrompt(
+            targetPluginId = targetPluginId,
+            targetDisplayName = targetDisplayName,
+            intent = intent,
+            dependents = dependents,
+            openInstances =
+                dependents.associate { dependent ->
+                    dependent.pluginId to (counter?.invoke(dependent.pluginId) ?: 0)
+                },
+        )
+    }
+
+    /**
+     * Notes that [dependentIds] agreed to be restarted once [targetPluginId] is loaded again.
+     *
+     * An empty list cancels the arrangement, which is what the delegate does when the forced
+     * unload it just got permission for turns out to have failed.
+     */
+    fun record(
+        targetPluginId: String,
+        dependentIds: List<String>,
+    ) {
+        PendingDependentRestarts.record(targetPluginId, dependentIds)
+        if (dependentIds.isEmpty()) return
+        // Arm a real deadline rather than waiting for the next load to sweep.
+        //
+        // Found live, on the first end-to-end run: the AI Gateway's update was confirmed, the
+        // gateway unloaded, and its store download then returned HTTP 404. Nothing loaded after
+        // that, so a sweep triggered by loading never ran and three plugins sat holding a handle
+        // into a classloader that had closed - the exact state this whole change exists to
+        // prevent, reached by the change itself. "Some plugin will load again soon" is an
+        // assumption about a session, not a guarantee.
+        restartScope.launch {
+            delay(restartDeadlineMs)
+            // Claims only if a successful load has not already claimed it, so the normal path
+            // costs nothing and this can never restart the same dependents twice.
+            val stranded = PendingDependentRestarts.take(targetPluginId)
+            if (stranded.isNotEmpty()) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Restarting dependents of a plugin that never reloaded",
+                    mapOf(
+                        "pluginId" to targetPluginId,
+                        "dependents" to stranded.joinToString(", "),
+                    ),
+                )
+                restartAll(stranded, afterPluginId = targetPluginId)
+            }
+        }
+    }
+
+    /**
+     * Restarts whatever was recorded against [targetPluginId], plus any record that has gone
+     * stale because its plugin never came back.
+     *
+     * **Detached, and never called with the manager mutex held.** Each restart re-enters
+     * `uninstallPlugin` and `installPlugin`, both of which take that mutex, so calling this from
+     * inside the locked section would deadlock the manager against itself. `installPlugin`
+     * therefore calls it after its `withLock` returns.
+     */
+    fun flushAfterLoad(targetPluginId: String) {
+        val due =
+            buildList {
+                addAll(PendingDependentRestarts.take(targetPluginId))
+                PendingDependentRestarts.takeExpired().values.forEach(::addAll)
+            }.distinct()
+        restartAll(due, afterPluginId = targetPluginId)
+    }
+
+    /**
+     * Restarts [dependentIds] now, for a removal.
+     *
+     * Nothing is coming back, so there is no load to wait for. They are restarted anyway rather
+     * than left alone: each resolved a handle to a plugin whose classloader is now closed, and a
+     * restart makes them re-resolve it to null, which is at least the truth about what is
+     * installed.
+     */
+    fun restartNow(dependentIds: List<String>) {
+        restartAll(dependentIds, afterPluginId = null)
+    }
+
+    /**
+     * One failure does not strand the rest, matching the api hot swap's unload loop.
+     *
+     * `runCatching` rather than a `catch` block so an `Error` from a closed classloader is held
+     * too - that is precisely the failure a stale dependent produces. Cancellation is rethrown:
+     * this scope is only cancelled on shutdown, and swallowing it there would keep the loop
+     * running against a dying process.
+     */
+    private fun restartAll(
+        dependentIds: List<String>,
+        afterPluginId: String?,
+    ) {
+        val restart = restartPlugin ?: return
+        if (dependentIds.isEmpty()) return
+        restartScope.launch {
+            for (dependentId in dependentIds) {
+                runCatching { restart(dependentId) }
+                    .onFailure { cause ->
+                        if (cause is CancellationException) throw cause
+                        logger.warn(
+                            LogCategory.SYSTEM,
+                            "Failed to restart a dependent plugin (continuing)",
+                            mapOf(
+                                "dependentPluginId" to dependentId,
+                                "afterPluginId" to (afterPluginId ?: "removal"),
+                                "error" to (cause.message ?: cause::class.simpleName ?: "unknown"),
+                            ),
+                        )
+                    }
+            }
+        }
+    }
+}
+
+/**
+ * Dependents waiting to be restarted once the plugin they depend on is back.
+ *
+ * An update is an unload followed by a load that this side does not perform - the Toolbox
+ * downloads and loads the new jar itself, and `PluginUpdateBridge` hands the load to
+ * `PluginUpdateManager`. So the restart cannot happen at the moment of the unload: the
+ * dependents would reload, resolve their dependency to null, and be wrong again a second later
+ * when the new version registered. Recording the intent and flushing when the target next loads
+ * is what makes the restart land on the new version.
+ *
+ * Removal is the opposite case and is not recorded here at all: nothing is coming back, so the
+ * caller flushes immediately.
+ */
+object PendingDependentRestarts {
+    private val logger = BossLogger.forComponent("PendingDependentRestarts")
+
+    private data class Entry(
+        val dependentIds: List<String>,
+        val recordedAtMs: Long,
+    )
+
+    private val pending = ConcurrentHashMap<String, Entry>()
+
+    /**
+     * Notes that [dependentIds] should be restarted when [targetPluginId] next loads.
+     *
+     * Ordered by the caller (load priority); this keeps the order it is given. A second record
+     * for the same target replaces the first rather than merging: the set is recomputed from the
+     * live manifests each time it is asked, so the newer answer is the accurate one.
+     */
+    fun record(
+        targetPluginId: String,
+        dependentIds: List<String>,
+        nowMs: Long = System.currentTimeMillis(),
+    ) {
+        if (dependentIds.isEmpty()) {
+            pending.remove(targetPluginId)
+            return
+        }
+        pending[targetPluginId] = Entry(dependentIds.toList(), nowMs)
+    }
+
+    /**
+     * Claims the dependents recorded for [targetPluginId], leaving nothing behind.
+     *
+     * Claiming rather than reading, because the flush must happen exactly once: the target can
+     * load more than once in a session, and a set that survived its flush would restart the
+     * dependents again on an unrelated reload.
+     */
+    fun take(targetPluginId: String): List<String> = pending.remove(targetPluginId)?.dependentIds.orEmpty()
+
+    /**
+     * Claims every record older than [ttlMs], for the update that never completed.
+     *
+     * A download can fail, a jar can be rejected as binary-incompatible, and a person can close
+     * the window between the unload and the load. In all of those the target never comes back,
+     * and the dependents are left holding a handle into a classloader that closed - the exact
+     * state this whole change exists to prevent. Restarting them late is not ideal, but it
+     * leaves them consistent with what is actually loaded.
+     *
+     * **A second line of defence, not the main one.** [DependentRestartCoordinator.record] arms a
+     * timer per record, which is what actually catches the failed update; this sweep runs on the
+     * next load of any plugin and covers a record whose timer did not survive. Both claim through
+     * [take], so whichever gets there first is the only one that restarts anything.
+     */
+    fun takeExpired(
+        nowMs: Long = System.currentTimeMillis(),
+        ttlMs: Long = EXPIRY_MS,
+    ): Map<String, List<String>> {
+        val expired = pending.filterValues { entry -> nowMs - entry.recordedAtMs >= ttlMs }
+        expired.keys.forEach { key -> pending.remove(key) }
+        if (expired.isNotEmpty()) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Restarting dependents of a plugin that never reloaded",
+                mapOf("plugins" to expired.keys.joinToString(", ")),
+            )
+        }
+        return expired.mapValues { (_, entry) -> entry.dependentIds }
+    }
+
+    /** Test seam; the host never needs this. */
+    fun clear() {
+        pending.clear()
+    }
+
+    /** Longer than a store download, short enough that a dependent is not left stale for long. */
+    const val EXPIRY_MS = 60_000L
+}
+
+/**
+ * The words the dialog uses, kept out of the composable so they can be tested.
+ *
+ * Update and remove are genuinely different promises - one says the dependents come back on a
+ * newer version, the other says one of them is about to lose what it needs - and getting that
+ * backwards is the kind of thing a screenshot review misses.
+ */
+object DependentRestartCopy {
+    fun title(intent: PluginUnloadIntent): String =
+        when (intent) {
+            PluginUnloadIntent.REMOVE -> "Remove a plugin others use?"
+            PluginUnloadIntent.UPDATE, PluginUnloadIntent.UNSPECIFIED -> "Restart dependent plugins?"
+        }
+
+    fun confirmLabel(intent: PluginUnloadIntent): String =
+        when (intent) {
+            PluginUnloadIntent.REMOVE -> "Remove and Restart"
+            PluginUnloadIntent.UPDATE, PluginUnloadIntent.UNSPECIFIED -> "Update and Restart"
+        }
+
+    /**
+     * The sentence under the title, naming the target and what confirming does.
+     *
+     * `UNSPECIFIED` is worded for neither case, because it is what the pre-1.0.79
+     * `unloadPlugin` reports and that method serves both the Toolbox's Update and its Remove.
+     * Promising "they will reopen on the new version" there would be a lie half the time.
+     */
+    fun message(
+        intent: PluginUnloadIntent,
+        targetDisplayName: String,
+        dependents: List<DependentPlugin>,
+    ): String {
+        val they = if (dependents.size == 1) "it" else "them"
+        val needs = if (dependents.size == 1) "needs" else "need"
+        return when (intent) {
+            PluginUnloadIntent.UPDATE -> {
+                "Updating $targetDisplayName restarts the plugins below. Their open tabs close, " +
+                    "and reopening one loads it against the new version."
+            }
+
+            PluginUnloadIntent.REMOVE -> {
+                "The plugins below $needs $targetDisplayName. Removing it closes their open tabs " +
+                    "and restarts $they without it - anything of theirs that needs " +
+                    "$targetDisplayName stops working."
+            }
+
+            PluginUnloadIntent.UNSPECIFIED -> {
+                "The plugins below depend on $targetDisplayName. Continuing closes their open " +
+                    "tabs and restarts $they."
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1181,8 +1181,40 @@ class DynamicPluginManager(
                 )
             }
         }
+        // The plugin is back. Anything that agreed to be restarted for its sake now can be,
+        // against the version that actually loaded rather than the gap where nothing was.
+        // Outside the mutex for the same reason as the two hooks above, and more sharply: each
+        // restart re-enters uninstallPlugin and installPlugin, so calling this under the lock
+        // would deadlock the manager against itself. Only for a plugin that really registered -
+        // a DISABLED result means the new version is not running, and restarting its dependents
+        // would point them at nothing.
+        result.getOrNull()?.takeIf { it.state == PluginState.LOADED }?.let { info ->
+            DependentRestartCoordinator.flushAfterLoad(info.manifest.pluginId)
+        }
         return result
     }
+
+    /**
+     * Loaded, enabled plugins that declare a dependency on [pluginId] - optional ones included.
+     *
+     * A superset of what [checkCanUnload] vetoes on, and the same underlying set: see
+     * `PluginDependencyResolution.dependentsOf` for why the prompt counts optional declarations
+     * that the veto does not. Ordered by load priority, so restarting them walks the same order
+     * a cold start would.
+     *
+     * Reads live state without the mutex. Callers use it to decide whether to ask a question
+     * before starting an unload, and the authoritative check runs inside the lock anyway - the
+     * same best-effort arrangement as `uninstallPlugin`'s pre-mutex teardown gate.
+     */
+    fun dependentsOf(pluginId: String): List<DependentPlugin> =
+        PluginDependencyResolution
+            .dependentsOf(
+                pluginId = pluginId,
+                loadedManifests = pluginLoader.getLoadedPlugins().map { it.manifest },
+                // Fails closed, exactly as in checkCanUnload: only a state we positively
+                // recognise as DISABLED takes a dependent out of the list.
+                isDisabled = { id -> _pluginStates.value[id]?.state == PluginState.DISABLED },
+            ).sortedBy { dependent -> dependent.loadPriority }
 
     /**
      * Check if a plugin can be unloaded without issues.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -39,6 +39,21 @@ data class MissingPluginDependency(
 }
 
 /**
+ * A loaded plugin that declares a dependency on the one being unloaded.
+ *
+ * The host's own shape, distinct from the api's `DependentPluginInfo`: this one carries
+ * [loadPriority] so the restart runs in the same order a load would, and it is what the
+ * commonMain dialog and the pure tests speak. The delegate converts at the api boundary.
+ */
+data class DependentPlugin(
+    val pluginId: String,
+    val displayName: String,
+    /** True when the dependent declared it `optional`, i.e. it works without it. */
+    val optional: Boolean,
+    val loadPriority: Int = 100,
+)
+
+/**
  * Works out which of a plugin's declared dependencies are absent.
  *
  * Pure, so the interesting rules are testable without a plugin loader: manifest
@@ -154,6 +169,49 @@ object PluginDependencyResolution {
             .map { dependency -> manifest.toMissing(dependency) }
 
     /**
+     * Every loaded, enabled plugin that declares a dependency on [pluginId] - optional ones
+     * included - for the prompt that offers to restart them.
+     *
+     * [blockingDependentsOf] is this list narrowed to the hard declarations, so the veto and the
+     * prompt cannot disagree about who depends on what. They deliberately answer *different*
+     * questions on top of the same set:
+     *
+     * - the **veto** counts only `optional: false`, because that is what the manifest means by
+     *   "cannot work without it";
+     * - the **prompt** counts optional dependents too, because that is the case it exists for.
+     *   All three of the AI Gateway's consumers declare it optional, so its update already
+     *   succeeded and left them running against a classloader that had closed underneath them.
+     *   "Works without it" describes a cold start, not a handle resolved before the swap.
+     *
+     * Self-declarations and DISABLED dependents drop out for the reasons given on
+     * [blockingDependentsOf]; [isDisabled] has no default there and none here either.
+     */
+    fun dependentsOf(
+        pluginId: String,
+        loadedManifests: List<PluginManifest>,
+        isDisabled: (pluginId: String) -> Boolean,
+    ): List<DependentPlugin> =
+        loadedManifests
+            .filterNot { manifest -> manifest.pluginId == pluginId }
+            .mapNotNull { manifest ->
+                manifest.dependencies
+                    .filter { dependency -> dependency.pluginId == pluginId }
+                    // A manifest declaring the same dependency twice with different flags is
+                    // treated by its stricter declaration, as `missingFor` does: calling
+                    // something optional that the plugin actually requires is the worse way to
+                    // be wrong, and here it would also drop the dependent from the veto.
+                    .minByOrNull { dependency -> dependency.optional }
+                    ?.let { dependency ->
+                        DependentPlugin(
+                            pluginId = manifest.pluginId,
+                            displayName = manifest.displayName,
+                            optional = dependency.optional,
+                            loadPriority = manifest.loadPriority,
+                        )
+                    }
+            }.filterNot { dependent -> isDisabled(dependent.pluginId) }
+
+    /**
      * Display names of the [loadedManifests] that would actually break if [pluginId] were
      * unloaded, for `DynamicPluginManager.checkCanUnload`.
      *
@@ -192,17 +250,14 @@ object PluginDependencyResolution {
         loadedManifests: List<PluginManifest>,
         isDisabled: (pluginId: String) -> Boolean,
     ): List<String> =
-        loadedManifests
-            // A manifest naming itself is a mistake ([missingFor] drops it on the install side
-            // too), but here it would be a permanent one: the plugin could never be unloaded,
-            // updated or removed, and the reason shown would name the plugin being unloaded.
-            .filterNot { manifest -> manifest.pluginId == pluginId }
-            .filter { manifest ->
-                manifest.dependencies.any { dependency ->
-                    dependency.pluginId == pluginId && !dependency.optional
-                }
-            }.filterNot { manifest -> isDisabled(manifest.pluginId) }
-            .map { manifest -> manifest.displayName }
+        // Expressed on top of [dependentsOf] rather than repeating its filters, so the plugins
+        // the prompt offers to restart are always a superset of the ones the veto names. When
+        // those two drifted before, the prompt could describe a set the unload had already
+        // refused over - and the self-declaration and DISABLED rules would have to be right
+        // twice.
+        dependentsOf(pluginId, loadedManifests, isDisabled)
+            .filterNot { dependent -> dependent.optional }
+            .map { dependent -> dependent.displayName }
 
     private fun PluginManifest.toMissing(dependency: PluginDependency) =
         MissingPluginDependency(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -83,6 +83,16 @@ actual object PluginLoaderDelegateSetup {
         if (DynamicPluginManager.pluginPanelsRefresh == null) {
             DynamicPluginManager.pluginPanelsRefresh = { id, panelIds -> delegate.refreshPluginPanels(id, panelIds) }
         }
+        // Restarting a plugin that depends on one being updated or removed, after the user
+        // agreed to it. Closing its tabs is EDT work and reloading it needs the persisted jar
+        // path, neither of which commonMain can reach - hence the hook rather than a direct call
+        // from the manager.
+        if (DependentRestartCoordinator.restartPlugin == null) {
+            DependentRestartCoordinator.restartPlugin = { id -> delegate.resetPluginInstances(id) }
+        }
+        if (DependentRestartCoordinator.instanceCount == null) {
+            DependentRestartCoordinator.instanceCount = { id -> delegate.getRunningInstanceCount(id) }
+        }
         // Which build each plugin is running. The signals (signature sidecar, jar mtime) are on
         // disk, so the answer comes from here rather than from commonMain.
         if (DynamicPluginManager.pluginBuildProbe == null) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginStoreVersionBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginStoreVersionBridge.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.plugin
 import ai.rever.boss.plugin.KeyedDetachedJobs
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.api.PluginUnloadIntent
 import ai.rever.boss.plugin.repository.shortFailureReason
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -72,8 +73,16 @@ actual object PluginStoreVersionBridge {
         version: String,
         sourceUrl: String?,
         manager: DynamicPluginManager,
-    ): Result<String> =
-        DETACHED_SWAPS.run(
+    ): Result<String> {
+        // Outside the detached job on purpose: the question belongs to the window the user is
+        // looking at, and detaching it would let the swap start before anyone had answered.
+        // Same reasoning as PluginUpdateBridge - this path forces the unload too, so it never
+        // met the veto and never restarted the dependents.
+        val displayName = manager.getPluginInfo(pluginId)?.manifest?.displayName ?: pluginId
+        if (!confirmDependentRestart(pluginId, displayName, PluginUnloadIntent.UPDATE, manager)) {
+            return Result.failure(DependentRestartDeclinedException(pluginId))
+        }
+        return DETACHED_SWAPS.run(
             key = pluginId,
             onDetachedFailure = { error ->
                 // The window closed while this ran, so nothing is left to show the failure to.
@@ -102,4 +111,5 @@ actual object PluginStoreVersionBridge {
                 },
             )
         }
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.components.plugin
 import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.api.PluginUnloadIntent
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
@@ -90,6 +91,15 @@ actual object PluginUpdateBridge {
         val update =
             mgr.availableUpdates.value.firstOrNull { it.pluginId == pluginId }
                 ?: return Result.failure(Exception("No update available"))
+
+        // Ask before downloading anything. This path unloads with `force = true`, so it never
+        // met the dependents veto - and never restarted the dependents either, which left them
+        // holding a handle into the classloader this update is about to close. Asked here rather
+        // than inside `updatePlugin`'s unload lambda so a decline costs no download, and so the
+        // question arrives before the "Updating…" status message stops making sense.
+        if (!confirmDependentRestart(pluginId, update.displayName, PluginUnloadIntent.UPDATE, manager)) {
+            return Result.failure(DependentRestartDeclinedException(pluginId))
+        }
 
         // newVersion comes from the (remote) store manifest, and SemanticVersion.parse does NOT
         // reject path separators in prerelease/build metadata — so sanitize the filename and verify

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -1,5 +1,8 @@
 package ai.rever.boss.plugin
 
+import ai.rever.boss.components.plugin.DependentPlugin
+import ai.rever.boss.components.plugin.DependentRestartCoordinator
+import ai.rever.boss.components.plugin.DependentRestartEventBus
 import ai.rever.boss.components.plugin.DynamicPluginInfo
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MicrokernelRuntime
@@ -8,11 +11,14 @@ import ai.rever.boss.components.plugin.resolveReloadJarPath
 import ai.rever.boss.components.registery.PanelComponentStoreRegistry
 import ai.rever.boss.components.window_panel.SplitViewStateRegistry
 import ai.rever.boss.components.window_panel.components.main_window_panels.BossTabsComponent
+import ai.rever.boss.plugin.api.DependentPluginInfo
 import ai.rever.boss.plugin.api.InaccessiblePluginInfo
 import ai.rever.boss.plugin.api.LoadedPluginInfo
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.api.PluginLoaderDelegate
 import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.api.PluginUnloadIntent
+import ai.rever.boss.plugin.api.PluginUnloadResult
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.loader.PluginUnloadException
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
@@ -168,15 +174,158 @@ class PluginLoaderDelegateImpl(
         }
     }
 
-    override suspend fun unloadPlugin(pluginId: String): Boolean =
+    /**
+     * The pre-1.0.79 verb, kept because an installed Toolbox still calls it.
+     *
+     * Routed through [unloadPluginForIntent] with [PluginUnloadIntent.UNSPECIFIED] rather than
+     * left on the old path, so the dependent-restart prompt reaches a Toolbox that has not been
+     * updated yet. The intent verb buys wording and restart timing, not the feature itself.
+     */
+    override suspend fun unloadPlugin(pluginId: String): Boolean {
+        val result = unloadPluginForIntent(pluginId, PluginUnloadIntent.UNSPECIFIED)
+        return result.unloaded
+    }
+
+    override fun getDependentPlugins(pluginId: String): List<DependentPluginInfo> =
+        dynamicPluginManager.dependentsOf(pluginId).map { dependent ->
+            DependentPluginInfo(
+                pluginId = dependent.pluginId,
+                displayName = dependent.displayName,
+                optional = dependent.optional,
+                runningInstances = getRunningInstanceCount(dependent.pluginId),
+            )
+        }
+
+    /**
+     * Unload, asking first when other plugins depend on this one.
+     *
+     * Before this, a loaded hard dependent made the unload fail outright, and because the
+     * Toolbox updates a plugin by uninstalling and reinstalling it, that refusal landed on the
+     * Update button - the AI Gateway could not be updated while any consumer was running. The
+     * refusal was also unexplained: [unloadPlugin] hands back a `Boolean`, so the reasons naming
+     * the blocking plugins never left the host.
+     *
+     * Three things are deliberate here:
+     *
+     * - **The prompt is raised outside the manager mutex**, like the tab teardown in
+     *   `uninstallPlugin`. It waits on a person; holding the lock across that would freeze every
+     *   other plugin operation in the window for as long as the dialog is open.
+     * - **Confirming forces the unload.** Having asked the question the veto exists to ask,
+     *   re-applying it would just refuse what the user agreed to. `canUnload = false` system
+     *   plugins are still refused, because that gate answers a different question and no dialog
+     *   was shown for it - so the pre-check keeps its own `canUnload` term.
+     * - **Nothing is asked when there are no dependents.** The overwhelmingly common unload must
+     *   look exactly as it did.
+     */
+    override suspend fun unloadPluginForIntent(
+        pluginId: String,
+        intent: PluginUnloadIntent,
+    ): PluginUnloadResult {
+        val target = dynamicPluginManager.getPluginInfo(pluginId)
+        val dependents = dependentsFor(pluginId)
+        // Nothing to ask about, or a plugin the manifest gate protects - which is refused
+        // whatever the user would have said, so asking would be a dialog with one real answer.
+        // Mirrors uninstallPlugin's own ordering, which checks canUnload before the dependents.
+        if (dependents.isEmpty() || target?.manifest?.canUnload == false) {
+            return unloadPluginUnasked(pluginId, force = false)
+        }
+
+        val confirmed =
+            DependentRestartEventBus.ask(
+                DependentRestartCoordinator.promptFor(
+                    targetPluginId = pluginId,
+                    targetDisplayName = target?.manifest?.displayName ?: pluginId,
+                    intent = intent,
+                    dependents = dependents,
+                ),
+            )
+        return if (confirmed) {
+            // Logged as well as the decline, so the log says a question was asked and answered.
+            // Without this a confirmed prompt was invisible: the only trace was a force=true
+            // unload, which is indistinguishable from the paths that always forced.
+            logger.info(
+                LogCategory.SYSTEM,
+                "Dependent-restart prompt confirmed; forcing the unload",
+                mapOf(
+                    "pluginId" to pluginId,
+                    "intent" to intent.name,
+                    "dependents" to dependents.joinToString(", ") { it.pluginId },
+                ),
+            )
+            unloadConfirmed(pluginId, intent, dependents.map { it.pluginId })
+        } else {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Dependent-restart prompt declined; leaving the plugin loaded",
+                mapOf("pluginId" to pluginId, "intent" to intent.name),
+            )
+            PluginUnloadResult(unloaded = false, cancelledByUser = true)
+        }
+    }
+
+    /**
+     * The unload the user just agreed to, plus the arrangement to restart what depended on it.
+     *
+     * Forced, because the veto exists to ask exactly the question that was already asked -
+     * re-applying it here would refuse what the user agreed to.
+     */
+    private suspend fun unloadConfirmed(
+        pluginId: String,
+        intent: PluginUnloadIntent,
+        dependentIds: List<String>,
+    ): PluginUnloadResult {
+        // Recorded BEFORE the unload, not after: for an update, whoever reinstalls the plugin
+        // can be quicker than this function's own continuation, and a record written after the
+        // load had already happened would never be claimed.
+        if (intent != PluginUnloadIntent.REMOVE) {
+            DependentRestartCoordinator.record(pluginId, dependentIds)
+        }
+        val result = unloadPluginUnasked(pluginId, force = true)
+        when {
+            // The forced unload failed after all, so nothing should be restarted on its behalf.
+            !result.unloaded -> DependentRestartCoordinator.record(pluginId, emptyList())
+
+            // A removal has no load to wait for, so restart now. The dependents re-resolve their
+            // handle to null, which is the truth about what is installed.
+            intent == PluginUnloadIntent.REMOVE -> DependentRestartCoordinator.restartNow(dependentIds)
+        }
+        return result
+    }
+
+    /**
+     * Best-effort, outside the manager mutex: failing to enumerate dependents must not fail the
+     * unload, because the authoritative veto still runs inside `uninstallPlugin`.
+     */
+    private fun dependentsFor(pluginId: String): List<DependentPlugin> =
+        runCatching { dynamicPluginManager.dependentsOf(pluginId) }
+            .onFailure { cause ->
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Could not enumerate dependents before unload (continuing unasked)",
+                    mapOf(
+                        "pluginId" to pluginId,
+                        "error" to (cause.message ?: cause::class.simpleName ?: "unknown"),
+                    ),
+                )
+            }.getOrDefault(emptyList())
+
+    private suspend fun unloadPluginUnasked(
+        pluginId: String,
+        force: Boolean,
+    ): PluginUnloadResult =
         try {
-            logger.info(LogCategory.SYSTEM, "Unloading plugin via delegate", mapOf("pluginId" to pluginId))
-            val result = dynamicPluginManager.uninstallPlugin(pluginId, force = false)
-            // The Boolean this returns is all the caller gets, so a failure would otherwise
-            // leave no trace anywhere: uninstallPlugin logs "Uninstalling plugin" *before*
-            // deciding, so the log just stopped mid-sequence and the reasons the manager
-            // assembled (which name the plugins standing in the way) were dropped here. That is
-            // what made the Toolbox's Update button look like it did nothing at all.
+            logger.info(
+                LogCategory.SYSTEM,
+                "Unloading plugin via delegate",
+                mapOf("pluginId" to pluginId, "force" to force.toString()),
+            )
+            val result = dynamicPluginManager.uninstallPlugin(pluginId, force = force)
+            // Logged here as well as returned, because [unloadPlugin] still reduces this to a
+            // Boolean for callers that have not moved to the intent verb: uninstallPlugin logs
+            // "Uninstalling plugin" *before* deciding, so without this the log stopped
+            // mid-sequence and the reasons the manager assembled (which name the plugins
+            // standing in the way) were dropped here. That is what made the Toolbox's Update
+            // button look like it did nothing at all.
             //
             // Refusal and failure are logged apart because uninstallPlugin returns
             // Result.failure for both, and they send a reader to opposite places: a refusal
@@ -203,10 +352,10 @@ class PluginLoaderDelegateImpl(
                     cause,
                 )
             }
-            result.isSuccess
+            PluginUnloadResult(unloaded = result.isSuccess, reasons = refusalReasons)
         } catch (e: Exception) {
             logger.error(LogCategory.SYSTEM, "Exception unloading plugin", error = e)
-            false
+            PluginUnloadResult(unloaded = false)
         }
 
     override suspend fun reloadPlugin(pluginId: String): LoadedPluginInfo? {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginRemoval.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginRemoval.kt
@@ -1,6 +1,10 @@
 package ai.rever.boss.plugin
 
+import ai.rever.boss.components.plugin.DependentRestartCoordinator
+import ai.rever.boss.components.plugin.DependentRestartDeclinedException
+import ai.rever.boss.components.plugin.DependentRestartEventBus
 import ai.rever.boss.components.plugin.DynamicPluginManager
+import ai.rever.boss.plugin.api.PluginUnloadIntent
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
@@ -33,13 +37,43 @@ object PluginRemoval {
                 logger.error(LogCategory.SYSTEM, "Detached plugin removal failed", error = error)
             },
         ) {
-            val unloaded = manager.uninstallPlugin(pluginId, force = false)
+            // This path does NOT go through PluginLoaderDelegateImpl - it calls the manager
+            // directly - so it needs its own copy of the question, or the host's own Uninstall
+            // would still hard-refuse while the Toolbox's asked. Only when the manifest allows
+            // the unload at all: a `canUnload = false` plugin is refused whatever the answer, so
+            // asking would be a dialog with one real outcome. (The menu gates on that too, but
+            // this function is reachable from the deep-link handler as well.)
+            val info = manager.getPluginInfo(pluginId)
+            val dependents =
+                if (info?.manifest?.canUnload == false) emptyList() else manager.dependentsOf(pluginId)
+            val confirmed =
+                dependents.isEmpty() ||
+                    DependentRestartEventBus.ask(
+                        DependentRestartCoordinator.promptFor(
+                            targetPluginId = pluginId,
+                            targetDisplayName = info?.manifest?.displayName ?: pluginId,
+                            intent = PluginUnloadIntent.REMOVE,
+                            dependents = dependents,
+                        ),
+                    )
+            if (!confirmed) {
+                return@run Result.failure(DependentRestartDeclinedException(pluginId))
+            }
+
+            // Forced only once the user has agreed to the consequence the veto exists to warn
+            // about. With no dependents this is the unchanged non-forced path, so the manifest
+            // gate and the unload-aware checks still apply as they always did.
+            val unloaded = manager.uninstallPlugin(pluginId, force = dependents.isNotEmpty())
             if (unloaded.isFailure) {
                 return@run unloaded
             }
             // Only once the plugin is unloaded: deleting a jar out from under a live classloader is
             // how you get NoClassDefFoundError from code that is still running.
             PluginArtifactCleanup.remove(pluginId, jarPath)
+            // Nothing is coming back, so the dependents are restarted now rather than recorded:
+            // each is holding a handle into a classloader that has just closed, and a restart
+            // makes it re-resolve to null - the truth about what is now installed.
+            DependentRestartCoordinator.restartNow(dependents.map { it.pluginId })
             Result.success(Unit)
         }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/DependentRestartTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/DependentRestartTest.kt
@@ -1,0 +1,405 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginUnloadIntent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The question asked before a depended-upon plugin is unloaded, and the bookkeeping that
+ * restarts its dependents afterwards.
+ *
+ * Both halves are pure so they can be pinned without a plugin loader, a window or a store.
+ * That matters more here than for most of this subsystem: the failure modes are a dialog that
+ * never appears and an unload that waits forever, neither of which shows up in a screenshot.
+ */
+class DependentRestartTest {
+    private fun dependent(
+        pluginId: String,
+        displayName: String = pluginId,
+        optional: Boolean = false,
+        loadPriority: Int = 100,
+    ) = DependentPlugin(
+        pluginId = pluginId,
+        displayName = displayName,
+        optional = optional,
+        loadPriority = loadPriority,
+    )
+
+    private fun prompt(
+        targetPluginId: String = "com.example.gateway",
+        intent: PluginUnloadIntent = PluginUnloadIntent.UPDATE,
+        dependents: List<DependentPlugin> = listOf(dependent("com.example.flow", "Flow")),
+    ) = DependentRestartPrompt(
+        targetPluginId = targetPluginId,
+        targetDisplayName = "AI Gateway",
+        intent = intent,
+        dependents = dependents,
+    )
+
+    @BeforeTest
+    @AfterTest
+    fun resetPending() {
+        // An object, so its map outlives a test the way it outlives an unload. Two tests
+        // sharing a record is the same coupling two windows would have.
+        PendingDependentRestarts.clear()
+    }
+
+    /**
+     * Runs [block] with the coordinator's restart deadline shortened and its restart hook
+     * collecting into [restarted], restoring both afterwards.
+     *
+     * Real time, not virtual: the timer deliberately runs on a scope that outlives its caller,
+     * which is the property being tested, so a `TestScope` would test something else. The
+     * deadline is shortened instead - a real 60s wait per test is not worth the fidelity.
+     */
+    private fun withShortDeadline(
+        restarted: MutableList<String>,
+        block: suspend CoroutineScope.() -> Unit,
+    ) {
+        val previousHook = DependentRestartCoordinator.restartPlugin
+        val previousDeadline = DependentRestartCoordinator.restartDeadlineMs
+        DependentRestartCoordinator.restartPlugin = { id -> restarted += id }
+        DependentRestartCoordinator.restartDeadlineMs = SHORT_DEADLINE_MS
+        try {
+            runBlocking { block() }
+        } finally {
+            DependentRestartCoordinator.restartPlugin = previousHook
+            DependentRestartCoordinator.restartDeadlineMs = previousDeadline
+        }
+    }
+
+    private companion object {
+        const val SHORT_DEADLINE_MS = 100L
+
+        /** Generous: this waits on real wall-clock work, so it must not be flaky under load. */
+        const val TEST_TIMEOUT_MS = 10_000L
+    }
+
+    // ---- the bus ----
+
+    @Test
+    fun `no dependents means no question`() =
+        runTest {
+            val bus = DependentRestartBus()
+
+            // The overwhelmingly common unload. It must not wait on a dialog that would never
+            // be shown, and it must not consume a buffer slot on the way past.
+            assertTrue(bus.ask(prompt(dependents = emptyList())))
+        }
+
+    @Test
+    fun `the answer the collector gives is what ask returns`() =
+        runTest {
+            val bus = DependentRestartBus()
+            val pending = prompt()
+
+            val asked = async { bus.ask(pending) }
+            runCurrent()
+            bus.restartPrompts
+                .first()
+                .answer
+                .complete(true)
+
+            assertTrue(asked.await())
+        }
+
+    @Test
+    fun `a decline comes back as false`() =
+        runTest {
+            val bus = DependentRestartBus()
+            val pending = prompt()
+
+            val asked = async { bus.ask(pending) }
+            runCurrent()
+            bus.restartPrompts
+                .first()
+                .answer
+                .complete(false)
+
+            assertFalse(asked.await())
+        }
+
+    @Test
+    fun `a prompt nobody ever answers is refused rather than waited on forever`() =
+        runTest {
+            val bus = DependentRestartBus()
+
+            // The window closed with the dialog open: the collector is gone and nothing will
+            // ever complete the deferred. Without the timeout the caller - the Toolbox's own
+            // update coroutine - would wait for the life of the process.
+            val asked = async { bus.ask(prompt()) }
+            advanceTimeBy(DependentRestartBus.ANSWER_TIMEOUT_MS + 1)
+            advanceUntilIdle()
+
+            assertFalse(asked.await())
+        }
+
+    @Test
+    fun `a second question waits its turn instead of replacing the first`() =
+        runTest {
+            val bus = DependentRestartBus()
+            val first = prompt(targetPluginId = "com.example.gateway")
+            val second = prompt(targetPluginId = "com.example.other")
+
+            val firstAsk = async { bus.ask(first) }
+            val secondAsk = async { bus.ask(second) }
+            runCurrent()
+
+            // Both are buffered; the collector sees them in order and each carries its own
+            // answer, so answering one cannot answer the other.
+            val delivered = mutableListOf<String>()
+            bus.restartPrompts
+                .first { received ->
+                    delivered += received.targetPluginId
+                    received.answer.complete(received.targetPluginId == "com.example.gateway")
+                    delivered.size == 2
+                }
+
+            assertEquals(listOf("com.example.gateway", "com.example.other"), delivered)
+            assertTrue(firstAsk.await())
+            assertFalse(secondAsk.await())
+        }
+
+    // ---- the deferred restart ----
+
+    @Test
+    fun `a recorded set is claimed once`() {
+        PendingDependentRestarts.record("com.example.gateway", listOf("com.example.flow"))
+
+        assertEquals(listOf("com.example.flow"), PendingDependentRestarts.take("com.example.gateway"))
+        // Claimed, not read: the target can load again later in the session, and a record that
+        // survived its flush would restart the dependents on an unrelated reload.
+        assertEquals(emptyList(), PendingDependentRestarts.take("com.example.gateway"))
+    }
+
+    @Test
+    fun `recording an empty list cancels the arrangement`() {
+        PendingDependentRestarts.record("com.example.gateway", listOf("com.example.flow"))
+
+        // What the delegate does when the forced unload it just agreed to actually failed.
+        PendingDependentRestarts.record("com.example.gateway", emptyList())
+
+        assertEquals(emptyList(), PendingDependentRestarts.take("com.example.gateway"))
+    }
+
+    @Test
+    fun `a later record replaces an earlier one`() {
+        PendingDependentRestarts.record("com.example.gateway", listOf("com.example.flow"))
+        PendingDependentRestarts.record("com.example.gateway", listOf("com.example.llmrpa"))
+
+        // The set is recomputed from live manifests each time it is asked, so the newer answer
+        // is the accurate one - merging would restart a plugin that no longer depends on this.
+        assertEquals(listOf("com.example.llmrpa"), PendingDependentRestarts.take("com.example.gateway"))
+    }
+
+    @Test
+    fun `the recorded order is preserved`() {
+        val byPriority = listOf("com.example.first", "com.example.second", "com.example.third")
+        PendingDependentRestarts.record("com.example.gateway", byPriority)
+
+        // The caller sorts by load priority; this must not reorder it.
+        assertEquals(byPriority, PendingDependentRestarts.take("com.example.gateway"))
+    }
+
+    @Test
+    fun `a record whose plugin never came back expires`() {
+        PendingDependentRestarts.record("com.example.gateway", listOf("com.example.flow"), nowMs = 0L)
+
+        // A failed download, a rejected jar, a window closed between the unload and the load:
+        // the target never reloads, so nothing would ever claim this and the dependent would
+        // be left pointing at a closed classloader.
+        val expired = PendingDependentRestarts.takeExpired(nowMs = PendingDependentRestarts.EXPIRY_MS)
+
+        assertEquals(mapOf("com.example.gateway" to listOf("com.example.flow")), expired)
+        assertEquals(emptyList(), PendingDependentRestarts.take("com.example.gateway"))
+    }
+
+    @Test
+    fun `a plugin that never reloads still gets its dependents restarted`() {
+        // The live failure this test exists for: the AI Gateway's update was confirmed, the
+        // gateway unloaded, its download returned HTTP 404, and nothing loaded afterwards - so a
+        // sweep that only ran on the next load never ran at all, and three plugins were left
+        // holding a handle into a closed classloader.
+        val restarted = java.util.Collections.synchronizedList(mutableListOf<String>())
+        withShortDeadline(restarted) {
+            DependentRestartCoordinator.record(
+                "com.example.gateway",
+                listOf("com.example.flow", "com.example.llmrpa"),
+            )
+            withTimeout(TEST_TIMEOUT_MS) { while (restarted.size < 2) delay(10) }
+        }
+        assertEquals(listOf("com.example.flow", "com.example.llmrpa"), restarted.toList())
+    }
+
+    @Test
+    fun `a plugin that comes back does not get its dependents restarted twice`() {
+        val restarted = java.util.Collections.synchronizedList(mutableListOf<String>())
+        withShortDeadline(restarted) {
+            DependentRestartCoordinator.record("com.example.gateway", listOf("com.example.flow"))
+            // The normal path: the new version loads, which claims the record.
+            DependentRestartCoordinator.flushAfterLoad("com.example.gateway")
+            withTimeout(TEST_TIMEOUT_MS) { while (restarted.isEmpty()) delay(10) }
+            // Well past the deadline the timer would otherwise have fired on. It finds nothing
+            // left to claim, so the dependent restarts once, not once per mechanism.
+            delay(SHORT_DEADLINE_MS * 4)
+        }
+        assertEquals(listOf("com.example.flow"), restarted.toList())
+    }
+
+    @Test
+    fun `a fresh record is not expired out from under the load that will claim it`() {
+        PendingDependentRestarts.record("com.example.gateway", listOf("com.example.flow"), nowMs = 0L)
+
+        val expired = PendingDependentRestarts.takeExpired(nowMs = PendingDependentRestarts.EXPIRY_MS - 1)
+
+        assertTrue(expired.isEmpty())
+        assertEquals(listOf("com.example.flow"), PendingDependentRestarts.take("com.example.gateway"))
+    }
+
+    // ---- the words ----
+
+    @Test
+    fun `an update promises the dependents come back`() {
+        val message =
+            DependentRestartCopy.message(
+                intent = PluginUnloadIntent.UPDATE,
+                targetDisplayName = "AI Gateway",
+                dependents = listOf(dependent("com.example.flow", "Flow")),
+            )
+
+        assertContains(message, "AI Gateway")
+        assertContains(message, "new version")
+        assertEquals("Update and Restart", DependentRestartCopy.confirmLabel(PluginUnloadIntent.UPDATE))
+        assertEquals("Restart dependent plugins?", DependentRestartCopy.title(PluginUnloadIntent.UPDATE))
+    }
+
+    @Test
+    fun `a removal says what stops working`() {
+        val message =
+            DependentRestartCopy.message(
+                intent = PluginUnloadIntent.REMOVE,
+                targetDisplayName = "AI Gateway",
+                dependents = listOf(dependent("com.example.flow", "Flow")),
+            )
+
+        // Nothing comes back, so promising a new version here would be a lie.
+        assertFalse(message.contains("new version"))
+        assertContains(message, "stops working")
+        assertEquals("Remove and Restart", DependentRestartCopy.confirmLabel(PluginUnloadIntent.REMOVE))
+        assertEquals("Remove a plugin others use?", DependentRestartCopy.title(PluginUnloadIntent.REMOVE))
+    }
+
+    @Test
+    fun `an unstated intent promises neither`() {
+        val message =
+            DependentRestartCopy.message(
+                intent = PluginUnloadIntent.UNSPECIFIED,
+                targetDisplayName = "AI Gateway",
+                dependents = listOf(dependent("com.example.flow", "Flow")),
+            )
+
+        // This is what a pre-1.0.79 Toolbox reaches, and that one method serves both its Update
+        // and its Remove - so either promise would be wrong half the time.
+        assertFalse(message.contains("new version"))
+        assertFalse(message.contains("stops working"))
+        assertContains(message, "AI Gateway")
+    }
+
+    @Test
+    fun `the sentence agrees with the number of dependents`() {
+        val one =
+            DependentRestartCopy.message(
+                intent = PluginUnloadIntent.REMOVE,
+                targetDisplayName = "AI Gateway",
+                dependents = listOf(dependent("com.example.flow", "Flow")),
+            )
+        val many =
+            DependentRestartCopy.message(
+                intent = PluginUnloadIntent.REMOVE,
+                targetDisplayName = "AI Gateway",
+                dependents =
+                    listOf(
+                        dependent("com.example.flow", "Flow"),
+                        dependent("com.example.llmrpa", "LLM RPA"),
+                    ),
+            )
+
+        assertContains(one, "needs AI Gateway")
+        assertContains(many, "need AI Gateway")
+    }
+
+    @Test
+    fun `open tab counts are read per dependent`() {
+        val flow = dependent("com.example.flow", "Flow")
+        val llmrpa = dependent("com.example.llmrpa", "LLM RPA")
+        val pending =
+            DependentRestartPrompt(
+                targetPluginId = "com.example.gateway",
+                targetDisplayName = "AI Gateway",
+                intent = PluginUnloadIntent.UPDATE,
+                dependents = listOf(flow, llmrpa),
+                openInstances = mapOf("com.example.flow" to 2),
+            )
+
+        assertEquals(2, pending.openInstancesOf(flow))
+        // Absent, not zero-recorded: a headless host has no counter wired at all, and the
+        // dialog must render the row rather than blaming the dependent for having no tabs.
+        assertEquals(0, pending.openInstancesOf(llmrpa))
+    }
+
+    @Test
+    fun `a prompt that reaches nobody refuses the unload`() =
+        runTest {
+            val bus = DependentRestartBus()
+
+            // Five prompts against a four-slot buffer with no collector. The fifth cannot be
+            // delivered, and "we could not ask" has to answer the same as "the user said no" -
+            // the plugin is still loaded either way, which is exactly today's refusal.
+            val answers =
+                (1..5).map { index ->
+                    async { bus.ask(prompt(targetPluginId = "com.example.p$index")) }
+                }
+            advanceTimeBy(DependentRestartBus.ANSWER_TIMEOUT_MS + 1)
+            advanceUntilIdle()
+
+            assertTrue(answers.all { !it.await() })
+        }
+
+    @Test
+    fun `confirming records the dependents and declining records nothing`() =
+        runTest {
+            // The shape the delegate relies on: the record has to exist before the unload, and
+            // must not exist at all when the answer was no.
+            val bus = DependentRestartBus()
+            val declined = prompt(targetPluginId = "com.example.gateway")
+
+            val asked = async { bus.ask(declined) }
+            runCurrent()
+            launch {
+                bus.restartPrompts
+                    .first()
+                    .answer
+                    .complete(false)
+            }
+            advanceUntilIdle()
+
+            assertFalse(asked.await())
+            assertEquals(emptyList(), PendingDependentRestarts.take("com.example.gateway"))
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolutionTest.kt
@@ -749,3 +749,177 @@ class PluginDependencyBusTest {
             )
         }
 }
+
+/**
+ * What the dependent-restart prompt lists, as against what the unload veto counts.
+ *
+ * The two read the same set through `dependentsOf`, and these pin where they diverge: the veto
+ * counts only hard declarations, the prompt counts every loaded dependent. Getting that backwards
+ * either refuses an update nobody asked to have refused, or silently leaves a plugin running
+ * against a classloader that has closed.
+ */
+class PluginDependentsTest {
+    private fun manifest(
+        pluginId: String = "com.example.dependent",
+        displayName: String = "Dependent",
+        dependencies: List<PluginDependency> = emptyList(),
+    ) = PluginManifest(
+        pluginId = pluginId,
+        displayName = displayName,
+        version = "1.0.0",
+        apiVersion = "1.0.0",
+        mainClass = "com.example.Main",
+        dependencies = dependencies,
+    )
+
+    private fun dependency(
+        pluginId: String,
+        optional: Boolean = false,
+    ) = PluginDependency(pluginId = pluginId, version = "1.0.0", optional = optional)
+
+    @Test
+    fun `an optional dependent is listed for restart even though it does not block`() {
+        // The whole reason the restart prompt exists. The gateway's consumers all declare it
+        // optional, so the veto lets the update through - and used to leave them running
+        // against a classloader that had closed underneath them.
+        val loaded =
+            listOf(
+                manifest(
+                    pluginId = "com.example.jupyter",
+                    displayName = "Jupyter Notebook",
+                    dependencies = listOf(dependency("com.example.gateway", optional = true)),
+                ),
+            )
+
+        val dependents =
+            PluginDependencyResolution.dependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests = loaded,
+                isDisabled = { false },
+            )
+
+        assertEquals(listOf("com.example.jupyter"), dependents.map { it.pluginId })
+        assertTrue(dependents.single().optional)
+        assertEquals(
+            emptyList(),
+            PluginDependencyResolution.blockingDependentsOf("com.example.gateway", loaded) { false },
+        )
+    }
+
+    @Test
+    fun `dependentsOf lists required and optional together`() {
+        val dependents =
+            PluginDependencyResolution.dependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies = listOf(dependency("com.example.gateway", optional = true)),
+                        ),
+                        manifest(
+                            pluginId = "com.example.llmrpa",
+                            displayName = "LLM RPA",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                        manifest(
+                            pluginId = "com.example.unrelated",
+                            displayName = "Unrelated",
+                            dependencies = listOf(dependency("com.example.other")),
+                        ),
+                    ),
+                isDisabled = { false },
+            )
+
+        assertEquals(listOf("com.example.flow", "com.example.llmrpa"), dependents.map { it.pluginId })
+        assertEquals(listOf(true, false), dependents.map { it.optional })
+    }
+
+    @Test
+    fun `a manifest naming itself is not its own dependent`() {
+        // Same rule as the veto, and for the same reason: it would make the plugin permanently
+        // unremovable, and here it would also offer to restart the plugin being unloaded.
+        val dependents =
+            PluginDependencyResolution.dependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.gateway",
+                            displayName = "AI Gateway",
+                            dependencies = listOf(dependency("com.example.gateway")),
+                        ),
+                    ),
+                isDisabled = { false },
+            )
+
+        assertEquals(emptyList(), dependents)
+    }
+
+    @Test
+    fun `a disabled dependent is not listed for restart`() {
+        val dependents =
+            PluginDependencyResolution.dependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies = listOf(dependency("com.example.gateway", optional = true)),
+                        ),
+                    ),
+                // disablePlugin leaves the plugin in getLoadedPlugins(), so without this it
+                // would be restarted on behalf of something that is not running.
+                isDisabled = { id -> id == "com.example.flow" },
+            )
+
+        assertEquals(emptyList(), dependents)
+    }
+
+    @Test
+    fun `a dependency declared twice is listed by its stricter declaration`() {
+        // Matches missingFor and the veto: calling something optional that the plugin actually
+        // requires would also drop it from blockingDependentsOf, which reads off this list.
+        val dependents =
+            PluginDependencyResolution.dependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies =
+                                listOf(
+                                    dependency("com.example.gateway", optional = true),
+                                    dependency("com.example.gateway", optional = false),
+                                ),
+                        ),
+                    ),
+                isDisabled = { false },
+            )
+
+        assertEquals(1, dependents.size)
+        assertFalse(dependents.single().optional)
+        assertEquals(
+            listOf("Flow"),
+            PluginDependencyResolution.blockingDependentsOf(
+                pluginId = "com.example.gateway",
+                loadedManifests =
+                    listOf(
+                        manifest(
+                            pluginId = "com.example.flow",
+                            displayName = "Flow",
+                            dependencies =
+                                listOf(
+                                    dependency("com.example.gateway", optional = true),
+                                    dependency("com.example.gateway", optional = false),
+                                ),
+                        ),
+                    ),
+                isDisabled = { false },
+            ),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,23 +71,24 @@ intellij-platform = "243.21565.199"
 # releases ONLY: plugin-platform/plugin-api-core downloads this release's jar and
 # filters the api package locally (no Maven registry involved).
 #
-# 1.0.77 is the release cut by risa-labs-inc/boss-plugin-api#33, which adds
-# SplitViewOperations.openPanelAsTab + supportsOpenPanelAsTab - the members
-# SplitViewOperationsImpl on this branch implements (BossConsole#177).
+# 1.0.79 adds PluginLoaderDelegate.unloadPluginForIntent + getDependentPlugins and the
+# PluginUnloadIntent / PluginUnloadResult / DependentPluginInfo types - what
+# PluginLoaderDelegateImpl on this branch implements so a plugin whose dependents are
+# loaded can be updated after a prompt instead of being refused outright.
 #
-# That interface is @HostImplemented: plugin-api-core filters it into the host and
+# PluginLoaderDelegate is @HostImplemented: plugin-api-core filters it into the host and
 # serves it parent-first, so THIS pin is what every plugin resolves. Nothing a
 # plugin declares can reach these members before this bump lands in a release -
-# minApiVersion cannot, which is why the api documents them as a minBossVersion gate.
+# minApiVersion cannot, which is why the api documents them as a minBossVersion gate
+# and tells callers to catch LinkageError.
 #
-# It is a SUPERSET of the 1.0.76 it replaces, verified against the release jar
-# rather than assumed - releases are cut from the api repo's main, so 1.0.77 keeps
-# #25's browser telemetry events (the reason for the 1.0.76 pin) along with
-# everything below them. Worth checking rather than trusting the ordering:
-# fetchApiPluginJar has no Maven fallback, so a pin that dropped a type would
-# surface as an unrelated compile error, and this comment is the only record of
-# which api PR a pin corresponds to.
-boss-plugin-api = "1.0.77"
+# It is a SUPERSET of the 1.0.77 it replaces: 1.0.79 is cut from the api repo's main at
+# the 1.0.78 bump, so it keeps #33's SplitViewOperations.openPanelAsTab (the reason for
+# the 1.0.77 pin) and #34's AiCliSessionAPI along with everything below them. Worth
+# checking rather than trusting the ordering: fetchApiPluginJar has no Maven fallback, so
+# a pin that dropped a type would surface as an unrelated compile error, and this comment
+# is the only record of which api PR a pin corresponds to.
+boss-plugin-api = "1.0.79"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
## Why

A plugin that other plugins depend on could not be updated from the Toolbox, and the AI Gateway was the live case.

```
Toolbox "Update"
  PluginManagerAPIImpl.updatePluginInternal   uninstall-then-reinstall
  PluginLoaderDelegateImpl.unloadPlugin       uninstallPlugin(force = false)
  DynamicPluginManager.checkCanUnload
  PluginDependencyResolution.blockingDependentsOf   -> ["Flow"]
  -> PluginUnloadException("Plugin 'Flow' depends on this plugin")
  -> the delegate returns a bare `false`, reasons dropped
  -> "could not replace the installed version"
```

`AGENTS.md` already recorded this as known and pointed at the fix: *"closing it needs an update-shaped verb (or an intent parameter) on the api."* boss-plugin-api#35 adds it.

The host's own update paths had the **opposite** bug. `PluginUpdateBridge` and `PluginStoreVersionBridge` pass `force = true`, so they never refused - and never restarted the dependents either, leaving each one holding a handle into a classloader that had just closed.

Both now ask the same question, and the answer is a dialog naming the plugins rather than a refusal that names them only in the host log.

## What

**One definition of "who depends on this".** `dependentsOf` returns every loaded, enabled dependent; `blockingDependentsOf` is that list narrowed to the hard declarations, so the veto and the prompt cannot drift. They answer different questions on purpose:

- the **veto** counts only `optional: false`, which is what the manifest means by "cannot work without it";
- the **prompt** counts optional dependents too. All three gateway consumers declare it optional, so its update already succeeded and silently left them stale. "Works without it" describes a cold start, not a handle resolved before the swap.

**The question, and the answer coming back.** `DependentRestartBus` is a `Channel`, not a `SharedFlow`, so exactly one window asks - a broadcast would let two windows answer the same question and the second answer would land after the unload had run. Every failure mode answers `false` rather than hanging: no dependents, nobody collecting, or a window that closes with the dialog still open.

**The restart.** `DependentRestartCoordinator` records the dependents at confirm time and flushes when the plugin loads again, so the restart lands on the new version instead of the gap. A removal has no load to wait for, so it restarts immediately: the dependents re-resolve to null, which is the truth about what is installed.

**`PluginRemoval` needed its own copy of the question.** It calls the manager directly rather than going through the delegate, so it would otherwise have kept hard-refusing while the Toolbox asked.

## Found by running it

The first live confirmed update went: prompt shown, confirmed, gateway unloaded, store download returned **HTTP 404**. Nothing loaded afterwards, so an expiry that only swept on the next plugin load never ran, and three plugins sat stranded - the exact state this change exists to prevent, produced by the change itself.

So `record` now arms a real deadline. Reverting that timer turns `a plugin that never reloads still gets its dependents restarted` red.

The same run exposed a jar-deletion bug in the Toolbox that this PR unmasks by removing the veto; fixed in the Toolbox PR.

## Tests

25 new, all pure. Three mutations were used to prove they bite:

| Mutation | Caught by |
|---|---|
| drop optional dependents from the restart list | `an optional dependent is listed for restart even though it does not block` |
| `take` reads instead of claiming | `a recorded set is claimed once` |
| remove the answer timeout | `a prompt nobody ever answers is refused rather than waited on forever` |
| remove the restart deadline | `a plugin that never reloads still gets its dependents restarted` |

`detekt` and `ktlintCheck` green.

## Merge order

boss-plugin-api#35 must merge and release **first**: `fetchApiPluginJar` has no Maven fallback, so this branch's 1.0.79 pin cannot resolve until v1.0.79 exists and CI will 404 until then. Verified locally against a jar built from that branch.