### PR TITLE
🔐 Split reading the organisation request queue out of organisation.approve

### DIFF
--- a/supabase/migrations/20260816000000_organisation_request_read.sql
+++ b/supabase/migrations/20260816000000_organisation_request_read.sql
@@ -1,0 +1,128 @@
+-- ============================================================================
+-- BOSS Database Schema: reading the organisation-request queue is its own permission
+--
+-- File: 20260816000000_organisation_request_read.sql
+--
+-- Seeing the organisation-creation request queue was gated on organisation.approve,
+-- which 20260801010000 grants to TWO roles: admin and boss_admin. So every
+-- boss_admin could list every pending request, including the requester's email and
+-- the free-text justification. The requirement is that only `admin` sees that queue
+-- for now, and that widening it later is a grant rather than a migration.
+--
+-- WHY A NEW PERMISSION RATHER THAN REVOKING organisation.approve FROM boss_admin:
+-- organisation.approve means more than one thing. It gates acting on a request
+-- (approve/reject) and it gates the organisations SELECT policy that lets a reviewer
+-- see private organisations in order to judge a name clash. Revoking it would take
+-- all three away together, and it cannot be un-granted from the roles plugin at all,
+-- because that UI hides the Remove button for is_system permissions while its
+-- add-list does not filter them - a system permission is a one-way door there.
+-- Splitting the read out leaves the other two capabilities exactly as they were.
+--
+-- WHY is_system = false, deliberately, unlike the four permissions beside it:
+-- for exactly the reason above. This permission exists to be granted and un-granted
+-- as the policy changes, so it must stay reachable from the roles plugin's UI. The
+-- four organisation.* permissions in 20260801010000 are is_system because they are
+-- structural; this one is policy.
+--
+-- WHY IT IS GRANTED TO NOBODY HERE: authorize() and user_holds_permission() both
+-- short-circuit for global admins (20260625000000:212, 20260801010000), so `admin`
+-- holds it the moment it exists and the queue keeps working with no grant at all.
+-- The explicit grant to admin is left to the operator, so that the set of roles
+-- holding it is a deliberate, auditable act rather than a side effect of a deploy.
+--
+-- NOT CHANGED, ON PURPOSE: approve_organisation_request, reject_organisation_request
+-- and the "Organisation reviewers can view all organisations" policy still read
+-- organisation.approve. They are separate capabilities, and a boss_admin keeping them
+-- is the status quo, not a regression introduced here.
+-- ============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- The permission
+-- ---------------------------------------------------------------------------
+-- A plugin manifest cannot declare this one: register_plugin_permission refuses the
+-- reserved domains (role, user, api_key, rpa, secret, plugins, organisation, org),
+-- so an organisation.* permission has to be seeded here, as the other four were.
+--
+-- The name has exactly one dot because that is what the RBAC name check enforces
+-- (^[a-z][a-z0-9_]{1,30}\.[a-z][a-z0-9_]{1,30}$) -- organisation.requests.view
+-- would be rejected.
+
+INSERT INTO "public"."permissions" ("name", "description", "is_system") VALUES
+    ('organisation.request_read',
+     'Read the global organisation-creation request queue. Distinct from organisation.approve, which is the power to act on a request. Not is_system, so it can be granted and revoked from the roles UI as the policy changes.',
+     false)
+ON CONFLICT ("name") DO NOTHING;
+
+
+-- ---------------------------------------------------------------------------
+-- Site 1: the RPC the desktop plugin actually calls
+-- ---------------------------------------------------------------------------
+-- Body copied verbatim from 20260808000000, which added r.website to the projection.
+-- The ONLY change is the permission named on the v_is_reviewer line. Same signature,
+-- same {success, is_reviewer, data} envelope, so no client changes shape.
+--
+-- v_is_reviewer is load-bearing twice over: it is returned to the client, which
+-- renders the Requests button on it, AND it is the row filter -- so a caller without
+-- the permission does not merely lose the button, they stop seeing other people's
+-- rows at all. Both halves move together by construction.
+
+CREATE OR REPLACE FUNCTION "public"."list_organisation_requests"(
+    "p_status" "text" DEFAULT NULL::"text",
+    "p_limit" integer DEFAULT 50,
+    "p_offset" integer DEFAULT 0,
+    "p_actor_id" "uuid" DEFAULT NULL::"uuid"
+) RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor UUID;
+    v_is_reviewer BOOLEAN;
+    v_rows JSONB;
+BEGIN
+    v_actor := public.resolve_org_actor(p_actor_id);
+    IF v_actor IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'Not authenticated');
+    END IF;
+
+    v_is_reviewer := public.user_holds_permission(v_actor, 'organisation.request_read');
+
+    SELECT COALESCE(jsonb_agg(row_to_json(t)::jsonb), '[]'::jsonb)
+      INTO v_rows
+      FROM (
+        SELECT r.id, r.requester_id, ru.email AS requester_email,
+               r.name, r.slug, r.description, r.domain, r.website, r.justification,
+               r.status, r.reviewer_id, vu.email AS reviewer_email,
+               r.review_notes, r.reviewed_at, r.created_org_id, r.created_at
+        FROM public.organisation_requests r
+        LEFT JOIN auth.users ru ON ru.id = r.requester_id
+        LEFT JOIN auth.users vu ON vu.id = r.reviewer_id
+        WHERE (v_is_reviewer OR r.requester_id = v_actor)
+          AND (p_status IS NULL OR r.status = p_status)
+        ORDER BY r.created_at DESC
+        LIMIT GREATEST(LEAST(COALESCE(p_limit, 50), 200), 1)
+        OFFSET GREATEST(COALESCE(p_offset, 0), 0)
+      ) t;
+
+    RETURN jsonb_build_object('success', true, 'is_reviewer', v_is_reviewer, 'data', v_rows);
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."list_organisation_requests"("text", integer, integer, "uuid") IS 'Organisation-creation requests. Holders of organisation.request_read see all; everyone else sees only their own. Returns is_reviewer so the client knows which UI to render.';
+
+
+-- ---------------------------------------------------------------------------
+-- Site 2: the direct table read
+-- ---------------------------------------------------------------------------
+-- Nothing reads organisation_requests through PostgREST today -- both clients go
+-- through the RPC above. The policy is switched anyway, because leaving it on
+-- organisation.approve would mean a boss_admin who lost the queue in the UI could
+-- still select the same rows straight off the table, which is a gate that only
+-- looks like one. "Requesters can view their own organisation requests" is
+-- untouched, so a requester keeps seeing their own row either way.
+
+DROP POLICY IF EXISTS "Reviewers can view all organisation requests" ON "public"."organisation_requests";
+CREATE POLICY "Reviewers can view all organisation requests" ON "public"."organisation_requests"
+    FOR SELECT TO "authenticated"
+    USING ("public"."authorize"('organisation.request_read'));

--- a/supabase/tests/organisation_request_read_test.sql
+++ b/supabase/tests/organisation_request_read_test.sql
@@ -1,0 +1,285 @@
+-- pgTAP tests for organisation.request_read (migration 20260816000000).
+--
+-- The property under test is a separation, not a feature: reading the
+-- organisation-creation queue used to ride on organisation.approve, which is granted
+-- to admin AND boss_admin, so every boss_admin could list every pending request with
+-- its requester email and free-text justification. Splitting the read out is only
+-- worth anything if BOTH halves hold:
+--   - a holder of organisation.request_read still sees the whole queue, and
+--   - a holder of organisation.approve ALONE no longer does,
+-- so each subject below is a different user, and no subject is a global admin except
+-- the one arm that is specifically about the admin short-circuit. A fixture that gave
+-- a subject a second reason to pass would make this file agree with the bug.
+
+begin;
+select plan(24);
+
+-- ---------------------------------------------------------------------------
+-- Fixtures
+-- ---------------------------------------------------------------------------
+insert into auth.users (id, email, email_confirmed_at) values
+    ('6a000000-0000-0000-0000-000000000001', 'rrasker@pgtap.test',  now()),
+    ('6a000000-0000-0000-0000-000000000002', 'rrother@pgtap.test',  now()),
+    ('6a000000-0000-0000-0000-000000000003', 'rrreader@pgtap.test', now()),
+    ('6a000000-0000-0000-0000-000000000004', 'rrbossad@pgtap.test', now()),
+    ('6a000000-0000-0000-0000-000000000005', 'rradmin@pgtap.test',  now());
+
+-- The reader gets the permission through a role of its own, NOT through admin.
+-- Using admin here would pass via is_user_admin's short-circuit whether or not the
+-- permission was ever wired up, which is the failure mode this file exists to avoid.
+insert into public.roles (name, description, is_system)
+values ('pgtap_req_reader', 'pgTAP fixture role holding organisation.request_read', false)
+on conflict (name) do nothing;
+
+insert into public.role_permissions (role_id, permission_id)
+select r.id, p.id
+  from public.roles r, public.permissions p
+ where r.name = 'pgtap_req_reader' and p.name = 'organisation.request_read'
+on conflict do nothing;
+
+insert into public.user_roles (user_id, role_id)
+select '6a000000-0000-0000-0000-000000000003', r.id
+  from public.roles r where r.name = 'pgtap_req_reader'
+on conflict do nothing;
+
+insert into public.user_roles (user_id, role_id)
+select '6a000000-0000-0000-0000-000000000004', r.id
+  from public.roles r where r.name = 'boss_admin'
+on conflict do nothing;
+
+insert into public.user_roles (user_id, role_id)
+select '6a000000-0000-0000-0000-000000000005', r.id
+  from public.roles r where r.name = 'admin'
+on conflict do nothing;
+
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+-- Two requests from two different requesters, so "sees only their own" is
+-- distinguishable from "sees everything" (with one row it would not be).
+select public.submit_organisation_request(
+    'RR Asker Org', 'pgtrrask', null, null, 'because',
+    null, '6a000000-0000-0000-0000-000000000001');
+select public.submit_organisation_request(
+    'RR Other Org', 'pgtrroth', null, null, 'because',
+    null, '6a000000-0000-0000-0000-000000000002');
+
+-- Guard: if the fixtures did not land, every row-count assertion below would pass
+-- against an empty table and prove nothing.
+select is(
+    (select count(*) from public.organisation_requests where slug in ('pgtrrask','pgtrroth')),
+    2::bigint,
+    'fixture: two requests exist, from two different requesters'
+);
+
+
+-- ===========================================================================
+-- SECTION 1: the permission itself
+-- ===========================================================================
+select ok(
+    exists (select 1 from public.permissions where name = 'organisation.request_read'),
+    'organisation.request_read exists'
+);
+
+-- Not is_system, and that is load-bearing rather than cosmetic: the roles plugin
+-- hides the Remove button for is_system permissions while its add-list does not
+-- filter them, so a system permission can be granted and then never taken back.
+-- This permission exists to be re-pointed as the policy widens.
+select ok(
+    not (select is_system from public.permissions where name = 'organisation.request_read'),
+    'organisation.request_read is NOT a system permission, so it can be un-granted from the roles UI'
+);
+
+-- The migration deliberately grants it to nobody -- admin works via the
+-- short-circuit, and which roles hold it should be a deliberate operator act.
+select is(
+    (select count(*) from public.role_permissions rp
+       join public.permissions p on p.id = rp.permission_id
+      where p.name = 'organisation.request_read'
+        and rp.role_id <> (select id from public.roles where name = 'pgtap_req_reader')),
+    0::bigint,
+    'the migration grants organisation.request_read to no role (only this test fixture holds it)'
+);
+
+-- The name has to survive the RBAC name check, which allows exactly one dot.
+-- Read the name off the seeded row rather than restating the literal, so this
+-- checks what the migration actually inserted.
+select matches(
+    (select name from public.permissions
+      where description like 'Read the global organisation-creation request queue%'),
+    '^[a-z][a-z0-9_]{1,30}\.[a-z][a-z0-9_]{1,30}$',
+    'the seeded permission name satisfies the enforced RBAC name pattern (exactly one dot)'
+);
+
+
+-- ===========================================================================
+-- SECTION 2: who sees the queue
+-- ===========================================================================
+-- A holder of the new permission, who is not an admin.
+select is(
+    (public.list_organisation_requests(null, 50, 0,
+        '6a000000-0000-0000-0000-000000000003') ->> 'is_reviewer')::boolean,
+    true,
+    'a holder of organisation.request_read is a reviewer'
+);
+select is(
+    (select count(*) from jsonb_array_elements(
+        public.list_organisation_requests(null, 50, 0,
+            '6a000000-0000-0000-0000-000000000003') -> 'data')),
+    2::bigint,
+    'a holder of organisation.request_read sees requests from every requester'
+);
+select ok(
+    not public.is_user_admin('6a000000-0000-0000-0000-000000000003'),
+    'and that reader is NOT a global admin, so the arm above is not the admin short-circuit'
+);
+
+
+-- ===========================================================================
+-- SECTION 3: the regression -- organisation.approve alone no longer reads
+-- ===========================================================================
+-- The fixture is only meaningful if this subject really does still hold
+-- organisation.approve. Assert that first, or a boss_admin who had lost every
+-- permission would satisfy the two assertions after it for the wrong reason.
+select ok(
+    public.get_effective_permissions('6a000000-0000-0000-0000-000000000004')
+        @> array['organisation.approve']::text[],
+    'fixture: the boss_admin subject does hold organisation.approve'
+);
+select ok(
+    not (public.get_effective_permissions('6a000000-0000-0000-0000-000000000004')
+        @> array['organisation.request_read']::text[]),
+    'boss_admin does not inherit organisation.request_read (admin is the PARENT of boss_admin, not the child)'
+);
+select is(
+    (public.list_organisation_requests(null, 50, 0,
+        '6a000000-0000-0000-0000-000000000004') ->> 'is_reviewer')::boolean,
+    false,
+    'a boss_admin is no longer a reviewer of the request queue'
+);
+select is(
+    (select count(*) from jsonb_array_elements(
+        public.list_organisation_requests(null, 50, 0,
+            '6a000000-0000-0000-0000-000000000004') -> 'data')),
+    0::bigint,
+    'a boss_admin sees no other requester rows -- is_reviewer is the row filter, not just a UI flag'
+);
+
+
+-- ===========================================================================
+-- SECTION 4: the arms that must NOT change
+-- ===========================================================================
+-- A global admin, before anyone grants them anything: authorize() and
+-- user_holds_permission() both short-circuit on is_user_admin, which is why the
+-- migration can ship without a grant and leave the operator's queue working.
+select is(
+    (public.list_organisation_requests(null, 50, 0,
+        '6a000000-0000-0000-0000-000000000005') ->> 'is_reviewer')::boolean,
+    true,
+    'a global admin is still a reviewer with no explicit grant (is_user_admin short-circuit)'
+);
+select is(
+    (select count(*) from jsonb_array_elements(
+        public.list_organisation_requests(null, 50, 0,
+            '6a000000-0000-0000-0000-000000000005') -> 'data')),
+    2::bigint,
+    'a global admin still sees the whole queue'
+);
+
+-- A requester keeps their own row. This is the arm that stops the change from
+-- being "nobody sees anything", which would also make sections 2 and 3 pass.
+select is(
+    (public.list_organisation_requests(null, 50, 0,
+        '6a000000-0000-0000-0000-000000000001') ->> 'is_reviewer')::boolean,
+    false,
+    'a plain requester is not a reviewer'
+);
+select is(
+    (select count(*) from jsonb_array_elements(
+        public.list_organisation_requests(null, 50, 0,
+            '6a000000-0000-0000-0000-000000000001') -> 'data')),
+    1::bigint,
+    'a plain requester still sees exactly their own request'
+);
+select is(
+    (select e ->> 'slug' from jsonb_array_elements(
+        public.list_organisation_requests(null, 50, 0,
+            '6a000000-0000-0000-0000-000000000001') -> 'data') e),
+    'pgtrrask',
+    'and the row a requester sees is theirs, not the other requester''s'
+);
+
+
+-- ===========================================================================
+-- SECTION 5: the sites deliberately left on organisation.approve
+-- ===========================================================================
+-- Acting on a request is a different capability from reading the queue. If a later
+-- change wants to move these too, that is a decision to take on purpose -- these
+-- assertions are here so it cannot happen by accident while editing this file.
+select ok(
+    pg_get_functiondef('public.approve_organisation_request(uuid,text,uuid)'::regprocedure)
+        like '%organisation.approve%',
+    'approve_organisation_request still gates on organisation.approve'
+);
+select ok(
+    pg_get_functiondef('public.reject_organisation_request(uuid,text,uuid)'::regprocedure)
+        like '%organisation.approve%',
+    'reject_organisation_request still gates on organisation.approve'
+);
+select ok(
+    exists (
+        select 1 from pg_policies
+         where schemaname = 'public' and tablename = 'organisations'
+           and qual like '%organisation.approve%'
+    ),
+    'the organisations SELECT policy still lets an approver see private organisations'
+);
+
+
+-- ===========================================================================
+-- SECTION 6: the direct table read moved too
+-- ===========================================================================
+-- Nothing reads this table through PostgREST today, but leaving the policy on
+-- organisation.approve would mean a boss_admin who lost the queue in the RPC could
+-- select the same rows straight off the table.
+select ok(
+    exists (
+        select 1 from pg_policies
+         where schemaname = 'public' and tablename = 'organisation_requests'
+           and policyname = 'Reviewers can view all organisation requests'
+           and qual like '%organisation.request_read%'
+    ),
+    'the reviewer RLS policy on organisation_requests reads organisation.request_read'
+);
+select ok(
+    not exists (
+        select 1 from pg_policies
+         where schemaname = 'public' and tablename = 'organisation_requests'
+           and qual like '%organisation.approve%'
+    ),
+    'no policy on organisation_requests still reads organisation.approve'
+);
+
+
+-- ===========================================================================
+-- SECTION 7: is_system = false does not weaken the org-role deny-list
+-- ===========================================================================
+-- The obvious worry about seeding this permission non-system is that it becomes
+-- attachable to an organisation's own admin role, which would hand every org admin
+-- the global request queue -- a much worse leak than the boss_admin one being fixed.
+-- It does not: is_org_grantable_permission tests the permission DOMAIN, and its own
+-- comment says it deliberately does not read permissions.is_system (role.assign and
+-- role.create are is_system = false). These two assertions pin that reasoning, so a
+-- later change to either the flag or the deny-list cannot quietly cross them.
+select ok(
+    not public.is_org_grantable_permission(
+        (select id from public.permissions where name = 'organisation.request_read')),
+    'organisation.request_read cannot be attached to an organisation-owned role'
+);
+select ok(
+    not public.is_org_grantable_permission(
+        (select id from public.permissions where name = 'organisation.approve')),
+    'and neither can organisation.approve -- the deny-list is by domain, not by is_system'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## The leak

Seeing the organisation-creation request queue was gated on `organisation.approve`, which `20260801010000` grants to **two** roles:

```sql
('admin',      'organisation.approve'),
('boss_admin', 'organisation.approve')
```

So every `boss_admin` could list every pending request, with the requester's email and the free-text justification. Only `admin` should see it for now, and widening it later should be a grant rather than a migration.

## Why not just revoke it from boss_admin

That was the smaller change and the wrong one, twice over.

`organisation.approve` means three things at once: reading the queue, acting on a request (approve/reject), and the `organisations` SELECT policy that lets a reviewer see private orgs in order to judge a name clash. Revoking takes all three.

And it cannot be un-granted from the roles plugin at all. That UI hides the Remove button for `is_system` permissions (`RoleCreationContent.kt:707`) while `getAvailablePermissionsForRole` does **not** filter them, so a system permission is a one-way door there: grantable, never revocable. (`remove_permission_from_role` itself has no `is_system` check - the block is purely in the UI.)

## What this does

A new permission, `organisation.request_read`, seeded **`is_system = false`** - deliberately, and this is the load-bearing detail. It exists to be re-pointed as the policy widens, so it has to stay reachable from that UI.

Two sites move to it:

| Site | Why |
|---|---|
| `list_organisation_requests` | `v_is_reviewer` is returned to the client **and** is the row filter, so the button and the rows move together by construction |
| RLS SELECT `organisation_requests` | nothing reads the table over PostgREST today, but leaving it would mean a `boss_admin` who lost the queue in the UI could select the same rows directly |

The RPC body is copied verbatim from `20260808000000`; `diff` shows exactly one changed line.

**Granted to no role.** `authorize()` (`20260625000000:212`) and `user_holds_permission` both short-circuit on `is_user_admin`, so `admin` holds it the moment it exists and the queue keeps working with no grant at all. Which roles hold it stays a deliberate operator act rather than a side effect of a deploy.

**Deliberately unchanged**: `approve_organisation_request`, `reject_organisation_request`, and the `organisations` SELECT policy still read `organisation.approve`. A `boss_admin` can still decide a request id they already knew. That is the status quo, not a regression introduced here, and it is asserted rather than left implicit.

## Verification

24 pgTAP assertions in `supabase/tests/organisation_request_read_test.sql`. Every subject is a different user and none is a global admin except the one arm that is specifically about the short-circuit, so no fixture hands a subject a second reason to pass. There is a fixture guard asserting the two requests actually exist, or every row-count assertion would pass against an empty table.

Verified by mutation, each mutation confirmed to have landed before running:

| Mutation | Assertions killed |
|---|---|
| RPC reverted to `organisation.approve` | 4 (6, 7, 11, 12) |
| RLS policy reverted | 2 (21, 22) |
| `is_system` flipped to `true` | 1 (3) |

Sections 5 and 7 pin the things that must **not** move: approve/reject still on `organisation.approve`, and `is_org_grantable_permission` still refusing both permissions to an org-owned role. That last one answers the obvious worry about a non-system permission - the deny-list is by domain and its own comment says it deliberately does not read `is_system`.

Ran against the local stack with migration and test in one rolled-back transaction.

## After merge

```
role_grant_permission(role="admin", permission="organisation.request_read")
```
Not required for the queue to work (the short-circuit covers it), but it makes the grant explicit and auditable.

Plugin side: risa-labs-inc/boss-plugin-organisation#5 - comments only, no behaviour change, since the button already renders on the server's `is_reviewer`.