### PR TITLE
feat(editor): Auto Save item in the File menu

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
@@ -5,9 +5,9 @@ import ai.rever.boss.plugin.api.EditorTabPluginAPI
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 
@@ -73,9 +73,9 @@ object EditorAPIAccess {
      */
     @Composable
     fun rememberAutoSaveEnabled(): State<Boolean>? {
-        val provider = rememberProvider() ?: return null
-        val enabled = remember(provider) { provider.autoSaveEnabled() } ?: return null
-        return enabled.collectAsState()
+        val provider = rememberProvider()
+        val enabled = remember(provider) { provider?.autoSaveEnabled() }
+        return enabled?.collectAsState()
     }
 
     /** Turns auto save on or off in the editor plugin. No-op when it is not installed. */

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 
@@ -59,6 +60,27 @@ object EditorAPIAccess {
         val plugin = cachedDefaultPlugin ?: return null
         val registryVersion by plugin.apiRegistryVersion.collectAsState()
         return remember(registryVersion) { getProvider() }
+    }
+
+    // ==================== Auto Save ====================
+
+    /**
+     * Observable auto save state for menu rendering, or null when there is nothing to render a
+     * control for: no editor-tab plugin installed, or one that predates the setting.
+     *
+     * Callers should hide the control on null rather than showing an unchecked one, which would
+     * be indistinguishable from auto save being off and would do nothing when clicked.
+     */
+    @Composable
+    fun rememberAutoSaveEnabled(): State<Boolean>? {
+        val provider = rememberProvider() ?: return null
+        val enabled = remember(provider) { provider.autoSaveEnabled() } ?: return null
+        return enabled.collectAsState()
+    }
+
+    /** Turns auto save on or off in the editor plugin. No-op when it is not installed. */
+    fun setAutoSaveEnabled(enabled: Boolean) {
+        getProvider()?.setAutoSaveEnabled(enabled)
     }
 
     // ==================== Composable Bridges (Settings) ====================

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -1,6 +1,5 @@
 package ai.rever.boss.window
 
-import ai.rever.boss.services.editor.EditorAPIAccess
 import ai.rever.boss.BossAppWithAuth
 import ai.rever.boss.components.bars.ChromeBar
 import ai.rever.boss.components.bars.displayName
@@ -23,6 +22,7 @@ import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.plugin.ui.LocalHeavyweightOverlays
+import ai.rever.boss.services.editor.EditorAPIAccess
 import ai.rever.boss.services.terminal.TerminalAPIAccess
 import ai.rever.boss.updater.UpdateCoordinator
 import ai.rever.boss.utils.CLIInstaller

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.services.editor.EditorAPIAccess
 import ai.rever.boss.BossAppWithAuth
 import ai.rever.boss.components.bars.ChromeBar
 import ai.rever.boss.components.bars.displayName
@@ -408,6 +409,21 @@ fun ApplicationScope.BossWindow(
                         MenuActionsHandler.triggerCloseTab(windowState.id)
                     },
                 )
+
+                // Auto save belongs to the editor plugin, which owns the save path and the
+                // setting; the host only renders the control because plugins cannot contribute
+                // to the native menu bar. Null means no editor plugin, or one older than the
+                // setting - hide the item rather than show one that does nothing.
+                val autoSaveEnabled = EditorAPIAccess.rememberAutoSaveEnabled()
+                if (autoSaveEnabled != null) {
+                    Separator()
+
+                    CheckboxItem(
+                        "Auto Save",
+                        checked = autoSaveEnabled.value,
+                        onCheckedChange = { EditorAPIAccess.setAutoSaveEnabled(it) },
+                    )
+                }
 
                 Separator()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,7 @@ intellij-platform = "243.21565.199"
 # checking rather than trusting the ordering: fetchApiPluginJar has no Maven fallback, so
 # a pin that dropped a type would surface as an unrelated compile error, and this comment
 # is the only record of which api PR a pin corresponds to.
-boss-plugin-api = "1.0.79"
+boss-plugin-api = "1.0.80"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
Third of three, for the requested Auto Save option under **File** in the OS menu bar.

- boss-plugin-api [#36](https://github.com/risa-labs-inc/boss-plugin-api/pull/36) - merged, released as **1.0.80** (pinned here)
- editor-tab [#24](https://github.com/risa-labs-inc/boss-plugin-editor-tab/pull/24) - the setting and the behaviour

## What the host does, and what it deliberately does not

It renders the control. That is all it should do, and the only reason it needs host code at all is that **plugins cannot contribute to the native menu bar** - there is no `PanelMenu` equivalent for it.

The setting itself stays in editor-tab, which owns the save path, the modified flag and the debounce. Worth recording why it could not simply live in `~/.boss/editor-settings.json`: that file belongs to BossEditor's `EditorSettingsManager`, whose `saveToFile()` serializes the whole `EditorSettings` and overwrites it, so a key added there by the host would be erased the next time the user changed any editor setting.

```kotlin
val autoSaveEnabled = EditorAPIAccess.rememberAutoSaveEnabled()
if (autoSaveEnabled != null) {
    Separator()
    CheckboxItem(
        "Auto Save",
        checked = autoSaveEnabled.value,
        onCheckedChange = { EditorAPIAccess.setAutoSaveEnabled(it) },
    )
}
```

## The null case is the interesting one

`rememberAutoSaveEnabled()` returns null when there is no editor-tab plugin installed, **or** when the installed one predates the setting. The item is hidden in both cases.

The alternative - a `Boolean` defaulting to false - would render an unchecked box indistinguishable from "auto save is off", which then does nothing when clicked. That is why the API returns a nullable `StateFlow` rather than a plain flag, and why this reads it through `rememberProvider()`, which recomposes on `apiRegistryVersion` so the item appears and disappears as the plugin is installed, reloaded or removed.

## Verification

**Confirmed working in a dev build.** Running this branch against editor-tab 1.4.18, the Auto Save checkbox renders under File and toggles the editor's setting.

`detekt` + `ktlintCheck` green (two violations fixed in the second commit: `ReturnCount` on `rememberAutoSaveEnabled`, and import ordering in both touched files). `:composeApp:compileKotlinDesktop` green.

Still worth a look during review, since only the happy path has been exercised: the item should be **absent** against an editor-tab older than the auto-save release, and should come back after a plugin hot reload.

## Shipping note

This is the piece that needs a **BossConsole release** to reach users - the other two ship as plugin/API releases. editor-tab #24 also puts the same toggle in the editor's Settings panel, so the feature is usable from a plugin-only release if you would rather not cut a host build for it; this PR can then ride along with the next host release rather than driving one.
