### PR TITLE
BossAlertDialog: an alert's width is what it wants, not what it must have

### DIFF
--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -358,31 +359,48 @@ fun BossAlertDialog(
     val colors = BossTheme.colors
     val space = BossTheme.space
     BossDialog(onDismissRequest = onDismissRequest, properties = properties) {
-        Surface(
-            modifier =
-                modifier
-                    .width(AlertWidth)
-                    .wrapContentHeight(),
-            shape = shape ?: BossTheme.radius.dialogShape,
-            color = backgroundColor.takeOrElse { colors.panel },
-            contentColor = contentColor.takeOrElse { colors.textPrimary },
-        ) {
-            Column(modifier = Modifier.padding(space.xl)) {
-                if (title != null) {
-                    CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
-                        ProvideTextStyle(BossTheme.type.title, title)
+        // [AlertWidth] is what an alert WANTS, not what it must have.
+        //
+        // `.width(AlertWidth)` set the minimum as well as the maximum, so in the scrimmed
+        // in-window path — where this Surface is measured against the app window rather than
+        // against a dialog window of its own — a window narrower than 400dp got a card it could
+        // not fit, clipped at the edge. Reported against the Atlas plugin, whose panel slot is
+        // routinely narrower than that: a Row of actions inside a card that cannot shrink is
+        // measured first child to last, so the last one — the primary — was squeezed to zero
+        // width on a consent surface. Measured at 240dp, not inferred.
+        //
+        // BoxWithConstraints rather than `widthIn(max = AlertWidth)`: with only a maximum, a
+        // Surface wraps its content, so every short alert in the app would suddenly be narrower
+        // than 400dp. Taking the smaller of what we want and what there is leaves the wide case
+        // byte-identical and changes only the case that was broken.
+        BoxWithConstraints(contentAlignment = Alignment.Center) {
+            val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
+            Surface(
+                modifier =
+                    modifier
+                        .width(AlertWidth.coerceAtMost(available))
+                        .wrapContentHeight(),
+                shape = shape ?: BossTheme.radius.dialogShape,
+                color = backgroundColor.takeOrElse { colors.panel },
+                contentColor = contentColor.takeOrElse { colors.textPrimary },
+            ) {
+                Column(modifier = Modifier.padding(space.xl)) {
+                    if (title != null) {
+                        CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
+                            ProvideTextStyle(BossTheme.type.title, title)
+                        }
                     }
-                }
-                if (title != null && text != null) {
-                    Spacer(Modifier.height(space.md))
-                }
-                if (text != null) {
-                    CompositionLocalProvider(LocalContentColor provides colors.textSecondary) {
-                        ProvideTextStyle(BossTheme.type.body, text)
+                    if (title != null && text != null) {
+                        Spacer(Modifier.height(space.md))
                     }
+                    if (text != null) {
+                        CompositionLocalProvider(LocalContentColor provides colors.textSecondary) {
+                            ProvideTextStyle(BossTheme.type.body, text)
+                        }
+                    }
+                    Spacer(Modifier.height(space.xl))
+                    buttons()
                 }
-                Spacer(Modifier.height(space.xl))
-                buttons()
             }
         }
     }


### PR DESCRIPTION
## The defect

`BossAlertDialog` sizes its card with `Modifier.width(AlertWidth)` — a single `Dp`. `width()` sets the minimum as well as the maximum, so 400dp is a floor the card cannot go below.

That is fine on the lightweight path, where the content gets a dialog window of its own. It is not fine on the **scrimmed in-window path**: there the `Surface` is measured against the app window, so a window — or a panel slot — narrower than 400dp gets a card it cannot fit, and the overflow is clipped at the edge.

## Why it is worth a PR rather than a plugin-side workaround

No change inside a plugin's dialog content can make a fixed-width parent adapt.

It was reported against the Atlas plugin (`risa-labs-inc/boss-plugin-atlas#85`), whose panel slot is routinely narrower than 400dp, and it lands on that plugin's **approval dialog** — its consent surface. Inside a card that cannot shrink, a `Row` of actions is measured first child to last, and the last child gets what is left. Measured at 240dp:

```
Don't allow          left=0dp    width=95dp   (intact)
Always in this chat  left=101dp  width=139dp  (squeezed from 148)
Allow once           left=240dp  width=0dp    (gone)
```

The primary action came out zero-width, leaving "Always in this chat" as the only visible way to proceed — so a user who meant to permit a single call had nothing to click but the button that permits every later one too. The plugin fixes its own row separately; this PR is the half that makes a narrow card possible at all.

## The change

```kotlin
BoxWithConstraints(contentAlignment = Alignment.Center) {
    val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
    Surface(modifier = modifier.width(AlertWidth.coerceAtMost(available)).wrapContentHeight(), …)
}
```

**Not `widthIn(max = AlertWidth)`.** With only a maximum, a `Surface` wraps its content — so every short alert in the app (a two-line confirm, say) would suddenly be narrower than 400dp. That is a visual change to every dialog in BOSS, to fix one that was too wide for its window.

Taking the smaller of *what we want* and *what there is* means:

- **Room for 400dp → exactly 400dp, unchanged.** On the lightweight dialog path `maxWidth` is effectively unbounded, so the result is `AlertWidth` and the rendered output is identical.
- **Not enough room → the card tracks the window,** with `space.lg` clear of each edge.

## Deliberately out of scope, with one caveat worth knowing

**Height.** The reporting issue also suggests `heightIn` plus a scrolling body. Constraining height without giving the body a scroll only moves where a tall dialog clips, and adding a scroll would make every dialog's content measure against an unbounded height — which reaches any existing dialog that uses `weight` or `fillMaxHeight` inside its content. That is a larger change with its own review, not a rider on this one.

**The caveat:** the plugin-side fix for the same report wraps its action row instead of squeezing it, which costs roughly 80dp of height at exactly the narrow widths this PR enables, and puts the primary action on the last line. So on a *short* window the two axes are now coupled rather than independent. The scrim path centres its content, so a card taller than the window loses its top as well as its bottom.

This PR is still correct on its own — a card that tracks the window is better than one that cannot — but if the vertical axis is worth fixing here, `risa-labs-inc/boss-plugin-atlas#100` records what to measure first. Happy to follow up with it in this repo if the owners would rather have both halves at once.

## Checks

- `:plugin-platform:plugin-ui-core:compileKotlinDesktop` — BUILD SUCCESSFUL.
- No public API change: `BossAlertDialog`'s signature is untouched, so the binary-compatibility validator has nothing to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
