### PR TITLE
BossAlertDialog: a short window took the alert's actions, the way a narrow one took its width

### DIFF
--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/BossAlertDialogComposeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/BossAlertDialogComposeTest.kt
@@ -2,12 +2,15 @@ package ai.rever.boss.components.overlays
 
 import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossOverlayHost
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -120,5 +123,30 @@ class BossAlertDialogComposeTest {
         rule.onNodeWithText("Discard").assertIsDisplayed()
         rule.onNodeWithText("Keep editing").performClick()
         assertTrue(clicks == listOf("cancel"), "expected only the clicked button to fire, got $clicks")
+    }
+
+    @Test
+    fun `a body taller than the window does not squeeze the confirm button`() {
+        // Raised in review of BossConsole#216: the card only gives its body the flexible space when
+        // its height is bounded, and this file is the only place that exercises the LIGHTWEIGHT
+        // path. If desktop's Dialog window hands its content a screen-bounded height, that change
+        // is not inert here - every host dialog with a long body starts scrolling it, which is
+        // probably an improvement but should be a known one. Either way the property that must hold
+        // is the same as on the scrimmed path: the actions keep their height.
+        rule.setContent {
+            BossAlertDialog(
+                onDismissRequest = {},
+                title = { Text("Reset Browser") },
+                text = { Column { repeat(40) { Text("line $it of a long body") } } },
+                dismissButton = { TextButton(onClick = {}) { Text("Cancel") } },
+                confirmButton = { TextButton(onClick = {}) { Text("Reset") } },
+            )
+        }
+
+        val confirm = rule.onNodeWithText("Reset").getUnclippedBoundsInRoot()
+        assertTrue(
+            (confirm.bottom - confirm.top) > 0.dp,
+            "the confirm button measured ${confirm.bottom - confirm.top} tall under a 40-line body",
+        )
     }
 }

--- a/plugin-platform/plugin-ui-core/build.gradle.kts
+++ b/plugin-platform/plugin-ui-core/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.risaboss"
-version = "1.0.8"
+version = "1.0.9"
 
 kotlin {
     compilerOptions {

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossAlertCard.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossAlertCard.kt
@@ -1,0 +1,181 @@
+package ai.rever.boss.plugin.ui
+
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+// ---------------------------------------------------------------------------
+// Alert card
+// ---------------------------------------------------------------------------
+//
+// Its own file rather than living in BossDialog.kt: that file was already carrying the dialog
+// routing, the scrim, the popup and the anchor maths, and the card's own reasoning about measurement
+// is long enough that detekt's per-file function budget and per-function length both objected.
+
+/** Width of a BOSS alert card, matching the house confirmation dialog. */
+internal val AlertWidth: Dp = 400.dp
+
+/**
+ * The card [BossAlertDialog] puts inside a dialog, split out so it can be measured.
+ *
+ * `BossAlertDialog` itself cannot be: on the path a test scene can host it routes to a platform
+ * dialog window, and such a window does not inherit the size of whatever composed it. Both bugs
+ * below are about a card with LESS room than it wants, which only a constrained parent produces -
+ * hence `internal`, and `BossAlertCardLayoutTest` constraining it directly.
+ *
+ * **Width: [AlertWidth] is what an alert wants, not what it must have.** `.width(AlertWidth)` set
+ * the minimum as well as the maximum, so a window narrower than 400dp got a card it could not fit.
+ * `BoxWithConstraints` rather than `widthIn(max = …)`, because with only a maximum a `Surface` wraps
+ * its content and every short alert in the app would have become narrower than 400dp.
+ *
+ * **Height: the actions are what a short window used to lose, and it is the same bug.** A `Column`
+ * offers each non-weighted child what the previous ones left, so the body took what it wanted and
+ * the actions - measured last - were offered nothing: 0dp tall in a 300dp frame, exactly as the
+ * primary came out 0dp wide in a card too narrow for its action row. So the body takes the flexible
+ * space and scrolls, while the title and the actions keep theirs.
+ *
+ * Three things about that are load-bearing, and each has a test that fails without it:
+ *
+ *  - **`fill = false`** - a bare `weight(1f)` fills its share, stretching every short alert to the
+ *    window.
+ *  - **the flex is gated on a BOUNDED height, read from the constraints the `Column` receives** (see
+ *    [AlertBody]). A weighted child of an unbounded axis gets a share of almost nothing.
+ *  - **`heightIn` is the margin, not the fix** - incoming constraints already bound the card; that
+ *    line only holds it `space.lg` clear of the parent's edges.
+ *
+ * **This fixes the squeeze where the card is measured against a parent, which is the scrimmed path**
+ * (`ScrimmedModalContent` is a `fillMaxSize` Box, and that is where the report came from). On the
+ * lightweight `Dialog` path it is inert by design, and the ceiling there is the *screen* rather than
+ * the card: a tall card on a shorter display still puts its actions out of reach. Pre-existing.
+ *
+ * **There is a floor, about 176dp.** Only the body flexes, so padding, title and spacers are still
+ * measured first. Measured: full-height actions at a 180dp parent, 20dp at 160dp, 0dp at 140dp, and
+ * the title itself goes at 80dp. Pinned by `theActionsSurviveTheShortestWindowThatCanHoldThem`.
+ * Going lower means shrinking padding or dropping the title, which is a design decision.
+ *
+ * **A [text] slot that caps itself against its parent loses that reference point.** A cap written as
+ * `min(myMax, constraints.maxHeight)` coerces against an infinite maximum here and always takes its
+ * full constant, so it stops shrinking with a short window - two nested scroll regions instead of
+ * one. A slot that wants to shrink has to be told its budget rather than derive it. `verticalScroll`
+ * also applies `clipScrollableContainer`, so the body is clipped in the scroll direction.
+ *
+ * The measurements behind all of the above, and the audit of what a `text` slot may contain, are in
+ * the PR that introduced it (risa-labs-inc/BossConsole#216) rather than here.
+ */
+@Composable
+internal fun BossAlertCard(
+    buttons: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    title: (@Composable () -> Unit)? = null,
+    text: (@Composable () -> Unit)? = null,
+    shape: Shape? = null,
+    backgroundColor: Color = Color.Unspecified,
+    contentColor: Color = Color.Unspecified,
+) {
+    val colors = BossTheme.colors
+    val space = BossTheme.space
+    BoxWithConstraints(contentAlignment = Alignment.Center) {
+        val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
+        val parentBoundsUs = constraints.hasBoundedHeight
+        Surface(
+            modifier =
+                modifier
+                    .width(AlertWidth.coerceAtMost(available))
+                    .then(
+                        if (parentBoundsUs) {
+                            // The margin, not the fix - see the KDoc. Pinned by
+                            // theCardKeepsAMarginFromAParentShorterThanItself.
+                            Modifier.heightIn(max = (maxHeight - space.lg * 2).coerceAtLeast(0.dp))
+                        } else {
+                            Modifier
+                        },
+                    ).wrapContentHeight(),
+            shape = shape ?: BossTheme.radius.dialogShape,
+            color = backgroundColor.takeOrElse { colors.panel },
+            contentColor = contentColor.takeOrElse { colors.textPrimary },
+        ) {
+            // Not redundant with the outer one: the caller's `modifier` sits between the outer
+            // constraints and this point, so reading them here is what makes the branch below true
+            // by construction for the axis the weight uses. See the KDoc; pinned by
+            // aCallerModifierThatRemovesTheHeightBoundDoesNotCollapseTheBody.
+            BoxWithConstraints {
+                val bodyCanFlex = constraints.hasBoundedHeight
+                Column(modifier = Modifier.padding(space.xl)) {
+                    if (title != null) {
+                        CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
+                            ProvideTextStyle(BossTheme.type.title, title)
+                        }
+                    }
+                    if (title != null && text != null) {
+                        Spacer(Modifier.height(space.md))
+                    }
+                    if (text != null) {
+                        AlertBody(text, bodyCanFlex, colors.textSecondary)
+                    }
+                    Spacer(Modifier.height(space.xl))
+                    buttons()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The card's body: the part that gives way when the card is shorter than its content.
+ *
+ * [canFlex] must come from the constraints the enclosing `Column` receives, not from the card's own
+ * incoming constraints - the caller's `modifier` sits between the two, and a caller that removes the
+ * height bound would otherwise get the weighted branch against an infinite axis, which is the
+ * collapse the flag exists to prevent, reached through it rather than around it.
+ */
+@Composable
+private fun ColumnScope.AlertBody(
+    text: @Composable () -> Unit,
+    canFlex: Boolean,
+    contentColor: Color,
+) {
+    val scroll = rememberScrollState()
+    Box(
+        modifier =
+            if (canFlex) {
+                Modifier.weight(1f, fill = false).verticalScroll(scroll)
+            } else {
+                Modifier
+            },
+    ) {
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
+            ProvideTextStyle(BossTheme.type.body, text)
+        }
+        // The affordance the scroll would otherwise not have, drawn only when something is below the
+        // fold. matchParentSize so the scrollbar takes no part in sizing the body.
+        if (canFlex && scroll.maxValue in 1 until Int.MAX_VALUE) {
+            Box(Modifier.matchParentSize(), contentAlignment = Alignment.TopEnd) {
+                VerticalScrollbar(rememberScrollbarAdapter(scroll), Modifier.fillMaxHeight())
+            }
+        }
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -300,11 +300,12 @@ internal val AlertWidth: Dp = 400.dp
  *
  * @param confirmButton The primary action. Rendered last, i.e. rightmost.
  * @param dismissButton The secondary action, rendered to the left of [confirmButton].
- * @param text The body. **It may be measured with an unbounded height**, because the card gives the
- * body the flexible space and scrolls it so a short window cannot squeeze the actions to nothing.
- * A composable that refuses an unbounded main axis — a `LazyColumn`, or a nested `verticalScroll` —
- * throws `IllegalStateException` unless it is capped, so give any such content a
- * `Modifier.heightIn(max = …)`. This is the one thing about this card a caller has to know.
+ * @param text The body. **When the card's parent bounds its height, the body is placed in a scroll
+ * container and therefore measured with an UNBOUNDED height** — that is the bounded-parent branch,
+ * not the unbounded one, and it is the branch most alerts take. A composable that refuses an
+ * unbounded main axis — a `LazyColumn`, a `LazyVerticalGrid`, a nested `verticalScroll` — will not
+ * lay out there unless it caps itself, so give any such content a `Modifier.heightIn(max = …)`.
+ * This is the one thing about this card a caller has to know.
  * @param shape Card shape; null takes the design system's dialog radius.
  * @param backgroundColor Card fill; [Color.Unspecified] takes the theme's panel color.
  * @param contentColor Default content color; [Color.Unspecified] takes the theme's primary text.
@@ -352,11 +353,12 @@ fun BossAlertDialog(
  * Mirrors Material 2's `buttons` overload. Use it when the actions are not a confirm/dismiss pair:
  * three buttons, a progress row, or no buttons at all.
  *
- * @param text The body. **It may be measured with an unbounded height**, because the card gives the
- * body the flexible space and scrolls it so a short window cannot squeeze the actions to nothing.
- * A composable that refuses an unbounded main axis — a `LazyColumn`, or a nested `verticalScroll` —
- * throws `IllegalStateException` unless it is capped, so give any such content a
- * `Modifier.heightIn(max = …)`. This is the one thing about this card a caller has to know.
+ * @param text The body. **When the card's parent bounds its height, the body is placed in a scroll
+ * container and therefore measured with an UNBOUNDED height** — that is the bounded-parent branch,
+ * not the unbounded one, and it is the branch most alerts take. A composable that refuses an
+ * unbounded main axis — a `LazyColumn`, a `LazyVerticalGrid`, a nested `verticalScroll` — will not
+ * lay out there unless it caps itself, so give any such content a `Modifier.heightIn(max = …)`.
+ * This is the one thing about this card a caller has to know.
  */
 @Composable
 fun BossAlertDialog(
@@ -437,6 +439,13 @@ fun BossAlertDialog(
  * nothing. And there is no bug to fix on that path in the first place, because a window that sizes
  * to its content cannot clip it, so scrolling there is pure loss.
  *
+ * **So this fixes the squeeze on the path where the card is measured against a parent, which is the
+ * scrimmed one** — `ScrimmedModalContent` is a `fillMaxSize` Box, so the card is bounded by the
+ * overlay window, and that is where the report came from. On the lightweight `Dialog` path the
+ * change is inert by design, and the ceiling there is the *screen* rather than the card: a window
+ * that sizes to its content cannot clip it, but a 1116dp card on a shorter display still puts its
+ * actions where they cannot be reached. That is pre-existing and not addressed here.
+ *
  * Scrolling hides content with no affordance of its own, which is a real cost on a card that may be
  * asking for consent. It is the lesser one — the alternative here is clipping, which hides the same
  * content AND removes the actions — but a call site with a long body should still bound and scroll
@@ -446,6 +455,21 @@ fun BossAlertDialog(
  * with `dialogScrollFence`: that lives in `composeApp` and is not on the plugin classpath, so a
  * plugin author following that advice could not write it. (Moving the fence into this module would
  * be reasonable — it is a `LayoutModifier` with no host dependency — but it is a separate change.)
+ *
+ * **An uncapped lazy list in [text] fails, and the failure mode is worse than an exception.**
+ * Compose rejects an infinite main axis for a scrollable container, so the documented cap is not
+ * advice, it is a requirement. Tried to pin the failure and could not: an uncapped `LazyColumn` in
+ * the body **hung** a `createComposeRule` scene rather than throwing, twice, at 200 items and at
+ * five. So the `@param` wording says "will not lay out" rather than naming an exception — the
+ * requirement is verified, the exact failure is not. What is pinned is the other half:
+ * `a capped lazy list in the body composes rather than throwing`.
+ *
+ * **A [text] slot that caps itself against its parent loses that reference point.** A cap written as
+ * `min(myMax, constraints.maxHeight)` — which is what the host's own `dialogScrollFence` computes —
+ * coerces against an infinite maximum here, so it always takes its full constant instead of
+ * shrinking with a short window. The content stays reachable, because the outer scroll takes the
+ * leftover, but it means two nested scroll regions rather than one. A slot that wants to shrink with
+ * the card has to be told the height it may use rather than deriving it from its constraints.
  *
  * `verticalScroll` also applies `clipScrollableContainer`, so the body is now clipped in the scroll
  * direction. Nothing in the host relied on content overflowing a [text] slot inline, but it is a
@@ -475,6 +499,12 @@ internal fun BossAlertCard(
                     .width(AlertWidth.coerceAtMost(available))
                     .then(
                         if (bounded) {
+                            // The MARGIN, not the fix. Incoming constraints already stop the card
+                            // exceeding its parent, so the weight below does the whole job of
+                            // keeping the actions measurable; this only holds the card `space.lg`
+                            // clear of the parent's top and bottom edges, matching the width. Its
+                            // own test is theCardKeepsAMarginFromAParentShorterThanItself, because
+                            // removing this line breaks no other assertion in the suite.
                             Modifier.heightIn(max = (maxHeight - space.lg * 2).coerceAtLeast(0.dp))
                         } else {
                             Modifier

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -283,7 +283,7 @@ internal fun ScrimmedModalContent(
 // ---------------------------------------------------------------------------
 
 /** Width of a BOSS alert card, matching the house confirmation dialog. */
-private val AlertWidth: Dp = 400.dp
+internal val AlertWidth: Dp = 400.dp
 
 /**
  * A title/text/buttons dialog in the BOSS design system, layered above the browser surface.
@@ -300,6 +300,11 @@ private val AlertWidth: Dp = 400.dp
  *
  * @param confirmButton The primary action. Rendered last, i.e. rightmost.
  * @param dismissButton The secondary action, rendered to the left of [confirmButton].
+ * @param text The body. **It may be measured with an unbounded height**, because the card gives the
+ * body the flexible space and scrolls it so a short window cannot squeeze the actions to nothing.
+ * A composable that refuses an unbounded main axis — a `LazyColumn`, or a nested `verticalScroll` —
+ * throws `IllegalStateException` unless it is capped, so give any such content a
+ * `Modifier.heightIn(max = …)`. This is the one thing about this card a caller has to know.
  * @param shape Card shape; null takes the design system's dialog radius.
  * @param backgroundColor Card fill; [Color.Unspecified] takes the theme's panel color.
  * @param contentColor Default content color; [Color.Unspecified] takes the theme's primary text.
@@ -346,6 +351,12 @@ fun BossAlertDialog(
  *
  * Mirrors Material 2's `buttons` overload. Use it when the actions are not a confirm/dismiss pair:
  * three buttons, a progress row, or no buttons at all.
+ *
+ * @param text The body. **It may be measured with an unbounded height**, because the card gives the
+ * body the flexible space and scrolls it so a short window cannot squeeze the actions to nothing.
+ * A composable that refuses an unbounded main axis — a `LazyColumn`, or a nested `verticalScroll` —
+ * throws `IllegalStateException` unless it is capped, so give any such content a
+ * `Modifier.heightIn(max = …)`. This is the one thing about this card a caller has to know.
  */
 @Composable
 fun BossAlertDialog(
@@ -410,6 +421,15 @@ fun BossAlertDialog(
  * would stretch every short dialog in the app to the window; `fill = false` lets the body stay its
  * own height, so a card that fits is measured exactly as before.
  *
+ * **There is a floor, and it is about 176dp.** Only the body flexes; the padding, the title and the
+ * two spacers are still measured before the actions. That chrome is `space.xl * 2` of padding plus a
+ * title line plus `space.md` plus `space.xl` plus Material's 36dp button minimum — so once the
+ * parent is under roughly 176dp there is nothing left to give the actions and they collapse again.
+ * Measured: full 36dp at a 180dp parent, 33dp at 173dp, 20dp at 160dp, **0dp at 140dp**, and the
+ * title itself goes at 80dp. Pinned by `theActionsSurviveTheShortestWindowThatCanHoldThem`, so the
+ * floor cannot move quietly. Going lower would mean shrinking the padding or dropping the title,
+ * which is a design decision rather than a layout fix, and a 140dp-tall dialog is arguably not one.
+ *
  * The `hasBoundedHeight` branch matters just as much. Given a 40-line body and no height bound —
  * the shape of a dialog window that sizes to its content — this card measures 1116dp and renders
  * the whole body inline. Applying the weight there anyway measures **156dp**, with the body
@@ -419,8 +439,17 @@ fun BossAlertDialog(
  *
  * Scrolling hides content with no affordance of its own, which is a real cost on a card that may be
  * asking for consent. It is the lesser one — the alternative here is clipping, which hides the same
- * content AND removes the actions — but a call site with a long body should still supply its own
- * scrollbar inside [text], the way the update dialog's release notes do.
+ * content AND removes the actions — but a call site with a long body should still bound and scroll
+ * it explicitly: `Modifier.heightIn(max = …).verticalScroll(…)`, plus a scrollbar of its own.
+ *
+ * Deliberately spelled out rather than pointing at the update dialog's release notes, which do this
+ * with `dialogScrollFence`: that lives in `composeApp` and is not on the plugin classpath, so a
+ * plugin author following that advice could not write it. (Moving the fence into this module would
+ * be reasonable — it is a `LayoutModifier` with no host dependency — but it is a separate change.)
+ *
+ * `verticalScroll` also applies `clipScrollableContainer`, so the body is now clipped in the scroll
+ * direction. Nothing in the host relied on content overflowing a [text] slot inline, but it is a
+ * second behaviour change riding along with the first.
  */
 @Composable
 internal fun BossAlertCard(
@@ -437,6 +466,9 @@ internal fun BossAlertCard(
     BoxWithConstraints(contentAlignment = Alignment.Center) {
         val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
         val bounded = constraints.hasBoundedHeight
+        // Hoisted rather than called inside the modifier branch below, so the scroll position
+        // survives a flip of `bounded` rather than being remembered under a different call site.
+        val bodyScroll = rememberScrollState()
         Surface(
             modifier =
                 modifier
@@ -467,7 +499,7 @@ internal fun BossAlertCard(
                             if (bounded) {
                                 Modifier
                                     .weight(1f, fill = false)
-                                    .verticalScroll(rememberScrollState())
+                                    .verticalScroll(bodyScroll)
                             } else {
                                 Modifier
                             },

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -12,9 +12,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Surface
@@ -356,51 +359,126 @@ fun BossAlertDialog(
     contentColor: Color = Color.Unspecified,
     properties: DialogProperties = DialogProperties(),
 ) {
+    BossDialog(onDismissRequest = onDismissRequest, properties = properties) {
+        BossAlertCard(
+            buttons = buttons,
+            modifier = modifier,
+            title = title,
+            text = text,
+            shape = shape,
+            backgroundColor = backgroundColor,
+            contentColor = contentColor,
+        )
+    }
+}
+
+/**
+ * The card [BossAlertDialog] puts inside a dialog, split out so it can be measured.
+ *
+ * `BossAlertDialog` itself cannot be: on the path a test scene can host it routes to a platform
+ * dialog window, and such a window does not inherit the size of whatever composed it. The bugs
+ * below are both about a card that has LESS room than it wants, which is a state only reachable by
+ * constraining the parent — so the card is `internal` and `BossAlertCardLayoutTest` constrains it
+ * directly. The dialog around it stays untested here and pinned by `BossDialogRoutingTest`.
+ *
+ * **Width: [AlertWidth] is what an alert wants, not what it must have.** `.width(AlertWidth)` set
+ * the minimum as well as the maximum, so on the scrimmed path — where this Surface is measured
+ * against the app window rather than against a dialog window of its own — a window narrower than
+ * 400dp got a card it could not fit and clipped it at the edge. Reported against the Atlas plugin,
+ * whose panel slot is routinely narrower than that: a Row of actions inside a card that cannot
+ * shrink is measured first child to last, so the last one — the primary — was squeezed to zero
+ * width on a consent surface. Measured at 240dp, not inferred.
+ *
+ * `BoxWithConstraints` rather than `widthIn(max = AlertWidth)`: with only a maximum a Surface wraps
+ * its content, so every short alert in the app would suddenly be narrower than 400dp. Taking the
+ * smaller of what we want and what there is leaves the wide case byte-identical and changes only
+ * the case that was broken.
+ *
+ * **Height: the actions are what a short window used to lose, and it is the width bug again.** A
+ * Column measures its non-weighted children in order and offers each what the previous ones left,
+ * so in a window shorter than the content the body took what it wanted and the actions — measured
+ * last — were offered nothing. Measured in a 300dp frame, "Don't allow" came out **0dp tall** at
+ * y=276, exactly as the primary came out 0dp *wide* in a card too narrow for the action row. Not
+ * clipped, not pushed off the edge: squeezed to nothing by a sibling that was measured first, on a
+ * card whose whole job is to be agreed to or refused.
+ *
+ * The *body* is the part that should give way, so it takes the flexible space and scrolls while the
+ * title and the actions keep theirs.
+ *
+ * **`fill = false`, and the whole thing conditional on a bounded height, are both load-bearing,
+ * and both were measured rather than reasoned about.** `weight(1f)` alone fills its share, which
+ * would stretch every short dialog in the app to the window; `fill = false` lets the body stay its
+ * own height, so a card that fits is measured exactly as before.
+ *
+ * The `hasBoundedHeight` branch matters just as much. Given a 40-line body and no height bound —
+ * the shape of a dialog window that sizes to its content — this card measures 1116dp and renders
+ * the whole body inline. Applying the weight there anyway measures **156dp**, with the body
+ * scrolled down to roughly one line: a weighted child of an unbounded axis gets a share of almost
+ * nothing. And there is no bug to fix on that path in the first place, because a window that sizes
+ * to its content cannot clip it, so scrolling there is pure loss.
+ *
+ * Scrolling hides content with no affordance of its own, which is a real cost on a card that may be
+ * asking for consent. It is the lesser one — the alternative here is clipping, which hides the same
+ * content AND removes the actions — but a call site with a long body should still supply its own
+ * scrollbar inside [text], the way the update dialog's release notes do.
+ */
+@Composable
+internal fun BossAlertCard(
+    buttons: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    title: (@Composable () -> Unit)? = null,
+    text: (@Composable () -> Unit)? = null,
+    shape: Shape? = null,
+    backgroundColor: Color = Color.Unspecified,
+    contentColor: Color = Color.Unspecified,
+) {
     val colors = BossTheme.colors
     val space = BossTheme.space
-    BossDialog(onDismissRequest = onDismissRequest, properties = properties) {
-        // [AlertWidth] is what an alert WANTS, not what it must have.
-        //
-        // `.width(AlertWidth)` set the minimum as well as the maximum, so in the scrimmed
-        // in-window path — where this Surface is measured against the app window rather than
-        // against a dialog window of its own — a window narrower than 400dp got a card it could
-        // not fit, clipped at the edge. Reported against the Atlas plugin, whose panel slot is
-        // routinely narrower than that: a Row of actions inside a card that cannot shrink is
-        // measured first child to last, so the last one — the primary — was squeezed to zero
-        // width on a consent surface. Measured at 240dp, not inferred.
-        //
-        // BoxWithConstraints rather than `widthIn(max = AlertWidth)`: with only a maximum, a
-        // Surface wraps its content, so every short alert in the app would suddenly be narrower
-        // than 400dp. Taking the smaller of what we want and what there is leaves the wide case
-        // byte-identical and changes only the case that was broken.
-        BoxWithConstraints(contentAlignment = Alignment.Center) {
-            val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
-            Surface(
-                modifier =
-                    modifier
-                        .width(AlertWidth.coerceAtMost(available))
-                        .wrapContentHeight(),
-                shape = shape ?: BossTheme.radius.dialogShape,
-                color = backgroundColor.takeOrElse { colors.panel },
-                contentColor = contentColor.takeOrElse { colors.textPrimary },
-            ) {
-                Column(modifier = Modifier.padding(space.xl)) {
-                    if (title != null) {
-                        CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
-                            ProvideTextStyle(BossTheme.type.title, title)
-                        }
+    BoxWithConstraints(contentAlignment = Alignment.Center) {
+        val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
+        val bounded = constraints.hasBoundedHeight
+        Surface(
+            modifier =
+                modifier
+                    .width(AlertWidth.coerceAtMost(available))
+                    .then(
+                        if (bounded) {
+                            Modifier.heightIn(max = (maxHeight - space.lg * 2).coerceAtLeast(0.dp))
+                        } else {
+                            Modifier
+                        },
+                    ).wrapContentHeight(),
+            shape = shape ?: BossTheme.radius.dialogShape,
+            color = backgroundColor.takeOrElse { colors.panel },
+            contentColor = contentColor.takeOrElse { colors.textPrimary },
+        ) {
+            Column(modifier = Modifier.padding(space.xl)) {
+                if (title != null) {
+                    CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
+                        ProvideTextStyle(BossTheme.type.title, title)
                     }
-                    if (title != null && text != null) {
-                        Spacer(Modifier.height(space.md))
-                    }
-                    if (text != null) {
+                }
+                if (title != null && text != null) {
+                    Spacer(Modifier.height(space.md))
+                }
+                if (text != null) {
+                    Box(
+                        modifier =
+                            if (bounded) {
+                                Modifier
+                                    .weight(1f, fill = false)
+                                    .verticalScroll(rememberScrollState())
+                            } else {
+                                Modifier
+                            },
+                    ) {
                         CompositionLocalProvider(LocalContentColor provides colors.textSecondary) {
                             ProvideTextStyle(BossTheme.type.body, text)
                         }
                     }
-                    Spacer(Modifier.height(space.xl))
-                    buttons()
                 }
+                Spacer(Modifier.height(space.xl))
+                buttons()
             }
         }
     }

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossDialog.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.plugin.ui
 
+import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -17,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.ProvideTextStyle
@@ -282,9 +285,6 @@ internal fun ScrimmedModalContent(
 // Alert dialog
 // ---------------------------------------------------------------------------
 
-/** Width of a BOSS alert card, matching the house confirmation dialog. */
-internal val AlertWidth: Dp = 400.dp
-
 /**
  * A title/text/buttons dialog in the BOSS design system, layered above the browser surface.
  *
@@ -382,167 +382,6 @@ fun BossAlertDialog(
             backgroundColor = backgroundColor,
             contentColor = contentColor,
         )
-    }
-}
-
-/**
- * The card [BossAlertDialog] puts inside a dialog, split out so it can be measured.
- *
- * `BossAlertDialog` itself cannot be: on the path a test scene can host it routes to a platform
- * dialog window, and such a window does not inherit the size of whatever composed it. The bugs
- * below are both about a card that has LESS room than it wants, which is a state only reachable by
- * constraining the parent — so the card is `internal` and `BossAlertCardLayoutTest` constrains it
- * directly. The dialog around it stays untested here and pinned by `BossDialogRoutingTest`.
- *
- * **Width: [AlertWidth] is what an alert wants, not what it must have.** `.width(AlertWidth)` set
- * the minimum as well as the maximum, so on the scrimmed path — where this Surface is measured
- * against the app window rather than against a dialog window of its own — a window narrower than
- * 400dp got a card it could not fit and clipped it at the edge. Reported against the Atlas plugin,
- * whose panel slot is routinely narrower than that: a Row of actions inside a card that cannot
- * shrink is measured first child to last, so the last one — the primary — was squeezed to zero
- * width on a consent surface. Measured at 240dp, not inferred.
- *
- * `BoxWithConstraints` rather than `widthIn(max = AlertWidth)`: with only a maximum a Surface wraps
- * its content, so every short alert in the app would suddenly be narrower than 400dp. Taking the
- * smaller of what we want and what there is leaves the wide case byte-identical and changes only
- * the case that was broken.
- *
- * **Height: the actions are what a short window used to lose, and it is the width bug again.** A
- * Column measures its non-weighted children in order and offers each what the previous ones left,
- * so in a window shorter than the content the body took what it wanted and the actions — measured
- * last — were offered nothing. Measured in a 300dp frame, "Don't allow" came out **0dp tall** at
- * y=276, exactly as the primary came out 0dp *wide* in a card too narrow for the action row. Not
- * clipped, not pushed off the edge: squeezed to nothing by a sibling that was measured first, on a
- * card whose whole job is to be agreed to or refused.
- *
- * The *body* is the part that should give way, so it takes the flexible space and scrolls while the
- * title and the actions keep theirs.
- *
- * **`fill = false`, and the whole thing conditional on a bounded height, are both load-bearing,
- * and both were measured rather than reasoned about.** `weight(1f)` alone fills its share, which
- * would stretch every short dialog in the app to the window; `fill = false` lets the body stay its
- * own height, so a card that fits is measured exactly as before.
- *
- * **There is a floor, and it is about 176dp.** Only the body flexes; the padding, the title and the
- * two spacers are still measured before the actions. That chrome is `space.xl * 2` of padding plus a
- * title line plus `space.md` plus `space.xl` plus Material's 36dp button minimum — so once the
- * parent is under roughly 176dp there is nothing left to give the actions and they collapse again.
- * Measured: full 36dp at a 180dp parent, 33dp at 173dp, 20dp at 160dp, **0dp at 140dp**, and the
- * title itself goes at 80dp. Pinned by `theActionsSurviveTheShortestWindowThatCanHoldThem`, so the
- * floor cannot move quietly. Going lower would mean shrinking the padding or dropping the title,
- * which is a design decision rather than a layout fix, and a 140dp-tall dialog is arguably not one.
- *
- * The `hasBoundedHeight` branch matters just as much. Given a 40-line body and no height bound —
- * the shape of a dialog window that sizes to its content — this card measures 1116dp and renders
- * the whole body inline. Applying the weight there anyway measures **156dp**, with the body
- * scrolled down to roughly one line: a weighted child of an unbounded axis gets a share of almost
- * nothing. And there is no bug to fix on that path in the first place, because a window that sizes
- * to its content cannot clip it, so scrolling there is pure loss.
- *
- * **So this fixes the squeeze on the path where the card is measured against a parent, which is the
- * scrimmed one** — `ScrimmedModalContent` is a `fillMaxSize` Box, so the card is bounded by the
- * overlay window, and that is where the report came from. On the lightweight `Dialog` path the
- * change is inert by design, and the ceiling there is the *screen* rather than the card: a window
- * that sizes to its content cannot clip it, but a 1116dp card on a shorter display still puts its
- * actions where they cannot be reached. That is pre-existing and not addressed here.
- *
- * Scrolling hides content with no affordance of its own, which is a real cost on a card that may be
- * asking for consent. It is the lesser one — the alternative here is clipping, which hides the same
- * content AND removes the actions — but a call site with a long body should still bound and scroll
- * it explicitly: `Modifier.heightIn(max = …).verticalScroll(…)`, plus a scrollbar of its own.
- *
- * Deliberately spelled out rather than pointing at the update dialog's release notes, which do this
- * with `dialogScrollFence`: that lives in `composeApp` and is not on the plugin classpath, so a
- * plugin author following that advice could not write it. (Moving the fence into this module would
- * be reasonable — it is a `LayoutModifier` with no host dependency — but it is a separate change.)
- *
- * **An uncapped lazy list in [text] fails, and the failure mode is worse than an exception.**
- * Compose rejects an infinite main axis for a scrollable container, so the documented cap is not
- * advice, it is a requirement. Tried to pin the failure and could not: an uncapped `LazyColumn` in
- * the body **hung** a `createComposeRule` scene rather than throwing, twice, at 200 items and at
- * five. So the `@param` wording says "will not lay out" rather than naming an exception — the
- * requirement is verified, the exact failure is not. What is pinned is the other half:
- * `a capped lazy list in the body composes rather than throwing`.
- *
- * **A [text] slot that caps itself against its parent loses that reference point.** A cap written as
- * `min(myMax, constraints.maxHeight)` — which is what the host's own `dialogScrollFence` computes —
- * coerces against an infinite maximum here, so it always takes its full constant instead of
- * shrinking with a short window. The content stays reachable, because the outer scroll takes the
- * leftover, but it means two nested scroll regions rather than one. A slot that wants to shrink with
- * the card has to be told the height it may use rather than deriving it from its constraints.
- *
- * `verticalScroll` also applies `clipScrollableContainer`, so the body is now clipped in the scroll
- * direction. Nothing in the host relied on content overflowing a [text] slot inline, but it is a
- * second behaviour change riding along with the first.
- */
-@Composable
-internal fun BossAlertCard(
-    buttons: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    title: (@Composable () -> Unit)? = null,
-    text: (@Composable () -> Unit)? = null,
-    shape: Shape? = null,
-    backgroundColor: Color = Color.Unspecified,
-    contentColor: Color = Color.Unspecified,
-) {
-    val colors = BossTheme.colors
-    val space = BossTheme.space
-    BoxWithConstraints(contentAlignment = Alignment.Center) {
-        val available = (maxWidth - space.lg * 2).coerceAtLeast(0.dp)
-        val bounded = constraints.hasBoundedHeight
-        // Hoisted rather than called inside the modifier branch below, so the scroll position
-        // survives a flip of `bounded` rather than being remembered under a different call site.
-        val bodyScroll = rememberScrollState()
-        Surface(
-            modifier =
-                modifier
-                    .width(AlertWidth.coerceAtMost(available))
-                    .then(
-                        if (bounded) {
-                            // The MARGIN, not the fix. Incoming constraints already stop the card
-                            // exceeding its parent, so the weight below does the whole job of
-                            // keeping the actions measurable; this only holds the card `space.lg`
-                            // clear of the parent's top and bottom edges, matching the width. Its
-                            // own test is theCardKeepsAMarginFromAParentShorterThanItself, because
-                            // removing this line breaks no other assertion in the suite.
-                            Modifier.heightIn(max = (maxHeight - space.lg * 2).coerceAtLeast(0.dp))
-                        } else {
-                            Modifier
-                        },
-                    ).wrapContentHeight(),
-            shape = shape ?: BossTheme.radius.dialogShape,
-            color = backgroundColor.takeOrElse { colors.panel },
-            contentColor = contentColor.takeOrElse { colors.textPrimary },
-        ) {
-            Column(modifier = Modifier.padding(space.xl)) {
-                if (title != null) {
-                    CompositionLocalProvider(LocalContentColor provides colors.textPrimary) {
-                        ProvideTextStyle(BossTheme.type.title, title)
-                    }
-                }
-                if (title != null && text != null) {
-                    Spacer(Modifier.height(space.md))
-                }
-                if (text != null) {
-                    Box(
-                        modifier =
-                            if (bounded) {
-                                Modifier
-                                    .weight(1f, fill = false)
-                                    .verticalScroll(bodyScroll)
-                            } else {
-                                Modifier
-                            },
-                    ) {
-                        CompositionLocalProvider(LocalContentColor provides colors.textSecondary) {
-                            ProvideTextStyle(BossTheme.type.body, text)
-                        }
-                    }
-                }
-                Spacer(Modifier.height(space.xl))
-                buttons()
-            }
-        }
     }
 }
 

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
@@ -2,8 +2,11 @@ package ai.rever.boss.plugin.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
@@ -11,6 +14,7 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -21,6 +25,7 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
+import kotlin.math.absoluteValue
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -166,11 +171,16 @@ class BossAlertCardLayoutTest {
         setCard(width = 400.dp, height = 260.dp, body = { TallBody() })
 
         val card = cardBounds()
+        val frame = rule.onNodeWithTag(FRAME).getUnclippedBoundsInRoot()
         listOf("Allow this?", actionLabel).forEach { label ->
             val b = boundsOf(label)
             assertTrue(b.bottom - b.top > 0.dp, "\"$label\" was squeezed to ${b.bottom - b.top}")
             assertTrue(b.top >= card.top, "\"$label\" starts ${card.top - b.top} above the card")
             assertTrue(b.bottom <= card.bottom, "\"$label\" ends ${b.bottom - card.bottom} below the card")
+            // The frame as well as the card: containment in the card is the stronger claim, but a
+            // change that moved the whole card off its parent would satisfy it.
+            assertTrue(b.top >= frame.top, "\"$label\" starts ${frame.top - b.top} above the frame")
+            assertTrue(b.bottom <= frame.bottom, "\"$label\" ends ${b.bottom - frame.bottom} below the frame")
         }
     }
 
@@ -193,10 +203,12 @@ class BossAlertCardLayoutTest {
         setCard(width = 900.dp, height = 600.dp) { Text("x") }
 
         val cardWidth = cardBounds().let { it.right - it.left }
-        assertEquals(
-            AlertWidth,
-            cardWidth,
-            "a card in a 900.dp frame measured $cardWidth rather than AlertWidth",
+        // Tolerance rather than exact Dp equality: the width round-trips through pixels, so it is
+        // exact only at density 1, and a fractional density would make this red for a reason that
+        // has nothing to do with the property.
+        assertTrue(
+            (cardWidth - AlertWidth).value.absoluteValue <= 1f,
+            "a card in a 900.dp frame measured $cardWidth rather than AlertWidth ($AlertWidth)",
         )
     }
 
@@ -206,14 +218,66 @@ class BossAlertCardLayoutTest {
         // measured before the actions: below roughly 176dp there is nothing left to give them.
         // Measured - 36dp at 180dp, 33dp at 173dp, 20dp at 160dp, 0dp at 140dp - so this asserts
         // the last height that fully works rather than pretending the floor is not there.
+        // The expected height is measured in a roomy frame rather than hardcoded to Material's 36dp
+        // TextButton minimum: a spacing-token or type-scale change would otherwise turn this red
+        // with the same message and a different cause.
+        setCard(width = 400.dp, height = 600.dp) { Text("one short line") }
+        val unconstrained = heightOf(actionLabel)
+
         setCard(width = 400.dp, height = 180.dp) { TallBody() }
+        val atTheFloor = heightOf(actionLabel)
 
         assertEquals(
-            36.dp,
-            heightOf(actionLabel),
-            "the actions measured ${heightOf(actionLabel)} at a 180.dp parent - the floor moved, " +
-                "and the fixed chrome above the body is what pushed it",
+            unconstrained,
+            atTheFloor,
+            "the actions measured $atTheFloor at a 180.dp parent against $unconstrained with room " +
+                "to spare - the floor moved, and the fixed chrome above the body is what pushed it",
         )
+    }
+
+    @Test
+    fun `the card keeps a margin from a parent shorter than itself`() {
+        // The height cap's own test. Removing that .then(heightIn(...)) block breaks no other
+        // assertion here - incoming constraints already stop the card exceeding its parent, so the
+        // weight does the whole job of keeping the actions measurable. What the cap adds is this
+        // margin, and without a test it reads like part of the fix.
+        setCard(width = 400.dp, height = 300.dp) { TallBody() }
+
+        val frame = rule.onNodeWithTag(FRAME).getUnclippedBoundsInRoot()
+        val card = cardBounds()
+        assertTrue(
+            card.top >= frame.top && card.bottom <= frame.bottom - MARGIN + 1.dp,
+            "the card spans ${card.top}..${card.bottom} in a frame of ${frame.top}..${frame.bottom} " +
+                "- it is not holding $MARGIN clear of the parent's edges",
+        )
+    }
+
+    @Test
+    fun `a capped lazy list in the body composes rather than throwing`() {
+        // The contract the public overloads now document, pinned. The body is measured with an
+        // unbounded height on this branch, so an UNCAPPED lazy list throws here - that is what
+        // callers are being told to avoid, and this asserts that doing as told is sufficient. If it
+        // ever stops being sufficient, nothing else in the suite would say so.
+        rule.setContent {
+            BossTheme {
+                Box(Modifier.size(400.dp, 300.dp).testTag(FRAME)) {
+                    Box(Modifier.testTag(CARD)) {
+                        BossAlertCard(
+                            buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                            title = { Text("Allow this?") },
+                            text = {
+                                LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
+                                    items(200) { Text("row $it") }
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        assertTrue(heightOf(actionLabel) > 0.dp, "the actions did not survive a capped lazy body")
+        rule.onNodeWithText("row 0").assertIsDisplayed()
     }
 
     @Test
@@ -238,6 +302,8 @@ class BossAlertCardLayoutTest {
     private companion object {
         const val FRAME = "alert-frame"
         const val CARD = "alert-card"
+        val MARGIN = 16.dp
+
         const val BODY_LINES = 40
 
         fun bodyLine(i: Int) = "line $i of a long body"

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
@@ -1,0 +1,221 @@
+package ai.rever.boss.plugin.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What [BossAlertCard] does when it has less room than it wants.
+ *
+ * Measured against the card rather than the scene throughout, and against a constrained parent
+ * rather than through [BossAlertDialog] — the dialog routes to a platform window that does not
+ * inherit its composer's size, so "less room than it wants" is not a state reachable through it.
+ * That is why the card is `internal`.
+ */
+class BossAlertCardLayoutTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val actionLabel = "Don't allow"
+
+    /**
+     * A body that wants more height than the frame has.
+     *
+     * Lines of text rather than `Modifier.height(2_000.dp)`: a size modifier is coerced into the
+     * incoming constraints, so a "2000dp" box in a 300dp frame is simply 300dp and nothing
+     * overflows — the first version of this test measured that and proved nothing. Text reports the
+     * height its lines actually need.
+     */
+    @Composable
+    private fun TallBody() = Column { repeat(BODY_LINES) { Text(bodyLine(it)) } }
+
+    private fun setCard(
+        width: Dp,
+        height: Dp,
+        body: @Composable () -> Unit,
+    ) {
+        rule.setContent {
+            BossTheme {
+                // A short viewport is the whole point, so the frame is sized rather than filled.
+                Box(Modifier.size(width, height).testTag(FRAME)) {
+                    BossAlertCard(
+                        buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                        title = { Text("Allow this?") },
+                        text = body,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun heightOf(label: String): Dp =
+        rule.onNodeWithText(label).getUnclippedBoundsInRoot().let { it.bottom - it.top }
+
+    @Test
+    fun `the actions keep their height when the body is taller than the window`() {
+        // The defect, measured: a Column offers each non-weighted child what the previous ones
+        // left, so the body took what it wanted and the actions — measured last — were offered
+        // nothing. In this frame "Don't allow" came out 0dp tall at y=276.
+        //
+        // Height, not bounds. The actions are never pushed outside the card: they are squeezed to
+        // nothing inside it, and a zero-height node still reports a position within the frame, so
+        // a containment assertion passes against the defect. The first version of this test made
+        // exactly that mistake — the same mistake, on the other axis, that a `deny.left >= 0`
+        // assertion made in the plugin that reported this.
+        setCard(width = 400.dp, height = 300.dp, body = { TallBody() })
+
+        assertTrue(
+            heightOf(actionLabel) > 0.dp,
+            "\"$actionLabel\" measured ${heightOf(actionLabel)} tall — the body was measured " +
+                "first and left the actions nothing, so the card asks for consent with nothing " +
+                "to click",
+        )
+    }
+
+    @Test
+    fun `a card that fits is measured exactly as it was before the body could flex`() {
+        // weight(1f) without fill = false would stretch this to the full 600dp. The guard is that
+        // a short dialog is still its content's height, which is what every existing call site
+        // looks like.
+        var tall = Dp.Unspecified
+        rule.setContent {
+            BossTheme {
+                Box(Modifier.size(400.dp, 600.dp)) {
+                    Box(Modifier.testTag(CARD)) {
+                        BossAlertCard(
+                            buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                            title = { Text("Allow this?") },
+                            text = { Text("one short line") },
+                        )
+                    }
+                }
+            }
+        }
+        val card = rule.onNodeWithTag(CARD).getUnclippedBoundsInRoot()
+        tall = card.bottom - card.top
+        assertTrue(
+            tall < 300.dp,
+            "a one-line alert measured $tall tall in a 600dp frame — the body is filling its " +
+                "weighted share instead of wrapping, so every short dialog in the app just grew",
+        )
+    }
+
+    @Test
+    fun `an unbounded height shows the whole body rather than scrolling it`() {
+        // Guards this fix's own hazard rather than the original defect, and the measurements are
+        // why the `hasBoundedHeight` branch exists. With an unbounded height the card is 1116dp
+        // and the body renders inline; with the weight applied unconditionally it is 156dp and the
+        // body is scrolled down to about one line. A window that sizes to its content cannot clip
+        // it, so there is nothing to trade away there — scrolling is pure loss.
+        //
+        // Two traps this test had to get past, both of which made it pass against the defect:
+        //
+        //  - A sized Box is not unbounded. Inside `setContent` even an unsized Box inherits the
+        //    test window's bounded height, so `hasBoundedHeight` stays true. A verticalScroll
+        //    parent is what hands its child an infinite main axis, the way a window that sizes to
+        //    content does.
+        //  - A one-line body fits in the collapsed space, so `height > 0` holds either way. The
+        //    body has to be taller than the collapse.
+        //
+        // Scale-free assertion: if nothing is scrolled away, the actions sit BELOW the last line
+        // of the body. Collapsed, they sit above most of it — 90dp against the last line's 996dp.
+        rule.setContent {
+            BossTheme {
+                Column(Modifier.width(400.dp).verticalScroll(rememberScrollState())) {
+                    BossAlertCard(
+                        buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                        title = { Text("Allow this?") },
+                        text = { TallBody() },
+                    )
+                }
+            }
+        }
+
+        val lastLine = rule.onNodeWithText(LAST_LINE).getUnclippedBoundsInRoot()
+        val action = rule.onNodeWithText(actionLabel).getUnclippedBoundsInRoot()
+        assertTrue(
+            action.top > lastLine.top,
+            "the actions sit at ${action.top} and the body's last line at ${lastLine.top} — the " +
+                "body was given a weighted share of an unbounded axis and scrolled away under a " +
+                "parent that would have shown all of it",
+        )
+    }
+
+    @Test
+    fun `the title and the actions both keep their height and stay on the card`() {
+        // The body giving way is only correct if the two things framing it do not. A fix that
+        // scrolled the whole Column would keep both nodes full-height and move them off the card
+        // instead, so this checks height AND containment — the two failure modes are different
+        // and neither assertion sees the other.
+        setCard(width = 400.dp, height = 260.dp, body = { TallBody() })
+
+        val frame = rule.onNodeWithTag(FRAME).getUnclippedBoundsInRoot()
+        listOf("Allow this?", actionLabel).forEach { label ->
+            val b = rule.onNodeWithText(label).getUnclippedBoundsInRoot()
+            assertTrue(b.bottom - b.top > 0.dp, "\"$label\" was squeezed to ${b.bottom - b.top}")
+            assertTrue(b.top >= frame.top, "\"$label\" starts ${frame.top - b.top} above the card")
+            assertTrue(b.bottom <= frame.bottom, "\"$label\" ends ${b.bottom - frame.bottom} below the card")
+        }
+    }
+
+    @Test
+    fun `a narrow card shrinks and a roomy one does not`() {
+        // #214's property, still unpinned by a test in this repo: exactly AlertWidth where there is
+        // room for it, and the window's width where there is not.
+        listOf(240.dp to true, 900.dp to false).forEach { (frameWidth, shouldShrink) ->
+            rule.setContent {
+                BossTheme {
+                    Box(Modifier.size(frameWidth, 600.dp)) {
+                        Box(Modifier.testTag(CARD)) {
+                            BossAlertCard(
+                                buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                                text = { Text("x") },
+                            )
+                        }
+                    }
+                }
+            }
+            val card = rule.onNodeWithTag(CARD).getUnclippedBoundsInRoot()
+            val cardWidth = card.right - card.left
+            if (shouldShrink) {
+                assertTrue(
+                    cardWidth < frameWidth && cardWidth > 0.dp,
+                    "a card in a $frameWidth frame measured $cardWidth — it did not shrink to fit",
+                )
+            } else {
+                assertEquals(
+                    400.dp, cardWidth,
+                    "a card in a $frameWidth frame measured $cardWidth rather than AlertWidth",
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val FRAME = "alert-frame"
+        const val CARD = "alert-card"
+        const val BODY_LINES = 40
+
+        fun bodyLine(i: Int) = "line $i of a long body"
+
+        val LAST_LINE = bodyLine(BODY_LINES - 1)
+    }
+}

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
@@ -56,18 +57,25 @@ class BossAlertCardLayoutTest {
         rule.setContent {
             BossTheme {
                 // A short viewport is the whole point, so the frame is sized rather than filled.
+                // CARD is tagged separately and is what assertions compare against: the card is
+                // inset from the frame and centred in it, so an action row hanging below the card's
+                // own edge can still sit inside the frame.
                 Box(Modifier.size(width, height).testTag(FRAME)) {
-                    BossAlertCard(
-                        buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
-                        title = { Text("Allow this?") },
-                        text = body,
-                    )
+                    Box(Modifier.testTag(CARD)) {
+                        BossAlertCard(
+                            buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                            title = { Text("Allow this?") },
+                            text = body,
+                        )
+                    }
                 }
             }
         }
     }
 
     private fun boundsOf(label: String): DpRect = rule.onNodeWithText(label).getUnclippedBoundsInRoot()
+
+    private fun cardBounds(): DpRect = rule.onNodeWithTag(CARD).getUnclippedBoundsInRoot()
 
     private fun heightOf(label: String): Dp = boundsOf(label).run { bottom - top }
 
@@ -86,7 +94,7 @@ class BossAlertCardLayoutTest {
 
         assertTrue(
             heightOf(actionLabel) > 0.dp,
-            "\"$actionLabel\" measured ${heightOf(actionLabel)} tall — the body was measured " +
+            "\"$actionLabel\" measured ${heightOf(actionLabel)} tall - the body was measured " +
                 "first and left the actions nothing, so the card asks for consent with nothing " +
                 "to click",
         )
@@ -97,25 +105,13 @@ class BossAlertCardLayoutTest {
         // weight(1f) without fill = false would stretch this to the full 600dp. The guard is that
         // a short dialog is still its content's height, which is what every existing call site
         // looks like.
-        var tall = Dp.Unspecified
-        rule.setContent {
-            BossTheme {
-                Box(Modifier.size(400.dp, 600.dp)) {
-                    Box(Modifier.testTag(CARD)) {
-                        BossAlertCard(
-                            buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
-                            title = { Text("Allow this?") },
-                            text = { Text("one short line") },
-                        )
-                    }
-                }
-            }
-        }
-        val card = rule.onNodeWithTag(CARD).getUnclippedBoundsInRoot()
-        tall = card.bottom - card.top
+        setCard(width = 400.dp, height = 600.dp) { Text("one short line") }
+
+        val card = cardBounds()
+        val tall = card.bottom - card.top
         assertTrue(
             tall < 300.dp,
-            "a one-line alert measured $tall tall in a 600dp frame — the body is filling its " +
+            "a one-line alert measured $tall tall in a 600dp frame - the body is filling its " +
                 "weighted share instead of wrapping, so every short dialog in the app just grew",
         )
     }
@@ -155,7 +151,7 @@ class BossAlertCardLayoutTest {
         val action = boundsOf(actionLabel)
         assertTrue(
             action.top > lastLine.top,
-            "the actions sit at ${action.top} and the body's last line at ${lastLine.top} — the " +
+            "the actions sit at ${action.top} and the body's last line at ${lastLine.top} - the " +
                 "body was given a weighted share of an unbounded axis and scrolled away under a " +
                 "parent that would have shown all of it",
         )
@@ -169,47 +165,74 @@ class BossAlertCardLayoutTest {
         // and neither assertion sees the other.
         setCard(width = 400.dp, height = 260.dp, body = { TallBody() })
 
-        val frame = rule.onNodeWithTag(FRAME).getUnclippedBoundsInRoot()
+        val card = cardBounds()
         listOf("Allow this?", actionLabel).forEach { label ->
             val b = boundsOf(label)
             assertTrue(b.bottom - b.top > 0.dp, "\"$label\" was squeezed to ${b.bottom - b.top}")
-            assertTrue(b.top >= frame.top, "\"$label\" starts ${frame.top - b.top} above the card")
-            assertTrue(b.bottom <= frame.bottom, "\"$label\" ends ${b.bottom - frame.bottom} below the card")
+            assertTrue(b.top >= card.top, "\"$label\" starts ${card.top - b.top} above the card")
+            assertTrue(b.bottom <= card.bottom, "\"$label\" ends ${b.bottom - card.bottom} below the card")
         }
     }
 
     @Test
-    fun `a narrow card shrinks and a roomy one does not`() {
-        // #214's property, still unpinned by a test in this repo: exactly AlertWidth where there is
-        // room for it, and the window's width where there is not.
-        listOf(240.dp to true, 900.dp to false).forEach { (frameWidth, shouldShrink) ->
-            rule.setContent {
-                BossTheme {
-                    Box(Modifier.size(frameWidth, 600.dp)) {
-                        Box(Modifier.testTag(CARD)) {
-                            BossAlertCard(
-                                buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
-                                text = { Text("x") },
-                            )
-                        }
-                    }
-                }
-            }
-            val card = rule.onNodeWithTag(CARD).getUnclippedBoundsInRoot()
-            val cardWidth = card.right - card.left
-            if (shouldShrink) {
-                assertTrue(
-                    cardWidth < frameWidth && cardWidth > 0.dp,
-                    "a card in a $frameWidth frame measured $cardWidth — it did not shrink to fit",
-                )
-            } else {
-                assertEquals(
-                    400.dp,
-                    cardWidth,
-                    "a card in a $frameWidth frame measured $cardWidth rather than AlertWidth",
-                )
-            }
-        }
+    fun `a card narrower than it wants shrinks to fit`() {
+        // #214's property, previously unpinned by any test in this repo. Split from the roomy case
+        // rather than looped: two setContent calls in one test lean on desktop re-entrancy, and a
+        // failure would not say which iteration produced it.
+        setCard(width = 240.dp, height = 600.dp) { Text("x") }
+
+        val cardWidth = cardBounds().let { it.right - it.left }
+        assertTrue(
+            cardWidth < 240.dp && cardWidth > 0.dp,
+            "a card in a 240.dp frame measured $cardWidth - it did not shrink to fit",
+        )
+    }
+
+    @Test
+    fun `a card with room to spare is exactly AlertWidth`() {
+        setCard(width = 900.dp, height = 600.dp) { Text("x") }
+
+        val cardWidth = cardBounds().let { it.right - it.left }
+        assertEquals(
+            AlertWidth,
+            cardWidth,
+            "a card in a 900.dp frame measured $cardWidth rather than AlertWidth",
+        )
+    }
+
+    @Test
+    fun `the actions survive the shortest window that can hold them`() {
+        // The floor, pinned. Only the body flexes, so the padding, title and spacers are still
+        // measured before the actions: below roughly 176dp there is nothing left to give them.
+        // Measured - 36dp at 180dp, 33dp at 173dp, 20dp at 160dp, 0dp at 140dp - so this asserts
+        // the last height that fully works rather than pretending the floor is not there.
+        setCard(width = 400.dp, height = 180.dp) { TallBody() }
+
+        assertEquals(
+            36.dp,
+            heightOf(actionLabel),
+            "the actions measured ${heightOf(actionLabel)} at a 180.dp parent - the floor moved, " +
+                "and the fixed chrome above the body is what pushed it",
+        )
+    }
+
+    @Test
+    fun `the body scrolls rather than overflowing its box`() {
+        // The scrolling half of the trade, which nothing else here pins: dropping verticalScroll
+        // while keeping weight(1f, fill = false) leaves all the other assertions green, because the
+        // body's own Column would place its remaining lines outside the Box and overdraw the action
+        // row - actions still non-zero, still inside the card. That is arguably worse than the bug
+        // being fixed, and it is the exact behaviour the "scroll rather than clip" argument rests on.
+        setCard(width = 400.dp, height = 300.dp) { TallBody() }
+
+        val before = boundsOf(LAST_LINE).top
+        rule.onNodeWithText(LAST_LINE).performScrollTo()
+        val after = boundsOf(LAST_LINE).top
+        assertTrue(
+            after < before,
+            "scrolling to the body's last line moved it from $before to $after - the body is not " +
+                "scrollable, so its overflow is drawn over the actions instead of inside a viewport",
+        )
     }
 
     private companion object {

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
@@ -66,8 +67,9 @@ class BossAlertCardLayoutTest {
         }
     }
 
-    private fun heightOf(label: String): Dp =
-        rule.onNodeWithText(label).getUnclippedBoundsInRoot().let { it.bottom - it.top }
+    private fun boundsOf(label: String): DpRect = rule.onNodeWithText(label).getUnclippedBoundsInRoot()
+
+    private fun heightOf(label: String): Dp = boundsOf(label).run { bottom - top }
 
     @Test
     fun `the actions keep their height when the body is taller than the window`() {
@@ -149,8 +151,8 @@ class BossAlertCardLayoutTest {
             }
         }
 
-        val lastLine = rule.onNodeWithText(LAST_LINE).getUnclippedBoundsInRoot()
-        val action = rule.onNodeWithText(actionLabel).getUnclippedBoundsInRoot()
+        val lastLine = boundsOf(LAST_LINE)
+        val action = boundsOf(actionLabel)
         assertTrue(
             action.top > lastLine.top,
             "the actions sit at ${action.top} and the body's last line at ${lastLine.top} — the " +
@@ -169,7 +171,7 @@ class BossAlertCardLayoutTest {
 
         val frame = rule.onNodeWithTag(FRAME).getUnclippedBoundsInRoot()
         listOf("Allow this?", actionLabel).forEach { label ->
-            val b = rule.onNodeWithText(label).getUnclippedBoundsInRoot()
+            val b = boundsOf(label)
             assertTrue(b.bottom - b.top > 0.dp, "\"$label\" was squeezed to ${b.bottom - b.top}")
             assertTrue(b.top >= frame.top, "\"$label\" starts ${frame.top - b.top} above the card")
             assertTrue(b.bottom <= frame.bottom, "\"$label\" ends ${b.bottom - frame.bottom} below the card")
@@ -202,7 +204,8 @@ class BossAlertCardLayoutTest {
                 )
             } else {
                 assertEquals(
-                    400.dp, cardWidth,
+                    400.dp,
+                    cardWidth,
                     "a card in a $frameWidth frame measured $cardWidth rather than AlertWidth",
                 )
             }

--- a/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
+++ b/plugin-platform/plugin-ui-core/src/desktopTest/kotlin/ai/rever/boss/plugin/ui/BossAlertCardLayoutTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -187,8 +188,8 @@ class BossAlertCardLayoutTest {
     @Test
     fun `a card narrower than it wants shrinks to fit`() {
         // #214's property, previously unpinned by any test in this repo. Split from the roomy case
-        // rather than looped: two setContent calls in one test lean on desktop re-entrancy, and a
-        // failure would not say which iteration produced it.
+        // rather than looped, because they are two independent properties: a failure in a loop
+        // would not say which width produced it.
         setCard(width = 240.dp, height = 600.dp) { Text("x") }
 
         val cardWidth = cardBounds().let { it.right - it.left }
@@ -221,6 +222,11 @@ class BossAlertCardLayoutTest {
         // The expected height is measured in a roomy frame rather than hardcoded to Material's 36dp
         // TextButton minimum: a spacing-token or type-scale change would otherwise turn this red
         // with the same message and a different cause.
+        //
+        // Two setCard calls here, where the width tests were deliberately split into one each. The
+        // difference is that these two measurements are the SAME property at two heights and the
+        // assertion compares them, so splitting would mean sharing state between tests; the width
+        // cases were two independent properties that only shared a loop.
         setCard(width = 400.dp, height = 600.dp) { Text("one short line") }
         val unconstrained = heightOf(actionLabel)
 
@@ -237,18 +243,76 @@ class BossAlertCardLayoutTest {
 
     @Test
     fun `the card keeps a margin from a parent shorter than itself`() {
+        // space.lg captured from the theme rather than hardcoded, for the same reason the floor test
+        // measures the button instead of writing 36dp: a spacing-token change should not turn this
+        // red with a message blaming the height cap.
+        var margin = Dp.Unspecified
         // The height cap's own test. Removing that .then(heightIn(...)) block breaks no other
         // assertion here - incoming constraints already stop the card exceeding its parent, so the
         // weight does the whole job of keeping the actions measurable. What the cap adds is this
         // margin, and without a test it reads like part of the fix.
-        setCard(width = 400.dp, height = 300.dp) { TallBody() }
+        rule.setContent {
+            BossTheme {
+                margin = BossTheme.space.lg
+                Box(Modifier.size(400.dp, 300.dp).testTag(FRAME)) {
+                    Box(Modifier.testTag(CARD)) {
+                        BossAlertCard(
+                            buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                            title = { Text("Allow this?") },
+                            text = { TallBody() },
+                        )
+                    }
+                }
+            }
+        }
 
         val frame = rule.onNodeWithTag(FRAME).getUnclippedBoundsInRoot()
         val card = cardBounds()
+        val cardHeight = card.bottom - card.top
+        val frameHeight = frame.bottom - frame.top
+        // Height, not position. The cap's job is to leave `space.lg` at each end; WHERE the card
+        // then sits is the parent's business - the scrim centres it, this fixture's Box does not -
+        // so asserting card.top >= frame.top + margin measures the fixture, not the cap. An earlier
+        // version of this test did exactly that and failed against working code.
         assertTrue(
-            card.top >= frame.top && card.bottom <= frame.bottom - MARGIN + 1.dp,
-            "the card spans ${card.top}..${card.bottom} in a frame of ${frame.top}..${frame.bottom} " +
-                "- it is not holding $MARGIN clear of the parent's edges",
+            cardHeight <= frameHeight - margin * 2 + 1.dp && cardHeight > 0.dp,
+            "the card measured $cardHeight in a $frameHeight frame - that is not $margin clear of " +
+                "both of the parent's edges",
+        )
+    }
+
+    @Test
+    fun `a caller modifier that bounds the height gets the flexible body`() {
+        // Why the branch is read from the constraints the Column receives rather than the card's
+        // own: the caller's `modifier` sits between the two, so the two reads can disagree.
+        //
+        // Which way they can disagree is worth stating, because the first version of this test had
+        // it backwards. A caller modifier cannot REMOVE the bound in a way that matters - the card's
+        // own heightIn is applied after the caller's modifier, so it re-bounds anything the caller
+        // unbound. What a caller CAN do is bound a card whose parent did not: `Modifier.height(...)`
+        // under a scrolling parent. Read from the outside that is "unbounded, do not flex", and the
+        // actions are squeezed to nothing - the original bug, inside the guard. Read from the inside
+        // it flexes and they survive.
+        rule.setContent {
+            BossTheme {
+                Column(Modifier.width(400.dp).verticalScroll(rememberScrollState())) {
+                    Box(Modifier.testTag(CARD)) {
+                        BossAlertCard(
+                            modifier = Modifier.height(200.dp),
+                            buttons = { TextButton(onClick = {}) { Text(actionLabel) } },
+                            title = { Text("Allow this?") },
+                            text = { TallBody() },
+                        )
+                    }
+                }
+            }
+        }
+
+        assertTrue(
+            heightOf(actionLabel) > 0.dp,
+            "the actions measured ${heightOf(actionLabel)} in a card the CALLER bounded to 200.dp " +
+                "under an unbounded parent - the flex branch was decided by the card's incoming " +
+                "constraints instead of the ones its Column receives",
         )
     }
 
@@ -302,8 +366,6 @@ class BossAlertCardLayoutTest {
     private companion object {
         const val FRAME = "alert-frame"
         const val CARD = "alert-card"
-        val MARGIN = 16.dp
-
         const val BODY_LINES = 40
 
         fun bodyLine(i: Int) = "line $i of a long body"


### PR DESCRIPTION
The other half of #214, on the other axis. Fixes `risa-labs-inc/boss-plugin-atlas#100`.

## The defect is the width bug again

A `Column` measures its non-weighted children in order and offers each what the previous ones left. So in a window shorter than the content, the body took what it wanted and the actions - measured last - were offered nothing. Measured in a 300dp frame:

```
                  pre-fix                with this change
title       y=24   h=24dp          title       y=24    h=24dp
body        y=60   (fills)         body        y=60    (scrolls)
Don't allow y=276  h=0dp   ←       Don't allow y=202    h=36dp
card               h=300dp         card                h=268dp
```

Not clipped, not pushed off the edge: **squeezed to nothing inside the card** by a sibling measured before it, on a surface whose whole job is to be agreed to or refused. It is precisely what #214 fixed on the width axis, where the primary action came out 0dp *wide* in a card too narrow for its row - and it became reachable because #214 lets cards get narrow enough to wrap that row onto three lines, which is what the reporting issue is about.

## The change

The body is the part that should give way: it takes the flexible space and scrolls, while the title and the actions keep theirs. A height maximum is applied where the parent bounds us, with the same `space.lg` margin the width uses.

Both qualifiers are load-bearing, and both are measured rather than argued:

- **`fill = false`.** A bare `weight(1f)` fills its share, which stretched a one-line alert to the full window. Without this, every short dialog in BOSS grows.
- **The `hasBoundedHeight` branch.** Given a 40-line body and no height bound - the shape of a dialog window that sizes to its content - the card measures **1116dp** and renders the body inline. Applying the weight there anyway measures **156dp**, with the body scrolled to roughly one line. There is also no bug to fix on that path: a window that sizes to its content cannot clip it, so scrolling there is pure loss.

**`BossAlertCard` is extracted as `internal`** because none of this is reachable through `BossAlertDialog` in a test - it routes to a platform dialog window, and such a window does not inherit the size of whatever composed it. "Has less room than it wants" is only a state a constrained parent can produce. The plugin that reported this had to extract its action row for the same reason.

## Scope and blast radius

### The audit, re-run for the pattern that actually breaks

Review pointed out that my first audit searched `weight` / `fillMaxHeight` / `fillMaxSize` - the *harmless* patterns here - and not the one this change can break: an uncapped lazy list or nested scroll in a `text` slot, which the new outer `verticalScroll` measures with an infinite main axis. Re-run for `LazyColumn` / `LazyRow` / `LazyVerticalGrid` / `LazyHorizontalGrid` / `verticalScroll`, over this repo and over every plugin in `boss_plugins`:

```
BossConsole    29 text slots,  4 occurrences, all capped
boss_plugins   12 text slots, 14 occurrences, all capped
```

**Zero uncapped anywhere**, including Atlas - the plugin that reported this, and the one I would otherwise have broken. In this repo the capped ones are `GenericDialogHost.kt:195` / `:266` (`LazyColumn` under `heightIn(max = 300.dp)`) and the two `dialogScrollFence` dialogs.

The first run of that script reported three uncapped hits in Atlas and all three were false: one matched the word "verticalScroll" inside a *comment*, and two sat inside `heightIn(max = 160.dp)` / `heightIn(max = 200.dp)` boxes further up than the match window reached. It now strips comments before matching. Worth knowing if anyone re-runs it.

**The failure mode is documented as "will not lay out" rather than as an exception, because I could not pin it.** An uncapped `LazyColumn` in the body **hung** a `createComposeRule` scene rather than throwing - twice, at 200 items and at five. The requirement is verified; the exact failure is not. The other half *is* pinned: `a capped lazy list in the body composes rather than throwing`, which is the thing callers are being asked to do.

### The unbounded body is a published contract

**The `text` slot is now measured with an unbounded height, and that is a published contract.** `verticalScroll` hands its child `maxHeight = Infinity`, so this applies on the *bounded* path too - the path most alerts take. Anything that refuses an unbounded main axis (a `LazyColumn`, a nested scroll area) throws instead of laying out. Both public overloads now document this on their `text` param, rather than only `BossAlertCard`'s KDoc, because KDoc on an `internal` function is invisible to a plugin author reading the api jar.

That documentation is the real mitigation, because **an audit of this repo cannot settle the question**: `plugin-ui-core` is published to Maven Central and consumed out of repo - Atlas, the plugin that reported this, is exactly such a consumer. For what it is worth in-repo, I scripted an audit of all **29** call sites with a `text` slot, brace-matching each call and searching inside its slot for `weight` / `fillMaxHeight` / `fillMaxSize`: **zero hits**, and the `weight` uses near dialogs in `PresetSelector`, `SecuritySettings` and `BossTopBar` are all `Row`-scoped, so horizontal. Two caveats: the audit is lexical, so a slot that *calls* a composable which fills its height internally is invisible to it; and the margin is thin - both `LazyColumn`s in `GenericDialogHost` (`:195`, `:266`) sit directly in a `text` slot and survive only on their `heightIn(max = 300.dp)`.

**The height cap is the margin, not the fix.** Raised in review and correct: deleting `heightIn(max = maxHeight - space.lg * 2)` broke no assertion, because incoming constraints already bound the Column - the weight does the whole job of keeping the actions measurable. The cap only holds the card `space.lg` clear of the parent's edges, matching the width. Said so in the comment, and pinned by `theCardKeepsAMarginFromAParentShorterThanItself`.

**Which path this fixes.** The card only flexes when its height is bounded, which is the **scrimmed** path - `ScrimmedModalContent` is a `fillMaxSize` Box, and that is where the report came from. On the lightweight `Dialog` path the change is inert by design, and the ceiling there is the *screen* rather than the card: a 1116dp card on a shorter display still puts its actions out of reach. Pre-existing, and now stated in the KDoc rather than implied away by "a window that sizes to its content cannot clip it".

**One thing the two already-scrolling call sites do lose.** A cap written as `min(myMax, constraints.maxHeight)` - which is what `dialogScrollFence` computes - coerces against an infinite maximum here, so it always takes its full constant instead of shrinking with a short window. On a 300dp window `UpdateAvailableDialog`'s notes still measure their full 220dp inside a ~60dp viewport, giving two nested scroll regions rather than one. Content stays reachable because the outer scroll takes the leftover delta, so this is a UX regression on short windows rather than a break - and it is invisible to this module's tests because the fence lives in `composeApp`. Flagged rather than fixed; moving the fence into `plugin-ui-core` would address it and is the same follow-up the KDoc already suggests.

**There is a floor, at about 176dp,** and it is stated rather than fixed. Only the body flexes, so padding, title and spacers are still measured before the actions. Measured: 36dp of action at a 180dp parent, 33dp at 173dp, 20dp at 160dp, **0dp at 140dp**, and the title itself goes at 80dp. Pinned at 180dp by a test so it cannot move quietly. Flexing the title as well only moves which child pays; a card that cannot fit padding + title + spacers + a 36dp button is not a card with a layout problem.

The two call sites that already scroll their bodies (`UpdateAvailableDialog`'s release notes, `SelectWorkspaceDialog`'s list) keep working - they cap their own height with `dialogScrollFence`, so the outer scroll never sees unbounded content from them.

Scrolling hides content with no affordance of its own, which is a real cost on a card that may be asking for consent. It is the lesser cost - the alternative is clipping, which hides the same content *and* removes the actions - but the KDoc records it, and says a call site with a long body should supply its own scrollbar inside `text`, the way the update dialog does.

## Tests

`BossAlertCardLayoutTest`, five cases, each mutation-verified to fail on the change it names:

| mutation | fails |
|---|---|
| the pre-fix layout (no cap, no flexible body) | the actions test, and the title-and-actions test |
| `weight(1f)` without `fill = false` | the card-that-fits test |
| the weight applied unconditionally | the unbounded test |
| `verticalScroll` on the whole `Column` | the actions test, and the title-and-actions test |
| `verticalScroll` dropped, the weight kept | the body-scrolls test |
| the height cap deleted | the margin test |

It also pins #214's width property, which had no test in this repo: exactly `AlertWidth` where there is room, the window's width where there is not.

**Two of these tests could not fail when first written**, and both reasons are recorded in the file because they are easy to repeat:

- `Modifier.height(2_000.dp)` is coerced into the incoming constraints, so a "tall" body in a 300dp frame is simply 300dp and nothing overflows. Lines of text report the height they actually need.
- A zero-height node still reports a position inside the frame, so a containment assertion passes against a squeeze. **Height, not bounds** - the same correction a `deny.left >= 0.dp` assertion needed on the width axis.

A third gap came out of review, and it is the one worth naming: **dropping `.verticalScroll(...)` while keeping `weight(1f, fill = false)` failed none of the original five tests.** The body's inner `Column` clamps to the offered height, places its remaining lines outside the `Box`, and overdraws the action row - actions still non-zero, still inside the card, everything green. That is arguably worse than the bug being fixed, and it is exactly what the "scroll rather than clip" argument rests on. `theBodyScrollsRatherThanOverflowingItsBox` closes it with `performScrollTo()`.

The unbounded test needed a third fix: inside `setContent`, even an unsized `Box` inherits the test window's bounded height, so `hasBoundedHeight` stays true and the guard looks unnecessary. A `verticalScroll` parent is what actually hands its child an infinite main axis.

## Checks

- `:plugin-platform:plugin-ui-core:desktopTest` - **60 tests, 0 failures, 0 errors** across 9 classes, 10 of them in the new class. `ktlintCheck` and `detekt` clean.
- The trade worth naming, since it is the part that leaves the repo: `weight(1f, fill = false)` alone fixes the reported bug; `verticalScroll` is only what makes the truncated tail *reachable*. `weight(1f, fill = false).clipToBounds()` would keep the child's height bounded - no lazy-list hazard at all - at the cost of a tail nobody can get to. I kept the scroll, because an unreachable tail on a consent surface is the failure Atlas reported in the first place and the cap is one modifier that is now documented on the public API. But it is a compatibility surface rather than a code question, so if maintainers would rather not have the hazard possible at all, say so and I will switch it.
- `:composeApp:desktopTest` **is not runnable in this checkout**, so the existing `BossAlertDialogComposeTest` is unverified locally. `boss-process-manager` fails with 25 unresolved references to `ProcessManifest` / `PluginCapability`, which are **protobuf-generated** - a local codegen gap, not a broken `main`. (An earlier version of this note said the latter; it was wrong. `:boss-ipc:generateProto` reports `UP-TO-DATE` and all the Kotlin DSL wrappers exist, but the Java message classes do not, and `:boss-ipc:assemble` does not produce them either.) Unrelated to this change, and CI's `build` covers the case - which matters here, since that test hosts the dialog on the lightweight path and likely exercises the new bounded branch.
- No public API change: `BossAlertDialog`'s signature is untouched and the new card is `internal`. (`AlertWidth` went from `private` to `internal` so the width test can name the constant; `internal` is not public API either.)

## Open question for maintainers: does this need a version bump?

`plugin-ui-core` still says `version = "1.0.8"` and I have deliberately not touched it. The chain to the plugin that reported this is longer than one bump: Atlas does not consume `plugin-ui-core` directly, it compiles against the aggregate `boss-plugin-api` jar pinned by `.boss-plugin-api-version` (currently 1.0.78), and that jar ships its own copy of `ai.rever.boss.plugin.ui.BossDialogKt`. So reaching Atlas needs a bump and publish here, a `boss-plugin-api` release carrying it, and a pin bump there. Happy to include the bump if that is how these are released - it is a policy call, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
