### PR TITLE
fix(browser): make zoom work on Windows and unbreak the View menu

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -98,7 +98,7 @@
     <ID>CyclomaticComplexMethod:Fluck.kt$@Composable fun BrowserErrorView( error: Throwable, url: String, retryCount: Int = 0, maxRetries: Int = 3, onRetry: (() -&gt; Unit)? = null, onReset: (() -&gt; Unit)? = null, onResetBrowser: (() -&gt; Unit)? = null, onRetryEngine: (() -&gt; Unit)? = null, )</ID>
     <ID>CyclomaticComplexMethod:Fluck.kt$FluckTabComponent$@Composable override fun Content()</ID>
     <ID>CyclomaticComplexMethod:FluckBrowserSettings.kt$@Composable fun FluckBrowserSettings()</ID>
-    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor( browser: com.teamdev.jxbrowser.browser.Browser, ownerWindowId: String? = null, )</ID>
+    <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor( browser: com.teamdev.jxbrowser.browser.Browser, ownerWindowId: String? = null, zoomTarget: BrowserHandle? = null, )</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun classifyError(e: Throwable): EngineInitError</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun createEngineInstance( chromiumDir: java.nio.file.Path, profileDirPath: java.nio.file.Path, ): Engine</ID>
     <ID>CyclomaticComplexMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses()</ID>
@@ -282,7 +282,7 @@
     <ID>LongMethod:Fluck.kt$FluckTabComponent$@Composable override fun Content()</ID>
     <ID>LongMethod:FluckBrowserSettings.kt$@Composable fun FluckBrowserSettings()</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupBrowserDownloadHandler(browser: com.teamdev.jxbrowser.browser.Browser)</ID>
-    <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor( browser: com.teamdev.jxbrowser.browser.Browser, ownerWindowId: String? = null, )</ID>
+    <ID>LongMethod:FluckEngine.kt$FluckEngine$fun setupKeyboardInterceptor( browser: com.teamdev.jxbrowser.browser.Browser, ownerWindowId: String? = null, zoomTarget: BrowserHandle? = null, )</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$private fun createEngineInstance( chromiumDir: java.nio.file.Path, profileDirPath: java.nio.file.Path, ): Engine</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$private fun killStaleChromiumProcesses()</ID>
     <ID>LongMethod:FluckEngine.kt$FluckEngine$suspend fun resetBrowserProfile(): ResetResult</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppMenuActionEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppMenuActionEffects.kt
@@ -12,8 +12,6 @@ import ai.rever.boss.components.plugin.PluginUpdateBridge
 import ai.rever.boss.components.plugin.StoreVersionLookup
 import ai.rever.boss.components.plugin.StoreVersionPrompt
 import ai.rever.boss.components.plugin.UpdateCheckOutcome
-import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabComponent
-import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.components.sidebar.SidebarVisibilitySettings
 import ai.rever.boss.components.sidebar.SidebarVisibilitySettingsManager
 import ai.rever.boss.components.window_panel.NavigationDirection
@@ -23,6 +21,7 @@ import ai.rever.boss.components.workspaces.applyWorkspace
 import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.focusmode.FocusModeSettingsManager
+import ai.rever.boss.plugin.browser.ActiveBrowserRegistry
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabType
 import ai.rever.boss.project.DefaultWorkingDirectory
@@ -190,16 +189,25 @@ internal fun BossAppMenuActionEffects(
             }.launchIn(this)
     }
 
-    // Listen for zoom menu actions
+    // Listen for zoom menu actions.
+    //
+    // These act on the browser ActiveBrowserRegistry names for this window, not on a tab component
+    // the host can type-test. The live fluck tab is the dynamic plugin's FluckBrowserTabComponent,
+    // which implements ai.rever.boss.plugin.api.TabComponentWithUI directly and is not the built-in
+    // FluckTabComponent (dead since registerFluck() was disabled, and its zoom methods are no-op
+    // stubs anyway) - so `activeTab is FluckTabComponent` was a branch that could never be taken,
+    // which is why Zoom In / Zoom Out / Actual Size / Reload did nothing on every platform.
+    //
+    // splitViewState.activePanelId is deliberately no longer consulted: the registry already
+    // encodes it, because BrowserHandleImpl.Content reads LocalIsPanelActive, which
+    // BossMainWindowPanel provides as `panelId == activePanelId`. The registry additionally ranks a
+    // sidebar-slot browser below one in the main content area, which activePanelId alone cannot
+    // express. Asking both would be two answers to one question.
     LaunchedEffect(windowId) {
         MenuActionsHandler.zoomInEvents
             .onEach { eventWindowId ->
                 if (eventWindowId == windowId) {
-                    val activeTabsComponent = splitViewState.getPanelTabsComponent(splitViewState.activePanelId)
-                    val activeTab = activeTabsComponent?.getActiveComponent()
-                    if (activeTab is FluckTabComponent) {
-                        activeTab.zoomIn()
-                    }
+                    ActiveBrowserRegistry.activeIn(windowId)?.zoomIn()
                 }
             }.launchIn(this)
     }
@@ -208,11 +216,7 @@ internal fun BossAppMenuActionEffects(
         MenuActionsHandler.zoomOutEvents
             .onEach { eventWindowId ->
                 if (eventWindowId == windowId) {
-                    val activeTabsComponent = splitViewState.getPanelTabsComponent(splitViewState.activePanelId)
-                    val activeTab = activeTabsComponent?.getActiveComponent()
-                    if (activeTab is FluckTabComponent) {
-                        activeTab.zoomOut()
-                    }
+                    ActiveBrowserRegistry.activeIn(windowId)?.zoomOut()
                 }
             }.launchIn(this)
     }
@@ -221,11 +225,7 @@ internal fun BossAppMenuActionEffects(
         MenuActionsHandler.actualSizeEvents
             .onEach { eventWindowId ->
                 if (eventWindowId == windowId) {
-                    val activeTabsComponent = splitViewState.getPanelTabsComponent(splitViewState.activePanelId)
-                    val activeTab = activeTabsComponent?.getActiveComponent()
-                    if (activeTab is FluckTabComponent) {
-                        activeTab.actualSize()
-                    }
+                    ActiveBrowserRegistry.activeIn(windowId)?.resetZoom()
                 }
             }.launchIn(this)
     }
@@ -383,19 +383,14 @@ internal fun BossAppMenuActionEffects(
             }.launchIn(this)
     }
 
-    // Handle Browser Reload menu events
+    // Handle Browser Reload menu events. Same registry lookup, and for the same reason, as the
+    // zoom handlers above; the old double gate on FluckTabInfo *and* FluckTabComponent was two
+    // tests where the second could never pass.
     LaunchedEffect(windowId) {
         MenuActionsHandler.reloadBrowserEvents
             .onEach { eventWindowId ->
                 if (eventWindowId == windowId) {
-                    val activeTabsComp = splitViewState.getPanelTabsComponent(splitViewState.activePanelId)
-                    val activeTab = activeTabsComp?.tabsState?.value?.activeTab
-                    if (activeTab is FluckTabInfo) {
-                        val activeTabComponent = activeTabsComp.getActiveComponent()
-                        if (activeTabComponent is FluckTabComponent) {
-                            activeTabComponent.reload()
-                        }
-                    }
+                    ActiveBrowserRegistry.activeIn(windowId)?.reload()
                 }
             }.launchIn(this)
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserRegistry.kt
@@ -1,0 +1,130 @@
+package ai.rever.boss.plugin.browser
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Which embedded browser a WINDOW-scoped action should act on.
+ *
+ * The View menu's Zoom In / Zoom Out / Actual Size / Reload emit only a window id
+ * ([ai.rever.boss.window.MenuActionsHandler]), and the host cannot answer "which browser" from the
+ * tab tree: the live fluck tab is a DYNAMIC plugin's component, so the `activeTab is
+ * FluckTabComponent` test those handlers used to perform was one the host could never satisfy -
+ * the built-in `FluckTabComponent` stopped being instantiated when `registerFluck()` was disabled
+ * in favour of the plugin, and the plugin's class is unrelated to it. All four menu items were
+ * therefore no-ops on every platform.
+ *
+ * The one place that knows a browser surface is on screen, in which window and in which panel is
+ * `BrowserHandleImpl.Content()`, so that is where entries come from. Registering a handle rather
+ * than a tab component also keeps this independent of the plugin API: any browser-backed plugin
+ * tab is served without the plugin implementing anything.
+ *
+ * `java.util.concurrent` in a `commonMain` file is deliberate: composeApp declares a single
+ * `jvm("desktop")` target, and the same primitives are already used by `AWTKeyboardInterceptor`
+ * and `BrowserFindController`. The concurrency is real - see [register].
+ */
+object ActiveBrowserRegistry {
+    /**
+     * One composed browser surface.
+     *
+     * Value-equality is load-bearing: it is what lets [unregister] remove an entry only when it is
+     * still the current one.
+     */
+    internal data class Entry(
+        val handleId: String,
+        val windowId: String,
+        val inMainPanel: Boolean,
+        val panelActive: Boolean,
+        val sequence: Long,
+    )
+
+    private val entries = ConcurrentHashMap<String, Entry>()
+    private val handles = ConcurrentHashMap<String, BrowserHandle>()
+    private val sequencer = AtomicLong(0)
+
+    /**
+     * Record that [handle]'s surface is composed in [windowId].
+     *
+     * Written from the Compose UI thread and read from the menu flow collectors, hence the
+     * concurrent maps. [sequence] comes from an atomic counter so two panels re-registering within
+     * the same frame still get distinct, increasing ranks - though [selectActiveHandleId]
+     * deliberately does not depend on which of the two wins that race.
+     *
+     * @return a token to hand back to [unregister]; see the cross-window note there.
+     */
+    fun register(
+        handle: BrowserHandle,
+        windowId: String,
+        inMainPanel: Boolean,
+        panelActive: Boolean,
+    ): Any {
+        val entry =
+            Entry(
+                handleId = handle.id,
+                windowId = windowId,
+                inMainPanel = inMainPanel,
+                panelActive = panelActive,
+                sequence = sequencer.incrementAndGet(),
+            )
+        handles[handle.id] = handle
+        entries[handle.id] = entry
+        return entry
+    }
+
+    /**
+     * Remove [handleId]'s registration, but only if [token] is still the current one.
+     *
+     * A tab moving between windows builds one composition and tears down the other in an order
+     * this registry does not control - `BrowserHandleImpl` documents the same hazard for its
+     * visibility counter. Both compositions carry the SAME handle id, so an unconditional remove
+     * from the outgoing one would delete the incoming one's entry and leave the menu with nothing
+     * to act on. The value-equality remove is the same trick `BrowserWindowOwnershipRegistry` uses.
+     */
+    fun unregister(
+        handleId: String,
+        token: Any?,
+    ) {
+        if (token is Entry && entries.remove(handleId, token)) {
+            handles.remove(handleId)
+        }
+    }
+
+    /** Unconditional removal, for handle disposal - the handle is gone, so no successor exists. */
+    fun unregister(handleId: String) {
+        entries.remove(handleId)
+        handles.remove(handleId)
+    }
+
+    /** The browser a window-scoped action should act on in [windowId], or null if there is none. */
+    fun activeIn(windowId: String): BrowserHandle? {
+        val liveEntries = entries.values.filter { handles[it.handleId]?.isValid == true }
+        val handleId = selectActiveHandleId(liveEntries, windowId) ?: return null
+        return handles[handleId]?.takeIf { it.isValid }
+    }
+}
+
+/**
+ * Of the live browser surfaces composed in [windowId], which one owns a window-scoped action.
+ *
+ * Extracted as a pure function so the tie-break is unit-testable without a JxBrowser `Browser`.
+ *
+ * Ranked, most significant first:
+ *  1. `inMainPanel` - `LocalIsPanelActive` DEFAULTS TO TRUE, so a browser rendered in a sidebar
+ *     slot reports itself active too; only `LocalInMainWindowPanel` separates the two. This is the
+ *     same reasoning `BossMainWindowPanel` gives where it provides both locals.
+ *  2. `panelActive` - within the main content area, the split panel the user is in wins.
+ *  3. `sequence` - otherwise the most recently shown surface wins.
+ */
+internal fun selectActiveHandleId(
+    candidates: Collection<ActiveBrowserRegistry.Entry>,
+    windowId: String,
+): String? =
+    candidates
+        .filter { it.windowId == windowId }
+        .maxWithOrNull(
+            compareBy<ActiveBrowserRegistry.Entry>(
+                { it.inMainPanel },
+                { it.panelActive },
+                { it.sequence },
+            ),
+        )?.handleId

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -1139,8 +1139,10 @@ internal class BrowserHandleImpl(
         // find chord.
         BrowserFindController.register(browser, browserLock)
 
-        // Setup keyboard interceptor for menu shortcuts
-        FluckEngine.setupKeyboardInterceptor(browser, ownerWindowId)
+        // Setup keyboard interceptor for menu shortcuts. Passing `this` mid-construction is safe:
+        // the interceptor only captures it in a callback lambda, which JxBrowser cannot invoke
+        // until a key reaches a browser that is by then fully built.
+        FluckEngine.setupKeyboardInterceptor(browser, ownerWindowId, zoomTarget = this)
 
         // Let a click in the page close any Swing popup menu open over it
         FluckEngine.setupSwingPopupDismissOnPageClick(browser)
@@ -2527,6 +2529,44 @@ internal class BrowserHandleImpl(
             onDispose {}
         }
 
+        // Read here rather than at their first use further down: the registration effect below and
+        // the find-bar effect both need them, and a CompositionLocal read has no ordering
+        // constraint. The comment explaining what they mean lives with the find-bar effect.
+        val isPanelActive = LocalIsPanelActive.current
+        val inMainPanel = LocalInMainWindowPanel.current
+
+        // Which browser the View menu's Zoom In / Zoom Out / Actual Size / Reload act on in this
+        // window. Registered from here rather than from the tab component because the tab
+        // component is a DYNAMIC plugin's class (fluck-browser's FluckBrowserTabComponent): the
+        // host cannot name its type, which is exactly why the `is FluckTabComponent` test in
+        // BossAppMenuActionEffects was always false and those four menu items did nothing.
+        //
+        // Its own effect rather than a key on the currentWindowId effect above: that one is
+        // deliberately about telemetry attribution and must not fire when only panel activation
+        // changed, whereas this one must - clicking into the other half of a split changes nothing
+        // else here.
+        //
+        // Keyed on all three inputs, so a tab moved to another window re-registers under the new
+        // one; a tab hidden and re-shown leaves and re-enters composition, and the fresh
+        // registration's higher sequence is what makes "most recently shown wins" true without a
+        // separate hook; and a split whose active panel changed re-registers both surfaces with
+        // current flags.
+        DisposableEffect(hostWindowId, isPanelActive, inMainPanel) {
+            val registrationWindowId = hostWindowId
+            val token =
+                if (registrationWindowId != null) {
+                    ActiveBrowserRegistry.register(
+                        handle = this@BrowserHandleImpl,
+                        windowId = registrationWindowId,
+                        inMainPanel = inMainPanel,
+                        panelActive = isPanelActive,
+                    )
+                } else {
+                    null
+                }
+            onDispose { ActiveBrowserRegistry.unregister(id, token) }
+        }
+
         // Track last navigation time for debouncing mouse button navigation
         var lastNavigationTime by remember { mutableStateOf(0L) }
 
@@ -2719,8 +2759,9 @@ internal class BrowserHandleImpl(
         // and claims only if nothing better did, which makes the winner deterministic. The
         // non-preferred branch still gets served, a beat later, so a sidebar-only browser is not
         // cut off.
-        val isPanelActive = LocalIsPanelActive.current
-        val inMainPanel = LocalInMainWindowPanel.current
+        //
+        // isPanelActive and inMainPanel are read further up, where the registry registration also
+        // needs them.
         LaunchedEffect(browser, hostWindowId, isPanelActive, inMainPanel) {
             if (hostWindowId == null || !isPanelActive) return@LaunchedEffect
             MenuActionsHandler.browserFindEvents.collect { eventWindowId ->
@@ -2904,6 +2945,11 @@ internal class BrowserHandleImpl(
         // Release find-in-page state and its timers before closing the browser: a debounce that
         // fires afterwards would search a closed object.
         BrowserFindController.dispose(browser)
+
+        // Unconditional, unlike the composition's token-guarded removal: the handle is gone, so
+        // there is no successor registration this could delete. Covers a handle disposed out from
+        // under a surface that is still composed - an engine generation bump does exactly that.
+        ActiveBrowserRegistry.unregister(id)
 
         // Close browser
         if (!browser.isClosed) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -2454,6 +2454,90 @@ object FluckEngine {
         }
 
     /**
+     * Whether the native key interceptor has to serve zoom chords on this platform.
+     *
+     * Windows and Linux: yes, and it is the only layer that can. Under HARDWARE_ACCELERATED the
+     * native Chromium child window consumes the key, so neither the AWT keymap nor the plugin's
+     * Compose `onPreviewKeyEvent` ever sees one - the same reason Ctrl+R needed a case here.
+     *
+     * macOS: no. The chord reaches AWT there, which is why zoom was reported broken on Windows
+     * only, and the AWT keymap (`browser.zoom_in` and friends) plus the plugin's Compose handler
+     * already serve it. Claiming it here as well is the one configuration where two layers could
+     * both act on a single keypress, and the second zoom step would be indistinguishable from the
+     * user having pressed the key twice.
+     *
+     * If macOS keyboard zoom is ever found broken, this predicate is the thing to revisit: it
+     * would mean macOS delivers the chord to Chromium after all, and the native case should serve
+     * it there too.
+     */
+    private val interceptsZoomNatively: Boolean
+        get() = !SystemUtils.isMacOS
+
+    internal enum class BrowserZoomAction { IN, OUT, RESET }
+
+    /**
+     * The zoom action a main-modifier chord asks for, or null if it is not a zoom chord.
+     *
+     * JxBrowser 9.4.0 has no `KEY_CODE_EQUALS` and no `KEY_CODE_MINUS`. The main-row keys are
+     * [com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_OEM_PLUS] ('=' / '+') and
+     * [com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_OEM_MINUS] ('-' / '_'); the numpad keys are
+     * `KEY_CODE_ADD` and `KEY_CODE_SUBTRACT`. Reaching for the intuitive names does not fail to
+     * compile against a constant that exists under a different spelling - it silently fails to
+     * match at runtime, which is precisely the failure this function was added to remove, so
+     * `BrowserZoomKeyMappingTest` pins the mapping.
+     *
+     * Extracted as a pure function for the same reason [resolveBrowserKeyEventRoute] is: it is
+     * testable without a live `Browser`.
+     *
+     * [shiftDown] is a parameter because Ctrl+Shift+'=' is how many layouts spell Ctrl+'+', and
+     * Chrome zooms in on it. Shift is meaningless for zoom out and reset, which decline it.
+     */
+    internal fun resolveBrowserZoomAction(
+        keyCode: com.teamdev.jxbrowser.ui.KeyCode,
+        shiftDown: Boolean,
+    ): BrowserZoomAction? =
+        when (keyCode) {
+            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_OEM_PLUS,
+            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_ADD,
+            -> BrowserZoomAction.IN
+
+            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_OEM_MINUS,
+            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_SUBTRACT,
+            -> if (shiftDown) null else BrowserZoomAction.OUT
+
+            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_0,
+            com.teamdev.jxbrowser.ui.KeyCode.KEY_CODE_NUMPAD0,
+            -> if (shiftDown) null else BrowserZoomAction.RESET
+
+            else -> null
+        }
+
+    /**
+     * Applies [action] to [browser], preferring [zoomTarget] when one wraps it.
+     *
+     * Going through the handle rather than calling `browser.zoom()` directly is what keeps the
+     * fluck browser's zoom-percent indicator in step: the indicator is driven by
+     * `BrowserHandle.addZoomListener`, and only the handle's own zoom methods notify those
+     * listeners. The legacy `BrowserFunctions.createBrowser` path has no handle and falls back to
+     * the raw API, where there are no listeners to notify anyway.
+     *
+     * isClosed-guarded like every other browser call in this file: this runs on a JxBrowser
+     * callback thread and can race a tab close.
+     */
+    private fun applyBrowserZoom(
+        browser: com.teamdev.jxbrowser.browser.Browser,
+        zoomTarget: BrowserHandle?,
+        action: BrowserZoomAction,
+    ) {
+        if (browser.isClosed) return
+        when (action) {
+            BrowserZoomAction.IN -> if (zoomTarget != null) zoomTarget.zoomIn() else browser.zoom().`in`()
+            BrowserZoomAction.OUT -> if (zoomTarget != null) zoomTarget.zoomOut() else browser.zoom().out()
+            BrowserZoomAction.RESET -> if (zoomTarget != null) zoomTarget.resetZoom() else browser.zoom().reset()
+        }
+    }
+
+    /**
      * Dismiss any open Swing popup menu when the user clicks inside the web page.
      *
      * A heavyweight [javax.swing.JPopupMenu] normally closes itself on a click elsewhere: Swing's
@@ -2552,10 +2636,14 @@ object FluckEngine {
      *
      * @param ownerWindowId stable owner used for focus gating and shortcut dispatch; null preserves
      * legacy behavior for the old unscoped browser helper.
+     * @param zoomTarget the handle wrapping [browser], when one exists. Zoom goes through it rather
+     * than through `browser.zoom()` so the plugin's zoom-percent indicator stays in step - see
+     * [applyBrowserZoom].
      */
     fun setupKeyboardInterceptor(
         browser: com.teamdev.jxbrowser.browser.Browser,
         ownerWindowId: String? = null,
+        zoomTarget: BrowserHandle? = null,
     ) {
         // Adopt the browser for find-in-page before the callback below can serve a find chord.
         // A browser created outside a BrowserHandleImpl reaches this too (the legacy
@@ -2630,6 +2718,34 @@ object FluckEngine {
                         if (!browser.isClosed) browser.navigation().reload()
                         return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
                             .suppress()
+                    }
+
+                    // Zoom is BROWSER-scoped for the same reason reload directly above is: this
+                    // callback fires for the browser that received the key, so the browser is
+                    // already known and routing through the focused WINDOW could only make the
+                    // answer worse. On Windows that is not hypothetical - clicking a Chromium
+                    // native child window gives it OS focus without the click reaching Compose, so
+                    // the active split panel can still be the OTHER half. Sitting before the
+                    // shortcutWindowId gate also serves the legacy unowned browser, which that gate
+                    // has to drop.
+                    //
+                    // Without this, the chord reached nothing at all on Windows: under
+                    // HARDWARE_ACCELERATED the native surface consumes it, so neither the AWT
+                    // keymap nor the plugin's Compose handler ever sees a key event. Same failure
+                    // that made Ctrl+R need the case above. Skipped on macOS, where those layers do
+                    // get the chord - see interceptsZoomNatively.
+                    //
+                    // suppress() unconditionally, unlike the find chord below, which proceeds so a
+                    // site with its own find-in-page can pre-empt it: Chrome treats zoom as a
+                    // reserved accelerator pages cannot override, and suppressing is also what
+                    // stops Chromium applying its own built-in zoom on top of ours.
+                    if (interceptsZoomNatively) {
+                        val zoomAction = resolveBrowserZoomAction(keyCode, shiftDown = false)
+                        if (zoomAction != null) {
+                            applyBrowserZoom(browser, zoomTarget, zoomAction)
+                            return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                .suppress()
+                        }
                     }
                     if (shortcutWindowId != null) {
                         when (keyCode) {
@@ -2739,6 +2855,20 @@ object FluckEngine {
                     ) {
                         return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
                             .suppress()
+                    }
+
+                    // Ctrl+Shift+'=' is how a great many layouts spell Ctrl+'+', and Chrome zooms
+                    // in on it. Browser-scoped and placed before the window gate for the same
+                    // reason as "find previous" above. Zoom out and reset decline shift, so only
+                    // this one chord is claimed here. macOS-exempt on the same grounds as the
+                    // unshifted case above.
+                    if (interceptsZoomNatively) {
+                        val shiftZoomAction = resolveBrowserZoomAction(keyCode, shiftDown = true)
+                        if (shiftZoomAction != null) {
+                            applyBrowserZoom(browser, zoomTarget, shiftZoomAction)
+                            return@PressKeyCallback com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback.Response
+                                .suppress()
+                        }
                     }
                     if (shortcutWindowId != null) {
                         when (keyCode) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -2454,24 +2454,33 @@ object FluckEngine {
         }
 
     /**
-     * Whether the native key interceptor has to serve zoom chords on this platform.
+     * Whether the native key interceptor has to serve zoom chords in this configuration.
      *
-     * Windows and Linux: yes, and it is the only layer that can. Under HARDWARE_ACCELERATED the
-     * native Chromium child window consumes the key, so neither the AWT keymap nor the plugin's
-     * Compose `onPreviewKeyEvent` ever sees one - the same reason Ctrl+R needed a case here.
+     * Two conditions, because two different things can put the chord somewhere else.
      *
-     * macOS: no. The chord reaches AWT there, which is why zoom was reported broken on Windows
-     * only, and the AWT keymap (`browser.zoom_in` and friends) plus the plugin's Compose handler
-     * already serve it. Claiming it here as well is the one configuration where two layers could
-     * both act on a single keypress, and the second zoom step would be indistinguishable from the
-     * user having pressed the key twice.
+     * Rendering mode. Only HARDWARE_ACCELERATED gives Chromium a native child window that
+     * consumes the key before the JVM sees it, which is the whole reason this case exists - the
+     * same reason Ctrl+R needed one. Under OFF_SCREEN the chord arrives through AWT and Compose
+     * instead, so the AWT keymap and the plugin's `onPreviewKeyEvent` serve it and claiming it
+     * here as well risks a second zoom step. OFF_SCREEN is not hypothetical: it is reachable per
+     * install through BOSS_RENDERING_MODE or Settings > Browser Engine, so gating on the platform
+     * alone would leave anyone who flipped that setting exposed.
      *
-     * If macOS keyboard zoom is ever found broken, this predicate is the thing to revisit: it
-     * would mean macOS delivers the chord to Chromium after all, and the native case should serve
-     * it there too.
+     * Platform. macOS is exempt even under HARDWARE_ACCELERATED, because the chord reaches AWT
+     * there - which is why zoom was reported broken on Windows only - and the AWT keymap
+     * (`browser.zoom_in` and friends) plus the plugin's Compose handler already serve it.
+     *
+     * Both exemptions guard the same failure: two layers acting on one keypress, where the second
+     * zoom step is indistinguishable from the user having pressed the key twice.
+     *
+     * [JxBrowserConfig.renderingMode] is a `lazy` val, so this resolves once per process. That is
+     * the right granularity: changing the mode needs the engine rebuilt, so it cannot change under
+     * a running browser anyway.
      */
     private val interceptsZoomNatively: Boolean
-        get() = !SystemUtils.isMacOS
+        get() =
+            !SystemUtils.isMacOS &&
+                JxBrowserConfig.renderingMode == com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
 
     internal enum class BrowserZoomAction { IN, OUT, RESET }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserSelectionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ActiveBrowserSelectionTest.kt
@@ -1,0 +1,78 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [selectActiveHandleId] — the tie-break that decides which browser the View menu's
+ * Zoom In / Zoom Out / Actual Size / Reload act on.
+ *
+ * Pure by construction: the selector takes [ActiveBrowserRegistry.Entry] values rather than
+ * `BrowserHandle`s precisely so the interesting logic can be tested without a JxBrowser browser.
+ */
+class ActiveBrowserSelectionTest {
+    private fun entry(
+        handleId: String,
+        windowId: String = "w1",
+        inMainPanel: Boolean = true,
+        panelActive: Boolean = true,
+        sequence: Long = 1,
+    ) = ActiveBrowserRegistry.Entry(handleId, windowId, inMainPanel, panelActive, sequence)
+
+    @Test
+    fun `no candidates yields no browser`() {
+        assertNull(selectActiveHandleId(emptyList(), "w1"))
+    }
+
+    @Test
+    fun `a browser in another window is never chosen`() {
+        val candidates = listOf(entry("other", windowId = "w2", sequence = 99))
+        assertNull(selectActiveHandleId(candidates, "w1"))
+        assertEquals("other", selectActiveHandleId(candidates, "w2"))
+    }
+
+    @Test
+    fun `in a split, the active panel wins regardless of which registered last`() {
+        // Both surfaces re-register in the same frame when the active panel changes, and the order
+        // between them is not something the effects control. panelActive outranking sequence is
+        // what makes that race irrelevant, so assert it under BOTH orderings.
+        val activeFirst =
+            listOf(
+                entry("active", panelActive = true, sequence = 1),
+                entry("inactive", panelActive = false, sequence = 2),
+            )
+        assertEquals("active", selectActiveHandleId(activeFirst, "w1"))
+
+        val activeLast =
+            listOf(
+                entry("inactive", panelActive = false, sequence = 1),
+                entry("active", panelActive = true, sequence = 2),
+            )
+        assertEquals("active", selectActiveHandleId(activeLast, "w1"))
+    }
+
+    @Test
+    fun `a sidebar browser never beats one in the main content area`() {
+        // LocalIsPanelActive DEFAULTS TO TRUE, so a surface rendered outside a managed panel - a
+        // sidebar slot, a dialog, a test host - reports panelActive = true as well. Only
+        // inMainPanel separates them, which is why it has to outrank both other keys: here the
+        // sidebar entry wins on panelActive and on sequence and must still lose.
+        val candidates =
+            listOf(
+                entry("sidebar", inMainPanel = false, panelActive = true, sequence = 99),
+                entry("main", inMainPanel = true, panelActive = false, sequence = 1),
+            )
+        assertEquals("main", selectActiveHandleId(candidates, "w1"))
+    }
+
+    @Test
+    fun `otherwise the most recently shown browser wins`() {
+        val candidates =
+            listOf(
+                entry("older", sequence = 1),
+                entry("newer", sequence = 2),
+            )
+        assertEquals("newer", selectActiveHandleId(candidates, "w1"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserZoomKeyMappingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserZoomKeyMappingTest.kt
@@ -1,0 +1,90 @@
+package ai.rever.boss.plugin.browser
+
+import com.teamdev.jxbrowser.ui.KeyCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [FluckEngine.resolveBrowserZoomAction] — no JxBrowser browser required.
+ *
+ * These exist because the mapping's failure mode is silent. JxBrowser 9.4.0 has no
+ * `KEY_CODE_EQUALS` and no `KEY_CODE_MINUS`, so an implementation reaching for those intuitive
+ * names does not fail to compile — it compiles against whatever constant it does find and then
+ * never matches the key the user actually pressed. That is exactly how zoom came to do nothing on
+ * Windows, where the native interceptor is the only layer that sees the chord at all.
+ */
+class BrowserZoomKeyMappingTest {
+    @Test
+    fun `main-row and numpad plus zoom in`() {
+        assertEquals(
+            FluckEngine.BrowserZoomAction.IN,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_OEM_PLUS, shiftDown = false),
+        )
+        assertEquals(
+            FluckEngine.BrowserZoomAction.IN,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_ADD, shiftDown = false),
+        )
+    }
+
+    @Test
+    fun `main-row and numpad minus zoom out`() {
+        assertEquals(
+            FluckEngine.BrowserZoomAction.OUT,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_OEM_MINUS, shiftDown = false),
+        )
+        assertEquals(
+            FluckEngine.BrowserZoomAction.OUT,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_SUBTRACT, shiftDown = false),
+        )
+    }
+
+    @Test
+    fun `main-row and numpad zero reset zoom`() {
+        assertEquals(
+            FluckEngine.BrowserZoomAction.RESET,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_0, shiftDown = false),
+        )
+        assertEquals(
+            FluckEngine.BrowserZoomAction.RESET,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_NUMPAD0, shiftDown = false),
+        )
+    }
+
+    @Test
+    fun `shift claims only zoom in, the Ctrl+Shift+= spelling of Ctrl+plus`() {
+        assertEquals(
+            FluckEngine.BrowserZoomAction.IN,
+            FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_OEM_PLUS, shiftDown = true),
+        )
+        // Shift is meaningless for these two, so they decline it rather than swallowing a chord
+        // some page or other shortcut may want.
+        assertNull(FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_OEM_MINUS, shiftDown = true))
+        assertNull(FluckEngine.resolveBrowserZoomAction(KeyCode.KEY_CODE_0, shiftDown = true))
+    }
+
+    @Test
+    fun `keys owned by the other browser shortcuts are not zoom chords`() {
+        // The regression this pins: every one of these shares the interceptor's main-modifier
+        // branch with zoom, so a mapping written against the wrong constant could quietly claim
+        // one of them - or, more likely, claim nothing and leave zoom dead the way it was.
+        listOf(
+            KeyCode.KEY_CODE_R,
+            KeyCode.KEY_CODE_N,
+            KeyCode.KEY_CODE_T,
+            KeyCode.KEY_CODE_W,
+            KeyCode.KEY_CODE_G,
+            KeyCode.KEY_CODE_F,
+            KeyCode.KEY_CODE_1,
+        ).forEach { keyCode ->
+            assertNull(
+                FluckEngine.resolveBrowserZoomAction(keyCode, shiftDown = false),
+                "$keyCode must not be treated as a zoom chord",
+            )
+            assertNull(
+                FluckEngine.resolveBrowserZoomAction(keyCode, shiftDown = true),
+                "Shift+$keyCode must not be treated as a zoom chord",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Problem

In the fluck browser tab, `Ctrl+=` and `Ctrl+-` did nothing on Windows, and `View > Zoom In / Zoom Out / Actual Size / Reload` did nothing at all. These turned out to be two independent defects that happened to overlap.

### Break A - Windows keyboard

`JxBrowserConfig` selects `HARDWARE_ACCELERATED` on every platform, so Chromium owns a native child window and consumes keys before AWT or Compose sees them. `JxBrowserConfig` already documents "Ctrl+R not reaching a focused page" as a Windows regression fixed this way, and the fix was a native JxBrowser `PressKeyCallback` in `FluckEngine.setupKeyboardInterceptor`.

That interceptor handles `R`, `N`, `T`, `W`, `G` and `F`. It never got zoom cases, so the zoom chords fell through to `Response.proceed()` and reached nothing.

### Break B - View menu, every platform

The handlers in `BossAppMenuActionEffects` gated on `activeTab is FluckTabComponent`. That branch can never be taken: `registerFluck()` is commented out in `DefaultPlugin`, and the live tab is the dynamic plugin's `FluckBrowserTabComponent`, which implements `TabComponentWithUI` directly and is unrelated to the built-in `FluckTabComponent` (dead code, whose zoom methods are no-op stubs). All four menu items were no-ops on macOS too.

The producer side was fine throughout - `BossWindow` and `AWTKeyboardInterceptor` both reach `MenuActionsHandler` correctly.

## Approach

Host-side only. No change to `boss-plugin-api`, no fluck-browser plugin release.

**`ActiveBrowserRegistry`** (new, commonMain) tracks which `BrowserHandle` a window-scoped action should act on, registered from `BrowserHandleImpl.Content()` - the one place that knows a browser surface is on screen, in which window and in which panel. Registering a handle rather than a tab component is what lets the host name the browser without naming a plugin's class, so any browser-backed plugin tab is served without the plugin implementing anything.

Selection ranks `inMainPanel`, then `panelActive`, then most recently shown. `inMainPanel` has to come first because `LocalIsPanelActive` defaults to `true`, so a sidebar-slot browser reports itself active as well - the same trap `BossMainWindowPanel` calls out where it provides both locals.

Removal is a value-equality remove against a token. A tab moving between windows builds one composition and tears down the other in an order the registry does not control, and both carry the same handle id, so an unconditional remove from the outgoing one would delete the incoming one's entry.

**The native interceptor** gets zoom cases beside the existing reload case, before the `shortcutWindowId` routing block - zoom is browser-scoped for exactly the reason the reload comment already gives, and sitting before the gate also serves the legacy unowned browser.

Two details worth flagging for review:

- **JxBrowser 9.4.0 has no `KEY_CODE_EQUALS` and no `KEY_CODE_MINUS`.** The constants are `KEY_CODE_OEM_PLUS` and `KEY_CODE_OEM_MINUS`, plus `KEY_CODE_ADD` / `KEY_CODE_SUBTRACT` for numpad. Reaching for the intuitive names compiles against something else and then silently never matches, which is the same shape as the bug being fixed, so `BrowserZoomKeyMappingTest` pins the mapping and asserts the keys owned by the other shortcuts are not zoom chords.
- **Zoom routes through the `BrowserHandle`, not `browser.zoom()`.** Only the handle's methods call `notifyZoomListeners()`, which is what drives the plugin's zoom-percent indicator. The native case also acts on the browser it already holds rather than re-deriving one from the focused window: on Windows, clicking a Chromium native child window gives it OS focus without the click reaching Compose, so the active split panel can still be the other half.

`Ctrl+Shift+=` is handled too, since that is how many layouts spell `Ctrl++` and Chrome zooms in on it.

## macOS guard

The native case is skipped on macOS via `interceptsZoomNatively`. The chord reaches AWT there - which is why this was reported as Windows-only - so the AWT keymap and the plugin's Compose handler already serve it, and claiming it natively as well is the one configuration where two layers could act on a single keypress.

This is the one branch not exercised by testing, since verification was done on Windows. If macOS keyboard zoom is ever found broken, that predicate is the single thing to flip: it would mean macOS delivers the chord to Chromium after all.

## Testing

Verified working by hand on Windows 11 against a live browser tab: the zoom chords, all four View menu items, and the zoom-percent indicator tracking the keyboard path. The app logged `mode=HARDWARE_ACCELERATED, os=windows 11`, confirming the precondition rather than assuming it.

Automated:

- `BrowserZoomKeyMappingTest` - 5 tests over the pure key mapping
- `ActiveBrowserSelectionTest` - 5 tests over the pure selection tie-break, including the sidebar case and both orderings of the same-frame split re-registration race
- `./gradlew build`, `allTests`, `ktlintCheck`, `detekt` all green

One pre-existing failure is unrelated and environmental: `DesktopFileScannerTest > directoryHasChildren follows a symlink to a non-empty directory` needs symlink privilege, which the test machine does not have (`Administrator privilege required`). It fails independently of this change.

`detekt-baseline.xml` needed the two `setupKeyboardInterceptor` ids updated, since they pin the full signature and the method gained a parameter. The ids were taken verbatim from a regenerated baseline, then applied as a two-line edit to the existing file so nothing else moved.

## Not in scope, found in passing

`AWTKeyboardInterceptor.updateWindowContext` has zero callers, so the `ShortcutContext.BROWSER` gate always falls back to sniffing the AWT focus chain for a `*jxbrowser*` class. If that never resolves, the AWT keymap path for browser bindings is latently dead. Menu items are unaffected - they have no context gate. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
