### PR TITLE
README: the atlas plugin is called fluck-agent now

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Scoped deliberately: this covers the **Docker and Kubernetes plugins only**, bec
 | **[Top of Mind](https://github.com/risa-labs-inc/boss-plugin-topofmind)** | Quick access to frequently used items |
 | **[Admin Role Management](https://github.com/risa-labs-inc/boss-plugin-admin-role-management) / [Role Creation](https://github.com/risa-labs-inc/boss-plugin-role-creation)** | Manage roles and permissions; build custom roles (admin) |
 
-*…and more in [boss-plugins](https://github.com/risa-labs-inc/boss-plugins), including analytics, atlas (chat about the current page), and hardware integrations.*
+*…and more in [boss-plugins](https://github.com/risa-labs-inc/boss-plugins), including analytics, fluck-agent (chat about the current page), and hardware integrations.*
 
 ---
 


### PR DESCRIPTION
One line. Follows the plugin's rename from Atlas to Fluck Agent - risa-labs-inc/boss-plugin-fluck-agent#108, with the submodule path bumped in risa-labs-inc/boss-plugins#24.

## What is deliberately NOT touched

Every other `atlas` in this repo is **ChatGPT Atlas, the competitor browser** the Speedometer work measures against - the README results table, `benchmark.md`, all of `benchmarks/speedometer/**` (including `results-final/atlas-run{1,2,3}.json`) and the v9.2.65 release notes. Renaming those would corrupt a published benchmark.

The shipped v9.4.21 notes say "Reported against the Atlas plugin" because that was its name when they shipped. A release note is a record, not documentation, so it stays.

`BossDialog.kt` used to carry an "Atlas plugin" comment; it was already reworded away by #214/#216, so there is nothing left to change there.