### PR TITLE
plugin-store: let an organisation's admins publish for their own organisation

### DIFF
--- a/supabase/functions/plugin-store/routes/publish.ts
+++ b/supabase/functions/plugin-store/routes/publish.ts
@@ -13,8 +13,12 @@ import {
   PublishFromGitHubMetadataResponseSchema,
   ErrorResponseSchema
 } from "../types/schemas.ts"
-import { getPlugin, createPlugin, setPluginTags, getPluginById, updatePlugin } from "../services/plugins.ts"
-import { resolvePublishOrg } from "../services/publish-org.ts"
+import { getPlugin, createPlugin, setPluginTags, getPluginById, getPluginOrgId, updatePlugin } from "../services/plugins.ts"
+import {
+  authorizeExistingPluginPublish,
+  authorizeNewPluginPublish,
+  preflightPublishAuthz,
+} from "../services/publish-authz.ts"
 import { createVersion, versionExists, finalizeVersion, getVersionById } from "../services/versions.ts"
 import { getSignedUploadUrl, getSignedDownloadUrl, generateJarPath, uploadJar } from "../services/storage.ts"
 import { getAuthenticatedUser, getUserDisplayName, logApiKeyAction } from "../utils/auth.ts"
@@ -30,7 +34,6 @@ import {
   JarTooLargeError,
 } from "../services/github.ts"
 import {
-  PLUGIN_CREATE_PERMISSION,
   registerDefinedPermissions,
   validateDeclaredPermissions,
 } from "../utils/permissions.ts"
@@ -82,7 +85,8 @@ const publishPluginRoute = createRoute({
       }
     },
     403: {
-      description: 'Caller lacks the plugins.create permission, or the API key lacks the publish scope',
+      description: 'Caller may not publish: no plugins.create permission and no organisation they '
+        + 'may publish for, or the API key lacks the publish scope',
       content: {
         'application/json': {
           schema: ErrorResponseSchema
@@ -111,13 +115,22 @@ publish.openapi(publishPluginRoute, async (ctx) => {
     const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['publish'],
-      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
     if (!auth.ok) {
       return ctx.json({ success: false, error: auth.error }, auth.status)
     }
     const user = auth.user
+
+    // May they publish at all, and for whom. One call because the two halves are not separable:
+    // the org-scoped path exists precisely because "may you publish" cannot be answered without
+    // knowing where the plugin would land. Authorised BEFORE any row is written - this handler runs
+    // as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is bypassed and
+    // nothing else would refuse an organisation the caller has no rights in.
+    const authz = await authorizeNewPluginPublish(supabase, user, body.orgId)
+    if (!authz.ok) {
+      return ctx.json({ success: false, error: authz.error }, authz.status)
+    }
 
     // Reject dangling required permissions before creating any rows.
     const permCheck = await validateDeclaredPermissions(supabase, body)
@@ -134,14 +147,6 @@ publish.openapi(publishPluginRoute, async (ctx) => {
     // Get author display name - use custom name if provided, otherwise derive from email
     const authorName = body.authorName || await getUserDisplayName(supabase, user.userId)
 
-    // Which organisation owns it. Resolved and AUTHORISED before any row is written: this
-    // handler runs as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is
-    // bypassed and nothing else would refuse an organisation the caller has no rights in.
-    const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
-    if (!orgResolution.ok) {
-      return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
-    }
-
     // Create plugin
     const result = await createPlugin(
       supabase,
@@ -155,7 +160,10 @@ publish.openapi(publishPluginRoute, async (ctx) => {
       body.type,
       body.apiVersion,
       body.requiredPermissions,
-      orgResolution.orgId
+      authz.orgId,
+      // An organisation publishing for itself lands on its own shelf. A `plugins.create` publish
+      // keeps the column default ('public'), which is what every existing publisher gets.
+      authz.orgScoped ? 'org' : null
     )
 
     // Auto-register the permissions this plugin introduces (ungranted; admin grants later).
@@ -278,7 +286,6 @@ publish.openapi(publishVersionRoute, async (ctx) => {
     const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['version'],
-      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
     if (!auth.ok) {
@@ -295,6 +302,18 @@ publish.openapi(publishVersionRoute, async (ctx) => {
     // Verify ownership
     if (plugin.authorId !== user.userId) {
       return ctx.json({ success: false, error: 'Not authorized to publish to this plugin' }, 403)
+    }
+
+    // May they publish a version of THIS plugin. Gated on the organisation the plugin is already
+    // recorded against, never a fresh resolution: ownership is a property of the plugin, so
+    // re-deriving here would let a membership change move somebody else's work.
+    const authz = await authorizeExistingPluginPublish(
+      supabase,
+      user,
+      await getPluginOrgId(supabase, plugin.id)
+    )
+    if (!authz.ok) {
+      return ctx.json({ success: false, error: authz.error }, authz.status)
     }
 
     // Check if version already exists
@@ -443,7 +462,6 @@ publish.openapi(finalizeVersionRoute, async (ctx) => {
     const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['finalize'],
-      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
     if (!auth.ok) {
@@ -466,6 +484,18 @@ publish.openapi(finalizeVersionRoute, async (ctx) => {
     // Verify ownership
     if (plugin.authorId !== user.userId) {
       return ctx.json({ success: false, error: 'Not authorized' }, 403)
+    }
+
+    // May they publish a version of THIS plugin. Gated on the organisation the plugin is already
+    // recorded against, never a fresh resolution: ownership is a property of the plugin, so
+    // re-deriving here would let a membership change move somebody else's work.
+    const authz = await authorizeExistingPluginPublish(
+      supabase,
+      user,
+      await getPluginOrgId(supabase, plugin.id)
+    )
+    if (!authz.ok) {
+      return ctx.json({ success: false, error: authz.error }, authz.status)
     }
 
     // Recompute the hash server-side — the store signature must anchor to
@@ -636,13 +666,21 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
     const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['publish'],
-      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
     if (!auth.ok) {
       return ctx.json({ success: false, error: auth.error }, auth.status)
     }
     const user = auth.user
+
+    // Refuse a caller with no publishing rights at all BEFORE the GitHub fetch below. The full
+    // decision needs the manifest (it is what says whether the plugin already exists, and so which
+    // organisation to authorise against), and the manifest costs a release download - which is not
+    // work to do on behalf of somebody who cannot publish anything anywhere.
+    const preflight = await preflightPublishAuthz(supabase, user)
+    if (preflight) {
+      return ctx.json({ success: false, error: preflight.error }, preflight.status)
+    }
 
     // Fetch plugin from GitHub
     console.log(`Fetching plugin from GitHub: ${body.githubUrl}`)
@@ -682,6 +720,17 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
         }, 403)
       }
 
+      // May they publish a version of THIS plugin - gated on the organisation it is already
+      // recorded against, not on a fresh resolution of the caller's memberships.
+      const authz = await authorizeExistingPluginPublish(
+        supabase,
+        user,
+        await getPluginOrgId(supabase, existingPlugin.id)
+      )
+      if (!authz.ok) {
+        return ctx.json({ success: false, error: authz.error }, authz.status)
+      }
+
       pluginUuid = existingPlugin.id
 
       // Update plugin metadata from manifest
@@ -699,12 +748,11 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
       isNewPlugin = true
       const authorName = manifest.author || await getUserDisplayName(supabase, user.userId)
 
-      // Which organisation owns it. Resolved and AUTHORISED before any row is written: this
-      // handler runs as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is
-      // bypassed and nothing else would refuse an organisation the caller has no rights in.
-      const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
-      if (!orgResolution.ok) {
-        return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
+      // Which organisation owns it, and whether they may publish for it at all. The preflight
+      // above only established that they can publish SOMEWHERE.
+      const authz = await authorizeNewPluginPublish(supabase, user, body.orgId)
+      if (!authz.ok) {
+        return ctx.json({ success: false, error: authz.error }, authz.status)
       }
 
       const result = await createPlugin(
@@ -719,7 +767,9 @@ publish.openapi(publishFromGitHubRoute, async (ctx) => {
         ((manifest.type as string) || 'panel').toLowerCase(),
         manifest.apiVersion,
         manifest.requiredPermissions || [],
-        orgResolution.orgId
+        authz.orgId,
+        // An organisation publishing for itself lands on its own shelf, not the global one.
+        authz.orgScoped ? 'org' : null
       )
 
       pluginUuid = result.id
@@ -858,13 +908,21 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
     const auth = await getAuthenticatedUser(supabase, authHeader, apiKeyHeader, {
       allowApiKey: true,
       requiredScopes: ['publish'],
-      requiredPermission: PLUGIN_CREATE_PERMISSION,
     })
 
     if (!auth.ok) {
       return ctx.json({ success: false, error: auth.error }, auth.status)
     }
     const user = auth.user
+
+    // Refuse a caller with no publishing rights at all BEFORE the GitHub work below. The full
+    // decision needs the manifest (it is what says whether the plugin already exists, and so which
+    // organisation to authorise against), and reaching it costs several GitHub round trips plus a
+    // remote hash - not work to do on behalf of somebody who cannot publish anything anywhere.
+    const preflight = await preflightPublishAuthz(supabase, user)
+    if (preflight) {
+      return ctx.json({ success: false, error: preflight.error }, preflight.status)
+    }
 
     // Resolve the GitHub download URL for the JAR
     const parsed = parseGitHubUrl(body.githubUrl)
@@ -977,6 +1035,18 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
           error: 'Not authorized to publish to this plugin. You are not the owner.'
         }, 403)
       }
+
+      // May they publish a version of THIS plugin - gated on the organisation it is already
+      // recorded against, not on a fresh resolution of the caller's memberships.
+      const authz = await authorizeExistingPluginPublish(
+        supabase,
+        user,
+        await getPluginOrgId(supabase, existingPlugin.id)
+      )
+      if (!authz.ok) {
+        return ctx.json({ success: false, error: authz.error }, authz.status)
+      }
+
       pluginUuid = existingPlugin.id
 
       await updatePlugin(supabase, pluginUuid, {
@@ -991,12 +1061,11 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
       isNewPlugin = true
       const authorName = manifest.author || await getUserDisplayName(supabase, user.userId)
 
-      // Which organisation owns it. Resolved and AUTHORISED before any row is written: this
-      // handler runs as service role, so the `can_publish_org_plugin` WITH CHECK on `plugins` is
-      // bypassed and nothing else would refuse an organisation the caller has no rights in.
-      const orgResolution = await resolvePublishOrg(supabase, user, body.orgId)
-      if (!orgResolution.ok) {
-        return ctx.json({ success: false, error: orgResolution.error }, orgResolution.status)
+      // Which organisation owns it, and whether they may publish for it at all. The preflight
+      // above only established that they can publish SOMEWHERE.
+      const authz = await authorizeNewPluginPublish(supabase, user, body.orgId)
+      if (!authz.ok) {
+        return ctx.json({ success: false, error: authz.error }, authz.status)
       }
 
       const result = await createPlugin(
@@ -1011,7 +1080,9 @@ publish.openapi(publishFromGitHubMetadataRoute, async (ctx) => {
         ((manifest.type as string) || 'panel').toLowerCase(),
         manifest.apiVersion || '1.0.0',
         manifest.requiredPermissions || [],
-        orgResolution.orgId
+        authz.orgId,
+        // An organisation publishing for itself lands on its own shelf, not the global one.
+        authz.orgScoped ? 'org' : null
       )
       pluginUuid = result.id
     }

--- a/supabase/functions/plugin-store/services/plugins.ts
+++ b/supabase/functions/plugin-store/services/plugins.ts
@@ -175,6 +175,39 @@ export async function getPluginById(
 }
 
 /**
+ * The organisation a plugin already belongs to, by internal UUID.
+ *
+ * Its own one-column read rather than a field on `getPlugin`: that goes through the
+ * `get_plugin_with_stats` RPC, whose `RETURNS TABLE` cannot be `CREATE OR REPLACE`d - adding a
+ * column means a DROP, and 20260803000000_plugins_org_ownership.sql's header spells out why that
+ * is not something to do casually (the grants go with it, and the store browses anonymously).
+ *
+ * Null is a real answer: `plugins.org_id` is nullable, with `plugins_default_org` filling it in on
+ * INSERT. `authorizeExistingPluginPublish` treats null as "not an organisation you can claim",
+ * which is right in both directions - the trigger's answer for it would have been `@boss`.
+ *
+ * Throws on an unexpected failure rather than returning null, so an outage can never read as
+ * "belongs to no organisation" and widen a gate.
+ */
+export async function getPluginOrgId(
+  supabase: SupabaseClient,
+  id: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('plugins')
+    .select('org_id')
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    console.error('Error getting plugin organisation:', error)
+    throw new Error(`Failed to get plugin organisation: ${error.message}`)
+  }
+
+  return (data?.org_id as string | null) ?? null
+}
+
+/**
  * Create a new plugin
  */
 export async function createPlugin(
@@ -197,7 +230,17 @@ export async function createPlugin(
    * both become the boss organisation. Leaving the key out keeps that fallback visibly the
    * trigger's decision rather than looking like this function chose it.
    */
-  orgId: string | null = null
+  orgId: string | null = null,
+  /**
+   * Store visibility, or null to take the column default.
+   *
+   * OMITTED when null for the same reason as `org_id` above: `plugins.visibility` defaults to
+   * `'public'` and rule (3) of 20260803000000_plugins_org_ownership.sql says it must, because this
+   * function did not set it and any other default would have unpublished every new plugin. Passing
+   * `'org'` is how an org-scoped publish - one allowed by an organisation's own publish policy
+   * rather than by `plugins.create` - lands on that organisation's shelf instead of the global one.
+   */
+  visibility: 'public' | 'org' | 'unlisted' | null = null
 ): Promise<{ id: string }> {
   const { data, error } = await supabase
     .from('plugins')
@@ -213,7 +256,8 @@ export async function createPlugin(
       api_version: apiVersion,
       required_permissions: requiredPermissions,
       published: true,
-      ...(orgId ? { org_id: orgId } : {})
+      ...(orgId ? { org_id: orgId } : {}),
+      ...(visibility ? { visibility } : {})
     })
     .select('id')
     .single()

--- a/supabase/functions/plugin-store/services/publish-authz.ts
+++ b/supabase/functions/plugin-store/services/publish-authz.ts
@@ -77,11 +77,26 @@ export async function authorizeNewPluginPublish(
   requestedOrgId?: string | null,
 ): Promise<PublishAuthz> {
   const resolution = await resolvePublishOrg(supabase, user, requestedOrgId)
-  if (!resolution.ok) return resolution
 
+  // Rule 1 is decided BEFORE the resolver's refusal is honoured, and the order is the whole point.
+  // `resolvePublishOrg` refuses an "explicit" organisation the caller cannot publish for, and
+  // explicit includes the one an API KEY is bound to - so checking the permission afterwards let an
+  // organisation's publish_policy veto a global publisher, which is exactly what rule 1 says it
+  // cannot do. Observed live: `boss-nilesh-key` is bound to `@boss`, whose policy is `admins`, and
+  // its owner holds `plugins.create` but is not a boss org admin - so every first-ever publish of a
+  // new pluginId 403'd while existing plugins (which never resolve an org) kept working.
   if (await userHasPermission(supabase, user, PLUGIN_CREATE_PERMISSION)) {
-    return { ok: true, orgId: resolution.orgId, orgScoped: false }
+    if (resolution.ok) return { ok: true, orgId: resolution.orgId, orgScoped: false }
+    // An organisation the caller NAMED and cannot publish for stays a refusal even here: silently
+    // recording the plugin somewhere else than they asked is the failure this file already refuses
+    // to make for org publishers, and being unrestricted is not a reason to guess.
+    if (requestedOrgId?.trim()) return resolution
+    // An organisation inherited from the key is not a request. Fall back to the default and let
+    // `plugins_default_org` decide, which is what a global publisher got before this gate existed.
+    return { ok: true, orgId: null, orgScoped: false }
   }
+
+  if (!resolution.ok) return resolution
 
   if (resolution.orgId === null) {
     switch (resolution.source) {

--- a/supabase/functions/plugin-store/services/publish-authz.ts
+++ b/supabase/functions/plugin-store/services/publish-authz.ts
@@ -1,0 +1,179 @@
+/**
+ * May this caller publish at all, and if so, for whom?
+ *
+ * TWO WAYS TO BE ALLOWED, and keeping them apart is the whole point of this module:
+ *
+ *  1. `plugins.create` (or global admin). Unrestricted, the BOSS store included. This is what
+ *     `boss_plugin_admin` exists for and what every release API key uses; its behaviour here is
+ *     deliberately byte-identical to the `requiredPermission` gate this module replaced.
+ *
+ *  2. An organisation you may publish for. No global permission at all: the authority is the
+ *     organisation's own `publish_policy` / `publish_role_id`, evaluated by
+ *     `user_can_publish_org_plugin`. An org admin satisfies the default policy (`admins`), so an
+ *     approved organisation can ship plugins the day it is created instead of waiting for a
+ *     platform admin to grant `plugins.create`.
+ *
+ * THE SECOND PATH CAN NEVER REACH THE BOSS STORE, and that is structural rather than a permission
+ * check. `@boss` is `is_system`, and `nonSystemOrgIds` - the only list this module authorises
+ * against - drops system organisations. So the three ways a publish lands on `@boss` all refuse:
+ * naming it explicitly, naming nothing (the `plugins_default_org` trigger resolves null to boss),
+ * and a plugin whose recorded `org_id` is boss.
+ *
+ * Refusals name the reason. "You have no organisation", "your organisation's policy refuses you"
+ * and "that is the BOSS store" send the reader to three different places, and collapsing them into
+ * one "permission denied" is what made the previous gate unactionable for the people it caught.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { AuthResult } from "../utils/auth.ts"
+import { userHasPermission } from "../utils/auth.ts"
+import { PLUGIN_CREATE_PERMISSION } from "../utils/permissions.ts"
+import {
+  canPublishForOrg,
+  nonSystemOrgIds,
+  ORG_CHECK_UNAVAILABLE,
+  resolvePublishOrg,
+} from "./publish-org.ts"
+
+/**
+ * The outcome of the gate.
+ *
+ * `orgScoped` says WHICH path allowed it, and callers act on it: an org-scoped publish of a NEW
+ * plugin records `visibility = 'org'`, because a plugin an organisation published for itself
+ * belongs on that organisation's shelf, not on the global one. A `plugins.create` publish keeps the
+ * column default (`'public'`), which is what every existing publisher already gets.
+ */
+export type PublishAuthz =
+  | { ok: true; orgId: string | null; orgScoped: boolean }
+  | { ok: false; status: 403 | 500; error: string }
+
+const BOSS_STORE_REFUSAL =
+  `Publishing to the BOSS store requires the "${PLUGIN_CREATE_PERMISSION}" permission. ` +
+  "Name one of your own organisations to publish for instead."
+
+const POLICY_REFUSAL =
+  "Your organisation's publishing policy does not let you publish plugins for it. " +
+  "An organisation admin can change that in the Organisation panel."
+
+const NO_ORG_REFUSAL =
+  `Publishing requires either the "${PLUGIN_CREATE_PERMISSION}" permission or an organisation ` +
+  "you may publish for, and you belong to none."
+
+const AMBIGUOUS_ORG_REFUSAL =
+  "Name the organisation to publish for. You belong to more than one, and publishing without " +
+  `naming one goes to the BOSS store, which requires the "${PLUGIN_CREATE_PERMISSION}" permission.`
+
+/**
+ * Gate a NEW plugin, and decide which organisation owns it.
+ *
+ * Resolution comes first and the permission decision second, which is the reverse of the old
+ * order: the org-scoped path cannot be answered without knowing where the plugin would land.
+ * A caller holding `plugins.create` therefore takes exactly the resolution it always did,
+ * refusals included.
+ */
+export async function authorizeNewPluginPublish(
+  supabase: SupabaseClient,
+  user: AuthResult,
+  requestedOrgId?: string | null,
+): Promise<PublishAuthz> {
+  const resolution = await resolvePublishOrg(supabase, user, requestedOrgId)
+  if (!resolution.ok) return resolution
+
+  if (await userHasPermission(supabase, user, PLUGIN_CREATE_PERMISSION)) {
+    return { ok: true, orgId: resolution.orgId, orgScoped: false }
+  }
+
+  if (resolution.orgId === null) {
+    switch (resolution.source) {
+      case "unreadable":
+        return { ok: false, status: 500, error: ORG_CHECK_UNAVAILABLE }
+      case "policy_refused":
+        return { ok: false, status: 403, error: POLICY_REFUSAL }
+      case "many_orgs":
+        return { ok: false, status: 403, error: AMBIGUOUS_ORG_REFUSAL }
+      default:
+        return { ok: false, status: 403, error: NO_ORG_REFUSAL }
+    }
+  }
+
+  // A DERIVED organisation came out of `nonSystemOrgIds` already, so it is known to be the
+  // caller's and known not to be a system org. Only an explicitly named one still has to be
+  // checked - `user_can_publish_org_plugin` short-circuits true for a global admin and says
+  // nothing about `is_system`, so naming `@boss` would otherwise pass for anyone its own publish
+  // policy admits.
+  if (resolution.source === "explicit") {
+    const mine = await nonSystemOrgIds(supabase, user.userId)
+    if (mine === null) return { ok: false, status: 500, error: ORG_CHECK_UNAVAILABLE }
+    if (!mine.includes(resolution.orgId)) {
+      return { ok: false, status: 403, error: BOSS_STORE_REFUSAL }
+    }
+  }
+
+  return { ok: true, orgId: resolution.orgId, orgScoped: true }
+}
+
+/**
+ * A cheap "could this caller publish anything at all?" check, for routes that do expensive work
+ * before the owning organisation is even knowable.
+ *
+ * The GitHub publish routes fetch and hash a release JAR before they can read its manifest, and the
+ * manifest is what says whether the plugin already exists - so the real decision cannot happen
+ * until after the download. The permission gate this module replaced refused before it, and
+ * dropping that would let an authenticated caller with no publishing rights at all make the
+ * function pull arbitrary release archives. This restores the early refusal for exactly that case
+ * and decides nothing else: a caller who passes here is still fully authorised later, against the
+ * organisation the plugin actually lands in.
+ *
+ * Returns a refusal, or null to carry on.
+ */
+export async function preflightPublishAuthz(
+  supabase: SupabaseClient,
+  user: AuthResult,
+): Promise<{ status: 403 | 500; error: string } | null> {
+  if (await userHasPermission(supabase, user, PLUGIN_CREATE_PERMISSION)) return null
+
+  const mine = await nonSystemOrgIds(supabase, user.userId)
+  if (mine === null) return { status: 500, error: ORG_CHECK_UNAVAILABLE }
+  if (mine.length === 0) return { status: 403, error: NO_ORG_REFUSAL }
+  return null
+}
+
+/**
+ * Gate a new VERSION of a plugin that already exists.
+ *
+ * Gates on the organisation the plugin is RECORDED against, never a fresh resolution: ownership is
+ * a property of the plugin (see `resolvePublishOrg`'s own note), so re-deriving here would let a
+ * membership change move somebody else's plugin.
+ *
+ * Authorship is NOT checked here. Every route that calls this already refuses
+ * `plugin.authorId !== user.userId` before reaching it, for every caller including admins, and
+ * this deliberately does not widen that to "any admin of the owning organisation" - that is a
+ * separate product decision about co-maintainers.
+ */
+export async function authorizeExistingPluginPublish(
+  supabase: SupabaseClient,
+  user: AuthResult,
+  pluginOrgId: string | null,
+): Promise<PublishAuthz> {
+  if (await userHasPermission(supabase, user, PLUGIN_CREATE_PERMISSION)) {
+    return { ok: true, orgId: pluginOrgId, orgScoped: false }
+  }
+
+  // Null means the row predates `plugins_default_org` or was written around it; either way it is
+  // not an organisation this caller can claim, and the trigger's answer would have been `@boss`.
+  if (pluginOrgId === null) {
+    return { ok: false, status: 403, error: BOSS_STORE_REFUSAL }
+  }
+
+  const mine = await nonSystemOrgIds(supabase, user.userId)
+  if (mine === null) return { ok: false, status: 500, error: ORG_CHECK_UNAVAILABLE }
+  if (!mine.includes(pluginOrgId)) {
+    return { ok: false, status: 403, error: BOSS_STORE_REFUSAL }
+  }
+
+  const allowed = await canPublishForOrg(supabase, user.userId, pluginOrgId)
+  if (allowed === null) return { ok: false, status: 500, error: ORG_CHECK_UNAVAILABLE }
+  if (!allowed) return { ok: false, status: 403, error: POLICY_REFUSAL }
+
+  return { ok: true, orgId: pluginOrgId, orgScoped: true }
+}

--- a/supabase/functions/plugin-store/services/publish-org.ts
+++ b/supabase/functions/plugin-store/services/publish-org.ts
@@ -17,6 +17,9 @@
  * `user_can_publish_org_plugin` is that single source of truth - it evaluates `publish_role_id`
  * (which overrides) then `publish_policy`, and short-circuits true for a global admin. It is
  * deliberately not reimplemented in TypeScript.
+ *
+ * This module answers "which organisation, and may you publish for it". Whether you may publish
+ * AT ALL is services/publish-authz.ts, which layers the `plugins.create` / org-scoped rule on top.
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js"
@@ -37,10 +40,36 @@ export interface PublishingCaller {
   apiKeyOrgId?: string
 }
 
+/**
+ * How the organisation was arrived at.
+ *
+ * Carried because `orgId: null` means three different things and the org-scoped gate in
+ * publish-authz.ts has to tell them apart to refuse honestly: "you named nothing and have no single
+ * organisation to fall back on" and "your organisation's publish policy refuses you" send the
+ * reader to completely different places. Nothing in the pre-existing behaviour reads it.
+ */
+export type PublishOrgSource =
+  /** The caller named it, or their API key is bound to it. Authorised. */
+  | "explicit"
+  /** Their sole non-system organisation, authorised. */
+  | "derived"
+  /** Nothing named and the caller belongs to no non-system organisation. `orgId` is null. */
+  | "no_org"
+  /** Nothing named and more than one candidate, so there was nothing to derive. `orgId` is null. */
+  | "many_orgs"
+  /** A sole candidate existed and its publish policy refused them. `orgId` is null. */
+  | "policy_refused"
+  /** The membership list could not be read at all. `orgId` is null. */
+  | "unreadable"
+
 /** The organisation to record, or a refusal to hand back to the caller. */
 export type PublishOrgResolution =
-  | { ok: true; orgId: string | null }
+  | { ok: true; orgId: string | null; source: PublishOrgSource }
   | { ok: false; status: 403 | 500; error: string }
+
+/** The one wording for "we could not ask the database", shared by both gates. */
+export const ORG_CHECK_UNAVAILABLE =
+  "Could not verify your publishing rights for that organisation. Please try again."
 
 /**
  * Decide and authorise the owning organisation for a NEW plugin.
@@ -79,11 +108,7 @@ export async function resolvePublishOrg(
       // 500, not 503, because 503 is not in these routes' declared response set and widening
       // three OpenAPI definitions to express "transient" is not worth it. The message carries the
       // retry advice, which is the part the caller acts on.
-      return {
-        ok: false,
-        status: 500,
-        error: "Could not verify your publishing rights for that organisation. Please try again.",
-      }
+      return { ok: false, status: 500, error: ORG_CHECK_UNAVAILABLE }
     }
     if (!allowed) {
       return {
@@ -92,18 +117,21 @@ export async function resolvePublishOrg(
         error: "You do not have permission to publish plugins for that organisation.",
       }
     }
-    return { ok: true, orgId: explicit }
+    return { ok: true, orgId: explicit, source: "explicit" }
   }
 
-  const sole = await soleNonSystemOrg(supabase, user.userId)
-  if (!sole) return { ok: true, orgId: null }
+  const candidates = await nonSystemOrgIds(supabase, user.userId)
+  if (candidates === null) return { ok: true, orgId: null, source: "unreadable" }
+  if (candidates.length === 0) return { ok: true, orgId: null, source: "no_org" }
+  if (candidates.length > 1) return { ok: true, orgId: null, source: "many_orgs" }
+  const sole = candidates[0]
 
   // Authorised too, even though it was derived rather than named: membership alone is not
   // publishing rights. An organisation with publish_policy = 'owner_only' must not have every
   // member's plugins land on it.
   const allowed = await canPublishForOrg(supabase, user.userId, sole)
-  if (allowed !== true) return { ok: true, orgId: null }
-  return { ok: true, orgId: sole }
+  if (allowed !== true) return { ok: true, orgId: null, source: "policy_refused" }
+  return { ok: true, orgId: sole, source: "derived" }
 }
 
 /**
@@ -111,8 +139,11 @@ export async function resolvePublishOrg(
  *
  * Null is distinct from false on purpose: false is a decision, null is an outage, and the caller
  * treats them differently for an explicitly requested organisation.
+ *
+ * Exported for publish-authz.ts, which asks the same question about the organisation a plugin
+ * ALREADY belongs to - a path with no resolution to do.
  */
-async function canPublishForOrg(
+export async function canPublishForOrg(
   supabase: SupabaseClient,
   userId: string,
   orgId: string,
@@ -129,18 +160,24 @@ async function canPublishForOrg(
 }
 
 /**
- * The caller's only non-system organisation, or null when there is none or more than one.
+ * The caller's ACTIVE, NON-SYSTEM organisations, or null when the list could not be read.
  *
  * Read through `get_my_organisations(p_actor_id)` rather than the membership tables directly.
  * `p_actor_id` is the service_role-only impersonation parameter that exists for exactly this: the
  * function runs as service role, so `auth.uid()` is null and the RPC's default subject would be
  * nobody. Going through the RPC also means the definition of "my organisations" stays in one
  * place instead of being restated as a join here.
+ *
+ * System organisations are dropped here rather than by each caller, which is what makes this
+ * usable as the org-scoped gate's is_system test as well: an id absent from this list is either
+ * not the caller's or is `@boss`, and both must refuse. Null (unreadable) is NOT an empty list -
+ * the derivation treats it as "derive nothing" while the gate has to fail closed, so the
+ * distinction has to survive the return.
  */
-async function soleNonSystemOrg(
+export async function nonSystemOrgIds(
   supabase: SupabaseClient,
   userId: string,
-): Promise<string | null> {
+): Promise<string[] | null> {
   const { data, error } = await supabase.rpc("get_my_organisations", { p_actor_id: userId })
   if (error) {
     console.error("get_my_organisations failed while resolving a publish organisation:", error.message)
@@ -158,6 +195,5 @@ async function soleNonSystemOrg(
     .map((row) => (typeof row.id === "string" ? row.id : null))
     .filter((id): id is string => id !== null)
 
-  const unique = [...new Set(candidates)]
-  return unique.length === 1 ? unique[0] : null
+  return [...new Set(candidates)]
 }

--- a/supabase/functions/plugin-store/tests/auth-permissions.test.ts
+++ b/supabase/functions/plugin-store/tests/auth-permissions.test.ts
@@ -112,9 +112,17 @@ function stubSupabase(opts: StubOptions = {}): { client: SupabaseClient; calls: 
 
 // ---------------------------------------------------------------------------
 // Session (JWT) auth
+//
+// These exercise `getAuthenticatedUser`'s `requiredPermission` option, which is
+// the mechanism, not the publish policy. No route passes it today: publishing
+// moved to services/publish-authz.ts, where holding `plugins.create` is one of
+// TWO ways to be allowed (the other being an organisation whose publish policy
+// admits you). What is asserted here — a permission miss is 403 and not 401,
+// admins bypass, an API key is judged by its owner's live roles — is what that
+// module is built on top of, so it all still has to hold.
 // ---------------------------------------------------------------------------
 
-Deno.test("JWT holding plugins.create may publish", async () => {
+Deno.test("JWT holding plugins.create satisfies a requiredPermission gate", async () => {
   const { client } = stubSupabase()
   const token = jwt({ is_admin: false, user_permissions: ["plugins.create", "api_key.create"] })
 
@@ -132,7 +140,9 @@ Deno.test("JWT holding plugins.create may publish", async () => {
 Deno.test("JWT without plugins.create is 403, not 401", async () => {
   const { client } = stubSupabase()
   // A plain user: this is exactly what every authenticated caller could do
-  // before plugins.create existed.
+  // before plugins.create existed. On the publish path such a caller now gets a
+  // second chance through their organisation — see tests/publish-authz.test.ts —
+  // but the permission miss itself still has to read as 403.
   const token = jwt({ is_admin: false, user_permissions: ["user.read"] })
 
   const outcome = await getAuthenticatedUser(client, `Bearer ${token}`, undefined, {
@@ -192,7 +202,7 @@ Deno.test("no credentials is 401", async () => {
 // API-key auth — permissions come from the owner's roles, not a claim
 // ---------------------------------------------------------------------------
 
-Deno.test("API key publishes when its owner still holds plugins.create", async () => {
+Deno.test("API key auth resolves permissions from its OWNER, not from a claim", async () => {
   const { client, calls } = stubSupabase({ apiKey: { scopes: ["publish"] }, probe: true })
 
   const outcome = await getAuthenticatedUser(client, undefined, VALID_KEY, {
@@ -321,12 +331,19 @@ Deno.test("userHasPermission reads the claim for JWT callers without a round tri
 /**
  * The tests above prove the gate WORKS; these prove it is CONNECTED.
  *
- * Deleting `requiredPermission` from one of the five publish handlers leaves the
- * whole suite green and still type-checks (verified by mutation: 5 gates -> 4,
- * 15/15 passing) — the handlers are the only place the wiring exists, and there
- * is no HTTP harness here to exercise them. Reading the source is the cheap
- * guard; it costs one file read and catches the one edit most likely to reopen
- * publishing to every authenticated user.
+ * Deleting the gate from one of the five publish handlers leaves the whole suite
+ * green and still type-checks (verified by mutation: 5 gates -> 4, 15/15
+ * passing) — the handlers are the only place the wiring exists, and there is no
+ * HTTP harness here to exercise them. Reading the source is the cheap guard; it
+ * costs one file read and catches the one edit most likely to reopen publishing
+ * to every authenticated user.
+ *
+ * The gate used to be `requiredPermission: PLUGIN_CREATE_PERMISSION` on every
+ * handler. It is now one of the services/publish-authz.ts calls, because an
+ * organisation's own publish policy is a second way to be allowed and it cannot
+ * be evaluated before the owning organisation is known. So this asserts the
+ * INVARIANT — no publish handler without a gate — rather than one spelling of
+ * it, and accepts either.
  *
  * If these ever become awkward, replace them with real route tests — do not
  * simply delete them.
@@ -334,18 +351,37 @@ Deno.test("userHasPermission reads the claim for JWT callers without a round tri
 const routeSource = (name: string) =>
   Deno.readTextFileSync(new URL(`../routes/${name}`, import.meta.url))
 
-Deno.test("every publish handler passes requiredPermission to getAuthenticatedUser", () => {
+Deno.test("every publish handler gates on something", () => {
   const src = routeSource("publish.ts")
 
   const authCalls = src.match(/getAuthenticatedUser\(/g)?.length ?? 0
   assertEquals(authCalls, 5, "the five publishing handlers: publish, version, finalize, github, github/metadata")
 
-  const gated = src.match(/requiredPermission:\s*PLUGIN_CREATE_PERMISSION/g)?.length ?? 0
-  assertEquals(
-    gated,
-    authCalls,
-    "a getAuthenticatedUser call without requiredPermission is an ungated publish path",
-  )
+  // One segment per handler. The trailing createRoute definition each segment picks up cannot
+  // contain a gate, so it can only ever make this test stricter, never laxer.
+  const handlers = src.split("publish.openapi(").slice(1)
+  assertEquals(handlers.length, authCalls, "one openapi handler per getAuthenticatedUser call")
+
+  const GATES = [
+    "authorizeNewPluginPublish(",
+    "authorizeExistingPluginPublish(",
+    "preflightPublishAuthz(",
+    "requiredPermission:",
+  ]
+  handlers.forEach((handler, i) => {
+    assert(
+      GATES.some((gate) => handler.includes(gate)),
+      `publish handler #${i + 1} reaches a write with no authorization call - ` +
+        "every authenticated user can publish through it",
+    )
+  })
+
+  // The two GitHub handlers must refuse a caller with no publishing rights BEFORE they pull a
+  // release archive. Their real gate needs the manifest, which costs that download, so the
+  // preflight is the only thing standing between an authenticated non-publisher and making this
+  // function fetch arbitrary GitHub assets.
+  const preflights = src.match(/preflightPublishAuthz\(/g)?.length ?? 0
+  assertEquals(preflights, 2, "both GitHub publish handlers preflight before fetching")
 
   // Each handler must also surface the outcome's own status rather than a
   // hardcoded 401, or a 403 would be reported as "who are you?". Matched on the

--- a/supabase/functions/plugin-store/tests/publish-authz.test.ts
+++ b/supabase/functions/plugin-store/tests/publish-authz.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Who may publish, and the one thing they may not reach: the BOSS store.
+ *
+ * There are two ways to be allowed. `plugins.create` is unrestricted and unchanged - it is what
+ * `boss_plugin_admin` and every release API key use. The second is an organisation whose own
+ * `publish_policy` admits you, which exists so an approved organisation can ship plugins on day one
+ * instead of waiting for a platform admin to grant a global permission.
+ *
+ * THE REFUSALS ARE THE POINT. `@boss` is the system organisation every signup joins, so if the
+ * org-scoped path could reach it, "publish for your organisation" would silently mean "publish to
+ * the platform's own store" for every user in the system. There are three doors to it and each has
+ * its own test below: naming it, naming nothing (the `plugins_default_org` trigger resolves a null
+ * org to boss), and versioning a plugin already recorded against it.
+ */
+
+import { assert, assertEquals, assertFalse } from "@std/assert"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import {
+  authorizeExistingPluginPublish,
+  authorizeNewPluginPublish,
+  preflightPublishAuthz,
+} from "../services/publish-authz.ts"
+import type { PublishAuthz } from "../services/publish-authz.ts"
+import type { AuthResult } from "../utils/auth.ts"
+
+const USER = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const ORG_MINE = "11111111-1111-4111-8111-111111111111"
+const ORG_OTHER = "22222222-2222-4222-8222-222222222222"
+const ORG_BOSS = "33333333-3333-4333-8333-333333333333"
+
+interface StubOpts {
+  /** Answer for user_can_publish_org_plugin, per org id. An absent id answers false. */
+  canPublish?: Record<string, boolean>
+  /** Rows for get_my_organisations, in envelope `data` shape. */
+  orgs?: Array<Record<string, unknown>>
+  /** Answer for the user_has_permission probe (API-key callers, who carry no claim). */
+  probe?: boolean
+  /** RPC names that should return an error instead of data. */
+  failing?: string[]
+}
+
+function stub(opts: StubOpts = {}): { client: SupabaseClient; calls: string[] } {
+  const calls: string[] = []
+  const client = {
+    rpc: (fn: string, args: Record<string, unknown>) => {
+      calls.push(fn)
+      if (opts.failing?.includes(fn)) {
+        return Promise.resolve({ data: null, error: { message: "boom" } })
+      }
+      if (fn === "user_can_publish_org_plugin") {
+        return Promise.resolve({ data: opts.canPublish?.[args.p_org_id as string] === true, error: null })
+      }
+      if (fn === "get_my_organisations") {
+        return Promise.resolve({ data: { success: true, data: opts.orgs ?? [] }, error: null })
+      }
+      if (fn === "user_has_permission") {
+        return Promise.resolve({ data: opts.probe === true, error: null })
+      }
+      return Promise.resolve({ data: null, error: { message: `unexpected rpc ${fn}` } })
+    },
+  }
+  return { client: client as unknown as SupabaseClient, calls }
+}
+
+/** A signed-in caller. An empty claim list is a real answer, so no DB probe happens. */
+function user(extra: Partial<AuthResult> = {}): AuthResult {
+  return { userId: USER, email: "a@b.test", isAdmin: false, jwtPermissions: [], ...extra }
+}
+
+const creator = () => user({ jwtPermissions: ["plugins.create"] })
+
+/** An active, non-system membership row. */
+const member = (id: string) => ({ id, is_system: false, status: "active" })
+
+function allowed(result: PublishAuthz): { orgId: string | null; orgScoped: boolean } {
+  if (!result.ok) throw new Error(`expected success, got ${result.status}: ${result.error}`)
+  return { orgId: result.orgId, orgScoped: result.orgScoped }
+}
+
+function refused(result: PublishAuthz): { status: number; error: string } {
+  if (result.ok) throw new Error(`expected a refusal, got orgId=${result.orgId}`)
+  return { status: result.status, error: result.error }
+}
+
+// ---------------------------------------------------------------------------
+// plugins.create: unchanged in every direction
+// ---------------------------------------------------------------------------
+
+Deno.test("plugins.create still publishes to the BOSS store", async () => {
+  // The default resolution: nothing named, nothing derivable, so orgId is null and the
+  // plugins_default_org trigger records @boss. This is how every plugin in the store got there and
+  // it has to keep working - the release pipeline is this path.
+  const { client } = stub({ orgs: [] })
+  const result = await authorizeNewPluginPublish(client, creator())
+  assertEquals(allowed(result), { orgId: null, orgScoped: false })
+})
+
+Deno.test("plugins.create may name the system organisation explicitly", async () => {
+  const { client } = stub({ canPublish: { [ORG_BOSS]: true } })
+  const result = await authorizeNewPluginPublish(client, creator(), ORG_BOSS)
+  assertEquals(allowed(result), { orgId: ORG_BOSS, orgScoped: false })
+})
+
+Deno.test("a plugins.create publish for an organisation is still not org-scoped", async () => {
+  // orgScoped drives visibility, not attribution. Somebody holding the global permission who picks
+  // their organisation gets the column default ('public') exactly as they did before this gate
+  // existed; only the new path changes what lands in the store.
+  const { client } = stub({ canPublish: { [ORG_MINE]: true } })
+  const result = await authorizeNewPluginPublish(client, creator(), ORG_MINE)
+  assertEquals(allowed(result), { orgId: ORG_MINE, orgScoped: false })
+})
+
+Deno.test("an admin needs no permission and no organisation", async () => {
+  const { client, calls } = stub({ orgs: [] })
+  const result = await authorizeNewPluginPublish(client, user({ isAdmin: true }))
+  assertEquals(allowed(result).orgScoped, false)
+  assertFalse(calls.includes("user_has_permission"), "admin short-circuits before any probe")
+})
+
+// ---------------------------------------------------------------------------
+// The org-scoped path: allowed
+// ---------------------------------------------------------------------------
+
+Deno.test("an org admin with no plugins.create publishes for their own organisation", async () => {
+  // The whole point. publish_policy defaults to 'admins', so the founder of an approved
+  // organisation satisfies user_can_publish_org_plugin the day it is created.
+  const { client } = stub({ canPublish: { [ORG_MINE]: true }, orgs: [member(ORG_MINE)] })
+  const result = await authorizeNewPluginPublish(client, user(), ORG_MINE)
+  assertEquals(allowed(result), { orgId: ORG_MINE, orgScoped: true })
+})
+
+Deno.test("their sole organisation is derived when they name nothing", async () => {
+  const { client } = stub({
+    canPublish: { [ORG_MINE]: true },
+    // @boss is in everybody's list and must not count as the derived candidate.
+    orgs: [{ id: ORG_BOSS, is_system: true, status: "active" }, member(ORG_MINE)],
+  })
+  const result = await authorizeNewPluginPublish(client, user())
+  assertEquals(allowed(result), { orgId: ORG_MINE, orgScoped: true })
+})
+
+// ---------------------------------------------------------------------------
+// The org-scoped path: the BOSS store stays closed
+// ---------------------------------------------------------------------------
+
+Deno.test("naming the system organisation is refused even when its policy would admit them", async () => {
+  // THE test. user_can_publish_org_plugin says nothing about is_system - it evaluates membership
+  // and publish_policy, and every user is a member of @boss. So a 'members' policy there, or a
+  // publish_role_id everyone holds, would hand the platform's own store to everybody. Deleting the
+  // nonSystemOrgIds check in authorizeNewPluginPublish makes this the only failing test.
+  const { client } = stub({ canPublish: { [ORG_BOSS]: true }, orgs: [member(ORG_MINE)] })
+  const result = await authorizeNewPluginPublish(client, user(), ORG_BOSS)
+  assertEquals(refused(result).status, 403)
+  assert(refused(result).error.includes("plugins.create"), "the refusal names what would be needed")
+})
+
+Deno.test("naming an organisation they do not belong to is refused", async () => {
+  const { client } = stub({ canPublish: { [ORG_OTHER]: false }, orgs: [member(ORG_MINE)] })
+  assertEquals(refused(await authorizeNewPluginPublish(client, user(), ORG_OTHER)).status, 403)
+})
+
+Deno.test("belonging to two organisations and naming neither is refused, not defaulted", async () => {
+  // resolvePublishOrg deliberately derives nothing from two candidates, and for a plugins.create
+  // holder that means "let the trigger pick @boss". For an org-scoped caller the same silence would
+  // publish to the BOSS store, so it has to become an error that asks them to choose.
+  const { client } = stub({
+    canPublish: { [ORG_MINE]: true, [ORG_OTHER]: true },
+    orgs: [member(ORG_MINE), member(ORG_OTHER)],
+  })
+  const result = await authorizeNewPluginPublish(client, user())
+  assertEquals(refused(result).status, 403)
+  assert(refused(result).error.includes("Name the organisation"), "it says what to do about it")
+})
+
+Deno.test("belonging to no organisation is refused with the reason", async () => {
+  const { client } = stub({ orgs: [{ id: ORG_BOSS, is_system: true, status: "active" }] })
+  const result = await authorizeNewPluginPublish(client, user())
+  assertEquals(refused(result).status, 403)
+  assert(refused(result).error.includes("you belong to none"))
+})
+
+Deno.test("a sole organisation whose policy refuses them is refused, not defaulted to BOSS", async () => {
+  // publish_policy = 'owner_only' and they are not the owner. The pre-existing behaviour is to fall
+  // back to the default organisation, which for this caller would be the BOSS store - so the
+  // fallback has to become a refusal, and one that names the policy rather than the permission.
+  const { client } = stub({ canPublish: { [ORG_MINE]: false }, orgs: [member(ORG_MINE)] })
+  const result = await authorizeNewPluginPublish(client, user())
+  assertEquals(refused(result).status, 403)
+  assert(refused(result).error.includes("publishing policy"))
+})
+
+Deno.test("an unreadable membership list fails closed", async () => {
+  // Not "no organisations" (which would be a 403 telling them to join one) and above all not the
+  // BOSS default. An outage must not decide where a plugin lands.
+  const { client } = stub({ failing: ["get_my_organisations"] })
+  assertEquals(refused(await authorizeNewPluginPublish(client, user())).status, 500)
+})
+
+Deno.test("an unreadable membership list fails closed for a named organisation too", async () => {
+  const { client } = stub({ canPublish: { [ORG_MINE]: true }, failing: ["get_my_organisations"] })
+  assertEquals(refused(await authorizeNewPluginPublish(client, user(), ORG_MINE)).status, 500)
+})
+
+// ---------------------------------------------------------------------------
+// New versions of an existing plugin
+// ---------------------------------------------------------------------------
+
+Deno.test("an org publisher may version a plugin their organisation owns", async () => {
+  const { client } = stub({ canPublish: { [ORG_MINE]: true }, orgs: [member(ORG_MINE)] })
+  const result = await authorizeExistingPluginPublish(client, user(), ORG_MINE)
+  assertEquals(allowed(result), { orgId: ORG_MINE, orgScoped: true })
+})
+
+Deno.test("an org publisher may NOT version a plugin with no organisation", async () => {
+  // org_id is nullable and the trigger's answer for null is @boss, so treating null as "nobody owns
+  // it, go ahead" would be the BOSS store by another door.
+  const { client } = stub({ orgs: [member(ORG_MINE)] })
+  assertEquals(refused(await authorizeExistingPluginPublish(client, user(), null)).status, 403)
+})
+
+Deno.test("an org publisher may NOT version a plugin owned by another organisation", async () => {
+  const { client } = stub({ canPublish: { [ORG_OTHER]: true }, orgs: [member(ORG_MINE)] })
+  assertEquals(refused(await authorizeExistingPluginPublish(client, user(), ORG_OTHER)).status, 403)
+})
+
+Deno.test("an org publisher whose policy stopped admitting them may not version either", async () => {
+  // Membership is not publishing rights. The organisation switching to owner_only has to stop the
+  // next version, not only the next new plugin.
+  const { client } = stub({ canPublish: { [ORG_MINE]: false }, orgs: [member(ORG_MINE)] })
+  const result = await authorizeExistingPluginPublish(client, user(), ORG_MINE)
+  assertEquals(refused(result).status, 403)
+  assert(refused(result).error.includes("publishing policy"))
+})
+
+Deno.test("plugins.create versions any plugin it owns, boss-owned included", async () => {
+  const { client, calls } = stub({})
+  assertEquals(allowed(await authorizeExistingPluginPublish(client, creator(), null)).orgScoped, false)
+  assertFalse(calls.includes("get_my_organisations"), "no membership read is needed to decide")
+})
+
+Deno.test("an API key is judged by its owner's live roles", async () => {
+  // API-key auth carries no claim, so the permission is a DB probe against the OWNER - which is
+  // what makes a revoked role take effect immediately instead of at key expiry.
+  const withKey = user({ jwtPermissions: null, apiKeyOrgId: ORG_MINE })
+  const held = stub({ probe: true })
+  assertEquals(allowed(await authorizeExistingPluginPublish(held.client, withKey, ORG_MINE)).orgScoped, false)
+
+  // Same key, role gone. It falls through to the org path, and the organisation still admits it -
+  // a CI key bound to an organisation that may publish keeps working, now org-scoped.
+  const lost = stub({ probe: false, canPublish: { [ORG_MINE]: true }, orgs: [member(ORG_MINE)] })
+  assertEquals(allowed(await authorizeExistingPluginPublish(lost.client, withKey, ORG_MINE)).orgScoped, true)
+
+  // And with neither, it is refused.
+  const none = stub({ probe: false, canPublish: { [ORG_MINE]: false }, orgs: [member(ORG_MINE)] })
+  assertEquals(refused(await authorizeExistingPluginPublish(none.client, withKey, ORG_MINE)).status, 403)
+})
+
+// ---------------------------------------------------------------------------
+// The GitHub routes' preflight
+// ---------------------------------------------------------------------------
+
+Deno.test("preflight lets a plugins.create holder through without reading memberships", async () => {
+  const { client, calls } = stub({})
+  assertEquals(await preflightPublishAuthz(client, creator()), null)
+  assertFalse(calls.includes("get_my_organisations"))
+})
+
+Deno.test("preflight lets anyone with an organisation through, whatever its policy says", async () => {
+  // It must NOT evaluate publish_policy: the plugin may turn out to be an existing one owned by a
+  // different organisation of theirs. Deciding here would refuse publishes that are fine.
+  const { client } = stub({ orgs: [member(ORG_MINE)], canPublish: {} })
+  assertEquals(await preflightPublishAuthz(client, user()), null)
+})
+
+Deno.test("preflight refuses a caller with no rights before any GitHub work", async () => {
+  const { client } = stub({ orgs: [{ id: ORG_BOSS, is_system: true, status: "active" }] })
+  assertEquals((await preflightPublishAuthz(client, user()))?.status, 403)
+})
+
+Deno.test("preflight fails closed when memberships cannot be read", async () => {
+  const { client } = stub({ failing: ["get_my_organisations"] })
+  assertEquals((await preflightPublishAuthz(client, user()))?.status, 500)
+})

--- a/supabase/functions/plugin-store/tests/publish-authz.test.ts
+++ b/supabase/functions/plugin-store/tests/publish-authz.test.ts
@@ -67,7 +67,8 @@ function user(extra: Partial<AuthResult> = {}): AuthResult {
   return { userId: USER, email: "a@b.test", isAdmin: false, jwtPermissions: [], ...extra }
 }
 
-const creator = () => user({ jwtPermissions: ["plugins.create"] })
+const creator = (extra: Partial<AuthResult> = {}) =>
+  user({ jwtPermissions: ["plugins.create"], ...extra })
 
 /** An active, non-system membership row. */
 const member = (id: string) => ({ id, is_system: false, status: "active" })
@@ -93,6 +94,37 @@ Deno.test("plugins.create still publishes to the BOSS store", async () => {
   const { client } = stub({ orgs: [] })
   const result = await authorizeNewPluginPublish(client, creator())
   assertEquals(allowed(result), { orgId: null, orgScoped: false })
+})
+
+Deno.test("plugins.create is not vetoed by the organisation its API KEY is bound to", async () => {
+  // The regression this file did not cover. Every release key is bound to an organisation, and
+  // `resolvePublishOrg` treats that binding as "explicit" - so when the binding is an org whose
+  // publish_policy does not admit the key's owner, the resolver refuses. Rule 1 says a
+  // plugins.create holder is unrestricted, so the refusal must not reach them.
+  //
+  // Live shape: boss-nilesh-key is bound to @boss (policy `admins`); its owner holds
+  // plugins.create but is not a boss org admin. Before the fix this 403'd, which blocked the
+  // first-ever publish of EVERY new pluginId while existing plugins kept working.
+  const { client } = stub({ canPublish: { [ORG_BOSS]: false } })
+  const result = await authorizeNewPluginPublish(client, creator({ apiKeyOrgId: ORG_BOSS }))
+  assertEquals(allowed(result), { orgId: null, orgScoped: false })
+})
+
+Deno.test("plugins.create keeps the organisation its key is bound to when that org admits it", async () => {
+  // The other half: the binding is still honoured as attribution when it is not a refusal, so a
+  // key bound to an org it may publish for records that org rather than falling back to boss.
+  const { client } = stub({ canPublish: { [ORG_MINE]: true } })
+  const result = await authorizeNewPluginPublish(client, creator({ apiKeyOrgId: ORG_MINE }))
+  assertEquals(allowed(result), { orgId: ORG_MINE, orgScoped: false })
+})
+
+Deno.test("plugins.create naming an organisation it may not publish for is STILL refused", async () => {
+  // Deliberately not widened to "unrestricted means anything goes". Being told no about an org you
+  // NAMED must not silently record the plugin somewhere else - the same reasoning the org-scoped
+  // path already uses. The distinction is request vs. inherited-from-key, not permission level.
+  const { client } = stub({ canPublish: { [ORG_OTHER]: false } })
+  const result = await authorizeNewPluginPublish(client, creator(), ORG_OTHER)
+  assertEquals(refused(result).status, 403)
 })
 
 Deno.test("plugins.create may name the system organisation explicitly", async () => {

--- a/supabase/functions/plugin-store/utils/auth.ts
+++ b/supabase/functions/plugin-store/utils/auth.ts
@@ -50,6 +50,17 @@ export interface AuthOptions {
    * For API-key auth this is checked against the key owner's CURRENT roles, so
    * revoking a role stops that key immediately rather than at key expiry.
    */
+  /**
+   * A permission the caller must hold, checked after authentication.
+   *
+   * NO ROUTE PASSES THIS TODAY. The five publish handlers did, until publishing
+   * grew a second way to be allowed (an organisation whose own publish policy
+   * admits you), which cannot be evaluated before the owning organisation is
+   * known - so that decision moved to services/publish-authz.ts, which calls
+   * `userHasPermission` below directly. Kept because it is the right shape for
+   * any route whose answer really is one permission, and because dropping it
+   * would leave `userHasPermission`'s 403-not-401 contract untested.
+   */
   requiredPermission?: string
 }
 


### PR DESCRIPTION
An approved organisation cannot publish anything today, and there is no way for it to fix that itself.

Its admin role is seeded with `organisation.admin` + `organisation.read`. Publishing needs the global `plugins.create`, and no path leads from one to the other: `grant_organisation_role_permission` refuses a permission the granting admin does not hold, and the global `assign_permission_to_role` needs `role.update`, a domain `is_org_grantable_permission` denies to every organisation role. So every new organisation waits on a platform admin granting `boss_plugin_admin`.

## The rule

Two ways to be allowed, in the new `services/publish-authz.ts`:

- **`plugins.create` (or global admin)** - unrestricted, the BOSS store included. What `boss_plugin_admin` and every release API key use. Deliberately byte-identical to the `requiredPermission` gate it replaces.
- **An organisation whose own `publish_policy` / `publish_role_id` admits you** - evaluated by `user_can_publish_org_plugin`, no global permission involved. The default policy is `admins`, so a founder qualifies the day the organisation is approved.

No migration and no new permission: the organisation's own policy is the authority, and it already supports `owner_only` / `admins` / `members` plus a `publish_role_id` override, so delegating to members needs no grant either.

## Why the BOSS store stays closed, structurally

`user_can_publish_org_plugin` evaluates membership and `publish_policy` and says **nothing** about `is_system` - and every signup is a member of `@boss`. A `members` policy there, or a `publish_role_id` everyone holds, would hand the platform's own store to everybody.

So the gate authorises only against `nonSystemOrgIds`, which drops system organisations. All three doors refuse:

- naming `@boss` explicitly, even where its own policy would admit the caller
- naming nothing, which the `plugins_default_org` trigger resolves to boss
- versioning a plugin already recorded against it

## Supporting changes

- **`resolvePublishOrg` gained a `source` discriminator.** `orgId: null` meant three different things, and the org-scoped gate has to tell them apart: "you belong to no organisation", "your organisation's policy refuses you" and "that would be the BOSS store" send the reader to three different places.
- **Resolution now runs before the permission decision**, because the org-scoped answer depends on where the plugin would land. A `plugins.create` caller takes exactly the resolution it always did, refusals included.
- **An org-scoped publish records `visibility = 'org'`** rather than taking the column default, so an organisation's plugin lands on its own shelf; reaching the global one is a second, deliberate act through `set_plugin_visibility`. The `'public'` default is untouched, as rule (3) of `20260803000000_plugins_org_ownership.sql` requires.
- **The GitHub routes keep an early refusal.** Their real gate needs the manifest, which costs a release download, so `preflightPublishAuthz` turns away a caller with no publishing rights anywhere before any fetch happens.
- **`getPluginOrgId`** is its own one-column read: `get_plugin_with_stats` cannot gain a column without a DROP, and that migration's header spells out why that is not casual.

Authorship is untouched: every version route still refuses `plugin.author_id != caller`, admins included. Widening that to an organisation's other admins is a separate decision about co-maintainers.

## Testing

`deno test -A`: 58 passing. New `tests/publish-authz.test.ts` covers the allowed paths, all three BOSS doors, the ambiguous and empty membership cases, policy refusal, fail-closed on an unreadable membership list, the version paths, and the preflight.

Mutation-verified - each of these leaves the suite red:

| Mutation | Caught by |
|---|---|
| drop the `is_system` check on an explicitly named org | 2 tests |
| treat a null resolution as allowed | 4 tests |
| drop a preflight from a GitHub route | wiring test |
| drop the version-path gate | wiring test |

The wiring test that asserted `requiredPermission` on all five handlers now asserts the invariant instead - no publish handler without a gate - and accepts either spelling.

## Not in scope

- **CI publishing for org publishers.** Minting a key needs `api_key.create`, and `api_key` is a denied domain for organisation roles. One allowlist line plus a seed if we want it, and worth deciding on its own.
- **`set_plugin_visibility` still lets the owning organisation's admin set `'public'`**, so an organisation can reach the global shelf with no review. Tightening that is a change to that function.

## Deploy

`supabase functions deploy plugin-store --project-ref pcnwqamqdnsadranufjv --use-api --no-verify-jwt`. Pairs with risa-labs-inc/boss-plugin-plugin-manager#42, which shows the Create tab to org publishers; the server change is safe to deploy first (it only widens who may publish, and the client half is a tab those users cannot currently see).

Not smoke-tested live: that needs a `user`-role account with an approved organisation.