### PR TITLE
Stop a dead browser handle from freezing the app through the log path

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -10,6 +10,7 @@ import ai.rever.boss.components.plugin.panels.right_top.BrowserAccessor
 import ai.rever.boss.components.plugin.panels.right_top.storeSplitViewState
 import ai.rever.boss.components.plugin.providers.DashboardContentProviderImpl
 import ai.rever.boss.components.plugin.providers.DirectoryPickerProviderImpl
+import ai.rever.boss.components.plugin.providers.DisposableProvider
 import ai.rever.boss.components.plugin.providers.FileSystemDataProviderImpl
 import ai.rever.boss.components.plugin.providers.NavigationTargetProviderImpl
 import ai.rever.boss.components.plugin.providers.PanelEventProviderImpl
@@ -672,10 +673,14 @@ class DefaultPlugin(
         DefaultContextMenuProvider()
     }
 
-    // Log data provider for console plugin
-    override val logDataProvider: LogDataProvider by lazy {
-        createLogDataProvider()
-    }
+    // Log data provider for console plugin.
+    //
+    // The delegate is named so `dispose()` can ask whether it was ever created. Reading
+    // `logDataProvider` there would construct one - registering a listener on the
+    // process-wide log capture and starting its rebuild coroutine - purely in order to tear
+    // it down, on every window close in an app where nothing opened the console.
+    private val logDataProviderDelegate = lazy { createLogDataProvider() }
+    override val logDataProvider: LogDataProvider by logDataProviderDelegate
 
     // Plugin Store API key provider for secret manager and other plugins
     override val pluginStoreApiKeyProvider: PluginStoreApiKeyProvider by lazy {
@@ -940,6 +945,12 @@ class DefaultPlugin(
         runBlocking {
             dynamicPluginManager.disposeWindow()
             sandboxManager.dispose()
+        }
+        // Providers that registered themselves with a process-wide singleton, or that own a
+        // coroutine, do not go away with `pluginScope` - it is not their scope. Only the ones
+        // actually built: see [logDataProviderDelegate].
+        if (logDataProviderDelegate.isInitialized()) {
+            (logDataProvider as? DisposableProvider)?.dispose()
         }
         pluginScope.cancel()
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderFactory.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderFactory.kt
@@ -7,3 +7,19 @@ import ai.rever.boss.plugin.api.LogDataProvider
  * Desktop implementation returns LogDataProviderImpl which wraps GlobalLogCapture.
  */
 expect fun createLogDataProvider(): LogDataProvider
+
+/**
+ * A host-side provider that owns background work and must be released with its owner.
+ *
+ * Declared here rather than on `LogDataProvider` because that interface is part of
+ * `boss-plugin-api`: adding a member to it is an api release that every plugin's pinned
+ * version has to catch up with, for a lifecycle concern no plugin participates in. Plugins
+ * receive these providers already built and never dispose them.
+ *
+ * `DefaultPlugin` is created per window and its providers are created with it, so a provider
+ * holding a coroutine or a listener registration on a process-wide singleton outlives the
+ * window that made it unless something says otherwise. This is that something.
+ */
+interface DisposableProvider {
+    fun dispose()
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/panels/right_top/DesktopBrowserAccessor.kt
@@ -117,6 +117,31 @@ class DesktopBrowserIntegration(
 }
 
 /**
+ * The one candidate matching a tab's URL, reporting rather than hiding an ambiguity.
+ *
+ * Pure and separate from [findBrowserForTab] so it can be tested: the rest of that function
+ * needs a live SplitViewState and real JxBrowser handles, which is why none of it has ever had a
+ * test, and the selection is the part with actual logic in it.
+ *
+ * [onAmbiguous] is called with the match count when more than one candidate matches, and the
+ * first is still returned. Two tabs on one URL are genuinely indistinguishable here - nothing
+ * ties a browser handle to the tab that owns it, so this resolves by iteration order and can
+ * hand back the wrong tab. That is pre-existing and not fixable at this layer: closing it needs
+ * the tab id at browser-creation time, and `BrowserConfig` does not carry one. Reported rather
+ * than silently guessed, because the symptom otherwise is a plugin driving a page the user is
+ * not looking at, with nothing in the log to say so.
+ */
+internal fun <T> resolveSingleByUrl(
+    candidates: List<T>,
+    matches: (T) -> Boolean,
+    onAmbiguous: (Int) -> Unit,
+): T? {
+    val hits = candidates.filter(matches)
+    if (hits.size > 1) onAmbiguous(hits.size)
+    return hits.firstOrNull()
+}
+
+/**
  * Direct browser lookup function - returns thread-safe LockedBrowser wrapper
  */
 private fun findBrowserForTab(
@@ -208,10 +233,25 @@ private fun findBrowserForTab(
                     }
 
                 if (!tabUrl.isNullOrBlank()) {
+                    // Matched against each handle's navigation-fed URL, never a live read.
+                    // This used to call getCurrentUrl() per candidate, which is a blocking IPC
+                    // round trip into Chromium - so one lookup cost a round trip per open
+                    // browser, on a path panels poll, and a handle whose transport had gone
+                    // made each one a failure that had to fail first. See
+                    // BrowserHandleImpl.lastKnownUrl for why the cached value is the better
+                    // comparison and not merely the cheaper one.
                     val handle =
-                        BrowserServiceImpl.getActiveHandles().firstOrNull { h ->
-                            h.isValid && h.getCurrentUrl() == tabUrl
-                        }
+                        resolveSingleByUrl(
+                            candidates = BrowserServiceImpl.getActiveHandles(),
+                            matches = { it.isAtUrl(tabUrl) },
+                            onAmbiguous = { count ->
+                                browserAccessorLogger.warn(
+                                    LogCategory.BROWSER,
+                                    "Multiple browsers share this tab's URL - resolving by iteration order",
+                                    mapOf("tabId" to tabId, "candidates" to count.toString()),
+                                )
+                            },
+                        )
                     if (handle != null) {
                         return LockedBrowser(handle.getRawBrowser(), handle.getBrowserLock())
                     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderImpl.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin.providers
 
+import ai.rever.boss.logging.DesktopLogCapture
 import ai.rever.boss.logging.GlobalLogCapture
 import ai.rever.boss.logging.LogEntry
 import ai.rever.boss.logging.LogSource
@@ -7,9 +8,12 @@ import ai.rever.boss.plugin.api.LogDataProvider
 import ai.rever.boss.plugin.api.LogEntryData
 import ai.rever.boss.plugin.api.LogFilterData
 import ai.rever.boss.plugin.api.LogSourceData
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,10 +30,18 @@ import kotlinx.coroutines.launch
  *
  * The GlobalLogCapture singleton is started in main.kt at app startup,
  * so this provider has access to ALL logs from application start.
+ *
+ * The capture is process-wide; THIS is not. `DefaultPlugin` builds one per window, so each
+ * instance registers its own listener on that singleton and runs its own rebuild coroutine -
+ * hence [dispose], which `DefaultPlugin.dispose()` calls when its window goes away.
  */
-class LogDataProviderImpl : LogDataProvider {
-    // Access the main app's log capture singleton
-    private val logCapture = GlobalLogCapture.getLogCapture()
+class LogDataProviderImpl(
+    // Injectable so the coalescing can be tested. Defaults to the singleton the app runs on.
+    private val logCapture: DesktopLogCapture = GlobalLogCapture.getLogCapture(),
+    private val rebuildIntervalMs: Long = REBUILD_INTERVAL_MS,
+) : LogDataProvider,
+    DisposableProvider {
+    private val logger = BossLogger.forComponent("LogDataProviderImpl")
 
     // All logs (filtered by current filter and search)
     private val _logs = MutableStateFlow<List<LogEntryData>>(emptyList())
@@ -69,35 +81,78 @@ class LogDataProviderImpl : LogDataProvider {
     private val rebuildRequests = Channel<Unit>(Channel.CONFLATED)
 
     /**
-     * Not the caller's scope: this outlives any one window, and the provider is process-wide.
-     * Default rather than Main, because a rebuild must never run on the UI thread.
+     * Owned here, and cancelled by [dispose].
+     *
+     * Default rather than Main, because a rebuild must never run on the UI thread. NOT tied to
+     * a caller's scope, but not immortal either: `DefaultPlugin` is created per window, so this
+     * provider is too, and a `while (true)` consumer left running would mean every window ever
+     * opened still rebuilding the log list with nobody observing it.
      */
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    /** Held so [dispose] can unregister it - listeners are compared by identity. */
+    private val listener: (LogEntry) -> Unit = { rebuildRequests.trySend(Unit) }
 
     init {
         scope.launch {
             while (true) {
                 rebuildRequests.receive()
-                updateLogs()
+                // Guarded because this is the only consumer: an exception here would end the
+                // coroutine and the panel would silently stop updating for the rest of the
+                // session. SupervisorJob does not help - it is the same coroutine.
+                //
+                // Generic on purpose: the point is that no rebuild failure, of any kind, may
+                // take the consumer with it. Nothing here has a specific recoverable failure
+                // worth naming - it is a copy, a filter and a map.
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    updateLogs()
+                } catch (e: Exception) {
+                    logger.warn(LogCategory.SYSTEM, "Log list rebuild failed", error = e)
+                }
                 // Floor between rebuilds. A steady stream of output would otherwise still
                 // rebuild per line, since CONFLATED only merges what arrives while busy.
-                delay(REBUILD_INTERVAL_MS)
+                delay(rebuildIntervalMs)
             }
         }
 
         // Listen for new log entries. Must stay O(1) - see [rebuildRequests].
-        logCapture.addListener { _ ->
-            rebuildRequests.trySend(Unit)
-        }
+        logCapture.addListener(listener)
 
         // Initial load (will load all logs from app startup)
         updateLogs()
     }
 
     /**
+     * Stop rebuilding and stop listening.
+     *
+     * Both halves matter: cancelling the scope alone leaves a listener on the process-wide
+     * capture that keeps calling `trySend` on a channel nobody reads, and unregistering alone
+     * leaves the consumer parked forever on `receive`.
+     */
+    override fun dispose() {
+        logCapture.removeListener(listener)
+        scope.cancel()
+    }
+
+    /**
+     * Rebuilds performed since construction.
+     *
+     * A test seam, and the only workable one: the thing worth asserting is "one captured line
+     * does not cost one rebuild", and neither sampling `logs.value` nor collecting it can
+     * measure that. `StateFlow` conflates, so a collector is not shown every value, and a
+     * poller cannot count 2000 rebuilds that all happen inside a millisecond - a first version
+     * of the test did exactly that and passed against the per-line rebuild it was written for.
+     */
+    @Volatile
+    internal var rebuildCount: Int = 0
+        private set
+
+    /**
      * Update filtered logs based on current filter and search.
      */
     private fun updateLogs() {
+        rebuildCount++
         val allLogs = logCapture.getLogs()
 
         // Apply filter
@@ -122,14 +177,20 @@ class LogDataProviderImpl : LogDataProvider {
         _logs.value = searched.map { convertToLogEntryData(it) }
     }
 
+    // The setters below request a rebuild rather than performing one. Every write to
+    // `_logs.value` then comes from the single consumer coroutine, which is what keeps a
+    // background rebuild from landing after a filter change and repainting the previous
+    // filter's contents - with nothing to correct it until the next log line, which in a
+    // quiet app may never come.
+
     override fun setFilter(filter: LogFilterData) {
         _filter.value = filter
-        updateLogs()
+        rebuildRequests.trySend(Unit)
     }
 
     override fun setSearchQuery(query: String) {
         _searchQuery.value = query
-        updateLogs()
+        rebuildRequests.trySend(Unit)
     }
 
     override fun toggleAutoScroll() {
@@ -138,7 +199,7 @@ class LogDataProviderImpl : LogDataProvider {
 
     override fun clearLogs() {
         logCapture.clear()
-        updateLogs()
+        rebuildRequests.trySend(Unit)
     }
 
     override fun exportLogs(): String =

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderImpl.kt
@@ -7,9 +7,15 @@ import ai.rever.boss.plugin.api.LogDataProvider
 import ai.rever.boss.plugin.api.LogEntryData
 import ai.rever.boss.plugin.api.LogFilterData
 import ai.rever.boss.plugin.api.LogSourceData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 /**
  * Implementation of LogDataProvider that wraps GlobalLogCapture.
@@ -41,10 +47,47 @@ class LogDataProviderImpl : LogDataProvider {
     private val _autoScroll = MutableStateFlow(true)
     override val autoScroll: StateFlow<Boolean> = _autoScroll.asStateFlow()
 
+    /**
+     * Coalesces rebuild requests instead of rebuilding once per captured line.
+     *
+     * [updateLogs] is O(buffered lines): it copies the whole capture buffer, filters it, and
+     * allocates a `LogEntryData` for every entry. It used to run **synchronously from the log
+     * listener**, which `DesktopLogCapture` invokes from inside `PrintStream.write` - so each
+     * line of output rebuilt a list of up to 10,000 entries while holding the `System.out`
+     * monitor, and every other thread that wanted to log waited behind it.
+     *
+     * That made log volume self-amplifying. One 30-frame stack trace is ~30 captured lines, so a
+     * component logging a trace a few times a second had the app allocating hundreds of thousands
+     * of objects per second and serialising every logging thread in the process - including the
+     * UI thread - against a queue full of its own output. A repeating exception anywhere could
+     * therefore freeze the whole app, which is what a dead browser handle did in practice.
+     *
+     * CONFLATED, so a burst collapses to one rebuild: the panel wants the latest snapshot, never
+     * the intermediate ones. `trySend` from the listener cannot block or fail on a full buffer,
+     * which keeps the write path O(1) whatever the consumer is doing.
+     */
+    private val rebuildRequests = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Not the caller's scope: this outlives any one window, and the provider is process-wide.
+     * Default rather than Main, because a rebuild must never run on the UI thread.
+     */
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
     init {
-        // Listen for new log entries
+        scope.launch {
+            while (true) {
+                rebuildRequests.receive()
+                updateLogs()
+                // Floor between rebuilds. A steady stream of output would otherwise still
+                // rebuild per line, since CONFLATED only merges what arrives while busy.
+                delay(REBUILD_INTERVAL_MS)
+            }
+        }
+
+        // Listen for new log entries. Must stay O(1) - see [rebuildRequests].
         logCapture.addListener { _ ->
-            updateLogs()
+            rebuildRequests.trySend(Unit)
         }
 
         // Initial load (will load all logs from app startup)
@@ -116,4 +159,9 @@ class LogDataProviderImpl : LogDataProvider {
                     LogSource.STDERR -> LogSourceData.STDERR
                 },
         )
+
+    private companion object {
+        /** Minimum gap between log-list rebuilds while output keeps arriving. */
+        const val REBUILD_INTERVAL_MS = 150L
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/logging/DesktopLogCapture.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/logging/DesktopLogCapture.kt
@@ -41,7 +41,15 @@ class DesktopLogCapture {
     /**
      * Appends one captured line, trimming to [MAX_BUFFERED_LINES], then notifies listeners.
      *
-     * Both tee streams funnel through here so the count and the queue cannot drift apart.
+     * Both tee streams funnel through here so there is one place the count is maintained.
+     *
+     * The count can still drift from the queue by a little, and deliberately is not locked
+     * against it: an `add` landing between [clear]'s `buffer.clear()` and its `set(0)`
+     * understates by one, and a `record` that polls before a concurrent `clear` and decrements
+     * after can go momentarily negative. Both are bounded and self-correcting - the visible
+     * effect is the buffer sitting a few lines either side of the cap, which is what a cap on a
+     * debug log buffer is for. Locking the two together would put a mutex on the path every
+     * `println` in the process takes, which is the cost this whole change exists to remove.
      */
     private fun record(entry: LogEntry) {
         buffer.add(entry)
@@ -125,6 +133,17 @@ class DesktopLogCapture {
             listeners.remove(listener)
         }
     }
+
+    /**
+     * How many listeners are registered.
+     *
+     * A test seam. A provider that fails to unregister on dispose leaks silently: the leak is
+     * invisible through the provider's own state, because a cancelled consumer publishes
+     * nothing whether or not the listener is still attached. This is the only place the
+     * difference shows.
+     */
+    internal val listenerCount: Int
+        get() = synchronized(listeners) { listeners.size }
 
     /**
      * Notify all listeners of a new log entry.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/logging/DesktopLogCapture.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/logging/DesktopLogCapture.kt
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.io.PrintStream
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Desktop-specific log capture system.
@@ -20,6 +21,38 @@ class DesktopLogCapture {
 
     // Thread-safe buffer for captured logs (circular buffer implemented via pruning)
     private val buffer = ConcurrentLinkedQueue<LogEntry>()
+
+    /**
+     * Tracks [buffer]'s length so trimming never has to ask the queue for it.
+     *
+     * `ConcurrentLinkedQueue.size()` is O(n) by contract - it walks the list - and the trim that
+     * used it ran once per captured line, re-reading `size` on each iteration of its own loop. At
+     * the 10k cap that is a 10,000-node walk per line of output, paid on whichever thread did the
+     * logging while it held the `System.out` monitor (the tee runs inside `PrintStream.write`).
+     * Every other thread that wanted to log then queued behind it, so a burst of output from one
+     * component stalled threads with nothing to do with logging.
+     *
+     * Kept beside [buffer] rather than inside the tee because [clear] empties the queue, and a
+     * count owned by the tee would have been left overstated - which would have made the next
+     * writes trim a nearly empty buffer.
+     */
+    private val bufferedLines = AtomicInteger(0)
+
+    /**
+     * Appends one captured line, trimming to [MAX_BUFFERED_LINES], then notifies listeners.
+     *
+     * Both tee streams funnel through here so the count and the queue cannot drift apart.
+     */
+    private fun record(entry: LogEntry) {
+        buffer.add(entry)
+        var count = bufferedLines.incrementAndGet()
+        while (count > MAX_BUFFERED_LINES) {
+            // Queue already drained by a concurrent clear(): that resets the count, so stop.
+            if (buffer.poll() == null) break
+            count = bufferedLines.decrementAndGet()
+        }
+        notifyListeners(entry)
+    }
 
     // Listeners for new log entries
     private val listeners = mutableListOf<(LogEntry) -> Unit>()
@@ -37,8 +70,8 @@ class DesktopLogCapture {
         isCapturing = true
 
         // Create tee streams that write to both original stream and our buffer
-        val teeOut = TeeOutputStream(originalOut, buffer, LogSource.STDOUT, ::notifyListeners)
-        val teeErr = TeeOutputStream(originalErr, buffer, LogSource.STDERR, ::notifyListeners)
+        val teeOut = TeeOutputStream(originalOut, LogSource.STDOUT, ::record)
+        val teeErr = TeeOutputStream(originalErr, LogSource.STDERR, ::record)
 
         // Replace System streams
         System.setOut(PrintStream(teeOut, true, Charsets.UTF_8))
@@ -71,6 +104,7 @@ class DesktopLogCapture {
      */
     fun clear() {
         buffer.clear()
+        bufferedLines.set(0)
         logger.debug(LogCategory.SYSTEM, "Log buffer cleared")
     }
 
@@ -109,7 +143,6 @@ class DesktopLogCapture {
      */
     private class TeeOutputStream(
         private val originalStream: PrintStream,
-        private val buffer: ConcurrentLinkedQueue<LogEntry>,
         private val source: LogSource,
         private val onNewEntry: (LogEntry) -> Unit,
     ) : OutputStream() {
@@ -133,14 +166,8 @@ class DesktopLogCapture {
                             source = source,
                         )
 
-                    buffer.add(entry)
-
-                    // Prune old entries if over limit
-                    while (buffer.size > 10000) {
-                        buffer.poll()
-                    }
-
-                    // Notify listeners
+                    // Buffering, trimming and listener notification all live in
+                    // DesktopLogCapture.record so the queue and its counter stay in step.
                     onNewEntry(entry)
                 }
                 lineBuffer.reset()
@@ -157,5 +184,10 @@ class DesktopLogCapture {
         override fun close() {
             originalStream.close()
         }
+    }
+
+    private companion object {
+        /** Captured lines retained; oldest are dropped past this. */
+        const val MAX_BUFFERED_LINES = 10000
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
+import com.teamdev.jxbrowser.ObjectClosedException
 import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback
 import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback
@@ -267,6 +268,28 @@ internal class BrowserHandleImpl(
         )
 
     private val disposed = AtomicBoolean(false)
+
+    /**
+     * Latched when a synchronous RPC through this browser fails because its transport is gone.
+     *
+     * [isValid]'s generation clause covers a browser outliving *its engine*. It cannot see the
+     * other way a browser's IPC dies: this browser's own connection closing while the engine
+     * generation still matches - a renderer going away, a page calling `window.close()`, or a
+     * plugin disposing the browser behind its own handle. In that state `isClosed` still answers
+     * `false` (nothing arrived to mark it) and the generation still matches, so [isValid]
+     * answered `true` for a browser every call through which throws.
+     *
+     * That made the handle uncollectable: [BrowserServiceImpl.reconcileOrphanedBrowsers] prunes
+     * on `!isValid`, so a handle that can never be valid again was also never pruned, and stayed
+     * in `getActiveHandles()` for the rest of the session. Any scan over those handles then paid
+     * a failing round trip per zombie and, because these accessors threw, aborted at the first
+     * one - so the scan could never reach a live browser again either.
+     *
+     * Latched rather than probed: the condition is terminal (a closed connection is never
+     * reopened - a new browser gets a new handle), and probing would mean spending the failing
+     * round trip this exists to avoid.
+     */
+    private val connectionDead = AtomicBoolean(false)
 
     /**
      * Whether [Content] has ever been composed for this handle.
@@ -1984,8 +2007,63 @@ internal class BrowserHandleImpl(
     override val isValid: Boolean
         get() =
             !disposed.get() &&
+                !connectionDead.get() &&
                 FluckEngine.currentEngineGeneration == engineGeneration &&
                 runCatching { !browser.isClosed }.getOrDefault(false)
+
+    /**
+     * Runs a synchronous JxBrowser accessor, returning [fallback] instead of throwing.
+     *
+     * Every sync accessor here is an IPC round trip that can fail at any moment, and they are
+     * called from plugin code and from scans over [BrowserServiceImpl.getActiveHandles] - an
+     * `if (isValid)` guard cannot make them safe, because the connection can die between the
+     * check and the call. A throw out of one of these is what turned a single dead browser into
+     * a permanently broken lookup, so they report failure by value like the rest of this class.
+     *
+     * A transport failure also latches [connectionDead], which is what lets the handle be pruned.
+     * The log stays at debug: the whole point is that this path can repeat on a hot caller, and
+     * it was a WARN-with-stack-trace per failure that flooded the console buffer.
+     */
+    private fun <T> syncCall(
+        op: String,
+        fallback: T,
+        block: () -> T,
+    ): T {
+        if (!isValid) return fallback
+        return try {
+            block()
+        } catch (e: Exception) {
+            if (isTransportFailure(e)) connectionDead.set(true)
+            logger.debug(
+                LogCategory.BROWSER,
+                "Browser sync call failed",
+                mapOf("handleId" to id, "op" to op, "error" to (e.message ?: e.javaClass.simpleName)),
+            )
+            fallback
+        }
+    }
+
+    /**
+     * Whether [e] means "this browser's IPC is gone" rather than "this one call failed".
+     *
+     * JxBrowser surfaces a closed transport as a plain [IllegalStateException] carrying
+     * "The connection has been closed." / "Failed to receive the response.", and a closed object
+     * as `ObjectClosedException`. Matched on the exception chain because the transport error
+     * arrives as the `cause` of the call-site failure. Anything unrecognised is treated as a
+     * transient call failure, so a new message shape costs a retry rather than a wrongly
+     * discarded live browser.
+     */
+    private fun isTransportFailure(e: Throwable): Boolean =
+        generateSequence(e) { prev -> prev.cause?.takeIf { it !== prev } }
+            // Bounded: a cause cycle longer than self-reference would otherwise not terminate.
+            .take(MAX_CAUSE_DEPTH)
+            .any { cause ->
+                cause is ObjectClosedException ||
+                    (cause.message ?: "").let {
+                        it.contains("connection has been closed", ignoreCase = true) ||
+                            it.contains("Failed to receive the response", ignoreCase = true)
+                    }
+            }
 
     override suspend fun loadUrl(url: String) {
         if (!isValid) {
@@ -2032,15 +2110,9 @@ internal class BrowserHandleImpl(
         }
     }
 
-    override fun getCurrentUrl(): String {
-        if (!isValid) return ""
-        return browser.url()
-    }
+    override fun getCurrentUrl(): String = syncCall("url", "") { browser.url() }
 
-    override fun getTitle(): String {
-        if (!isValid) return ""
-        return browser.title()
-    }
+    override fun getTitle(): String = syncCall("title", "") { browser.title() }
 
     override fun addNavigationListener(listener: (String) -> Unit) {
         navigationListeners.add(listener)
@@ -2093,18 +2165,15 @@ internal class BrowserHandleImpl(
         }
     }
 
-    override fun canGoBack(): Boolean = isValid && browser.navigation().canGoBack()
+    override fun canGoBack(): Boolean = syncCall("canGoBack", false) { browser.navigation().canGoBack() }
 
-    override fun canGoForward(): Boolean = isValid && browser.navigation().canGoForward()
+    override fun canGoForward(): Boolean = syncCall("canGoForward", false) { browser.navigation().canGoForward() }
 
     // ============================================================
     // ZOOM CONTROLS
     // ============================================================
 
-    override fun getZoomLevel(): Double {
-        if (!isValid) return 1.0
-        return browser.zoom().level().value()
-    }
+    override fun getZoomLevel(): Double = syncCall("zoomLevel", 1.0) { browser.zoom().level().value() }
 
     override fun setZoomLevel(level: Double) {
         if (!isValid) return
@@ -3174,6 +3243,9 @@ internal class BrowserHandleImpl(
     )
 
     companion object {
+        /** Cause-chain depth [isTransportFailure] inspects before giving up. */
+        private const val MAX_CAUSE_DEPTH = 16
+
         /**
          * Popup browsers we are currently waiting to capture an upload body for.
          * Populated by the popup handler before [BeforeSendUploadDataCallback] fires;

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -260,6 +260,35 @@ internal class BrowserHandleImpl(
      */
     @Volatile private var lastCommittedMainFrameUrl: String = ""
 
+    /**
+     * Whether this handle's page is [url], without asking Chromium.
+     *
+     * Built on [lastCommittedMainFrameUrl] rather than on a second field of its own: main added
+     * that one for the page-event bridge while this was in review, for the same reason - reading
+     * a field instead of betting on whether `Browser.url()` is a synchronous round trip - and two
+     * volatiles tracking one value is how they drift.
+     *
+     * Exists so a handle can be matched against a tab's URL without an IPC round trip.
+     * `DesktopBrowserAccessor.findBrowserForTab` resolves a dynamic plugin's browser tab by
+     * scanning every active handle for the one whose URL equals the tab's, and it used to read
+     * each candidate's `getCurrentUrl()` - a blocking call into Chromium per handle, on a path a
+     * panel can poll. With a dozen tabs open that was a dozen round trips per lookup, and a
+     * handle whose transport had gone made each one a failure that had to fail first.
+     *
+     * The comparison is sound because the field is fed from the same `NavigationFinished`
+     * main-frame branch that notifies [navigationListeners], which is where the plugin's own tab
+     * state gets its URL from: both sides now come from one event, rather than a tracked value on
+     * one side and a live read on the other. Same-document navigations reach that branch too, so
+     * an SPA route change is reflected.
+     *
+     * Falls back to the creation URL while the field is still blank, so a browser that has not
+     * navigated yet is matchable. Deliberately not an exposed getter - a caller holding the
+     * string would be tempted to read live when it looked stale, which is the round trip this
+     * removes - and deliberately NOT the `browser.url()` fallback [lastCommittedMainFrameUrl]'s
+     * other reader uses, since that is the round trip.
+     */
+    internal fun isAtUrl(url: String): Boolean = lastCommittedMainFrameUrl.ifBlank { config.url } == url
+
     /** Receives in-page interaction batches, attributed to the page that is actually loaded. */
     private val interactionBridge =
         BrowserInteractionBridge(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -2046,12 +2046,23 @@ internal class BrowserHandleImpl(
     /**
      * Whether [e] means "this browser's IPC is gone" rather than "this one call failed".
      *
-     * JxBrowser surfaces a closed transport as a plain [IllegalStateException] carrying
-     * "The connection has been closed." / "Failed to receive the response.", and a closed object
-     * as `ObjectClosedException`. Matched on the exception chain because the transport error
-     * arrives as the `cause` of the call-site failure. Anything unrecognised is treated as a
-     * transient call failure, so a new message shape costs a retry rather than a wrongly
-     * discarded live browser.
+     * Only two things are treated as terminal: `ObjectClosedException`, and an
+     * [IllegalStateException] carrying "The connection has been closed." - both of which say
+     * the transport itself is gone, and a closed connection is never reopened.
+     *
+     * Deliberately NOT "Failed to receive the response.", even though that is the message on
+     * the exception this was written for. It describes a round trip that did not come back,
+     * which is also what a live-but-wedged renderer produces - see the frame-stall probe above,
+     * which exists because `executeJavaScript` can block indefinitely against a page that is
+     * still alive. Latching on it would let one slow round trip permanently invalidate a
+     * healthy browser: every navigation and zoom call silently refusing on a tab that renders
+     * fine, which is a worse bug than the one this fixes.
+     *
+     * Nothing is lost by excluding it, because the chain is what is matched, not the top
+     * message: the observed failures arrived as "Failed to receive the response." with
+     * "The connection has been closed." as their `cause`, so the terminal reason is still
+     * found. Anything unrecognised counts as a transient call failure - a new message shape
+     * costs a retry rather than a wrongly discarded live browser.
      */
     private fun isTransportFailure(e: Throwable): Boolean =
         generateSequence(e) { prev -> prev.cause?.takeIf { it !== prev } }
@@ -2059,10 +2070,7 @@ internal class BrowserHandleImpl(
             .take(MAX_CAUSE_DEPTH)
             .any { cause ->
                 cause is ObjectClosedException ||
-                    (cause.message ?: "").let {
-                        it.contains("connection has been closed", ignoreCase = true) ||
-                            it.contains("Failed to receive the response", ignoreCase = true)
-                    }
+                    (cause.message ?: "").contains("connection has been closed", ignoreCase = true)
             }
 
     override suspend fun loadUrl(url: String) {
@@ -2139,31 +2147,29 @@ internal class BrowserHandleImpl(
     }
 
     override fun goBack() {
-        if (isValid && browser.navigation().canGoBack()) {
+        if (!canGoBack()) return
+        syncCall("goBack", Unit) {
             visitTracker.expect(BrowserNavigationType.BACK_FORWARD)
             browser.navigation().goBack()
         }
     }
 
     override fun goForward() {
-        if (isValid && browser.navigation().canGoForward()) {
+        if (!canGoForward()) return
+        syncCall("goForward", Unit) {
             visitTracker.expect(BrowserNavigationType.BACK_FORWARD)
             browser.navigation().goForward()
         }
     }
 
     override fun reload() {
-        if (isValid) {
+        syncCall("reload", Unit) {
             visitTracker.expect(BrowserNavigationType.RELOAD)
             browser.navigation().reload()
         }
     }
 
-    override fun stop() {
-        if (isValid) {
-            browser.navigation().stop()
-        }
-    }
+    override fun stop() = syncCall("stop", Unit) { browser.navigation().stop() }
 
     override fun canGoBack(): Boolean = syncCall("canGoBack", false) { browser.navigation().canGoBack() }
 
@@ -2176,26 +2182,22 @@ internal class BrowserHandleImpl(
     override fun getZoomLevel(): Double = syncCall("zoomLevel", 1.0) { browser.zoom().level().value() }
 
     override fun setZoomLevel(level: Double) {
-        if (!isValid) return
-        browser.zoom().level(ZoomLevel.of(level))
+        syncCall("setZoomLevel", Unit) { browser.zoom().level(ZoomLevel.of(level)) }
         notifyZoomListeners()
     }
 
     override fun zoomIn() {
-        if (!isValid) return
-        browser.zoom().`in`()
+        syncCall("zoomIn", Unit) { browser.zoom().`in`() }
         notifyZoomListeners()
     }
 
     override fun zoomOut() {
-        if (!isValid) return
-        browser.zoom().out()
+        syncCall("zoomOut", Unit) { browser.zoom().out() }
         notifyZoomListeners()
     }
 
     override fun resetZoom() {
-        if (!isValid) return
-        browser.zoom().reset()
+        syncCall("resetZoom", Unit) { browser.zoom().reset() }
         notifyZoomListeners()
     }
 
@@ -2237,8 +2239,10 @@ internal class BrowserHandleImpl(
     // ============================================================
 
     override fun isSecure(): Boolean {
-        if (!isValid) return false
-        val url = browser.url()
+        // Through getCurrentUrl, not browser.url(): this was the same unguarded round trip,
+        // reached from toolbar UI, and "" does not start with https so a dead handle reads
+        // as not-secure rather than throwing into the composable.
+        val url = getCurrentUrl()
         return url.startsWith("https://")
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -249,11 +249,6 @@ object BrowserServiceImpl : BrowserService {
     // Track active browser handles for resource management
     private val activeBrowsers = ConcurrentHashMap<String, BrowserHandleImpl>()
 
-    // Long-lived, for cleanup that outlives the caller's scope. reconcileOrphanedBrowsers() is
-    // called from non-suspending accessors but the named-profile bookkeeping has to stat a
-    // directory, and a SupervisorJob keeps one failing cleanup from cancelling the rest.
-    private val cleanupScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
     /**
      * Drops handles whose browser has gone away without passing through a dispose path.
      *
@@ -275,19 +270,45 @@ object BrowserServiceImpl : BrowserService {
      * disposes its browser through the plugin's own handle, exactly the path that never reaches
      * this map.
      *
-     * Pruning is synchronous (callers are not suspending), but the managed-profile cleanup is
-     * not: for a named profile it has to stat the directory, so it runs on [cleanupScope].
+     * Fully synchronous, including the managed-profile release. An earlier revision handed the
+     * named-profile bookkeeping to a long-lived IO scope because it can stat a directory; now
+     * that pruning goes through [disposeTrackedBrowserBlocking] - the same path window teardown
+     * takes - it uses the same non-suspending `releaseManaged`, so there is one release path
+     * rather than two that could disagree about whether a fence was dropped.
      *
      * @return the number of live handles after pruning.
      */
     internal fun reconcileOrphanedBrowsers(): Int {
         val orphans = activeBrowsers.entries.filter { !it.value.isValid }
         for ((id, handle) in orphans) {
-            if (activeBrowsers.remove(id, handle)) {
-                browserOwners.unregister(id)
-                managedByHandle.remove(id)?.let { ref ->
-                    cleanupScope.launch { finishManagedProfile(ref) }
-                }
+            // Through the same blocking dispose as window teardown, not a bare map removal.
+            // An earlier version removed the entry, unregistered ownership and released the
+            // profile, but never called `handle.dispose()` - which is not a no-op for a
+            // browser whose transport is gone: it shuts two single-thread executors, cancels
+            // three scopes, unsubscribes every JxBrowser listener and unregisters from
+            // BrowserFindController and ActiveBrowserRegistry, all host-side state that
+            // outlives a dead connection.
+            //
+            // Dropping the entry without that made the leak permanent rather than merely
+            // untidy: `disposeAllForWindow` resolves handles out of `activeBrowsers` and
+            // through `browserOwners`, so once reconcile had removed and unregistered one,
+            // window teardown could never reach it again. Pruning less thoroughly than
+            // teardown means whatever prune wins the race decides whether the resources are
+            // ever released.
+            //
+            // Caught per handle: dispose touches a dead transport (`browser.close()` can
+            // throw) and marshals `exitFullscreen` onto the EDT, and one failure must not
+            // strand the rest of the orphans. `dispose()` is idempotent via its own CAS, so
+            // a handle that teardown also reaches later is safe.
+            try {
+                disposeTrackedBrowserBlocking(handle)
+            } catch (e: Exception) {
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Error disposing orphaned browser handle",
+                    mapOf("handleId" to id),
+                    e,
+                )
             }
         }
         if (orphans.isNotEmpty()) {
@@ -686,16 +707,17 @@ object BrowserServiceImpl : BrowserService {
     /**
      * Return all active browser handles for internal lookup (e.g. RPA recorder).
      *
-     * Reconciles first, and returns only handles that are still valid. Callers scan this list
-     * and call through what it hands them, so a dead handle here costs a failing IPC round trip
-     * per lookup - and these are lookups on hot paths, repeated for as long as the caller keeps
-     * polling. Pruning on the way out is what keeps a browser that died without passing through
-     * a dispose path from being scanned for the rest of the session.
+     * Filtered, because callers scan this list and call through whatever it hands them: a dead
+     * handle here costs a failing IPC round trip per lookup, on paths that poll for as long as
+     * a panel stays open.
+     *
+     * Filtered rather than pruned. [reconcileOrphanedBrowsers] would also remove them, but it
+     * disposes as it goes - which blocks, marshals onto the EDT, and is the wrong thing to put
+     * on a lookup this hot. The filter alone is what makes the scan safe, and it is safe
+     * whether or not anything ever prunes; leaving the entries in place also keeps them
+     * reachable by window teardown, which is what actually owns their disposal.
      */
-    internal fun getActiveHandles(): List<BrowserHandleImpl> {
-        reconcileOrphanedBrowsers()
-        return activeBrowsers.values.filter { it.isValid }
-    }
+    internal fun getActiveHandles(): List<BrowserHandleImpl> = activeBrowsers.values.filter { it.isValid }
 
     /**
      * Dispose plugin browsers owned by one application window.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserServiceImpl.kt
@@ -683,8 +683,19 @@ object BrowserServiceImpl : BrowserService {
         return browserOwners.count(windowId)
     }
 
-    /** Return all active browser handles for internal lookup (e.g. RPA recorder). */
-    internal fun getActiveHandles(): List<BrowserHandleImpl> = activeBrowsers.values.toList()
+    /**
+     * Return all active browser handles for internal lookup (e.g. RPA recorder).
+     *
+     * Reconciles first, and returns only handles that are still valid. Callers scan this list
+     * and call through what it hands them, so a dead handle here costs a failing IPC round trip
+     * per lookup - and these are lookups on hot paths, repeated for as long as the caller keeps
+     * polling. Pruning on the way out is what keeps a browser that died without passing through
+     * a dispose path from being scanned for the rest of the session.
+     */
+    internal fun getActiveHandles(): List<BrowserHandleImpl> {
+        reconcileOrphanedBrowsers()
+        return activeBrowsers.values.filter { it.isValid }
+    }
 
     /**
      * Dispose plugin browsers owned by one application window.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderCoalescingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/providers/LogDataProviderCoalescingTest.kt
@@ -1,0 +1,176 @@
+package ai.rever.boss.components.plugin.providers
+
+import ai.rever.boss.logging.DesktopLogCapture
+import java.io.OutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * That one captured line no longer costs one full rebuild of the log list.
+ *
+ * This is the change that stopped the freeze, and it had no test. `updateLogs` copies the whole
+ * capture buffer, filters it and allocates a `LogEntryData` per entry - and it ran
+ * synchronously from the log listener, which `DesktopLogCapture` invokes from inside
+ * `PrintStream.write`. So every line rebuilt a list of up to 10,000 entries while holding the
+ * `System.out` monitor, and every other thread in the process that wanted to log queued behind
+ * it. One 30-frame stack trace is ~30 lines; a component logging a few of those a second was
+ * enough to stall threads that had nothing to do with logging.
+ *
+ * Both the capture and the interval are constructor parameters purely so this is reachable:
+ * against the `GlobalLogCapture` singleton and a hardcoded interval it was not testable at all.
+ *
+ * Real waits, because the consumer is timer-driven.
+ */
+class LogDataProviderCoalescingTest {
+    /**
+     * Redirects `System.out` to a null sink before the capture is constructed.
+     *
+     * [DesktopLogCapture] snapshots `System.out` when built, so this makes its tee write
+     * nowhere: the thousands of lines below stay out of the Gradle test report, and the
+     * measurement is not dominated by console throughput.
+     */
+    private fun withCapture(block: (DesktopLogCapture) -> Unit) {
+        val savedOut = System.out
+        val savedErr = System.err
+        val sink = PrintStream(OutputStream.nullOutputStream(), true, Charsets.UTF_8)
+        try {
+            System.setOut(sink)
+            System.setErr(sink)
+            val capture = DesktopLogCapture()
+            try {
+                capture.start()
+                block(capture)
+            } finally {
+                capture.stop()
+            }
+        } finally {
+            System.setOut(savedOut)
+            System.setErr(savedErr)
+        }
+    }
+
+    @Test
+    fun `a burst of captured lines produces far fewer rebuilds than lines`() {
+        withCapture { capture ->
+            val provider = LogDataProviderImpl(logCapture = capture, rebuildIntervalMs = 50L)
+            try {
+                // Counted at the source rather than sampled - see `rebuildCount`. The
+                // construction-time rebuild is excluded so the bound is about the burst.
+                val before = provider.rebuildCount
+
+                val lines = 2_000
+                repeat(lines) { println("burst $it") }
+                // Let the consumer settle so the last coalesced rebuild is included.
+                Thread.sleep(400)
+                val rebuilds = provider.rebuildCount - before
+
+                // The point of the change: rebuilds are bounded by elapsed time over the
+                // interval, not by line count. Pre-fix this was one rebuild per line, so the
+                // bound is stated against `lines` to stay meaningful if the burst size moves.
+                assertTrue(
+                    rebuilds < lines / 10,
+                    "$lines captured lines caused $rebuilds rebuilds - the listener is " +
+                        "rebuilding per line again",
+                )
+                // …and the control: it did rebuild. A provider whose consumer never ran would
+                // pass the bound above on zero.
+                assertTrue(rebuilds >= 1, "the provider never rebuilt at all, so the bound above proves nothing")
+
+                // The coalescing must not lose the tail: whatever the last rebuild published
+                // has to include the final line, or the panel silently trails the log.
+                val published = provider.logs.value.map { it.message }
+                assertTrue(
+                    published.any { it.contains("burst ${lines - 1}") },
+                    "the last captured line never reached the published list",
+                )
+            } finally {
+                provider.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun `dispose stops rebuilding and stops listening`() {
+        withCapture { capture ->
+            val before = capture.listenerCount
+            val provider = LogDataProviderImpl(logCapture = capture, rebuildIntervalMs = 20L)
+            assertEquals(
+                before + 1,
+                capture.listenerCount,
+                "setup: the provider must register a listener for its removal to mean anything",
+            )
+            println("before dispose")
+            Thread.sleep(200)
+            val settled = provider.logs.value
+            assertTrue(
+                settled.any { it.message.contains("before dispose") },
+                "setup: the provider must be publishing before dispose is tested",
+            )
+
+            provider.dispose()
+
+            // Both halves, asserted separately because one hides the other: a cancelled
+            // consumer publishes nothing whether or not the listener is still attached, so
+            // the `logs.value` check below passes on a leaked listener. Only the count sees
+            // it - and a listener left on a process-wide singleton is the leak that
+            // accumulates per window.
+            assertEquals(
+                before,
+                capture.listenerCount,
+                "dispose() left its listener registered on the process-wide capture",
+            )
+
+            repeat(500) { println("after dispose $it") }
+            Thread.sleep(300)
+
+            assertTrue(
+                provider.logs.value === settled,
+                "the provider published after dispose() - its consumer is still running",
+            )
+            // The capture itself is unaffected: dispose releases this provider, not the
+            // process-wide buffer other windows may still be reading.
+            assertTrue(
+                capture.getLogs().any { it.message.contains("after dispose 499") },
+                "dispose() must not stop the underlying capture",
+            )
+        }
+    }
+
+    @Test
+    fun `a filter change republishes without waiting for another log line`() {
+        withCapture { capture ->
+            val provider = LogDataProviderImpl(logCapture = capture, rebuildIntervalMs = 20L)
+            try {
+                println("to stderr never")
+                System.err.println("only on stderr")
+                Thread.sleep(200)
+                assertTrue(provider.logs.value.size >= 2, "setup: both lines should be published")
+
+                // Routed through the same request channel as a log line, so the single
+                // consumer owns every write to `logs`. It still has to land: a quiet app
+                // produces no further lines to trigger it.
+                provider.setFilter(ai.rever.boss.plugin.api.LogFilterData.STDERR)
+
+                val deadline = System.currentTimeMillis() + 2_000
+                var messages = provider.logs.value.map { it.message }
+                while (System.currentTimeMillis() < deadline && messages.any { it.contains("to stderr never") }) {
+                    Thread.sleep(5)
+                    messages = provider.logs.value.map { it.message }
+                }
+                assertEquals(
+                    emptyList(),
+                    messages.filter { it.contains("to stderr never") },
+                    "a filter change never republished, so the panel would show the old filter until the next log line",
+                )
+                assertTrue(
+                    messages.any { it.contains("only on stderr") },
+                    "the stderr filter dropped the stderr line too",
+                )
+            } finally {
+                provider.dispose()
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/logging/DesktopLogCaptureTrimTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/logging/DesktopLogCaptureTrimTest.kt
@@ -1,0 +1,106 @@
+package ai.rever.boss.logging
+
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the cost of capturing a line, and the bookkeeping that made it cheap.
+ *
+ * The capture buffer is a `ConcurrentLinkedQueue`, whose `size()` is O(n) by contract - it walks
+ * the list. The trim that enforced the 10k cap called it once per captured line, and re-read it
+ * on every iteration of its own loop, so a full buffer meant a 10,000-node walk per line. The tee
+ * runs inside `PrintStream.write`, so that walk was paid while holding the `System.out` monitor
+ * and every other thread in the process that wanted to log queued behind it. A component logging
+ * stack traces a few times a second was enough to stall threads that had nothing to do with
+ * logging, which is how one dead browser handle froze the whole app.
+ *
+ * The timing test is the one that would have caught it. The counter tests exist because replacing
+ * `size()` with a tracked count introduces a way to be wrong that the old code could not be:
+ * a count that drifts from the queue trims a buffer that is not full, silently discarding logs.
+ *
+ * These tests install and restore `System.out` / `System.err`, so they must not run in parallel
+ * with anything asserting on stdout.
+ */
+class DesktopLogCaptureTrimTest {
+    private fun withCapture(block: (DesktopLogCapture) -> Unit) {
+        val capture = DesktopLogCapture()
+        val savedOut = System.out
+        val savedErr = System.err
+        try {
+            capture.start()
+            block(capture)
+        } finally {
+            capture.stop()
+            // stop() restores what it saw at construction; make the restore unconditional so a
+            // failure inside block() cannot leave the suite without a usable stdout.
+            System.setOut(savedOut)
+            System.setErr(savedErr)
+        }
+    }
+
+    /**
+     * Compares capturing into a full buffer against capturing into an empty one.
+     *
+     * A **ratio**, not a wall-clock bound. The cost per line is dominated by writing through to
+     * the real stdout, which varies by machine and swamps an absolute threshold: a first attempt
+     * at this test asserted "30k lines in under 20s" and passed against the very bug it was
+     * written for. What actually distinguishes the two implementations is whether the per-line
+     * cost depends on how much is already buffered - which is exactly what the ratio measures,
+     * and which cancels out the machine.
+     *
+     * Measured either side of the fix on the same machine: 6.5x with the `size()` trim
+     * (120ms empty vs 780ms full), 0.57x with the counter (21ms vs 12ms - the full-buffer pass
+     * comes out faster, being the more JIT-warmed of the two). 3.0 sits clear of both.
+     */
+    @Test
+    fun `the cost of capturing a line does not grow with the buffer`() {
+        withCapture { capture ->
+            // Trim never fires: the buffer is filling toward the cap.
+            val emptyBuffer = measureTimeMillis { repeat(5_000) { println("empty $it") } }
+
+            repeat(10_000) { println("fill $it") }
+            assertEquals(10_000, capture.getLogs().size, "buffer should hold exactly the cap")
+
+            // Trim fires on every line now, against a full buffer.
+            val fullBuffer = measureTimeMillis { repeat(5_000) { println("full $it") } }
+
+            val ratio = fullBuffer.toDouble() / maxOf(emptyBuffer, 1)
+            assertTrue(
+                ratio < 3.0,
+                "capturing into a full buffer cost ${ratio}x an empty one " +
+                    "(${fullBuffer}ms vs ${emptyBuffer}ms) - the per-line trim scales with the buffer again",
+            )
+        }
+    }
+
+    @Test
+    fun `the buffer holds the newest lines, not the oldest`() {
+        withCapture { capture ->
+            repeat(10_050) { println("seq $it") }
+            val logs = capture.getLogs()
+            assertEquals(10_000, logs.size)
+            // Oldest 50 dropped, so the window is [50, 10049].
+            assertTrue(logs.first().message.endsWith("seq 50"), "unexpected first line: ${logs.first().message}")
+            assertTrue(logs.last().message.endsWith("seq 10049"), "unexpected last line: ${logs.last().message}")
+        }
+    }
+
+    @Test
+    fun `clear resets the count so a later burst is not over-trimmed`() {
+        withCapture { capture ->
+            // Fill past the cap so the tracked count is at its ceiling.
+            repeat(12_000) { println("first $it") }
+            assertEquals(10_000, capture.getLogs().size)
+
+            capture.clear()
+            assertEquals(0, capture.getLogs().size)
+
+            // A count left overstated by clear() would trim these away as if the buffer were
+            // still full, and the panel would show almost nothing after a Clear.
+            repeat(100) { println("second $it") }
+            assertEquals(100, capture.getLogs().size, "lines after clear() were trimmed against a stale count")
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/logging/DesktopLogCaptureTrimTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/logging/DesktopLogCaptureTrimTest.kt
@@ -1,8 +1,11 @@
 package ai.rever.boss.logging
 
+import java.io.OutputStream
+import java.io.PrintStream
 import kotlin.system.measureTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -24,66 +27,121 @@ import kotlin.test.assertTrue
  * with anything asserting on stdout.
  */
 class DesktopLogCaptureTrimTest {
+    /**
+     * Runs [block] against a started capture whose tee writes to a null sink.
+     *
+     * The redirect happens BEFORE the constructor on purpose: [DesktopLogCapture] snapshots
+     * `System.out` when it is built, so this makes its `originalOut` the null sink and the tee
+     * writes nowhere. Two things follow. The ~30,000 lines these tests produce stop going to
+     * the real stdout and into the Gradle test report; and, more importantly, the per-line cost
+     * of writing to a console - which by this file's own analysis is what swamps the signal -
+     * comes out of both halves of the ratio measurement.
+     */
     private fun withCapture(block: (DesktopLogCapture) -> Unit) {
-        val capture = DesktopLogCapture()
         val savedOut = System.out
         val savedErr = System.err
+        val sink = PrintStream(OutputStream.nullOutputStream(), true, Charsets.UTF_8)
         try {
-            capture.start()
-            block(capture)
+            System.setOut(sink)
+            System.setErr(sink)
+            val capture = DesktopLogCapture()
+            try {
+                capture.start()
+                block(capture)
+            } finally {
+                capture.stop()
+            }
         } finally {
-            capture.stop()
-            // stop() restores what it saw at construction; make the restore unconditional so a
-            // failure inside block() cannot leave the suite without a usable stdout.
+            // stop() restores what the capture saw at construction, which is the sink. Restore
+            // unconditionally so a failure inside block() cannot leave the suite without a
+            // usable stdout.
             System.setOut(savedOut)
             System.setErr(savedErr)
         }
     }
 
     /**
-     * Compares capturing into a full buffer against capturing into an empty one.
+     * The test's own lines, ignoring anything else that reached the buffer.
      *
-     * A **ratio**, not a wall-clock bound. The cost per line is dominated by writing through to
-     * the real stdout, which varies by machine and swamps an absolute threshold: a first attempt
-     * at this test asserted "30k lines in under 20s" and passed against the very bug it was
-     * written for. What actually distinguishes the two implementations is whether the per-line
-     * cost depends on how much is already buffered - which is exactly what the ratio measures,
-     * and which cancels out the machine.
+     * Exact counts over the whole buffer are brittle here: it captures global `System.out`, so
+     * any other output in this JVM lands in it - and the capture itself contributes, since
+     * `start()` logs "Log capture started" AFTER installing the tee and `clear()` logs at debug.
+     * The latter is not hypothetical: an exact-count assertion after `clear()` fails outright
+     * under `BOSS_LOG_LEVEL=DEBUG`.
+     */
+    private fun DesktopLogCapture.linesTagged(tag: String): List<String> =
+        getLogs()
+            .map { it.message }
+            .filter { it.contains(tag) }
+
+    /**
+     * Compares capturing into a full buffer against capturing into an unfilled one.
      *
-     * Measured either side of the fix on the same machine: 6.5x with the `size()` trim
-     * (120ms empty vs 780ms full), 0.57x with the counter (21ms vs 12ms - the full-buffer pass
-     * comes out faster, being the more JIT-warmed of the two). 3.0 sits clear of both.
+     * A **ratio**, not a wall-clock bound. A first attempt at this test asserted "30k lines in
+     * under 20s" and passed against the very bug it was written for, because per-line cost
+     * varies by machine and swamps an absolute threshold. What distinguishes the two
+     * implementations is whether the per-line cost depends on how much is already buffered,
+     * which is what the ratio measures and what cancels the machine out.
+     *
+     * Both sides write the same number of lines, in batches under the cap, so the baseline is
+     * genuinely "the trim never fires" rather than "it fires for most of the run". Spread over
+     * several fresh captures for that reason: one baseline long enough to time reliably would
+     * itself fill the buffer and start trimming.
+     *
+     * Measured either side of the fix on one machine: **5.1x** with the `size()` trim
+     * (5121ms full vs 1006ms baseline) against **0.9x** with the counter (9ms vs 10ms). Note
+     * how much the *absolute* baseline moves - 1006ms to 10ms - because `while (size > cap)`
+     * evaluates an O(n) walk once per line even while the buffer is still filling. That is
+     * also why the ratio is 5x rather than the ~70x a full-buffer-only comparison shows: the
+     * old code makes the control slow too, which flatters it here. 3.0 sits between the two
+     * with headroom for a loaded machine on the ~10ms side.
      */
     @Test
     fun `the cost of capturing a line does not grow with the buffer`() {
-        withCapture { capture ->
-            // Trim never fires: the buffer is filling toward the cap.
-            val emptyBuffer = measureTimeMillis { repeat(5_000) { println("empty $it") } }
+        // Under the 10k cap, so nothing is trimmed while the baseline is being measured.
+        val batch = 9_000
+        val rounds = 5
 
+        var baseline = 0L
+        repeat(rounds) {
+            withCapture {
+                baseline += measureTimeMillis { repeat(batch) { println("empty $it") } }
+            }
+        }
+
+        var fullBuffer = 0L
+        withCapture { capture ->
             repeat(10_000) { println("fill $it") }
             assertEquals(10_000, capture.getLogs().size, "buffer should hold exactly the cap")
-
-            // Trim fires on every line now, against a full buffer.
-            val fullBuffer = measureTimeMillis { repeat(5_000) { println("full $it") } }
-
-            val ratio = fullBuffer.toDouble() / maxOf(emptyBuffer, 1)
-            assertTrue(
-                ratio < 3.0,
-                "capturing into a full buffer cost ${ratio}x an empty one " +
-                    "(${fullBuffer}ms vs ${emptyBuffer}ms) - the per-line trim scales with the buffer again",
-            )
+            // The same total line count as the baseline, every line of it trimming.
+            repeat(rounds) {
+                fullBuffer += measureTimeMillis { repeat(batch) { println("full $it") } }
+            }
         }
+
+        val ratio = fullBuffer.toDouble() / maxOf(baseline, 1)
+        assertTrue(
+            ratio < 3.0,
+            "capturing $rounds x $batch lines into a full buffer cost ${ratio}x the same count " +
+                "into an unfilled one (${fullBuffer}ms vs ${baseline}ms) - " +
+                "the per-line trim scales with the buffer again",
+        )
     }
 
     @Test
     fun `the buffer holds the newest lines, not the oldest`() {
         withCapture { capture ->
             repeat(10_050) { println("seq $it") }
-            val logs = capture.getLogs()
-            assertEquals(10_000, logs.size)
-            // Oldest 50 dropped, so the window is [50, 10049].
-            assertTrue(logs.first().message.endsWith("seq 50"), "unexpected first line: ${logs.first().message}")
-            assertTrue(logs.last().message.endsWith("seq 10049"), "unexpected last line: ${logs.last().message}")
+            // The buffer holds the cap; OUR lines are fewer, because the capture's own
+            // "Log capture started" got in ahead of them and was dropped from the front.
+            assertEquals(10_000, capture.getLogs().size, "buffer should hold exactly the cap")
+            val seq = capture.linesTagged("seq ")
+            // Oldest dropped first, so whatever survives ends at the newest line.
+            assertTrue(seq.last().endsWith("seq 10049"), "unexpected last line: ${seq.last()}")
+            // …and the front was trimmed rather than the back: 10050 lines into a 10000 cap
+            // cannot all be present.
+            assertTrue(seq.size in 9_000..10_000, "unexpected surviving count: ${seq.size}")
+            assertFalse(seq.any { it.endsWith("seq 0") }, "the oldest line survived a full buffer")
         }
     }
 
@@ -95,12 +153,18 @@ class DesktopLogCaptureTrimTest {
             assertEquals(10_000, capture.getLogs().size)
 
             capture.clear()
-            assertEquals(0, capture.getLogs().size)
 
             // A count left overstated by clear() would trim these away as if the buffer were
-            // still full, and the panel would show almost nothing after a Clear.
+            // still full, and the panel would show almost nothing after a Clear. Counted by
+            // tag, not by buffer size: clear() itself logs at debug, so an exact size here
+            // fails under BOSS_LOG_LEVEL=DEBUG.
             repeat(100) { println("second $it") }
-            assertEquals(100, capture.getLogs().size, "lines after clear() were trimmed against a stale count")
+            assertEquals(
+                100,
+                capture.linesTagged("second ").size,
+                "lines after clear() were trimmed against a stale count",
+            )
+            assertEquals(0, capture.linesTagged("first ").size, "clear() left earlier lines behind")
         }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ResolveSingleByUrlTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/ResolveSingleByUrlTest.kt
@@ -1,0 +1,142 @@
+package ai.rever.boss.plugin.browser
+
+import ai.rever.boss.components.plugin.panels.right_top.resolveSingleByUrl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * How a dynamic plugin's browser tab is resolved to one of the open browsers.
+ *
+ * `findBrowserForTab` needs a live `SplitViewState` and real JxBrowser handles, which is why it
+ * has never had a test - so the selection was pulled out as [resolveSingleByUrl], following the
+ * same split as `BrowserWindowOwnershipRegistry` beside `BrowserServiceImpl`. It lives in this
+ * package rather than beside the function because `right_top` does not satisfy detekt's
+ * PackageNaming; `internal` is module-wide, so the import is all that is needed.
+ *
+ * What this does NOT cover, stated so nobody reads more into it: the cached URL itself.
+ * `BrowserHandleImpl.lastKnownUrl` is seeded from the creation config and updated from a
+ * `NavigationFinished` callback, and neither can be exercised here - the class needs a JxBrowser
+ * `Browser`, there is no mocking library on this source set, and that interface is far too wide
+ * to stub by hand. That is the same reason no test constructs a handle today.
+ */
+class ResolveSingleByUrlTest {
+    private data class Candidate(
+        val name: String,
+        val url: String,
+    )
+
+    private val a = Candidate("a", "https://example.com/one")
+    private val b = Candidate("b", "https://example.com/two")
+
+    @Test
+    fun `the single match is returned and nothing is reported`() {
+        var reported: Int? = null
+        val picked =
+            resolveSingleByUrl(
+                candidates = listOf(a, b),
+                matches = { it.url == "https://example.com/two" },
+                onAmbiguous = { reported = it },
+            )
+        assertEquals(b, picked)
+        assertNull(reported, "one match is not an ambiguity")
+    }
+
+    @Test
+    fun `no match resolves to null rather than an arbitrary candidate`() {
+        var reported: Int? = null
+        val picked =
+            resolveSingleByUrl(
+                candidates = listOf(a, b),
+                matches = { it.url == "https://example.com/absent" },
+                onAmbiguous = { reported = it },
+            )
+        assertNull(picked, "a URL nothing is at must not resolve to some other tab's browser")
+        assertNull(reported)
+    }
+
+    @Test
+    fun `an empty candidate list is not an ambiguity`() {
+        var reported: Int? = null
+        val picked =
+            resolveSingleByUrl(
+                candidates = emptyList<Candidate>(),
+                matches = { true },
+                onAmbiguous = { reported = it },
+            )
+        assertNull(picked)
+        assertNull(reported, "nothing to choose between is not a conflict to report")
+    }
+
+    // The next two cover one scenario - two browsers on one URL - but they are separate
+    // detectors and so separate tests: dropping the report and reversing the pick are
+    // different regressions, and a single test asserting both would go on passing for one of
+    // them after an edit made for the other.
+
+    @Test
+    fun `two browsers on one URL still resolve to the first`() {
+        // Deliberately unchanged: iteration order decides, because nothing here can tell which
+        // tab owns which handle.
+        val duplicate = Candidate("a-again", a.url)
+        val picked =
+            resolveSingleByUrl(
+                candidates = listOf(a, duplicate, b),
+                matches = { it.url == a.url },
+                onAmbiguous = { },
+            )
+        assertEquals(a, picked, "the first match must still win, as before")
+    }
+
+    @Test
+    fun `two browsers on one URL are reported with their count`() {
+        // What actually changes: it stops being silent. A plugin driving the wrong tab used to
+        // leave no trace at all.
+        val duplicate = Candidate("a-again", a.url)
+        var reported: Int? = null
+        resolveSingleByUrl(
+            candidates = listOf(a, duplicate, b),
+            matches = { it.url == a.url },
+            onAmbiguous = { reported = it },
+        )
+        assertEquals(2, reported, "the ambiguity must be reported with its count")
+    }
+
+    @Test
+    fun `every candidate is offered to the predicate exactly once`() {
+        // The predicate is what reads each handle's cached URL. Calling it twice per candidate
+        // would double the cost this change exists to remove, and skipping candidates would
+        // make a lookup depend on list order in a second, hidden way.
+        val seen = mutableListOf<String>()
+        resolveSingleByUrl(
+            candidates = listOf(a, b),
+            matches = {
+                seen += it.name
+                false
+            },
+            onAmbiguous = { },
+        )
+        assertEquals(listOf("a", "b"), seen)
+    }
+
+    @Test
+    fun `the predicate is the only thing consulted`() {
+        // Guards the property the whole fix rests on: selection asks each candidate one
+        // question and nothing else. A future revision that fell back to a live URL read when
+        // the cached one looked stale would reintroduce the per-handle IPC round trip, and
+        // this test is where that shows up - the candidates here have no way to answer
+        // anything but the predicate.
+        var calls = 0
+        val picked =
+            resolveSingleByUrl(
+                candidates = listOf(a, b),
+                matches = {
+                    calls++
+                    it == b
+                },
+                onAmbiguous = { },
+            )
+        assertEquals(b, picked)
+        assertTrue(calls == 2, "the predicate should have been asked once per candidate, was $calls")
+    }
+}


### PR DESCRIPTION
## What happened

A fluck browser tab froze, then the whole window did, while the app's MCP server kept answering in under 200ms.

Both event loops were idle - the AWT EDT parked in `getNextEvent`, the AppKit main thread in `_DPSBlockUntilNextEventMatchingListInMode` - so nothing was blocking the UI directly. The live process showed 12 browser tabs against 4 Chromium RPC connections, and one error repeating ~150 times a minute. 5,000 captured console lines spanned **59 seconds**, all of it the same stack trace, which is why no history of the original trigger survived in the buffer.

Two independent defects, and it took both to freeze the app.

## 1. A handle could not be collected once its transport died

`isValid` is `!disposed && generation matches && !browser.isClosed`. Its own KDoc explains that `isClosed` only reports what this side has been *told*, and the generation clause covers a browser outliving its engine. It does not cover **this browser's** connection closing while the generation still matches - a renderer going away, a page calling `window.close()`, a plugin disposing the browser behind its own handle.

In that state `isClosed` stays `false` and `isValid` answers `true` for a browser every call through which throws. `reconcileOrphanedBrowsers` prunes on `!isValid`, so a handle that could never be valid again was also never pruned - it stayed in `getActiveHandles()` for the rest of the session. The prune had never logged once.

`getCurrentUrl()` then threw out of those handles, and `DesktopBrowserAccessor.findBrowserForTab` scans `getActiveHandles()` calling it on each - so the throw aborted the whole scan at the first zombie and the lookup could never reach a live browser again. A permanently broken feature, not a slow one. A fluck-agent selection poll retried it every ~1.5s.

## 2. The freeze itself was the log path

Every captured line ran `LogDataProviderImpl.updateLogs` **synchronously from the log listener**, which `DesktopLogCapture` invokes from inside `PrintStream.write`. So each line copied the whole capture buffer, filtered it, and allocated a `LogEntryData` per entry - up to 10,000 - while holding the `System.out` monitor. The trim beside it called `ConcurrentLinkedQueue.size()`, O(n) by contract, once per line and again per iteration of its own loop.

One 30-frame trace is ~30 lines. A component logging a few traces a second had the app allocating hundreds of thousands of objects per second (**6411 GCs, 59s of GC time**) and serialising every logging thread in the process - the UI thread included - against a queue full of its own output.

**Any repeating exception anywhere would do this.** A dead browser handle is just what found it.

## Changes

- `BrowserHandleImpl` latches `connectionDead` when a sync call fails on a gone transport, so `isValid` goes false and the existing prune collects the handle. Sync accessors report failure by value through `syncCall` instead of throwing, at debug rather than WARN-with-stack-trace.
- `BrowserServiceImpl.getActiveHandles` reconciles and returns only valid handles, so a scan cannot be handed something it will fail to call through.
- `DesktopLogCapture` tracks its own length instead of asking the queue.
- `LogDataProviderImpl` coalesces rebuilds onto its own scope with a floor between them, keeping the listener O(1) and off the writer's thread.

## On the test

`DesktopLogCaptureTrimTest` asserts the **ratio** of capturing into a full buffer versus an empty one, not a wall-clock bound. A first attempt bounded 30k lines at 20s and **passed against the bug it was written for** - per-line stdout cost swamps the difference and varies by machine. Measured either side of the fix on one machine: **6.5x before** (120ms vs 780ms), **0.57x after**. Verified failing with the fix reverted.

Two further tests pin the counter, which is a way to be wrong the old code could not be: a count that drifts from the queue trims a buffer that is not full and silently drops logs.

## Hibernation is not involved

The timing looked like tab hibernation, but the fluck-browser plugin gates it on `BOSS_TAB_HIBERNATION`, which is unset in the affected process, and no hibernation line appears in its log at all.

## Verification

- `./gradlew :composeApp:desktopTest` - 2433 tests, 0 failures, 0 skipped
- `./gradlew ktlintCheck detekt` - green