### PR TITLE
ci(windows): sign the ARM64 MSI, and prove every MSI signature landed

### DIFF
--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -494,12 +494,15 @@ jobs:
           if ($sig.SignerCertificate) {
             Write-Host "Signer: $($sig.SignerCertificate.Subject)"
           }
-          if ($sig.Status -eq 'NotSigned') {
-            if ('${{ steps.check-secret.outputs.can_sign }}' -eq 'true') {
-              Write-Host "::error::MSI is unsigned even though signing credentials were present"
+          if ($sig.Status -ne 'Valid') {
+            if ('${{ steps.check-secret.outputs.can_sign }}' -ne 'true') {
+              Write-Host "::warning::Windows MSI is UNSIGNED, status $($sig.Status) (no CODE_SIGNING_* secrets configured)"
+            } elseif ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
+              Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
               exit 1
+            } else {
+              Write-Host "::warning::MSI signature status is $($sig.Status), expected Valid"
             }
-            Write-Host "::warning::Windows MSI is UNSIGNED (no CODE_SIGNING_* secrets configured)"
           }
 
       - name: 📋 Rename MSI to Lite convention

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -486,6 +486,22 @@ jobs:
           SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
 
+      - name: 🔏 Verify MSI Signature
+        shell: powershell
+        run: |
+          $sig = Get-AuthenticodeSignature -FilePath "${{ steps.find-msi.outputs.msi-path }}"
+          Write-Host "Signature status: $($sig.Status)"
+          if ($sig.SignerCertificate) {
+            Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+          }
+          if ($sig.Status -eq 'NotSigned') {
+            if ('${{ steps.check-secret.outputs.can_sign }}' -eq 'true') {
+              Write-Host "::error::MSI is unsigned even though signing credentials were present"
+              exit 1
+            }
+            Write-Host "::warning::Windows MSI is UNSIGNED (no CODE_SIGNING_* secrets configured)"
+          }
+
       - name: 📋 Rename MSI to Lite convention
         env:
           VERSION: ${{ needs.prepare-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1323,12 +1323,19 @@ jobs:
           if ($sig.SignerCertificate) {
             Write-Host "Signer: $($sig.SignerCertificate.Subject)"
           }
-          if ($sig.Status -eq 'NotSigned') {
-            if ('${{ steps.check-secret.outputs.can_sign }}' -eq 'true') {
-              Write-Host "::error::MSI is unsigned even though signing credentials were present"
+          if ($sig.Status -ne 'Valid') {
+            if ('${{ steps.check-secret.outputs.can_sign }}' -ne 'true') {
+              Write-Host "::warning::Windows MSI is UNSIGNED, status $($sig.Status) (no CODE_SIGNING_* secrets configured)"
+            } elseif ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
+              # Credentials were present and smctl exited 0, yet no usable
+              # signature is on the file. That is the silent case worth blocking.
+              Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
               exit 1
+            } else {
+              # NotTrusted / UnknownError and friends: the signature may be fine
+              # and the runner's trust store or parser may not be. Loud, not fatal.
+              Write-Host "::warning::MSI signature status is $($sig.Status), expected Valid"
             }
-            Write-Host "::warning::Windows MSI is UNSIGNED (no CODE_SIGNING_* secrets configured)"
           }
 
       - name: 📊 Verify Build Artifacts
@@ -1492,17 +1499,20 @@ jobs:
             exit 1
           }
 
+      # PowerShell, like every other step in this job: this one is not gated and
+      # not continue-on-error, so a shell that fails to resolve here would cost
+      # the release its ARM64 asset entirely.
       - name: Check if signing secret is available (Windows ARM64)
         id: check-secret
-        run: |
-          if [ -n "$CERT_HOST" ]; then
-            echo "can_sign=true" >> $GITHUB_OUTPUT
-          else
-            echo "can_sign=false" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
+        shell: powershell
         env:
           CERT_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+        run: |
+          if ($env:CERT_HOST) {
+            echo "can_sign=true" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "can_sign=false" >> $env:GITHUB_OUTPUT
+          }
 
       - name: Find MSI File (Windows ARM64)
         id: find-msi
@@ -1522,6 +1532,7 @@ jobs:
 
       - name: Decode Client Certificate (Windows ARM64)
         if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
+        continue-on-error: true
         shell: powershell
         run: |
           try {
@@ -1531,6 +1542,20 @@ jobs:
             Write-Host "Client cert decoded successfully to $certPath"
           } catch {
             Write-Host "Error decoding client cert: $_"
+            exit 1
+          }
+
+      - name: Verify Client Cert File Exists (Windows ARM64)
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
+        continue-on-error: true
+        shell: powershell
+        run: |
+          $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
+          if (Test-Path $certPath) {
+            Write-Host "[OK] Cert file exists at $certPath"
+            Write-Host "File size: $((Get-Item $certPath).Length) bytes"
+          } else {
+            Write-Host "[ERROR] Cert file MISSING at $certPath"
             exit 1
           }
 
@@ -1579,7 +1604,7 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
 
       - name: Check SMKSP Log (Windows ARM64 diagnostics)
-        if: always()  # Runs even if signing fails
+        if: ${{ always() && steps.check-secret.outputs.can_sign == 'true' }}  # Runs even if signing fails
         shell: powershell
         run: |
           $logPath = "$env:USERPROFILE\.signingmanager\logs\smksp.log"
@@ -1590,8 +1615,13 @@ jobs:
             Write-Host "SMKSP log not found."
           }
 
+      # continue-on-error: GitHub prepends $ErrorActionPreference = 'stop' to
+      # powershell steps, so a throwing cmdlet here would abort the job before
+      # the upload and cost the release its ARM64 asset. Reporting must never do
+      # that in a job whose whole signing path is best effort.
       - name: 🔏 Verify MSI Signature (Windows ARM64)
         if: ${{ steps.find-msi.outputs.msi-path != '' }}
+        continue-on-error: true
         shell: powershell
         run: |
           $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
@@ -1600,9 +1630,15 @@ jobs:
           if ($sig.SignerCertificate) {
             Write-Host "Signer: $($sig.SignerCertificate.Subject)"
           }
-          if ($sig.Status -eq 'NotSigned') {
-            Write-Host "::warning::Windows ARM64 MSI is UNSIGNED - DigiCert KeyLocker signing did not run or failed on the ARM runner"
+          if ($sig.Status -ne 'Valid') {
+            Write-Host "::warning::Windows ARM64 MSI signature is $($sig.Status), expected Valid - DigiCert KeyLocker signing did not run or failed on the ARM runner"
           }
+          # A warning annotation is easy to miss on a job that is green by
+          # design, so put the verdict in the run summary too. Explicit UTF-8
+          # without BOM: Windows PowerShell's >> writes UTF-16, which the
+          # summary renders as mojibake.
+          $line = "### Windows ARM64 MSI signature: $($sig.Status)`n"
+          [System.IO.File]::AppendAllText($env:GITHUB_STEP_SUMMARY, $line, (New-Object System.Text.UTF8Encoding($false)))
 
       - name: 📊 Verify Build Artifacts (Windows ARM64)
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1314,6 +1314,23 @@ jobs:
           }
         shell: powershell
 
+      - name: 🔏 Verify MSI Signature
+        shell: powershell
+        run: |
+          $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
+          $sig = Get-AuthenticodeSignature -FilePath $msiPath
+          Write-Host "Signature status: $($sig.Status)"
+          if ($sig.SignerCertificate) {
+            Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+          }
+          if ($sig.Status -eq 'NotSigned') {
+            if ('${{ steps.check-secret.outputs.can_sign }}' -eq 'true') {
+              Write-Host "::error::MSI is unsigned even though signing credentials were present"
+              exit 1
+            }
+            Write-Host "::warning::Windows MSI is UNSIGNED (no CODE_SIGNING_* secrets configured)"
+          }
+
       - name: 📊 Verify Build Artifacts
         run: |
           $msiPath = "composeApp/build/compose/binaries/main/msi/BOSS-*.msi"
@@ -1473,6 +1490,118 @@ jobs:
           } else {
             Write-Host "VersionConstants.kt not found - this indicates build issue"
             exit 1
+          }
+
+      - name: Check if signing secret is available (Windows ARM64)
+        id: check-secret
+        run: |
+          if [ -n "$CERT_HOST" ]; then
+            echo "can_sign=true" >> $GITHUB_OUTPUT
+          else
+            echo "can_sign=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        env:
+          CERT_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+
+      - name: Find MSI File (Windows ARM64)
+        id: find-msi
+        shell: powershell
+        run: |
+          $msiFiles = Get-ChildItem "composeApp/build/compose/binaries/main/msi/BOSS-*.msi" -ErrorAction SilentlyContinue
+          if ($msiFiles) {
+            $msiPath = $msiFiles[0].FullName
+            Write-Host "Found MSI: $msiPath"
+            echo "msi-path=$msiPath" >> $env:GITHUB_OUTPUT
+          } else {
+            # Not fatal: "Verify Build Artifacts (Windows ARM64)" below still
+            # searches recursively, and that fallback existed before signing did.
+            Write-Host "::warning::MSI not found at the expected path - skipping signing"
+            echo "msi-path=" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Decode Client Certificate (Windows ARM64)
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
+        shell: powershell
+        run: |
+          try {
+            $certBytes = [System.Convert]::FromBase64String("${{ secrets.CODE_SIGNING_CLIENT_CERT }}")
+            $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
+            [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+            Write-Host "Client cert decoded successfully to $certPath"
+          } catch {
+            Write-Host "Error decoding client cert: $_"
+            exit 1
+          }
+
+      # DigiCert's client tools are x64 binaries and signtool comes from the x86
+      # Windows Kits directory; both run under emulation on windows-11-arm. That
+      # path is unproven, so every signing step here is continue-on-error: if the
+      # tooling cannot run we still upload the MSI instead of dropping the ARM64
+      # asset from the release. "Verify MSI Signature" reports what actually
+      # landed, so an unsigned ARM64 MSI is loud rather than silent.
+      - name: Install DigiCert STM Client Tools (Windows ARM64)
+        id: install-digicert
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
+        continue-on-error: true
+        uses: digicert/ssm-code-signing@v1.2.1
+        env:
+          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+
+      - name: Reset SMCTL Credentials (Windows ARM64)
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          smctl credentials delete
+          smctl credentials save ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }} ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+        shell: cmd
+        env:
+          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+
+      - name: Sign Windows ARM64 MSI with DigiCert KeyLocker
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          echo "Signing MSI: ${{ steps.find-msi.outputs.msi-path }}"
+          echo "Using keypair: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}"
+          smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"
+        shell: bash
+        env:
+          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+
+      - name: Check SMKSP Log (Windows ARM64 diagnostics)
+        if: always()  # Runs even if signing fails
+        shell: powershell
+        run: |
+          $logPath = "$env:USERPROFILE\.signingmanager\logs\smksp.log"
+          if (Test-Path $logPath) {
+            Write-Host "SMKSP Log Contents:"
+            Get-Content $logPath -Tail 50  # Last 50 lines for recent errors
+          } else {
+            Write-Host "SMKSP log not found."
+          }
+
+      - name: 🔏 Verify MSI Signature (Windows ARM64)
+        if: ${{ steps.find-msi.outputs.msi-path != '' }}
+        shell: powershell
+        run: |
+          $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
+          $sig = Get-AuthenticodeSignature -FilePath $msiPath
+          Write-Host "Signature status: $($sig.Status)"
+          if ($sig.SignerCertificate) {
+            Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+          }
+          if ($sig.Status -eq 'NotSigned') {
+            Write-Host "::warning::Windows ARM64 MSI is UNSIGNED - DigiCert KeyLocker signing did not run or failed on the ARM runner"
           }
 
       - name: 📊 Verify Build Artifacts (Windows ARM64)

--- a/CODE_SIGNING_SETUP.md
+++ b/CODE_SIGNING_SETUP.md
@@ -85,7 +85,9 @@ build an unsigned MSI.
 - **Format**: Base64-encoded PKCS#12 (`.p12`) file
 - **Description**: KeyLocker client authentication certificate. The workflow
   decodes it to `Certificate_pkcs12.p12` and passes it as `SM_CLIENT_CERT_FILE`.
-- **How to generate**: `base64 -i Certificate_pkcs12.p12 | pbcopy`
+- **How to generate** (macOS): `base64 -i Certificate_pkcs12.p12 | pbcopy`
+- **How to generate** (Windows):
+  `[Convert]::ToBase64String([IO.File]::ReadAllBytes('Certificate_pkcs12.p12')) | Set-Clipboard`
 
 #### `CODE_SIGNING_CLIENT_CERT_PASSWORD`
 - **Format**: Plain text password
@@ -101,9 +103,9 @@ build an unsigned MSI.
 
 | Artifact | Job | Signed |
 |----------|-----|--------|
-| `BOSS-<version>.msi` (x64) | `build-windows` | Yes, and the job fails if the MSI comes out unsigned while credentials are present |
+| `BOSS-<version>.msi` (x64) | `build-windows` | Yes. The job fails if credentials were present and the MSI comes out `NotSigned` or `HashMismatch`; any other non-`Valid` status is a warning |
 | `BOSS-<version>.msi` (arm64) | `build-windows-arm64` | Best effort, see below |
-| Bundled branded Chromium binaries | `build-chromium-branding` | No |
+| Bundled branded Chromium binaries (Windows) | `build-chromium-branding` | No, `signCommand` is stripped unconditionally on the Windows legs |
 | `BOSS.exe` inside the MSI | jpackage | No |
 
 The MSI is signed as a container, so SmartScreen is satisfied at install time,
@@ -114,8 +116,9 @@ but the binaries inside the installed tree carry no signature of their own.
 on the `windows-11-arm` runner. Every signing step in that job is
 `continue-on-error: true`: if the tooling cannot run, the job still uploads the
 unsigned MSI instead of dropping the ARM64 asset from the release. The
-`Verify MSI Signature (Windows ARM64)` step then emits a workflow warning, so an
-unsigned ARM64 build is visible in the run summary rather than silent.
+`Verify MSI Signature (Windows ARM64)` step then emits a workflow warning and
+writes the signature status into the run summary, so an unsigned ARM64 build is
+visible rather than silent on a job that is green by design.
 
 ## Setting Up GitHub Secrets
 

--- a/CODE_SIGNING_SETUP.md
+++ b/CODE_SIGNING_SETUP.md
@@ -57,30 +57,65 @@ This document outlines how to set up code signing certificates and configure Git
 
 ## Windows Code Signing Setup
 
+Windows installers are signed with DigiCert Software Trust Manager (KeyLocker)
+via the `digicert/ssm-code-signing` action, in both `release.yml` and
+`release-lite.yml`.
+
 ### Prerequisites
-1. **DigiCert KeyLocker Account** with code signing certificate
-2. **DigiCert KeyLocker API credentials**
+1. **DigiCert KeyLocker account** with a code signing certificate
+2. **KeyLocker API key** and **client authentication certificate** (PKCS#12)
 
 ### Required GitHub Secrets
 
-#### `DIGICERT_API_KEY`
-- **Format**: API key string
-- **Description**: DigiCert KeyLocker API key
-- **How to generate**: DigiCert console → API Keys → Generate new key
+The secret names below are the ones the workflows actually read. All five must
+be present; if `CODE_SIGNING_CERT_HOST` is empty the workflows skip signing and
+build an unsigned MSI.
 
-#### `DIGICERT_CLIENT_AUTH_KEY`
-- **Format**: Client authentication key
-- **Description**: DigiCert KeyLocker client authentication
-- **How to generate**: Provided by DigiCert when setting up KeyLocker
-
-#### `DIGICERT_KEYLOCKER_HOST`
+#### `CODE_SIGNING_CERT_HOST`
 - **Format**: Hostname
-- **Example**: `"clientauth.one.digicert.com"`
-- **Description**: DigiCert KeyLocker service endpoint
+- **Example**: `clientauth.one.digicert.com`
+- **Description**: KeyLocker endpoint, passed to the client tools as `SM_HOST`
 
-#### `DIGICERT_KEYLOCKER_CERTIFICATE_NAME`
-- **Format**: Certificate name
-- **Description**: Name of your code signing certificate in KeyLocker
+#### `CODE_SIGNING_CERT_HOST_API_KEY`
+- **Format**: API key string
+- **Description**: KeyLocker API key (`SM_API_KEY`)
+- **How to generate**: DigiCert ONE console → Access → API Tokens
+
+#### `CODE_SIGNING_CLIENT_CERT`
+- **Format**: Base64-encoded PKCS#12 (`.p12`) file
+- **Description**: KeyLocker client authentication certificate. The workflow
+  decodes it to `Certificate_pkcs12.p12` and passes it as `SM_CLIENT_CERT_FILE`.
+- **How to generate**: `base64 -i Certificate_pkcs12.p12 | pbcopy`
+
+#### `CODE_SIGNING_CLIENT_CERT_PASSWORD`
+- **Format**: Plain text password
+- **Description**: Password for the client authentication certificate
+  (`SM_CLIENT_CERT_PASSWORD`)
+
+#### `CODE_SIGNING_KEYPAIR_ALIAS`
+- **Format**: Keypair alias string
+- **Description**: Alias of the signing keypair in KeyLocker, passed to
+  `smctl sign --keypair-alias`
+
+### What gets signed
+
+| Artifact | Job | Signed |
+|----------|-----|--------|
+| `BOSS-<version>.msi` (x64) | `build-windows` | Yes, and the job fails if the MSI comes out unsigned while credentials are present |
+| `BOSS-<version>.msi` (arm64) | `build-windows-arm64` | Best effort, see below |
+| Bundled branded Chromium binaries | `build-chromium-branding` | No |
+| `BOSS.exe` inside the MSI | jpackage | No |
+
+The MSI is signed as a container, so SmartScreen is satisfied at install time,
+but the binaries inside the installed tree carry no signature of their own.
+
+**Windows ARM64 is best effort.** The DigiCert client tools are x64 binaries and
+`signtool` comes from the x86 Windows Kits directory, so both run under emulation
+on the `windows-11-arm` runner. Every signing step in that job is
+`continue-on-error: true`: if the tooling cannot run, the job still uploads the
+unsigned MSI instead of dropping the ARM64 asset from the release. The
+`Verify MSI Signature (Windows ARM64)` step then emits a workflow warning, so an
+unsigned ARM64 build is visible in the run summary rather than silent.
 
 ## Setting Up GitHub Secrets
 
@@ -103,10 +138,17 @@ security find-identity -v -p codesigning
 ### Local Testing (Windows)
 ```bash
 # Test DigiCert KeyLocker connection
-smksp_registrar.exe list
+smctl healthcheck
 
-# Test build with signing
+# List the keypairs the API key can reach (confirms CODE_SIGNING_KEYPAIR_ALIAS)
+smctl keypair ls
+
+# Build, then sign the MSI the same way CI does
 ./gradlew packageMsi
+smctl sign --keypair-alias "<alias>" --input "composeApp/build/compose/binaries/main/msi/BOSS-<version>.msi"
+
+# Confirm the signature landed
+powershell -Command "Get-AuthenticodeSignature 'composeApp/build/compose/binaries/main/msi/BOSS-<version>.msi'"
 ```
 
 ## Production Release Process
@@ -116,7 +158,7 @@ smksp_registrar.exe list
    - Version increment
    - Cross-platform builds with code signing
    - macOS notarization
-   - Windows MSI signing
+   - Windows MSI signing (x64 enforced, arm64 best effort)
    - GitHub release creation
    - Artifact upload
 
@@ -145,9 +187,14 @@ smksp_registrar.exe list
 - **Team ID mismatch**: Ensure team ID matches certificate
 
 ### Windows Issues
+- **Signing silently skipped**: `CODE_SIGNING_CERT_HOST` is empty or missing, so
+  the `Check if signing secret is available` step set `can_sign=false`
 - **KeyLocker connection fails**: Check API credentials and host
 - **Certificate not accessible**: Verify KeyLocker setup and permissions
-- **MSI signing fails**: Check certificate name and DigiCert service status
+- **MSI signing fails**: Check the keypair alias and DigiCert service status; the
+  `Check SMKSP Log` step prints the tail of `%USERPROFILE%\.signingmanager\logs\smksp.log`
+- **ARM64 MSI unsigned**: Expected if the x64 client tools cannot run under
+  emulation on the ARM runner; the run emits a warning and ships the MSI anyway
 
 ## Cost Considerations
 


### PR DESCRIPTION
## The gap

DigiCert KeyLocker signing has been wired up and working for the x64 MSI since the `CODE_SIGNING_*` secrets were added, confirmed on the latest release run (`Sign Windows MSI with DigiCert KeyLocker => success`). But `build-windows-arm64` went straight from `Package Windows ARM64 MSI` to `Upload Windows ARM64 MSI` with no signing steps, so every Windows-on-ARM user has been getting an unsigned installer.

## What this does

**1. Signs the ARM64 MSI.** Mirrors the x64 chain into `build-windows-arm64`: check secret, find MSI, decode client cert, install DigiCert STM tools, reset smctl credentials, `smctl sign`.

DigiCert's client tools are x64 binaries and `signtool` comes from the x86 Windows Kits directory, so both run under emulation on `windows-11-arm`. The ARM64 runner image does ship the Windows SDKs (10.0.19041/22621/26100), so this should work, but it is unproven until a release run exercises it. So:

- every signing step in that job is `continue-on-error: true`
- the MSI lookup warns instead of `exit 1`, and the signing steps are gated on a non-empty path, which keeps the pre-existing recursive fallback in `Verify Build Artifacts` reachable

Net effect: if the tooling cannot run under emulation, the release still gets its ARM64 asset, exactly as today. It just gets signed as well when it can be.

**2. Proves the signature actually landed.** Best effort is only acceptable if it is visible, so a `Verify MSI Signature` step reads `Get-AuthenticodeSignature` and reports status plus signer subject, added to all three Windows jobs (`release.yml` x64 + arm64, `release-lite.yml` x64).

- **x64: fails the job** when the MSI is `NotSigned` while `can_sign == true`. That is the exact condition that would otherwise ship an unsigned installer under a green build, since every signing step is gated on a secret being non-empty and skips silently when it is not. Shout if you would rather it warn.
- **arm64: warns only**, since signing there is best effort by design.

**3. Fixes `CODE_SIGNING_SETUP.md`.** The Windows half documented four secrets (`DIGICERT_API_KEY`, `DIGICERT_CLIENT_AUTH_KEY`, `DIGICERT_KEYLOCKER_HOST`, `DIGICERT_KEYLOCKER_CERTIFICATE_NAME`) that do not exist in the repo and are read by nothing. Replaced with the five real ones, plus:

- a table of what is and is not signed. The bundled branded Chromium binaries are explicitly built unsigned (`build-chromium-branding.yml` strips `signCommand`), and the jpackage `BOSS.exe` inside the MSI is unsigned too. The MSI is signed as a container, so SmartScreen is satisfied at install time, but the installed tree is not.
- the ARM64 best-effort caveat
- local `smctl` commands that match what CI runs (the old ones referenced `smksp_registrar.exe list`, which is not part of this flow)

## Verification

- Both workflows parse as YAML; step lists and ids confirmed per job.
- The signing path itself cannot be tested outside a release run: the secrets are repository secrets and the ARM64 emulation question is only answerable on a real `windows-11-arm` runner. First release after merge will show either a signed ARM64 MSI or the new warning.

## Not in scope

`release-lite.yml` has no ARM64 job, so nothing to add there beyond the verification step.