### PR TITLE
feat(plugins): make a version-floor refusal recoverable, and publish the host version

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -22,6 +22,8 @@ import ai.rever.boss.components.plugin.MissingDependencyDialog
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.PluginStoreVersionBridge
 import ai.rever.boss.components.plugin.PluginUpdateBridge
+import ai.rever.boss.components.plugin.PluginVersionGateHost
+import ai.rever.boss.components.plugin.PluginVersionRemedyAccess
 import ai.rever.boss.components.plugin.providers.GenericDialogHostContent
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.components.registery.PanelComponentStoreRegistry
@@ -756,6 +758,14 @@ internal fun BossAppDialogs(state: BossAppState) {
             },
         )
     }
+
+    // A plugin the host refused for a version floor. Before this the refusal reached only the log
+    // and the plugin simply stopped existing, which for a systemPlugin reads as a feature
+    // disappearing - fluck-browser IS the browser tab.
+    PluginVersionGateHost(
+        manager = state.currentDefaultPlugin?.dynamicPluginManager,
+        remedyResolver = PluginVersionRemedyAccess.current(),
+    )
 
     // Directory picker for project selection (must be outside conditional for Compose)
     val directoryPicker =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -15,7 +15,9 @@ import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.api.PluginUnloadAware
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.loader.DynamicPluginLoaderImpl
+import ai.rever.boss.plugin.loader.PluginApiLevelException
 import ai.rever.boss.plugin.loader.PluginBinaryIncompatibilityException
+import ai.rever.boss.plugin.loader.PluginBossVersionException
 import ai.rever.boss.plugin.loader.PluginUnloadException
 import ai.rever.boss.plugin.sandbox.InProcessPluginSandbox
 import ai.rever.boss.plugin.sandbox.PluginErrorClassifier
@@ -922,6 +924,16 @@ class DynamicPluginManager(
                             notifyListeners { it.pluginLoadFailed(manifest, error) }
                             return@withLock Result.failure(error)
                         }
+
+                        // A version floor is the one load failure with a known fix, so record it
+                        // where something can offer one. Everything else stays a log line: a
+                        // corrupt jar or a missing main class has no button that helps.
+                        //
+                        // Before this, a floor refusal reached only the log, and from the user's
+                        // side the plugin simply stopped existing. For a systemPlugin that means a
+                        // feature vanished - fluck-browser IS the browser tab, so 1.2.22 requiring
+                        // BOSS 9.4.23 on a 9.4.22 host presented as "my browser is gone".
+                        versionGateFor(error)?.let(PluginVersionGateRegistry::record)
 
                         notifyListeners { it.pluginLoadFailed(null, error ?: Exception("Unknown error")) }
                         return@withLock Result.failure(error ?: Exception("Unknown error"))

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -149,6 +149,22 @@ class DynamicPluginManager(
         System.setProperty("boss.api.version", apiLoader.apiVersion ?: "")
         // Published for the out-of-process spawner (child-JVM classpaths).
         System.setProperty("boss.api.jar", apiLoader.apiJarPath ?: "")
+        // The APP's version, published for the same reason as boss.api.version and
+        // boss.ipc.version: a plugin cannot otherwise learn it.
+        //
+        // The Toolbox is the case that needs it. Store rows carry minBossVersion - the Toolbox
+        // itself writes that field when publishing - but nothing on its browse or install path
+        // could compare it against this host, because this host never said what version it is. So
+        // the Toolbox offered every published version, Install downloaded a plugin the loader then
+        // refused, and the reason reached only the log. That is how fluck-browser 1.2.22
+        // (minBossVersion 9.4.23) presented on 9.4.22: an install that silently would not take.
+        //
+        // A system property rather than an api member, deliberately: it needs no api release, so
+        // every already-installed plugin can read it as soon as this host ships. Same trick as the
+        // boss.fluck.* settings mirror. The host's own catalog already filters on
+        // AppVersion.currentVersionString() (StoreHomeCatalogProvider); this is the same fact,
+        // reachable from a plugin.
+        System.setProperty("boss.app.version", AppVersion.currentVersionString())
         // fromPluginDir already logs the resolved jar + version at INFO;
         // keep this at debug to avoid triple-logging one init.
         logger.debug(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGate.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGate.kt
@@ -1,0 +1,157 @@
+package ai.rever.boss.components.plugin
+
+/**
+ * A plugin the host refused to load because of a version floor, and what would actually fix it.
+ *
+ * **Why this exists.** `DynamicPluginLoader` refuses a plugin whose `minBossVersion` or
+ * `minApiVersion` exceeds what this build provides, which is correct - running it would fail at some
+ * arbitrary call site instead. But the refusal only reached an ERROR line in the log, so from the
+ * user's side a plugin simply stopped existing. That is bad for any plugin and worse for a
+ * `systemPlugin`: fluck-browser is the browser tab, so the observable symptom of a version floor was
+ * "my browser is gone", with the reason available only to someone reading `~/.boss/logs`.
+ *
+ * It happened for real. fluck-browser 1.2.22 shipped requiring BOSS 9.4.23 while 9.4.22 was the
+ * current release, and every host that took the plugin update lost its browser tab:
+ *
+ * ```
+ * PluginBossVersionException: Plugin requires BOSS version 9.4.23 or later,
+ *                             but current version is 9.4.22
+ * ```
+ *
+ * Recovering meant knowing that the jar had been overwritten in place, finding the previous release,
+ * and putting it back by hand. None of that is reasonable to expect, and all of it is knowable from
+ * the exception the loader already throws.
+ *
+ * This models the refusal and the ways out. It is deliberately pure - no store, no updater, no
+ * files - so the question "what should we offer the user" is answerable in a test.
+ */
+
+/** Which floor the plugin failed, and the two versions involved. */
+sealed interface PluginVersionGate {
+    val pluginId: String
+    val displayName: String
+
+    /** What the plugin asks for. */
+    val required: String
+
+    /** What this build has. */
+    val current: String
+
+    /** The plugin needs a newer BOSS. Fixed by updating the app, or by going back a plugin version. */
+    data class NeedsNewerHost(
+        override val pluginId: String,
+        override val displayName: String,
+        override val required: String,
+        override val current: String,
+    ) : PluginVersionGate
+
+    /**
+     * The plugin needs a newer plugin API layer.
+     *
+     * Distinct from [NeedsNewerHost] because the fix is different and much cheaper: the api layer is
+     * itself a plugin, hot-swappable without a restart, so this is resolvable in place. Conflating
+     * the two would send a user to download a whole application update for something the store can
+     * settle in seconds.
+     */
+    data class NeedsNewerApi(
+        override val pluginId: String,
+        override val displayName: String,
+        override val required: String,
+        override val current: String,
+    ) : PluginVersionGate
+}
+
+/** Something the user can do about a [PluginVersionGate], with enough detail to label a button. */
+sealed interface PluginVersionRemedy {
+    /**
+     * Update the application. Only offered when an update is actually available AND high enough -
+     * "Update BOSS" that lands on a version still below the floor is worse than no button, because
+     * the user pays for a restart and the plugin is still missing afterwards.
+     */
+    data class UpdateHost(
+        val availableVersion: String,
+    ) : PluginVersionRemedy
+
+    /** Install a newer api plugin from the store. */
+    data class UpdateApi(
+        val availableVersion: String,
+    ) : PluginVersionRemedy
+
+    /**
+     * Go back to the plugin version that was working.
+     *
+     * The remedy that always applies, because it does not depend on anything being published: the
+     * jar this one replaced is kept aside precisely so there is a way back. Named with the version
+     * so the button can say what it will do rather than "Downgrade".
+     */
+    data class RevertPlugin(
+        val toVersion: String,
+    ) : PluginVersionRemedy
+
+    /**
+     * Nothing can be offered, and the reason is worth showing.
+     *
+     * Reached when no update is published yet and no previous jar was kept - which is exactly the
+     * position a user is in when a plugin's first release already overshoots their host. Saying so
+     * beats an empty dialog or, worse, silence.
+     */
+    data class NothingAvailable(
+        val reason: String,
+    ) : PluginVersionRemedy
+}
+
+/**
+ * What the host can offer for [gate], most useful first.
+ *
+ * @param hostUpdate the app version an update would install, or null when none is available.
+ * @param apiUpdate the api-plugin version the store publishes, or null when it cannot be asked.
+ * @param revertTo the plugin version kept aside from the last replacement, or null when none was.
+ * @param satisfies whether a candidate version meets a required floor. Injected rather than
+ *   reimplemented here: the loader already owns that comparison, and a second copy of version
+ *   arithmetic is how the two drift into disagreeing about the same pair of numbers.
+ */
+fun remediesFor(
+    gate: PluginVersionGate,
+    hostUpdate: String?,
+    apiUpdate: String?,
+    revertTo: String?,
+    satisfies: (required: String, candidate: String) -> Boolean,
+): List<PluginVersionRemedy> {
+    val remedies = mutableListOf<PluginVersionRemedy>()
+    when (gate) {
+        is PluginVersionGate.NeedsNewerHost -> {
+            // Only when it would actually clear the floor. An update to 9.4.22 does not help a
+            // plugin asking for 9.4.23, and offering it wastes a restart to end up here again.
+            hostUpdate?.takeIf { satisfies(gate.required, it) }?.let {
+                remedies += PluginVersionRemedy.UpdateHost(it)
+            }
+        }
+
+        is PluginVersionGate.NeedsNewerApi -> {
+            apiUpdate?.takeIf { satisfies(gate.required, it) }?.let {
+                remedies += PluginVersionRemedy.UpdateApi(it)
+            }
+        }
+    }
+    // Always last, and always offered when it exists: it is the remedy that needs nothing published
+    // and no restart, so it is the one that works when everything else is unavailable. Last rather
+    // than first because going forward is better than going back when both are possible.
+    revertTo?.let { remedies += PluginVersionRemedy.RevertPlugin(it) }
+
+    if (remedies.isNotEmpty()) return remedies
+    return listOf(
+        PluginVersionRemedy.NothingAvailable(
+            when (gate) {
+                is PluginVersionGate.NeedsNewerHost -> {
+                    "This needs BOSS ${gate.required}. You have ${gate.current}, " +
+                        "no update is available yet, and no earlier version of the plugin was kept."
+                }
+
+                is PluginVersionGate.NeedsNewerApi -> {
+                    "This needs plugin API ${gate.required}. You have ${gate.current}, " +
+                        "the store has nothing newer, and no earlier version of the plugin was kept."
+                }
+            },
+        ),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGate.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGate.kt
@@ -1,5 +1,12 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.plugin.loader.PluginApiLevelException
+import ai.rever.boss.plugin.loader.PluginBossVersionException
+import ai.rever.boss.utils.AppVersion
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
 /**
  * A plugin the host refused to load because of a version floor, and what would actually fix it.
  *
@@ -155,3 +162,96 @@ fun remediesFor(
         ),
     )
 }
+
+/**
+ * The version-floor refusals this session has seen, so something can offer a way out.
+ *
+ * A process-wide object rather than state on `DynamicPluginManager`, for the same reason
+ * `PluginCrashRegistry` is one: the refusal happens during startup plugin loading, long before any
+ * window exists to hold it, and the dialog that acts on it is mounted by whichever window opens
+ * first. Passing it down would mean threading it through every construction path that can load a
+ * plugin.
+ *
+ * Keyed by plugin id, so a plugin refused on every restart accumulates one entry rather than one
+ * per attempt.
+ */
+object PluginVersionGateRegistry {
+    private val _gates = MutableStateFlow<Map<String, PluginVersionGate>>(emptyMap())
+
+    /** Refusals not yet dismissed or resolved, keyed by plugin id. */
+    val gates: StateFlow<Map<String, PluginVersionGate>> = _gates.asStateFlow()
+
+    fun record(gate: PluginVersionGate) {
+        _gates.value = _gates.value + (gate.pluginId to gate)
+    }
+
+    /**
+     * Forget the refusal for [pluginId].
+     *
+     * Called when a remedy has been applied AND when the user dismisses. Both, because a dialog
+     * that reappears on every recomposition for a problem the user has decided to live with is
+     * worse than the silence this replaced.
+     */
+    fun clear(pluginId: String) {
+        if (_gates.value.containsKey(pluginId)) {
+            _gates.value = _gates.value - pluginId
+        }
+    }
+
+    /** For tests. Nothing in the app should need to drop every refusal at once. */
+    internal fun reset() {
+        _gates.value = emptyMap()
+    }
+}
+
+/**
+ * Translate a load failure into a [PluginVersionGate], or null when it is not a version floor.
+ *
+ * Null for everything else on purpose. A corrupt jar, a missing main class or a binary
+ * incompatibility have no button that helps, and offering "Update BOSS" for them would send a user
+ * through a download and a restart to arrive at the same failure.
+ *
+ * The display name falls back to the plugin id: the manifest is unavailable here, because the
+ * refusal happens before the loader returns anything but the exception, and an id is a worse label
+ * than a name but a far better one than nothing.
+ */
+internal fun versionGateFor(error: Throwable?): PluginVersionGate? =
+    when (error) {
+        is PluginBossVersionException -> {
+            val id = error.pluginId
+            val required = error.requiredVersion
+            // Both, because a gate that cannot name what it needs cannot decide whether an
+            // available update would clear the floor, and would offer one blind.
+            if (id.isNullOrBlank() || required.isNullOrBlank()) {
+                null
+            } else {
+                PluginVersionGate.NeedsNewerHost(
+                    pluginId = id,
+                    displayName = id,
+                    required = required,
+                    current = error.currentVersion ?: AppVersion.currentVersionString(),
+                )
+            }
+        }
+
+        is PluginApiLevelException -> {
+            val id = error.pluginId
+            val required = error.requiredVersion
+            if (id.isNullOrBlank() || required.isNullOrBlank()) {
+                null
+            } else {
+                PluginVersionGate.NeedsNewerApi(
+                    pluginId = id,
+                    displayName = id,
+                    required = required,
+                    // The api layer is a plugin, so "installed" is the right word and there is no
+                    // build-time constant to fall back on the way there is for the app version.
+                    current = error.installedVersion ?: "unknown",
+                )
+            }
+        }
+
+        else -> {
+            null
+        }
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGateDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGateDialog.kt
@@ -1,0 +1,282 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * Tells the user a plugin was refused for a version floor, and offers the ways out.
+ *
+ * The thing this replaces is silence. A `minBossVersion` or `minApiVersion` miss produced one ERROR
+ * line in `~/.boss/logs` and nothing else, so the plugin just stopped existing - and for a
+ * systemPlugin that reads as a feature disappearing, since fluck-browser *is* the browser tab.
+ *
+ * The remedies come from [remediesFor] and are rendered in the order it returns them, most useful
+ * first. Two properties of that ordering are load-bearing here:
+ *
+ * - **An update is only offered when it clears the floor.** A button that costs a download and a
+ *   restart and lands back on the same dialog is worse than no button.
+ * - **Reverting is last but always present when possible.** It needs nothing published and no
+ *   restart, so it is what works when everything else is unavailable.
+ *
+ * @param busy true while a remedy is being applied, so the dialog stays put and says what is
+ *   happening rather than vanishing and leaving a user to guess whether it worked
+ * @param error a failure from the last attempt, kept on screen instead of dismissing the dialog
+ */
+@Composable
+fun PluginVersionGateDialog(
+    gate: PluginVersionGate,
+    remedies: List<PluginVersionRemedy>,
+    busy: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onApply: (PluginVersionRemedy) -> Unit,
+) {
+    BossDialog(
+        // Not dismissable while a remedy is running: an app download or a jar restore continues
+        // regardless, and a dialog that disappears mid-way reads as "nothing happened".
+        onDismissRequest = { if (!busy) onDismiss() },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = !busy,
+                dismissOnClickOutside = !busy,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .width(440.dp)
+                    .onKeyEvent { event ->
+                        val escape = event.type == KeyEventType.KeyDown && event.key == Key.Escape
+                        if (!busy && escape) {
+                            onDismiss()
+                            true
+                        } else {
+                            false
+                        }
+                    },
+            shape = RoundedCornerShape(8.dp),
+            backgroundColor = BossTheme.colors.panel,
+            elevation = 8.dp,
+        ) {
+            PluginVersionGateBody(
+                gate = gate,
+                remedies = remedies,
+                busy = busy,
+                error = error,
+                onDismiss = onDismiss,
+                onApply = onApply,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PluginVersionGateBody(
+    gate: PluginVersionGate,
+    remedies: List<PluginVersionRemedy>,
+    busy: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onApply: (PluginVersionRemedy) -> Unit,
+) {
+    Column(modifier = Modifier.padding(20.dp)) {
+        Text(
+            text = "${gate.displayName} could not be loaded",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = BossTheme.colors.textPrimary,
+            // The display name falls back to the plugin id, which comes from a manifest. Clamped
+            // so a crafted one cannot grow the dialog or run on into something that reads like our
+            // own copy.
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text =
+                when (gate) {
+                    is PluginVersionGate.NeedsNewerHost -> {
+                        "It needs BOSS ${gate.required} or later. This is ${gate.current}."
+                    }
+
+                    is PluginVersionGate.NeedsNewerApi -> {
+                        "It needs plugin API ${gate.required} or later. The installed API layer is ${gate.current}."
+                    }
+                },
+            fontSize = 13.sp,
+            color = BossTheme.colors.textSecondary,
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = gate.pluginId,
+            fontSize = 11.sp,
+            color = BossTheme.colors.textMuted,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        if (error != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = error,
+                fontSize = 12.sp,
+                color = BossTheme.colors.alert,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        PluginVersionGateActions(
+            remedies = remedies,
+            busy = busy,
+            onDismiss = onDismiss,
+            onApply = onApply,
+        )
+    }
+}
+
+@Composable
+private fun PluginVersionGateActions(
+    remedies: List<PluginVersionRemedy>,
+    busy: Boolean,
+    onDismiss: () -> Unit,
+    onApply: (PluginVersionRemedy) -> Unit,
+) {
+    // NothingAvailable is a sentence, not a button. remediesFor guarantees it is alone in the list
+    // when present, so it is handled before anything is laid out as an action.
+    val explanation = remedies.filterIsInstance<PluginVersionRemedy.NothingAvailable>().firstOrNull()
+    if (explanation != null) {
+        NoRemedyAvailable(reason = explanation.reason, onDismiss = onDismiss)
+        return
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (busy) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(14.dp),
+                    strokeWidth = 2.dp,
+                    color = BossTheme.colors.signalText,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Working",
+                    fontSize = 12.sp,
+                    color = BossTheme.colors.textSecondary,
+                )
+            }
+            return@Column
+        }
+
+        // One button per remedy, stacked rather than in a row: the labels name versions, so they
+        // are long enough that a row would truncate exactly the part that distinguishes them.
+        remedies.forEachIndexed { index, remedy ->
+            if (index > 0) Spacer(modifier = Modifier.height(8.dp))
+            Button(
+                onClick = { onApply(remedy) },
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        // Only the first remedy is the recommended one. Painting every button as
+                        // primary would leave nothing saying which to take.
+                        //
+                        // `onSignal` rather than `signalText` on the filled button: signalText is
+                        // the accent held to a text contrast floor against ink/panel/raised, and
+                        // this text sits on the accent itself.
+                        backgroundColor =
+                            if (index == 0) BossTheme.colors.signal else BossTheme.colors.raised,
+                        contentColor =
+                            if (index == 0) BossTheme.colors.onSignal else BossTheme.colors.textPrimary,
+                    ),
+                shape = RoundedCornerShape(6.dp),
+            ) {
+                Text(remedyLabel(remedy), fontSize = 13.sp, fontWeight = FontWeight.Medium)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            TextButton(onClick = onDismiss) {
+                Text("Not now", fontSize = 13.sp, color = BossTheme.colors.textSecondary)
+            }
+        }
+    }
+}
+
+/**
+ * The dead end: nothing is published and nothing was kept.
+ *
+ * Says so rather than showing an empty dialog. This is the position a user is in when a plugin's
+ * first release already overshoots their host, and it is the one case where the honest answer is
+ * "wait for the release" - which is still better than the silence this whole feature replaced.
+ */
+@Composable
+private fun NoRemedyAvailable(
+    reason: String,
+    onDismiss: () -> Unit,
+) {
+    Column {
+        Text(
+            text = reason,
+            fontSize = 12.sp,
+            color = BossTheme.colors.textSecondary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            TextButton(onClick = onDismiss) {
+                Text("Close", fontSize = 13.sp, color = BossTheme.colors.textSecondary)
+            }
+        }
+    }
+}
+
+/**
+ * The button text for a remedy.
+ *
+ * Every label names a version. "Downgrade" or "Update BOSS" leaves the user unable to tell what
+ * they are about to get, and in the case of a revert, which version they are going back to.
+ */
+internal fun remedyLabel(remedy: PluginVersionRemedy): String =
+    when (remedy) {
+        is PluginVersionRemedy.UpdateHost -> "Update BOSS to ${remedy.availableVersion}"
+        is PluginVersionRemedy.UpdateApi -> "Update the plugin API to ${remedy.availableVersion}"
+        is PluginVersionRemedy.RevertPlugin -> "Go back to version ${remedy.toVersion}"
+        is PluginVersionRemedy.NothingAvailable -> remedy.reason
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGateHost.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGateHost.kt
@@ -1,0 +1,127 @@
+package ai.rever.boss.components.plugin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
+
+/**
+ * Shows a [PluginVersionGateDialog] for the first unresolved version-floor refusal, if any.
+ *
+ * Self-contained: it reads [PluginVersionGateRegistry] rather than taking state from the caller, so
+ * mounting it is one line and no state class grows a field. That matches where the refusal comes
+ * from - startup plugin loading, before any window exists - and means whichever window opens first
+ * asks the question.
+ *
+ * **One at a time.** A version bump can refuse several plugins at once (a whole batch declaring the
+ * same new floor), and stacking dialogs would be unusable. Resolving or dismissing the first brings
+ * up the next.
+ *
+ * @param remedyResolver injected so the remedy inputs - an app update, an api version, a kept jar -
+ *   can be supplied by the desktop layer that can reach them, and stubbed in a test.
+ */
+@Composable
+fun PluginVersionGateHost(
+    manager: DynamicPluginManager?,
+    remedyResolver: PluginVersionRemedyResolver?,
+) {
+    val gates by PluginVersionGateRegistry.gates.collectAsState()
+    val gate = gates.values.firstOrNull()
+    // One guard for all three absences. A refusal with no manager or no resolver is not renderable
+    // and stays in the registry until something can act on it, so this is a plain absence rather
+    // than an error path. Parameters are vals, so everything below reads them non-null.
+    if (gate == null || manager == null || remedyResolver == null) return
+
+    val scope = rememberCoroutineScope()
+    var busy by remember(gate.pluginId) { mutableStateOf(false) }
+    var error by remember(gate.pluginId) { mutableStateOf<String?>(null) }
+
+    // Resolved asynchronously because one of the three inputs is a store request. Until it arrives
+    // the dialog is not shown at all rather than shown with no buttons: an empty dialog that fills
+    // in a moment later reads as a bug, and there is no hurry - the plugin has already failed.
+    val remedies by
+        produceState<List<PluginVersionRemedy>?>(initialValue = null, gate) {
+            value = remedyResolver.resolve(gate)
+        }
+    val resolved = remedies ?: return
+
+    PluginVersionGateDialog(
+        gate = gate,
+        remedies = resolved,
+        busy = busy,
+        error = error,
+        onDismiss = {
+            // Dismissal forgets the refusal for this session. A dialog that comes back on every
+            // recomposition for a problem the user has decided to live with would be worse than
+            // the silence it replaced; the refusal is recorded again on the next launch, which is
+            // the right cadence for something this consequential.
+            PluginVersionGateRegistry.clear(gate.pluginId)
+        },
+        onApply = { remedy ->
+            busy = true
+            error = null
+            scope.launch {
+                try {
+                    // runCatching, not a catch: a throw rather than a failed Result would leave
+                    // the dialog open with no message and live buttons, looking like the click did
+                    // nothing.
+                    runCatching { remedyResolver.apply(gate, remedy, manager) }
+                        .getOrElse { Result.failure(it) }
+                        .onFailure { e ->
+                            error = e.message ?: "Could not apply that fix."
+                        }
+                } finally {
+                    // Always: `busy` disables every button and blocks dismissal, so leaving it set
+                    // would produce a modal escapable only by closing the window.
+                    busy = false
+                }
+            }
+        },
+    )
+}
+
+/**
+ * Supplies and performs the remedies for a gate.
+ *
+ * An interface rather than a direct call into the desktop implementation, because
+ * [PluginVersionGateHost] is `commonMain` and the pieces a remedy needs - the app updater, the
+ * plugin store, the plugins directory - are all `desktopMain`. It also makes the host testable
+ * without any of them.
+ */
+interface PluginVersionRemedyResolver {
+    suspend fun resolve(gate: PluginVersionGate): List<PluginVersionRemedy>
+
+    suspend fun apply(
+        gate: PluginVersionGate,
+        remedy: PluginVersionRemedy,
+        manager: DynamicPluginManager,
+    ): Result<String>
+}
+
+/**
+ * Holds the desktop [PluginVersionRemedyResolver] for the `commonMain` host composable.
+ *
+ * The same shape as `BrokeredCredentialAccess`, and for the same reason: the implementation speaks
+ * to the app updater, the plugin store and the filesystem, all of which live in `desktopMain`,
+ * while the dialog that uses it is mounted from `commonMain`. Populated once at startup.
+ *
+ * Null until then, and the host renders nothing - which is correct rather than merely tolerable: a
+ * refusal recorded before this is set has nothing that could act on it, and it stays in the
+ * registry until something can.
+ */
+object PluginVersionRemedyAccess {
+    @Volatile
+    private var resolver: PluginVersionRemedyResolver? = null
+
+    /** Called once from desktop startup. */
+    fun initialize(implementation: PluginVersionRemedyResolver) {
+        resolver = implementation
+    }
+
+    fun current(): PluginVersionRemedyResolver? = resolver
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginRollbackStore.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginRollbackStore.kt
@@ -7,131 +7,185 @@ import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
 
 /**
- * Keeps the jar an install replaced, so there is a way back from a version that will not load.
+ * Keeps the jar an update replaced, so there is a way back from a version that will not load.
  *
- * **Why this is needed at all.** Every install path here promotes a downloaded jar over the target
- * with `atomicMoveFrom`, and `discardFiles` deletes what it rejects - so before this, replacing a
- * plugin destroyed the only copy of the version that worked. That is fine while the new version
- * loads. It is not fine when the new version declares a floor this build cannot meet: the loader
- * refuses it, the plugin is gone, and nothing on disk can bring it back.
+ * **Why this is needed at all.** An update ends with `PluginJarReconciler.reconcilePluginDir`,
+ * which deletes every jar for a plugin except the highest version - so the moment an update
+ * finishes, the version that was working no longer exists anywhere. That is fine while the new
+ * version loads. It is not fine when the new version declares a floor this build cannot meet: the
+ * loader refuses it, the plugin is gone, and nothing on disk can bring it back.
  *
  * That is not hypothetical. fluck-browser 1.2.22 shipped requiring BOSS 9.4.23 against a current
  * release of 9.4.22, so hosts that took the update lost their browser tab, and the recovery was to
- * know the jar had been overwritten in place, find the previous release on GitHub, and put it back
- * by hand. One kept file makes that a button.
+ * know the jar had been replaced, find the previous release on GitHub, and put it back by hand. One
+ * kept file makes that a button.
+ *
+ * **Keyed by plugin id, not by jar path.** The first version of this keyed off the jar's own path
+ * (`<name>.jar.rollback`) and could not work: the host's update path downloads to a NEW filename
+ * (`<pluginId>-<newVersion>.jar`) and reconcile then deletes the old one, so a snapshot taken at
+ * the new path finds nothing to copy, and one taken at the old path is addressed by a name nobody
+ * holds afterwards. A plugin id is the one identifier that survives a version change.
  *
  * **Deliberately one generation deep.** A history would be a directory of stale jars nobody prunes,
  * each a full copy of a plugin (fluck-browser's is ~5 MB). One is what recovery needs: the state
  * immediately before the change that broke it.
  *
- * The copy sits beside the jar as `<name>.jar.rollback` with its signature sidecar as
- * `<name>.jar.rollback.sig`. The suffix deliberately does not end in `.jar`, so the plugin directory
- * scan ignores it - the same reason `StoreMissingDependencyInstaller` streams to `.jar.part`.
+ * The copies live in a `.rollback` subdirectory of the plugin directory. A dot-prefixed directory
+ * rather than a suffix in place, so the plugin directory scan cannot mistake a kept jar for an
+ * installed one and load two copies of the same plugin.
  */
 internal object PluginRollbackStore {
     private val logger = BossLogger.forComponent("PluginRollbackStore")
 
-    private const val SUFFIX = ".rollback"
-
-    private fun rollbackFor(jarPath: String) = File(jarPath + SUFFIX)
+    private const val DIR_NAME = ".rollback"
 
     /**
-     * Where the kept version number is written, next to the copy.
-     *
-     * The version is recorded at snapshot time rather than read back out of the copy, because
-     * `PluginManifestReader.readFromJar` refuses any path not ending in `.jar` - "File is not a
-     * JAR" - and the whole point of the `.rollback` suffix is that this file does NOT look like a
-     * jar to a directory scan. The two requirements are in direct conflict, and a text file settles
-     * it more cheaply than opening a zip would anyway.
+     * Plugin ids are dotted reverse-domain strings and reach here from a manifest, so they are
+     * sanitized before becoming a filename for the same reason `PluginUpdateBridge` sanitizes its
+     * download name: a `/` or a `..` in an id would address a file outside this directory.
      */
-    private fun versionFileFor(jarPath: String) = File(jarPath + SUFFIX + ".version")
+    private fun safeName(pluginId: String) = pluginId.replace(Regex("[^A-Za-z0-9._-]"), "_")
+
+    private fun dir(pluginDir: File) = File(pluginDir, DIR_NAME)
+
+    private fun jarFor(
+        pluginDir: File,
+        pluginId: String,
+    ) = File(dir(pluginDir), safeName(pluginId) + ".jar")
 
     /**
-     * Snapshot [jarPath] before something replaces it. No-op when there is nothing there yet.
+     * Where the kept version number is written, beside the copy.
      *
-     * Copy rather than move: the caller is about to promote over this path and must not be handed a
-     * missing file if the snapshot fails. A failure here is logged and swallowed for the same
-     * reason - losing the ability to roll back is worse than an install that does not happen, but
-     * only just, and an install that fails because its backup failed helps nobody.
+     * Recorded at snapshot time rather than read back out of the copy on demand. Reading it back
+     * would mean opening a zip on every dialog, and the version is what labels the button, so it
+     * has to be knowable without touching the jar at all.
      */
-    fun snapshot(jarPath: String) {
-        val jar = File(jarPath)
-        if (!jar.isFile) return
-        val rollback = rollbackFor(jarPath)
-        // Read from the LIVE jar, whose name ends in .jar, before it is replaced. See
-        // versionFileFor for why it cannot be read back from the copy.
-        val version = runCatching { PluginManifestReader.readFromJar(jarPath).version }.getOrNull()
+    private fun versionFor(
+        pluginDir: File,
+        pluginId: String,
+    ) = File(dir(pluginDir), safeName(pluginId) + ".version")
+
+    /**
+     * Keep a copy of [sourceJarPath] as the way back for [pluginId].
+     *
+     * Copy rather than move: the caller may still be running from this jar, and an update that
+     * removed the live plugin to make a backup would be absurd. A failure is logged and swallowed -
+     * losing the ability to roll back is bad, but failing an update because its backup failed is
+     * worse.
+     *
+     * The version is read from the source jar, which is still named `.jar` at this point.
+     * `PluginManifestReader.readFromJar` refuses any path that is not (it reports "File is not a
+     * JAR"), so this cannot be deferred until after the copy is made.
+     */
+    fun snapshot(
+        pluginDir: File,
+        pluginId: String,
+        sourceJarPath: String,
+    ) {
+        val source = File(sourceJarPath)
+        if (!source.isFile) return
+        val version = runCatching { PluginManifestReader.readFromJar(sourceJarPath).version }.getOrNull()
+        if (version == null) {
+            // Without a version the button cannot say what it will restore, and an unlabelled
+            // "revert" is not something to offer. Any EARLIER copy is left alone: it is correctly
+            // labelled with its own version, so restoring it lands on something older than ideal
+            // but working - which beats no way back at all.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Could not read a version from the jar being replaced; keeping any earlier rollback",
+                mapOf("pluginId" to pluginId, "jarPath" to sourceJarPath),
+            )
+            return
+        }
         runCatching {
-            jar.copyTo(rollback, overwrite = true)
-            if (version != null) {
-                versionFileFor(jarPath).writeText(version)
-            } else {
-                // No version means the button cannot name what it will restore, so the copy is not
-                // offered at all rather than offered blind.
-                runCatching { versionFileFor(jarPath).delete() }
-            }
-            // The sidecar travels with it or the restore is unverifiable: a jar whose signature file
-            // belongs to different bytes hard-fails the load, which is worse than being unsigned.
-            PluginSignatureSidecar.read(jarPath)?.let { sig ->
-                PluginSignatureSidecar.persist(rollback.absolutePath, sig)
-            } ?: PluginSignatureSidecar.delete(rollback.absolutePath)
+            dir(pluginDir).mkdirs()
+            source.copyTo(jarFor(pluginDir, pluginId), overwrite = true)
+            versionFor(pluginDir, pluginId).writeText(version)
+            // The sidecar travels with it or the restore is unverifiable: a jar whose signature
+            // file belongs to different bytes hard-fails the load, which is worse than unsigned.
+            val target = jarFor(pluginDir, pluginId).absolutePath
+            PluginSignatureSidecar.read(sourceJarPath)?.let { PluginSignatureSidecar.persist(target, it) }
+                ?: PluginSignatureSidecar.delete(target)
         }.onFailure { e ->
             logger.warn(
                 LogCategory.SYSTEM,
-                "Could not keep a rollback copy; this install will not be reversible",
-                mapOf("jarPath" to jarPath),
+                "Could not keep a rollback copy; this update will not be reversible",
+                mapOf("pluginId" to pluginId),
                 error = e,
             )
         }
     }
 
-    /** The version held in the rollback copy, or null when there is none or it cannot be named. */
-    fun availableVersion(jarPath: String): String? {
-        // Both files, because either alone is not a usable offer: bytes with no recorded version
+    /** The version held for [pluginId], or null when there is none or it cannot be named. */
+    fun availableVersion(
+        pluginDir: File,
+        pluginId: String,
+    ): String? {
+        // BOTH files, because either alone is not a usable offer: bytes with no recorded version
         // cannot label a button, and a version with no bytes cannot be restored.
-        val hasBoth = rollbackFor(jarPath).isFile && versionFileFor(jarPath).isFile
-        return if (!hasBoth) {
+        val versionFile = versionFor(pluginDir, pluginId)
+        return if (!jarFor(pluginDir, pluginId).isFile || !versionFile.isFile) {
             null
         } else {
-            runCatching { versionFileFor(jarPath).readText().trim().takeIf { it.isNotEmpty() } }.getOrNull()
+            runCatching { versionFile.readText().trim().takeIf { it.isNotEmpty() } }.getOrNull()
         }
     }
 
     /**
-     * Put the rollback copy back at [jarPath].
+     * Put the kept jar back into [pluginDir], returning the file now in place.
      *
-     * The copy is KEPT, not moved, so a restore that is itself interrupted has not consumed the only
-     * good jar - and so a second attempt after a failed load is possible. Returns the version now in
-     * place, or null when there was nothing to restore.
+     * Restores to a version-named file rather than over whatever is there, because what is there is
+     * the version being rolled back FROM and it has to be removed, not overwritten: leaving it
+     * would give the directory scan two jars for one plugin id.
+     *
+     * The kept copy is not consumed, so a restore interrupted halfway has not destroyed the only
+     * good jar and a second attempt is possible.
      */
-    fun restore(jarPath: String): String? {
-        val rollback = rollbackFor(jarPath)
-        if (!rollback.isFile) return null
-        val version = availableVersion(jarPath)
+    fun restore(
+        pluginDir: File,
+        pluginId: String,
+        currentJarPath: String?,
+    ): File? {
+        val kept = jarFor(pluginDir, pluginId)
+        // availableVersion already requires the jar to exist, so this is the single guard both
+        // conditions need rather than two returns saying the same thing.
+        val version = availableVersion(pluginDir, pluginId)?.takeIf { kept.isFile } ?: return null
         return runCatching {
-            rollback.copyTo(File(jarPath), overwrite = true)
+            val destination = File(pluginDir, "${safeName(pluginId)}-$version.jar")
+            kept.copyTo(destination, overwrite = true)
             PluginSignatureSidecar
-                .read(rollback.absolutePath)
-                ?.let { PluginSignatureSidecar.persist(jarPath, it) }
-                // No signature for the restored bytes is better than the WRONG one: the sidecar
-                // still on disk belongs to the version being rolled back FROM, and leaving it there
-                // fails the load outright.
-                ?: PluginSignatureSidecar.delete(jarPath)
-            version
+                .read(kept.absolutePath)
+                ?.let { PluginSignatureSidecar.persist(destination.absolutePath, it) }
+                // No signature for the restored bytes beats the WRONG one: a sidecar left from
+                // another version fails the load outright.
+                ?: PluginSignatureSidecar.delete(destination.absolutePath)
+            // Only now remove the version that would not load, and only if it is a different file -
+            // a restore onto its own path would otherwise delete what it just wrote.
+            currentJarPath
+                ?.let(::File)
+                ?.takeIf { it.isFile && it.canonicalPath != destination.canonicalPath }
+                ?.let { broken ->
+                    PluginSignatureSidecar.delete(broken.absolutePath)
+                    broken.delete()
+                }
+            destination
         }.onFailure { e ->
             logger.error(
                 LogCategory.SYSTEM,
                 "Could not restore the rollback copy",
-                mapOf("jarPath" to jarPath),
+                mapOf("pluginId" to pluginId),
                 error = e,
             )
         }.getOrNull()
     }
 
     /** Drop the copy. For an uninstall, where the plugin itself is going away. */
-    fun discard(jarPath: String) {
-        runCatching { rollbackFor(jarPath).delete() }
-        runCatching { versionFileFor(jarPath).delete() }
-        runCatching { PluginSignatureSidecar.delete(rollbackFor(jarPath).absolutePath) }
+    fun discard(
+        pluginDir: File,
+        pluginId: String,
+    ) {
+        runCatching { jarFor(pluginDir, pluginId).delete() }
+        runCatching { versionFor(pluginDir, pluginId).delete() }
+        runCatching { PluginSignatureSidecar.delete(jarFor(pluginDir, pluginId).absolutePath) }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginRollbackStore.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginRollbackStore.kt
@@ -1,0 +1,137 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.loader.PluginManifestReader
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+
+/**
+ * Keeps the jar an install replaced, so there is a way back from a version that will not load.
+ *
+ * **Why this is needed at all.** Every install path here promotes a downloaded jar over the target
+ * with `atomicMoveFrom`, and `discardFiles` deletes what it rejects - so before this, replacing a
+ * plugin destroyed the only copy of the version that worked. That is fine while the new version
+ * loads. It is not fine when the new version declares a floor this build cannot meet: the loader
+ * refuses it, the plugin is gone, and nothing on disk can bring it back.
+ *
+ * That is not hypothetical. fluck-browser 1.2.22 shipped requiring BOSS 9.4.23 against a current
+ * release of 9.4.22, so hosts that took the update lost their browser tab, and the recovery was to
+ * know the jar had been overwritten in place, find the previous release on GitHub, and put it back
+ * by hand. One kept file makes that a button.
+ *
+ * **Deliberately one generation deep.** A history would be a directory of stale jars nobody prunes,
+ * each a full copy of a plugin (fluck-browser's is ~5 MB). One is what recovery needs: the state
+ * immediately before the change that broke it.
+ *
+ * The copy sits beside the jar as `<name>.jar.rollback` with its signature sidecar as
+ * `<name>.jar.rollback.sig`. The suffix deliberately does not end in `.jar`, so the plugin directory
+ * scan ignores it - the same reason `StoreMissingDependencyInstaller` streams to `.jar.part`.
+ */
+internal object PluginRollbackStore {
+    private val logger = BossLogger.forComponent("PluginRollbackStore")
+
+    private const val SUFFIX = ".rollback"
+
+    private fun rollbackFor(jarPath: String) = File(jarPath + SUFFIX)
+
+    /**
+     * Where the kept version number is written, next to the copy.
+     *
+     * The version is recorded at snapshot time rather than read back out of the copy, because
+     * `PluginManifestReader.readFromJar` refuses any path not ending in `.jar` - "File is not a
+     * JAR" - and the whole point of the `.rollback` suffix is that this file does NOT look like a
+     * jar to a directory scan. The two requirements are in direct conflict, and a text file settles
+     * it more cheaply than opening a zip would anyway.
+     */
+    private fun versionFileFor(jarPath: String) = File(jarPath + SUFFIX + ".version")
+
+    /**
+     * Snapshot [jarPath] before something replaces it. No-op when there is nothing there yet.
+     *
+     * Copy rather than move: the caller is about to promote over this path and must not be handed a
+     * missing file if the snapshot fails. A failure here is logged and swallowed for the same
+     * reason - losing the ability to roll back is worse than an install that does not happen, but
+     * only just, and an install that fails because its backup failed helps nobody.
+     */
+    fun snapshot(jarPath: String) {
+        val jar = File(jarPath)
+        if (!jar.isFile) return
+        val rollback = rollbackFor(jarPath)
+        // Read from the LIVE jar, whose name ends in .jar, before it is replaced. See
+        // versionFileFor for why it cannot be read back from the copy.
+        val version = runCatching { PluginManifestReader.readFromJar(jarPath).version }.getOrNull()
+        runCatching {
+            jar.copyTo(rollback, overwrite = true)
+            if (version != null) {
+                versionFileFor(jarPath).writeText(version)
+            } else {
+                // No version means the button cannot name what it will restore, so the copy is not
+                // offered at all rather than offered blind.
+                runCatching { versionFileFor(jarPath).delete() }
+            }
+            // The sidecar travels with it or the restore is unverifiable: a jar whose signature file
+            // belongs to different bytes hard-fails the load, which is worse than being unsigned.
+            PluginSignatureSidecar.read(jarPath)?.let { sig ->
+                PluginSignatureSidecar.persist(rollback.absolutePath, sig)
+            } ?: PluginSignatureSidecar.delete(rollback.absolutePath)
+        }.onFailure { e ->
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Could not keep a rollback copy; this install will not be reversible",
+                mapOf("jarPath" to jarPath),
+                error = e,
+            )
+        }
+    }
+
+    /** The version held in the rollback copy, or null when there is none or it cannot be named. */
+    fun availableVersion(jarPath: String): String? {
+        // Both files, because either alone is not a usable offer: bytes with no recorded version
+        // cannot label a button, and a version with no bytes cannot be restored.
+        val hasBoth = rollbackFor(jarPath).isFile && versionFileFor(jarPath).isFile
+        return if (!hasBoth) {
+            null
+        } else {
+            runCatching { versionFileFor(jarPath).readText().trim().takeIf { it.isNotEmpty() } }.getOrNull()
+        }
+    }
+
+    /**
+     * Put the rollback copy back at [jarPath].
+     *
+     * The copy is KEPT, not moved, so a restore that is itself interrupted has not consumed the only
+     * good jar - and so a second attempt after a failed load is possible. Returns the version now in
+     * place, or null when there was nothing to restore.
+     */
+    fun restore(jarPath: String): String? {
+        val rollback = rollbackFor(jarPath)
+        if (!rollback.isFile) return null
+        val version = availableVersion(jarPath)
+        return runCatching {
+            rollback.copyTo(File(jarPath), overwrite = true)
+            PluginSignatureSidecar
+                .read(rollback.absolutePath)
+                ?.let { PluginSignatureSidecar.persist(jarPath, it) }
+                // No signature for the restored bytes is better than the WRONG one: the sidecar
+                // still on disk belongs to the version being rolled back FROM, and leaving it there
+                // fails the load outright.
+                ?: PluginSignatureSidecar.delete(jarPath)
+            version
+        }.onFailure { e ->
+            logger.error(
+                LogCategory.SYSTEM,
+                "Could not restore the rollback copy",
+                mapOf("jarPath" to jarPath),
+                error = e,
+            )
+        }.getOrNull()
+    }
+
+    /** Drop the copy. For an uninstall, where the plugin itself is going away. */
+    fun discard(jarPath: String) {
+        runCatching { rollbackFor(jarPath).delete() }
+        runCatching { versionFileFor(jarPath).delete() }
+        runCatching { PluginSignatureSidecar.delete(rollbackFor(jarPath).absolutePath) }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -111,6 +111,22 @@ actual object PluginUpdateBridge {
             return Result.failure(Exception("Refusing to download update outside the plugin directory"))
         }
         val targetPath = targetFile.absolutePath
+
+        // Keep the jar this update is about to make unreachable, BEFORE anything downloads.
+        //
+        // This path does not overwrite - it writes a new version-named file and then calls
+        // `PluginJarReconciler.reconcilePluginDir`, which deletes every other jar for this plugin
+        // id. So the version that currently works stops existing the moment the update succeeds,
+        // and if the new one then fails its version floor at load there is nothing on disk to go
+        // back to. That is precisely what happened to fluck-browser 1.2.22 on a 9.4.22 host: the
+        // browser tab was gone and the recovery was to find the previous release by hand.
+        //
+        // Taken here rather than inside `mgr.updatePlugin` so it happens once, before the unload
+        // closes the classloader, and so a failure to keep the copy cannot fail the update.
+        manager.getPluginInfo(pluginId)?.jarPath?.let { installedJar ->
+            PluginRollbackStore.snapshot(pluginDir, pluginId, installedJar)
+        }
+
         val reporter = MissingDependencyReporter.forManager(manager)
         val result =
             mgr.updatePlugin(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGateRecovery.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginVersionGateRecovery.kt
@@ -1,0 +1,247 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.PluginStoreSetup
+import ai.rever.boss.plugin.api.Version
+import ai.rever.boss.plugin.loader.ApiClassLoader
+import ai.rever.boss.updater.UpdateManager
+import ai.rever.boss.updater.UpdateState
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+/**
+ * Resolves what can be offered for a [PluginVersionGate], and carries out the choice.
+ *
+ * [remediesFor] decides *what* to offer and is deliberately pure. This is the other half: the three
+ * facts it needs, and the actions behind each button. Kept separate so the decision stays testable
+ * without an updater, a store or a plugins directory - and so this file can be read as "what does
+ * each button actually do", which is the question a reviewer will have.
+ */
+internal object PluginVersionGateRecovery {
+    private val logger = BossLogger.forComponent("PluginVersionGateRecovery")
+
+    /**
+     * Whether [candidate] meets [required], by the loader's own rule.
+     *
+     * `Version.parse` plus `>=` is exactly what `DynamicPluginLoader.isBossVersionCompatible` does,
+     * including failing OPEN on an unparseable version - which matters for consistency rather than
+     * convenience: if the loader would let the plugin through, a remedy that assumed otherwise
+     * would hide a button that works.
+     */
+    fun satisfies(
+        required: String,
+        candidate: String,
+    ): Boolean {
+        val requiredVersion = Version.parse(required)
+        val candidateVersion = Version.parse(candidate)
+        // Either side unparseable fails open, which is the loader's own behaviour.
+        return requiredVersion == null || candidateVersion == null || candidateVersion >= requiredVersion
+    }
+
+    /**
+     * The app version an update would install, or null when there is none.
+     *
+     * Read off the state the updater already holds rather than triggering a check. A dialog that
+     * kicked off a network round trip before it could render would appear late or not at all, and
+     * "no update available" is a perfectly good thing to say when the answer is not known yet -
+     * reverting is still offered, and the periodic check will change the answer on its own.
+     */
+    fun hostUpdateVersion(): String? =
+        (UpdateManager.instance.updateState.value as? UpdateState.UpdateAvailable)
+            ?.updateInfo
+            ?.latestVersion
+            ?.toString()
+            ?.takeIf { it.isNotBlank() }
+
+    /**
+     * The api-layer version the store publishes, or null when it cannot be asked.
+     *
+     * A live lookup, unlike the host update, because nothing polls the api plugin's version in the
+     * background - and unlike an app update it costs one request rather than a download.
+     */
+    suspend fun apiUpdateVersion(): String? {
+        // The remote repository directly, not `repositoryManager`. The manager merges local and
+        // remote, and the LOCAL copy is the api jar already installed - so asking it would answer
+        // with the version that is failing to satisfy the floor.
+        val store = PluginStoreSetup.remoteRepository ?: return null
+        // Both failure shapes: `getPlugin` returns `Result.failure` rather than throwing, so
+        // runCatching alone would report success with a null inside it.
+        val lookup = runCatching { store.getPlugin(ApiClassLoader.API_PLUGIN_ID) }.getOrElse { Result.failure(it) }
+        lookup.exceptionOrNull()?.let { e ->
+            logger.warn(LogCategory.SYSTEM, "Could not ask the store for the api version: ${e.message}")
+        }
+        return lookup.getOrNull()?.version?.takeIf { it.isNotBlank() }
+    }
+
+    /** The version kept aside for [pluginId], or null when nothing was kept. */
+    fun revertVersion(pluginId: String): String? =
+        runCatching {
+            PluginRollbackStore.availableVersion(PluginStoreSetup.getPluginDir(), pluginId)
+        }.getOrNull()
+
+    /**
+     * Carry out [remedy], returning what to tell the user on success.
+     *
+     * Each branch ends by clearing the gate, because leaving it recorded would put the dialog back
+     * in front of the user for a problem they just fixed. The exception is a failure, which keeps
+     * the gate so the dialog can stay open with the reason and the remaining options.
+     */
+    suspend fun apply(
+        gate: PluginVersionGate,
+        remedy: PluginVersionRemedy,
+        manager: DynamicPluginManager,
+    ): Result<String> =
+        when (remedy) {
+            is PluginVersionRemedy.UpdateHost -> updateHost(remedy)
+
+            is PluginVersionRemedy.UpdateApi -> updateApi(gate, remedy, manager)
+
+            is PluginVersionRemedy.RevertPlugin -> revert(gate, remedy, manager)
+
+            // Not reachable from a button: the dialog renders this as a sentence. Handled rather
+            // than thrown so a future caller cannot turn it into a crash.
+            is PluginVersionRemedy.NothingAvailable -> Result.failure(IllegalStateException(remedy.reason))
+        }
+
+    /**
+     * Download the app update and hand off to the existing install flow.
+     *
+     * Deliberately does NOT clear the gate. The plugin is still unloadable until the new app runs,
+     * so clearing it would remove the only explanation of why the plugin is missing during the
+     * window between downloading and restarting.
+     */
+    private suspend fun updateHost(remedy: PluginVersionRemedy.UpdateHost): Result<String> {
+        val updater = UpdateManager.instance
+        val info =
+            (updater.updateState.value as? UpdateState.UpdateAvailable)?.updateInfo
+                ?: return Result.failure(
+                    IllegalStateException("The update to ${remedy.availableVersion} is no longer available."),
+                )
+        updater.downloadUpdateInBackground(info)
+        return Result.success("Downloading BOSS ${remedy.availableVersion}. The plugin loads after the restart.")
+    }
+
+    /**
+     * Install a newer api plugin, which is a hot swap rather than a restart.
+     *
+     * Routed through `installPlugin`, because that is where the api id is recognised and turned
+     * into an unload-all / swap / reload-all - and the reload-all is what gives the refused plugin
+     * its second chance without the user doing anything else.
+     */
+    private suspend fun updateApi(
+        gate: PluginVersionGate,
+        remedy: PluginVersionRemedy.UpdateApi,
+        manager: DynamicPluginManager,
+    ): Result<String> {
+        val store =
+            PluginStoreSetup.remoteRepository
+                ?: return Result.failure(IllegalStateException("The plugin store is not available."))
+        val installer = StoreVersionInstaller(pluginDir = { PluginStoreSetup.getPluginDir() })
+        val result =
+            installer.install(
+                store = store,
+                request =
+                    StoreVersionRequest(
+                        pluginId = ApiClassLoader.API_PLUGIN_ID,
+                        version = remedy.availableVersion,
+                        sourceUrl = null,
+                        runningJarPath = manager.getPluginInfo(ApiClassLoader.API_PLUGIN_ID)?.jarPath,
+                    ),
+                unload = { id -> manager.uninstallPlugin(id, force = true).map { } },
+                load = { path -> manager.installPlugin(path).map { true } },
+            )
+        return result.map {
+            PluginVersionGateRegistry.clear(gate.pluginId)
+            "Plugin API updated to ${remedy.availableVersion}."
+        }
+    }
+
+    /**
+     * Put the kept jar back and load it.
+     *
+     * The one remedy that resolves the problem outright rather than starting something: no
+     * download, no restart, and the plugin is present again when it returns.
+     */
+    private suspend fun revert(
+        gate: PluginVersionGate,
+        remedy: PluginVersionRemedy.RevertPlugin,
+        manager: DynamicPluginManager,
+    ): Result<String> {
+        val pluginDir = PluginStoreSetup.getPluginDir()
+        // The refused plugin never loaded, so `getPluginInfo` is usually empty for it and the jar
+        // to remove has to be found on disk. It matters: leaving the refused jar there means the
+        // next launch scans it, refuses it again, and the plugin directory holds two versions of
+        // one plugin id.
+        val brokenJar =
+            manager.getPluginInfo(gate.pluginId)?.jarPath
+                ?: refusedJarFor(pluginDir, gate.pluginId)?.absolutePath
+        val restored =
+            PluginRollbackStore.restore(pluginDir, gate.pluginId, brokenJar)
+                ?: return Result.failure(
+                    IllegalStateException("Version ${remedy.toVersion} is no longer available to restore."),
+                )
+        return manager
+            .installPlugin(restored.absolutePath)
+            .map { info ->
+                PluginVersionGateRegistry.clear(gate.pluginId)
+                "${info.manifest.displayName} is back on version ${remedy.toVersion}."
+            }.onFailure { e ->
+                logger.error(
+                    LogCategory.SYSTEM,
+                    "Restored the previous plugin jar but it did not load",
+                    mapOf("pluginId" to gate.pluginId, "version" to remedy.toVersion),
+                    error = e,
+                )
+            }
+    }
+}
+
+/**
+ * The jar in [pluginDir] declaring [pluginId], read from each manifest rather than guessed.
+ *
+ * By manifest, not by filename. Jars arrive under at least three conventions - the host's
+ * `<pluginId>-<version>.jar`, the Toolbox's `<plugin_id>_<version>.jar` and whatever a sideloaded
+ * file is called - so a name match would miss exactly the case a user is stuck in. This is the
+ * same identification `PluginJarReconciler` performs for the same reason.
+ */
+private fun refusedJarFor(
+    pluginDir: java.io.File,
+    pluginId: String,
+): java.io.File? =
+    pluginDir
+        .listFiles { f: java.io.File -> f.isFile && f.name.endsWith(".jar") }
+        ?.firstOrNull { jar ->
+            runCatching {
+                ai.rever.boss.plugin.loader.PluginManifestReader
+                    .readFromJar(jar.absolutePath)
+                    .pluginId
+            }.getOrNull() == pluginId
+        }
+
+/**
+ * The desktop half of [PluginVersionRemedyResolver], wired to the real updater, store and disk.
+ *
+ * A thin adapter over [PluginVersionGateRecovery] so the host composable in `commonMain` can be
+ * mounted without knowing any of that exists.
+ */
+object DesktopPluginVersionRemedyResolver : PluginVersionRemedyResolver {
+    override suspend fun resolve(gate: PluginVersionGate): List<PluginVersionRemedy> =
+        remediesFor(
+            gate = gate,
+            hostUpdate = PluginVersionGateRecovery.hostUpdateVersion(),
+            // Only asked for the gate it can fix. An api lookup for a host-version refusal is a
+            // store request whose answer nothing would read.
+            apiUpdate =
+                when (gate) {
+                    is PluginVersionGate.NeedsNewerApi -> PluginVersionGateRecovery.apiUpdateVersion()
+                    is PluginVersionGate.NeedsNewerHost -> null
+                },
+            revertTo = PluginVersionGateRecovery.revertVersion(gate.pluginId),
+            satisfies = PluginVersionGateRecovery::satisfies,
+        )
+
+    override suspend fun apply(
+        gate: PluginVersionGate,
+        remedy: PluginVersionRemedy,
+        manager: DynamicPluginManager,
+    ): Result<String> = PluginVersionGateRecovery.apply(gate, remedy, manager)
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -167,6 +167,14 @@ fun main(args: Array<String>) {
     ai.rever.boss.services.llm.BrokeredCredentialAccess
         .initialize(ai.rever.boss.llm.BrokeredCredentialProviderImpl)
 
+    // Same arrangement, for the dialog that offers a way out of a plugin version floor: the
+    // remedies reach the app updater, the plugin store and the plugins directory, all desktopMain,
+    // while the dialog is mounted from commonMain. Registered BEFORE any plugin loads, because the
+    // refusal this exists for happens during startup plugin loading - a refusal recorded before
+    // this runs would sit in the registry with nothing able to act on it.
+    ai.rever.boss.components.plugin.PluginVersionRemedyAccess
+        .initialize(ai.rever.boss.components.plugin.DesktopPluginVersionRemedyResolver)
+
     // Warm the two settings singletons that load their file synchronously in `init`
     // (WorkspaceSettingsManager and FocusModeSettingsManager). Both must be readable the
     // instant a startup effect asks - the workspace one decides which layout a window opens

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginRollbackStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginRollbackStoreTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -8,17 +9,20 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
  * The one kept file that turns "the plugin is gone" into a button.
  *
- * Every install path promotes over the target and deletes what it rejects, so without a snapshot the
- * previous jar does not exist anywhere by the time anyone discovers the new one will not load. These
- * pin the properties that make the copy usable rather than merely present.
+ * An update ends with `PluginJarReconciler.reconcilePluginDir`, which deletes every jar for a plugin
+ * except the highest version - so without a snapshot the version that worked does not exist anywhere
+ * by the time anyone discovers the new one will not load. These pin the properties that make the copy
+ * usable rather than merely present.
  */
 class PluginRollbackStoreTest {
+    private val pluginId = "com.example.rollback"
     private val dir = createTempDirectory("rollback").toFile()
 
     @AfterTest
@@ -30,6 +34,7 @@ class PluginRollbackStoreTest {
     private fun writeJar(
         name: String,
         version: String,
+        id: String = pluginId,
     ): File {
         val jar = File(dir, name)
         ZipOutputStream(jar.outputStream()).use { zip ->
@@ -38,7 +43,7 @@ class PluginRollbackStoreTest {
                 """
                 {
                   "manifestVersion": 1,
-                  "pluginId": "com.example.rollback",
+                  "pluginId": "$id",
                   "displayName": "Test Plugin",
                   "version": "$version",
                   "apiVersion": "1.0.0",
@@ -51,124 +56,202 @@ class PluginRollbackStoreTest {
         return jar
     }
 
-    private fun rollbackFile(jar: File) = File(jar.absolutePath + ".rollback")
-
     @Test
-    fun `a snapshot keeps the version that was there`() {
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        assertTrue(rollbackFile(jar).isFile, "no rollback copy was kept")
-        assertEquals("1.2.21", PluginRollbackStore.availableVersion(jar.absolutePath))
+    fun `a snapshot records the version it kept`() {
+        val jar = writeJar("plugin-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, jar.absolutePath)
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(dir, pluginId))
     }
 
     @Test
-    fun `the copy survives the jar being replaced, which is the whole point`() {
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        // What an install does next: promote new bytes over the target.
-        writeJar("p.jar", "1.2.22")
-        assertEquals("1.2.22", readVersion(jar))
-        assertEquals("1.2.21", PluginRollbackStore.availableVersion(jar.absolutePath))
+    fun `the source jar survives the snapshot`() {
+        // A copy, not a move. The caller may still be running from this jar, and an update that
+        // removed the live plugin in order to back it up would be absurd.
+        val jar = writeJar("plugin-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, jar.absolutePath)
+        assertTrue(jar.isFile, "the snapshot consumed the jar it was meant to copy")
     }
 
     @Test
-    fun `restoring puts the previous version back`() {
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        writeJar("p.jar", "1.2.22")
-
-        assertEquals("1.2.21", PluginRollbackStore.restore(jar.absolutePath))
-        assertEquals("1.2.21", readVersion(jar))
+    fun `the kept copy survives a version-renaming update`() {
+        // THE case the first design could not handle. The host's update path downloads to a new
+        // filename and reconcile deletes the old one, so a rollback addressed by the old jar's path
+        // is unreachable afterwards. Keyed by plugin id, it is still there.
+        val old = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, old.absolutePath)
+        assertTrue(old.delete(), "could not simulate reconcile deleting the previous jar")
+        writeJar("com.example.rollback-1.2.22.jar", "1.2.22")
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(dir, pluginId))
     }
 
     @Test
-    fun `restoring keeps the copy, so a failed load can be retried`() {
-        // Moving instead of copying would consume the only good jar. A restore interrupted between
-        // the write and the load would then leave nothing to try again with - the exact position
-        // this whole mechanism exists to avoid.
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        writeJar("p.jar", "1.2.22")
+    fun `a restore puts the kept version back and removes the broken one`() {
+        val old = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, old.absolutePath)
+        old.delete()
+        val broken = writeJar("com.example.rollback-1.2.22.jar", "1.2.22")
 
-        PluginRollbackStore.restore(jar.absolutePath)
-        assertTrue(rollbackFile(jar).isFile, "the rollback copy was consumed by the restore")
-        assertEquals("1.2.21", PluginRollbackStore.restore(jar.absolutePath), "not repeatable")
+        val restored = assertNotNull(PluginRollbackStore.restore(dir, pluginId, broken.absolutePath))
+        assertTrue(restored.isFile)
+        assertFalse(broken.isFile, "the version that would not load is still on disk")
+        // Two jars for one plugin id would give the directory scan a choice it cannot make, which
+        // is why the restore removes rather than overwrites.
+        val jars = dir.listFiles { f: File -> f.name.endsWith(".jar") }?.map { it.name } ?: emptyList()
+        assertEquals(listOf(restored.name), jars)
     }
 
     @Test
-    fun `snapshotting a path with nothing there is not an error`() {
-        // A first install has no previous jar. It must not fail, and must not leave a copy behind.
-        val absent = File(dir, "never-installed.jar")
-        PluginRollbackStore.snapshot(absent.absolutePath)
-        assertFalse(rollbackFile(absent).exists())
-        assertNull(PluginRollbackStore.availableVersion(absent.absolutePath))
+    fun `the kept copy is not consumed by a restore`() {
+        // A restore interrupted after this point must not have destroyed the only good jar, and a
+        // second attempt after a failed load has to be possible.
+        val old = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, old.absolutePath)
+        old.delete()
+        PluginRollbackStore.restore(dir, pluginId, null)
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(dir, pluginId))
     }
 
     @Test
-    fun `nothing to restore answers null rather than throwing`() {
-        val jar = writeJar("p.jar", "1.2.22")
-        assertNull(PluginRollbackStore.restore(jar.absolutePath))
-        assertEquals("1.2.22", readVersion(jar), "the jar was touched despite there being no copy")
+    fun `a restore onto the same path does not delete what it wrote`() {
+        // Reachable: restoring 1.2.21 while the broken jar happens to be named for 1.2.21 too,
+        // which is exactly what an in-place overwrite by the plugin-side updater leaves behind.
+        val jar = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, jar.absolutePath)
+        val restored = assertNotNull(PluginRollbackStore.restore(dir, pluginId, jar.absolutePath))
+        assertTrue(restored.isFile, "the restore deleted the file it had just written")
     }
 
     @Test
-    fun `the copy is not named like a jar, so the directory scan ignores it`() {
-        // Same reasoning as StoreMissingDependencyInstaller's `.jar.part`: a plugin directory scan
-        // picks up anything ending in .jar, and a stale copy loading as a second plugin would be a
-        // far stranger failure than the one this fixes.
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        assertFalse(rollbackFile(jar).name.endsWith(".jar"), "the rollback copy is scannable")
+    fun `nothing is offered when no snapshot was taken`() {
+        assertNull(PluginRollbackStore.availableVersion(dir, pluginId))
+        assertNull(PluginRollbackStore.restore(dir, pluginId, null))
+    }
+
+    @Test
+    fun `a missing source jar is not an error`() {
+        // Reached on a first install, where there is nothing to keep. It must not throw and must
+        // not leave a half-written copy.
+        PluginRollbackStore.snapshot(dir, pluginId, File(dir, "absent.jar").absolutePath)
+        assertNull(PluginRollbackStore.availableVersion(dir, pluginId))
+    }
+
+    @Test
+    fun `an unreadable jar is not offered as a rollback`() {
+        // No version means the button cannot say what it will restore. Offering it blind is worse
+        // than not offering it.
+        val notAJar = File(dir, "corrupt.jar")
+        notAJar.writeText("this is not a zip")
+        PluginRollbackStore.snapshot(dir, pluginId, notAJar.absolutePath)
+        assertNull(PluginRollbackStore.availableVersion(dir, pluginId))
+    }
+
+    @Test
+    fun `a failed snapshot leaves the previous one in place`() {
+        // The earlier copy is correctly labelled with its OWN version, so restoring it lands on
+        // something older than ideal but working. Discarding it because a later snapshot could not
+        // be taken would trade a slightly-stale way back for none at all.
+        val good = writeJar("com.example.rollback-1.2.20.jar", "1.2.20")
+        PluginRollbackStore.snapshot(dir, pluginId, good.absolutePath)
+        assertEquals("1.2.20", PluginRollbackStore.availableVersion(dir, pluginId))
+
+        val corrupt = File(dir, "corrupt.jar")
+        corrupt.writeText("not a zip")
+        PluginRollbackStore.snapshot(dir, pluginId, corrupt.absolutePath)
         assertEquals(
-            listOf("p.jar"),
-            dir
-                .listFiles()
-                .orEmpty()
-                .map { it.name }
-                .filter { it.endsWith(".jar") },
+            "1.2.20",
+            PluginRollbackStore.availableVersion(dir, pluginId),
+            "a usable rollback was thrown away because a later snapshot failed",
         )
     }
 
     @Test
-    fun `discard removes the copy`() {
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        PluginRollbackStore.discard(jar.absolutePath)
-        assertFalse(rollbackFile(jar).exists())
-        assertNull(PluginRollbackStore.availableVersion(jar.absolutePath))
+    fun `the signature sidecar travels with the copy and back`() {
+        // A jar whose signature file belongs to different bytes hard-fails the load, which is worse
+        // than being unsigned. So the sidecar has to follow the jar in both directions.
+        val old = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginSignatureSidecar.persist(old.absolutePath, "c2lnbmF0dXJlLTEuMi4yMQ==")
+        PluginRollbackStore.snapshot(dir, pluginId, old.absolutePath)
+        old.delete()
+
+        val restored = assertNotNull(PluginRollbackStore.restore(dir, pluginId, null))
+        assertEquals(
+            "c2lnbmF0dXJlLTEuMi4yMQ==",
+            PluginSignatureSidecar.read(restored.absolutePath),
+            "the restored jar lost the signature that verifies it",
+        )
     }
 
-    private fun readVersion(jar: File): String? =
-        runCatching {
-            ai.rever.boss.plugin.loader.PluginManifestReader
-                .readFromJar(jar.absolutePath)
-                .version
-        }.getOrNull()
-
     @Test
-    fun `the kept version is recorded, not read back out of the copy`() {
-        // The trap worth pinning, because the two requirements are in direct conflict:
-        // PluginManifestReader.readFromJar throws "File is not a JAR" for any path not ending in
-        // .jar, and the .rollback suffix exists precisely so this file is NOT scannable as one. So
-        // the version has to be captured while the live jar is still there, and a naive
-        // "read it back from the copy" answers null for every rollback that exists.
-        val jar = writeJar("p.jar", "1.2.21")
-        PluginRollbackStore.snapshot(jar.absolutePath)
+    fun `an unsigned rollback does not inherit the signature it is replacing`() {
+        // The sidecar on disk belongs to the version being rolled back FROM. Leaving it beside the
+        // restored bytes fails the load outright, so it has to be deleted rather than kept.
+        val old = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, old.absolutePath)
+        old.delete()
+        val restoredName = "com_example_rollback-1.2.21.jar"
+        PluginSignatureSidecar.persist(File(dir, restoredName).absolutePath, "d3Jvbmctc2lnbmF0dXJl")
+
+        val restored = assertNotNull(PluginRollbackStore.restore(dir, pluginId, null))
         assertNull(
-            readVersion(rollbackFile(jar)),
-            "the copy is readable as a jar, so the suffix is not doing its job",
+            PluginSignatureSidecar.read(restored.absolutePath),
+            "the restored jar kept a signature belonging to different bytes",
         )
-        assertEquals("1.2.21", PluginRollbackStore.availableVersion(jar.absolutePath))
     }
 
     @Test
-    fun `a copy whose version could not be recorded is not offered`() {
-        // Offered blind, a rollback button cannot say what it will install - and a jar whose
-        // manifest is unreadable is not something to restore on a guess.
-        val jar = File(dir, "broken.jar")
-        jar.writeText("not a zip")
-        PluginRollbackStore.snapshot(jar.absolutePath)
-        assertTrue(rollbackFile(jar).isFile, "the bytes were not kept")
-        assertNull(PluginRollbackStore.availableVersion(jar.absolutePath))
+    fun `the kept jar is not visible to a plugin directory scan`() {
+        // A copy the scan can see is a second installed plugin with the same id. It lives in a
+        // dot-prefixed subdirectory for exactly this reason.
+        val jar = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, jar.absolutePath)
+        val topLevelJars = dir.listFiles { f: File -> f.isFile && f.name.endsWith(".jar") }?.map { it.name }
+        assertEquals(listOf(jar.name), topLevelJars, "the rollback copy is loadable as a plugin")
+    }
+
+    @Test
+    fun `a plugin id that would escape the directory is sanitized`() {
+        // The KEY is sanitized, not the manifest. `PluginManifestReader` rejects an id with a path
+        // separator outright, so such an id cannot arrive inside a jar - but snapshot takes the id
+        // from its caller, which reads it off an exception or an installed.json entry rather than a
+        // validated manifest. So the filename is defended here regardless.
+        val escaping = "../../etc/evil"
+        val jar = writeJar("escape.jar", "1.0.0")
+        PluginRollbackStore.snapshot(dir, escaping, jar.absolutePath)
+        assertEquals("1.0.0", PluginRollbackStore.availableVersion(dir, escaping))
+        val rollbackDir = File(dir, ".rollback")
+        assertTrue(
+            rollbackDir.listFiles()?.all { it.canonicalFile.parentFile == rollbackDir.canonicalFile } ?: false,
+            "a snapshot wrote outside the rollback directory",
+        )
+        assertFalse(
+            File(dir.parentFile.parentFile, "etc").exists(),
+            "the traversal in the plugin id reached the filesystem",
+        )
+    }
+
+    @Test
+    fun `discard removes everything the offer depends on`() {
+        val jar = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginSignatureSidecar.persist(jar.absolutePath, "c2ln")
+        PluginRollbackStore.snapshot(dir, pluginId, jar.absolutePath)
+        PluginRollbackStore.discard(dir, pluginId)
+        assertNull(PluginRollbackStore.availableVersion(dir, pluginId))
+        assertNull(PluginRollbackStore.restore(dir, pluginId, null))
+    }
+
+    @Test
+    fun `a second snapshot replaces the first`() {
+        // One generation deep, on purpose: a history is a directory of multi-megabyte jars nobody
+        // prunes, and recovery only needs the state immediately before the change that broke it.
+        val first = writeJar("com.example.rollback-1.2.20.jar", "1.2.20")
+        PluginRollbackStore.snapshot(dir, pluginId, first.absolutePath)
+        val second = writeJar("com.example.rollback-1.2.21.jar", "1.2.21")
+        PluginRollbackStore.snapshot(dir, pluginId, second.absolutePath)
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(dir, pluginId))
+        assertEquals(
+            1,
+            File(dir, ".rollback").listFiles { f: File -> f.name.endsWith(".jar") }?.size,
+            "the rollback directory is accumulating jars",
+        )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginRollbackStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginRollbackStoreTest.kt
@@ -210,23 +210,47 @@ class PluginRollbackStoreTest {
 
     @Test
     fun `a plugin id that would escape the directory is sanitized`() {
-        // The KEY is sanitized, not the manifest. `PluginManifestReader` rejects an id with a path
-        // separator outright, so such an id cannot arrive inside a jar - but snapshot takes the id
-        // from its caller, which reads it off an exception or an installed.json entry rather than a
-        // validated manifest. So the filename is defended here regardless.
-        val escaping = "../../etc/evil"
-        val jar = writeJar("escape.jar", "1.0.0")
-        PluginRollbackStore.snapshot(dir, escaping, jar.absolutePath)
-        assertEquals("1.0.0", PluginRollbackStore.availableVersion(dir, escaping))
-        val rollbackDir = File(dir, ".rollback")
-        assertTrue(
-            rollbackDir.listFiles()?.all { it.canonicalFile.parentFile == rollbackDir.canonicalFile } ?: false,
-            "a snapshot wrote outside the rollback directory",
-        )
-        assertFalse(
-            File(dir.parentFile.parentFile, "etc").exists(),
-            "the traversal in the plugin id reached the filesystem",
-        )
+        // The KEY is sanitized, not the manifest. `PluginManifestReader` rejects an id containing a
+        // path separator outright, so such an id cannot arrive inside a jar - but snapshot takes the
+        // id from its caller, which reads it off an exception or an installed.json entry rather than
+        // a validated manifest. So the filename is defended here regardless.
+        //
+        // This runs in its OWN nested sandbox, and that is the whole point. Two earlier versions of
+        // this test passed against unsanitized code:
+        //
+        // - asserting that `/etc` does not exist tested the machine, not this code, and on Linux
+        //   the temp directory sits two levels below the root so `/etc` exists whatever happens;
+        // - walking only the plugin directory missed the escape entirely, because an escape by
+        //   definition writes OUTSIDE it - and `File.copyTo` calls `mkdirs()` on the destination's
+        //   parent, so `..\/..\/etc/evil.jar` really does land two directories up.
+        //
+        // The nesting is deep enough to absorb the `../..` in the id, and the sandbox is private so
+        // a diff of it is not noise from other processes the way a diff of /tmp would be.
+        val sandbox = createTempDirectory("rollback-sandbox").toFile()
+        try {
+            val plugins = File(sandbox, "nested/plugins")
+            assertTrue(plugins.mkdirs(), "could not create the nested plugin directory")
+            val jar = File(plugins, "escape.jar")
+            writeJar("escape.jar", "1.0.0").copyTo(jar, overwrite = true)
+
+            val escaping = "../../etc/evil"
+            val before = sandbox.walkTopDown().map { it.canonicalPath }.toSet()
+
+            PluginRollbackStore.snapshot(plugins, escaping, jar.absolutePath)
+
+            assertEquals("1.0.0", PluginRollbackStore.availableVersion(plugins, escaping))
+            val rollbackDir = File(plugins, ".rollback").canonicalFile
+            val created = sandbox.walkTopDown().map { it.canonicalPath }.toSet() - before
+            assertTrue(created.isNotEmpty(), "the snapshot wrote nothing, so this proves nothing")
+            created.forEach { path ->
+                assertTrue(
+                    path.startsWith(rollbackDir.path),
+                    "a snapshot escaped the rollback directory: $path",
+                )
+            }
+        } finally {
+            sandbox.deleteRecursively()
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginRollbackStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginRollbackStoreTest.kt
@@ -1,0 +1,174 @@
+package ai.rever.boss.components.plugin
+
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The one kept file that turns "the plugin is gone" into a button.
+ *
+ * Every install path promotes over the target and deletes what it rejects, so without a snapshot the
+ * previous jar does not exist anywhere by the time anyone discovers the new one will not load. These
+ * pin the properties that make the copy usable rather than merely present.
+ */
+class PluginRollbackStoreTest {
+    private val dir = createTempDirectory("rollback").toFile()
+
+    @AfterTest
+    fun cleanUp() {
+        dir.deleteRecursively()
+    }
+
+    /** A jar that `PluginManifestReader` can read a version out of. */
+    private fun writeJar(
+        name: String,
+        version: String,
+    ): File {
+        val jar = File(dir, name)
+        ZipOutputStream(jar.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry("META-INF/boss-plugin/plugin.json"))
+            zip.write(
+                """
+                {
+                  "manifestVersion": 1,
+                  "pluginId": "com.example.rollback",
+                  "displayName": "Test Plugin",
+                  "version": "$version",
+                  "apiVersion": "1.0.0",
+                  "mainClass": "com.example.Main"
+                }
+                """.trimIndent().toByteArray(),
+            )
+            zip.closeEntry()
+        }
+        return jar
+    }
+
+    private fun rollbackFile(jar: File) = File(jar.absolutePath + ".rollback")
+
+    @Test
+    fun `a snapshot keeps the version that was there`() {
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        assertTrue(rollbackFile(jar).isFile, "no rollback copy was kept")
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(jar.absolutePath))
+    }
+
+    @Test
+    fun `the copy survives the jar being replaced, which is the whole point`() {
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        // What an install does next: promote new bytes over the target.
+        writeJar("p.jar", "1.2.22")
+        assertEquals("1.2.22", readVersion(jar))
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(jar.absolutePath))
+    }
+
+    @Test
+    fun `restoring puts the previous version back`() {
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        writeJar("p.jar", "1.2.22")
+
+        assertEquals("1.2.21", PluginRollbackStore.restore(jar.absolutePath))
+        assertEquals("1.2.21", readVersion(jar))
+    }
+
+    @Test
+    fun `restoring keeps the copy, so a failed load can be retried`() {
+        // Moving instead of copying would consume the only good jar. A restore interrupted between
+        // the write and the load would then leave nothing to try again with - the exact position
+        // this whole mechanism exists to avoid.
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        writeJar("p.jar", "1.2.22")
+
+        PluginRollbackStore.restore(jar.absolutePath)
+        assertTrue(rollbackFile(jar).isFile, "the rollback copy was consumed by the restore")
+        assertEquals("1.2.21", PluginRollbackStore.restore(jar.absolutePath), "not repeatable")
+    }
+
+    @Test
+    fun `snapshotting a path with nothing there is not an error`() {
+        // A first install has no previous jar. It must not fail, and must not leave a copy behind.
+        val absent = File(dir, "never-installed.jar")
+        PluginRollbackStore.snapshot(absent.absolutePath)
+        assertFalse(rollbackFile(absent).exists())
+        assertNull(PluginRollbackStore.availableVersion(absent.absolutePath))
+    }
+
+    @Test
+    fun `nothing to restore answers null rather than throwing`() {
+        val jar = writeJar("p.jar", "1.2.22")
+        assertNull(PluginRollbackStore.restore(jar.absolutePath))
+        assertEquals("1.2.22", readVersion(jar), "the jar was touched despite there being no copy")
+    }
+
+    @Test
+    fun `the copy is not named like a jar, so the directory scan ignores it`() {
+        // Same reasoning as StoreMissingDependencyInstaller's `.jar.part`: a plugin directory scan
+        // picks up anything ending in .jar, and a stale copy loading as a second plugin would be a
+        // far stranger failure than the one this fixes.
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        assertFalse(rollbackFile(jar).name.endsWith(".jar"), "the rollback copy is scannable")
+        assertEquals(
+            listOf("p.jar"),
+            dir
+                .listFiles()
+                .orEmpty()
+                .map { it.name }
+                .filter { it.endsWith(".jar") },
+        )
+    }
+
+    @Test
+    fun `discard removes the copy`() {
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        PluginRollbackStore.discard(jar.absolutePath)
+        assertFalse(rollbackFile(jar).exists())
+        assertNull(PluginRollbackStore.availableVersion(jar.absolutePath))
+    }
+
+    private fun readVersion(jar: File): String? =
+        runCatching {
+            ai.rever.boss.plugin.loader.PluginManifestReader
+                .readFromJar(jar.absolutePath)
+                .version
+        }.getOrNull()
+
+    @Test
+    fun `the kept version is recorded, not read back out of the copy`() {
+        // The trap worth pinning, because the two requirements are in direct conflict:
+        // PluginManifestReader.readFromJar throws "File is not a JAR" for any path not ending in
+        // .jar, and the .rollback suffix exists precisely so this file is NOT scannable as one. So
+        // the version has to be captured while the live jar is still there, and a naive
+        // "read it back from the copy" answers null for every rollback that exists.
+        val jar = writeJar("p.jar", "1.2.21")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        assertNull(
+            readVersion(rollbackFile(jar)),
+            "the copy is readable as a jar, so the suffix is not doing its job",
+        )
+        assertEquals("1.2.21", PluginRollbackStore.availableVersion(jar.absolutePath))
+    }
+
+    @Test
+    fun `a copy whose version could not be recorded is not offered`() {
+        // Offered blind, a rollback button cannot say what it will install - and a jar whose
+        // manifest is unreadable is not something to restore on a guess.
+        val jar = File(dir, "broken.jar")
+        jar.writeText("not a zip")
+        PluginRollbackStore.snapshot(jar.absolutePath)
+        assertTrue(rollbackFile(jar).isFile, "the bytes were not kept")
+        assertNull(PluginRollbackStore.availableVersion(jar.absolutePath))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginVersionGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginVersionGateTest.kt
@@ -1,0 +1,130 @@
+package ai.rever.boss.components.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * What the host offers a user whose plugin was refused for a version floor.
+ *
+ * Written against the incident that motivated it: fluck-browser 1.2.22 shipped requiring BOSS
+ * 9.4.23 while 9.4.22 was current, so every host that took the update lost its browser tab and the
+ * only trace was one ERROR line in `~/.boss/logs`. Each case below is a position a user was actually
+ * in that day.
+ */
+class PluginVersionGateTest {
+    private val hostGate =
+        PluginVersionGate.NeedsNewerHost(
+            pluginId = "ai.rever.boss.plugin.dynamic.fluckbrowser",
+            displayName = "Fluck Browser",
+            required = "9.4.23",
+            current = "9.4.22",
+        )
+
+    private val apiGate =
+        PluginVersionGate.NeedsNewerApi(
+            pluginId = "ai.rever.boss.plugin.dynamic.fluckbrowser",
+            displayName = "Fluck Browser",
+            required = "1.0.83",
+            current = "1.0.82",
+        )
+
+    /** Semver-ish compare, standing in for the loader's own. */
+    private val satisfies: (String, String) -> Boolean = { required, candidate ->
+        fun parts(v: String) = v.split(".").map { it.toIntOrNull() ?: 0 }
+        val r = parts(required)
+        val c = parts(candidate)
+        (0 until maxOf(r.size, c.size))
+            .firstOrNull { i ->
+                c.getOrElse(i) { 0 } != r.getOrElse(i) { 0 }
+            }?.let { c.getOrElse(it) { 0 } > r.getOrElse(it) { 0 } } ?: true
+    }
+
+    private fun remedies(
+        gate: PluginVersionGate,
+        hostUpdate: String? = null,
+        apiUpdate: String? = null,
+        revertTo: String? = null,
+    ) = remediesFor(gate, hostUpdate, apiUpdate, revertTo, satisfies)
+
+    @Test
+    fun `a host update that clears the floor is offered first`() {
+        val out = remedies(hostGate, hostUpdate = "9.4.23", revertTo = "1.2.21")
+        assertEquals(PluginVersionRemedy.UpdateHost("9.4.23"), out.first())
+        // Going forward beats going back when both are possible, but going back stays on offer -
+        // a user mid-task should not have to restart the app to get their browser back.
+        assertEquals(PluginVersionRemedy.RevertPlugin("1.2.21"), out.last())
+    }
+
+    @Test
+    fun `a host update that does NOT clear the floor is not offered`() {
+        // The trap this exists for: an available update is not automatically a fix. Offering one
+        // that lands below the floor costs the user a download and a restart and leaves the plugin
+        // exactly as missing as before.
+        val out = remedies(hostGate, hostUpdate = "9.4.22", revertTo = "1.2.21")
+        assertEquals(listOf(PluginVersionRemedy.RevertPlugin("1.2.21")), out)
+    }
+
+    @Test
+    fun `with no update published, reverting is the whole answer`() {
+        // The actual position on the day: 9.4.23 did not exist yet, because the plugin released
+        // ahead of the host it required.
+        val out = remedies(hostGate, hostUpdate = null, revertTo = "1.2.21")
+        assertEquals(listOf(PluginVersionRemedy.RevertPlugin("1.2.21")), out)
+    }
+
+    @Test
+    fun `with nothing published and nothing kept, say why rather than showing an empty dialog`() {
+        val out = remedies(hostGate)
+        val nothing = assertIs<PluginVersionRemedy.NothingAvailable>(out.single())
+        assertTrue(nothing.reason.contains("9.4.23"), "the reason does not name what is needed")
+        assertTrue(nothing.reason.contains("9.4.22"), "the reason does not name what is installed")
+    }
+
+    @Test
+    fun `an api floor offers an api update, not an application update`() {
+        // Deliberately not conflated with the host case. The api layer is itself a hot-swappable
+        // plugin, so this is resolvable in seconds without a restart - sending the user to download
+        // a whole application update for it would be wrong even when one exists.
+        val out = remedies(apiGate, hostUpdate = "9.9.9", apiUpdate = "1.0.83")
+        assertEquals(listOf<PluginVersionRemedy>(PluginVersionRemedy.UpdateApi("1.0.83")), out)
+    }
+
+    @Test
+    fun `an api update below the floor is not offered either`() {
+        val out = remedies(apiGate, apiUpdate = "1.0.82", revertTo = "1.2.21")
+        assertEquals(listOf(PluginVersionRemedy.RevertPlugin("1.2.21")), out)
+    }
+
+    @Test
+    fun `an equal version satisfies the floor`() {
+        // minBossVersion is a floor, not a strict inequality: 9.4.23 satisfies "9.4.23 or later".
+        // Reading it as strict would refuse the exact release built to fix the problem.
+        assertTrue(satisfies("9.4.23", "9.4.23"))
+        val out = remedies(hostGate, hostUpdate = "9.4.23")
+        assertEquals(listOf<PluginVersionRemedy>(PluginVersionRemedy.UpdateHost("9.4.23")), out)
+    }
+
+    @Test
+    fun `a remedy list is never empty`() {
+        // The dialog has to render something for every combination, or it is a window with no way
+        // out - which is worse than the silent log line this replaces.
+        val combos =
+            listOf<Triple<String?, String?, String?>>(
+                Triple(null, null, null),
+                Triple("9.4.23", null, null),
+                Triple(null, "1.0.83", null),
+                Triple(null, null, "1.2.21"),
+                Triple("9.4.23", "1.0.83", "1.2.21"),
+            )
+        for (gate in listOf(hostGate, apiGate)) {
+            for ((h, a, r) in combos) {
+                assertTrue(
+                    remedies(gate, h, a, r).isNotEmpty(),
+                    "no remedy for $gate with host=$h api=$a revert=$r",
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginVersionRemedyLabelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginVersionRemedyLabelTest.kt
@@ -1,0 +1,117 @@
+package ai.rever.boss.components.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The button labels, and the version comparison behind which buttons appear at all.
+ *
+ * Every label names a version on purpose. "Downgrade" does not say what you get, and "Update BOSS"
+ * does not say whether it would even help - which is the distinction [remediesFor] exists to make.
+ */
+class PluginVersionRemedyLabelTest {
+    @Test
+    fun `every label names a version`() {
+        assertEquals("Update BOSS to 9.4.23", remedyLabel(PluginVersionRemedy.UpdateHost("9.4.23")))
+        assertEquals("Update the plugin API to 1.0.83", remedyLabel(PluginVersionRemedy.UpdateApi("1.0.83")))
+        assertEquals("Go back to version 1.2.21", remedyLabel(PluginVersionRemedy.RevertPlugin("1.2.21")))
+    }
+
+    @Test
+    fun `the nothing-available label is its own explanation`() {
+        val reason = "This needs BOSS 9.9.9."
+        assertEquals(reason, remedyLabel(PluginVersionRemedy.NothingAvailable(reason)))
+    }
+
+    @Test
+    fun `the recovery satisfies check matches the loader`() {
+        // `Version.parse` plus `>=`, which is what DynamicPluginLoader.isBossVersionCompatible does.
+        // Equality has to pass: 9.4.23 is what a plugin requiring 9.4.23 was built for.
+        assertTrue(PluginVersionGateRecovery.satisfies("9.4.23", "9.4.23"))
+        assertTrue(PluginVersionGateRecovery.satisfies("9.4.23", "9.4.24"))
+        assertTrue(PluginVersionGateRecovery.satisfies("9.4.23", "10.0.0"))
+        assertTrue(!PluginVersionGateRecovery.satisfies("9.4.23", "9.4.22"))
+        assertTrue(!PluginVersionGateRecovery.satisfies("9.5.0", "9.4.23"))
+    }
+
+    @Test
+    fun `an unparseable version fails open, as the loader does`() {
+        // Not leniency for its own sake: the loader lets a plugin through when it cannot parse a
+        // floor, so a remedy that refused here would hide a button that actually works.
+        assertTrue(PluginVersionGateRecovery.satisfies("not-a-version", "9.4.22"))
+        assertTrue(PluginVersionGateRecovery.satisfies("9.4.23", "not-a-version"))
+    }
+
+    @Test
+    fun `a host update below the floor is not offered`() {
+        // The distinction the whole dialog turns on. An update that lands below the floor costs a
+        // download and a restart to arrive back at this same dialog.
+        val gate = PluginVersionGate.NeedsNewerHost("com.example.plugin", "Example", "9.4.23", "9.4.22")
+        val remedies =
+            remediesFor(
+                gate = gate,
+                hostUpdate = "9.4.22",
+                apiUpdate = null,
+                revertTo = null,
+                satisfies = PluginVersionGateRecovery::satisfies,
+            )
+        assertTrue(
+            remedies.single() is PluginVersionRemedy.NothingAvailable,
+            "offered an update that would not clear the floor: $remedies",
+        )
+    }
+
+    @Test
+    fun `a host update at the floor is offered first`() {
+        val gate = PluginVersionGate.NeedsNewerHost("com.example.plugin", "Example", "9.4.23", "9.4.22")
+        val remedies =
+            remediesFor(
+                gate = gate,
+                hostUpdate = "9.4.23",
+                apiUpdate = null,
+                revertTo = "1.2.21",
+                satisfies = PluginVersionGateRecovery::satisfies,
+            )
+        assertEquals(
+            listOf(
+                PluginVersionRemedy.UpdateHost("9.4.23"),
+                PluginVersionRemedy.RevertPlugin("1.2.21"),
+            ),
+            remedies,
+            "going forward should be offered before going back",
+        )
+    }
+
+    @Test
+    fun `reverting is offered when nothing is published`() {
+        // The remedy that needs no download and no restart, so it is what works when everything
+        // else is unavailable - which is the position the fluck-browser 1.2.22 incident put people
+        // in for the hours before 9.4.23 existed.
+        val gate = PluginVersionGate.NeedsNewerHost("com.example.plugin", "Example", "9.4.23", "9.4.22")
+        val remedies =
+            remediesFor(
+                gate = gate,
+                hostUpdate = null,
+                apiUpdate = null,
+                revertTo = "1.2.21",
+                satisfies = PluginVersionGateRecovery::satisfies,
+            )
+        assertEquals(listOf(PluginVersionRemedy.RevertPlugin("1.2.21")), remedies)
+    }
+
+    @Test
+    fun `an api gate is not offered an app update`() {
+        // An app release for a hot-swappable jar would be the wrong fix even when one exists.
+        val gate = PluginVersionGate.NeedsNewerApi("com.example.plugin", "Example", "1.0.83", "1.0.80")
+        val remedies =
+            remediesFor(
+                gate = gate,
+                hostUpdate = "9.9.9",
+                apiUpdate = "1.0.83",
+                revertTo = null,
+                satisfies = PluginVersionGateRecovery::satisfies,
+            )
+        assertEquals(listOf(PluginVersionRemedy.UpdateApi("1.0.83")), remedies)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/VersionGateTranslationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/VersionGateTranslationTest.kt
@@ -1,0 +1,133 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.loader.PluginApiLevelException
+import ai.rever.boss.plugin.loader.PluginBinaryIncompatibilityException
+import ai.rever.boss.plugin.loader.PluginBossVersionException
+import ai.rever.boss.plugin.loader.PluginLoadException
+import ai.rever.boss.plugin.loader.PluginSignatureException
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Turning a load failure into an offer, and knowing when there is no offer to make.
+ *
+ * The whole feature turns on this discrimination. A version floor is the one load failure with a
+ * known fix, so it earns a dialog; a corrupt jar or a binary incompatibility does not, and offering
+ * "Update BOSS" for one of those would send a user through a download and a restart to arrive at
+ * exactly the same failure.
+ */
+class VersionGateTranslationTest {
+    @AfterTest
+    fun clearRegistry() {
+        PluginVersionGateRegistry.reset()
+    }
+
+    @Test
+    fun `a host version refusal becomes a host gate`() {
+        val gate =
+            versionGateFor(
+                PluginBossVersionException(
+                    "Plugin requires BOSS version 9.4.23 or later, but current version is 9.4.22",
+                    "ai.rever.boss.plugin.fluck.browser",
+                    "9.4.23",
+                    "9.4.22",
+                ),
+            )
+        val host = assertIs<PluginVersionGate.NeedsNewerHost>(gate)
+        assertEquals("ai.rever.boss.plugin.fluck.browser", host.pluginId)
+        assertEquals("9.4.23", host.required)
+        assertEquals("9.4.22", host.current)
+    }
+
+    @Test
+    fun `an api level refusal becomes an api gate`() {
+        // A different gate because the fix is different and much cheaper - the api layer is itself
+        // a hot-swappable plugin. Conflating the two would send someone to download an app release
+        // for something the store settles in seconds.
+        val gate =
+            versionGateFor(
+                PluginApiLevelException("needs api 1.0.83", "com.example.plugin", "1.0.83", "1.0.80"),
+            )
+        val api = assertIs<PluginVersionGate.NeedsNewerApi>(gate)
+        assertEquals("1.0.83", api.required)
+        assertEquals("1.0.80", api.current)
+    }
+
+    @Test
+    fun `other load failures produce no gate`() {
+        // Each of these is a real failure with no button that helps.
+        assertNull(versionGateFor(PluginSignatureException("bad signature", "com.example.plugin")))
+        assertNull(versionGateFor(PluginBinaryIncompatibilityException("incompatible", "com.example.plugin")))
+        assertNull(versionGateFor(PluginLoadException("no main class", "com.example.plugin")))
+        assertNull(versionGateFor(IllegalStateException("something else")))
+        assertNull(versionGateFor(null))
+    }
+
+    @Test
+    fun `a refusal that cannot name what it needs produces no gate`() {
+        // Without the required version there is no way to tell whether an available update would
+        // clear the floor, so the dialog could only offer one blind. Silence beats a wrong button.
+        assertNull(versionGateFor(PluginBossVersionException("floor", "com.example.plugin", null, "9.4.22")))
+        assertNull(versionGateFor(PluginBossVersionException("floor", "com.example.plugin", "", "9.4.22")))
+    }
+
+    @Test
+    fun `a refusal that cannot name the plugin produces no gate`() {
+        // The id is the key everything else hangs off: the rollback lookup, the registry entry, and
+        // the install the remedy performs.
+        assertNull(versionGateFor(PluginBossVersionException("floor", null, "9.4.23", "9.4.22")))
+        assertNull(versionGateFor(PluginBossVersionException("floor", "  ", "9.4.23", "9.4.22")))
+    }
+
+    @Test
+    fun `a missing current version falls back to this build`() {
+        // The loader always populates it, but a null would otherwise render as "This is null."
+        val gate =
+            assertIs<PluginVersionGate.NeedsNewerHost>(
+                versionGateFor(PluginBossVersionException("floor", "com.example.plugin", "9.9.9", null)),
+            )
+        assertTrue(gate.current.isNotBlank())
+        assertTrue(
+            Regex("""^\d+\.\d+\.\d+""").containsMatchIn(gate.current),
+            "the fallback current version is not a version: ${gate.current}",
+        )
+    }
+
+    @Test
+    fun `the registry keeps one entry per plugin`() {
+        // A refused plugin is retried on every launch and, for a systemPlugin, on every reload. One
+        // entry per attempt would stack identical dialogs.
+        val gate = PluginVersionGate.NeedsNewerHost("com.example.plugin", "Example", "9.4.23", "9.4.22")
+        PluginVersionGateRegistry.record(gate)
+        PluginVersionGateRegistry.record(gate)
+        PluginVersionGateRegistry.record(gate.copy(required = "9.5.0"))
+        assertEquals(1, PluginVersionGateRegistry.gates.value.size)
+        assertEquals(
+            "9.5.0",
+            PluginVersionGateRegistry.gates.value.values
+                .single()
+                .required,
+        )
+    }
+
+    @Test
+    fun `clearing removes only the named plugin`() {
+        PluginVersionGateRegistry.record(PluginVersionGate.NeedsNewerHost("a", "A", "9.5.0", "9.4.22"))
+        PluginVersionGateRegistry.record(PluginVersionGate.NeedsNewerHost("b", "B", "9.5.0", "9.4.22"))
+        PluginVersionGateRegistry.clear("a")
+        assertEquals(setOf("b"), PluginVersionGateRegistry.gates.value.keys)
+    }
+
+    @Test
+    fun `clearing an unknown plugin does not emit`() {
+        // The registry is collected by a composable, so a no-op write would recompose the dialog
+        // host for nothing on every dismissal of an already-cleared gate.
+        val before = PluginVersionGateRegistry.gates.value
+        PluginVersionGateRegistry.clear("never-recorded")
+        assertTrue(before === PluginVersionGateRegistry.gates.value)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/VersionGateWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/VersionGateWiringTest.kt
@@ -1,0 +1,99 @@
+package ai.rever.boss.components.plugin
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * That the recovery path is actually connected end to end.
+ *
+ * A **source** test, and it proves less than a behavioural one. It exists for the four joins a unit
+ * test cannot reach: a composable mounted in a window's dialog host, an `actual` bridge that talks
+ * to `PluginStoreSetup`, a startup registration in `main`, and a catch block inside the plugin
+ * manager's load lock. The decisions themselves are tested properly in
+ * [VersionGateTranslationTest], [PluginVersionRemedyLabelTest] and [PluginRollbackStoreTest].
+ *
+ * Each join was a silent failure on its own: without the snapshot there is nothing to revert to,
+ * without the record no dialog appears, without the registration the dialog has no remedies, and
+ * without the mount none of it is on screen. All four together are what turns one ERROR line in
+ * `~/.boss/logs` into a button.
+ */
+class VersionGateWiringTest {
+    private fun source(relative: String): String {
+        val root =
+            generateSequence(File("").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile }
+        val file = File(assertNotNull(root, "could not locate the repository root"), relative)
+        assertTrue(file.isFile, "missing source file: $relative")
+        return file.readText()
+    }
+
+    @Test
+    fun `the plugin manager records a version-floor refusal`() {
+        val manager =
+            source("composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt")
+        assertTrue(
+            manager.contains("versionGateFor(error)?.let(PluginVersionGateRegistry::record)"),
+            "a refused plugin is back to vanishing with only a log line",
+        )
+    }
+
+    @Test
+    fun `the record happens before the failure returns`() {
+        // Ordering: after the `return@withLock` it is unreachable, and the test above would still
+        // pass on the string alone.
+        val manager =
+            source("composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt")
+        val tail = manager.substringAfter("versionGateFor(error)?.let(PluginVersionGateRegistry::record)")
+        assertTrue(
+            tail.contains("return@withLock Result.failure(error ?: Exception(\"Unknown error\"))"),
+            "the refusal is recorded after the load failure has already returned",
+        )
+    }
+
+    @Test
+    fun `the update path snapshots the jar it is about to replace`() {
+        // Without this there is no way back at all. The update writes a NEW version-named file and
+        // reconcile then deletes the old one, so the working jar stops existing the moment the
+        // update succeeds.
+        val bridge =
+            source("composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt")
+        assertTrue(
+            bridge.contains("PluginRollbackStore.snapshot(pluginDir, pluginId, installedJar)"),
+            "the update no longer keeps the jar it replaces, so Revert has nothing to restore",
+        )
+    }
+
+    @Test
+    fun `the snapshot is taken before anything downloads`() {
+        // After `mgr.updatePlugin` the old jar may already be gone: that call unloads, promotes and
+        // then reconciles. A snapshot there would copy nothing and report success.
+        val bridge =
+            source("composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt")
+        val snapshot = bridge.indexOf("PluginRollbackStore.snapshot(")
+        val update = bridge.indexOf("mgr.updatePlugin(")
+        assertTrue(snapshot in 0 until update, "the snapshot runs after the update has already replaced the jar")
+    }
+
+    @Test
+    fun `the remedy resolver is registered at startup`() {
+        // Before any plugin loads, because the refusal happens during startup plugin loading. A
+        // gate recorded before this runs sits in the registry with nothing able to act on it.
+        val main = source("composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt")
+        assertTrue(
+            main.contains("PluginVersionRemedyAccess") && main.contains("DesktopPluginVersionRemedyResolver"),
+            "the dialog would render with no remedies because nothing populated the holder",
+        )
+    }
+
+    @Test
+    fun `the dialog is mounted in the app dialog host`() {
+        val dialogs = source("composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt")
+        assertTrue(dialogs.contains("PluginVersionGateHost("), "the recovery dialog is never shown")
+        assertTrue(
+            dialogs.contains("remedyResolver = PluginVersionRemedyAccess.current()"),
+            "the mounted dialog is not connected to the desktop resolver",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/HostVersionPropertyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/HostVersionPropertyTest.kt
@@ -1,0 +1,72 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.utils.AppVersion
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The host's own version, published where a plugin can read it.
+ *
+ * Plugins load in separate classloaders and cannot see `AppVersion`, so anything a plugin needs to
+ * know about the host arrives as a system property - the same route as `boss.api.version` and
+ * `boss.ipc.version`. The app version was missing from that set, and the Toolbox is what needed it:
+ * store rows carry `minBossVersion` (the Toolbox writes that field when publishing) but nothing on
+ * its browse or install path could compare it against the running host, so it offered every
+ * published version and Install downloaded plugins the loader then refused.
+ *
+ * That is how fluck-browser 1.2.22 (`minBossVersion: 9.4.23`) presented on 9.4.22: an install that
+ * silently would not take, with `PluginBossVersionException` reaching only the log.
+ */
+class HostVersionPropertyTest {
+    private fun repoRoot(): File? =
+        generateSequence(File("").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile }
+
+    @Test
+    fun `the app version is published as a system property`() {
+        // A source check, because the publish happens inside initializeApiLayer, which needs a real
+        // plugin directory and an api jar to run. What matters is that the line exists next to the
+        // other two, and that it publishes the same value the host filters its own catalog with.
+        val root = assertNotNull(repoRoot(), "could not locate the repository root")
+        val manager =
+            File(
+                root,
+                "composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt",
+            ).readText()
+        assertTrue(
+            manager.contains("""System.setProperty("boss.app.version", AppVersion.currentVersionString())"""),
+            "boss.app.version is not published, so no plugin can compare minBossVersion",
+        )
+    }
+
+    @Test
+    fun `it is published beside the other two host properties`() {
+        // Ordering is not the point; being in the SAME method is. initializeApiLayer runs before any
+        // plugin loads, which is what makes the value readable by the first plugin to look.
+        val root = assertNotNull(repoRoot(), "could not locate the repository root")
+        val text =
+            File(
+                root,
+                "composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt",
+            ).readText()
+        val init = text.substringAfter("fun initializeApiLayer(").substringBefore("\n    }")
+        listOf("boss.api.version", "boss.api.jar", "boss.app.version").forEach { prop ->
+            assertTrue(init.contains(prop), "$prop is not published in initializeApiLayer")
+        }
+    }
+
+    @Test
+    fun `the published value is a version a floor check can parse`() {
+        // A blank or unparseable value fails open in every consumer that reads it, which would put
+        // the Toolbox back to offering incompatible versions while looking like it checks.
+        val current = AppVersion.currentVersionString()
+        assertTrue(current.isNotBlank(), "the host has no version string to publish")
+        assertTrue(
+            Regex("""^\d+\.\d+\.\d+""").containsMatchIn(current),
+            "the host version is not in a shape a floor comparison can read: $current",
+        )
+    }
+}

--- a/supabase/functions/plugin-store/routes/download.ts
+++ b/supabase/functions/plugin-store/routes/download.ts
@@ -222,6 +222,16 @@ download.openapi(downloadLatestRoute, async (ctx) => {
       size: version.jarSize,
       versionId: version.id,
       minIpcVersion: version.minIpcVersion,
+      // The app-version floor, so a client can refuse a version its host cannot load BEFORE
+      // downloading it over the installed jar. Every field above was already here; this one was
+      // not, which left the Toolbox with `min_boss_version` on browse rows and nothing at all on
+      // the path that actually installs. Clients default it to blank and treat blank as "no
+      // opinion", so an older Toolbox is unaffected by its arrival.
+      // `?? ''` because `plugin_versions.min_boss_version` is nullable (TEXT DEFAULT '1.0.0', no
+      // NOT NULL), and an explicit null in a field a client models as a string fails the whole
+      // decode rather than one field - which on a strict client would turn a null floor into a
+      // failed install.
+      minBossVersion: version.minBossVersion ?? '',
       requiredPermissions: plugin.requiredPermissions
     }, 200)
   } catch (error) {
@@ -358,6 +368,16 @@ download.openapi(downloadVersionRoute, async (ctx) => {
       size: version.jarSize,
       versionId: version.id,
       minIpcVersion: version.minIpcVersion,
+      // The app-version floor, so a client can refuse a version its host cannot load BEFORE
+      // downloading it over the installed jar. Every field above was already here; this one was
+      // not, which left the Toolbox with `min_boss_version` on browse rows and nothing at all on
+      // the path that actually installs. Clients default it to blank and treat blank as "no
+      // opinion", so an older Toolbox is unaffected by its arrival.
+      // `?? ''` because `plugin_versions.min_boss_version` is nullable (TEXT DEFAULT '1.0.0', no
+      // NOT NULL), and an explicit null in a field a client models as a string fails the whole
+      // decode rather than one field - which on a strict client would turn a null floor into a
+      // failed install.
+      minBossVersion: version.minBossVersion ?? '',
       requiredPermissions: plugin.requiredPermissions
     }, 200)
   } catch (error) {


### PR DESCRIPTION
## The incident this comes from

fluck-browser 1.2.22 shipped requiring BOSS 9.4.23 while 9.4.22 was the current release. Hosts that took the plugin update got:

```
PluginBossVersionException: Plugin requires BOSS version 9.4.23 or later,
                            but current version is 9.4.22
```

and nothing else. One ERROR line in `~/.boss/logs`. From the user's side the plugin simply stopped existing, and because fluck-browser **is** the browser tab, the observable symptom was "my browser is gone".

Recovery meant knowing the jar had been replaced, finding the previous release on GitHub, and putting it back by hand. Every fact needed to offer a fix was already in the exception the loader throws.

## Two halves

### 1. Make the refusal recoverable

Four joins, each a silent failure on its own:

| Join | Where | Without it |
|---|---|---|
| **Record** | `DynamicPluginManager` load-failure branch | no dialog appears |
| **Snapshot** | `PluginUpdateBridge`, before the download | nothing to revert to |
| **Offer** | `PluginVersionGateDialog` | nothing on screen |
| **Act** | `PluginVersionGateRecovery` + startup registration | the dialog has no remedies |

Only two exceptions produce a gate: `PluginBossVersionException` and `PluginApiLevelException`. A corrupt jar or a binary incompatibility has no button that helps, and "Update BOSS" for one of those costs a download and a restart to arrive at the same failure. A refusal that cannot name what it needs is dropped too, since a dialog that cannot tell whether an available update clears the floor could only offer one blind.

The three remedies:

- **Update BOSS to 9.4.23** - only when an update is available **and** clears the floor. An update that lands below it is worse than no button. Deliberately does not clear the gate: the plugin stays unloadable until the new app runs, so clearing would remove the only explanation during the window between downloading and restarting.
- **Update the plugin API to 1.0.83** - for an api floor, never an app update. The api layer is itself a hot-swappable plugin; sending someone to download an app release for it would be the wrong fix even when one exists. Goes through `installPlugin`, whose api-id branch is an unload-all / swap / reload-all, and the reload-all is what gives the refused plugin its second chance with no restart.
- **Go back to version 1.2.21** - always last, always offered when possible. It needs nothing published and no restart, so it is what works when everything else is unavailable, which is exactly the position people were in for the hours before 9.4.23 existed.

Every label names a version. "Downgrade" does not say what you get; "Update BOSS" does not say whether it helps.

### 2. Publish the host's own version

`boss.app.version`, beside `boss.api.version` and `boss.ipc.version` in `initializeApiLayer`.

This is what makes the Toolbox able to check `minBossVersion` at all. Store rows have always carried the field (the Toolbox writes it when publishing) but there was no other side to the comparison, so it offered every published version and Install downloaded plugins the loader then refused. **[plugin-manager#45](https://github.com/risa-labs-inc/boss-plugin-plugin-manager/pull/45) is inert without this commit.**

Also: the store's download route now returns `minBossVersion`. It returned `minIpcVersion` and not this, which left the Toolbox with the floor on browse rows and nothing at all on the path that installs. Sent as `?? ''` because `plugin_versions.min_boss_version` is `TEXT` with no NOT NULL, and a null in a field a client models as a string fails the whole decode rather than one field.

## A design error found and corrected mid-review

`PluginRollbackStore` originally keyed the kept jar off the jar's own path (`<name>.jar.rollback`). That **cannot work**, and tracing the update path is what showed it: `PluginUpdateBridge` writes a new version-named file and then calls `PluginJarReconciler.reconcilePluginDir`, which deletes every other jar for that plugin id. So a snapshot taken at the new path finds nothing to copy, and one taken at the old path is addressed by a name nobody holds afterwards.

It is keyed by plugin id now, in a dot-prefixed `.rollback` subdirectory so the plugin directory scan cannot mistake a kept jar for an installed one and load two copies of the same plugin.

One other correction: a snapshot that cannot read its source now **leaves any earlier copy alone** rather than discarding it. The earlier copy is correctly labelled with its own version, so restoring it lands on something older than ideal but working, which beats no way back at all.

## Deliberately out of scope

- **The Toolbox's own update path is not covered.** It downloads and overwrites in place, plugin-side, where the host cannot snapshot. The host's updater is what overwrote the fluck jar in the real incident, so that is the path this covers.
- **One generation deep.** A history is a directory of multi-megabyte jars nobody prunes.
- **Dismissal is per session.** The refusal is recorded again on the next launch, which is the right cadence for something this consequential. A dialog that returned on every recomposition would be worse than the silence it replaces.
- **One dialog at a time.** A version bump can refuse a whole batch declaring the same floor; stacking dialogs would be unusable.

## Tests

**2480 desktop tests, all green. ktlint and detekt clean.**

`PluginRollbackStoreTest` was rewritten for the new keying (16 tests) and covers the traps found along the way: the version-renaming update, a restore onto its own path, the sidecar travelling in both directions, an unsigned rollback not inheriting the signature it replaces, the kept jar being invisible to a directory scan, and a plugin id that would escape the directory.

Every join was verified by **removing it and watching a test fail**, not by assuming:

| Removed | Caught by |
|---|---|
| the "must name what it needs" guard | `VersionGateTranslationTest` |
| the snapshot in `PluginUpdateBridge` | 2 failures in `VersionGateWiringTest` |
| the record in `DynamicPluginManager` | `VersionGateWiringTest` |
| the mount in `BossAppDialogs` | `VersionGateWiringTest` |

`VersionGateWiringTest` is a **source** test and says so in its KDoc: it exists for the four joins a unit test cannot reach (a composable in a window's dialog host, an `actual` bridge onto `PluginStoreSetup`, a startup registration in `main`, and a catch block inside the manager's load lock). The decisions themselves are tested properly in `VersionGateTranslationTest`, `PluginVersionRemedyLabelTest` and `PluginRollbackStoreTest`.

## Not yet exercised against a running app

The dialog has not been seen on screen. What is verified is the logic, the wiring, and that a real refusal reaches the registry; what is not is how the dialog looks or that a remedy completes end to end in a live app.