### PR TITLE
feat(theme): Windows opens on the light theme

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettings.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.theme
 
 import ai.rever.boss.plugin.ui.BossThemes
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Persisted host theme preference. `appThemeId` matches a [BossThemes] id
@@ -9,11 +10,63 @@ import kotlinx.serialization.Serializable
  * ~/.boss/app-theme-settings.json.
  *
  * Note that `BossConsoleRust` reads and writes this same file, so its
- * `ThemeId::DEFAULT` must stay in lockstep with [BossThemes.DEFAULT_ID] — a
+ * `ThemeId::DEFAULT` must stay in lockstep with [BossThemes.DEFAULT_ID] - a
  * settings file that omits `appThemeId` means "the default", and the two apps
- * would otherwise disagree about which theme that is.
+ * would otherwise disagree about which theme that is. Windows now opens on
+ * [BossThemes.WINDOWS_DEFAULT_ID] instead, but only when there is no file at
+ * all; see [decodeOrDefaults] for why the two cases are not the same.
  */
 @Serializable
 data class AppThemeSettings(
     val appThemeId: String = BossThemes.DEFAULT_ID,
-)
+) {
+    companion object {
+        /**
+         * One Json for reading and writing, with `encodeDefaults = true`.
+         *
+         * The previous writer omitted `appThemeId` whenever it equalled the
+         * class default, which is survivable only while every platform shares
+         * one default. With a Windows default it is not: a Windows user who
+         * picks Blueprint writes a file that says nothing, and absence is the
+         * one thing that has to keep meaning Blueprint. Writing the id always
+         * ends the ambiguity for every file written from here on.
+         */
+        internal val storageJson =
+            Json {
+                prettyPrint = true
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            }
+
+        /** First-run settings for a platform, before anything is on disk. */
+        fun defaultsFor(isWindows: Boolean): AppThemeSettings = AppThemeSettings(BossThemes.defaultIdFor(isWindows))
+
+        /**
+         * Resolve the stored preference, where `content` is the settings file's
+         * text or null when there is no file.
+         *
+         * The distinction is the whole feature. This file is written only by
+         * `AppThemeSettingsManager.select()`, so its existence *is* the record
+         * that someone chose a theme:
+         *
+         * - **no file** - nobody has ever chosen, so the platform default applies
+         *   and Windows opens light.
+         * - **a file** - someone chose. A missing `appThemeId` is then a choice
+         *   of the class default, written by the old `encodeDefaults = false`
+         *   writer, and resolving it from the platform default would silently
+         *   flip a Windows user who deliberately picked Blueprint.
+         *
+         * A file that will not parse falls back to the platform default: the
+         * choice it recorded is unreadable, so there is nothing to preserve.
+         */
+        fun decodeOrDefaults(
+            content: String?,
+            isWindows: Boolean,
+        ): AppThemeSettings =
+            if (content == null) {
+                defaultsFor(isWindows)
+            } else {
+                storageJson.decodeFromString(serializer(), content)
+            }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettingsManager.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.theme
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.plugin.ui.BossThemes
+import ai.rever.boss.utils.SystemUtils
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
@@ -13,24 +14,25 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 
 /**
  * Persists the user's host theme choice and keeps the live [BossThemeController]
  * in sync. Follows the BOSS settings pattern (JSON in ~/.boss, sync load on
- * init, async save). Desktop-only — the host app ships desktop only.
+ * init, async save). Desktop-only - the host app ships desktop only.
+ *
+ * The load is synchronous on purpose: `ensureInitialized()` is this object's
+ * first accessor, so an asynchronous `init` would lose the race against its own
+ * first reader and the app would open on the compiled-in default.
  */
 object AppThemeSettingsManager {
     private val logger = BossLogger.forComponent("AppThemeSettingsManager")
     private val settingsFile = BossDirectories.resolve("app-theme-settings.json")
-    private val json =
-        Json {
-            prettyPrint = true
-            ignoreUnknownKeys = true
-        }
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    private val _settings = MutableStateFlow(AppThemeSettings())
+    private val platformDefaults: AppThemeSettings
+        get() = AppThemeSettings.defaultsFor(SystemUtils.isWindows)
+
+    private val _settings = MutableStateFlow(platformDefaults)
     val settings: StateFlow<AppThemeSettings> = _settings.asStateFlow()
 
     init {
@@ -41,7 +43,12 @@ object AppThemeSettingsManager {
     /**
      * Applies the persisted theme to [BossThemeController] so the app opens in
      * the saved look. Call once early in startup, before the first frame is
-     * composed. Idempotent — selecting the same theme again just re-sets the id.
+     * composed. Idempotent - selecting the same theme again just re-sets the id.
+     *
+     * This deliberately does not write the resolved id back. Persisting a
+     * platform default on first launch would pin it, and every later change to
+     * what a platform opens with would then reach nobody who had ever run the
+     * app.
      */
     fun ensureInitialized() {
         BossThemeController.select(_settings.value.appThemeId)
@@ -57,23 +64,23 @@ object AppThemeSettingsManager {
 
     private fun loadSync() {
         try {
-            if (settingsFile.exists()) {
-                _settings.value =
-                    json.decodeFromString(
-                        AppThemeSettings.serializer(),
-                        settingsFile.readText(),
-                    )
-            }
+            val content = if (settingsFile.exists()) settingsFile.readText() else null
+            _settings.value = AppThemeSettings.decodeOrDefaults(content, SystemUtils.isWindows)
         } catch (e: Exception) {
             logger.warn(LogCategory.SYSTEM, "Failed to load app theme settings, using default", error = e)
-            _settings.value = AppThemeSettings()
+            _settings.value = platformDefaults
         }
     }
 
     private suspend fun save() =
         withContext(Dispatchers.IO) {
             try {
-                settingsFile.writeText(json.encodeToString(AppThemeSettings.serializer(), _settings.value))
+                settingsFile.writeText(
+                    AppThemeSettings.storageJson.encodeToString(
+                        AppThemeSettings.serializer(),
+                        _settings.value,
+                    ),
+                )
                 logger.debug(LogCategory.SYSTEM, "Saved app theme", mapOf("themeId" to _settings.value.appThemeId))
             } catch (e: Exception) {
                 logger.warn(LogCategory.SYSTEM, "Failed to save app theme settings", error = e)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/theme/AppThemeDefaultsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/theme/AppThemeDefaultsTest.kt
@@ -1,0 +1,121 @@
+package ai.rever.boss.theme
+
+import ai.rever.boss.plugin.ui.BossThemes
+import ai.rever.boss.utils.SystemUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks down the platform default theme and, more importantly, what an existing
+ * settings file means once the default stops being the same everywhere.
+ *
+ * Both branches are driven through the explicit `isWindows` parameter rather
+ * than the running host, so the Windows behaviour is covered on every CI leg
+ * and not only on `windows-latest`.
+ */
+class AppThemeDefaultsTest {
+    @Test
+    fun `windows opens light and every other platform keeps the dark default`() {
+        assertEquals(BossThemes.WINDOWS_DEFAULT_ID, BossThemes.defaultIdFor(isWindows = true))
+        assertEquals(BossThemes.DEFAULT_ID, BossThemes.defaultIdFor(isWindows = false))
+    }
+
+    /**
+     * The request was "light on Windows", not "this particular id", so assert the
+     * property rather than only the name. A future re-point of
+     * [BossThemes.WINDOWS_DEFAULT_ID] at a dark theme is the failure worth catching.
+     */
+    @Test
+    fun `the windows default is a registered light theme`() {
+        val windowsDefault = BossThemes.byId(BossThemes.defaultIdFor(isWindows = true))
+
+        assertEquals(BossThemes.WINDOWS_DEFAULT_ID, windowsDefault.id)
+        assertTrue(windowsDefault.isLight, "Windows must open on a light theme")
+        assertFalse(
+            BossThemes.byId(BossThemes.defaultIdFor(isWindows = false)).isLight,
+            "the non-Windows default is unchanged and still dark",
+        )
+    }
+
+    /** Guards a typo'd id, which `byId` would otherwise absorb into the fallback. */
+    @Test
+    fun `both platform defaults name themes that actually exist`() {
+        val ids = BossThemes.all.map { it.id }
+
+        assertTrue(BossThemes.DEFAULT_ID in ids)
+        assertTrue(BossThemes.WINDOWS_DEFAULT_ID in ids)
+    }
+
+    @Test
+    fun `this host is wired to its own platform branch`() {
+        assertEquals(
+            BossThemes.defaultIdFor(SystemUtils.isWindows),
+            AppThemeSettings.defaultsFor(SystemUtils.isWindows).appThemeId,
+        )
+    }
+
+    @Test
+    fun `a first run with no settings file opens on the platform default`() {
+        assertEquals(
+            BossThemes.WINDOWS_DEFAULT_ID,
+            AppThemeSettings.decodeOrDefaults(content = null, isWindows = true).appThemeId,
+        )
+        assertEquals(
+            BossThemes.DEFAULT_ID,
+            AppThemeSettings.decodeOrDefaults(content = null, isWindows = false).appThemeId,
+        )
+    }
+
+    /**
+     * The regression this feature would otherwise ship. The file is written only
+     * by `select()`, and the old writer omitted the id when it equalled the class
+     * default, so `{}` on disk is a Windows user who deliberately picked
+     * Blueprint. Resolving that absence from the platform default flips them to
+     * light on the very next launch, with no way to make it stick.
+     */
+    @Test
+    fun `an existing file that omits the id keeps the dark default on windows`() {
+        assertEquals(
+            BossThemes.DEFAULT_ID,
+            AppThemeSettings.decodeOrDefaults(content = "{}", isWindows = true).appThemeId,
+        )
+    }
+
+    @Test
+    fun `a stored id always wins over the platform default`() {
+        val stored = """{"appThemeId":"operator"}"""
+
+        assertEquals("operator", AppThemeSettings.decodeOrDefaults(stored, isWindows = true).appThemeId)
+        assertEquals("operator", AppThemeSettings.decodeOrDefaults(stored, isWindows = false).appThemeId)
+    }
+
+    /**
+     * With `encodeDefaults = false` a Windows user choosing Blueprint wrote `{}`,
+     * which the next launch read back as the platform default. The round trip has
+     * to survive the one value that used to disappear.
+     */
+    @Test
+    fun `choosing the dark default on windows round-trips`() {
+        val written =
+            AppThemeSettings.storageJson.encodeToString(
+                AppThemeSettings.serializer(),
+                AppThemeSettings(appThemeId = BossThemes.DEFAULT_ID),
+            )
+
+        assertTrue("appThemeId" in written, "the id must be written even when it equals the class default")
+        assertEquals(
+            BossThemes.DEFAULT_ID,
+            AppThemeSettings.decodeOrDefaults(written, isWindows = true).appThemeId,
+        )
+    }
+
+    /** Unknown keys are the shape of a file written by a newer build, or by BossConsoleRust. */
+    @Test
+    fun `an unknown key does not throw away the stored theme`() {
+        val stored = """{"appThemeId":"daylight","futureKey":true}"""
+
+        assertEquals("daylight", AppThemeSettings.decodeOrDefaults(stored, isWindows = true).appThemeId)
+    }
+}

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -44,8 +44,8 @@ a theme is one `BossAppTheme` plus one list entry.
 
 | Theme | id | | Identity |
 |-------|----|-|----------|
-| **Blueprint** | `blueprint` | dark | Electric blue on ink - matches [bossconsole.ai](https://bossconsole.ai). **The default.** |
-| **Blueprint Light** | `blueprint-light` | light | The same blue, re-grounded on the site's `--paper` |
+| **Blueprint** | `blueprint` | dark | Electric blue on ink - matches [bossconsole.ai](https://bossconsole.ai). **The default on macOS and Linux.** |
+| **Blueprint Light** | `blueprint-light` | light | The same blue, re-grounded on the site's `--paper`. **The default on Windows.** |
 | **Operator** | `operator` | dark | The original amber-on-ink identity |
 | **Daylight** | `daylight` | light | Clean light theme |
 | **Clean** | `clean` | dark | Neutral charcoal, steel-blue accent |
@@ -53,13 +53,31 @@ a theme is one `BossAppTheme` plus one list entry.
 The choice is explicit and persisted (`~/.boss/app-theme-settings.json`); the OS
 theme setting is never consulted.
 
+**The default is per-platform.** Windows opens on Blueprint Light, everything else
+on Blueprint. `BossThemes.defaultIdFor(isWindows)` is the only place that branches;
+`BossThemes.DEFAULT_ID` stays the *class* default, which is what an existing
+settings file means when it says nothing.
+
 **Who a default change re-skins.** `AppThemeSettingsManager` writes that file only
-from `select()` - `ensureInitialized()` resolves the id without saving. So a file
-that omits `appThemeId`, *or no file at all*, means "whatever the default is", and
-**anyone who never explicitly picked a theme moves to Blueprint on update**. Only an
-explicit selection survives. That is intended here (it is the brand alignment this
-theme exists for); if a future default change should instead be a no-op for current
-users, `ensureInitialized()` has to persist the resolved id once.
+from `select()` - `ensureInitialized()` resolves the id without saving. The file's
+existence is therefore the record that someone chose, and the two absences are not
+the same thing:
+
+| On disk | Means | Resolves to |
+|---------|-------|-------------|
+| no file | nobody has ever picked | the platform default |
+| a file with no `appThemeId` | someone picked the class default, under the old `encodeDefaults = false` writer | `DEFAULT_ID`, on every platform |
+| a file with an `appThemeId` | someone picked that | that theme |
+
+The middle row is the one that costs something to get wrong: resolving it from the
+platform default would flip a Windows user who deliberately chose Blueprint back to
+light on their next launch, with no way to make the choice stick. Writes now use
+`encodeDefaults = true`, so files written from here on always name the id and the
+ambiguity ends with the files that already exist.
+
+`ensureInitialized()` still does not persist what it resolved. Pinning a platform
+default on first launch would mean the next change to what a platform opens with
+reaches nobody who has ever run the app.
 
 That property is why the four mirrors below have to agree on the default, not just
 on the palettes.
@@ -311,10 +329,15 @@ raw-palette names `chalk` / `mist` / `muted`.
 | Terminal defaults | BossTerm `…/settings/TerminalSettings.kt` (`activeThemeId = "boss-blueprint"`, and the fg/bg/selection defaults must match that theme) |
 | Terminal chrome tokens | BossTerm `…/settings/theme/UiTheme.kt` (`EXACT_TOKENS` - both BOSS identities skip derivation) |
 
-**Defaults:** the host default is `blueprint` (`BossThemes.DEFAULT_ID`) and the
-BossTerm default is `boss-blueprint` (`DEFAULT_THEME_ID` /
-`TerminalSettings.activeThemeId`). Existing saved settings keep their current
-theme; only fresh installs pick up a new default.
+**Defaults:** the host default is `blueprint` (`BossThemes.DEFAULT_ID`) on macOS
+and Linux and `blueprint-light` (`BossThemes.WINDOWS_DEFAULT_ID`) on Windows,
+resolved through `BossThemes.defaultIdFor(isWindows)`. The BossTerm default is
+`boss-blueprint` (`DEFAULT_THEME_ID` / `TerminalSettings.activeThemeId`) on every
+platform, but that default is what standalone BossTerm opens with: inside BOSS the
+`terminal-tab` plugin's `ApplyHostThemeToTerminal()` pushes the host tokens into
+BossTerm's `ThemeManager` on every compose, so the terminal follows the host and a
+Windows first run comes up light throughout. Existing saved settings keep their
+current theme; only fresh installs pick up a new default.
 
 **Four mirrors, one settings file.** The palettes exist in four places and they
 have to agree:
@@ -330,3 +353,9 @@ The Rust mirror reads and writes **the same** `~/.boss/app-theme-settings.json`,
 and a file that omits `appThemeId` means "the default" - so its `ThemeId::DEFAULT`
 must move whenever `BossThemes.DEFAULT_ID` does, or the two hosts render different
 themes from identical settings.
+
+`DEFAULT_ID` has not moved, so that mirror is still in step. The **Windows**
+default is a second thing to mirror: until `boss-core` grows the equivalent of
+`defaultIdFor(isWindows)`, a Windows first run opens light under this host and
+dark under the Rust one. Neither ships on Windows today, so this is a note for
+whoever gets there first, not a live divergence.

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossThemes.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossThemes.kt
@@ -185,6 +185,16 @@ private fun lightMaterial(s: BossColorScheme): Colors =
 object BossThemes {
     const val DEFAULT_ID = "blueprint"
 
+    /**
+     * What Windows opens with. Blueprint Light rather than Daylight: it is the
+     * light half of the same identity [DEFAULT_ID] names, so the two platforms
+     * differ in value and not in brand, and Daylight carries a known contrast
+     * defect (its amber signal sits at 2.63:1 on its own near-white floor, under
+     * the 3:1 floor for UI components) that has no business being anyone's
+     * out-of-the-box look. `BossThemesRegistryTest` records that debt.
+     */
+    const val WINDOWS_DEFAULT_ID = "blueprint-light"
+
     val BLUEPRINT =
         BossAppTheme(
             id = "blueprint",
@@ -243,6 +253,19 @@ object BossThemes {
      * KDoc warned about, and a comment is a weaker guarantee than an expression.
      */
     fun byId(id: String?): BossAppTheme = all.find { it.id == id } ?: default
+
+    /**
+     * The default theme id for a platform, in the platform-explicit form the
+     * host's other platform defaults use (`StartupPanelPolicy`,
+     * `FocusModeSettings`), so both branches are reachable from a test on any
+     * CI leg. Callers resolve `isWindows` themselves: this module is
+     * commonMain and has no business reading system properties.
+     *
+     * [DEFAULT_ID] deliberately stays the *class* default. It is what an
+     * existing settings file means when it omits `appThemeId`, and only a
+     * first run with no file at all resolves through here.
+     */
+    fun defaultIdFor(isWindows: Boolean): String = if (isWindows) WINDOWS_DEFAULT_ID else DEFAULT_ID
 }
 
 /**


### PR DESCRIPTION
Windows now starts on **Blueprint Light**. macOS and Linux are unchanged on Blueprint.

## Which light theme, and why

There are two light themes registered, and the choice is not arbitrary:

- **Blueprint Light** (chosen) is the light half of the identity that is already the default, so the platforms differ in value, not in brand.
- **Daylight** is recorded in `BossThemesRegistryTest` under `SIGNAL_CONTRAST_DEBT`: its amber `signal` measures 2.63:1 against its own near-white floor, below the 3:1 WCAG floor for UI components. Making it the Windows default would ship a known, already-documented contrast defect as the out-of-the-box look for a whole platform.

If you want Daylight instead, it is `BossThemes.WINDOWS_DEFAULT_ID` and nothing else.

## The change

`BossThemes.defaultIdFor(isWindows)` is the only branch, in the platform-explicit form `StartupPanelPolicy.autoOpensProjectPanelsFor` and `FocusModeSettings.defaultsFor` already use, so both branches are exercised on every CI leg instead of only on `windows-latest`. `plugin-ui-core` is commonMain and has no business reading system properties, so the caller resolves `isWindows`.

`BossThemes.DEFAULT_ID` deliberately does **not** move. It stays the *class* default, which keeps `BossThemesRegistryTest` and `ThemeTokenReactivityTest` meaningful (both pin behaviour to `DEFAULT_ID`, and the latter would degrade to `assertNotEquals(x, x)` on the Windows CI leg if the default resolved to a light theme) and, more importantly, it is what an existing settings file means when it says nothing.

## Why this is not a one-line default change

`~/.boss/app-theme-settings.json` is written **only** by `select()`, so the file existing *is* the record that somebody chose a theme. And the old writer used `encodeDefaults = false`, which omitted `appThemeId` whenever it equalled the class default. Put those together and a Windows user who deliberately picked Blueprint has a file on disk that says nothing at all.

Resolving that absence from the platform default flips them to light on their next launch, with no way to make the choice stick. So the two absences are now different things:

| On disk | Means | Resolves to |
|---------|-------|-------------|
| no file | nobody ever picked | the platform default (light on Windows) |
| a file with no `appThemeId` | somebody picked the class default, under the old writer | `DEFAULT_ID`, on every platform |
| a file with an `appThemeId` | somebody picked that | that theme |

Writes now use `encodeDefaults = true`, so files written from here on always name the id and the ambiguity dies with the files that already exist. A file that will not parse falls back to the platform default, since whatever it recorded is unreadable and there is nothing to preserve.

`ensureInitialized()` still does not persist what it resolved. Pinning a platform default on first launch would mean the *next* change to what a platform opens with reaches nobody who has ever run the app.

## Verification

`./gradlew :composeApp:desktopTest --tests "ai.rever.boss.theme.*"` - 24 tests, 0 failures (9 new, and the 15 existing theme tests still pass unchanged). ktlint on all three touched source sets and detekt on both modules are green.

**Both traps were verified by reverting the fix**, not just by the tests passing:

- setting `encodeDefaults = false` back fails exactly one test, `choosing the dark default on windows round-trips`
- resolving an absent key from the platform default fails exactly one test, `an existing file that omits the id keeps the dark default on windows`

## Two consequences, documented rather than discovered later

- **The terminal follows.** `terminal-tab`'s `ApplyHostThemeToTerminal()` pushes host tokens into BossTerm's `ThemeManager` on every compose, so a Windows first run is light throughout rather than a light host wrapped around a dark grid. BossTerm's own `boss-blueprint` default is what *standalone* BossTerm opens with. `FluckEngine` likewise flips Chromium's `prefers-color-scheme`, so web content in the browser tab comes up light too.
- **`BossConsoleRust` reads the same file.** `DEFAULT_ID` has not moved, so its `ThemeId::DEFAULT` is still in step, but it has no equivalent of `defaultIdFor` yet. Neither host ships on Windows today, so this is a note for whoever gets there first, not a live divergence. Recorded in `DESIGN_SYSTEM.md`.

## Not in scope

No migration for existing installs beyond the absence rule above, and no change to what any non-Windows platform opens with.