### PR TITLE
Stop a plugin with no UI on screen from ending the app

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -405,6 +405,17 @@ internal fun BossAppStartupEffects(state: BossAppState) {
         state.currentDefaultPlugin = plugin
         state.draggablePanelComponent.update()
 
+        // Teach crash attribution about plugins that have no UI on screen.
+        //
+        // Attribution used to consider only plugins with a *mounted* error
+        // boundary, so a plugin with nothing on screen could not be blamed for a
+        // crash it plainly caused - and an unattributable StackOverflowError
+        // escalates to ending the app. That is how a self-recursive method in
+        // terminal-tab took BOSS down from one click, with every surviving stack
+        // frame naming it. Read lazily, on the crash path only.
+        ai.rever.boss.plugin.sandbox.ui.KnownPlugins
+            .install { plugin.dynamicPluginManager.pluginStates.value.keys }
+
         // Initialize BookmarkAPIAccess so UI code can access bookmarks via the plugin system
         BookmarkAPIAccess.initialize(plugin)
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashDisposition.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashDisposition.kt
@@ -70,3 +70,20 @@ fun classifyCrash(
  * carve-outs are worthless unless they agree - and for one round they did not.
  */
 internal fun Throwable.hasUncontainableCause(): Boolean = chainOfCauses().any { isUncontainable(it) }
+
+/**
+ * Fatal to the *process*, as opposed to merely uncontainable by a repaint.
+ *
+ * A strict subset of [hasUncontainableCause], and the distinction earns its keep
+ * in [decideWindowExceptionRoute]. Both an [OutOfMemoryError] and a
+ * [StackOverflowError] are uncontainable there, but for different reasons and
+ * with different remedies: after an OOM the heap is gone and every recovery path
+ * — a status message, a coroutine, a repaint of every window — allocates on a
+ * heap that has nothing left, so there is nothing to do but escalate. After a
+ * stack overflow the stack has already unwound and the process is healthy; the
+ * only thing you must not do is re-enter whatever recursed. Quarantining the
+ * plugin that recursed does exactly that, and keeps the session.
+ *
+ * Kept narrow on purpose. Anything added here becomes a reason to end the app.
+ */
+internal fun Throwable.hasFatalCause(): Boolean = chainOfCauses().any { it is OutOfMemoryError }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/WindowExceptionRoute.kt
@@ -16,6 +16,12 @@ enum class WindowExceptionRoute {
     /** Attributable to a plugin; the crash interceptor owns it. */
     PluginHandled,
 
+    /**
+     * Blamed on a plugin that has no boundary to hand it to. Quarantine that
+     * plugin and keep the app.
+     */
+    QuarantinePlugin,
+
     /** Contain: keep the window, recover the plugin panels, tell the user. */
     Contain,
 
@@ -37,19 +43,37 @@ enum class WindowExceptionRoute {
  *    it, and that carve-out is worthless unless this agrees: containing here
  *    would log, toast, and repaint every window, which under heap exhaustion is
  *    more allocation, three times, before the circuit breaker gives up.
- * 3. **Too many failures too fast** — the scene is not recovering, so stop
+ * 3. **Blamed on a plugin** ([blamedPluginId]) — quarantine it and keep the app.
+ *    This sits *below* the fatal check and *above* the uncontainable one, and
+ *    that placement is the whole point of the branch.
+ *
+ *    A `StackOverflowError` is uncontainable in the sense the boundary means:
+ *    you cannot recover by repainting, because the repaint re-enters whatever
+ *    recursed. But the stack has unwound by the time we get here — the *process*
+ *    is fine — and if we know which plugin did it we can remove that plugin
+ *    instead of repainting everything. Escalating was throwing away a session to
+ *    avoid a redraw we were not going to attempt anyway.
+ *
+ *    This is not hypothetical: `TerminalTabPluginAPIImpl.setPendingSidebarCommand`
+ *    recursed into itself, and BOSS exited. Every frame named the plugin; it just
+ *    had no boundary mounted, so [attributedPluginId] was null and nothing below
+ *    looked at the blame again.
+ * 4. **Too many failures too fast** — the scene is not recovering, so stop
  *    pretending. Note this consumes a slot in [policy], so it must be reached
  *    only for faults actually eligible for containment; that is why the
  *    uncontainable check sits above it rather than below.
- * 4. Otherwise contain.
+ * 5. Otherwise contain.
  */
 fun decideWindowExceptionRoute(
     throwable: Throwable,
     attributedPluginId: String?,
     policy: RenderCrashPolicy,
+    blamedPluginId: String? = null,
 ): WindowExceptionRoute =
     when {
         attributedPluginId != null -> WindowExceptionRoute.PluginHandled
+        throwable.hasFatalCause() -> WindowExceptionRoute.Escalate
+        blamedPluginId != null -> WindowExceptionRoute.QuarantinePlugin
         throwable.hasUncontainableCause() -> WindowExceptionRoute.Escalate
         !policy.recordFailureAndShouldContain() -> WindowExceptionRoute.Escalate
         else -> WindowExceptionRoute.Contain

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.crash.RenderCrashPolicy
 import ai.rever.boss.crash.RenderRecoveryToaster
 import ai.rever.boss.crash.WindowExceptionRoute
 import ai.rever.boss.crash.decideWindowExceptionRoute
+import ai.rever.boss.crash.hasFatalCause
 import ai.rever.boss.crash.noteRecoveryOutcome
 import ai.rever.boss.logging.GlobalLogCapture
 import ai.rever.boss.performance.PerformanceDataProviderImpl
@@ -72,6 +73,50 @@ private val logger = BossLogger.forComponent("Main")
  * is not just a `!=` against the last message.
  */
 private val renderRecoveryToaster = RenderRecoveryToaster()
+
+/**
+ * A fault we can pin on a plugin that has no boundary to hand it to.
+ *
+ * The gap this closes: [PluginCrashInterceptor.attributeToPlugin] only answers
+ * for plugins with a *mounted* error boundary, so a plugin with no UI on screen
+ * was unattributable — and an unattributable `StackOverflowError` escalated to
+ * ending the app. `TerminalTabPluginAPIImpl.setPendingSidebarCommand` recursed
+ * into itself from a click and took BOSS down that way, with all ~1024 surviving
+ * frames naming the plugin.
+ *
+ * Recorded through `recordCrash` rather than `recordRenderFault`: unlike
+ * [PluginRenderRecovery]'s narrowing loop, which quarantines a *suspect* and must
+ * not close somebody's tab on a guess, this is a plugin we can name — from the
+ * host's own execution-boundary tag, or from a stack made of nothing else.
+ *
+ * The window is kept. No repaint: nothing here rebuilt the scene, and repainting
+ * is what must not happen after a stack overflow.
+ */
+private fun quarantineBlamedPlugin(
+    pluginId: String,
+    throwable: Throwable,
+) {
+    logger.error(
+        LogCategory.UI,
+        "Render exception blamed on a plugin with no error boundary - quarantining it, window kept alive",
+        mapOf(
+            "pluginId" to pluginId,
+            "errorType" to throwable.javaClass.simpleName,
+        ),
+        throwable,
+    )
+    // Written to disk rather than raised as a dialog: the session survives, and a
+    // crash we recovered from has no business interrupting the user. Same
+    // reasoning as containRenderFault.
+    ai.rever.boss.crash.CrashHandler
+        .recordContained(throwable)
+    if (pluginId.isNotBlank()) {
+        // notify = true: this is the only message the user will get, and unlike a
+        // contained render fault there is a named plugin to put in it.
+        ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
+            .recordCrash(pluginId, throwable)
+    }
+}
 
 /**
  * Keep the window, recover the plugin panels, and tell the user.
@@ -809,7 +854,17 @@ fun main(args: Array<String>) {
                         return WindowExceptionHandler { throwable ->
                             val pluginId =
                                 PluginCrashInterceptor.attributeToPlugin(throwable)
-                            when (decideWindowExceptionRoute(throwable, pluginId, renderCrashPolicy)) {
+                            // Not computed under an OOM. Blame walks the stack and
+                            // may call into the plugin manager, which allocates —
+                            // and a fatal heap is escalated regardless, so the
+                            // answer could not change the route anyway.
+                            val blamedPluginId =
+                                if (pluginId != null || throwable.hasFatalCause()) {
+                                    null
+                                } else {
+                                    PluginCrashInterceptor.blameFor(throwable)
+                                }
+                            when (decideWindowExceptionRoute(throwable, pluginId, renderCrashPolicy, blamedPluginId)) {
                                 WindowExceptionRoute.PluginHandled -> {
                                     logger.warn(
                                         LogCategory.SYSTEM,
@@ -820,6 +875,10 @@ fun main(args: Array<String>) {
                                         ),
                                     )
                                     PluginCrashInterceptor.tryHandle(pluginId.orEmpty(), throwable)
+                                }
+
+                                WindowExceptionRoute.QuarantinePlugin -> {
+                                    quarantineBlamedPlugin(blamedPluginId.orEmpty(), throwable)
                                 }
 
                                 WindowExceptionRoute.Contain -> {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/WindowExceptionRouteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/WindowExceptionRouteTest.kt
@@ -108,4 +108,108 @@ class WindowExceptionRouteTest {
 
         assertEquals(WindowExceptionRoute.PluginHandled, route)
     }
+
+    // ---------------------------------------------------------------- blame
+
+    /**
+     * The case this branch exists for.
+     *
+     * `TerminalTabPluginAPIImpl.setPendingSidebarCommand` recursed into itself and
+     * threw StackOverflowError from a click. Every one of the ~1024 frames the JVM
+     * kept named the plugin, but terminal-tab had no boundary mounted, so
+     * attribution returned null and BOSS exited. The stack has unwound by the time
+     * we route; the process is fine, and there is a plugin to remove.
+     */
+    @Test
+    fun `a StackOverflowError blamed on a plugin is quarantined instead of ending the app`() {
+        val route =
+            decideWindowExceptionRoute(
+                StackOverflowError(),
+                attributedPluginId = null,
+                policy = policy(),
+                blamedPluginId = "ai.rever.boss.plugin.dynamic.terminaltab",
+            )
+
+        assertEquals(WindowExceptionRoute.QuarantinePlugin, route)
+    }
+
+    /**
+     * An OOM is fatal to the *process*, not merely uncontainable by a repaint.
+     * Blame changes nothing: every recovery path allocates, and there is no heap
+     * left to allocate from. This ordering is why hasFatalCause sits above the
+     * blame branch rather than below it.
+     */
+    @Test
+    fun `an OutOfMemoryError escalates even when a plugin is to blame`() {
+        val route =
+            decideWindowExceptionRoute(
+                OutOfMemoryError("Java heap space"),
+                attributedPluginId = null,
+                policy = policy(),
+                blamedPluginId = "some.plugin",
+            )
+
+        assertEquals(WindowExceptionRoute.Escalate, route)
+    }
+
+    @Test
+    fun `a wrapped OutOfMemoryError escalates even when a plugin is to blame`() {
+        val wrapped = java.lang.reflect.InvocationTargetException(OutOfMemoryError("heap"))
+
+        assertEquals(
+            WindowExceptionRoute.Escalate,
+            decideWindowExceptionRoute(wrapped, null, policy(), blamedPluginId = "some.plugin"),
+        )
+    }
+
+    /** A live boundary still wins: it can show a fallback, quarantining cannot. */
+    @Test
+    fun `an attributed crash prefers the boundary over quarantine`() {
+        val route =
+            decideWindowExceptionRoute(
+                StackOverflowError(),
+                attributedPluginId = "with.boundary",
+                policy = policy(),
+                blamedPluginId = "with.boundary",
+            )
+
+        assertEquals(WindowExceptionRoute.PluginHandled, route)
+    }
+
+    /** Nobody to blame leaves the previous behaviour exactly as it was. */
+    @Test
+    fun `an unblamed StackOverflowError still escalates`() {
+        assertEquals(
+            WindowExceptionRoute.Escalate,
+            decideWindowExceptionRoute(StackOverflowError(), null, policy(), blamedPluginId = null),
+        )
+    }
+
+    /**
+     * An ordinary fault with a name on it is quarantined rather than contained:
+     * containment is the narrowing loop for faults nobody can place, and running
+     * it when we already know the answer would rebuild every panel to rediscover
+     * it.
+     */
+    @Test
+    fun `a blamed ordinary fault is quarantined rather than contained`() {
+        assertEquals(
+            WindowExceptionRoute.QuarantinePlugin,
+            decideWindowExceptionRoute(IllegalStateException("boom"), null, policy(), "some.plugin"),
+        )
+    }
+
+    /** Quarantine must not consume containment budget - it is not a containment. */
+    @Test
+    fun `quarantining does not spend a containment slot`() {
+        val policy = policy()
+        repeat(5) { decideWindowExceptionRoute(StackOverflowError(), null, policy, "some.plugin") }
+
+        assertEquals(0, policy.recentFailureCount())
+        assertEquals(
+            WindowExceptionRoute.Contain,
+            decideWindowExceptionRoute(IllegalStateException("boom"), null, policy),
+            "a real containable fault should still have its full budget",
+        )
+    }
 }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/KnownPlugins.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/KnownPlugins.kt
@@ -1,0 +1,46 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+/**
+ * Every plugin the host has loaded, whether or not it has UI on screen.
+ *
+ * Crash attribution used to consider only plugins with a *mounted* error
+ * boundary, because the boundary registry was the only list of plugin ids this
+ * module had. A plugin with nothing on screen was therefore unattributable - and
+ * an unattributable `StackOverflowError` escalates to ending the app. That is how
+ * a self-recursive method in `terminal-tab` took BOSS down from a single click,
+ * with every one of the ~1024 surviving stack frames naming the plugin.
+ *
+ * Its own object rather than a pair of functions on `PluginCrashRegistry`: this
+ * is a different question from crash *state*, and the registry is already at
+ * detekt's function ceiling. Common rather than desktop because
+ * `PluginCrashInterceptor`, which needs it, is desktop-only while the host
+ * installs it from common code.
+ */
+object KnownPlugins {
+    @Volatile
+    private var supplier: (() -> Set<String>)? = null
+
+    /**
+     * Install the host's loaded-plugin enumeration. Last install wins.
+     *
+     * Read lazily on the crash path rather than snapshotted, so plugins loaded
+     * after startup are covered without anything having to re-register.
+     */
+    fun install(supplier: () -> Set<String>) {
+        this.supplier = supplier
+    }
+
+    /**
+     * Loaded plugin ids, or empty when nothing has been installed.
+     *
+     * Never throws. This runs while a crash is being routed, and a supplier
+     * reaching into a plugin manager that is mid-teardown must not be the reason
+     * the crash handler fails.
+     */
+    fun ids(): Set<String> = runCatching { supplier?.invoke() }.getOrNull().orEmpty()
+
+    /** Tests share one process; leaving a supplier installed leaks across them. */
+    internal fun resetForTest() {
+        supplier = null
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginCrashInterceptor.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginCrashInterceptor.kt
@@ -224,14 +224,65 @@ object PluginCrashInterceptor {
     }
 
     /**
-     * Attribute an exception to a plugin by inspecting the stack trace and thread name.
+     * Candidates to test a stack trace against: every plugin we know of, not just
+     * the ones with a mounted error boundary.
      *
-     * Checks for:
-     * 1. Thread name containing plugin sandbox identifier (`plugin-sandbox-<pluginId>`)
-     * 2. Stack frame class names matching registered plugin package prefixes
-     * 3. Stack frame classloaders resolved via cached plugin classloaders
+     * The loaded set comes from [KnownPlugins.ids], which the
+     * host installs — this module keeps no dependency on `plugin-loader`, the
+     * same reason [PluginExecutionBoundary] takes its resolver by injection.
+     */
+    private fun blameCandidates(): Set<String> = interceptors.keys + classLoaderToPluginId.values + KnownPlugins.ids()
+
+    /**
+     * Which plugin is *responsible* for [throwable], whether or not it has a live
+     * error boundary.
      *
-     * @return The plugin ID if attributed, null otherwise
+     * Distinct from [attributeToPlugin], which answers the narrower "which
+     * registered boundary should handle it" and is filtered to plugins that can
+     * actually render a fallback. Both questions are real and conflating them is
+     * what let a plugin take the host down:
+     *
+     * `TerminalTabPluginAPIImpl.setPendingSidebarCommand` recursed into itself and
+     * threw `StackOverflowError` from a click. Every one of the ~1024 frames the
+     * JVM kept was `ai.rever.boss.plugin.dynamic.terminaltab.*`, so the culprit was
+     * never in doubt — but terminal-tab had no boundary mounted at that moment, so
+     * [attributeToPlugin] returned null, `decideWindowExceptionRoute` fell through
+     * to the uncontainable check, and the app exited. A plugin with no UI on
+     * screen could kill the session precisely *because* it had no UI on screen.
+     *
+     * Same strategies, same order, minus the registration filter.
+     */
+    fun blameFor(
+        throwable: Throwable,
+        thread: Thread? = null,
+    ): String? {
+        // Exact: the host tagged this while calling into the plugin.
+        val tagged = PluginExecutionBoundary.attributionFor(throwable)
+        if (tagged != null) return tagged
+
+        val candidates = blameCandidates()
+        return if (candidates.isEmpty()) {
+            null
+        } else {
+            byThreadName(candidates, thread)
+                ?: byStackFrames(throwable, candidates)
+                ?: resolveByClassLoader(throwable) { true }
+        }
+    }
+
+    /**
+     * Which registered boundary should handle [throwable], or null.
+     *
+     * The narrow question, and the filter is the point of it: a boundary that is
+     * not mounted cannot render a fallback, so naming its plugin here would route
+     * the crash to nobody. [blameFor] answers the broader "who is responsible",
+     * which is what the window handler falls back on so that a plugin with no UI
+     * on screen can still be quarantined instead of ending the app.
+     *
+     * Strategies, in order: the execution-boundary tag, the sandbox thread name,
+     * stack-frame package prefixes, then defining classloaders.
+     *
+     * @return The plugin ID if attributed to a *mounted* boundary, null otherwise
      */
     fun attributeToPlugin(
         throwable: Throwable,
@@ -241,12 +292,7 @@ object PluginCrashInterceptor {
         //
         // Consulted first because it is the only exact source - the host tagged the
         // throwable while calling into the plugin, rather than inferring from frames
-        // that may already be gone. Without it the two attributions in this codebase
-        // could disagree about the same throwable: CrashHandler would say "plugin x"
-        // from the tag while this said "nobody", and the render router would then
-        // Contain or Escalate instead of handing it to the plugin's boundary. Two
-        // copies of one decision drifting apart is the failure this change set spent
-        // several rounds removing elsewhere.
+        // that may already be gone.
         //
         // Still filtered by `interceptors`: this function answers "which registered
         // boundary should handle it", and a tag naming a plugin with no live
@@ -256,64 +302,41 @@ object PluginCrashInterceptor {
             ?.takeIf { interceptors.containsKey(it) }
             ?.let { return it }
 
-        // Strategy 1: Check thread name for plugin sandbox threads
-        val threadName = thread?.name ?: Thread.currentThread().name
-        for (pluginId in interceptors.keys) {
-            if (threadName.contains("plugin-sandbox-$pluginId")) {
-                return pluginId
-            }
-        }
+        val mounted = interceptors.keys
+        return byThreadName(mounted, thread)
+            ?: byStackFrames(throwable, mounted)
+            ?: resolveByClassLoader(throwable) { interceptors.containsKey(it) }
+    }
 
-        // Strategy 2: Match stack trace class names against registered plugin package prefixes.
-        // Plugin classes follow the convention ai.rever.boss.plugin.dynamic.<shortId>.* where
-        // the pluginId is ai.rever.boss.plugin.dynamic.<shortId>. This is a fast string
-        // comparison that avoids class loading entirely.
-        try {
-            for (element in throwable.stackTrace) {
-                for (pluginId in interceptors.keys) {
-                    if (element.className.startsWith("$pluginId.")) {
-                        return pluginId
-                    }
-                }
+    /**
+     * Strategy 3, shared by [attributeToPlugin] and [blameFor].
+     *
+     * The slow path (O(stackFrames × classloaders), with `Class.forName` calls),
+     * so both callers reach it only after the cheap string comparisons have
+     * failed. [accept] is what differs between them: the narrow question filters
+     * to plugins with a live boundary, the broad one takes any plugin.
+     */
+    private fun resolveByClassLoader(
+        throwable: Throwable,
+        accept: (String) -> Boolean,
+    ): String? {
+        if (classLoaderToPluginId.isEmpty()) return null
+        logger.debug(
+            LogCategory.UI,
+            "Attribution falling through to strategy 3 (classloader resolution)",
+            mapOf(
+                "errorType" to throwable.javaClass.simpleName,
+                "stackDepth" to throwable.stackTrace.size,
+                "loaderCount" to classLoaderToPluginId.size,
+            ),
+        )
+        return runCatching {
+            throwable.stackTrace.firstNotNullOfOrNull { element ->
+                classLoaderToPluginId.entries
+                    .firstOrNull { (loader, pId) -> accept(pId) && definedBy(element.className, loader) }
+                    ?.value
             }
-        } catch (_: Throwable) {
-            // Don't let attribution itself crash
-        }
-
-        // Strategy 3: Resolve stack trace classes via cached plugin classloaders.
-        // This is the slow path (O(stackFrames × classloaders) with Class.forName calls).
-        // Strategies 1 and 2 should cover most cases; log when we fall through here.
-        if (classLoaderToPluginId.isNotEmpty()) {
-            logger.debug(
-                LogCategory.UI,
-                "Attribution falling through to strategy 3 (classloader resolution)",
-                mapOf(
-                    "errorType" to throwable.javaClass.simpleName,
-                    "stackDepth" to throwable.stackTrace.size,
-                    "loaderCount" to classLoaderToPluginId.size,
-                ),
-            )
-            try {
-                for (element in throwable.stackTrace) {
-                    for ((loader, pId) in classLoaderToPluginId) {
-                        if (!interceptors.containsKey(pId)) continue
-                        val clazz =
-                            try {
-                                Class.forName(element.className, false, loader)
-                            } catch (_: Throwable) {
-                                null
-                            }
-                        if (clazz != null && clazz.classLoader == loader) {
-                            return pId
-                        }
-                    }
-                }
-            } catch (_: Throwable) {
-                // Don't let attribution itself crash
-            }
-        }
-
-        return null
+        }.getOrNull() // Don't let attribution itself crash.
     }
 
     /**
@@ -345,3 +368,41 @@ object PluginCrashInterceptor {
         }
     }
 }
+
+// The three pure strategies live at file level rather than on the object. They
+// need only their arguments, and the object is at detekt's function ceiling -
+// which is a fair signal here, since none of these is part of its surface.
+
+/** Strategy 1: a sandbox thread names the plugin it was created for. */
+private fun byThreadName(
+    candidates: Set<String>,
+    thread: Thread?,
+): String? {
+    val name = thread?.name ?: Thread.currentThread().name
+    return candidates.firstOrNull { name.contains("plugin-sandbox-$it") }
+}
+
+/**
+ * Strategy 2: a frame's class sits under the plugin's package.
+ *
+ * The trailing dot is load-bearing - without it `dynamic.terminal` matches every
+ * frame of `dynamic.terminaltab` and blames the wrong plugin.
+ */
+private fun byStackFrames(
+    throwable: Throwable,
+    candidates: Set<String>,
+): String? =
+    runCatching {
+        throwable.stackTrace.firstNotNullOfOrNull { element ->
+            candidates.firstOrNull { element.className.startsWith("$it.") }
+        }
+    }.getOrNull() // Attribution must never be the thing that fails.
+
+/** Whether [loader] is the one that defined [className], not merely able to see it. */
+private fun definedBy(
+    className: String,
+    loader: ClassLoader,
+): Boolean =
+    runCatching {
+        Class.forName(className, false, loader).classLoader == loader
+    }.getOrDefault(false)

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginCrashBlameTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginCrashBlameTest.kt
@@ -1,0 +1,126 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import ai.rever.boss.plugin.sandbox.PluginExecutionBoundary
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Blaming a plugin that has no error boundary on screen.
+ *
+ * Two questions used to be one, and conflating them cost a session:
+ *
+ * - [PluginCrashInterceptor.attributeToPlugin] answers "which registered boundary
+ *   should handle this", and is filtered to plugins that can render a fallback.
+ * - [PluginCrashInterceptor.blameFor] answers "who is responsible", full stop.
+ *
+ * `TerminalTabPluginAPIImpl.setPendingSidebarCommand` recursed into itself and
+ * threw StackOverflowError from a click. All ~1024 frames the JVM kept were
+ * `ai.rever.boss.plugin.dynamic.terminaltab.*`, so the culprit was never in
+ * doubt - but terminal-tab had no boundary mounted, attribution returned null,
+ * and `decideWindowExceptionRoute` fell through to escalation. A plugin with no
+ * UI on screen could end the app precisely *because* it had no UI on screen.
+ */
+class PluginCrashBlameTest {
+    private val terminalTab = "ai.rever.boss.plugin.dynamic.terminaltab"
+
+    @BeforeTest
+    @AfterTest
+    fun reset() {
+        KnownPlugins.resetForTest()
+        PluginExecutionBoundary.resetForTest()
+    }
+
+    /** A stack trace whose frames belong to [pluginId], and to nothing else. */
+    private fun recursionIn(pluginId: String): Throwable =
+        StackOverflowError().apply {
+            stackTrace =
+                Array(64) {
+                    StackTraceElement(
+                        "$pluginId.TerminalTabPluginAPIImpl",
+                        "setPendingSidebarCommand",
+                        "TerminalTabPluginAPIImpl.kt",
+                        218,
+                    )
+                }
+        }
+
+    @Test
+    fun `blames a loaded plugin with no boundary mounted`() {
+        KnownPlugins.install { setOf(terminalTab) }
+
+        assertEquals(terminalTab, PluginCrashInterceptor.blameFor(recursionIn(terminalTab)))
+    }
+
+    /**
+     * The narrow question must keep its old answer. A plugin with no boundary has
+     * nothing to hand the error to, so `attributeToPlugin` still declines - the
+     * route handles it through quarantine instead.
+     */
+    @Test
+    fun `attribution still declines a plugin with no boundary`() {
+        KnownPlugins.install { setOf(terminalTab) }
+
+        assertNull(PluginCrashInterceptor.attributeToPlugin(recursionIn(terminalTab)))
+    }
+
+    /** The host's own stack is nobody's fault. */
+    @Test
+    fun `does not blame a plugin for a host stack`() {
+        KnownPlugins.install { setOf(terminalTab) }
+        val hostFault =
+            IllegalStateException("boom").apply {
+                stackTrace =
+                    arrayOf(
+                        StackTraceElement(
+                            "ai.rever.boss.components.overlays.ContextMenuKt",
+                            "invoke",
+                            "ContextMenu.kt",
+                            40,
+                        ),
+                    )
+            }
+
+        assertNull(PluginCrashInterceptor.blameFor(hostFault))
+    }
+
+    /**
+     * A prefix match must respect the package boundary, or `…dynamic.terminal`
+     * would answer for every frame of `…dynamic.terminaltab`.
+     */
+    @Test
+    fun `does not blame a plugin whose id is a prefix of the real one`() {
+        val sibling = "ai.rever.boss.plugin.dynamic.terminal"
+        KnownPlugins.install { setOf(sibling) }
+
+        assertNull(PluginCrashInterceptor.blameFor(recursionIn(terminalTab)))
+    }
+
+    /** Nothing installed is the pre-wiring state, and must not throw or guess. */
+    @Test
+    fun `answers null when the host has installed no plugin list`() {
+        assertNull(PluginCrashInterceptor.blameFor(recursionIn(terminalTab)))
+    }
+
+    /** A supplier that throws must not be the reason a crash handler fails. */
+    @Test
+    fun `survives a supplier that throws`() {
+        KnownPlugins.install { error("plugin manager is mid-teardown") }
+
+        assertNull(PluginCrashInterceptor.blameFor(recursionIn(terminalTab)))
+    }
+
+    /**
+     * The execution-boundary tag outranks the stack, and needs no plugin list:
+     * it is the exact answer, recorded by the host while calling into the plugin.
+     */
+    @Test
+    fun `prefers the execution-boundary tag over the stack`() {
+        val tagged = recursionIn(terminalTab)
+        PluginExecutionBoundary.tag(tagged, "some.other.plugin")
+
+        assertEquals("some.other.plugin", PluginCrashInterceptor.blameFor(tagged))
+    }
+}


### PR DESCRIPTION
## The gap

Two different questions were answered by one function, and they come apart exactly when it matters.

- `PluginCrashInterceptor.attributeToPlugin` asks **"which registered boundary should handle this"**, and is correctly filtered to plugins that can render a fallback.
- `decideWindowExceptionRoute` used it to answer **"is anyone to blame"**, which is broader, and got null for a plugin that is plainly at fault but has nothing mounted.

That is how `terminal-tab` took BOSS down. `TerminalTabPluginAPIImpl.setPendingSidebarCommand` recursed into itself and threw `StackOverflowError` from a click (fixed on the plugin side in risa-labs-inc/boss-plugin-terminal-tab#74). Every one of the ~1024 frames the JVM kept was `ai.rever.boss.plugin.dynamic.terminaltab.*`, so the culprit was never in doubt:

```
Main: Render exception is not containable - escalating to the default handler | {errorType=StackOverflowError}
CrashHandler: Uncaught exception on thread AWT-EventQueue-0
CrashHandler: Fatal crash while a crash dialog is open - terminating without a second dialog
CrashHandler: Terminating application after crash
```

Attribution returned null only because terminal-tab was not in the `interceptors` map. **A plugin could end the session precisely because it had no UI on screen.**

## The fix

**`PluginCrashInterceptor.blameFor`** answers the broad question: the same strategies in the same order, minus the registration filter, over every *loaded* plugin rather than every *mounted* one. `attributeToPlugin` keeps its narrow meaning and its old answers, and the two now share the strategy helpers rather than holding two copies of the classloader scan.

**`KnownPlugins`** carries the loaded-plugin enumeration, installed by the host from `dynamicPluginManager.pluginStates` and read lazily on the crash path. Its own object because `PluginCrashInterceptor` is desktop-only while the host installs it from common code. Never throws: a supplier reaching into a plugin manager mid-teardown must not be why a crash handler fails.

**A `QuarantinePlugin` route**, placed deliberately:

```kotlin
attributedPluginId != null        -> PluginHandled      // a live boundary can show a fallback
throwable.hasFatalCause()         -> Escalate           // OOM, the heap is gone
blamedPluginId != null            -> QuarantinePlugin   // named culprit, process is fine
throwable.hasUncontainableCause() -> Escalate           // unchanged for anything unblamed
```

The new `hasFatalCause` splits what `isUncontainable` had conflated. `OutOfMemoryError` and `StackOverflowError` are both uncontainable-by-repaint, but for different reasons and with different remedies. After an OOM every recovery path allocates on a dead heap, so escalating is all that is left. After a stack overflow the stack has already unwound and the process is healthy; the only thing you must not do is re-enter whatever recursed, and quarantining the plugin does exactly that. Escalating was spending a session to avoid a redraw we were never going to attempt.

Blame is not computed under an OOM, since it walks the stack and may call into the plugin manager, and the answer could not change the route anyway.

## Not done, deliberately

- **`getPluginAPI` handles are not wrapped in an attribution proxy.** That would tag cross-plugin calls exactly, and was my first plan. But these interfaces carry `@Composable` members and routing those through `java.lang.reflect.Proxy` risks the terminal UI, for a benefit the blame path already delivers.
- **`isUncontainable` is unchanged**, so the render boundary's own OOM/StackOverflow carve-out still reads the same.

## Tests

| suite | tests |
|---|---|
| `WindowExceptionRouteTest` | 15 (8 new) |
| `PluginCrashBlameTest` | 7 new |
| whole repo | **2609, 0 failures** |

ktlint and detekt clean. Detekt drove more restructuring than the fix needed: `PluginCrashInterceptor` hit the object function ceiling, so the three pure strategies now sit at file level.

Mutation-checked: restoring the pre-fix ordering (uncontainable above blame) fails `a StackOverflowError blamed on a plugin is quarantined instead of ending the app`.

## One correction to the earlier diagnosis

I first reported that attribution failed because the JVM truncates a StackOverflowError trace past the frames identifying the caller. The truncation is real, but it was not the cause here - strategy 2 would have matched `terminaltab` on any of those 1024 frames. It returned null because terminal-tab had no registered boundary at all. The fix addresses the actual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
