### PR TITLE
ci(jxbrowser): open the version pin PR when the engine is published

### DIFF
--- a/.github/scripts/open-jxbrowser-pin-pr.sh
+++ b/.github/scripts/open-jxbrowser-pin-pr.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Open (or update) the pull request that moves the `jxbrowser` pin in
+# gradle/libs.versions.toml onto a version whose engine bundle is already
+# published.
+#
+# The watcher builds the engine automatically but nothing bumped the pin, so the
+# pin could sit a release behind a fully published engine indefinitely - 9.4.1
+# was published on 2026-08-14 and bumped by hand on 2026-08-21. This closes that
+# half of the loop.
+#
+# Deliberately NOT a step in build-chromium-branding.yml: the pin may only move
+# once the engine is completely published, and the watcher already recomputes
+# that state every four hours. Running here means the normal path (branding
+# publishes, next watcher run opens the PR) and the catch-up path (an engine that
+# was published while the pin stood still) are one code path, not two.
+#
+# Inputs (env):
+#   VERSION            JxBrowser version whose engine is fully published (required)
+#   TOML_FILE          pin location (default gradle/libs.versions.toml)
+#   BASE_BRANCH        PR base (default main)
+#   DRY_RUN            when true, decide and report but never push or open a PR
+#   GIT_AUTHOR_NAME    commit identity (default Risa Labs)
+#   GIT_AUTHOR_EMAIL   commit identity (default enterprise@risalabs.ai)
+#   GH_TOKEN           token used for push and PR creation
+#   GITHUB_REPOSITORY  owner/repo
+#   GITHUB_OUTPUT      GitHub Actions output file (stdout outside Actions)
+set -euo pipefail
+
+TOML_FILE="${TOML_FILE:-gradle/libs.versions.toml}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+DRY_RUN="${DRY_RUN:-false}"
+GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-Risa Labs}"
+GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-enterprise@risalabs.ai}"
+REPO="${GITHUB_REPOSITORY:-risa-labs-inc/BossConsole}"
+OUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+emit() { printf '%s\n' "$1" >> "$OUT"; }
+
+# Every exit path names itself so the workflow summary can report the decision
+# instead of "the step passed".
+decided() {
+  local action="$1" detail="${2:-}"
+  echo "→ $action${detail:+: $detail}"
+  emit "pin_action=$action"
+  exit 0
+}
+
+required_commands=(gh jq git)
+for cmd in "${required_commands[@]}"; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "ERROR: required command is unavailable: $cmd" >&2
+    exit 1
+  }
+done
+
+[[ -n "${VERSION:-}" ]] || {
+  echo "ERROR: VERSION is required" >&2
+  exit 1
+}
+
+# Anchored at both ends, and validated before VERSION reaches a branch name, a
+# commit message or a jq argument. TeamDev ships three- and four-part versions
+# (9.4.0, 9.4.0.1); anything else is a malformed upstream read, not a release.
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]] || {
+  echo "ERROR: invalid JxBrowser version: $VERSION" >&2
+  exit 1
+}
+
+[[ -f "$TOML_FILE" ]] || {
+  echo "ERROR: version catalog is unreadable: $TOML_FILE" >&2
+  exit 1
+}
+
+# `^jxbrowser = ` and nothing looser: `jxbrowser-gradle-plugin` sits on the very
+# next line and tracks the Gradle plugin, which does not move with the engine.
+pin_line_pattern='^jxbrowser = "'
+current="$(sed -n 's/^jxbrowser = "\([^"]*\)".*/\1/p' "$TOML_FILE" | head -1)"
+[[ -n "$current" ]] || {
+  echo "ERROR: no jxbrowser pin found in $TOML_FILE" >&2
+  exit 1
+}
+echo "Current pin: $current"
+echo "Published engine: $VERSION"
+emit "current_pin=$current"
+
+[[ "$current" != "$VERSION" ]] || decided up_to_date "pin already on $VERSION"
+
+# Numeric, field-by-field, and never lexical: 9.4.10 is newer than 9.4.9, and
+# a string compare gets that backwards. Also the downgrade guard - a TeamDev
+# metadata regression, or a backfill dispatch for an older version, must not
+# walk the pin backwards.
+version_gt() {
+  local a="$1" b="$2" i
+  local -a fa fb
+  IFS='.' read -r -a fa <<< "$a"
+  IFS='.' read -r -a fb <<< "$b"
+  for ((i = 0; i < 4; i++)); do
+    local va="${fa[i]:-0}" vb="${fb[i]:-0}"
+    ((10#$va > 10#$vb)) && return 0
+    ((10#$va < 10#$vb)) && return 1
+  done
+  return 1
+}
+
+version_gt "$VERSION" "$current" || decided not_newer "$VERSION does not supersede $current"
+
+branch="chore/jxbrowser-$VERSION"
+emit "pin_branch=$branch"
+
+# One lookup over every state, because each state means something different:
+#   open   -> the PR is already waiting; a second one would be noise
+#   merged -> the pin moved and this run raced a just-merged PR
+#   closed -> a human declined this bump, and reopening it every four hours
+#             would override that decision
+existing="$(gh pr list \
+  --repo "$REPO" \
+  --head "$branch" \
+  --state all \
+  --limit 10 \
+  --json number,state,url 2>/dev/null || echo '[]')"
+
+open_pr="$(jq -r 'first(.[] | select(.state == "OPEN") | .url) // empty' <<< "$existing")"
+if [[ -n "$open_pr" ]]; then
+  emit "pin_pr_url=$open_pr"
+  decided pr_exists "$open_pr"
+fi
+
+closed_pr="$(jq -r 'first(.[] | select(.state == "CLOSED") | .url) // empty' <<< "$existing")"
+if [[ -n "$closed_pr" ]]; then
+  emit "pin_pr_url=$closed_pr"
+  decided declined "$closed_pr was closed without merging"
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  decided would_open "$branch"
+fi
+
+# Rewrite in place, then prove it landed. A silent no-op here is the worst
+# outcome available: the run goes green, the PR body claims a bump, and the diff
+# is empty. The anchored pattern makes a stale-anchor miss possible in exactly
+# one way (someone reformats the catalog), so it is checked rather than trusted.
+git config user.name "$GIT_AUTHOR_NAME"
+git config user.email "$GIT_AUTHOR_EMAIL"
+git checkout -b "$branch"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+sed "s/${pin_line_pattern}[^\"]*\"/jxbrowser = \"$VERSION\"/" "$TOML_FILE" > "$tmp"
+mv "$tmp" "$TOML_FILE"
+trap - EXIT
+
+rewritten="$(sed -n 's/^jxbrowser = "\([^"]*\)".*/\1/p' "$TOML_FILE" | head -1)"
+[[ "$rewritten" == "$VERSION" ]] || {
+  echo "ERROR: the pin rewrite did not land; $TOML_FILE still reads $rewritten" >&2
+  exit 1
+}
+if git diff --quiet -- "$TOML_FILE"; then
+  echo "ERROR: the pin rewrite produced no diff in $TOML_FILE" >&2
+  exit 1
+fi
+# Exactly one line moved. Catches a pattern that also caught
+# jxbrowser-gradle-plugin, which would ship a silent plugin downgrade.
+changed="$(git diff --numstat -- "$TOML_FILE" | awk '{print $1"/"$2}')"
+[[ "$changed" == "1/1" ]] || {
+  echo "ERROR: expected exactly one changed line in $TOML_FILE, got $changed" >&2
+  git diff -- "$TOML_FILE" >&2
+  exit 1
+}
+
+git add "$TOML_FILE"
+git commit -m "chore(deps): move the browser engine to JxBrowser $VERSION
+
+The engine bundle for $VERSION is published on both sources, so the pin
+can follow. Opened automatically by the JxBrowser auto-release watcher;
+$current was the previous pin.
+
+libs.versions.toml is the single source of truth here - it generates
+VersionConstants.JXBROWSER_VERSION, which every engine call site reads."
+
+git push --force-with-lease origin "$branch"
+
+body="$(cat <<EOF
+Moves the \`jxbrowser\` pin from \`$current\` to \`$VERSION\`.
+
+The engine bundle for \`$VERSION\` is published and complete, so the pin can
+follow it. Opened automatically by the JxBrowser auto-release watcher, which
+builds the engine but until now left the pin bump to whoever noticed.
+
+### Before merging
+
+The watcher gates on the GitHub \`chromium-v$VERSION\` release carrying every
+required asset. Two things it does not check, worth a glance:
+
+- \`minimumSystemVersion\` in \`composeApp/build.gradle.kts\` tracks the engine
+  bundle's macOS floor. A same-branch patch bump normally leaves it alone, but a
+  Chromium branch bump has moved it before (9.4.0 took it 12.0 -> 13.0). Confirm
+  with \`LSMinimumSystemVersion\` on the engine's \`BOSS.app/Contents/Info.plist\`
+  plus \`LC_BUILD_VERSION\` minos on the framework and \`libtoolkit.dylib\`.
+- The jar's expected Chromium build must match the engine's framework directory:
+  \`unzip -p jxbrowser-$VERSION.jar com/teamdev/jxbrowser/version.info\` against
+  \`Versions/\` in the bundle. A mismatch is an \`UnsatisfiedLinkError\` on first
+  native load, not a build failure, so CI passing is not evidence either way.
+
+Anyone carrying an explicit \`$current\` engine pin needs no migration:
+\`BrowserEngineSettingsManager.withoutUnusablePin()\` clears any pin that is not
+the bundled version on load.
+EOF
+)"
+
+pr_url="$(gh pr create \
+  --repo "$REPO" \
+  --base "$BASE_BRANCH" \
+  --head "$branch" \
+  --title "chore(deps): move the browser engine to JxBrowser $VERSION" \
+  --body "$body")"
+
+emit "pin_pr_url=$pr_url"
+decided pr_opened "$pr_url"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,14 @@ jobs:
         # deterministic and does not consume credentials.
         run: bash scripts/test/test-jxbrowser-autorelease.sh
 
+      - name: 🧪 JxBrowser version pin PR tests
+        # The pin bump runs unattended every four hours against the version
+        # catalog, so the expensive failures are silent ones: a rewrite that
+        # matches nothing, one that also catches jxbrowser-gradle-plugin on the
+        # next line, a lexical compare that reads 9.4.10 as older than 9.4.9, or
+        # reopening a bump a human closed. git and gh are stubbed.
+        run: bash scripts/test/test-jxbrowser-pin-pr.sh
+
       - name: 🧪 Browser interaction collector
         # BrowserInteractionScript is JavaScript inside a Kotlin string, so the
         # Kotlin suite can only grep it - and every budget bug in it so far was

--- a/.github/workflows/jxbrowser-autorelease.yml
+++ b/.github/workflows/jxbrowser-autorelease.yml
@@ -22,9 +22,12 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  # contents: write and pull-requests: write are for the pin-bump PR below; the
+  # resolver itself only reads.
+  contents: write
   actions: write
   issues: write
+  pull-requests: write
 
 jobs:
   check-and-dispatch:
@@ -32,6 +35,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # The pin-bump step pushes a branch, so the checkout has to carry a
+          # token that can. PROJECT_TOKEN is preferred over github.token for one
+          # reason: GitHub does not raise pull_request events for PRs opened with
+          # the default token, so a bump PR created that way would sit with zero
+          # CI runs - and CI is the entire point of proposing it as a PR instead
+          # of committing straight to main. Falls back rather than failing hard,
+          # because a PR with no checks still beats no PR at all.
+          token: ${{ secrets.PROJECT_TOKEN || github.token }}
 
       - name: Resolve latest JxBrowser release
         id: release
@@ -264,6 +276,53 @@ jobs:
             --ref main \
             -f jxbrowser_version="$JXBROWSER_VERSION"
 
+      # Runs when the engine for the resolved version is published and complete,
+      # which is exactly the state the resolver calls release_already_published.
+      # That makes one code path serve both routes: the normal one (branding
+      # publishes, the next scheduled run opens the PR, so at most four hours
+      # later) and the catch-up one (an engine published while the pin stood
+      # still). The script is idempotent across those four-hourly runs and leaves
+      # a closed-unmerged PR alone rather than reopening a declined bump.
+      - name: Open the version pin PR
+        id: pin
+        if: steps.release.outputs.reason == 'release_already_published'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || github.token }}
+          VERSION: ${{ steps.release.outputs.latest_version }}
+          BASE_BRANCH: main
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && 'true' || 'false' }}
+        run: bash .github/scripts/open-jxbrowser-pin-pr.sh
+
+      - name: Report a broken pin bump
+        if: steps.pin.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.latest_version }}
+        run: |
+          set -euo pipefail
+          issue_title="JxBrowser $VERSION pin bump could not be opened"
+          issues="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$issue_title in:title" \
+            --json number,title)"
+          issue_number="$(jq -r --arg title "$issue_title" \
+            'first(.[] | select(.title == $title) | .number) // empty' <<< "$issues")"
+          if [[ -n "$issue_number" ]]; then
+            echo "Issue #$issue_number already tracks this failure."
+            exit 0
+          fi
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$issue_title" \
+            --body "The BOSS Chromium engine for JxBrowser $VERSION is published, but the automated pin bump in \`gradle/libs.versions.toml\` failed. The pin is still behind, so the shipped app keeps the previous engine until this is bumped by hand.
+
+          A push permission problem is the likeliest cause: the workflow prefers \`PROJECT_TOKEN\` and falls back to the default token, which cannot always push a branch.
+
+          Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
       - name: Summary
         if: always()
         env:
@@ -271,6 +330,9 @@ jobs:
           SHOULD_DISPATCH: ${{ steps.release.outputs.should_dispatch }}
           REASON: ${{ steps.release.outputs.reason }}
           DRY_RUN: ${{ inputs.dry_run }}
+          PIN_ACTION: ${{ steps.pin.outputs.pin_action }}
+          PIN_CURRENT: ${{ steps.pin.outputs.current_pin }}
+          PIN_PR_URL: ${{ steps.pin.outputs.pin_pr_url }}
         run: |
           {
             echo "## JxBrowser auto-release"
@@ -279,4 +341,8 @@ jobs:
             echo "- Dispatch required: \`${SHOULD_DISPATCH:-unknown}\`"
             echo "- Reason: \`${REASON:-check_failed}\`"
             echo "- Dry run: \`${DRY_RUN:-false}\`"
+            if [[ -n "${PIN_ACTION:-}" ]]; then
+              echo "- Pin (\`${PIN_CURRENT:-unknown}\`): \`$PIN_ACTION\`"
+              [[ -n "${PIN_PR_URL:-}" ]] && echo "- Pin PR: $PIN_PR_URL"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test/test-jxbrowser-pin-pr.sh
+++ b/scripts/test/test-jxbrowser-pin-pr.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Decision-table tests for open-jxbrowser-pin-pr.sh.
+#
+# git and gh are mocked, so nothing here touches a network or a real branch. The
+# fixture catalog carries the real neighbouring keys, because the pin rewrite's
+# most expensive failure mode is quietly editing `jxbrowser-gradle-plugin` on the
+# next line instead.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/.github/scripts/open-jxbrowser-pin-pr.sh"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+mock_bin="$test_dir/bin"
+mkdir -p "$mock_bin"
+
+# Records what it was asked to do so assertions can read the calls back, and
+# refuses anything the script has no business running.
+cat > "$mock_bin/git" <<'MOCK_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${MOCK_GIT_LOG:?}"
+case "$1" in
+  config|add|checkout) exit 0 ;;
+  commit)
+    printf '%s\n' "$*" > "${MOCK_COMMIT_MSG:?}"
+    exit 0
+    ;;
+  push)
+    [[ "${MOCK_PUSH_EXIT:-0}" == "0" ]] || exit "$MOCK_PUSH_EXIT"
+    exit 0
+    ;;
+  diff)
+    # --quiet: zero means "no change", which the script treats as a failed edit.
+    if [[ "$*" == *"--quiet"* ]]; then
+      [[ "${MOCK_DIFF_EMPTY:-false}" == "true" ]] && exit 0
+      exit 1
+    fi
+    if [[ "$*" == *"--numstat"* ]]; then
+      printf '%s\tgradle/libs.versions.toml\n' "${MOCK_NUMSTAT:-1	1}"
+      exit 0
+    fi
+    exit 0
+    ;;
+esac
+echo "Unexpected mock git call: $*" >&2
+exit 2
+MOCK_GIT
+
+cat > "$mock_bin/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "pr list")
+    printf '%s\n' "${MOCK_PR_LIST:-[]}"
+    ;;
+  "pr create")
+    printf '%s\n' "$*" > "${MOCK_PR_CREATE:?}"
+    printf 'https://github.com/risa-labs-inc/BossConsole/pull/999\n'
+    ;;
+  *)
+    echo "Unexpected mock gh call: $*" >&2
+    exit 2
+    ;;
+esac
+MOCK_GH
+chmod +x "$mock_bin/git" "$mock_bin/gh"
+
+make_catalog() {
+  local pin="$1" path="$2"
+  cat > "$path" <<EOF
+ktor = "3.5.2"
+zxing = "3.5.4"
+jxbrowser = "$pin"
+jxbrowser-gradle-plugin = "2.1.0"
+jna = "5.19.1"
+EOF
+}
+
+# Runs the script in its own directory so the mocked git never sees the real one.
+run_case() {
+  local name="$1" pin="$2" version="$3" expected_action="$4"
+  shift 4
+  local case_dir="$test_dir/$name"
+  mkdir -p "$case_dir/gradle"
+  local toml="$case_dir/gradle/libs.versions.toml"
+  make_catalog "$pin" "$toml"
+
+  local output="$case_dir/output" log="$case_dir/log"
+  : > "$case_dir/git.log"
+
+  if ! (
+    cd "$case_dir"
+    PATH="$mock_bin:$PATH" \
+      VERSION="$version" \
+      TOML_FILE="gradle/libs.versions.toml" \
+      GITHUB_REPOSITORY="risa-labs-inc/BossConsole" \
+      GITHUB_OUTPUT="$output" \
+      MOCK_GIT_LOG="$case_dir/git.log" \
+      MOCK_COMMIT_MSG="$case_dir/commit.msg" \
+      MOCK_PR_CREATE="$case_dir/pr.create" \
+      env "$@" bash "$script"
+  ) > "$log" 2>&1; then
+    echo "FAILED: $name" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+
+  if ! grep -Fqx "pin_action=$expected_action" "$output"; then
+    echo "Expected pin_action=$expected_action for $name" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  echo "✓ $name"
+}
+
+expect_failure() {
+  local name="$1" pin="$2" version="$3"
+  shift 3
+  local case_dir="$test_dir/$name"
+  mkdir -p "$case_dir/gradle"
+  make_catalog "$pin" "$case_dir/gradle/libs.versions.toml"
+  : > "$case_dir/git.log"
+
+  if (
+    cd "$case_dir"
+    PATH="$mock_bin:$PATH" \
+      VERSION="$version" \
+      TOML_FILE="gradle/libs.versions.toml" \
+      GITHUB_REPOSITORY="risa-labs-inc/BossConsole" \
+      GITHUB_OUTPUT="$case_dir/output" \
+      MOCK_GIT_LOG="$case_dir/git.log" \
+      MOCK_COMMIT_MSG="$case_dir/commit.msg" \
+      MOCK_PR_CREATE="$case_dir/pr.create" \
+      env "$@" bash "$script"
+  ) > "$case_dir/log" 2>&1; then
+    echo "Expected $name to fail" >&2
+    cat "$case_dir/log" >&2
+    exit 1
+  fi
+  echo "✓ $name"
+}
+
+open_pr='[{"number":227,"state":"OPEN","url":"https://github.com/x/y/pull/227"}]'
+closed_pr='[{"number":227,"state":"CLOSED","url":"https://github.com/x/y/pull/227"}]'
+merged_pr='[{"number":227,"state":"MERGED","url":"https://github.com/x/y/pull/227"}]'
+
+# --- the happy path ----------------------------------------------------------
+run_case pin_behind_opens_pr 9.4.0 9.4.1 pr_opened
+
+# The bump landed on the right line, and only that line.
+happy="$test_dir/pin_behind_opens_pr/gradle/libs.versions.toml"
+grep -Fqx 'jxbrowser = "9.4.1"' "$happy" || {
+  echo "The pin was not rewritten" >&2; cat "$happy" >&2; exit 1
+}
+grep -Fqx 'jxbrowser-gradle-plugin = "2.1.0"' "$happy" || {
+  echo "The Gradle plugin pin must not move with the engine" >&2; cat "$happy" >&2; exit 1
+}
+grep -Fqx 'ktor = "3.5.2"' "$happy" || { echo "Unrelated keys must survive" >&2; exit 1; }
+grep -q 'chore/jxbrowser-9.4.1' "$test_dir/pin_behind_opens_pr/git.log" || {
+  echo "Expected a deterministic branch name" >&2
+  cat "$test_dir/pin_behind_opens_pr/git.log" >&2
+  exit 1
+}
+grep -q -- '--force-with-lease' "$test_dir/pin_behind_opens_pr/git.log" || {
+  echo "Expected the push to be lease-guarded" >&2; exit 1
+}
+grep -q '9.4.1' "$test_dir/pin_behind_opens_pr/commit.msg" || {
+  echo "Expected the commit message to name the version" >&2; exit 1
+}
+grep -Fqx 'config user.name Risa Labs' "$test_dir/pin_behind_opens_pr/git.log" || {
+  echo "Expected the project commit identity" >&2
+  cat "$test_dir/pin_behind_opens_pr/git.log" >&2
+  exit 1
+}
+# Scoped to the identity lines on purpose: matching "bot" across the whole log
+# also matches "both" in the commit body, which is how this assertion first
+# passed for the wrong reason.
+identity="$(grep '^config user\.' "$test_dir/pin_behind_opens_pr/git.log" || true)"
+if grep -qi 'bot' <<< "$identity"; then
+  echo "A bot identity must never author these commits: $identity" >&2
+  exit 1
+fi
+grep -Fq -- '--base main' "$test_dir/pin_behind_opens_pr/pr.create" || {
+  echo "Expected the PR to target main" >&2; exit 1
+}
+
+# --- states that must not open anything --------------------------------------
+run_case pin_already_current 9.4.1 9.4.1 up_to_date
+run_case downgrade_refused 9.4.1 9.4.0 not_newer
+run_case same_version_four_part 9.4.0.1 9.4.0.1 up_to_date
+run_case four_part_downgrade_refused 9.4.0.1 9.4.0 not_newer
+run_case open_pr_is_not_duplicated 9.4.0 9.4.1 pr_exists MOCK_PR_LIST="$open_pr"
+run_case closed_pr_is_respected 9.4.0 9.4.1 declined MOCK_PR_LIST="$closed_pr"
+run_case dry_run_decides_only 9.4.0 9.4.1 would_open DRY_RUN=true
+
+# A merged PR for this version is not a reason to stand down: the pin on disk is
+# what decides, and if it is still behind then the merge did not move it.
+run_case merged_pr_does_not_block 9.4.0 9.4.1 pr_opened MOCK_PR_LIST="$merged_pr"
+
+# Nothing may be pushed on any of the no-op paths.
+for name in pin_already_current downgrade_refused open_pr_is_not_duplicated \
+  closed_pr_is_respected dry_run_decides_only; do
+  if grep -q "push" "$test_dir/$name/git.log" 2>/dev/null; then
+    echo "$name must not push" >&2
+    cat "$test_dir/$name/git.log" >&2
+    exit 1
+  fi
+done
+echo "✓ no_push_on_noop_paths"
+
+# --- numeric, not lexical ----------------------------------------------------
+# The bug a string compare ships: "9.4.9" > "9.4.10" lexically, so the pin would
+# refuse a real upgrade and sit still while looking healthy.
+run_case patch_ten_supersedes_nine 9.4.9 9.4.10 pr_opened
+run_case minor_ten_supersedes_nine 9.9.0 9.10.0 pr_opened
+run_case four_part_supersedes_three 9.4.0 9.4.0.1 pr_opened
+
+# --- input validation and edit verification ----------------------------------
+expect_failure rejects_tag_prefix 9.4.0 v9.4.1
+expect_failure rejects_two_part_version 9.4.0 9.4
+expect_failure rejects_command_injection 9.4.0 '9.4.1 && echo pwned'
+expect_failure rejects_path_traversal 9.4.0 '9.4.1/../../etc'
+expect_failure rejects_prerelease 9.4.0 9.4.1-beta.1
+expect_failure rejects_empty_version 9.4.0 ''
+
+# A rewrite that produces no diff is a stale anchor, not a success.
+expect_failure empty_diff_is_a_failure 9.4.0 9.4.1 MOCK_DIFF_EMPTY=true
+# More than one changed line means the pattern caught a neighbour too.
+expect_failure multi_line_diff_is_a_failure 9.4.0 9.4.1 MOCK_NUMSTAT='2	2'
+# A failed push must fail the step, not report a PR that does not exist.
+expect_failure push_failure_is_a_failure 9.4.0 9.4.1 MOCK_PUSH_EXIT=1
+
+# A catalog with no jxbrowser pin at all.
+no_pin_dir="$test_dir/missing_pin/gradle"
+mkdir -p "$no_pin_dir"
+printf 'ktor = "3.5.2"\n' > "$no_pin_dir/libs.versions.toml"
+if (
+  cd "$test_dir/missing_pin"
+  PATH="$mock_bin:$PATH" VERSION=9.4.1 TOML_FILE="gradle/libs.versions.toml" \
+    GITHUB_OUTPUT="$test_dir/missing_pin/output" MOCK_GIT_LOG="$test_dir/missing_pin/git.log" \
+    bash "$script"
+) > "$test_dir/missing_pin/log" 2>&1; then
+  echo "Expected a catalog with no pin to fail" >&2
+  exit 1
+fi
+echo "✓ missing_pin_is_a_failure"
+
+# An unreadable catalog path.
+if (
+  cd "$test_dir"
+  PATH="$mock_bin:$PATH" VERSION=9.4.1 TOML_FILE="gradle/nope.toml" \
+    GITHUB_OUTPUT="$test_dir/absent.output" MOCK_GIT_LOG="$test_dir/absent.git.log" \
+    bash "$script"
+) > "$test_dir/absent.log" 2>&1; then
+  echo "Expected a missing catalog to fail" >&2
+  exit 1
+fi
+echo "✓ missing_catalog_is_a_failure"
+
+echo "All JxBrowser pin PR tests passed."


### PR DESCRIPTION
## What

Teaches the JxBrowser auto-release watcher to open the pin-bump PR itself, closing the half of the loop that was still manual.

The watcher already polls TeamDev every four hours and dispatches the branding build, so a new engine bundle appears on GitHub and Supabase on its own. Nothing moved the `jxbrowser` pin in `gradle/libs.versions.toml`, so the shipped app kept running the old engine until someone noticed. 9.4.1 published on 2026-08-14 and was pinned by hand on 2026-08-21 (#227). That week of drift is what this removes.

## Where it hooks, and why there

The step gates on `release_already_published` - the resolver's existing name for "the engine for this version exists and carries every required asset". That single gate serves both routes:

- **normal**: branding publishes, the next scheduled run opens the PR, so at most four hours later
- **catch-up**: an engine was published while the pin stood still (today's 9.4.1 case)

Deliberately **not** a step in `build-chromium-branding.yml`. The pin may only move once the engine is completely published, and the watcher already recomputes that state every four hours, so putting it there would mean two code paths for one decision.

**A PR rather than a push to main**, because the pin is the one thing CI cannot check for itself. A mismatched pin is an `UnsatisfiedLinkError` on `libtoolkit` at the first native load, not a build failure, so a green build says nothing about it. The generated body carries the two manual checks for the reviewer: the jar's `version.info` against the bundle's framework directory, and the macOS floor, which rides along with the engine bundle (9.4.0 took it 12.0 -> 13.0).

## Guards

It runs unattended every four hours, so the failure modes worth spending code on are the silent ones. Every one below has a test, and every test was **run against the mutation it describes** before being trusted:

| Guard | What goes wrong without it |
|---|---|
| Rewrite anchored to `^jxbrowser = "` | `jxbrowser-gradle-plugin` is the very next line and tracks something that does not move with the engine. An unanchored pattern ships a silent plugin downgrade. |
| Edit verified to have landed, and to have moved exactly one line | A stale anchor otherwise goes green with an empty diff and a PR body claiming a bump. |
| Numeric field-by-field compare | Lexically `9.4.9` > `9.4.10`, so the pin would refuse a real upgrade while looking healthy. |
| Forward-only | A metadata regression or a backfill dispatch for an older version must not walk the pin backwards. |
| Open PR not duplicated | Four-hourly runs would otherwise stack PRs. |
| Closed-unmerged PR left alone | Reopening a bump a human declined, every four hours, is worse than doing nothing. |

An anchored `VERSION` regex validates before the value reaches a branch name, commit message or jq argument. Version validation, the pin lookup and a missing catalog all fail loudly rather than proceeding.

## Token choice

Pushes with `${{ secrets.PROJECT_TOKEN || github.token }}`. GitHub does not raise `pull_request` events for PRs opened with `GITHUB_TOKEN`, so a bump PR created that way would sit with **zero CI runs** - which defeats the point of proposing it as a PR instead of committing to main. `PROJECT_TOKEN` is already an org PAT used here to check out the private BossConsoleLite repo.

It falls back rather than failing hard, since a PR with no checks still beats no PR. If the push cannot happen at all, the workflow files an issue rather than failing quietly. Commits use the repo's established `Risa Labs <enterprise@risalabs.ai>` identity, never a bot name.

## Testing

`scripts/test/test-jxbrowser-pin-pr.sh`, registered in the Shell Script Tests job. `git` and `gh` are stubbed, so it consumes no credentials and touches no branch. **24 cases, all passing**, covering every decision (`pr_opened`, `up_to_date`, `not_newer`, `pr_exists`, `declined`, `would_open`), three- and four-part versions, the numeric-compare cases, injection and traversal attempts in `VERSION`, and the failure paths (empty diff, multi-line diff, failed push, missing pin, missing catalog).

Four mutations were introduced and each was caught by the intended test: a lexical compare, an unanchored sed pattern, a dropped closed-PR guard, and a dropped edit verification.

Beyond the fixtures, an integration run against the **real** `gradle/libs.versions.toml` (with `git`/`gh` stubbed) produces exactly the diff #227 made by hand - line 53, `9.4.0` -> `9.4.1`, one line changed, nothing else. The existing `test-jxbrowser-autorelease.sh` suite still passes.

## Note on sequencing

Independent of #227 and based on `main`. Once #227 merges, the pin equals the latest published engine and the automation reports `up_to_date` until TeamDev ships again.
