### PR TITLE
fix(windows): run certsync before signing, and say why signing failed

### DIFF
--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -476,6 +476,26 @@ jobs:
         env:
           SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
 
+      # certsync puts the certificate where signtool looks for it. Without it
+      # smctl prints FAILED and exits 0; see release.yml for the full note.
+      - name: Sync KeyLocker Certificate to the Windows Store
+        if: steps.check-secret.outputs.can_sign == 'true'
+        continue-on-error: true
+        run: |
+          rem smctl exits 0 whether a subcommand works or not, and cmd keeps going
+          rem after a failure, so all four run and the log carries every answer.
+          smctl healthcheck
+          smctl windows ksp list
+          smctl keypair ls
+          smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
+        shell: cmd
+        env:
+          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+
       - name: Sign Windows MSI
         if: steps.check-secret.outputs.can_sign == 'true'
         run: smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -35,6 +35,11 @@ on:
         required: true
         default: true
         type: boolean
+      allow_unsigned_windows:
+        description: 'Publish even if the Windows MSI is unsigned (signing is broken and you need this release out)'
+        required: false
+        default: false
+        type: boolean
 
 env:
   GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.caching=true'
@@ -508,6 +513,8 @@ jobs:
 
       - name: 🔏 Verify MSI Signature
         shell: powershell
+        env:
+          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
         run: |
           $sig = Get-AuthenticodeSignature -FilePath "${{ steps.find-msi.outputs.msi-path }}"
           Write-Host "Signature status: $($sig.Status)"
@@ -518,8 +525,13 @@ jobs:
             if ('${{ steps.check-secret.outputs.can_sign }}' -ne 'true') {
               Write-Host "::warning::Windows MSI is UNSIGNED, status $($sig.Status) (no CODE_SIGNING_* secrets configured)"
             } elseif ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
-              Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
-              exit 1
+              if ($env:ALLOW_UNSIGNED -eq 'true') {
+                Write-Host "::warning::Signature enforcement overridden: publishing a $($sig.Status) Windows MSI because allow_unsigned_windows was set"
+              } else {
+                Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
+                Write-Host "::error::To ship this release anyway, re-run with allow_unsigned_windows enabled."
+                exit 1
+              }
             } else {
               Write-Host "::warning::MSI signature status is $($sig.Status), expected Valid"
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1289,6 +1289,40 @@ jobs:
           SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
 
+      # The missing step, and the reason every MSI since the signing secrets landed
+      # on 2026-07-21 came out unsigned: `smctl sign` shells out to signtool, which
+      # looks for the certificate in the Windows certificate store, and nothing had
+      # ever put it there. DigiCert's own pipeline guidance is to run certsync as
+      # the first step of every signing job. Without it smctl prints
+      # "signCommand command for file <path> FAILED" and exits 0, so the release
+      # shipped an unsigned installer under a green build.
+      #
+      # healthcheck / ksp list / keypair ls come along because smctl gives no
+      # reason for a signing failure. If certsync is not the whole story, the next
+      # run says which of the credential, the KSP registration or the keypair alias
+      # is wrong, instead of costing another release to find out.
+      #
+      # continue-on-error: this step is diagnostics plus a precondition, and the
+      # authoritative verdict is "Verify MSI Signature" reading the file itself. A
+      # certsync failure should let the sign attempt proceed and be judged there.
+      - name: Sync KeyLocker Certificate to the Windows Store
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
+        continue-on-error: true
+        run: |
+          rem smctl exits 0 whether a subcommand works or not, and cmd keeps going
+          rem after a failure, so all four run and the log carries every answer.
+          smctl healthcheck
+          smctl windows ksp list
+          smctl keypair ls
+          smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
+        shell: cmd
+        env:
+          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+
       - name: Sign Windows MSI with DigiCert KeyLocker
         if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
         run: |
@@ -1588,6 +1622,25 @@ jobs:
           SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
           SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+
+      # Same certsync precondition as the x64 job above; see the comment there.
+      - name: Sync KeyLocker Certificate to the Windows Store (Windows ARM64)
+        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          rem smctl exits 0 whether a subcommand works or not, and cmd keeps going
+          rem after a failure, so all four run and the log carries every answer.
+          smctl healthcheck
+          smctl windows ksp list
+          smctl keypair ls
+          smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
+        shell: cmd
+        env:
+          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
 
       - name: Sign Windows ARM64 MSI with DigiCert KeyLocker
         if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ on:
         required: true
         default: true
         type: boolean
+      allow_unsigned_windows:
+        description: 'Publish even if the Windows MSI is unsigned (signing is broken and you need this release out)'
+        required: false
+        default: false
+        type: boolean
   # Allow this workflow to be called from other workflows (e.g., promote-release)
   workflow_call:
     inputs:
@@ -60,6 +65,11 @@ on:
         type: boolean
       skip_version_increment:
         description: 'Skip version increment (for promotion)'
+        required: false
+        default: false
+        type: boolean
+      allow_unsigned_windows:
+        description: 'Publish even if the Windows MSI is unsigned'
         required: false
         default: false
         type: boolean
@@ -1063,6 +1073,10 @@ jobs:
     needs: prepare-version
     if: needs.prepare-version.outputs.should-build == 'true'
     runs-on: windows-latest
+    # What the signature actually came out as, so create-release can say so in
+    # the release body rather than leaving it to whoever reads the run log.
+    outputs:
+      msi-signature: ${{ steps.verify-signature.outputs.status }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -1349,7 +1363,12 @@ jobs:
         shell: powershell
 
       - name: 🔏 Verify MSI Signature
+        id: verify-signature
         shell: powershell
+        env:
+          # Fails closed: on a push-triggered release the inputs context is empty,
+          # so this is 'false' and the gate below stays a gate.
+          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
         run: |
           $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
           $sig = Get-AuthenticodeSignature -FilePath $msiPath
@@ -1357,14 +1376,20 @@ jobs:
           if ($sig.SignerCertificate) {
             Write-Host "Signer: $($sig.SignerCertificate.Subject)"
           }
+          echo "status=$($sig.Status)" >> $env:GITHUB_OUTPUT
           if ($sig.Status -ne 'Valid') {
             if ('${{ steps.check-secret.outputs.can_sign }}' -ne 'true') {
               Write-Host "::warning::Windows MSI is UNSIGNED, status $($sig.Status) (no CODE_SIGNING_* secrets configured)"
             } elseif ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
               # Credentials were present and smctl exited 0, yet no usable
               # signature is on the file. That is the silent case worth blocking.
-              Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
-              exit 1
+              if ($env:ALLOW_UNSIGNED -eq 'true') {
+                Write-Host "::warning::Signature enforcement overridden: publishing a $($sig.Status) Windows MSI because allow_unsigned_windows was set"
+              } else {
+                Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
+                Write-Host "::error::Read the 'Sync KeyLocker Certificate to the Windows Store' step for why. To ship this release anyway, re-run the workflow with allow_unsigned_windows enabled."
+                exit 1
+              }
             } else {
               # NotTrusted / UnknownError and friends: the signature may be fine
               # and the runner's trust store or parser may not be. Loud, not fatal.
@@ -1404,6 +1429,8 @@ jobs:
     if: needs.prepare-version.outputs.should-build == 'true'
     runs-on: windows-11-arm
     continue-on-error: true  # Graceful failure if ARM runner unavailable
+    outputs:
+      msi-signature: ${{ steps.verify-signature.outputs.status }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -1673,6 +1700,7 @@ jobs:
       # the upload and cost the release its ARM64 asset. Reporting must never do
       # that in a job whose whole signing path is best effort.
       - name: 🔏 Verify MSI Signature (Windows ARM64)
+        id: verify-signature
         if: ${{ steps.find-msi.outputs.msi-path != '' }}
         continue-on-error: true
         shell: powershell
@@ -1680,6 +1708,7 @@ jobs:
           $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
           $sig = Get-AuthenticodeSignature -FilePath $msiPath
           Write-Host "Signature status: $($sig.Status)"
+          echo "status=$($sig.Status)" >> $env:GITHUB_OUTPUT
           if ($sig.SignerCertificate) {
             Write-Host "Signer: $($sig.SignerCertificate.Subject)"
           }
@@ -1982,6 +2011,35 @@ jobs:
 
           🤖 *This release was automatically built and published by GitHub Actions*
           EOF
+
+          # A release whose Windows installer is not Valid-signed says so at the top
+          # of its own body. Driven by what the verify steps measured on the
+          # artifacts, never by whether the override was requested: the override is
+          # a no-op when signing works, and an unconfigured-secrets build reaches
+          # here too. An empty value means that job did not get as far as measuring.
+          X64_SIG='${{ needs.build-windows.outputs.msi-signature }}'
+          ARM_SIG='${{ needs.build-windows-arm64.outputs.msi-signature }}'
+          UNSIGNED=''
+          if [ -n "$X64_SIG" ] && [ "$X64_SIG" != 'Valid' ]; then
+            UNSIGNED="x64 ($X64_SIG)"
+          fi
+          if [ -n "$ARM_SIG" ] && [ "$ARM_SIG" != 'Valid' ]; then
+            if [ -n "$UNSIGNED" ]; then
+              UNSIGNED="$UNSIGNED, arm64 ($ARM_SIG)"
+            else
+              UNSIGNED="arm64 ($ARM_SIG)"
+            fi
+          fi
+          if [ -n "$UNSIGNED" ]; then
+            echo "Windows installer is not signed: $UNSIGNED - prepending a notice"
+            {
+              echo "> ⚠️ **The Windows installer in this release is not signed:** $UNSIGNED."
+              echo "> Windows will warn on install, and SmartScreen may block it."
+              echo ""
+              cat release-notes.md
+            } > release-notes.body
+            mv release-notes.body release-notes.md
+          fi
 
           # Set output for release creation
           echo "notes-file=release-notes.md" >> $GITHUB_OUTPUT

--- a/CODE_SIGNING_SETUP.md
+++ b/CODE_SIGNING_SETUP.md
@@ -131,6 +131,28 @@ Two consequences worth keeping:
   KSP registration or the keypair alias is at fault rather than costing a release
   to find out.
 
+### Shipping a release when signing is broken
+
+`Verify MSI Signature` fails the release rather than publish an unsigned
+installer, which is right, but it means broken signing blocks every release. The
+deliberate way out is the `allow_unsigned_windows` workflow input on both
+`🚀 Release Build` and `🚀 BOSS Lite Release`:
+
+- **Off by default**, and it fails closed: a push-triggered release has no
+  `inputs` context at all, so the gate stays a gate. Only an explicit
+  `workflow_dispatch` (or a `workflow_call` that passes it) can set it.
+- It downgrades the hard failure to a workflow warning. It does not skip signing:
+  certsync and the sign attempt still run, so the run still carries the
+  diagnostics that say why signing failed.
+- **The release says so.** `create-release` reads the signature status the verify
+  steps measured and prepends a notice to the release body naming which installer
+  is unsigned and what its status was. That is driven by the measurement, not by
+  the input, so it also fires for a build with no signing secrets configured, and
+  it stays silent when the override was requested but signing actually worked.
+
+The error message on a blocked release names the input, so nobody has to find
+this page first.
+
 ### What gets signed
 
 | Artifact | Job | Signed |

--- a/CODE_SIGNING_SETUP.md
+++ b/CODE_SIGNING_SETUP.md
@@ -99,6 +99,38 @@ build an unsigned MSI.
 - **Description**: Alias of the signing keypair in KeyLocker, passed to
   `smctl sign --keypair-alias`
 
+### `certsync` is not optional, and `smctl sign` lies about failing
+
+`smctl sign` shells out to `signtool`, which looks for the certificate in the
+**Windows certificate store**. Nothing puts it there for you, so every signing
+job has to run this first:
+
+```
+smctl windows certsync --keypair-alias="<alias>"
+```
+
+Without it `smctl` prints
+
+```
+signCommand command for file <path> FAILED
+```
+
+and **exits 0**. That combination is why the x64 MSI came out unsigned in every
+release from the day the secrets were added (2026-07-21) to 9.4.24 while the
+`Sign Windows MSI with DigiCert KeyLocker` step reported success: nothing in the
+job looked at the file, and the exit code said everything was fine.
+
+Two consequences worth keeping:
+
+- **Never trust the sign step's exit code.** `Verify MSI Signature` reads
+  `Get-AuthenticodeSignature` off the artifact and is the only authoritative
+  answer. It is what caught this.
+- **`smctl` gives no reason for a signing failure**, so the signing jobs also run
+  `smctl healthcheck`, `smctl windows ksp list` and `smctl keypair ls` next to
+  certsync. When signing breaks again, the run says whether the credential, the
+  KSP registration or the keypair alias is at fault rather than costing a release
+  to find out.
+
 ### What gets signed
 
 | Artifact | Job | Signed |
@@ -143,8 +175,13 @@ security find-identity -v -p codesigning
 # Test DigiCert KeyLocker connection
 smctl healthcheck
 
-# List the keypairs the API key can reach (confirms CODE_SIGNING_KEYPAIR_ALIAS)
+# Confirm the KSP is registered and the API key can reach the keypair
+smctl windows ksp list
 smctl keypair ls
+
+# Put the certificate in the Windows store. Signing fails without this, and
+# fails by printing FAILED and exiting 0.
+smctl windows certsync --keypair-alias="<alias>"
 
 # Build, then sign the MSI the same way CI does
 ./gradlew packageMsi
@@ -194,8 +231,14 @@ powershell -Command "Get-AuthenticodeSignature 'composeApp/build/compose/binarie
   the `Check if signing secret is available` step set `can_sign=false`
 - **KeyLocker connection fails**: Check API credentials and host
 - **Certificate not accessible**: Verify KeyLocker setup and permissions
-- **MSI signing fails**: Check the keypair alias and DigiCert service status; the
-  `Check SMKSP Log` step prints the tail of `%USERPROFILE%\.signingmanager\logs\smksp.log`
+- **MSI signing fails**: read the `Sync KeyLocker Certificate to the Windows Store`
+  step first - `healthcheck` covers the credential, `ksp list` the KSP registration,
+  `keypair ls` the alias, and a failing `certsync` means signtool will not find a
+  certificate. The `Check SMKSP Log` step prints the tail of
+  `%USERPROFILE%\.signingmanager\logs\smksp.log`, though "log not found" is normal
+  when the failure happened before the KSP was ever loaded
+- **`signCommand ... FAILED` but the step is green**: expected, `smctl sign` exits 0
+  regardless. `Verify MSI Signature` is what fails the job
 - **ARM64 MSI unsigned**: Expected if the x64 client tools cannot run under
   emulation on the ARM runner; the run emits a warning and ships the MSI anyway
 


### PR DESCRIPTION
## What broke

Every Windows MSI since the signing secrets were added on 2026-07-21 has shipped **unsigned**, under a green build.

`smctl sign` prints

```
signCommand command for file ...\BOSS-9.4.25.msi FAILED
```

and **exits 0**. The sign step went green, nothing looked at the artifact, and the release published an unsigned installer. The `Verify MSI Signature` step from #224 caught it on the first release after merging - run [32475688682](https://github.com/risa-labs-inc/BossConsole/actions/runs/32475688682), `Signature status: NotSigned`. That run's 9.4.25 did not publish, so the latest release is still 9.4.24.

This never worked rather than regressed. Sampling `build-windows` logs across releases back to 2026-07-21 - 9.4.21, 9.4.22, 9.4.23, 9.4.24 and older - every single one prints the same `FAILED` line.

## The cause

`smctl sign` shells out to `signtool`, which resolves the certificate from the **Windows certificate store**. Nothing had ever put it there. DigiCert's pipeline guidance is to run

```
smctl windows certsync --keypair-alias=<alias>
```

as the first step of every signing job. The workflow never did.

Everything else in the job was already fine, which is why this was invisible: the client tools install, WinKit 10.0.26100.0 is found, `Credentials saved to OS store` succeeds. Then signing fails 2.5s later with no reason given.

## The fix

A `Sync KeyLocker Certificate to the Windows Store` step in all three Windows signing jobs (`release.yml` x64 and arm64, `release-lite.yml`), after the credentials are saved and before the sign attempt:

```
smctl healthcheck
smctl windows ksp list
smctl keypair ls
smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
```

Three deliberate details:

- **The diagnostics ride along because `smctl` gives no reason for a signing failure.** If certsync is not the whole story, the next run says whether the credential, the KSP registration or the keypair alias is at fault, instead of costing another release to find out.
- **`shell: cmd`**, so a failing subcommand does not swallow the ones after it and the log carries all four answers. A `bash -e` step would stop at the first failure, which is the one case where the later output matters most.
- **`continue-on-error: true`**, because this is a precondition plus diagnostics, not the verdict. A certsync failure should still let the sign attempt happen and be judged by `Verify MSI Signature` reading the actual file.

The keypair alias goes in through `env:` rather than the command line, unlike the existing `Reset SMCTL Credentials` step, so `cmd` cannot mis-parse a value containing `&`, `^` or `|`.

`smctl sign` keeps no `--verbose` flag: it is not in DigiCert's documented flag set (`--keypair-alias`, `--fingerprint`, `--input`, `--certificate`, `--config-file`, `--tool`, `--simple`, `--unsigned`), and guessing one would waste a release run.

## Verification, and what cannot be verified here

Both workflows parse; step order confirmed per job (install → credentials → certsync → sign → verify).

The fix itself is only testable in a real release run - the credentials are repository secrets and the failure is inside DigiCert's tooling. **This is a hypothesis with strong evidence, not a confirmed fix**, and the next release proves or disproves it in one shot:

- signing works: `Verify MSI Signature` reports `Valid` and the release publishes
- certsync was necessary but not sufficient: the job fails the same way, but now `healthcheck` / `ksp list` / `keypair ls` name the actual problem

Worth being explicit: while this is unresolved, `Verify MSI Signature` **blocks every release**. That is the correct behaviour - it is refusing to ship an unsigned installer - but if you need to cut a release before signing works, say so and I will add an explicit `allow_unsigned_windows` dispatch input rather than have anyone quietly relax the gate.

## Side finding, on #224's open question

The ARM64 job reached the identical `signCommand ... FAILED` and `NotSigned`, then stayed green and uploaded as designed. So the x64 DigiCert tooling runs fine under emulation on `windows-11-arm` - the emulation risk #224 hedged against is not real, and ARM64 was never the problem. Once signing works, the ARM64 job's `continue-on-error` hedging can be tightened.

## Not in this PR

This is now the third copy of the same signing chain and the drift is real. A `.github/actions/sign-windows-msi` composite is the obvious next step, and #224's review already asked for it, but folding a refactor into a release-blocking fix would muddy which change made signing work.