### PR TITLE
Give the Toolbox the provenance it was inferring from a homepage

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -95,6 +95,11 @@ class PluginLoaderDelegateImpl(
             description = info.manifest.description,
             author = info.manifest.author,
             url = info.manifest.url,
+            // Blank on a FIRST install, because the caller persists the row after this returns.
+            // That is the right answer anyway - blank means "ask the store", which is where a
+            // plugin being installed for the first time by any store path came from. On an update
+            // the row is already there and still carries the original provenance.
+            sourceUrl = PluginPersistence.getSourceUrl(info.manifest.pluginId).orEmpty(),
             type =
                 info.manifest.type.name
                     .lowercase(),
@@ -454,6 +459,11 @@ class PluginLoaderDelegateImpl(
                     description = info.manifest.description,
                     author = info.manifest.author,
                     url = info.manifest.url,
+                    // The list the Toolbox's installed view is built from, so this is the site that
+                    // decides where its Update goes. Read per plugin rather than hoisted: the
+                    // persisted config is held in memory behind a lock, so each call is a find on a
+                    // list, not a file read.
+                    sourceUrl = PluginPersistence.getSourceUrl(info.manifest.pluginId).orEmpty(),
                     type =
                         info.manifest.type.name
                             .lowercase(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,7 +107,16 @@ intellij-platform = "243.21565.199"
 # Superset of 1.0.80: 1.0.81 made fillCredentials a deprecated no-op (the host already stopped
 # implementing it in #215) and 1.0.82 was doc-only, so nothing a host module or an installed plugin
 # resolves has been withdrawn.
-boss-plugin-api = "1.0.83"
+#
+# 1.0.84 adds LoadedPluginInfo.sourceUrl, which PluginLoaderDelegateImpl on this branch fills from
+# PluginPersistence. Without it the only location a plugin can see is the manifest homepage, and the
+# Toolbox was reading that as a download source - which sent every store plugin's update to an
+# unauthenticated GitHub API call and 404d for every private repo. Same forced order as above: api
+# first (boss-plugin-api#40 cuts v1.0.84), then this, **and this pin 404s CI until that release
+# exists**.
+#
+# Superset of 1.0.83: the field is additive with a "" default and nothing was withdrawn.
+boss-plugin-api = "1.0.84"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
## Why

The host has recorded, per install, where a plugin was fetched from - the `sourceUrl` on the installed.json row - but never handed it to plugins. `LoadedPluginInfo` exposed only `url`, the manifest homepage, so a plugin needing to know where to fetch an update from had one candidate and it was the wrong one: a store plugin still declares its development repo as its homepage, and for our plugins that repo is usually private.

The Toolbox duly read `url` as a download source and aimed an unauthenticated GitHub API call at it. GitHub answers **404** for a private repo, so the failure looked like a network fault. Worse, its update path uninstalled before it had the replacement bytes, so the plugin ended up deleted and unloaded with no way to retry. Fluck Agent was destroyed by its own update twice; `finances` too.

Distribution across my 40 installed rows shows how lopsided the guess was: 39 have blank/null `sourceUrl` (store installs) and exactly one is a real GitHub install.

## Change

Fill the new `LoadedPluginInfo.sourceUrl` (boss-plugin-api#40) from `PluginPersistence.getSourceUrl` at both sites that build one, so the answer comes from what the host actually recorded rather than from a homepage.

Blank keeps meaning "ask the store", which is also what a first install sees, since the row is written after `loadPlugin` returns. On an update the row is already there and still carries the original provenance, which is the case that matters.

Read per plugin rather than hoisted: the persisted config is held in memory behind a lock, so each call is a `find` on a list, not a file read.

## API pin

Bumps `boss-plugin-api` 1.0.83 -> 1.0.84 for the field. Superset of 1.0.83; additive with a `""` default, nothing withdrawn.

Same forced order as the existing pins documented in `libs.versions.toml`: **api first** (boss-plugin-api#40 cuts v1.0.84), then this. `fetchApiPluginJar` has no Maven fallback, so **this pin 404s CI until that release exists**.

## Verification

`:composeApp:compileKotlinDesktop` green against a locally built 1.0.84 jar (resolved from the sibling checkout, worktree layout path). `ktlintCheck detekt` green.

The Toolbox side is risa-labs-inc/boss-plugin-plugin-manager#47, and it deliberately does **not** depend on this landing: it catches `LinkageError` around the `sourceUrl` read rather than raising `minApiVersion`, so the store-first fix (the part that stops the data loss) ships on its own and this only improves precision afterwards.