### PR TITLE
perf(release): take ~3 minutes off the release critical path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,13 +139,23 @@ jobs:
       # fetched the Gradle distribution and resolved from cold here - 166s of
       # serial latency ahead of all five platform builds, measured on run
       # 32446645832. Same actions and pins as every other job in this workflow.
+      #
+      # Gated to the two events that actually run Gradle. "Increment Version"
+      # below is this job's only ./gradlew call and carries the same condition,
+      # so on a `push:` tag release these would be pure added latency: a JDK
+      # install, a Gradle Home cache restore, and - because setup-gradle's post
+      # step runs before the job is marked complete, and `needs:` waits on job
+      # completion - a cache save too, all at the head of the critical path that
+      # all five platform builds queue behind.
       - name: ☕ Setup JDK
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         uses: actions/setup-java@v5.6.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: 🎯 Setup Gradle
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
@@ -213,12 +223,16 @@ jobs:
             ./gradlew setPrereleaseSuffix -Psuffix="${RELEASE_TYPE}.${PRERELEASE_NUM}" -PskipGitCheck=true
           else
             # Ensure we clear any existing prerelease suffix for stable releases.
-            # ClearPrereleaseSuffixTask returns immediately when the suffix is
-            # already blank, so on a stable-after-stable release this Gradle run
-            # is a no-op - and a second configuration pass over 30+ modules is
-            # the most expensive no-op in the release. incrementVersion does not
-            # touch the suffix, so reading the file here sees the same value the
-            # task would. A missing key means nothing to clear either.
+            # ClearPrereleaseSuffixTask returns before it writes anything when the
+            # suffix is already blank: all four of its writes - app.prerelease.suffix,
+            # app.version, app.release.channel and app.build.date - sit after that
+            # early return, so skipping the run when the suffix is blank changes
+            # nothing on disk. The guard is exact, not approximately exact.
+            #
+            # Worth skipping because a second Gradle configuration pass over 30+
+            # modules is the most expensive no-op in the release. incrementVersion
+            # does not touch the suffix, so reading the file here sees the same
+            # value the task would. A missing key means nothing to clear either.
             CURRENT_SUFFIX="$(grep '^app.prerelease.suffix=' version.properties | cut -d'=' -f2- || true)"
             if [[ -n "$CURRENT_SUFFIX" ]]; then
               ./gradlew clearPrereleaseSuffix -PskipGitCheck=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,21 @@ jobs:
         with:
           token: ${{ secrets.PUBLIC_REPO_TOKEN }}
 
+      # This was the only job running ./gradlew without them, so every release
+      # fetched the Gradle distribution and resolved from cold here - 166s of
+      # serial latency ahead of all five platform builds, measured on run
+      # 32446645832. Same actions and pins as every other job in this workflow.
+      - name: ☕ Setup JDK
+        uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: 🎯 Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: false
+
       - name: 🔄 Increment Version (Manual Trigger)
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         env:
@@ -197,8 +212,19 @@ jobs:
             echo "Setting prerelease suffix: ${RELEASE_TYPE}.${PRERELEASE_NUM}"
             ./gradlew setPrereleaseSuffix -Psuffix="${RELEASE_TYPE}.${PRERELEASE_NUM}" -PskipGitCheck=true
           else
-            # Ensure we clear any existing prerelease suffix for stable releases
-            ./gradlew clearPrereleaseSuffix -PskipGitCheck=true
+            # Ensure we clear any existing prerelease suffix for stable releases.
+            # ClearPrereleaseSuffixTask returns immediately when the suffix is
+            # already blank, so on a stable-after-stable release this Gradle run
+            # is a no-op - and a second configuration pass over 30+ modules is
+            # the most expensive no-op in the release. incrementVersion does not
+            # touch the suffix, so reading the file here sees the same value the
+            # task would. A missing key means nothing to clear either.
+            CURRENT_SUFFIX="$(grep '^app.prerelease.suffix=' version.properties | cut -d'=' -f2- || true)"
+            if [[ -n "$CURRENT_SUFFIX" ]]; then
+              ./gradlew clearPrereleaseSuffix -PskipGitCheck=true
+            else
+              echo "ℹ️ No prerelease suffix to clear - skipping the Gradle run"
+            fi
           fi
 
           # Get the new version
@@ -404,9 +430,8 @@ jobs:
         run: |
           echo "🔧 Setting up build environment for ${{ matrix.platform }}"
           echo "📦 Version: ${{ needs.prepare-version.outputs.version }}"
-          
-          # Verify version consistency
-          ./gradlew showVersion
+          # No ./gradlew here: "Verify Built Version" below is the real check,
+          # and it reads the generated VersionConstants rather than this file.
 
       # macOS specific setup
       - name: 🍎 Setup macOS Environment
@@ -707,9 +732,8 @@ jobs:
         run: |
           echo "🔧 Setting up build environment for Linux AMD64"
           echo "📦 Version: ${{ needs.prepare-version.outputs.version }}"
-
-          # Verify version consistency
-          ./gradlew showVersion
+          # No ./gradlew here: "Verify Built Version" below is the real check,
+          # and it reads the generated VersionConstants rather than this file.
 
       - name: 🔍 Get JxBrowser Version
         run: |
@@ -895,9 +919,8 @@ jobs:
         run: |
           echo "🔧 Setting up build environment for Linux ARM64"
           echo "📦 Version: ${{ needs.prepare-version.outputs.version }}"
-
-          # Verify version consistency
-          ./gradlew showVersion
+          # No ./gradlew here: "Verify Built Version" below is the real check,
+          # and it reads the generated VersionConstants rather than this file.
 
       - name: 📦 Install Linux Packaging Dependencies
         run: |
@@ -1097,9 +1120,8 @@ jobs:
         run: |
           echo "🔧 Setting up build environment for Windows"
           echo "📦 Version: ${{ needs.prepare-version.outputs.version }}"
-
-          # Verify version consistency
-          ./gradlew showVersion
+          # No ./gradlew here: "Verify Built Version" below is the real check,
+          # and it reads the generated VersionConstants rather than this file.
 
       - name: 🔍 Get JxBrowser Version
         shell: bash
@@ -1452,7 +1474,8 @@ jobs:
         run: |
           Write-Host "Setting up build environment for Windows ARM64"
           Write-Host "Version: ${{ needs.prepare-version.outputs.version }}"
-          ./gradlew showVersion
+          # No ./gradlew here: "Verify Built Version" below is the real check,
+          # and it reads the generated VersionConstants rather than this file.
 
       - name: 🔍 Get JxBrowser Version
         shell: powershell


### PR DESCRIPTION
Measured before changing anything. On run [32446645832](https://github.com/risa-labs-inc/BossConsole/actions/runs/32446645832) (a clean 15m release) the critical path is:

| Stage | Duration |
|---|---|
| `prepare-version` | 2m55s |
| `build-macos-arm64` (slowest platform) | 10m17s |
| `create-release` | 1m39s |

Every other platform job finishes inside the macOS job's shadow, so only these three stages matter.

## What this changes

**1. `prepare-version` had no `setup-java` and no `setup-gradle`** - the only job in this workflow that runs `./gradlew` without them. So every release fetched the Gradle distribution and resolved dependencies from cold, right at the front of the run. Its one `🔄 Increment Version` step measures **166s**, which is essentially the whole job, and all five platform builds queue behind it. Now uses the same two actions at the same pins as every other job here.

**2. That step ran a second full Gradle invocation to clear the prerelease suffix, unconditionally.** `ClearPrereleaseSuffixTask` returns immediately when the suffix is already blank (`VersionTasks.kt:378-382`), so on a stable-after-stable release that was a second configuration pass over 30+ modules to do nothing. Now guarded by reading `version.properties` first.

Equivalent, not just similar: `IncrementVersionTask` does not touch the suffix, so the file holds exactly the value the task would read. I checked the guard against a present-and-empty key (today's state), a set key (`beta.2`), and a missing key, under `set -euo pipefail` - the `|| true` matters, since `grep` exits 1 on no match and pipefail would otherwise kill the step.

**3. All five platform jobs ran `./gradlew showVersion`** to print a file the checkout already pinned: **18s on macOS, 42s on Windows**, each one a full Gradle configuration pass. The authoritative check is `🔍 Verify Built Version`, which reads the generated `VersionConstants.kt` and is what would actually catch issue #111 recurring. The `echo` of the version stays; only the Gradle call goes.

Expected saving is roughly 3 minutes off ~15, most of it from the front of the run where nothing else can overlap. The `prepare-version` figure is the least certain of the three: the first run after this merges still populates a cold cache.

## What I deliberately did not touch

Measurement killed several plausible-sounding ideas, so they are worth recording:

- **Notarization is 263s**, the single largest step in the release. That is Apple's queue; there is nothing local to win.
- **The Gradle build and package steps** are 179s + 94s on macOS, 275s + 95s on Windows. They **cannot** be merged: branded Chromium is bundled into the app image between them, which is the entire reason they are separate steps.
- **Caching the branded Chromium download would save nothing.** It measures 5-6s per job.
- **`compression-level: 0` on the artifact uploads** is worth about as little - the DMG upload is 7s, the MSI 10s.
- **`create-release` assembles the upstream IPC JARs on the tail** (28s, plus 7s of Gradle setup) for work that depends on no platform build. Moving it to a job that runs alongside the platform builds would recover ~35s, at the cost of an artifact round trip. Left out as the worst ratio of risk to reward in this set; happy to do it separately.
- **`create-release` `needs` both optional ARM legs.** Its `if:` tolerates their failure but `needs` still waits for them to finish. On this run macOS was the binding constraint anyway (04:34:43 vs ARM64's 04:34:06), so decoupling them buys nothing today - but it would if a future ARM leg gets slower.

## Verification

The workflow parses, no `gradlew showVersion` remains, and the suffix guard was exercised in all three input states. The timings themselves can only be confirmed by the next release run.