### PR TITLE
Stop the JxBrowser auto-release reporting a no-op as a failure

### DIFF
--- a/.github/workflows/jxbrowser-autorelease.yml
+++ b/.github/workflows/jxbrowser-autorelease.yml
@@ -343,6 +343,16 @@ jobs:
             echo "- Dry run: \`${DRY_RUN:-false}\`"
             if [[ -n "${PIN_ACTION:-}" ]]; then
               echo "- Pin (\`${PIN_CURRENT:-unknown}\`): \`$PIN_ACTION\`"
-              [[ -n "${PIN_PR_URL:-}" ]] && echo "- Pin PR: $PIN_PR_URL"
+              # A full `if`, not `[[ ... ]] && echo`. These blocks run under `bash -e`, and a
+              # trailing AND-list whose test is false returns 1 - which -e cannot tell apart from
+              # a command that failed. Being the last statement in this `if`, and so of the
+              # enclosing group, that exit status became the step's, and the job's.
+              #
+              # It fired on every run that had nothing to do, because `pin_pr_url` is empty
+              # precisely when there was no PR to open. A daily scheduled no-op reported itself
+              # as a failure, which is also where a real engine-release failure would have shown.
+              if [[ -n "${PIN_PR_URL:-}" ]]; then
+                echo "- Pin PR: $PIN_PR_URL"
+              fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
[Run 32551864729](https://github.com/risa-labs-inc/BossConsole/actions/runs/32551864729) failed, and every decision it made was correct:

```
VERSION: 9.4.1
SHOULD_DISPATCH: false
REASON: release_already_published
PIN_ACTION: up_to_date
PIN_CURRENT: 9.4.1
PIN_PR_URL:            ← empty
```

Engine already released, pin already on 9.4.1, nothing to dispatch. The right outcome was "no work to do". It then failed while writing the run summary.

## Cause

```bash
[[ -n "${PIN_PR_URL:-}" ]] && echo "- Pin PR: $PIN_PR_URL"
```

These blocks run under `bash -e`. With no PR url the test is false, so the AND-list returns 1 — and `-e` cannot distinguish that from a command that failed. It was the last statement in its `if`, hence of the enclosing `{ … } >> "$GITHUB_STEP_SUMMARY"` group, so its status became the step's and the job's.

## Why it matters more than one red run

`pin_pr_url` is empty **precisely when there was no PR to open**, which is the normal state for this watcher. So it failed on every quiet run, not occasionally: a daily red cron that means nothing, sitting exactly where a genuine engine-release failure would have surfaced.

Introduced in #229, which added the `PIN_*` lines to the summary. Before that the block ended in a plain `echo` and so always returned 0.

## Fix

A full `if`, matching the shape already used for `PIN_ACTION` two lines above. Chosen over `|| true` or flipping to `[[ -z … ]] || echo …` because this failure mode is one a reader has to already know about to spot, so the code shouldn't rely on them knowing it.

## Verification

Extracted the summary block from both this branch and `origin/main`, then ran each under `bash -e` with the failing run's exact inputs:

| block | inputs | exit |
|---|---|---|
| `origin/main` | `PIN_ACTION=up_to_date`, `PIN_PR_URL=""` | **1** (reproduces the failure) |
| this branch | same | **0** |
| this branch | `PIN_ACTION=pr_opened`, `PIN_PR_URL=<url>` | 0, Pin PR line rendered |
| this branch | no `PIN_ACTION` at all | 0 |

The reproduction is the load-bearing row — without it, an exit 0 on the new block proves nothing about whether the bug was ever there. Also confirmed the extracted body is byte-identical to the script I exercised, and that no body line is indented at or above the `run: |` key, which would silently truncate the YAML block scalar.