### PR TITLE
perf(ci): stop every PR queueing behind a cold Gradle that printed a file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,27 +131,38 @@ jobs:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v7
 
-      - name: ☕ Setup JDK
-        uses: actions/setup-java@v5.6.0
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
+      # No JDK and no Gradle here on purpose. This job's two outputs are read
+      # out of version.properties with grep, and the `./gradlew showVersion`
+      # that used to follow them only printed the same file back: ShowVersionTask
+      # is a read-only task that loads version.properties and formats it, and it
+      # derives nothing the file does not already hold.
+      #
+      # It cost the whole job. Measured on three consecutive runs, the step took
+      # 153s / 157s / 211s out of a 160s / 163s / 221s job - a cold Gradle
+      # distribution download and a full configuration pass, with no
+      # setup-gradle cache to fall back on. build-test (three OSes),
+      # code-quality, compatibility-test and database-tests all `needs:` this
+      # job, so every pull request queued its entire matrix behind it.
+      #
+      # Printing the properties file directly gives a reader strictly more than
+      # the formatted box did, in milliseconds. `🧪 Test Version System` in
+      # compatibility-test still exercises showVersion itself, where the task is
+      # the thing under test and the job has a Gradle cache.
       - name: 🔍 Version Information
         id: get-version
         run: |
           # Get version info using our centralized system
           VERSION=$(grep "^app.version=" version.properties | cut -d'=' -f2)
           BUILD_NUMBER=$(grep "^app.build.number=" version.properties | cut -d'=' -f2)
-          
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "build-number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
-          
+
           echo "📦 Version: $VERSION"
           echo "🔢 Build Number: $BUILD_NUMBER"
-          
-          # Show detailed version info
-          ./gradlew showVersion
+
+          echo "📋 version.properties:"
+          sed 's/^/   /' version.properties
 
   build-test:
     needs: version-check


### PR DESCRIPTION
Follow-up to the review on #232, which flagged this as the same cold-Gradle-to-print-a-file pattern on a workflow that runs far more often than releases do. It turned out worse than the release case.

## What it cost

`version-check` is the **fan-out root** of `build.yml` - `build-test` (three OSes), `code-quality`, `compatibility-test` and `database-tests` all `needs:` it. It had `setup-java` but no `setup-gradle`, and ended with `./gradlew showVersion`.

That one line was the entire job. Measured across three consecutive runs:

| run | `🔍 Version Information` | whole job |
|---|---|---|
| 32556113268 | 153s | 160s |
| 32555546499 | 157s | 163s |
| 32555131816 | 211s | 221s |

Checkout was 2-3s and the JDK setup 0-1s. With no Gradle cache the step downloaded the distribution and ran a full configuration pass, on **every pull request**, before any other job could start. `database-tests` doesn't even use Java and was still waiting on it.

## Why removing it is safe

- The job's two outputs are grepped out of `version.properties` on the two lines directly above the Gradle call. Gradle contributed nothing to them.
- `ShowVersionTask` is a `VersionPropertyReadTask`: it loads the same `version.properties` and formats it - version, build number, channel, prerelease suffix, and jar/dmg/msi names derived from those. Nothing it prints is unavailable from the file.
- Nothing downstream reads its stdout; it was the last line of the step.

So the step now prints the properties file itself, which is **strictly more** than the formatted box showed, in milliseconds. The JDK setup goes too, since nothing left in the job touches Java. Same step `id`, same two outputs, same grep expressions - only the tail changes.

## Deliberately left alone

`🧪 Test Version System` in `compatibility-test` also calls `showVersion`, but there the task is the thing under test rather than a progress message, and that job has a Gradle cache. The review made the same call.

## Verification

- YAML parses; `version-check` is down to two steps (Checkout, Version Information) with both outputs intact.
- `env.JAVA_VERSION` is still referenced by three other jobs, so the env block stays load-bearing.
- The replacement print was run against the real `version.properties` at this HEAD (9.4.29) and emits all 11 keys.
- The `showVersion` step at line 322 is untouched; the only other occurrence in the diff is the comment pointing at it.

Expected effect is roughly **2.5 to 3.5 minutes off the front of every PR run**, and unlike #232 there is no cache-warming caveat - the work is deleted rather than cached.