### PR TITLE
refactor(ci): one action for Windows MSI signing, and drop the ARM64 hedging

### DIFF
--- a/.github/actions/sign-windows-msi/action.yml
+++ b/.github/actions/sign-windows-msi/action.yml
@@ -1,0 +1,241 @@
+name: Sign a Windows MSI with DigiCert KeyLocker
+description: >
+  Signs one MSI through DigiCert Software Trust Manager and verifies the
+  signature actually landed on the file. Replaces three near-identical copies of
+  this chain in release.yml (x64 and arm64) and release-lite.yml.
+
+# Why this exists as an action rather than three copies: the copies had already
+# drifted. release-lite.yml's credential reset passed one SM_* variable where the
+# others passed four, and the arm64 copy had lost the cert-file diagnostic the
+# x64 copy kept. Every fix to the signing chain in August 2026 had to be written
+# three times, and the certsync fix that finally made signing work was one of
+# them.
+#
+# Two facts about DigiCert's tooling shape everything below, both learned the
+# expensive way:
+#
+#  - `smctl sign` exits 0 whether it signed or not. It prints
+#    "signCommand command for file <path> FAILED" and returns success, so the
+#    step's exit code is worthless and the only real check is reading the
+#    signature off the artifact. Every Windows MSI between 2026-07-21 and 9.4.24
+#    shipped unsigned under a green build for exactly this reason.
+#  - `smctl sign` shells out to signtool, which resolves the certificate from the
+#    Windows certificate store. Nothing puts it there for you, so
+#    `smctl windows certsync` has to run first.
+inputs:
+  msi-path:
+    description: Absolute path to the MSI to sign.
+    required: true
+  cert-host:
+    description: >
+      KeyLocker host (SM_HOST). Empty means "no signing credentials configured":
+      the whole chain is skipped and an unsigned MSI is reported as a warning
+      rather than an error, so forks and credential-less builds still work.
+    required: false
+    default: ''
+  api-key:
+    description: KeyLocker API key (SM_API_KEY).
+    required: false
+    default: ''
+  client-cert:
+    description: Base64-encoded PKCS#12 client authentication certificate.
+    required: false
+    default: ''
+  client-cert-password:
+    description: Password for the client authentication certificate.
+    required: false
+    default: ''
+  keypair-alias:
+    description: >
+      Alias of the signing keypair in KeyLocker. Must name a keypair the
+      credential above is authorized on: a keypair with limit_by_users set will
+      refuse every other identity, and smctl reports that refusal as the
+      thoroughly misleading "Certificate for keypair alias: ... not found".
+    required: false
+    default: ''
+  allow-unsigned:
+    description: >
+      'true' downgrades an unsigned result from a job failure to a warning. For
+      the deliberate case where signing is broken and a release has to go out
+      anyway. Anything other than 'true' keeps the gate.
+    required: false
+    default: 'false'
+  label:
+    description: Name for this artifact in log messages, e.g. "Windows ARM64".
+    required: false
+    default: Windows
+
+outputs:
+  status:
+    description: >
+      The Authenticode status read off the MSI - Valid, NotSigned, HashMismatch,
+      NotTrusted, UnknownError. Empty if the verify step did not run. Callers
+      publish this as a job output so the release body can name an installer that
+      is not signed.
+    value: ${{ steps.verify.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    # PowerShell rather than bash: every Windows runner has it natively, and this
+    # step is not gated on anything, so a shell that failed to resolve here would
+    # take the whole job with it.
+    - name: Check if signing credentials are available
+      id: check-secret
+      shell: powershell
+      env:
+        CERT_HOST: ${{ inputs.cert-host }}
+      run: |
+        if ($env:CERT_HOST) {
+          echo "can_sign=true" >> $env:GITHUB_OUTPUT
+        } else {
+          Write-Host "::warning::No KeyLocker host configured - skipping signing for ${{ inputs.label }}"
+          echo "can_sign=false" >> $env:GITHUB_OUTPUT
+        }
+
+    - name: Decode client certificate
+      if: steps.check-secret.outputs.can_sign == 'true'
+      shell: powershell
+      env:
+        CLIENT_CERT: ${{ inputs.client-cert }}
+      run: |
+        try {
+          $certBytes = [System.Convert]::FromBase64String($env:CLIENT_CERT)
+          $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
+          [System.IO.File]::WriteAllBytes($certPath, $certBytes)
+          Write-Host "Client cert decoded to $certPath ($($certBytes.Length) bytes)"
+        } catch {
+          Write-Host "::error::Could not decode the client authentication certificate: $_"
+          exit 1
+        }
+
+    - name: Verify client cert file exists
+      if: steps.check-secret.outputs.can_sign == 'true'
+      shell: powershell
+      run: |
+        $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
+        if (Test-Path $certPath) {
+          Write-Host "[OK] Cert file exists at $certPath, $((Get-Item $certPath).Length) bytes"
+        } else {
+          Write-Host "::error::Cert file MISSING at $certPath"
+          exit 1
+        }
+
+    - name: Install DigiCert STM client tools
+      if: steps.check-secret.outputs.can_sign == 'true'
+      uses: digicert/ssm-code-signing@v1.2.1
+      env:
+        SM_HOST: ${{ inputs.cert-host }}
+        SM_API_KEY: ${{ inputs.api-key }}
+        SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+        SM_CLIENT_CERT_PASSWORD: ${{ inputs.client-cert-password }}
+
+    # Credentials go in through the environment, not the command line. cmd would
+    # mis-parse a password containing & ^ | or a space, and it would fail looking
+    # exactly like a KeyLocker outage.
+    - name: Reset SMCTL credentials
+      if: steps.check-secret.outputs.can_sign == 'true'
+      shell: cmd
+      env:
+        SM_HOST: ${{ inputs.cert-host }}
+        SM_API_KEY: ${{ inputs.api-key }}
+        SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+        SM_CLIENT_CERT_PASSWORD: ${{ inputs.client-cert-password }}
+      run: |
+        smctl credentials delete
+        smctl credentials save "%SM_API_KEY%" "%SM_CLIENT_CERT_PASSWORD%"
+
+    # certsync is the precondition; the other three are diagnostics, because
+    # smctl gives no reason for a signing failure. Between them they say whether
+    # the credential, the KSP registration or the keypair alias is at fault,
+    # rather than costing a release run to find out.
+    #
+    # This step must never fail the job: the authoritative verdict is the verify
+    # step reading the file, and a certsync failure should still let the sign
+    # attempt happen and be judged there. Composite actions do not support
+    # continue-on-error on their steps, so the script says so itself with a
+    # trailing `exit /b 0` - which is arguably the better place for the intent.
+    - name: Sync KeyLocker certificate to the Windows store
+      if: steps.check-secret.outputs.can_sign == 'true'
+      shell: cmd
+      env:
+        SM_HOST: ${{ inputs.cert-host }}
+        SM_API_KEY: ${{ inputs.api-key }}
+        SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+        SM_CLIENT_CERT_PASSWORD: ${{ inputs.client-cert-password }}
+        KEYPAIR_ALIAS: ${{ inputs.keypair-alias }}
+      run: |
+        smctl healthcheck
+        smctl windows ksp list
+        smctl keypair ls
+        smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
+        exit /b 0
+
+    - name: Sign the MSI
+      if: steps.check-secret.outputs.can_sign == 'true'
+      shell: bash
+      env:
+        SM_HOST: ${{ inputs.cert-host }}
+        SM_API_KEY: ${{ inputs.api-key }}
+        SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
+        SM_CLIENT_CERT_PASSWORD: ${{ inputs.client-cert-password }}
+        KEYPAIR_ALIAS: ${{ inputs.keypair-alias }}
+        MSI_PATH: ${{ inputs.msi-path }}
+      run: |
+        echo "Signing ${{ inputs.label }} MSI: $MSI_PATH"
+        smctl sign --keypair-alias "$KEYPAIR_ALIAS" --input "$MSI_PATH"
+
+    - name: Check SMKSP log
+      if: always() && steps.check-secret.outputs.can_sign == 'true'
+      shell: powershell
+      run: |
+        $logPath = "$env:USERPROFILE\.signingmanager\logs\smksp.log"
+        if (Test-Path $logPath) {
+          Write-Host "SMKSP log, last 50 lines:"
+          Get-Content $logPath -Tail 50
+        } else {
+          # Normal when the failure happened before the KSP was ever loaded.
+          Write-Host "SMKSP log not found."
+        }
+
+    # The only authoritative check in this action, and the one that caught the
+    # month of unsigned releases. Everything above can report success while the
+    # file carries no signature.
+    - name: Verify MSI signature
+      id: verify
+      shell: powershell
+      env:
+        MSI_PATH: ${{ inputs.msi-path }}
+        ALLOW_UNSIGNED: ${{ inputs.allow-unsigned }}
+        CAN_SIGN: ${{ steps.check-secret.outputs.can_sign }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        $sig = Get-AuthenticodeSignature -FilePath $env:MSI_PATH
+        Write-Host "Signature status: $($sig.Status)"
+        if ($sig.SignerCertificate) {
+          Write-Host "Signer: $($sig.SignerCertificate.Subject)"
+        }
+        echo "status=$($sig.Status)" >> $env:GITHUB_OUTPUT
+
+        if ($sig.Status -eq 'Valid') { exit 0 }
+
+        if ($env:CAN_SIGN -ne 'true') {
+          Write-Host "::warning::$($env:LABEL) MSI is UNSIGNED, status $($sig.Status) (no signing credentials configured)"
+          exit 0
+        }
+
+        if ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
+          # Credentials were present and smctl exited 0, yet no usable signature
+          # is on the file. This is the silent case worth blocking a release over.
+          if ($env:ALLOW_UNSIGNED -eq 'true') {
+            Write-Host "::warning::Signature enforcement overridden: publishing a $($sig.Status) $($env:LABEL) MSI because allow_unsigned_windows was set"
+            exit 0
+          }
+          Write-Host "::error::$($env:LABEL) MSI signature is $($sig.Status) even though signing credentials were present"
+          Write-Host "::error::Read the 'Sync KeyLocker certificate to the Windows store' step above for why. To ship this release anyway, re-run with allow_unsigned_windows enabled."
+          exit 1
+        }
+
+        # NotTrusted / UnknownError and friends: the signature may be fine and
+        # the runner's trust store or parser may not be. Loud, but not fatal.
+        Write-Host "::warning::$($env:LABEL) MSI signature status is $($sig.Status), expected Valid"

--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -446,96 +446,34 @@ jobs:
           }
         shell: powershell
 
-      - name: Check if DigiCert signing is available
-        id: check-secret
-        run: |
-          if [ -n "$CERT_HOST" ]; then
-            echo "can_sign=true" >> $GITHUB_OUTPUT
-          else
-            echo "can_sign=false" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-        env:
-          CERT_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+      # This job's workspace is a checkout of BossConsoleLite, not of this repo,
+      # so a bare ./.github/actions path would not exist. Fetched the same way
+      # and for the same reason as the notarization helper in build-macos:
+      # sparse and path-scoped so it cannot disturb the Lite workspace, and
+      # pinned to this workflow's own commit so the action and the step that
+      # calls it always match.
+      - name: 📥 Fetch the shared Windows signing action
+        uses: actions/checkout@v7
+        with:
+          path: .boss-ci
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
-      - name: Decode Client Certificate
-        if: steps.check-secret.outputs.can_sign == 'true'
-        run: |
-          $certBytes = [System.Convert]::FromBase64String("${{ secrets.CODE_SIGNING_CLIENT_CERT }}")
-          [System.IO.File]::WriteAllBytes("${{ runner.temp }}\Certificate_pkcs12.p12", $certBytes)
-        shell: powershell
-
-      - name: Install DigiCert STM Client Tools
-        if: steps.check-secret.outputs.can_sign == 'true'
-        uses: digicert/ssm-code-signing@v1.2.1
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      - name: Reset SMCTL Credentials
-        if: steps.check-secret.outputs.can_sign == 'true'
-        run: smctl credentials delete && smctl credentials save ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }} ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-
-      # certsync puts the certificate where signtool looks for it. Without it
-      # smctl prints FAILED and exits 0; see release.yml for the full note.
-      - name: Sync KeyLocker Certificate to the Windows Store
-        if: steps.check-secret.outputs.can_sign == 'true'
-        continue-on-error: true
-        run: |
-          rem smctl exits 0 whether a subcommand works or not, and cmd keeps going
-          rem after a failure, so all four run and the log carries every answer.
-          smctl healthcheck
-          smctl windows ksp list
-          smctl keypair ls
-          smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-
-      - name: Sign Windows MSI
-        if: steps.check-secret.outputs.can_sign == 'true'
-        run: smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"
-        shell: bash
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      - name: 🔏 Verify MSI Signature
-        shell: powershell
-        env:
-          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
-        run: |
-          $sig = Get-AuthenticodeSignature -FilePath "${{ steps.find-msi.outputs.msi-path }}"
-          Write-Host "Signature status: $($sig.Status)"
-          if ($sig.SignerCertificate) {
-            Write-Host "Signer: $($sig.SignerCertificate.Subject)"
-          }
-          if ($sig.Status -ne 'Valid') {
-            if ('${{ steps.check-secret.outputs.can_sign }}' -ne 'true') {
-              Write-Host "::warning::Windows MSI is UNSIGNED, status $($sig.Status) (no CODE_SIGNING_* secrets configured)"
-            } elseif ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
-              if ($env:ALLOW_UNSIGNED -eq 'true') {
-                Write-Host "::warning::Signature enforcement overridden: publishing a $($sig.Status) Windows MSI because allow_unsigned_windows was set"
-              } else {
-                Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
-                Write-Host "::error::To ship this release anyway, re-run with allow_unsigned_windows enabled."
-                exit 1
-              }
-            } else {
-              Write-Host "::warning::MSI signature status is $($sig.Status), expected Valid"
-            }
-          }
+      # Same action the two release.yml Windows jobs use. Signing happens before
+      # the rename below because an Authenticode signature covers the file's
+      # contents, not its name.
+      - name: 🔏 Sign and verify the Windows MSI
+        id: sign-msi
+        uses: ./.boss-ci/.github/actions/sign-windows-msi
+        with:
+          msi-path: ${{ steps.find-msi.outputs.msi-path }}
+          cert-host: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          api-key: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          client-cert: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
+          client-cert-password: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          keypair-alias: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+          allow-unsigned: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
+          label: BOSS Lite Windows
 
       - name: 📋 Rename MSI to Lite convention
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1113,7 +1113,7 @@ jobs:
     # What the signature actually came out as, so create-release can say so in
     # the release body rather than leaving it to whoever reads the run log.
     outputs:
-      msi-signature: ${{ steps.verify-signature.outputs.status }}
+      msi-signature: ${{ steps.sign-msi.outputs.status }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -1264,18 +1264,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Check if signing secret is available
-        id: check-secret
-        run: |
-          if [ -n "$CERT_HOST" ]; then
-            echo "can_sign=true" >> $GITHUB_OUTPUT
-          else
-            echo "can_sign=false" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-        env:
-          CERT_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-
       - name: Find MSI File
         id: find-msi
         run: |
@@ -1290,148 +1278,24 @@ jobs:
           }
         shell: powershell
 
-      - name: Decode Client Certificate
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        run: |
-          try {
-            $certContent = "${{ secrets.CODE_SIGNING_CLIENT_CERT }}"
-            $certBytes = [System.Convert]::FromBase64String($certContent)
-            $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
-            [System.IO.File]::WriteAllBytes($certPath, $certBytes)
-            Write-Host "Client cert decoded successfully to $certPath"
-          } catch {
-            Write-Host "Error decoding client cert: $_"
-            exit 1
-          }
-        shell: powershell
 
-      - name: Verify Client Cert File Exists
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        run: |
-          $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
-          if (Test-Path $certPath) {
-            Write-Host "[OK] Cert file exists at $certPath"
-            Write-Host "File size: $((Get-Item $certPath).Length) bytes"
-          } else {
-            Write-Host "[ERROR] Cert file MISSING at $certPath"
-            exit 1
-          }
-        shell: powershell
-
-      - name: Install DigiCert STM Client Tools
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        uses: digicert/ssm-code-signing@v1.2.1
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      - name: Reset SMCTL Credentials
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        run: |
-          smctl credentials delete
-          smctl credentials save ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }} ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      # The missing step, and the reason every MSI since the signing secrets landed
-      # on 2026-07-21 came out unsigned: `smctl sign` shells out to signtool, which
-      # looks for the certificate in the Windows certificate store, and nothing had
-      # ever put it there. DigiCert's own pipeline guidance is to run certsync as
-      # the first step of every signing job. Without it smctl prints
-      # "signCommand command for file <path> FAILED" and exits 0, so the release
-      # shipped an unsigned installer under a green build.
-      #
-      # healthcheck / ksp list / keypair ls come along because smctl gives no
-      # reason for a signing failure. If certsync is not the whole story, the next
-      # run says which of the credential, the KSP registration or the keypair alias
-      # is wrong, instead of costing another release to find out.
-      #
-      # continue-on-error: this step is diagnostics plus a precondition, and the
-      # authoritative verdict is "Verify MSI Signature" reading the file itself. A
-      # certsync failure should let the sign attempt proceed and be judged there.
-      - name: Sync KeyLocker Certificate to the Windows Store
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        continue-on-error: true
-        run: |
-          rem smctl exits 0 whether a subcommand works or not, and cmd keeps going
-          rem after a failure, so all four run and the log carries every answer.
-          smctl healthcheck
-          smctl windows ksp list
-          smctl keypair ls
-          smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-
-      - name: Sign Windows MSI with DigiCert KeyLocker
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' }}
-        run: |
-          echo "Signing MSI: ${{ steps.find-msi.outputs.msi-path }}"
-          echo "Using keypair: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}"
-          smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"
-        shell: bash
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      - name: Check SMKSP Log (for diagnostics)
-        if: always()  # Runs even if signing fails
-        run: |
-          $logPath = "$env:USERPROFILE\.signingmanager\logs\smksp.log"
-          if (Test-Path $logPath) {
-            Write-Host "SMKSP Log Contents:"
-            Get-Content $logPath -Tail 50  # Last 50 lines for recent errors
-          } else {
-            Write-Host "SMKSP log not found."
-          }
-        shell: powershell
-
-      - name: 🔏 Verify MSI Signature
-        id: verify-signature
-        shell: powershell
-        env:
-          # Fails closed: on a push-triggered release the inputs context is empty,
-          # so this is 'false' and the gate below stays a gate.
-          ALLOW_UNSIGNED: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
-        run: |
-          $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
-          $sig = Get-AuthenticodeSignature -FilePath $msiPath
-          Write-Host "Signature status: $($sig.Status)"
-          if ($sig.SignerCertificate) {
-            Write-Host "Signer: $($sig.SignerCertificate.Subject)"
-          }
-          echo "status=$($sig.Status)" >> $env:GITHUB_OUTPUT
-          if ($sig.Status -ne 'Valid') {
-            if ('${{ steps.check-secret.outputs.can_sign }}' -ne 'true') {
-              Write-Host "::warning::Windows MSI is UNSIGNED, status $($sig.Status) (no CODE_SIGNING_* secrets configured)"
-            } elseif ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
-              # Credentials were present and smctl exited 0, yet no usable
-              # signature is on the file. That is the silent case worth blocking.
-              if ($env:ALLOW_UNSIGNED -eq 'true') {
-                Write-Host "::warning::Signature enforcement overridden: publishing a $($sig.Status) Windows MSI because allow_unsigned_windows was set"
-              } else {
-                Write-Host "::error::MSI signature is $($sig.Status) even though signing credentials were present"
-                Write-Host "::error::Read the 'Sync KeyLocker Certificate to the Windows Store' step for why. To ship this release anyway, re-run the workflow with allow_unsigned_windows enabled."
-                exit 1
-              }
-            } else {
-              # NotTrusted / UnknownError and friends: the signature may be fine
-              # and the runner's trust store or parser may not be. Loud, not fatal.
-              Write-Host "::warning::MSI signature status is $($sig.Status), expected Valid"
-            }
-          }
+      # One action for all three Windows signing jobs. See
+      # .github/actions/sign-windows-msi/action.yml for why the verify step is the
+      # only check in it that means anything.
+      - name: 🔏 Sign and verify the Windows MSI
+        id: sign-msi
+        uses: ./.github/actions/sign-windows-msi
+        with:
+          msi-path: ${{ steps.find-msi.outputs.msi-path }}
+          cert-host: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          api-key: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          client-cert: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
+          client-cert-password: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          keypair-alias: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+          # Fails closed: a push-triggered release has no inputs context, so this
+          # is 'false' and the gate stays a gate.
+          allow-unsigned: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
+          label: Windows x64
 
       - name: 📊 Verify Build Artifacts
         run: |
@@ -1466,7 +1330,7 @@ jobs:
     runs-on: windows-11-arm
     continue-on-error: true  # Graceful failure if ARM runner unavailable
     outputs:
-      msi-signature: ${{ steps.verify-signature.outputs.status }}
+      msi-signature: ${{ steps.sign-msi.outputs.status }}
 
     steps:
       - name: 📥 Checkout Repository
@@ -1600,18 +1464,6 @@ jobs:
       # PowerShell, like every other step in this job: this one is not gated and
       # not continue-on-error, so a shell that fails to resolve here would cost
       # the release its ARM64 asset entirely.
-      - name: Check if signing secret is available (Windows ARM64)
-        id: check-secret
-        shell: powershell
-        env:
-          CERT_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-        run: |
-          if ($env:CERT_HOST) {
-            echo "can_sign=true" >> $env:GITHUB_OUTPUT
-          } else {
-            echo "can_sign=false" >> $env:GITHUB_OUTPUT
-          }
-
       - name: Find MSI File (Windows ARM64)
         id: find-msi
         shell: powershell
@@ -1628,136 +1480,25 @@ jobs:
             echo "msi-path=" >> $env:GITHUB_OUTPUT
           }
 
-      - name: Decode Client Certificate (Windows ARM64)
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
-        continue-on-error: true
-        shell: powershell
-        run: |
-          try {
-            $certBytes = [System.Convert]::FromBase64String("${{ secrets.CODE_SIGNING_CLIENT_CERT }}")
-            $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
-            [System.IO.File]::WriteAllBytes($certPath, $certBytes)
-            Write-Host "Client cert decoded successfully to $certPath"
-          } catch {
-            Write-Host "Error decoding client cert: $_"
-            exit 1
-          }
 
-      - name: Verify Client Cert File Exists (Windows ARM64)
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
-        continue-on-error: true
-        shell: powershell
-        run: |
-          $certPath = "${{ runner.temp }}\Certificate_pkcs12.p12"
-          if (Test-Path $certPath) {
-            Write-Host "[OK] Cert file exists at $certPath"
-            Write-Host "File size: $((Get-Item $certPath).Length) bytes"
-          } else {
-            Write-Host "[ERROR] Cert file MISSING at $certPath"
-            exit 1
-          }
-
-      # DigiCert's client tools are x64 binaries and signtool comes from the x86
-      # Windows Kits directory; both run under emulation on windows-11-arm. That
-      # path is unproven, so every signing step here is continue-on-error: if the
-      # tooling cannot run we still upload the MSI instead of dropping the ARM64
-      # asset from the release. "Verify MSI Signature" reports what actually
-      # landed, so an unsigned ARM64 MSI is loud rather than silent.
-      - name: Install DigiCert STM Client Tools (Windows ARM64)
-        id: install-digicert
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.find-msi.outputs.msi-path != '' }}
-        continue-on-error: true
-        uses: digicert/ssm-code-signing@v1.2.1
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      - name: Reset SMCTL Credentials (Windows ARM64)
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}
-        continue-on-error: true
-        run: |
-          smctl credentials delete
-          smctl credentials save ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }} ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      # Same certsync precondition as the x64 job above; see the comment there.
-      - name: Sync KeyLocker Certificate to the Windows Store (Windows ARM64)
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}
-        continue-on-error: true
-        run: |
-          rem smctl exits 0 whether a subcommand works or not, and cmd keeps going
-          rem after a failure, so all four run and the log carries every answer.
-          smctl healthcheck
-          smctl windows ksp list
-          smctl keypair ls
-          smctl windows certsync --keypair-alias="%KEYPAIR_ALIAS%"
-        shell: cmd
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-
-      - name: Sign Windows ARM64 MSI with DigiCert KeyLocker
-        if: ${{ steps.check-secret.outputs.can_sign == 'true' && steps.install-digicert.outcome == 'success' }}
-        continue-on-error: true
-        run: |
-          echo "Signing MSI: ${{ steps.find-msi.outputs.msi-path }}"
-          echo "Using keypair: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}"
-          smctl sign --keypair-alias "${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}" --input "${{ steps.find-msi.outputs.msi-path }}"
-        shell: bash
-        env:
-          SM_HOST: ${{ secrets.CODE_SIGNING_CERT_HOST }}
-          SM_API_KEY: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
-          SM_CLIENT_CERT_FILE: ${{ runner.temp }}\Certificate_pkcs12.p12
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-
-      - name: Check SMKSP Log (Windows ARM64 diagnostics)
-        if: ${{ always() && steps.check-secret.outputs.can_sign == 'true' }}  # Runs even if signing fails
-        shell: powershell
-        run: |
-          $logPath = "$env:USERPROFILE\.signingmanager\logs\smksp.log"
-          if (Test-Path $logPath) {
-            Write-Host "SMKSP Log Contents:"
-            Get-Content $logPath -Tail 50  # Last 50 lines for recent errors
-          } else {
-            Write-Host "SMKSP log not found."
-          }
-
-      # continue-on-error: GitHub prepends $ErrorActionPreference = 'stop' to
-      # powershell steps, so a throwing cmdlet here would abort the job before
-      # the upload and cost the release its ARM64 asset. Reporting must never do
-      # that in a job whose whole signing path is best effort.
-      - name: 🔏 Verify MSI Signature (Windows ARM64)
-        id: verify-signature
+      # One action for all three Windows signing jobs. See
+      # .github/actions/sign-windows-msi/action.yml for why the verify step is the
+      # only check in it that means anything.
+      - name: 🔏 Sign and verify the Windows MSI
+        id: sign-msi
         if: ${{ steps.find-msi.outputs.msi-path != '' }}
-        continue-on-error: true
-        shell: powershell
-        run: |
-          $msiPath = "${{ steps.find-msi.outputs.msi-path }}"
-          $sig = Get-AuthenticodeSignature -FilePath $msiPath
-          Write-Host "Signature status: $($sig.Status)"
-          echo "status=$($sig.Status)" >> $env:GITHUB_OUTPUT
-          if ($sig.SignerCertificate) {
-            Write-Host "Signer: $($sig.SignerCertificate.Subject)"
-          }
-          if ($sig.Status -ne 'Valid') {
-            Write-Host "::warning::Windows ARM64 MSI signature is $($sig.Status), expected Valid - DigiCert KeyLocker signing did not run or failed on the ARM runner"
-          }
-          # A warning annotation is easy to miss on a job that is green by
-          # design, so put the verdict in the run summary too. Explicit UTF-8
-          # without BOM: Windows PowerShell's >> writes UTF-16, which the
-          # summary renders as mojibake.
-          $line = "### Windows ARM64 MSI signature: $($sig.Status)`n"
-          [System.IO.File]::AppendAllText($env:GITHUB_STEP_SUMMARY, $line, (New-Object System.Text.UTF8Encoding($false)))
+        uses: ./.github/actions/sign-windows-msi
+        with:
+          msi-path: ${{ steps.find-msi.outputs.msi-path }}
+          cert-host: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          api-key: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          client-cert: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
+          client-cert-password: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          keypair-alias: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+          # Fails closed: a push-triggered release has no inputs context, so this
+          # is 'false' and the gate stays a gate.
+          allow-unsigned: ${{ inputs.allow_unsigned_windows == true || inputs.allow_unsigned_windows == 'true' }}
+          label: Windows ARM64
 
       - name: 📊 Verify Build Artifacts (Windows ARM64)
         shell: powershell

--- a/.github/workflows/sign-action-smoke.yml
+++ b/.github/workflows/sign-action-smoke.yml
@@ -1,0 +1,103 @@
+name: 🔏 Windows Signing Smoke Test
+
+# Exercises .github/actions/sign-windows-msi end to end against a throwaway
+# binary, in about two minutes and without building or releasing anything.
+#
+# It exists because the signing chain failed silently for a month. `smctl sign`
+# exits 0 whether it signed or not, so the only way to know the chain works is to
+# read the signature off a file afterwards - and until now the only place that
+# happened was a real release, which needs the `release` environment and is
+# restricted to main. That made every change to the signing chain unverifiable
+# before merge, which is how a missing certsync survived from 2026-07-21 to 9.4.24.
+#
+# Deliberately NOT triggered on every pull request: each run consumes one
+# signature from the KeyLocker allocation. Path-filtered to the action itself,
+# plus manual dispatch.
+on:
+  pull_request:
+    paths:
+      - '.github/actions/sign-windows-msi/**'
+      - '.github/workflows/sign-action-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sign-a-throwaway-binary:
+    runs-on: windows-latest
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v7
+
+      # Compile our own trivial PE rather than copying a system binary, so the
+      # thing being signed is unambiguously ours and starts out unsigned - which
+      # is what makes the signer assertion below meaningful.
+      - name: 🔨 Build a throwaway binary to sign
+        id: target
+        shell: powershell
+        run: |
+          $csc = "$env:SystemRoot\Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+          if (-not (Test-Path $csc)) {
+            Write-Host "::error::csc.exe not found at $csc - cannot build a test binary"
+            exit 1
+          }
+          $src = "$env:RUNNER_TEMP\SmokeTarget.cs"
+          $out = "$env:RUNNER_TEMP\SmokeTarget.exe"
+          Set-Content -Path $src -Value 'class P { static void Main() { System.Console.WriteLine("smoke"); } }'
+          & $csc /nologo /out:$out $src
+          if (-not (Test-Path $out)) {
+            Write-Host "::error::compilation produced no binary"
+            exit 1
+          }
+
+          # Must start unsigned, or a passing test would prove nothing.
+          $before = (Get-AuthenticodeSignature -FilePath $out).Status
+          Write-Host "Built $out, signature before signing: $before"
+          if ($before -ne 'NotSigned') {
+            Write-Host "::error::test binary is already signed ($before) - the assertion below would be vacuous"
+            exit 1
+          }
+          echo "path=$out" >> $env:GITHUB_OUTPUT
+
+      - name: 🔏 Sign it through the shared action
+        id: sign
+        uses: ./.github/actions/sign-windows-msi
+        with:
+          msi-path: ${{ steps.target.outputs.path }}
+          cert-host: ${{ secrets.CODE_SIGNING_CERT_HOST }}
+          api-key: ${{ secrets.CODE_SIGNING_CERT_HOST_API_KEY }}
+          client-cert: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
+          client-cert-password: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          keypair-alias: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+          label: smoke test
+
+      # The action's own verify step already fails on NotSigned. This asserts the
+      # two things it cannot: that the status reached the caller as an output, and
+      # that OUR certificate did the signing rather than something pre-existing.
+      - name: ✅ Assert the action signed it with our certificate
+        shell: powershell
+        env:
+          REPORTED: ${{ steps.sign.outputs.status }}
+          TARGET: ${{ steps.target.outputs.path }}
+        run: |
+          Write-Host "Action reported status: '$env:REPORTED'"
+          if ($env:REPORTED -ne 'Valid') {
+            Write-Host "::error::action output status was '$env:REPORTED', expected Valid"
+            exit 1
+          }
+
+          $sig = Get-AuthenticodeSignature -FilePath $env:TARGET
+          $subject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { '<none>' }
+          Write-Host "On-disk status: $($sig.Status)"
+          Write-Host "Signer: $subject"
+
+          if ($sig.Status -ne 'Valid') {
+            Write-Host "::error::on-disk signature is $($sig.Status) despite the action reporting Valid"
+            exit 1
+          }
+          if ($subject -notmatch 'Risa Labs') {
+            Write-Host "::error::signed by '$subject', which is not our certificate"
+            exit 1
+          }
+          Write-Host "Signing chain verified end to end."


### PR DESCRIPTION
Closes the follow-up #224's review asked for and #230 deferred: three near-identical copies of the DigiCert signing chain, collapsed into one composite action. Plus a smoke test, because building this surfaced that the signing chain has never been verifiable before merge.

## Why now

The copies had already drifted. `release-lite.yml`'s credential reset passed one `SM_*` variable where the other two passed four; the arm64 copy had lost the cert-file diagnostic the x64 copy kept. Every fix during the August signing incident had to be written three times - including the `certsync` step that finally made signing work.

`.github/actions/sign-windows-msi` now owns: check credentials, decode cert, verify cert file, install client tools, reset credentials, certsync + diagnostics, sign, SMKSP log, verify signature. It outputs the Authenticode `status`, so both `release.yml` jobs keep publishing it as a job output and the release-body "not signed" notice keeps working unchanged.

Each job keeps its **own** `Find MSI File` step - the three use different globs and Lite renames the file afterwards, so that part genuinely differs.

## Two deliberate behaviour changes

**1. The ARM64 job loses its per-step `continue-on-error`.** That hedging existed because DigiCert's x64 tooling running under emulation on `windows-11-arm` was unproven. It is proven now: runs [32533729115](https://github.com/risa-labs-inc/BossConsole/actions/runs/32533729115) and [32550172641](https://github.com/risa-labs-inc/BossConsole/actions/runs/32550172641) both signed the arm64 MSI to `Valid`. Composite actions don't support `continue-on-error` on steps anyway, so keeping the hedge meant keeping the duplication.

The **job-level** `continue-on-error: true` stays, since the ARM runner can still be unavailable. Consequence worth stating plainly: if arm64 signing breaks now, the release loses the arm64 asset rather than shipping it unsigned. That is the right way round, and `allow_unsigned_windows` is still the escape hatch.

**2. Credentials move from command lines into `env`.** `smctl credentials save` used to interpolate the API key and password straight into a `cmd` line, where a value containing `&`, `^`, `|` or a space would be mis-parsed and fail looking exactly like a KeyLocker outage. #224's review flagged this; it was awkward to fix in three places and trivial in one.

## The smoke test, and why it is in this PR

Validating this refactor turned out to be impossible by the obvious route. Dispatching the release workflow from this branch is rejected before any job starts:

```
Branch "refactor/sign-windows-msi-composite" is not allowed to deploy to release
due to environment protection rules.
```

`prepare-version` declares `environment: release`, which is restricted to `main`. So the only place a signature had ever been read off an artifact was a published release - which is the structural reason a missing `certsync` survived from 2026-07-21 through 9.4.24 without anyone noticing.

`.github/workflows/sign-action-smoke.yml` closes that. It runs the action against a throwaway binary on `pull_request`, in about two minutes, with no build and nothing published. Two design points carry the value:

- **It compiles its own trivial PE with `csc` and asserts the file is `NotSigned` first.** Signing a copy of an already-signed system binary would let the test pass by reading somebody else's signature.
- **It asserts the `status` reached the caller as an action output *and* that the signer subject is ours.** Status alone would not catch signing with the wrong certificate, and the output check is the only coverage of the wire this PR's job outputs and the release-body notice depend on.

Path-filtered to the action and to itself rather than running on every pull request, because each run consumes one signature from the KeyLocker allocation.

## Verification

**The smoke test passed on this PR** ([run 32557569134](https://github.com/risa-labs-inc/BossConsole/actions/runs/32557569134)):

```
signature before signing: NotSigned
signCommand command for file SmokeTarget.exe was SUCCESSFUL
Signature status: Valid
Signer: CN="Risa Labs, Inc.", O="Risa Labs, Inc.", L=Palo Alto, S=California, C=US, ...
Signing chain verified end to end.
```

Every step of the composite ran: credentials check, cert decode, tool install, credential reset, certsync, sign, SMKSP log, verify.

Static checks:

- All four files parse; `build-windows` and `build-windows-arm64` go from 22 steps to 14 each, Lite's from 18 to 13.
- Zero remaining references to `smctl`, `digicert/ssm-code-signing`, `check-secret`, `verify-signature` or `install-digicert` in either workflow.
- Job outputs re-pointed to `steps.sign-msi.outputs.status`; ARM64's guard on a non-empty MSI path preserved, as is its non-fatal MSI lookup.
- No `continue-on-error` key inside the action - the single grep hit is the comment explaining its absence.

**What the smoke test does not cover:** it signs a PE, not an MSI, so MSI-specific behaviour is still only exercised by a real release. That is acceptable now that a release reads the signature off the artifact and fails on `NotSigned`, so it cannot regress silently the way it did before.

## Details worth a reviewer's eye

- **`certsync` stays non-fatal via `exit /b 0`** rather than a workflow key. Composites can't express `continue-on-error`, and putting the intent in the script arguably reads better: the step is a precondition plus diagnostics, and the verify step reading the file is the only authoritative verdict.
- **Lite needs an extra checkout.** Its workspace is a `BossConsoleLite` checkout, so a bare `./.github/actions` path would not exist - I hit this while writing it. It now sparse-checks-out this repo's actions directory into `.boss-ci`, the same way and for the same reason `build-macos` already fetches the shared notarization helper (`release-lite.yml:338`).
- **The action documents the two DigiCert facts that caused the incident** at the top: `smctl sign` exits 0 whether it signed or not, and it resolves the certificate from the Windows store so certsync must run first. Those are the two things a future editor most needs to know before touching this.