### PR TITLE
Pre-warm the browser engine on the launch that is about to use it

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
@@ -115,7 +115,12 @@ suspend fun applyWorkspace(
     // whole cold Chromium boot inside the tab, because the startup pre-warm's gate is "has this
     // machine ever used the browser" and a first install has not.
     if (needsBrowserEngine(requiredTabTypes)) {
-        warmEngine()
+        // On IO, and for the same reason the resolve() above is: every applyWorkspace call site is
+        // a Compose scope, i.e. Main, and the gate this reaches stats the engine directories and
+        // reads two version.txt files before it spawns anything. Milliseconds, but milliseconds on
+        // the UI thread on every window creation and every workspace switch. Still ahead of the
+        // wait below, which is the ordering the whole hook is for.
+        withContext(Dispatchers.IO) { warmEngine() }
     }
 
     splitViewState.tabRegistry.awaitTabTypes(requiredTabTypes)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
@@ -104,7 +104,17 @@ suspend fun applyWorkspace(
     // at startup the workspace flow emits before the dynamic plugins that own
     // browser/terminal/editor have registered their factories, and addTab
     // drops any tab whose type has no factory yet.
-    splitViewState.tabRegistry.awaitTabTypes(collectRequiredTabTypeIds(workspace.layout))
+    val requiredTabTypes = collectRequiredTabTypeIds(workspace.layout)
+
+    // Ahead of the wait, not after it: this layout is about to build a browser tab, and the wait
+    // below is dead time the engine boot can have for free. Without it a first install pays the
+    // whole cold Chromium boot inside the tab, because the startup pre-warm's gate is "has this
+    // machine ever used the browser" and a first install has not.
+    if (needsBrowserEngine(requiredTabTypes)) {
+        warmBrowserEngineForTabs()
+    }
+
+    splitViewState.tabRegistry.awaitTabTypes(requiredTabTypes)
 
     splitViewState.clearAllPanels()
 
@@ -143,6 +153,23 @@ private suspend fun TabRegistry.awaitTabTypes(typeIds: Set<TabTypeId>) {
         )
     }
 }
+
+/**
+ * Whether applying a layout with these tab types means booting the browser engine.
+ *
+ * Its own function so the predicate is testable, and named for the consequence rather than for the
+ * id it looks for: the browser tab type is the only thing in a workspace that costs a Chromium
+ * process tree.
+ */
+internal fun needsBrowserEngine(typeIds: Set<TabTypeId>): Boolean = FluckTabType.typeId in typeIds
+
+/**
+ * Start the browser engine boot in the background, if this platform has one.
+ *
+ * expect/actual only because [applyWorkspace] is commonMain and the engine is a desktop concern -
+ * the same seam `createBrowser()` in `Fluck.kt` uses.
+ */
+internal expect fun warmBrowserEngineForTabs()
 
 /** Collect the tab type IDs a workspace layout needs, ignoring unsupported/legacy entries. */
 private fun collectRequiredTabTypeIds(node: SplitConfig): Set<TabTypeId> =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
@@ -41,12 +41,16 @@ private val logger = BossLogger.forComponent("WorkspaceApplier")
  * @param restoreProject Whether to restore the project from the workspace. Set to false when
  *                       applying workspace due to project selection change (to avoid overwriting
  *                       the user's project selection).
+ * @param warmEngine Starts the browser engine boot. A parameter only so a test can observe that it
+ *                   is asked BEFORE the tab-type wait rather than after - move those lines below
+ *                   the wait and the whole benefit evaporates with every test still green.
  */
 suspend fun applyWorkspace(
     workspace: LayoutWorkspace,
     splitViewState: SplitViewState,
     windowProjectState: WindowProjectState? = null,
     restoreProject: Boolean = true,
+    warmEngine: () -> Unit = ::warmBrowserEngineForTabs,
 ) {
     // Generate ID if missing
     val workspaceId = workspace.id.ifEmpty { LayoutWorkspace.generateId() }
@@ -111,7 +115,7 @@ suspend fun applyWorkspace(
     // whole cold Chromium boot inside the tab, because the startup pre-warm's gate is "has this
     // machine ever used the browser" and a first install has not.
     if (needsBrowserEngine(requiredTabTypes)) {
-        warmBrowserEngineForTabs()
+        warmEngine()
     }
 
     splitViewState.tabRegistry.awaitTabTypes(requiredTabTypes)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmup.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmup.desktop.kt
@@ -1,0 +1,32 @@
+package ai.rever.boss.components.workspaces
+
+import ai.rever.boss.plugin.browser.FluckEngine
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+
+private val warmupLogger = BossLogger.forComponent("BrowserEngineWarmup")
+
+/**
+ * Forced, because the caller has better information than the default gate does: a layout carrying
+ * a browser tab is about to build one. The gate asks whether this machine has ever used the
+ * browser, which on a first install is no - so the head start was skipped exactly where the boot
+ * is most expensive and least expected.
+ *
+ * Contained rather than propagated. A pre-warm is an optimisation nobody asked for out loud, and
+ * failing to start one must not stop a workspace from being applied; the tab boots the engine
+ * itself and reports its own failure through the normal path.
+ */
+internal actual fun warmBrowserEngineForTabs() {
+    // runCatching, matching main.kt's two pre-warm call sites: only starting the boot thread
+    // happens here, so there is nothing cancellable to swallow, and the failure worth surviving
+    // is whatever the engine's own lazy init raises (an Error from a broken Chromium bundle
+    // included) rather than any one exception type.
+    runCatching { FluckEngine.prewarmInBackground(force = true) }
+        .onFailure {
+            warmupLogger.warn(
+                LogCategory.BROWSER,
+                "Browser engine pre-warm for a restored browser tab failed to start",
+                error = it,
+            )
+        }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmup.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmup.desktop.kt
@@ -6,22 +6,37 @@ import ai.rever.boss.utils.logging.LogCategory
 
 private val warmupLogger = BossLogger.forComponent("BrowserEngineWarmup")
 
+internal actual fun warmBrowserEngineForTabs() = warmBrowserEngine(FluckEngine::prewarmInBackground)
+
 /**
- * Forced, because the caller has better information than the default gate does: a layout carrying
- * a browser tab is about to build one. The gate asks whether this machine has ever used the
- * browser, which on a first install is no - so the head start was skipped exactly where the boot
- * is most expensive and least expected.
+ * Ask [prewarm] to start the engine boot, forced.
+ *
+ * Forced because the caller has better information than the default gate does: a layout carrying a
+ * browser tab is about to build one. The gate asks whether this machine has ever used the browser,
+ * which on a first install is no - so the head start was skipped exactly where the boot is most
+ * expensive and least expected.
+ *
+ * **The side effect is real and accepted.** A forced boot creates the browser profile directory,
+ * which is the very thing the unforced gate keys on - so a restored layout with a *background*
+ * browser tab the user never selects still satisfies that gate from then on. That is the intended
+ * trade: a layout with a browser tab is a browser user, and selecting the tab would boot the engine
+ * anyway. It is called out because the argument for not defaulting `force` on leans on this same
+ * side effect, and the next reader should see that it was weighed rather than missed.
  *
  * Contained rather than propagated. A pre-warm is an optimisation nobody asked for out loud, and
  * failing to start one must not stop a workspace from being applied; the tab boots the engine
  * itself and reports its own failure through the normal path.
+ *
+ * [prewarm] is a parameter for one reason: `force = true` IS the fix, and a silent regression to
+ * the default would leave every test green while the feature was gone - the same failure class as
+ * the bug being fixed, a call site that looks right and does nothing.
  */
-internal actual fun warmBrowserEngineForTabs() {
-    // runCatching, matching main.kt's two pre-warm call sites: only starting the boot thread
-    // happens here, so there is nothing cancellable to swallow, and the failure worth surviving
-    // is whatever the engine's own lazy init raises (an Error from a broken Chromium bundle
-    // included) rather than any one exception type.
-    runCatching { FluckEngine.prewarmInBackground(force = true) }
+internal fun warmBrowserEngine(prewarm: (Boolean) -> Unit) {
+    // runCatching, matching main.kt's pre-warm call site: only starting the boot thread happens
+    // here, so there is nothing cancellable to swallow, and the failure worth surviving is whatever
+    // the engine's own lazy init raises (an Error from a broken Chromium bundle included) rather
+    // than any one exception type.
+    runCatching { prewarm(true) }
         .onFailure {
             warmupLogger.warn(
                 LogCategory.BROWSER,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -960,9 +960,15 @@ fun main(args: Array<String>) {
                                 // The pre-warm was skipped at startup because the engine
                                 // was missing; now that it is installed, warm it so the
                                 // first tab does not pay the full boot.
+                                //
+                                // force, because it was skipped for a SECOND reason this
+                                // comment did not know about: the unforced gate wants an
+                                // existing browser profile, and a machine that has just
+                                // downloaded its engine has never had one. So this call
+                                // silently did nothing, on the one launch it was written for.
                                 runCatching {
                                     ai.rever.boss.plugin.browser.FluckEngine
-                                        .prewarmInBackground()
+                                        .prewarmInBackground(force = true)
                                 }
                                 isDownloadingChromium = false
                             }
@@ -1001,12 +1007,13 @@ fun main(args: Array<String>) {
                                             downloadProgress = progress
                                             if (progress.isComplete) {
                                                 WindowManager.createNewWindow()
-                                                // The pre-warm was skipped at startup because the engine
-                                                // was missing; now that it is installed, warm it so the
-                                                // first tab does not pay the full boot.
+                                                // Forced for the same reason as the first-attempt
+                                                // path above: a freshly downloaded engine has no
+                                                // browser profile yet, which the unforced gate reads
+                                                // as "this machine does not use the browser".
                                                 runCatching {
                                                     ai.rever.boss.plugin.browser.FluckEngine
-                                                        .prewarmInBackground()
+                                                        .prewarmInBackground(force = true)
                                                 }
                                                 isDownloadingChromium = false
                                             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -693,17 +693,17 @@ fun main(args: Array<String>) {
     // Skipped when the engine needs downloading: pre-warming against a mismatched
     // directory cannot succeed, and its only effect is to raise the very error
     // the download is about to fix.
-    // Gated on hasUsableEngine, not on !chromiumNeedsDownload: in the
-    // BootAndReport case there is no usable engine AND no download, so the latter
-    // would fire a guaranteed-futile boot that burns an attempt and sets an error
-    // — exactly what the comment above says pre-warming must not do.
-    if (hasUsableEngine) {
-        try {
-            ai.rever.boss.plugin.browser.FluckEngine
-                .prewarmInBackground()
-        } catch (e: Exception) {
-            logger.warn(LogCategory.SYSTEM, "Browser engine pre-warm failed to start", error = e)
-        }
+    // The "is there a usable engine" precondition is no longer applied here. It used to be, for
+    // the BootAndReport case - no usable engine AND no download, where a boot could only burn an
+    // attempt and set an error - and that reasoning still holds; it just belongs in the one gate
+    // every caller passes through. prewarmDecision re-evaluates it, freshly rather than from this
+    // startup-time snapshot, and logs which reason refused the call. Two copies of a precondition
+    // are two things that can disagree.
+    try {
+        ai.rever.boss.plugin.browser.FluckEngine
+            .prewarmInBackground()
+    } catch (e: Exception) {
+        logger.warn(LogCategory.SYSTEM, "Browser engine pre-warm failed to start", error = e)
     }
 
     // Parse CLI arguments if provided

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1045,28 +1045,42 @@ object FluckEngine {
      * the gate only decides whether the head start happens, never correctness.
      */
     fun prewarmInBackground(force: Boolean = false) {
-        val profileDir = BossDirectories.resolve(BrowserSettings.currentProfile)
-        if (!shouldPrewarm(
+        val decision =
+            prewarmDecision(
                 prewarmDisabled = configIsFalse(ChromiumFlagKeys.PREWARM),
-                profileExists = profileDir.exists(),
                 force = force,
+                engineUsable = { hasUsableEngine(cacheIsHealthy()) },
+                profileExists = { BossDirectories.resolve(BrowserSettings.currentProfile).exists() },
             )
-        ) {
-            if (!force) {
-                logger.debug(LogCategory.BROWSER, "Skipping engine pre-warm - no browser profile on this machine yet")
-            }
+        if (decision != PrewarmDecision.RUN) {
+            // The reason, not a guess at it. One shared exit used to log "no browser profile on
+            // this machine yet" for an opt-out that had nothing to do with the profile, and logged
+            // nothing at all for the most surprising outcome of the three - a caller that knew a
+            // tab was coming, overruled.
+            logger.debug(LogCategory.BROWSER, "Skipping engine pre-warm - ${decision.reason}")
             return
         }
-        // One boot thread per process. The getter is synchronized, so a second thread would only
+        // One boot thread at a time. The getter is synchronized, so a second thread would only
         // block on engineLock for the whole first boot and then log a "pre-warmed" line for work
-        // it did not do - and now that two call sites can ask (startup, and a browser tab on its
-        // way), that stopped being hypothetical.
-        if (!prewarmStarted.compareAndSet(false, true)) {
+        // it did not do - and now that several call sites can ask (startup, a completed download, a
+        // workspace carrying a browser tab), that stopped being hypothetical.
+        //
+        // Released in the `finally` below, so the flag means what its name and its log line claim:
+        // a boot thread is RUNNING. Held for the process lifetime instead, an engine recycle
+        // (which drops _engine and is exactly when a head start is worth something again) would
+        // leave every later caller refused for good.
+        if (!claimPrewarmSlot()) {
             logger.debug(LogCategory.BROWSER, "Engine pre-warm already under way")
             return
         }
         Thread({
             try {
+                // A live engine needs no head start, and saying it was pre-warmed here would be
+                // this method claiming credit for a boot somebody else paid for.
+                if (isEngineHealthy() && _engine != null) {
+                    logger.debug(LogCategory.BROWSER, "Engine pre-warm skipped - engine already running")
+                    return@Thread
+                }
                 val startNs = System.nanoTime()
                 engine
                 logger.info(
@@ -1096,31 +1110,70 @@ object FluckEngine {
                     )
                 }
                 clearInitStateIfErrorIs(e)
-                // Re-arm: this attempt bought nothing, and the next caller with a reason to ask
-                // (an engine download that has just finished) should not be refused because of it.
-                prewarmStarted.set(false)
+            } finally {
+                // Covers all three exits - booted, skipped as already running, failed. A failed
+                // attempt bought nothing and must not refuse the next caller with a reason to ask
+                // (a download that has just finished); a successful one leaves an engine the
+                // `already running` check above answers for.
+                releasePrewarmSlot()
             }
         }, "fluck-engine-prewarm").apply { isDaemon = true }.start()
     }
 
+    /** Whether a pre-warm runs, and if not, the reason a reader of the log needs. */
+    internal enum class PrewarmDecision(
+        val reason: String,
+    ) {
+        RUN("nothing in the way"),
+
+        /** BOSS_BROWSER_PREWARM=false. Outranks `force`. */
+        OPTED_OUT("BOSS_BROWSER_PREWARM opts out"),
+
+        /** No engine directory passes the version check, so a boot could only fail. */
+        NO_USABLE_ENGINE("no usable browser engine to warm"),
+
+        /** This machine has never opened a browser and nobody said one is coming. */
+        NEVER_USED_BROWSER("no browser profile on this machine yet"),
+    }
+
     /**
-     * Whether a pre-warm should run. Pure, so both branches of every input are testable without an
-     * engine, a profile directory or a machine that has never opened a browser.
+     * Whether a pre-warm should run, and why not when it should not.
      *
-     * The opt-out outranks [force]: BOSS_BROWSER_PREWARM=false is the user saying no Chromium boot
-     * they did not ask for, and a caller knowing a tab is coming does not overrule that - the tab
-     * will boot the engine itself when it gets there.
+     * Pure given its suppliers, so every branch is testable without an engine, a profile directory
+     * or a machine that has never opened a browser - and the suppliers are lazy so a decision the
+     * cheap checks already settled costs no filesystem work.
+     *
+     * Order is the whole content of this function:
+     *
+     * - **The opt-out outranks [force].** BOSS_BROWSER_PREWARM=false is the user saying no Chromium
+     *   boot they did not ask for; a caller knowing a tab is coming does not overrule that, and the
+     *   tab boots the engine itself when it gets there.
+     * - **A usable engine outranks [force] too**, and this is not a nicety. Without an engine the
+     *   boot walks straight into `getChromiumDir()` throwing, which logs an error and burns an
+     *   attempt for nothing. `applyWorkspace` runs on every window and every workspace switch, so
+     *   a forced call with no gate would repeat that indefinitely on an engine-less machine - and,
+     *   worse, could hold the boot slot at the moment a completed download wants it.
+     * - **[force] then outranks the profile check**, which is the change this whole gate is about.
      */
-    internal fun shouldPrewarm(
+    internal fun prewarmDecision(
         prewarmDisabled: Boolean,
-        profileExists: Boolean,
         force: Boolean,
-    ): Boolean =
+        engineUsable: () -> Boolean,
+        profileExists: () -> Boolean,
+    ): PrewarmDecision =
         when {
-            prewarmDisabled -> false
-            force -> true
-            else -> profileExists
+            prewarmDisabled -> PrewarmDecision.OPTED_OUT
+            !engineUsable() -> PrewarmDecision.NO_USABLE_ENGINE
+            force -> PrewarmDecision.RUN
+            profileExists() -> PrewarmDecision.RUN
+            else -> PrewarmDecision.NEVER_USED_BROWSER
         }
+
+    /** Claim the single pre-warm boot slot. False when a boot thread is already running. */
+    internal fun claimPrewarmSlot(): Boolean = prewarmStarted.compareAndSet(false, true)
+
+    /** Release the boot slot. See [prewarmInBackground] for why this is not one-way. */
+    internal fun releasePrewarmSlot() = prewarmStarted.set(false)
 
     /**
      * Clear the recorded init state ONLY if [expected] is still the recorded

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -1028,7 +1028,9 @@ object FluckEngine {
      * default: it creates the profile directory as a side effect, which would flip the unforced
      * gate on permanently and pre-warm every later launch for a user who never opens a browser.
      *
-     * Called once from app startup after [proactiveCleanupOnStartup]. A pre-warm
+     * Four callers now, which is the entire premise of the [prewarmStarted] slot below: app
+     * startup, either of the two engine-download completions, and a workspace about to apply a
+     * layout that carries a browser tab. A pre-warm
      * failure must not poison user-facing availability (the user never asked for
      * this boot), so it clears the recorded init error — the first real use
      * re-attempts initialization and surfaces its own error through the normal
@@ -1049,15 +1051,20 @@ object FluckEngine {
             prewarmDecision(
                 prewarmDisabled = configIsFalse(ChromiumFlagKeys.PREWARM),
                 force = force,
+                engineRunning = { _engine != null && isEngineHealthy() },
                 engineUsable = { hasUsableEngine(cacheIsHealthy()) },
                 profileExists = { BossDirectories.resolve(BrowserSettings.currentProfile).exists() },
             )
         if (decision != PrewarmDecision.RUN) {
-            // The reason, not a guess at it. One shared exit used to log "no browser profile on
-            // this machine yet" for an opt-out that had nothing to do with the profile, and logged
-            // nothing at all for the most surprising outcome of the three - a caller that knew a
-            // tab was coming, overruled.
-            logger.debug(LogCategory.BROWSER, "Skipping engine pre-warm - ${decision.reason}")
+            // The reason, not a guess at it, and as a field rather than interpolated into the
+            // message. One shared exit used to log "no browser profile on this machine yet" for an
+            // opt-out that had nothing to do with the profile, and logged nothing at all for the
+            // most surprising outcome - a caller that knew a tab was coming, overruled.
+            logger.debug(
+                LogCategory.BROWSER,
+                "Skipping engine pre-warm",
+                mapOf("reason" to decision.name, "forced" to force),
+            )
             return
         }
         // One boot thread at a time. The getter is synchronized, so a second thread would only
@@ -1073,67 +1080,94 @@ object FluckEngine {
             logger.debug(LogCategory.BROWSER, "Engine pre-warm already under way")
             return
         }
-        Thread({
-            try {
-                // A live engine needs no head start, and saying it was pre-warmed here would be
-                // this method claiming credit for a boot somebody else paid for.
-                if (isEngineHealthy() && _engine != null) {
-                    logger.debug(LogCategory.BROWSER, "Engine pre-warm skipped - engine already running")
-                    return@Thread
-                }
-                val startNs = System.nanoTime()
-                engine
-                logger.info(
-                    LogCategory.BROWSER,
-                    "Browser engine pre-warmed",
-                    mapOf(
-                        "durationMs" to (System.nanoTime() - startNs) / 1_000_000,
-                    ),
-                )
-            } catch (e: Throwable) {
-                // Errors (UnsatisfiedLinkError from a broken Chromium bundle, OOM)
-                // deserve visibility; plain Exceptions (transient network/license)
-                // are routine and stay at debug.
-                if (e is Error) {
-                    logger.warn(
-                        LogCategory.BROWSER,
-                        "Engine pre-warm failed with a serious error (lazy init will retry on first use)",
-                        error = e,
-                    )
-                } else {
-                    logger.debug(
-                        LogCategory.BROWSER,
-                        "Engine pre-warm failed (lazy init will retry on first use)",
-                        mapOf(
-                            "error" to (e.message ?: "unknown"),
-                        ),
-                    )
-                }
-                clearInitStateIfErrorIs(e)
-            } finally {
-                // Covers all three exits - booted, skipped as already running, failed. A failed
-                // attempt bought nothing and must not refuse the next caller with a reason to ask
-                // (a download that has just finished); a successful one leaves an engine the
-                // `already running` check above answers for.
-                releasePrewarmSlot()
-            }
-        }, "fluck-engine-prewarm").apply { isDaemon = true }.start()
+        startPrewarmThread()
     }
 
-    /** Whether a pre-warm runs, and if not, the reason a reader of the log needs. */
-    internal enum class PrewarmDecision(
-        val reason: String,
-    ) {
-        RUN("nothing in the way"),
+    /**
+     * Spawn the boot thread that holds the claimed slot.
+     *
+     * Separate from [prewarmInBackground] so the decision and the boot each read as one thing, and
+     * so the slot's two release paths sit next to each other.
+     */
+    private fun startPrewarmThread() {
+        val thread = Thread(::runPrewarmBoot, "fluck-engine-prewarm").apply { isDaemon = true }
+        // The slot's only other release lives inside the thread body, so a start that throws (OOM,
+        // a thread limit) would strand it claimed for the process - no pre-warm ever again,
+        // including the just-finished-download one. The same failure the release-in-finally exists
+        // to prevent, reached through a different door.
+        runCatching { thread.start() }.onFailure {
+            releasePrewarmSlot()
+            throw it
+        }
+    }
 
-        /** BOSS_BROWSER_PREWARM=false. Outranks `force`. */
-        OPTED_OUT("BOSS_BROWSER_PREWARM opts out"),
+    /** The boot itself, on the pre-warm thread, holding the slot for its lifetime. */
+    private fun runPrewarmBoot() {
+        try {
+            // A live engine needs no head start, and saying it was pre-warmed here would be this
+            // method claiming credit for a boot somebody else paid for. The decision above answers
+            // this too, from the caller's thread; this is the backstop for the window between the
+            // slot claim and here.
+            if (isEngineHealthy() && _engine != null) {
+                logger.debug(LogCategory.BROWSER, "Engine pre-warm skipped - engine already running")
+                return
+            }
+            val startNs = System.nanoTime()
+            engine
+            logger.info(
+                LogCategory.BROWSER,
+                "Browser engine pre-warmed",
+                mapOf(
+                    "durationMs" to (System.nanoTime() - startNs) / 1_000_000,
+                ),
+            )
+        } catch (e: Throwable) {
+            // Errors (UnsatisfiedLinkError from a broken Chromium bundle, OOM)
+            // deserve visibility; plain Exceptions (transient network/license)
+            // are routine and stay at debug.
+            if (e is Error) {
+                logger.warn(
+                    LogCategory.BROWSER,
+                    "Engine pre-warm failed with a serious error (lazy init will retry on first use)",
+                    error = e,
+                )
+            } else {
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Engine pre-warm failed (lazy init will retry on first use)",
+                    mapOf(
+                        "error" to (e.message ?: "unknown"),
+                    ),
+                )
+            }
+            clearInitStateIfErrorIs(e)
+        } finally {
+            // Covers all three exits - booted, skipped as already running, failed. A failed
+            // attempt bought nothing and must not refuse the next caller with a reason to ask
+            // (a download that has just finished); a successful one leaves an engine the
+            // `already running` check answers for.
+            releasePrewarmSlot()
+        }
+    }
+
+    /**
+     * Whether a pre-warm runs, and if not, the reason. Logged by name as a structured field, so a
+     * "why was my first browser tab slow" report can be grepped for the answer.
+     */
+    internal enum class PrewarmDecision {
+        RUN,
+
+        /** BOSS_BROWSER_PREWARM=false. Outranks everything, including `force`. */
+        OPTED_OUT,
+
+        /** An engine is already up; there is no head start left to give. */
+        ALREADY_RUNNING,
 
         /** No engine directory passes the version check, so a boot could only fail. */
-        NO_USABLE_ENGINE("no usable browser engine to warm"),
+        NO_USABLE_ENGINE,
 
         /** This machine has never opened a browser and nobody said one is coming. */
-        NEVER_USED_BROWSER("no browser profile on this machine yet"),
+        NEVER_USED_BROWSER,
     }
 
     /**
@@ -1148,6 +1182,12 @@ object FluckEngine {
      * - **The opt-out outranks [force].** BOSS_BROWSER_PREWARM=false is the user saying no Chromium
      *   boot they did not ask for; a caller knowing a tab is coming does not overrule that, and the
      *   tab boots the engine itself when it gets there.
+     * - **An engine already running settles it before any filesystem work.** Two volatile reads,
+     *   and it keeps the steady state cheap: `applyWorkspace` runs on every window and every
+     *   workspace switch, and without this each one stats the engine directories, claims the boot
+     *   slot and spawns a thread whose only job is to notice the engine is already up. The
+     *   equivalent check inside the boot thread stays as the race backstop between the claim and
+     *   the boot; it just should not be the only one.
      * - **A usable engine outranks [force] too**, and this is not a nicety. Without an engine the
      *   boot walks straight into `getChromiumDir()` throwing, which logs an error and burns an
      *   attempt for nothing. `applyWorkspace` runs on every window and every workspace switch, so
@@ -1158,11 +1198,13 @@ object FluckEngine {
     internal fun prewarmDecision(
         prewarmDisabled: Boolean,
         force: Boolean,
+        engineRunning: () -> Boolean,
         engineUsable: () -> Boolean,
         profileExists: () -> Boolean,
     ): PrewarmDecision =
         when {
             prewarmDisabled -> PrewarmDecision.OPTED_OUT
+            engineRunning() -> PrewarmDecision.ALREADY_RUNNING
             !engineUsable() -> PrewarmDecision.NO_USABLE_ENGINE
             force -> PrewarmDecision.RUN
             profileExists() -> PrewarmDecision.RUN

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/FluckEngine.kt
@@ -128,6 +128,14 @@ object FluckEngine {
     private var proactiveCleanupDone = false
 
     /**
+     * Whether a pre-warm boot thread is already running. See [prewarmInBackground]: more than one
+     * caller can now ask for the head start, and a second thread would just sit on engineLock for
+     * the duration of the first boot and then claim credit for it. Cleared again when an attempt
+     * fails, so a later caller (a completed engine download, say) still gets its chance.
+     */
+    private val prewarmStarted = AtomicBoolean(false)
+
+    /**
      * Engine generation counter - increments every time the engine is reinitialized.
      * Browser tabs can use this to detect when their browser instance is stale.
      */
@@ -1011,6 +1019,15 @@ object FluckEngine {
      * first real browser use creates the profile, and every launch after that
      * pre-warms. Opt out entirely with BOSS_BROWSER_PREWARM=false.
      *
+     * [force] is for the callers that already know a browser tab is coming, where the
+     * profile-existence gate is answering a question nobody asked. It reads "has this machine
+     * ever used the browser", and on a first install the answer is no for a reason that has
+     * nothing to do with the user's intent - so the pre-warm was skipped on precisely the launch
+     * that pays the most for skipping it, including immediately after the user waited through a
+     * several-hundred-megabyte download OF THE BROWSER ENGINE. Forcing is deliberately not the
+     * default: it creates the profile directory as a side effect, which would flip the unforced
+     * gate on permanently and pre-warm every later launch for a user who never opens a browser.
+     *
      * Called once from app startup after [proactiveCleanupOnStartup]. A pre-warm
      * failure must not poison user-facing availability (the user never asked for
      * this boot), so it clears the recorded init error — the first real use
@@ -1027,11 +1044,25 @@ object FluckEngine {
      * locked by another instance. The two profile notions intentionally differ —
      * the gate only decides whether the head start happens, never correctness.
      */
-    fun prewarmInBackground() {
-        if (configIsFalse(ChromiumFlagKeys.PREWARM)) return
+    fun prewarmInBackground(force: Boolean = false) {
         val profileDir = BossDirectories.resolve(BrowserSettings.currentProfile)
-        if (!profileDir.exists()) {
-            logger.debug(LogCategory.BROWSER, "Skipping engine pre-warm - no browser profile on this machine yet")
+        if (!shouldPrewarm(
+                prewarmDisabled = configIsFalse(ChromiumFlagKeys.PREWARM),
+                profileExists = profileDir.exists(),
+                force = force,
+            )
+        ) {
+            if (!force) {
+                logger.debug(LogCategory.BROWSER, "Skipping engine pre-warm - no browser profile on this machine yet")
+            }
+            return
+        }
+        // One boot thread per process. The getter is synchronized, so a second thread would only
+        // block on engineLock for the whole first boot and then log a "pre-warmed" line for work
+        // it did not do - and now that two call sites can ask (startup, and a browser tab on its
+        // way), that stopped being hypothetical.
+        if (!prewarmStarted.compareAndSet(false, true)) {
+            logger.debug(LogCategory.BROWSER, "Engine pre-warm already under way")
             return
         }
         Thread({
@@ -1065,9 +1096,31 @@ object FluckEngine {
                     )
                 }
                 clearInitStateIfErrorIs(e)
+                // Re-arm: this attempt bought nothing, and the next caller with a reason to ask
+                // (an engine download that has just finished) should not be refused because of it.
+                prewarmStarted.set(false)
             }
         }, "fluck-engine-prewarm").apply { isDaemon = true }.start()
     }
+
+    /**
+     * Whether a pre-warm should run. Pure, so both branches of every input are testable without an
+     * engine, a profile directory or a machine that has never opened a browser.
+     *
+     * The opt-out outranks [force]: BOSS_BROWSER_PREWARM=false is the user saying no Chromium boot
+     * they did not ask for, and a caller knowing a tab is coming does not overrule that - the tab
+     * will boot the engine itself when it gets there.
+     */
+    internal fun shouldPrewarm(
+        prewarmDisabled: Boolean,
+        profileExists: Boolean,
+        force: Boolean,
+    ): Boolean =
+        when {
+            prewarmDisabled -> false
+            force -> true
+            else -> profileExists
+        }
 
     /**
      * Clear the recorded init state ONLY if [expected] is still the recorded

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmupTriggerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmupTriggerTest.kt
@@ -1,22 +1,61 @@
 package ai.rever.boss.components.workspaces
 
+import ai.rever.boss.components.plugin.TabUpdateRegistry
+import ai.rever.boss.components.window_panel.SplitViewState
+import ai.rever.boss.plugin.api.TabComponentWithUI
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabRegistry
+import ai.rever.boss.plugin.api.TabTypeInfo
 import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.terminal.TerminalTabType
+import ai.rever.boss.plugin.workspace.PanelConfig
+import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
+import ai.rever.boss.plugin.workspace.TabConfig
+import androidx.compose.runtime.Composable
+import com.arkivanov.decompose.ComponentContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Which layouts are worth booting Chromium for before they are applied.
+ * When a layout being applied is worth booting Chromium for, and - the part that carries the
+ * change - that the boot is asked for BEFORE the wait for plugin tab types, not after.
  *
- * A browser tab is the only thing in a workspace that costs a process tree, and the pre-warm this
- * gates is the difference between the boot happening during the bounded wait for plugin tab types
- * and happening inside the tab, where the user watches it. The predicate has to stay narrow in the
- * other direction too: a terminal-only or editor-only layout must not start an engine nobody asked
- * for, which is the whole reason the unforced startup gate exists.
+ * The wait is bounded dead time at startup while the browser plugin registers its factory. Asking
+ * during it is what turns a cold engine boot from something the user watches inside their first tab
+ * into something that already happened. Move those lines below the wait and the benefit evaporates
+ * with every other test still green, which is why the ordering is pinned here and not just the
+ * predicate.
+ *
+ * The predicate has to stay narrow in the other direction too: a terminal-only or editor-only
+ * layout must not start an engine nobody asked for, which is the whole reason the unforced startup
+ * gate exists.
  */
 class BrowserEngineWarmupTriggerTest {
+    /** Minimal stand-in; the applier only builds TabInfo, it never renders the component. */
+    private class StubTabComponent(
+        ctx: ComponentContext,
+        override val config: TabInfo,
+        override val tabTypeInfo: TabTypeInfo,
+    ) : TabComponentWithUI,
+        ComponentContext by ctx {
+        @Composable
+        override fun Content() = Unit
+    }
+
+    @AfterTest
+    fun tearDown() {
+        TabUpdateRegistry.clear()
+    }
+
     @Test
     fun `a layout with a browser tab warms the engine`() {
         assertTrue(needsBrowserEngine(setOf(FluckTabType.typeId)))
@@ -29,4 +68,79 @@ class BrowserEngineWarmupTriggerTest {
         assertFalse(needsBrowserEngine(setOf(TerminalTabType.typeId)))
         assertFalse(needsBrowserEngine(setOf(TerminalTabType.typeId, CodeEditorTabType.typeId)))
     }
+
+    @Test
+    fun `the warm-up is requested before the applier waits for the browser tab type`() {
+        val registry = TabRegistry()
+        val splitViewState = SplitViewState(registry, windowId = "warmup-test-window")
+        val warmed = AtomicBoolean(false)
+
+        runBlocking {
+            // The browser tab type is deliberately NOT registered yet, so applyWorkspace parks in
+            // awaitTabTypes - exactly the startup situation. Anything the warm-up hook does after
+            // that wait cannot be observed until the type is registered, so seeing `warmed` flip
+            // while the applier is still parked IS the ordering assertion.
+            val applying =
+                launch(Dispatchers.Default) {
+                    applyWorkspace(
+                        workspace = browserWorkspace(),
+                        splitViewState = splitViewState,
+                        warmEngine = { warmed.set(true) },
+                    )
+                }
+
+            withTimeout(10_000) {
+                while (!warmed.get()) yield()
+            }
+            assertTrue(warmed.get(), "the engine boot must be asked for while the applier is waiting")
+            assertTrue(applying.isActive, "the applier must still be parked on the tab-type wait")
+
+            // Let it finish so the applier does not sit on the bounded wait for the whole timeout.
+            registry.registerTabType(FluckTabType) { config, ctx -> StubTabComponent(ctx, config, FluckTabType) }
+            applying.join()
+        }
+    }
+
+    @Test
+    fun `a terminal-only layout never asks for the engine`() {
+        val registry =
+            TabRegistry().apply {
+                registerTabType(TerminalTabType) { config, ctx -> StubTabComponent(ctx, config, TerminalTabType) }
+            }
+        val splitViewState = SplitViewState(registry, windowId = "warmup-test-window-terminal")
+        val warmed = AtomicBoolean(false)
+
+        runBlocking {
+            applyWorkspace(
+                workspace =
+                    LayoutWorkspace(
+                        id = "warmup-test-terminal",
+                        name = "Terminal only",
+                        description = "One terminal",
+                        layout =
+                            SinglePanel(
+                                PanelConfig(id = "main", tabs = listOf(TabConfig(type = "terminal", title = "Term"))),
+                            ),
+                    ),
+                splitViewState = splitViewState,
+                warmEngine = { warmed.set(true) },
+            )
+        }
+
+        assertFalse(warmed.get(), "a terminal-only session must not pay a Chromium spawn")
+    }
+
+    private fun browserWorkspace() =
+        LayoutWorkspace(
+            id = "warmup-test-browser",
+            name = "Browser only",
+            description = "One browser tab",
+            layout =
+                SinglePanel(
+                    PanelConfig(
+                        id = "main",
+                        tabs = listOf(TabConfig(type = "browser", title = "Loading...", url = "https://example.com")),
+                    ),
+                ),
+        )
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmupTriggerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmupTriggerTest.kt
@@ -1,0 +1,32 @@
+package ai.rever.boss.components.workspaces
+
+import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
+import ai.rever.boss.plugin.tab.fluck.FluckTabType
+import ai.rever.boss.plugin.tab.terminal.TerminalTabType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Which layouts are worth booting Chromium for before they are applied.
+ *
+ * A browser tab is the only thing in a workspace that costs a process tree, and the pre-warm this
+ * gates is the difference between the boot happening during the bounded wait for plugin tab types
+ * and happening inside the tab, where the user watches it. The predicate has to stay narrow in the
+ * other direction too: a terminal-only or editor-only layout must not start an engine nobody asked
+ * for, which is the whole reason the unforced startup gate exists.
+ */
+class BrowserEngineWarmupTriggerTest {
+    @Test
+    fun `a layout with a browser tab warms the engine`() {
+        assertTrue(needsBrowserEngine(setOf(FluckTabType.typeId)))
+        assertTrue(needsBrowserEngine(setOf(TerminalTabType.typeId, FluckTabType.typeId)))
+    }
+
+    @Test
+    fun `a layout without one does not`() {
+        assertFalse(needsBrowserEngine(emptySet()))
+        assertFalse(needsBrowserEngine(setOf(TerminalTabType.typeId)))
+        assertFalse(needsBrowserEngine(setOf(TerminalTabType.typeId, CodeEditorTabType.typeId)))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmupTriggerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/BrowserEngineWarmupTriggerTest.kt
@@ -14,14 +14,15 @@ import ai.rever.boss.plugin.workspace.SplitConfig.SinglePanel
 import ai.rever.boss.plugin.workspace.TabConfig
 import androidx.compose.runtime.Composable
 import com.arkivanov.decompose.ComponentContext
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -73,32 +74,49 @@ class BrowserEngineWarmupTriggerTest {
     fun `the warm-up is requested before the applier waits for the browser tab type`() {
         val registry = TabRegistry()
         val splitViewState = SplitViewState(registry, windowId = "warmup-test-window")
-        val warmed = AtomicBoolean(false)
+        val warmed = CompletableDeferred<Unit>()
 
         runBlocking {
             // The browser tab type is deliberately NOT registered yet, so applyWorkspace parks in
             // awaitTabTypes - exactly the startup situation. Anything the warm-up hook does after
-            // that wait cannot be observed until the type is registered, so seeing `warmed` flip
+            // that wait cannot be observed until the type is registered, so the warm-up completing
             // while the applier is still parked IS the ordering assertion.
             val applying =
                 launch(Dispatchers.Default) {
                     applyWorkspace(
                         workspace = browserWorkspace(),
                         splitViewState = splitViewState,
-                        warmEngine = { warmed.set(true) },
+                        warmEngine = { warmed.complete(Unit) },
                     )
                 }
 
-            withTimeout(10_000) {
-                while (!warmed.get()) yield()
-            }
-            assertTrue(warmed.get(), "the engine boot must be asked for while the applier is waiting")
-            assertTrue(applying.isActive, "the applier must still be parked on the tab-type wait")
+            // Awaited rather than spun on, so the assertion below does not depend on how long the
+            // registry wait happens to have left when the spin exits.
+            withTimeout(10_000) { warmed.await() }
+            assertFalse(applying.isCompleted, "the applier must still be parked on the tab-type wait")
 
             // Let it finish so the applier does not sit on the bounded wait for the whole timeout.
             registry.registerTabType(FluckTabType) { config, ctx -> StubTabComponent(ctx, config, FluckTabType) }
             applying.join()
         }
+    }
+
+    @Test
+    fun `the workspace hook forces the pre-warm, which is the whole fix`() {
+        // force = true IS the change. A silent regression to the plain prewarmInBackground() call
+        // leaves every other test here green while the feature is gone - the same failure class as
+        // the bug being fixed, a call site that looks right and does nothing.
+        val forced = mutableListOf<Boolean>()
+
+        warmBrowserEngine { forced += it }
+
+        assertEquals(listOf(true), forced)
+    }
+
+    @Test
+    fun `a pre-warm that will not start does not stop a workspace being applied`() {
+        // An optimisation nobody asked for out loud must not be able to fail an apply.
+        warmBrowserEngine { error("engine unavailable") }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EnginePrewarmGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EnginePrewarmGateTest.kt
@@ -1,0 +1,48 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The pre-warm gate, and the case it used to get wrong.
+ *
+ * The unforced gate reads "has this machine ever used the browser", which it answers by looking for
+ * the browser profile directory - a directory the first engine boot creates. On a first install the
+ * answer is therefore no, and the pre-warm was skipped on the one launch that pays most for
+ * skipping it, including immediately after the user sat through a download of the browser engine.
+ * Callers that already know a browser tab is coming pass `force`.
+ *
+ * `force` stays deliberately narrow: it creates the profile as a side effect, so making it the
+ * default would flip the unforced gate on permanently and pre-warm every later launch for someone
+ * who never opens a browser - the exact cost that gate exists to avoid.
+ */
+class EnginePrewarmGateTest {
+    @Test
+    fun `a machine that has used the browser pre-warms without being asked twice`() {
+        assertTrue(FluckEngine.shouldPrewarm(prewarmDisabled = false, profileExists = true, force = false))
+    }
+
+    @Test
+    fun `a first install does not pre-warm on its own`() {
+        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = false, profileExists = false, force = false))
+    }
+
+    @Test
+    fun `a caller that knows a browser tab is coming pre-warms on a first install`() {
+        // The regression this change fixes: same inputs as the test above, and the answer has to
+        // flip, or a restored browser tab / a just-downloaded engine keeps paying the cold boot
+        // inside the tab.
+        assertTrue(FluckEngine.shouldPrewarm(prewarmDisabled = false, profileExists = false, force = true))
+    }
+
+    @Test
+    fun `the opt-out outranks force`() {
+        // BOSS_BROWSER_PREWARM=false is the user declining a Chromium boot they did not ask for.
+        // A caller knowing a tab is coming does not overrule that - the tab boots the engine
+        // itself when it gets there.
+        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = true, profileExists = false, force = true))
+        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = true, profileExists = true, force = true))
+        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = true, profileExists = true, force = false))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EnginePrewarmGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EnginePrewarmGateTest.kt
@@ -1,7 +1,6 @@
 package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.plugin.browser.FluckEngine.PrewarmDecision
-import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -24,21 +23,16 @@ class EnginePrewarmGateTest {
     private fun decide(
         prewarmDisabled: Boolean = false,
         force: Boolean = false,
+        engineRunning: Boolean = false,
         engineUsable: Boolean = true,
         profileExists: Boolean = false,
     ) = FluckEngine.prewarmDecision(
         prewarmDisabled = prewarmDisabled,
         force = force,
+        engineRunning = { engineRunning },
         engineUsable = { engineUsable },
         profileExists = { profileExists },
     )
-
-    @AfterTest
-    fun releaseSlot() {
-        // The slot is process-wide state; leaving it claimed would refuse a pre-warm for the rest
-        // of the test JVM and make an unrelated suite fail somewhere else.
-        FluckEngine.releasePrewarmSlot()
-    }
 
     @Test
     fun `a machine that has used the browser pre-warms without being asked twice`() {
@@ -78,13 +72,39 @@ class EnginePrewarmGateTest {
     }
 
     @Test
-    fun `every refusal carries a reason, and none of them is the profile line by default`() {
+    fun `an engine already running settles it before any filesystem work`() {
+        // The steady state: engine up, user switching workspaces. Without this each switch would
+        // stat the engine directories, claim the boot slot and spawn a thread whose only job is to
+        // notice the engine is already there. Both suppliers throw, so reaching either fails.
+        val explode: () -> Boolean = { error("must not be asked") }
+
+        assertEquals(
+            PrewarmDecision.ALREADY_RUNNING,
+            FluckEngine.prewarmDecision(
+                prewarmDisabled = false,
+                force = true,
+                engineRunning = { true },
+                engineUsable = explode,
+                profileExists = explode,
+            ),
+        )
+    }
+
+    @Test
+    fun `every refusal is a distinct decision, so the log cannot say the wrong reason`() {
         // One shared exit used to log "no browser profile on this machine yet" for an opt-out that
         // had nothing to do with the profile, and logged nothing at all when a forced caller was
-        // overruled. The reason travels with the decision so the log cannot drift from it.
-        assertEquals("BOSS_BROWSER_PREWARM opts out", PrewarmDecision.OPTED_OUT.reason)
-        assertEquals("no usable browser engine to warm", PrewarmDecision.NO_USABLE_ENGINE.reason)
-        assertEquals("no browser profile on this machine yet", PrewarmDecision.NEVER_USED_BROWSER.reason)
+        // overruled. Each refusal now carries its own name into the log as a structured field.
+        assertEquals(
+            listOf(
+                PrewarmDecision.OPTED_OUT,
+                PrewarmDecision.ALREADY_RUNNING,
+                PrewarmDecision.NO_USABLE_ENGINE,
+                PrewarmDecision.NEVER_USED_BROWSER,
+            ).distinct().size,
+            4,
+        )
+        assertEquals(PrewarmDecision.OPTED_OUT, decide(prewarmDisabled = true, engineRunning = true))
     }
 
     @Test
@@ -98,6 +118,7 @@ class EnginePrewarmGateTest {
             FluckEngine.prewarmDecision(
                 prewarmDisabled = true,
                 force = false,
+                engineRunning = explode,
                 engineUsable = explode,
                 profileExists = explode,
             ),
@@ -107,6 +128,7 @@ class EnginePrewarmGateTest {
             FluckEngine.prewarmDecision(
                 prewarmDisabled = false,
                 force = true,
+                engineRunning = { false },
                 engineUsable = { true },
                 profileExists = explode,
             ),
@@ -115,6 +137,9 @@ class EnginePrewarmGateTest {
 
     @Test
     fun `the boot slot admits one thread and re-arms when it is released`() {
+        // Claims and releases only what it took, rather than clearing the flag in an @AfterTest:
+        // this is process-wide state, and a blanket release would hand a second boot thread to a
+        // real pre-warm started by any other suite in the same JVM.
         // The slot is what keeps a second thread from parking on engineLock for the whole of
         // somebody else's boot and then logging a "pre-warmed" line for work it did not do.
         assertTrue(FluckEngine.claimPrewarmSlot(), "the first claim must win")
@@ -126,5 +151,6 @@ class EnginePrewarmGateTest {
         // good, including a completed engine download.
         FluckEngine.releasePrewarmSlot()
         assertTrue(FluckEngine.claimPrewarmSlot(), "the slot must re-arm once the boot thread exits")
+        FluckEngine.releasePrewarmSlot()
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EnginePrewarmGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/EnginePrewarmGateTest.kt
@@ -1,14 +1,17 @@
 package ai.rever.boss.plugin.browser
 
+import ai.rever.boss.plugin.browser.FluckEngine.PrewarmDecision
+import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
  * The pre-warm gate, and the case it used to get wrong.
  *
- * The unforced gate reads "has this machine ever used the browser", which it answers by looking for
- * the browser profile directory - a directory the first engine boot creates. On a first install the
+ * The profile check reads "has this machine ever used the browser", answered by looking for the
+ * browser profile directory - a directory the first engine boot creates. On a first install the
  * answer is therefore no, and the pre-warm was skipped on the one launch that pays most for
  * skipping it, including immediately after the user sat through a download of the browser engine.
  * Callers that already know a browser tab is coming pass `force`.
@@ -18,14 +21,33 @@ import kotlin.test.assertTrue
  * who never opens a browser - the exact cost that gate exists to avoid.
  */
 class EnginePrewarmGateTest {
+    private fun decide(
+        prewarmDisabled: Boolean = false,
+        force: Boolean = false,
+        engineUsable: Boolean = true,
+        profileExists: Boolean = false,
+    ) = FluckEngine.prewarmDecision(
+        prewarmDisabled = prewarmDisabled,
+        force = force,
+        engineUsable = { engineUsable },
+        profileExists = { profileExists },
+    )
+
+    @AfterTest
+    fun releaseSlot() {
+        // The slot is process-wide state; leaving it claimed would refuse a pre-warm for the rest
+        // of the test JVM and make an unrelated suite fail somewhere else.
+        FluckEngine.releasePrewarmSlot()
+    }
+
     @Test
     fun `a machine that has used the browser pre-warms without being asked twice`() {
-        assertTrue(FluckEngine.shouldPrewarm(prewarmDisabled = false, profileExists = true, force = false))
+        assertEquals(PrewarmDecision.RUN, decide(profileExists = true))
     }
 
     @Test
     fun `a first install does not pre-warm on its own`() {
-        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = false, profileExists = false, force = false))
+        assertEquals(PrewarmDecision.NEVER_USED_BROWSER, decide(profileExists = false))
     }
 
     @Test
@@ -33,7 +55,7 @@ class EnginePrewarmGateTest {
         // The regression this change fixes: same inputs as the test above, and the answer has to
         // flip, or a restored browser tab / a just-downloaded engine keeps paying the cold boot
         // inside the tab.
-        assertTrue(FluckEngine.shouldPrewarm(prewarmDisabled = false, profileExists = false, force = true))
+        assertEquals(PrewarmDecision.RUN, decide(force = true, profileExists = false))
     }
 
     @Test
@@ -41,8 +63,68 @@ class EnginePrewarmGateTest {
         // BOSS_BROWSER_PREWARM=false is the user declining a Chromium boot they did not ask for.
         // A caller knowing a tab is coming does not overrule that - the tab boots the engine
         // itself when it gets there.
-        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = true, profileExists = false, force = true))
-        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = true, profileExists = true, force = true))
-        assertFalse(FluckEngine.shouldPrewarm(prewarmDisabled = true, profileExists = true, force = false))
+        assertEquals(PrewarmDecision.OPTED_OUT, decide(prewarmDisabled = true, force = true))
+        assertEquals(PrewarmDecision.OPTED_OUT, decide(prewarmDisabled = true, profileExists = true))
+    }
+
+    @Test
+    fun `no usable engine outranks force, because that boot could only fail`() {
+        // Without an engine directory the boot walks into getChromiumDir() throwing: an error log
+        // and a burnt attempt for nothing. applyWorkspace runs on every window and every workspace
+        // switch, so a forced call with no gate would repeat that indefinitely on an engine-less
+        // machine - and could hold the boot slot at the moment a completed download wants it.
+        assertEquals(PrewarmDecision.NO_USABLE_ENGINE, decide(engineUsable = false, force = true))
+        assertEquals(PrewarmDecision.NO_USABLE_ENGINE, decide(engineUsable = false, profileExists = true))
+    }
+
+    @Test
+    fun `every refusal carries a reason, and none of them is the profile line by default`() {
+        // One shared exit used to log "no browser profile on this machine yet" for an opt-out that
+        // had nothing to do with the profile, and logged nothing at all when a forced caller was
+        // overruled. The reason travels with the decision so the log cannot drift from it.
+        assertEquals("BOSS_BROWSER_PREWARM opts out", PrewarmDecision.OPTED_OUT.reason)
+        assertEquals("no usable browser engine to warm", PrewarmDecision.NO_USABLE_ENGINE.reason)
+        assertEquals("no browser profile on this machine yet", PrewarmDecision.NEVER_USED_BROWSER.reason)
+    }
+
+    @Test
+    fun `the cheap answers cost no filesystem work`() {
+        // Both suppliers throw, so reaching one fails the test. An opt-out is settled before either
+        // is asked, and force settles the profile question without asking it.
+        val explode: () -> Boolean = { error("must not be asked") }
+
+        assertEquals(
+            PrewarmDecision.OPTED_OUT,
+            FluckEngine.prewarmDecision(
+                prewarmDisabled = true,
+                force = false,
+                engineUsable = explode,
+                profileExists = explode,
+            ),
+        )
+        assertEquals(
+            PrewarmDecision.RUN,
+            FluckEngine.prewarmDecision(
+                prewarmDisabled = false,
+                force = true,
+                engineUsable = { true },
+                profileExists = explode,
+            ),
+        )
+    }
+
+    @Test
+    fun `the boot slot admits one thread and re-arms when it is released`() {
+        // The slot is what keeps a second thread from parking on engineLock for the whole of
+        // somebody else's boot and then logging a "pre-warmed" line for work it did not do.
+        assertTrue(FluckEngine.claimPrewarmSlot(), "the first claim must win")
+        assertFalse(FluckEngine.claimPrewarmSlot(), "a second claim must be refused while one runs")
+
+        // Released in a finally, so it covers a boot that failed as well as one that succeeded.
+        // Held for the process lifetime instead, an engine recycle - which drops the engine and is
+        // exactly when a head start is worth something again - would refuse every later caller for
+        // good, including a completed engine download.
+        FluckEngine.releasePrewarmSlot()
+        assertTrue(FluckEngine.claimPrewarmSlot(), "the slot must re-arm once the boot thread exits")
     }
 }


### PR DESCRIPTION
The engine pre-warm is skipped when `~/.boss/browser-profile` does not exist, so a terminal-only or editor-only session never pays a Chromium spawn. But that directory is created **by** the first engine boot, so the gate really answers "has this machine ever used the browser" - and on a first install the answer is no for a reason that has nothing to do with what the user is about to do. The pre-warm was therefore skipped on precisely the launch that pays most for skipping it, and the first browser tab paid the whole cold boot itself, inside the tab, while the user watched. (That window is where the browser tab's status screen shows, which is the other half of this: risa-labs-inc/boss-plugin-fluck-browser#30.)

The clearest case is the two post-download call sites in `main.kt`. Both already carried the comment

> The pre-warm was skipped at startup because the engine was missing; now that it is installed, warm it so the first tab does not pay the full boot.

and both silently did nothing, because a machine that has just downloaded its engine has never had a profile. Someone who sat through a several-hundred-megabyte download *of the browser engine* is the strongest signal there is that a browser tab is coming.

## What changed

- `prewarmInBackground(force: Boolean = false)`. Two callers pass it: those two download completions, and `applyWorkspace` when the layout it is about to apply contains a browser tab - taken **before** the bounded wait for plugin tab types, so the boot gets that wait for free instead of landing in the tab. That covers the browser-only workspace on a fresh install and any restore whose profile is missing.
- `shouldPrewarm` is pure, so both branches of all three inputs are testable without an engine or a machine that has never opened a browser.
- A `prewarmStarted` guard keeps it to one boot thread per process. The getter is `synchronized`, so a second thread would only sit on `engineLock` for the first boot's duration and then log a "pre-warmed" line for work it did not do - which stopped being hypothetical the moment two call sites could ask. It re-arms on failure, so an attempt that bought nothing does not refuse the next caller with a reason to ask.
- `needsBrowserEngine` is named for the consequence rather than the id it looks for, and its test pins the other direction too: a terminal-only or editor-only layout must not start an engine nobody asked for.

## What is deliberately unchanged

- **`force` is not the default.** It creates the profile directory as a side effect, so defaulting it on would flip the unforced gate permanently and pre-warm every later launch for someone who never opens a browser - the exact cost that gate exists to avoid.
- **`BOSS_BROWSER_PREWARM=false` outranks `force`.** That is the user declining a boot they did not ask for; a caller knowing a tab is coming does not overrule it, and the tab boots the engine itself when it gets there.

## Tests

`EnginePrewarmGateTest` + `BrowserEngineWarmupTriggerTest`, green, with `ktlintCheck` and `detekt` clean. Both new suites were re-run against the pre-fix decisions (gate without `force`, predicate widened to any tab type) and the two assertions that carry the fix fail there.