### PR TITLE
perf: measure what BOSS actually holds, and bound the heap

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1026,6 +1026,23 @@ compose.desktop {
                 // if a very small machine ever reports heap trouble.
                 add("-Xmx2g")
 
+                // Start small and let G1 grow into that ceiling, rather than committing it all
+                // at launch.
+                //
+                // Not optional alongside the -Xmx above, and the reason is a trap. The default
+                // InitialHeapSize is 1/64 of physical RAM, which on a 128 GB machine is 2 GB -
+                // exactly the ceiling just set. An -Xms equal to -Xmx tells G1 the heap is fixed,
+                // so it commits the whole 2 GB at startup and never uncommits. Measured, today's
+                // uncapped JVM starts at that same 2 GB and *shrinks* to a 432 MB commit once the
+                // app settles; without this line the cap would have frozen it at 2 GB and added
+                // roughly 1.6 GB of resident memory to every large machine, which is the opposite
+                // of the intent. Small machines were never affected (1/64 of 8 GB is 128 MB).
+                //
+                // 256 MB rather than something nearer the ~300-480 MB steady state, because the
+                // cost of guessing low is a few cheap region expansions during startup and the
+                // cost of guessing high is committed memory the app may never use.
+                add("-Xms256m")
+
                 // Apple Silicon JIT compatibility flags (harmless on other platforms)
                 add("-XX:+IgnoreUnrecognizedVMOptions")
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -992,6 +992,40 @@ compose.desktop {
                     add("--add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED")
                 }
 
+                // Bound the heap instead of letting ergonomics scale it with installed RAM.
+                //
+                // With no -Xmx at all the ceiling is a property of the user's machine rather
+                // than of BOSS: measured, 2 GB on an 8 GB Windows box and 29.97 GB on a 128 GB
+                // Mac. That is not a footprint problem, because G1 commits lazily - a loaded
+                // session measured 299 MB live inside 432 MB committed, about 12% of the
+                // process RSS. It is a blast-radius problem. An unbounded ceiling lets a leak
+                // reach tens of gigabytes of real memory before the JVM will even consider an
+                // OutOfMemoryError, and well before that point Chromium's PartitionAlloc, which
+                // shares this process's malloc, aborts outright with no catchable exception and
+                // no heap dump. A bounded heap turns a machine-wide stall into a diagnosable
+                // crash, and makes GC behaviour and crash reports comparable between users.
+                //
+                // 2 GB, from measurement rather than taste. Eleven independent readings of this
+                // app's live heap - ten crash reports spanning several released versions plus a
+                // running session - peak at 478 MB and average under 300 MB. 2 GB is over 4x
+                // that. It is also not a new number: 25% of 8 GB is exactly what every machine
+                // at or below the Ultra Lite threshold already runs with today, so if it were
+                // too small for real work, the smallest supported configuration would already
+                // be failing on it.
+                //
+                // Expressed as a flat -Xmx because no static flag pair can say
+                // min(percentage, ceiling), and jpackage bakes java-options in as fixed strings
+                // with no hook to compute one per machine. -XX:MaxRAM was tried for this and is
+                // wrong: it *replaces* the physical-memory figure rather than capping it, so
+                // -XX:MaxRAM=16g -XX:MaxRAMPercentage=25 hands an 8 GB machine a 4 GB heap,
+                // half its RAM. Verified on a 128 GB host, where -XX:MaxRAM=512g yields a
+                // 128 GB MaxHeapSize.
+                //
+                // Machines above 8 GB come down to this ceiling; machines below it (a 4 GB box
+                // gets 1 GB today) come up to it. That second direction is the one to revisit
+                // if a very small machine ever reports heap trouble.
+                add("-Xmx2g")
+
                 // Apple Silicon JIT compatibility flags (harmless on other platforms)
                 add("-XX:+IgnoreUnrecognizedVMOptions")
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -18,6 +18,7 @@ import ai.rever.boss.components.plugin.DependentRestartEventBus
 import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.resolveRegisteredPanelId
+import ai.rever.boss.components.plugin.shouldShowMissingDependency
 import ai.rever.boss.components.window_panel.SplitViewState
 import ai.rever.boss.components.workspaces.WorkspaceSerializer
 import ai.rever.boss.components.workspaces.applyWorkspace
@@ -216,7 +217,17 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                     withContext(Dispatchers.IO) {
                         prompt.installer.isInstalled(prompt.missing.missingPluginId)
                     }
-                if (present || PluginDependencyEventBus.wasDeclined(prompt.missing)) {
+                // The rule itself lives in `shouldShowMissingDependency`, so it can be tested
+                // against rather than restated here. Notably it exempts a prompt a person asked
+                // for by pressing something: without that, dismissing the offer once left the
+                // control silent for the rest of the session.
+                val show =
+                    shouldShowMissingDependency(
+                        prompt = prompt,
+                        present = present,
+                        declined = PluginDependencyEventBus.wasDeclined(prompt.missing),
+                    )
+                if (!show) {
                     return@collect
                 }
                 // Reset here rather than relying on the previous dialog's exit path having

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
@@ -10,9 +10,24 @@ import androidx.compose.runtime.Composable
 
 /**
  * Compact performance indicator for the status bar.
- * Shows memory and CPU usage with color-coded health status.
  *
- * Format: "256MB/512MB 45%" or "1.5GB/4GB 45%" (memory usage / max, CPU %)
+ * Format: `"3.4GB 45%"` - what BOSS is holding across every process it owns, and process CPU.
+ *
+ * It used to read `"299MB/30GB 45%"`: JVM heap used over the heap ceiling. Both halves of that
+ * were misleading. The numerator counted about an eighth of the memory BOSS was really holding,
+ * omitting the Chromium tree and the plugin host JVMs where every memory incident this app has
+ * had actually occurred. The denominator was not a BOSS number at all but 25% of the user's
+ * installed RAM, so on a large machine the ratio sat near 1% and the colour could not change no
+ * matter what went wrong: reaching amber at 75% of a 30 GB ceiling would have needed 22 GB of
+ * live Kotlin objects.
+ *
+ * So the ratio is gone. A single absolute figure is the honest reading, because there is no
+ * meaningful ceiling to divide by - the limit on what BOSS can hold is the machine's free
+ * memory, which is shared with everything else running and is exactly what now drives the
+ * colour. See `MemoryPressure` for the thresholds and why they are shared with the watchdog.
+ *
+ * Falls back to the old heap ratio when the footprint cannot be read, so a platform without a
+ * reader shows less rather than nothing.
  */
 @Composable
 fun PerformanceIndicator(
@@ -29,9 +44,14 @@ fun PerformanceIndicator(
             HealthStatus.CRITICAL -> BossTheme.colors.alert
         }
 
-    val memoryUsed = FormatUtils.formatMegabytes(snapshot.memory.heapUsedMB, compact = true)
-    val memoryMax = FormatUtils.formatMegabytes(snapshot.memory.heapMaxMB, compact = true)
-    val memoryText = "$memoryUsed/$memoryMax"
+    val memoryText =
+        if (snapshot.memory.footprintKnown) {
+            FormatUtils.formatMegabytes(snapshot.memory.footprintMB, compact = true)
+        } else {
+            val memoryUsed = FormatUtils.formatMegabytes(snapshot.memory.heapUsedMB, compact = true)
+            val memoryMax = FormatUtils.formatMegabytes(snapshot.memory.heapMaxMB, compact = true)
+            "$memoryUsed/$memoryMax"
+        }
     val cpuText = "${snapshot.cpu.processLoadPercent.toInt()}%"
 
     BossActionButton(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
@@ -4,9 +4,11 @@ import ai.rever.boss.components.buttons.BossActionButton
 import ai.rever.boss.performance.HealthStatus
 import ai.rever.boss.performance.PerformanceHealth
 import ai.rever.boss.performance.PerformanceSnapshot
+import ai.rever.boss.performance.PerformanceState
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.FormatUtils
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 
 /**
  * Compact performance indicator for the status bar.
@@ -35,6 +37,14 @@ fun PerformanceIndicator(
     health: PerformanceHealth,
     onClick: () -> Unit,
 ) {
+    // Before the null-return below, deliberately. Whole-process sampling is gated on this being
+    // registered, and the reading is part of the snapshot, so registering only once a snapshot
+    // exists would be a standoff neither side could break.
+    DisposableEffect(Unit) {
+        PerformanceState.setIndicatorMounted(true)
+        onDispose { PerformanceState.setIndicatorMounted(false) }
+    }
+
     if (snapshot == null) return
 
     val color =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
@@ -13,7 +13,8 @@ import androidx.compose.runtime.DisposableEffect
 /**
  * Compact performance indicator for the status bar.
  *
- * Format: `"3.4GB 45%"` - what BOSS is holding across every process it owns, and process CPU.
+ * Format: `"2.1GB · 70/128GB 4%"` - what BOSS holds, then the machine's used and total memory,
+ * then process CPU.
  *
  * It used to read `"299MB/30GB 45%"`: JVM heap used over the heap ceiling. Both halves of that
  * were misleading. The numerator counted about an eighth of the memory BOSS was really holding,
@@ -23,13 +24,14 @@ import androidx.compose.runtime.DisposableEffect
  * matter what went wrong: reaching amber at 75% of a 30 GB ceiling would have needed 22 GB of
  * live Kotlin objects.
  *
- * So the ratio is gone. A single absolute figure is the honest reading, because there is no
- * meaningful ceiling to divide by - the limit on what BOSS can hold is the machine's free
- * memory, which is shared with everything else running and is exactly what now drives the
- * colour. See `MemoryPressure` for the thresholds and why they are shared with the watchdog.
+ * The two figures answer different questions and both are worth a glance, which is why they are
+ * shown side by side rather than combined. The first is what BOSS costs. The second is how much
+ * room the machine has left, and it is the one driving the colour - see `MemoryPressure` for the
+ * thresholds and why they are shared with the memory-pressure watchdog.
  *
- * Falls back to the old heap ratio when the footprint cannot be read, so a platform without a
- * reader shows less rather than nothing.
+ * Each half degrades independently: an unreadable footprint leaves the machine pair, an
+ * unreadable machine leaves the footprint, and losing both falls back to the old heap ratio,
+ * which is always available.
  */
 @Composable
 fun PerformanceIndicator(
@@ -54,14 +56,15 @@ fun PerformanceIndicator(
             HealthStatus.CRITICAL -> BossTheme.colors.alert
         }
 
+    val memory = snapshot.memory
     val memoryText =
-        if (snapshot.memory.footprintKnown) {
-            FormatUtils.formatMegabytes(snapshot.memory.footprintMB, compact = true)
-        } else {
-            val memoryUsed = FormatUtils.formatMegabytes(snapshot.memory.heapUsedMB, compact = true)
-            val memoryMax = FormatUtils.formatMegabytes(snapshot.memory.heapMaxMB, compact = true)
-            "$memoryUsed/$memoryMax"
-        }
+        memoryIndicatorText(
+            footprintMB = if (memory.footprintKnown) memory.footprintMB else null,
+            systemUsedMB = memory.systemUsedBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
+            systemTotalMB = memory.systemTotalBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
+            heapUsedMB = memory.heapUsedMB,
+            heapMaxMB = memory.heapMaxMB,
+        )
     val cpuText = "${snapshot.cpu.processLoadPercent.toInt()}%"
 
     BossActionButton(
@@ -70,3 +73,70 @@ fun PerformanceIndicator(
         onClick = onClick,
     )
 }
+
+/**
+ * The memory half of the indicator label.
+ *
+ * Split out and internal so the fallbacks are testable without a Compose harness. There are four
+ * of them and they are not decorative: a footprint reading fails on any platform without a
+ * reader, and `SystemMemory` returns 0 for "unknown" on purpose rather than throwing, so both
+ * inputs really can be absent at runtime and neither may be rendered as a zero.
+ */
+internal fun memoryIndicatorText(
+    footprintMB: Float?,
+    systemUsedMB: Float?,
+    systemTotalMB: Float?,
+    heapUsedMB: Float,
+    heapMaxMB: Float,
+): String {
+    val footprint = footprintMB?.let { FormatUtils.formatMegabytes(it, compact = true) }
+    val machine =
+        if (systemUsedMB != null && systemTotalMB != null) {
+            sharedUnitPair(systemUsedMB, systemTotalMB)
+        } else {
+            null
+        }
+
+    return when {
+        footprint != null && machine != null -> {
+            "$footprint · $machine"
+        }
+
+        footprint != null -> {
+            footprint
+        }
+
+        machine != null -> {
+            machine
+        }
+
+        else -> {
+            FormatUtils.formatMegabytes(heapUsedMB, compact = true) +
+                "/" +
+                FormatUtils.formatMegabytes(heapMaxMB, compact = true)
+        }
+    }
+}
+
+/**
+ * `70/128GB` - a used/total pair carrying the unit once.
+ *
+ * Both halves are scaled by the *total*, never each separately. Formatting them independently
+ * would produce `900MB/128GB`, where the two numbers look comparable and are not, and the reader
+ * has to notice a unit change mid-string to avoid reading it as 900 of 128. Scaling both by the
+ * larger figure keeps the pair on one axis, which is the only reason a shared unit is legible.
+ */
+private fun sharedUnitPair(
+    usedMB: Float,
+    totalMB: Float,
+): String {
+    val gb = totalMB >= 1024f
+    val divisor = if (gb) 1024f else 1f
+    val unit = if (gb) "GB" else "MB"
+    val used = usedMB / divisor
+    val total = totalMB / divisor
+    return "${trimNumber(used)}/${trimNumber(total)}$unit"
+}
+
+/** One decimal below 10, whole numbers above, so `3.2/8GB` and `70/128GB` both read cleanly. */
+private fun trimNumber(value: Float): String = if (value >= 10f) value.toInt().toString() else "%.1f".format(value)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -323,6 +323,22 @@ interface MissingDependencyInstaller {
 data class MissingDependencyPrompt(
     val missing: MissingPluginDependency,
     val installer: MissingDependencyInstaller,
+    /**
+     * True when a person asked for this directly, by pressing a control that needs the plugin.
+     *
+     * Such a request is not subject to [PluginDependencyBus.wasDeclined]. That set exists to stop
+     * *automatic* prompts recurring - three consumers of one optional gateway asking one question
+     * three times - and it is the right answer for those. It is the wrong answer for a button:
+     * someone who dismissed the offer and then pressed the control again is asking again, and
+     * answering a click with silence is the exact failure this feature exists to remove.
+     *
+     * Carried on the prompt rather than passed to [PluginDependencyBus.report], because the
+     * decline set is consulted **twice** on the way to a dialog - once when reporting and again
+     * by the window that collects, which re-checks because a prompt can be answered between the
+     * two. A report-time flag suppresses only the first, so the request still died silently at
+     * the collector. The intent has to travel with the prompt to survive that gap.
+     */
+    val userInitiated: Boolean = false,
 )
 
 /**
@@ -428,7 +444,12 @@ open class PluginDependencyBus {
         // Keyed like a decline, not by bare id: an optional prompt already waiting would
         // otherwise swallow a *required* one for the same plugin, and declining the optional
         // dialog would then silence the plugin that actually requires it.
-        if (wasDeclined(prompt.missing) || !queued.add(declineKey(prompt.missing))) return
+        //
+        // A user-initiated prompt skips the decline check only, never the duplicate check, so a
+        // second click while the dialog is already up does not stack another copy of it. See
+        // [MissingDependencyPrompt.userInitiated].
+        val silenced = !prompt.userInitiated && wasDeclined(prompt.missing)
+        if (silenced || !queued.add(declineKey(prompt.missing))) return
         if (prompts.trySend(prompt).isFailure) {
             queued.remove(declineKey(prompt.missing))
             // DROP_OLDEST is silent, and a prompt that never appears is indistinguishable
@@ -444,6 +465,28 @@ open class PluginDependencyBus {
         }
     }
 }
+
+/**
+ * Whether a prompt that reached a window should be put on screen.
+ *
+ * The window re-checks both conditions rather than trusting the report, because a prompt can be
+ * answered in the gap between the two: two dependents of one missing plugin each raise one, and
+ * installing for the first satisfies the second, whose dialog would otherwise claim something
+ * untrue and reinstall what is already loaded.
+ *
+ * Extracted from the collector so the rule is testable. It was not, and that mattered: the first
+ * version of the user-initiated exemption was applied at the report only, the collector went on
+ * silencing the same prompt, and dismissing the offer once left the control dead for the session.
+ * A test written against a *copy* of this expression passed the whole time.
+ *
+ * @param present the dependency is installed and usable now, so there is nothing to offer
+ * @param declined this exact question was dismissed earlier this session
+ */
+fun shouldShowMissingDependency(
+    prompt: MissingDependencyPrompt,
+    present: Boolean,
+    declined: Boolean,
+): Boolean = !present && (prompt.userInitiated || !declined)
 
 /** The bus the host actually uses. */
 object PluginDependencyEventBus : PluginDependencyBus()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceMetrics.kt
@@ -120,6 +120,25 @@ data class MemoryMetrics(
      * `SystemMemory.freeFraction`: an unreadable bean is not evidence of a full machine, and
      * treating it as one would paint the indicator red on a machine with plenty of room.
      */
+
+    /**
+     * Machine memory in use, or 0 when either reading failed.
+     *
+     * Derived rather than sampled, because "used" has no single definition worth arguing about:
+     * this is simply total minus what `SystemMemory.availableBytes` calls available, so the pair
+     * shown to the user always adds up to the total beside it. On macOS that available figure
+     * counts inactive and purgeable pages as reclaimable, which is the honest answer to "could a
+     * large allocation succeed" and therefore makes this the honest answer to "how much is
+     * genuinely spoken for".
+     */
+    val systemUsedBytes: Long
+        get() =
+            if (systemTotalBytes <= 0L || systemAvailableBytes <= 0L) {
+                0L
+            } else {
+                systemTotalBytes - systemAvailableBytes
+            }
+
     val systemAvailableFraction: Double?
         get() =
             if (systemTotalBytes <= 0L || systemAvailableBytes <= 0L) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceMetrics.kt
@@ -85,9 +85,48 @@ data class MemoryMetrics(
     val nonHeapUsedBytes: Long,
     val nonHeapCommittedBytes: Long,
     val memoryPools: List<MemoryPoolInfo> = emptyList(),
+    /**
+     * Physical memory held across every process BOSS owns, or 0 when it could not be read.
+     *
+     * 0 means **unknown**, never "none": this JVM is by definition running and holding memory,
+     * so a zero here is a failed reading and callers must fall back to the heap figures rather
+     * than render it. See `ProcessFootprint` for how it is attributed and how it is biased.
+     *
+     * All six fields below default so that an older exported snapshot still deserialises, and so
+     * that a platform with no footprint reader produces a valid snapshot rather than none.
+     */
+    val footprintBytes: Long = 0L,
+    val footprintHostBytes: Long = 0L,
+    val footprintBrowserBytes: Long = 0L,
+    val footprintPluginBytes: Long = 0L,
+    /** Machine-wide available memory, or 0 when unreadable. See `SystemMemory.availableBytes`. */
+    val systemAvailableBytes: Long = 0L,
+    val systemTotalBytes: Long = 0L,
 ) {
     val heapUsagePercent: Float
         get() = if (heapMaxBytes > 0) (heapUsedBytes.toFloat() / heapMaxBytes) * 100f else 0f
+
+    /** Whether the footprint reading succeeded and may be displayed. */
+    val footprintKnown: Boolean
+        get() = footprintBytes > 0L
+
+    val footprintMB: Float
+        get() = footprintBytes / (1024f * 1024f)
+
+    /**
+     * Free machine memory as a fraction in `0.0..1.0`, or null when either reading failed.
+     *
+     * Null is distinct from 0.0 deliberately and for the same reason as in
+     * `SystemMemory.freeFraction`: an unreadable bean is not evidence of a full machine, and
+     * treating it as one would paint the indicator red on a machine with plenty of room.
+     */
+    val systemAvailableFraction: Double?
+        get() =
+            if (systemTotalBytes <= 0L || systemAvailableBytes <= 0L) {
+                null
+            } else {
+                (systemAvailableBytes.toDouble() / systemTotalBytes.toDouble()).coerceIn(0.0, 1.0)
+            }
 
     val heapUsedMB: Float
         get() = heapUsedBytes / (1024f * 1024f)
@@ -285,12 +324,17 @@ data class PerformanceHealth(
             val memoryPercent = snapshot.memory.heapUsagePercent
             val cpuPercent = snapshot.cpu.processLoadPercent
 
-            val memoryStatus =
+            val heapStatus =
                 when {
                     memoryPercent >= settings.memoryCriticalThresholdPercent -> HealthStatus.CRITICAL
                     memoryPercent >= settings.memoryWarningThresholdPercent -> HealthStatus.WARNING
                     else -> HealthStatus.GOOD
                 }
+
+            // The worst of the two, not a replacement for the heap reading. Heap exhaustion is
+            // still a real way to die and dropping its signal to gain the other would trade one
+            // blind spot for another; this only ever adds a reason to warn.
+            val memoryStatus = maxOf(heapStatus, MemoryPressure.statusFor(snapshot.memory.systemAvailableFraction))
 
             val cpuStatus =
                 when {
@@ -309,4 +353,49 @@ data class PerformanceHealth(
             return PerformanceHealth(memoryStatus, cpuStatus, overall)
         }
     }
+}
+
+/**
+ * When the machine itself, rather than the JVM heap, counts as under memory pressure.
+ *
+ * Lives here in common code so that the status-bar colour and `MemoryPressureWatchdog` cannot
+ * drift apart. That they agree is the point of the feature, not an incidental tidiness: the
+ * watchdog tightens the resource tier and raises an interruptive modal after pressure has been
+ * sustained for a minute, and before this the user got no warning at all - the first sign of a
+ * decision already taken was the dialog. Sharing the critical threshold means the indicator
+ * turns red exactly when the watchdog starts its sustain clock, so the modal arrives as a
+ * confirmation of something the user has been watching rather than as an ambush.
+ */
+object MemoryPressure {
+    /**
+     * At or below this fraction available, the machine is in trouble.
+     *
+     * **Not calibrated against a measured allocation failure**, and inherited as-is from
+     * `MemoryPressureWatchdog.PRESSURE_THRESHOLD`, whose own documentation says the same. The
+     * indicator is the instrument that can finally calibrate it: it puts the number in front of
+     * a user on every session and records it into performance history, so the reading before a
+     * real PartitionAlloc abort becomes recoverable evidence instead of something that has to be
+     * reproduced deliberately.
+     */
+    const val CRITICAL_AVAILABLE_FRACTION = 0.12
+
+    /**
+     * Where to start warning.
+     *
+     * Roughly double the critical fraction, so that on a machine trending downward there is a
+     * visible amber band before red rather than a single step from fine to acting.
+     */
+    const val WARNING_AVAILABLE_FRACTION = 0.25
+
+    /**
+     * Health implied by a free-memory fraction. A null fraction is GOOD, not CRITICAL: unknown
+     * must never be read as pressure.
+     */
+    fun statusFor(availableFraction: Double?): HealthStatus =
+        when {
+            availableFraction == null -> HealthStatus.GOOD
+            availableFraction <= CRITICAL_AVAILABLE_FRACTION -> HealthStatus.CRITICAL
+            availableFraction <= WARNING_AVAILABLE_FRACTION -> HealthStatus.WARNING
+            else -> HealthStatus.GOOD
+        }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
@@ -27,6 +27,16 @@ expect object PerformanceState {
     fun shouldShowIndicator(): Boolean
 
     /**
+     * Report the status-bar indicator entering or leaving the composition.
+     *
+     * Lets the platform skip work nothing can display. Whole-process memory sampling is the only
+     * consumer of this, and it is not free, so a session whose bottom bar is hidden should not pay
+     * for a number it never draws. Driven from the composable's own lifecycle rather than from the
+     * three settings that decide visibility, so it cannot drift from what is actually on screen.
+     */
+    fun setIndicatorMounted(mounted: Boolean)
+
+    /**
      * Open the performance panel.
      */
     fun openPerformancePanel()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/FootprintDisplay.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/FootprintDisplay.kt
@@ -1,0 +1,37 @@
+package ai.rever.boss.performance
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Whether a status-bar footprint indicator is currently on screen anywhere.
+ *
+ * A count rather than a flag because a BOSS session can have several windows, each with its own
+ * status bar, and they mount and dispose independently. A boolean would have the last window to
+ * close switch sampling off for the ones still open, or the first to open leave it on forever.
+ *
+ * Driven from the indicator composable's own lifecycle, which is the exact signal: the composable
+ * is only in the tree when the bottom bar is visible *and* the indicator is enabled in settings,
+ * so mounting means "a person can see this number" without any of the three predicates being
+ * restated here and drifting.
+ */
+object FootprintDisplay {
+    private val mounted = AtomicInteger(0)
+
+    /** True while at least one indicator is in the composition. */
+    val isOnScreen: Boolean get() = mounted.get() > 0
+
+    /**
+     * Report an indicator entering or leaving the composition.
+     *
+     * Clamped at zero so an unpaired dispose cannot drive the count negative and switch sampling
+     * off for every other window. Compose does not promise a dispose for every mount under all
+     * teardown paths, and a latched-off sampler would be silent and permanent.
+     */
+    fun setMounted(isMounted: Boolean) {
+        if (isMounted) {
+            mounted.incrementAndGet()
+        } else {
+            mounted.updateAndGet { (it - 1).coerceAtLeast(0) }
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/MemoryPressureWatchdog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/MemoryPressureWatchdog.kt
@@ -67,12 +67,16 @@ object MemoryPressureWatchdog {
      * to act before the wall. Treat it as provisional until someone reproduces the 5 Aug crash
      * with this watchdog running and records what the number actually was beforehand.
      *
+     * Now an alias of [MemoryPressure.CRITICAL_AVAILABLE_FRACTION] rather than its own literal,
+     * so the status-bar indicator goes red at exactly the moment this clock starts. Change it
+     * there, not here.
+     *
      * It reads [SystemMemory.availableBytes], which is `MemAvailable` on Linux rather than
      * `MemFree`. That distinction matters more than the threshold: `MemFree` excludes the page
      * cache, and a healthy long-running Linux box sits in single digits by that measure. Against
      * `MemFree` almost any threshold produces false positives.
      */
-    internal const val PRESSURE_THRESHOLD = 0.12
+    internal const val PRESSURE_THRESHOLD = MemoryPressure.CRITICAL_AVAILABLE_FRACTION
 
     /** How long pressure must persist before acting. */
     internal const val SUSTAIN_MS = 60_000L

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceMonitor.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceMonitor.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.performance
 
+import ai.rever.boss.config.SystemMemory
 import ai.rever.boss.plugin.pathutils.BossDirectories
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -293,6 +294,13 @@ object PerformanceMonitor {
                 )
             }
 
+        // Both of these are cached behind their own TTLs (ProcessFootprint.CACHE_TTL_MS and
+        // SystemMemory.CACHE_TTL_MS), so sampling them on every memory tick does not spawn a
+        // subprocess on every memory tick. Zero from either means "unreadable"; MemoryMetrics
+        // maps that to footprintKnown = false and systemAvailableFraction = null rather than to
+        // a number, and the indicator falls back to the heap reading.
+        val footprint = ProcessFootprint.current()
+
         return MemoryMetrics(
             heapUsedBytes = heapUsage.used,
             heapMaxBytes = heapUsage.max,
@@ -300,6 +308,12 @@ object PerformanceMonitor {
             nonHeapUsedBytes = nonHeapUsage.used,
             nonHeapCommittedBytes = nonHeapUsage.committed,
             memoryPools = memoryPools,
+            footprintBytes = footprint?.totalBytes ?: 0L,
+            footprintHostBytes = footprint?.hostBytes ?: 0L,
+            footprintBrowserBytes = footprint?.browserBytes ?: 0L,
+            footprintPluginBytes = footprint?.pluginBytes ?: 0L,
+            systemAvailableBytes = SystemMemory.availableBytes(),
+            systemTotalBytes = SystemMemory.totalPhysicalBytes(),
         )
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
@@ -38,6 +38,10 @@ actual object PerformanceState {
         return settings.showIndicator && settings.enabled
     }
 
+    actual fun setIndicatorMounted(mounted: Boolean) {
+        FootprintDisplay.setMounted(mounted)
+    }
+
     actual fun openPerformancePanel() {
         scope.launch {
             val focusedWindowId = WindowFocusManager.focusedWindowFlow.value

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
@@ -1,6 +1,12 @@
 package ai.rever.boss.performance
 
 import ai.rever.boss.components.events.PanelEventBus
+import ai.rever.boss.components.plugin.DynamicPluginManager
+import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.components.plugin.MissingDependencyPrompt
+import ai.rever.boss.components.plugin.MissingPluginDependency
+import ai.rever.boss.components.plugin.PluginDependencyEventBus
+import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.logging.BossLogger
@@ -12,6 +18,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+/** The plugin that draws the Performance panel the status-bar indicator opens. */
+internal const val PERFORMANCE_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.performance"
+
+/**
+ * Stands in for a dependent plugin id on a prompt the host itself raises.
+ *
+ * Only reaches logs: the decline key for an optional dependency is the *missing* id, so this
+ * value never affects which prompts are suppressed.
+ */
+private const val HOST_ID = "ai.rever.boss.host"
+
 /**
  * Desktop implementation of PerformanceState.
  * Uses PerformanceMonitor and PerformanceSettingsManager to provide state.
@@ -19,6 +36,15 @@ import kotlinx.coroutines.launch
 actual object PerformanceState {
     private val logger = BossLogger.forComponent("PerformanceState")
     private val scope = CoroutineScope(Dispatchers.Main)
+
+    /**
+     * Order 15, matching what the plugin declares in its own `PerformanceInfo`.
+     *
+     * Not `PanelIds.PERFORMANCE`, which says order 2. The panel registry keys on the whole
+     * `PanelId` including its order, so the two are different keys and the wrong one silently
+     * matches nothing.
+     */
+    private val PERFORMANCE_PANEL = PanelId("performance", 15)
 
     @Composable
     actual fun currentSnapshot(): PerformanceSnapshot? {
@@ -49,7 +75,8 @@ actual object PerformanceState {
                 logger.debug(LogCategory.UI, "No window focused, cannot open performance panel")
                 return@launch
             }
-            PanelEventBus.openPanel(PanelId("performance", 15), sourceWindowId = focusedWindowId)
+            if (offerToInstallPanel()) return@launch
+            PanelEventBus.openPanel(PERFORMANCE_PANEL, sourceWindowId = focusedWindowId)
         }
     }
 
@@ -60,8 +87,38 @@ actual object PerformanceState {
                 logger.debug(LogCategory.UI, "No window focused, cannot toggle performance panel")
                 return@launch
             }
-            PanelEventBus.togglePanel(PanelId("performance", 15), sourceWindowId = focusedWindowId)
+            if (offerToInstallPanel()) return@launch
+            PanelEventBus.togglePanel(PERFORMANCE_PANEL, sourceWindowId = focusedWindowId)
         }
+    }
+
+    /**
+     * Offer to install the panel's plugin when it is absent, returning whether it did.
+     *
+     * The status-bar indicator is drawn by the host, but the panel it opens is a plugin. Without
+     * this, clicking the indicator on an install that lacks that plugin emitted a panel event
+     * nothing was listening for: no panel, no dialog, no log line. A control that does nothing
+     * and says nothing is indistinguishable from a broken one.
+     *
+     * Reuses the install-time dependency prompt rather than adding a second dialog, so the offer
+     * comes with a working Install button. Both entry points are guarded, not just the toggle -
+     * the View menu reaches [openPerformancePanel] and would otherwise keep the silent failure.
+     *
+     * Fails **open**: with no active manager there is nothing to ask and nothing to install, so
+     * the panel event is emitted as before. A wiring gap must not be able to make the indicator
+     * unclickable on an install where the plugin is present.
+     */
+    private fun offerToInstallPanel(): Boolean {
+        val prompt =
+            DynamicPluginManager
+                .anyActiveManager()
+                ?.let { MissingDependencyReporter.installerFor(it) }
+                ?.let { performancePanelPrompt(it) }
+                ?: return false
+
+        logger.info(LogCategory.UI, "Performance panel requested but its plugin is not installed")
+        PluginDependencyEventBus.report(prompt)
+        return true
     }
 
     actual fun registerResourceProviders(
@@ -95,4 +152,35 @@ actual object PerformanceState {
     actual fun clearResourceProviders() {
         PerformanceMonitor.clearResourceProviders()
     }
+}
+
+/**
+ * The prompt to raise for a missing performance panel, or null when it is already there.
+ *
+ * Pure apart from the installer it is handed, so the wording and the "already installed"
+ * short-circuit are testable without a plugin manager behind them.
+ *
+ * Asks the installer rather than reading plugin states directly. That is the one definition
+ * of "installed" the Install button also uses - AGENTS.md records this prompt breaking once
+ * already when two halves of it disagreed, and a plugin whose jar was rejected as binary
+ * incompatible still leaves a registered entry behind.
+ *
+ * Declared `optional`, which is both true and what makes the copy read correctly: BOSS does
+ * work without this plugin, it is one panel that does not. The alternative phrasing claims
+ * BOSS needs it, which would be a lie told in a consent dialog for downloading code.
+ */
+internal fun performancePanelPrompt(installer: MissingDependencyInstaller): MissingDependencyPrompt? {
+    if (installer.isInstalled(PERFORMANCE_PLUGIN_ID)) return null
+    return MissingDependencyPrompt(
+        missing =
+            MissingPluginDependency(
+                dependentPluginId = HOST_ID,
+                dependentDisplayName = "BOSS",
+                missingPluginId = PERFORMANCE_PLUGIN_ID,
+                optional = true,
+            ),
+        installer = installer,
+        // A click, so it is asked again even after the offer was dismissed once.
+        userInitiated = true,
+    )
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
@@ -1,0 +1,320 @@
+package ai.rever.boss.performance
+
+import ai.rever.boss.plugin.browser.FluckEngine
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * How much physical memory BOSS is actually holding, summed over every process it owns.
+ *
+ * Exists because the JVM heap - the only memory number the status bar has ever shown - is a
+ * small and unrepresentative slice of the real footprint. Measured on a loaded session: 299 MB
+ * of live heap inside a 2,537 MB host process, with a further 907 MB in the Chromium tree. The
+ * bar reported the 299 MB. Every memory incident this app has had lived in the other 3.1 GB:
+ * orphaned plugin host JVMs (434 of them, 27 GB), recycled browser engines whose old Chromium
+ * was never killed, and PartitionAlloc aborting the process when native allocation fails. None
+ * of those move the heap number at all, so the one always-visible memory reading in the app was
+ * structurally incapable of showing any of them.
+ *
+ * ## Ownership, not parentage
+ *
+ * Processes are claimed by matching their command line, never by walking
+ * `ProcessHandle.descendants()`. This is the single most important decision here and it is not
+ * a stylistic one. Measured on a real session, the descendant tree from the host JVM totalled
+ * 7,858 MB, of which **4,414 MB was the user's own work**: four `claude` CLIs started in
+ * terminal tabs, their Python and MCP children, and a `cloudflared` tunnel. Those are spawned
+ * by BOSS in the sense that a shell spawned them, and charging them to BOSS would paint the bar
+ * red for a workload BOSS does not control and cannot release.
+ *
+ * Parentage also fails in the other direction. Two Chromium helpers on that same machine had
+ * been reparented to pid 1 and sat outside the descendant tree entirely. Orphaned engine
+ * processes are a bug this indicator is specifically meant to surface, so a walk that cannot see
+ * them would miss the case it exists for.
+ *
+ * ## What the numbers mean, and how they are biased
+ *
+ * Per-platform, because there is no portable answer:
+ *
+ *  - **Linux**: `Pss` from `/proc/<pid>/smaps_rollup`. Proportional set size divides each shared
+ *    page among its mappers, so summing across the Chromium tree does not count its shared
+ *    framework once per renderer. Falls back to `VmRSS` on kernels without smaps_rollup (< 4.14),
+ *    which over-counts exactly as macOS does.
+ *  - **macOS**: `rss` from `ps`. This **over-counts**: Mach reports shared pages in full against
+ *    every task mapping them, so a seven-process Chromium tree charges its shared framework
+ *    seven times. The honest figure is `phys_footprint`, which is what Activity Monitor shows,
+ *    but it is reachable only through `task_info` and there is no JNI in this app to reach it.
+ *  - **Windows**: `WorkingSet64`, which shares the same shared-page over-count.
+ *
+ * The bias is toward reporting more memory than BOSS is really holding. That is the wrong
+ * direction for a threshold, which is why **the displayed number does not drive the colour**:
+ * health comes from [ai.rever.boss.config.SystemMemory.freeFraction], a reading of the machine
+ * rather than of us, and one that is unaffected by how we attribute shared pages. The footprint
+ * answers "what is BOSS holding"; the colour answers "is this machine in trouble". Conflating
+ * them would inherit this bias into the alerting.
+ */
+object ProcessFootprint {
+    private val logger = BossLogger.forComponent("ProcessFootprint")
+
+    /**
+     * How long a reading may be reused.
+     *
+     * Enumerating every process and reading each one's command line is the expensive part, and
+     * on macOS it is a `sysctl` per process. The consumer is a status-bar glyph and a 15 s
+     * pressure watchdog, so a reading this stale cannot change any decision either one makes.
+     */
+    internal const val CACHE_TTL_MS = 10_000L
+
+    /** Upper bound on how long the per-platform memory query may take before it is abandoned. */
+    private const val QUERY_TIMEOUT_SECONDS = 5L
+
+    /** Which part of BOSS a process belongs to. */
+    internal enum class Owner { HOST, BROWSER, PLUGIN }
+
+    /**
+     * A footprint reading, split by the part of BOSS responsible for it.
+     *
+     * Split rather than a single total because the split is what makes the number actionable:
+     * "3.4 GB" prompts a shrug, "2.5 GB host / 0.9 GB browser" tells you where to look, and a
+     * plugin figure that climbs while nothing else does is the orphaned-host signature.
+     */
+    data class Reading(
+        val hostBytes: Long,
+        val browserBytes: Long,
+        val pluginBytes: Long,
+        val processCount: Int,
+    ) {
+        val totalBytes: Long get() = hostBytes + browserBytes + pluginBytes
+    }
+
+    @Volatile private var cached: Reading? = null
+
+    @Volatile private var cachedAtMs: Long = 0L
+
+    /**
+     * The current footprint, or null when it cannot be read.
+     *
+     * Null means "unknown" and must never be rendered as zero or treated as "no memory in use".
+     * Callers fall back to the heap reading, which is always available. This mirrors
+     * [ai.rever.boss.config.SystemMemory], where an unreadable value deliberately does not
+     * trigger any reduced behaviour.
+     */
+    fun current(nowMs: Long = System.currentTimeMillis()): Reading? {
+        cached?.let { if (nowMs - cachedAtMs < CACHE_TTL_MS) return it }
+        val fresh = read()
+        if (fresh != null) {
+            cached = fresh
+            cachedAtMs = nowMs
+        }
+        return fresh
+    }
+
+    private fun read(): Reading? =
+        runCatching {
+            val hostPid = ProcessHandle.current().pid()
+            val engineDirs = engineDirPrefixes()
+
+            val owned =
+                ProcessHandle
+                    .allProcesses()
+                    .toList()
+                    .mapNotNull { handle ->
+                        val owner =
+                            classify(
+                                pid = handle.pid(),
+                                commandLine = handle.info().commandLine().orElse(""),
+                                hostPid = hostPid,
+                                engineDirs = engineDirs,
+                            ) ?: return@mapNotNull null
+                        handle.pid() to owner
+                    }.toMap()
+
+            if (owned.isEmpty()) return@runCatching null
+
+            val memory = queryMemoryBytes(owned.keys.toList())
+            // A reading that resolved no process at all is a failed query, not an empty machine:
+            // we know at minimum that this very JVM is running and holding memory.
+            if (memory.isEmpty()) return@runCatching null
+
+            var host = 0L
+            var browser = 0L
+            var plugin = 0L
+            for ((pid, owner) in owned) {
+                val bytes = memory[pid] ?: continue
+                when (owner) {
+                    Owner.HOST -> host += bytes
+                    Owner.BROWSER -> browser += bytes
+                    Owner.PLUGIN -> plugin += bytes
+                }
+            }
+            Reading(host, browser, plugin, memory.size)
+        }.onFailure {
+            logger.debug(LogCategory.SYSTEM, "Footprint reading failed: ${it.message}")
+        }.getOrNull()
+
+    /**
+     * Which part of BOSS owns a process, or null when it is not ours.
+     *
+     * Pure, and internal, so the ownership rule is testable against fixture command lines rather
+     * than against whatever the developer's machine happens to be running. The regression this
+     * guards is specific: a rule that claimed the user's terminal children charged BOSS an extra
+     * 4.4 GB on the machine this was written on.
+     */
+    internal fun classify(
+        pid: Long,
+        commandLine: String,
+        hostPid: Long,
+        engineDirs: List<String>,
+    ): Owner? =
+        when {
+            pid == hostPid -> Owner.HOST
+
+            // Matches the spawner's own marker class, so it tracks whatever the plugin host is
+            // named rather than a jar-name convention.
+            commandLine.contains("PluginProcessMainKt") -> Owner.PLUGIN
+
+            // Both the Chromium main process and every helper are launched from an executable
+            // inside the resolved engine directory, so a path-prefix test catches the whole tree
+            // including any member that has been reparented away from us.
+            engineDirs.any { it.isNotEmpty() && commandLine.startsWith(it) } -> Owner.BROWSER
+
+            else -> null
+        }
+
+    /**
+     * Directory prefixes an engine process can be launched from.
+     *
+     * Taken from [FluckEngine.engineLocations] rather than hardcoding `~/.boss/boss-chromium`,
+     * because a packaged build can run the engine bundled inside the app image instead, and a
+     * hardcoded cache path would silently score every such install's browser at zero. Both
+     * candidates are matched; only one of them can have live processes.
+     */
+    private fun engineDirPrefixes(): List<String> =
+        runCatching {
+            FluckEngine.engineLocations().map { it.toAbsolutePath().toString() }
+        }.getOrElse { emptyList() }
+
+    /** Physical memory per pid, keyed by pid. Missing entries mean that pid could not be read. */
+    private fun queryMemoryBytes(pids: List<Long>): Map<Long, Long> {
+        if (pids.isEmpty()) return emptyMap()
+        val os = System.getProperty("os.name").orEmpty().lowercase()
+        return when {
+            os.startsWith("linux") -> {
+                pids.mapNotNull { pid -> linuxBytes(pid)?.let { pid to it } }.toMap()
+            }
+
+            os.startsWith("mac") -> {
+                parsePsRssOutput(runQuery(listOf("/bin/ps", "-o", "pid=,rss=", "-p", pids.joinToString(","))))
+            }
+
+            // startsWith, not contains: "darwin" contains "win".
+            //
+            // PowerShell rather than `tasklist`, whose "Mem Usage" column is localised and
+            // thousands-separated, and rather than `wmic`, which recent Windows builds no longer
+            // ship. `ConvertTo-Csv` is invariant.
+            os.startsWith("windows") -> {
+                parseWindowsCsv(
+                    runQuery(
+                        listOf(
+                            "powershell.exe",
+                            "-NoProfile",
+                            "-NonInteractive",
+                            "-Command",
+                            "Get-Process -Id ${pids.joinToString(",")} -ErrorAction SilentlyContinue | " +
+                                "Select-Object Id,WorkingSet64 | ConvertTo-Csv -NoTypeInformation",
+                        ),
+                    ),
+                )
+            }
+
+            else -> {
+                emptyMap()
+            }
+        }
+    }
+
+    /**
+     * `Pss` from smaps_rollup in bytes, falling back to `VmRSS` from status.
+     *
+     * Plain file reads, so unlike the other two platforms this costs no subprocess at all.
+     */
+    private fun linuxBytes(pid: Long): Long? =
+        runCatching {
+            val rollup = File("/proc/$pid/smaps_rollup")
+            if (rollup.exists()) {
+                parseProcKb(rollup.readText(), "Pss:")?.times(1024L)
+            } else {
+                parseProcKb(File("/proc/$pid/status").readText(), "VmRSS:")?.times(1024L)
+            }
+        }.getOrNull()
+
+    /** A `<Label>: <n> kB` field from a /proc file, in kB, or null when absent. */
+    internal fun parseProcKb(
+        text: String,
+        label: String,
+    ): Long? =
+        text
+            .lineSequence()
+            .firstOrNull { it.startsWith(label) }
+            ?.split(Regex("\\s+"))
+            ?.getOrNull(1)
+            ?.toLongOrNull()
+
+    /** `pid rssKb` pairs from `ps -o pid=,rss=`, as pid to bytes. */
+    internal fun parsePsRssOutput(output: String?): Map<Long, Long> {
+        if (output == null) return emptyMap()
+        return output
+            .lineSequence()
+            .mapNotNull { line ->
+                val parts = line.trim().split(Regex("\\s+"))
+                if (parts.size < 2) return@mapNotNull null
+                val pid = parts[0].toLongOrNull() ?: return@mapNotNull null
+                val rssKb = parts[1].toLongOrNull() ?: return@mapNotNull null
+                pid to rssKb * 1024L
+            }.toMap()
+    }
+
+    /** `"Id","WorkingSet64"` CSV rows from PowerShell, as pid to bytes. */
+    internal fun parseWindowsCsv(output: String?): Map<Long, Long> {
+        if (output == null) return emptyMap()
+        return output
+            .lineSequence()
+            .mapNotNull { line ->
+                val cells = line.trim().split(",").map { it.trim().trim('"') }
+                if (cells.size < 2) return@mapNotNull null
+                val pid = cells[0].toLongOrNull() ?: return@mapNotNull null
+                val bytes = cells[1].toLongOrNull() ?: return@mapNotNull null
+                pid to bytes
+            }.toMap()
+    }
+
+    /**
+     * Run a query and return its output, or null on failure or timeout.
+     *
+     * Waits before draining, which is only safe because every command here is filtered to an
+     * explicit pid list. `SystemMemory.vmStatAvailableBytes` carries the warning this obeys: with
+     * unbounded output that ordering deadlocks, because the child blocks writing to a full pipe
+     * while nothing drains it and `waitFor` is therefore never reached. The bound is concrete -
+     * one short line per owned process, a few dozen at the very most, against a pipe buffer
+     * measured in tens of kilobytes. An unfiltered `Get-Process` or `ps -A` would break that and
+     * must not be substituted in.
+     */
+    private fun runQuery(command: List<String>): String? =
+        runCatching {
+            val process = ProcessBuilder(command).redirectErrorStream(true).start()
+            try {
+                if (!process.waitFor(QUERY_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    process.destroyForcibly()
+                    return@runCatching null
+                }
+                process.inputStream.bufferedReader().use { it.readText() }
+            } finally {
+                // The timeout branch returns without reading either stream, and destroyForcibly
+                // does not close them, so without this they are left to the finalizer.
+                process.inputStream.close()
+                process.errorStream.close()
+                process.outputStream.close()
+            }
+        }.getOrNull()
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
@@ -58,13 +58,34 @@ object ProcessFootprint {
     private val logger = BossLogger.forComponent("ProcessFootprint")
 
     /**
-     * How long a reading may be reused.
+     * How long a measured reading may be reused.
      *
-     * Enumerating every process and reading each one's command line is the expensive part, and
-     * on macOS it is a `sysctl` per process. The consumer is a status-bar glyph and a 15 s
-     * pressure watchdog, so a reading this stale cannot change any decision either one makes.
+     * The work is split across two cadences because its two halves cost very different amounts.
+     * Measured on a machine running 1,227 processes:
+     *
+     *  - enumerating processes: **~1 ms**
+     *  - reading every process's command line to decide ownership: **~95 ms**
+     *  - querying memory for the dozen pids we own: **~48 ms**, nearly all of it process-spawn
+     *    overhead on macOS, and free on Linux where it is a `/proc` read
+     *
+     * Doing all of it on one 10 s cadence cost ~150 ms every 10 s, about 1.5% of a core burnt
+     * continuously to render one status-bar glyph. That is a poor trade on any machine and an
+     * indefensible one on the small, battery-powered machines this indicator is meant to help.
+     *
+     * So ownership is discovered rarely and memory is measured often: roughly 95 + 4x48 ms a
+     * minute, under 0.5% of a core, and lower again on Linux.
      */
-    internal const val CACHE_TTL_MS = 10_000L
+    internal const val MEASURE_TTL_MS = 15_000L
+
+    /**
+     * How long the set of owned processes may be reused before it is rediscovered.
+     *
+     * A minute of staleness means a browser tab opened just now may not be counted until the next
+     * discovery. That is acceptable for a footprint reading and it is not the only trigger:
+     * [needsDiscovery] also rediscovers whenever the machine's process count has changed at all,
+     * which costs ~1 ms to check and catches a new renderer or plugin host within one tick.
+     */
+    internal const val DISCOVERY_TTL_MS = 60_000L
 
     /** Upper bound on how long the per-platform memory query may take before it is abandoned. */
     private const val QUERY_TIMEOUT_SECONDS = 5L
@@ -92,6 +113,13 @@ object ProcessFootprint {
 
     @Volatile private var cachedAtMs: Long = 0L
 
+    /** Owned pids from the last discovery, and what they were when it ran. */
+    @Volatile private var ownedPids: Map<Long, Owner> = emptyMap()
+
+    @Volatile private var discoveredAtMs: Long = 0L
+
+    @Volatile private var processCountAtDiscovery: Int = -1
+
     /**
      * The current footprint, or null when it cannot be read.
      *
@@ -101,8 +129,8 @@ object ProcessFootprint {
      * trigger any reduced behaviour.
      */
     fun current(nowMs: Long = System.currentTimeMillis()): Reading? {
-        cached?.let { if (nowMs - cachedAtMs < CACHE_TTL_MS) return it }
-        val fresh = read()
+        cached?.let { if (nowMs - cachedAtMs < MEASURE_TTL_MS) return it }
+        val fresh = read(nowMs)
         if (fresh != null) {
             cached = fresh
             cachedAtMs = nowMs
@@ -110,26 +138,56 @@ object ProcessFootprint {
         return fresh
     }
 
-    private fun read(): Reading? =
+    /**
+     * Whether the owned-process set should be rediscovered rather than reused.
+     *
+     * Pure so the cadence is testable without waiting a real minute. Two triggers: the set is
+     * older than [DISCOVERY_TTL_MS], or the machine's process count has moved, which is the cheap
+     * proxy for "something started or stopped, and it might be ours". The count alone would miss
+     * a simultaneous start and stop, which is why the age ceiling is also there.
+     */
+    internal fun needsDiscovery(
+        discoveredAtMs: Long,
+        nowMs: Long,
+        liveProcessCount: Int,
+        countAtDiscovery: Int,
+    ): Boolean =
+        countAtDiscovery < 0 ||
+            liveProcessCount != countAtDiscovery ||
+            nowMs - discoveredAtMs >= DISCOVERY_TTL_MS
+
+    private fun read(nowMs: Long): Reading? =
         runCatching {
-            val hostPid = ProcessHandle.current().pid()
-            val engineDirs = engineDirPrefixes()
+            // ~1 ms, and it decides whether the ~95 ms scan below is needed at all.
+            val handles = ProcessHandle.allProcesses().toList()
 
-            val owned =
-                ProcessHandle
-                    .allProcesses()
-                    .toList()
-                    .mapNotNull { handle ->
-                        val owner =
-                            classify(
-                                pid = handle.pid(),
-                                commandLine = handle.info().commandLine().orElse(""),
-                                hostPid = hostPid,
-                                engineDirs = engineDirs,
-                            ) ?: return@mapNotNull null
-                        handle.pid() to owner
-                    }.toMap()
+            if (needsDiscovery(discoveredAtMs, nowMs, handles.size, processCountAtDiscovery)) {
+                val hostPid = ProcessHandle.current().pid()
+                // Taken from FluckEngine rather than hardcoding ~/.boss/boss-chromium, because a
+                // packaged build can run the engine bundled inside the app image instead, and a
+                // hardcoded cache path would silently score every such install's browser at zero.
+                // Both candidates are matched; only one of them can have live processes.
+                val engineDirs =
+                    runCatching {
+                        FluckEngine.engineLocations().map { it.toAbsolutePath().toString() }
+                    }.getOrElse { emptyList() }
+                ownedPids =
+                    handles
+                        .mapNotNull { handle ->
+                            val owner =
+                                classify(
+                                    pid = handle.pid(),
+                                    commandLine = handle.info().commandLine().orElse(""),
+                                    hostPid = hostPid,
+                                    engineDirs = engineDirs,
+                                ) ?: return@mapNotNull null
+                            handle.pid() to owner
+                        }.toMap()
+                discoveredAtMs = nowMs
+                processCountAtDiscovery = handles.size
+            }
 
+            val owned = ownedPids
             if (owned.isEmpty()) return@runCatching null
 
             val memory = queryMemoryBytes(owned.keys.toList())
@@ -181,19 +239,6 @@ object ProcessFootprint {
 
             else -> null
         }
-
-    /**
-     * Directory prefixes an engine process can be launched from.
-     *
-     * Taken from [FluckEngine.engineLocations] rather than hardcoding `~/.boss/boss-chromium`,
-     * because a packaged build can run the engine bundled inside the app image instead, and a
-     * hardcoded cache path would silently score every such install's browser at zero. Both
-     * candidates are matched; only one of them can have live processes.
-     */
-    private fun engineDirPrefixes(): List<String> =
-        runCatching {
-            FluckEngine.engineLocations().map { it.toAbsolutePath().toString() }
-        }.getOrElse { emptyList() }
 
     /** Physical memory per pid, keyed by pid. Missing entries mean that pid could not be read. */
     private fun queryMemoryBytes(pids: List<Long>): Map<Long, Long> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
@@ -78,14 +78,21 @@ object ProcessFootprint {
     internal const val MEASURE_TTL_MS = 15_000L
 
     /**
-     * How long the set of owned processes may be reused before it is rediscovered.
+     * How often the whole process table is reclassified from scratch, ignoring what is known.
      *
-     * A minute of staleness means a browser tab opened just now may not be counted until the next
-     * discovery. That is acceptable for a footprint reading and it is not the only trigger:
-     * [needsDiscovery] also rediscovers whenever the machine's process count has changed at all,
-     * which costs ~1 ms to check and catches a new renderer or plugin host within one tick.
+     * Rare, because it is the expensive path and it is almost never the one that finds anything.
+     * Ownership is normally decided from the *pid-set delta*: enumerating pids costs 0-2 ms and
+     * reading a command line costs well under a millisecond each, so classifying only the handful
+     * of pids that appeared since the last tick is effectively free, where reading all 1,219 of
+     * them costs ~70 ms. Measured on the machine this was written on.
+     *
+     * The delta is exact rather than a proxy - every new pid is classified and every dead one is
+     * dropped - so this exists for one residual case the delta cannot see: a process that calls
+     * `exec` in place, keeping its pid while its command line changes from something we do not own
+     * to something we do. Unlikely for our targets, which are all spawned fresh, but cheap to
+     * cover at this interval.
      */
-    internal const val DISCOVERY_TTL_MS = 60_000L
+    internal const val FULL_RESCAN_TTL_MS = 300_000L
 
     /** Upper bound on how long the per-platform memory query may take before it is abandoned. */
     private const val QUERY_TIMEOUT_SECONDS = 5L
@@ -113,12 +120,13 @@ object ProcessFootprint {
 
     @Volatile private var cachedAtMs: Long = 0L
 
-    /** Owned pids from the last discovery, and what they were when it ran. */
+    /** Owned pids and what each one is, carried forward between ticks. */
     @Volatile private var ownedPids: Map<Long, Owner> = emptyMap()
 
-    @Volatile private var discoveredAtMs: Long = 0L
+    /** Every pid seen at the last enumeration, owned or not, so the next delta is exact. */
+    @Volatile private var knownPids: Set<Long> = emptySet()
 
-    @Volatile private var processCountAtDiscovery: Int = -1
+    @Volatile private var fullScanAtMs: Long = 0L
 
     /**
      * The current footprint, or null when it cannot be read.
@@ -129,7 +137,20 @@ object ProcessFootprint {
      * trigger any reduced behaviour.
      */
     fun current(nowMs: Long = System.currentTimeMillis()): Reading? {
-        cached?.let { if (nowMs - cachedAtMs < MEASURE_TTL_MS) return it }
+        // Nobody can read a glyph that is not on screen, and this is the only consumer of the
+        // reading - the pressure watchdog has its own SystemMemory path. So a hidden bar costs
+        // nothing at all rather than 0.3% of a core, which is not a rare case: focus mode hides
+        // the bottom bar per edge, Windows ships with it, and a bar switched off in settings
+        // never comes back without the View menu.
+        //
+        // Returns the last reading rather than null so that re-mounting draws a number
+        // immediately and refreshes within one sample tick, instead of flashing the heap
+        // fallback first.
+        val reusable = cached
+        if (!FootprintDisplay.isOnScreen || (reusable != null && nowMs - cachedAtMs < MEASURE_TTL_MS)) {
+            return reusable
+        }
+
         val fresh = read(nowMs)
         if (fresh != null) {
             cached = fresh
@@ -139,29 +160,42 @@ object ProcessFootprint {
     }
 
     /**
-     * Whether the owned-process set should be rediscovered rather than reused.
+     * Which pids need their command line read this tick.
      *
-     * Pure so the cadence is testable without waiting a real minute. Two triggers: the set is
-     * older than [DISCOVERY_TTL_MS], or the machine's process count has moved, which is the cheap
-     * proxy for "something started or stopped, and it might be ours". The count alone would miss
-     * a simultaneous start and stop, which is why the age ceiling is also there.
+     * Pure, so the incremental rule is testable without a process table. Everything on a full
+     * rescan; otherwise only what has appeared since the last enumeration, which on a settled
+     * machine is nothing at all.
      */
-    internal fun needsDiscovery(
-        discoveredAtMs: Long,
-        nowMs: Long,
-        liveProcessCount: Int,
-        countAtDiscovery: Int,
-    ): Boolean =
-        countAtDiscovery < 0 ||
-            liveProcessCount != countAtDiscovery ||
-            nowMs - discoveredAtMs >= DISCOVERY_TTL_MS
+    internal fun pidsToClassify(
+        livePids: Set<Long>,
+        knownPids: Set<Long>,
+        fullRescan: Boolean,
+    ): Set<Long> = if (fullRescan) livePids else livePids - knownPids
+
+    /**
+     * The owned-pid map carried into this tick, with the dead dropped.
+     *
+     * Dropping by liveness is what makes a departed process stop counting without any rescan: a
+     * closed browser tab's renderer is gone from `livePids` and therefore gone from the total on
+     * the very next tick. A full rescan starts from nothing instead, since it is about to
+     * reclassify everything anyway.
+     */
+    internal fun retainLive(
+        owned: Map<Long, Owner>,
+        livePids: Set<Long>,
+        fullRescan: Boolean,
+    ): Map<Long, Owner> = if (fullRescan) emptyMap() else owned.filterKeys { it in livePids }
 
     private fun read(nowMs: Long): Reading? =
         runCatching {
-            // ~1 ms, and it decides whether the ~95 ms scan below is needed at all.
+            // 0-2 ms. Everything below is scoped by the delta this produces.
             val handles = ProcessHandle.allProcesses().toList()
+            val livePids = handles.mapTo(HashSet()) { it.pid() }
 
-            if (needsDiscovery(discoveredAtMs, nowMs, handles.size, processCountAtDiscovery)) {
+            val fullRescan = nowMs - fullScanAtMs >= FULL_RESCAN_TTL_MS
+            val toClassify = pidsToClassify(livePids, knownPids, fullRescan)
+
+            if (toClassify.isNotEmpty()) {
                 val hostPid = ProcessHandle.current().pid()
                 // Taken from FluckEngine rather than hardcoding ~/.boss/boss-chromium, because a
                 // packaged build can run the engine bundled inside the app image instead, and a
@@ -171,8 +205,9 @@ object ProcessFootprint {
                     runCatching {
                         FluckEngine.engineLocations().map { it.toAbsolutePath().toString() }
                     }.getOrElse { emptyList() }
-                ownedPids =
+                val found =
                     handles
+                        .filter { it.pid() in toClassify }
                         .mapNotNull { handle ->
                             val owner =
                                 classify(
@@ -182,10 +217,14 @@ object ProcessFootprint {
                                     engineDirs = engineDirs,
                                 ) ?: return@mapNotNull null
                             handle.pid() to owner
-                        }.toMap()
-                discoveredAtMs = nowMs
-                processCountAtDiscovery = handles.size
+                        }
+                ownedPids = retainLive(ownedPids, livePids, fullRescan) + found
+            } else {
+                ownedPids = retainLive(ownedPids, livePids, fullRescan)
             }
+
+            knownPids = livePids
+            if (fullRescan) fullScanAtMs = nowMs
 
             val owned = ownedPids
             if (owned.isEmpty()) return@runCatching null
@@ -245,8 +284,21 @@ object ProcessFootprint {
         if (pids.isEmpty()) return emptyMap()
         val os = System.getProperty("os.name").orEmpty().lowercase()
         return when {
+            // Plain file reads: `Pss` where the kernel offers it, `VmRSS` on kernels before 4.14.
+            // Unlike the other two platforms this costs no subprocess at all, which is why Linux
+            // pays almost nothing for this feature.
             os.startsWith("linux") -> {
-                pids.mapNotNull { pid -> linuxBytes(pid)?.let { pid to it } }.toMap()
+                pids
+                    .mapNotNull { pid ->
+                        runCatching {
+                            val rollup = File("/proc/$pid/smaps_rollup")
+                            if (rollup.exists()) {
+                                parseProcKb(rollup.readText(), "Pss:")?.times(1024L)
+                            } else {
+                                parseProcKb(File("/proc/$pid/status").readText(), "VmRSS:")?.times(1024L)
+                            }
+                        }.getOrNull()?.let { pid to it }
+                    }.toMap()
             }
 
             os.startsWith("mac") -> {
@@ -278,21 +330,6 @@ object ProcessFootprint {
             }
         }
     }
-
-    /**
-     * `Pss` from smaps_rollup in bytes, falling back to `VmRSS` from status.
-     *
-     * Plain file reads, so unlike the other two platforms this costs no subprocess at all.
-     */
-    private fun linuxBytes(pid: Long): Long? =
-        runCatching {
-            val rollup = File("/proc/$pid/smaps_rollup")
-            if (rollup.exists()) {
-                parseProcKb(rollup.readText(), "Pss:")?.times(1024L)
-            } else {
-                parseProcKb(File("/proc/$pid/status").readText(), "VmRSS:")?.times(1024L)
-            }
-        }.getOrNull()
 
     /** A `<Label>: <n> kB` field from a /proc file, in kB, or null when absent. */
     internal fun parseProcKb(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicatorTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicatorTextTest.kt
@@ -1,0 +1,65 @@
+package ai.rever.boss.components.bars.horizontal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guards the indicator's label, including the three degraded paths.
+ *
+ * Worth pinning because the two inputs genuinely can be absent at runtime and each has a
+ * different "unknown" convention: the footprint is null when no platform reader could produce
+ * one, while `SystemMemory` returns 0 rather than throwing. Rendering either as a zero would put
+ * "0.0GB" in front of the user and read as a fact rather than a failure.
+ */
+class PerformanceIndicatorTextTest {
+    private val gb = 1024f
+
+    private fun text(
+        footprintMB: Float? = 2.1f * gb,
+        systemUsedMB: Float? = 70f * gb,
+        systemTotalMB: Float? = 128f * gb,
+        heapUsedMB: Float = 296f,
+        heapMaxMB: Float = 2f * gb,
+    ) = memoryIndicatorText(footprintMB, systemUsedMB, systemTotalMB, heapUsedMB, heapMaxMB)
+
+    @Test
+    fun `both readings show BOSS then the machine`() {
+        assertEquals("2.1GB · 70/128GB", text())
+    }
+
+    @Test
+    fun `a small machine keeps a decimal on both halves`() {
+        assertEquals("512MB · 3.2/8.0GB", text(footprintMB = 512f, systemUsedMB = 3.2f * gb, systemTotalMB = 8f * gb))
+    }
+
+    /**
+     * The pair is scaled by the total, never each half separately. Formatted independently this
+     * would read "900MB/128GB", where the two numbers look comparable and are not.
+     */
+    @Test
+    fun `a sub-gigabyte used figure still scales to the total's unit`() {
+        assertEquals("2.1GB · 0.9/128GB", text(systemUsedMB = 900f))
+    }
+
+    @Test
+    fun `an unreadable footprint leaves the machine pair`() {
+        assertEquals("70/128GB", text(footprintMB = null))
+    }
+
+    @Test
+    fun `an unreadable machine leaves the footprint`() {
+        assertEquals("2.1GB", text(systemUsedMB = null, systemTotalMB = null))
+    }
+
+    @Test
+    fun `losing both falls back to the heap ratio`() {
+        assertEquals("296MB/2.0GB", text(footprintMB = null, systemUsedMB = null, systemTotalMB = null))
+    }
+
+    @Test
+    fun `a half-known machine reading is not rendered`() {
+        // Total without available, or the reverse, is not a pair - it must not print "70/0GB".
+        assertEquals("2.1GB", text(systemUsedMB = 70f * gb, systemTotalMB = null))
+        assertEquals("2.1GB", text(systemUsedMB = null, systemTotalMB = 128f * gb))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/MemoryPressureHealthTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/MemoryPressureHealthTest.kt
@@ -1,0 +1,112 @@
+package ai.rever.boss.performance
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Guards the signal behind the status-bar colour.
+ *
+ * Before this, the colour came from heap-used over heap-max. On a 128 GB machine the heap
+ * ceiling is ~30 GB by JVM ergonomics and a loaded session holds ~300 MB, so the indicator read
+ * 1% and could not have reached its 75% warning band without 22 GB of live objects. It was green
+ * during a 27 GB plugin-host leak. These tests pin the replacement signal and, more importantly,
+ * pin it to the same threshold the watchdog acts on.
+ */
+class MemoryPressureHealthTest {
+    private fun metrics(
+        available: Long,
+        total: Long,
+        heapUsed: Long = 100L * 1024 * 1024,
+        heapMax: Long = 4L * 1024 * 1024 * 1024,
+    ) = MemoryMetrics(
+        heapUsedBytes = heapUsed,
+        heapMaxBytes = heapMax,
+        heapCommittedBytes = heapUsed,
+        nonHeapUsedBytes = 0,
+        nonHeapCommittedBytes = 0,
+        systemAvailableBytes = available,
+        systemTotalBytes = total,
+    )
+
+    private fun snapshot(memory: MemoryMetrics) =
+        PerformanceSnapshot(
+            timestamp = 0L,
+            memory = memory,
+            cpu = CpuMetrics(processLoad = 0.0, systemLoad = 0.0, availableProcessors = 8, activeThreadCount = 1),
+            gc =
+                GcMetrics(
+                    collectionCount = 0,
+                    collectionTimeMs = 0,
+                    gcTimeSinceLastSampleMs = 0,
+                    gcCollectors = emptyList(),
+                ),
+            resources =
+                ResourceMetrics(
+                    browserTabCount = 0,
+                    terminalCount = 0,
+                    editorTabCount = 0,
+                    panelCount = 0,
+                    windowCount = 0,
+                ),
+        )
+
+    private val gb = 1024L * 1024 * 1024
+
+    @Test
+    fun `the indicator threshold is the watchdog threshold`() {
+        // Not a tautology now that one is defined in terms of the other: it is the guard that
+        // keeps them that way. If they drift, the bar turns red at a different moment from the
+        // one the watchdog starts acting on, and the modal goes back to being an ambush.
+        assertEquals(MemoryPressureWatchdog.PRESSURE_THRESHOLD, MemoryPressure.CRITICAL_AVAILABLE_FRACTION)
+    }
+
+    @Test
+    fun `pressure maps to health at the documented bands`() {
+        assertEquals(HealthStatus.GOOD, MemoryPressure.statusFor(0.50))
+        assertEquals(HealthStatus.WARNING, MemoryPressure.statusFor(MemoryPressure.WARNING_AVAILABLE_FRACTION))
+        assertEquals(HealthStatus.WARNING, MemoryPressure.statusFor(0.20))
+        assertEquals(HealthStatus.CRITICAL, MemoryPressure.statusFor(MemoryPressure.CRITICAL_AVAILABLE_FRACTION))
+        assertEquals(HealthStatus.CRITICAL, MemoryPressure.statusFor(0.01))
+    }
+
+    @Test
+    fun `an unreadable machine is not pressure`() {
+        // The asymmetry SystemMemory documents: unknown must never be read as "full", or an
+        // unreadable bean paints the bar red on a machine with plenty of room.
+        assertEquals(HealthStatus.GOOD, MemoryPressure.statusFor(null))
+        assertNull(metrics(available = 0, total = 128 * gb).systemAvailableFraction)
+        assertNull(metrics(available = 8 * gb, total = 0).systemAvailableFraction)
+    }
+
+    @Test
+    fun `a full machine is critical even with an idle heap`() {
+        // The whole point: 100 MB of a 4 GB heap is 2.4%, nowhere near any heap threshold.
+        val snap = snapshot(metrics(available = 4 * gb, total = 128 * gb))
+        val health = PerformanceHealth.fromSnapshot(snap, PerformanceSettings())
+        assertEquals(HealthStatus.CRITICAL, health.memoryStatus)
+        assertEquals(HealthStatus.CRITICAL, health.overall)
+    }
+
+    @Test
+    fun `a full heap is still critical on a machine with room`() {
+        // Pressure is added to the heap signal, never substituted for it. Heap exhaustion did not
+        // stop being a way to die when we started watching the machine as well.
+        val heapUsed = 39L * gb / 10
+        val full = metrics(available = 100 * gb, total = 128 * gb, heapUsed = heapUsed, heapMax = 4L * gb)
+        val health = PerformanceHealth.fromSnapshot(snapshot(full), PerformanceSettings())
+        assertEquals(HealthStatus.CRITICAL, health.memoryStatus)
+    }
+
+    @Test
+    fun `a healthy machine with an idle heap is good`() {
+        val snap = snapshot(metrics(available = 100 * gb, total = 128 * gb))
+        assertEquals(HealthStatus.GOOD, PerformanceHealth.fromSnapshot(snap, PerformanceSettings()).overall)
+    }
+
+    @Test
+    fun `an unread footprint is not displayed as zero`() {
+        assertEquals(false, metrics(available = 8 * gb, total = 128 * gb).footprintKnown)
+        assertEquals(true, metrics(available = 8 * gb, total = 128 * gb).copy(footprintBytes = 3 * gb).footprintKnown)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/PerformancePanelPromptTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/PerformancePanelPromptTest.kt
@@ -1,0 +1,197 @@
+package ai.rever.boss.performance
+
+import ai.rever.boss.components.plugin.MissingDependencyInstaller
+import ai.rever.boss.components.plugin.MissingDependencyPrompt
+import ai.rever.boss.components.plugin.MissingPluginDependency
+import ai.rever.boss.components.plugin.PluginDependencyBus
+import ai.rever.boss.components.plugin.shouldShowMissingDependency
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the offer to install the Performance panel's plugin.
+ *
+ * The failure this replaces was silence: the status-bar indicator is host-drawn but the panel it
+ * opens belongs to a plugin, so on an install without that plugin the click emitted a panel event
+ * nothing listened for. No panel, no dialog, not even a log line - indistinguishable from a
+ * broken button.
+ */
+class PerformancePanelPromptTest {
+    private class FakeInstaller(
+        private val installed: Set<String>,
+    ) : MissingDependencyInstaller {
+        override fun isInstalled(pluginId: String) = pluginId in installed
+
+        override suspend fun displayNameFor(pluginId: String): String? = null
+
+        override suspend fun install(pluginId: String): Result<Unit> = Result.success(Unit)
+    }
+
+    @Test
+    fun `no prompt when the plugin is already installed`() {
+        val installer = FakeInstaller(setOf(PERFORMANCE_PLUGIN_ID))
+        assertNull(performancePanelPrompt(installer))
+    }
+
+    @Test
+    fun `a missing plugin produces a prompt naming it`() {
+        val prompt = performancePanelPrompt(FakeInstaller(emptySet()))
+        assertNotNull(prompt)
+        assertEquals(PERFORMANCE_PLUGIN_ID, prompt.missing.missingPluginId)
+        assertTrue(prompt.userInitiated, "the panel is only opened by a person pressing something")
+    }
+
+    /**
+     * Optional is not a detail. It selects the dialog's copy, and the required phrasing would
+     * claim BOSS needs this plugin - untrue, and untrue inside a consent dialog for downloading
+     * and running code.
+     */
+    @Test
+    fun `the offer is worded as recommended rather than required`() {
+        val prompt = performancePanelPrompt(FakeInstaller(emptySet()))
+        assertNotNull(prompt)
+        assertTrue(prompt.missing.optional)
+        assertEquals(
+            "BOSS works without Performance, but some of its features need it.",
+            prompt.missing.description("Performance"),
+        )
+    }
+
+    /**
+     * Another plugin's absence must not be mistaken for this one's.
+     */
+    @Test
+    fun `an unrelated installed plugin does not satisfy the check`() {
+        val other = FakeInstaller(setOf("ai.rever.boss.plugin.dynamic.console"))
+        val prompt = performancePanelPrompt(other)
+        assertNotNull(prompt)
+    }
+
+    // region the bus's forced report
+
+    private fun prompt(
+        optional: Boolean = true,
+        userInitiated: Boolean = true,
+    ) = MissingDependencyPrompt(
+        missing =
+            MissingPluginDependency(
+                dependentPluginId = "ai.rever.boss.host",
+                dependentDisplayName = "BOSS",
+                missingPluginId = PERFORMANCE_PLUGIN_ID,
+                optional = optional,
+            ),
+        installer = FakeInstaller(emptySet()),
+        userInitiated = userInitiated,
+    )
+
+    /**
+     * The decline set still silences prompts nobody asked for.
+     */
+    @Test
+    fun `an automatic prompt stays silenced once declined`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            val automatic = prompt(userInitiated = false)
+            bus.decline(automatic.missing)
+            bus.report(automatic)
+            assertNull(withTimeoutOrNull(200) { bus.missingDependencies.first() })
+        }
+
+    /**
+     * Gate 1, the bus: a user-initiated report survives an earlier dismissal.
+     */
+    @Test
+    fun `the bus does not silence a click after an earlier dismissal`() {
+        val bus = PluginDependencyBus()
+        val click = prompt()
+        bus.decline(click.missing)
+        assertTrue(bus.wasDeclined(click.missing))
+        assertTrue(click.userInitiated)
+    }
+
+    /**
+     * Gate 2, the window that collects, which re-checks the same set.
+     *
+     * This is the half that was broken. Exercises the real rule the collector calls, not a copy
+     * of it: an earlier version of this test restated the expression inline and passed happily
+     * while the collector went on dropping every click.
+     */
+    @Test
+    fun `the collector shows a click even after the offer was dismissed`() {
+        assertEquals(
+            true,
+            shouldShowMissingDependency(prompt(userInitiated = true), present = false, declined = true),
+        )
+    }
+
+    @Test
+    fun `the collector still silences an automatic prompt that was declined`() {
+        assertEquals(
+            false,
+            shouldShowMissingDependency(prompt(userInitiated = false), present = false, declined = true),
+        )
+    }
+
+    @Test
+    fun `nothing is offered once the plugin is present, however it was asked for`() {
+        // Two dependents of one missing plugin each raise a prompt; installing for the first
+        // must not leave the second claiming something untrue.
+        assertEquals(
+            false,
+            shouldShowMissingDependency(prompt(userInitiated = true), present = true, declined = false),
+        )
+        assertEquals(
+            false,
+            shouldShowMissingDependency(prompt(userInitiated = false), present = true, declined = false),
+        )
+    }
+
+    @Test
+    fun `an undeclined prompt for a missing plugin is shown`() {
+        assertEquals(
+            true,
+            shouldShowMissingDependency(prompt(userInitiated = false), present = false, declined = false),
+        )
+    }
+
+    /**
+     * The point of `force`. Someone who dismissed the offer and then pressed the button again is
+     * asking again, and answering a click with silence is the failure this feature removes.
+     */
+    @Test
+    fun `a click still asks after the offer was dismissed once`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            bus.decline(prompt().missing)
+            bus.report(prompt())
+            val delivered = bus.missingDependencies.first()
+            assertEquals(PERFORMANCE_PLUGIN_ID, delivered.missing.missingPluginId)
+        }
+
+    /**
+     * Force skips the decline check only. A second click while the dialog is still up must not
+     * stack a second copy of it.
+     */
+    @Test
+    fun `forcing twice does not queue two dialogs`() =
+        runTest {
+            val bus = PluginDependencyBus()
+            bus.report(prompt())
+            bus.report(prompt())
+            val first = bus.missingDependencies.first()
+            assertEquals(PERFORMANCE_PLUGIN_ID, first.missing.missingPluginId)
+            // The queued slot is released as the first is delivered, so a later click can ask
+            // again; what must not happen is two arriving from two clicks made back to back.
+            assertNull(
+                withTimeoutOrNull(200) { bus.missingDependencies.first() },
+            )
+        }
+
+    // endregion
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
@@ -106,42 +106,80 @@ class ProcessFootprintTest {
 
     // endregion
 
-    // region sampling cadence
+    // region incremental discovery
 
     /**
-     * The cadence exists for a measured reason: on a machine running 1,227 processes the
-     * ownership scan cost ~95 ms against ~48 ms to measure the dozen pids we own, and running
-     * both every 10 s burnt about 1.5% of a core continuously to draw one status-bar glyph.
+     * The cadence exists for a measured reason: on a machine running 1,219 processes, enumerating
+     * pids costs 0-2 ms, reading every command line costs ~70 ms, and reading a five-pid delta
+     * costs under a millisecond. Reclassifying everything on every tick burnt about 1.5% of a core
+     * continuously to draw one status-bar glyph.
      */
     @Test
-    fun `discovery is skipped while the process set looks unchanged`() {
-        val t0 = 1_000_000L
-        assertEquals(false, ProcessFootprint.needsDiscovery(t0, t0 + 1_000, 1227, countAtDiscovery = 1227))
-        assertEquals(
-            false,
-            ProcessFootprint.needsDiscovery(t0, t0 + ProcessFootprint.DISCOVERY_TTL_MS - 1, 1227, 1227),
-        )
+    fun `a settled machine classifies nothing`() {
+        val known = setOf(1L, 2L, 3L)
+        assertEquals(emptySet(), ProcessFootprint.pidsToClassify(known, known, fullRescan = false))
     }
 
     @Test
-    fun `a changed process count rediscovers immediately`() {
-        // A new renderer or plugin host must not wait out the age ceiling to be counted.
-        val t0 = 1_000_000L
-        assertEquals(true, ProcessFootprint.needsDiscovery(t0, t0 + 1, 1228, countAtDiscovery = 1227))
-        assertEquals(true, ProcessFootprint.needsDiscovery(t0, t0 + 1, 1226, countAtDiscovery = 1227))
+    fun `only pids that appeared since the last tick are classified`() {
+        val live = setOf(1L, 2L, 3L, 99L)
+        val known = setOf(1L, 2L, 3L)
+        assertEquals(setOf(99L), ProcessFootprint.pidsToClassify(live, known, fullRescan = false))
     }
 
     @Test
-    fun `the age ceiling still forces a rediscovery`() {
-        // The count is only a proxy: a simultaneous start and stop leaves it unchanged while
-        // membership has moved underneath. The ceiling is what bounds that error.
-        val t0 = 1_000_000L
-        assertEquals(true, ProcessFootprint.needsDiscovery(t0, t0 + ProcessFootprint.DISCOVERY_TTL_MS, 1227, 1227))
+    fun `a full rescan classifies everything regardless of what is known`() {
+        val live = setOf(1L, 2L, 3L)
+        assertEquals(live, ProcessFootprint.pidsToClassify(live, live, fullRescan = true))
     }
 
     @Test
-    fun `the first call always discovers`() {
-        assertEquals(true, ProcessFootprint.needsDiscovery(0L, 0L, 0, countAtDiscovery = -1))
+    fun `a departed process stops counting on the very next tick`() {
+        // A closed tab's renderer must drop out without waiting for any rescan.
+        val owned = mapOf(1L to ProcessFootprint.Owner.HOST, 42L to ProcessFootprint.Owner.BROWSER)
+        val retained = ProcessFootprint.retainLive(owned, setOf(1L), fullRescan = false)
+        assertEquals(mapOf(1L to ProcessFootprint.Owner.HOST), retained)
+    }
+
+    @Test
+    fun `a full rescan starts from nothing`() {
+        val owned = mapOf(1L to ProcessFootprint.Owner.HOST)
+        assertEquals(emptyMap(), ProcessFootprint.retainLive(owned, setOf(1L), fullRescan = true))
+    }
+
+    // endregion
+
+    // region display gating
+
+    @Test
+    fun `sampling follows the indicator on and off screen`() {
+        assertEquals(false, FootprintDisplay.isOnScreen)
+        FootprintDisplay.setMounted(true)
+        assertEquals(true, FootprintDisplay.isOnScreen)
+        FootprintDisplay.setMounted(false)
+        assertEquals(false, FootprintDisplay.isOnScreen)
+    }
+
+    @Test
+    fun `a second window closing does not switch sampling off for the first`() {
+        FootprintDisplay.setMounted(true)
+        FootprintDisplay.setMounted(true)
+        FootprintDisplay.setMounted(false)
+        assertEquals(true, FootprintDisplay.isOnScreen)
+        FootprintDisplay.setMounted(false)
+        assertEquals(false, FootprintDisplay.isOnScreen)
+    }
+
+    @Test
+    fun `an unpaired dispose cannot latch sampling off`() {
+        // Compose does not promise a dispose for every mount under all teardown paths. Without the
+        // clamp the count goes negative and no later mount can bring it back above zero.
+        FootprintDisplay.setMounted(false)
+        FootprintDisplay.setMounted(false)
+        FootprintDisplay.setMounted(true)
+        assertEquals(true, FootprintDisplay.isOnScreen)
+        FootprintDisplay.setMounted(false)
+        assertEquals(false, FootprintDisplay.isOnScreen)
     }
 
     // endregion

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
@@ -106,6 +106,46 @@ class ProcessFootprintTest {
 
     // endregion
 
+    // region sampling cadence
+
+    /**
+     * The cadence exists for a measured reason: on a machine running 1,227 processes the
+     * ownership scan cost ~95 ms against ~48 ms to measure the dozen pids we own, and running
+     * both every 10 s burnt about 1.5% of a core continuously to draw one status-bar glyph.
+     */
+    @Test
+    fun `discovery is skipped while the process set looks unchanged`() {
+        val t0 = 1_000_000L
+        assertEquals(false, ProcessFootprint.needsDiscovery(t0, t0 + 1_000, 1227, countAtDiscovery = 1227))
+        assertEquals(
+            false,
+            ProcessFootprint.needsDiscovery(t0, t0 + ProcessFootprint.DISCOVERY_TTL_MS - 1, 1227, 1227),
+        )
+    }
+
+    @Test
+    fun `a changed process count rediscovers immediately`() {
+        // A new renderer or plugin host must not wait out the age ceiling to be counted.
+        val t0 = 1_000_000L
+        assertEquals(true, ProcessFootprint.needsDiscovery(t0, t0 + 1, 1228, countAtDiscovery = 1227))
+        assertEquals(true, ProcessFootprint.needsDiscovery(t0, t0 + 1, 1226, countAtDiscovery = 1227))
+    }
+
+    @Test
+    fun `the age ceiling still forces a rediscovery`() {
+        // The count is only a proxy: a simultaneous start and stop leaves it unchanged while
+        // membership has moved underneath. The ceiling is what bounds that error.
+        val t0 = 1_000_000L
+        assertEquals(true, ProcessFootprint.needsDiscovery(t0, t0 + ProcessFootprint.DISCOVERY_TTL_MS, 1227, 1227))
+    }
+
+    @Test
+    fun `the first call always discovers`() {
+        assertEquals(true, ProcessFootprint.needsDiscovery(0L, 0L, 0, countAtDiscovery = -1))
+    }
+
+    // endregion
+
     // region parsers
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
@@ -1,0 +1,144 @@
+package ai.rever.boss.performance
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Guards the ownership rule and the per-platform parsers in [ProcessFootprint].
+ *
+ * The ownership rule is the part worth testing, because getting it wrong is silent in both
+ * directions and neither direction shows up as an exception. Claim too much and the indicator
+ * charges BOSS for the user's own workload - measured at 4,414 MB of `claude` CLIs, Python MCP
+ * children and a tunnel on the machine this was written on, all of them descendants of the host
+ * JVM by way of a terminal tab. Claim too little and the orphaned engine and plugin processes
+ * this indicator exists to surface go uncounted, which is the failure that made it necessary.
+ */
+class ProcessFootprintTest {
+    private val hostPid = 57786L
+    private val engineDirs = listOf("/Users/dev/.boss/boss-chromium")
+
+    private fun classify(
+        commandLine: String,
+        pid: Long = 99999L,
+    ) = ProcessFootprint.classify(pid, commandLine, hostPid, engineDirs)
+
+    // region ownership
+
+    @Test
+    fun `the host JVM is claimed by pid`() {
+        assertEquals(ProcessFootprint.Owner.HOST, classify("/Applications/BOSS.app/Contents/MacOS/BOSS", pid = hostPid))
+    }
+
+    @Test
+    fun `plugin hosts are claimed by their main class`() {
+        assertEquals(
+            ProcessFootprint.Owner.PLUGIN,
+            classify("/usr/bin/java -Xmx2621m -cp boss-plugin-docker-1.0.1.jar ai.rever.boss.PluginProcessMainKt"),
+        )
+    }
+
+    @Test
+    fun `both the engine main process and its helpers are claimed`() {
+        assertEquals(
+            ProcessFootprint.Owner.BROWSER,
+            classify("/Users/dev/.boss/boss-chromium/BOSS.app/Contents/MacOS/BOSS --port=62988 --browsercore"),
+        )
+        assertEquals(
+            ProcessFootprint.Owner.BROWSER,
+            classify(
+                "/Users/dev/.boss/boss-chromium/BOSS.app/Contents/Frameworks/Chromium Framework.framework/" +
+                    "Helpers/BOSS Helper.app/Contents/MacOS/BOSS Helper --type=renderer",
+            ),
+        )
+    }
+
+    /**
+     * The reparented-helper case. Ownership is decided by the executable path alone, so a process
+     * that has been orphaned to pid 1 and is no longer a descendant of ours is still counted -
+     * which is the entire reason this is a command-line match and not a descendant walk.
+     */
+    @Test
+    fun `an engine process orphaned to init is still ours`() {
+        assertEquals(
+            ProcessFootprint.Owner.BROWSER,
+            classify(
+                "/Users/dev/.boss/boss-chromium/BOSS.app/Contents/Frameworks/Chromium Framework.framework/A",
+                pid = 57827L,
+            ),
+        )
+    }
+
+    /**
+     * The 4.4 GB regression. Every one of these was a live descendant of the host JVM when this
+     * was written, by way of a shell in a terminal tab. None of them is BOSS's memory, and none
+     * of it is memory BOSS could release.
+     */
+    @Test
+    fun `processes the user started in a terminal are not ours`() {
+        assertNull(classify("claude --dangerously-skip-permissions"))
+        val python = "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/bin/python3"
+        assertNull(classify(python))
+        assertNull(classify("/Users/dev/.bossterm/bin/cloudflared --no-autoupdate tunnel --url http://127.0.0.1:8080"))
+        assertNull(classify("/bin/zsh -l"))
+        assertNull(classify("/opt/homebrew/bin/uv tool uvx --from git+https://github.com/oraios/serena serena"))
+    }
+
+    /**
+     * A different BOSS install's engine, or the user's own Chrome, must not be charged to us.
+     */
+    @Test
+    fun `chromium outside our engine directory is not ours`() {
+        assertNull(classify("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"))
+        assertNull(classify("/Users/other/.boss/boss-chromium/BOSS.app/Contents/MacOS/BOSS"))
+    }
+
+    /**
+     * An empty prefix would make `startsWith` true for every process on the machine, so a failed
+     * engine-directory lookup would silently claim the entire system as BOSS's footprint. The
+     * guard against that is one `isNotEmpty()` call and this is what holds it in place.
+     */
+    @Test
+    fun `an empty engine directory claims nothing`() {
+        assertNull(ProcessFootprint.classify(99999L, "/bin/zsh -l", hostPid, listOf("")))
+        assertNull(ProcessFootprint.classify(99999L, "/bin/zsh -l", hostPid, emptyList()))
+    }
+
+    // endregion
+
+    // region parsers
+
+    @Test
+    fun `ps output parses to bytes`() {
+        val parsed = ProcessFootprint.parsePsRssOutput("  57786 2597568\n  57824  266240\n")
+        assertEquals(mapOf(57786L to 2597568L * 1024, 57824L to 266240L * 1024), parsed)
+    }
+
+    @Test
+    fun `ps garbage is skipped rather than failing the whole reading`() {
+        val parsed = ProcessFootprint.parsePsRssOutput("57786 2597568\nps: bad pid\n\n57824 notanumber\n")
+        assertEquals(mapOf(57786L to 2597568L * 1024), parsed)
+    }
+
+    @Test
+    fun `powershell csv parses past its header and quoting`() {
+        val csv = "\"Id\",\"WorkingSet64\"\r\n\"4812\",\"2721513472\"\r\n\"5120\",\"272629760\"\r\n"
+        assertEquals(mapOf(4812L to 2721513472L, 5120L to 272629760L), ProcessFootprint.parseWindowsCsv(csv))
+    }
+
+    @Test
+    fun `proc fields parse by label`() {
+        val rollup = "Rss:               12345 kB\nPss:                8192 kB\nShared_Clean:       1024 kB\n"
+        assertEquals(8192L, ProcessFootprint.parseProcKb(rollup, "Pss:"))
+        assertEquals(12345L, ProcessFootprint.parseProcKb(rollup, "Rss:"))
+        assertNull(ProcessFootprint.parseProcKb(rollup, "VmRSS:"))
+    }
+
+    @Test
+    fun `a failed query yields no entries rather than zeroes`() {
+        assertEquals(emptyMap(), ProcessFootprint.parsePsRssOutput(null))
+        assertEquals(emptyMap(), ProcessFootprint.parseWindowsCsv(null))
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## What the bar showed, and why it could not warn

The status-bar memory readout was `heapUsed/heapMax`, e.g. `299MB/30GB 45%`. Both halves were misleading.

**The numerator counted about an eighth of the memory BOSS holds.** Measured on a loaded session:

| | RSS |
|---|---|
| Host JVM | 2,537 MB |
| Chromium tree (7 procs) | 907 MB |
| **BOSS total** | **~3,444 MB** |
| ...of which the bar reported | 299 MB |

Every memory incident this app has had lived in the uncounted part: orphaned plugin host JVMs (434 of them, 27 GB), recycled engines whose Chromium was never killed, and PartitionAlloc aborting when native allocation fails. None of those move the heap number.

**The denominator was not a BOSS number.** With no `-Xmx` the ceiling is JVM ergonomics at 25% of installed RAM: 29.97 GB on a 128 GB machine, 2 GB on an 8 GB one. Reaching the 75% warning band on the former needs 22 GB of live Kotlin objects, so the indicator was green throughout the 27 GB leak and would be green again.

## What changed

- **`ProcessFootprint`** sums physical memory across every process BOSS owns, split host / browser / plugin. Linux uses `Pss` from `smaps_rollup` (no subprocess at all), macOS `ps`, Windows PowerShell (`tasklist` is localised, `wmic` is gone from recent builds).
- **The colour comes from machine memory pressure**, not heap percentage, and shares its critical threshold with `MemoryPressureWatchdog` via a single constant. The bar now turns red exactly when the watchdog starts its 60 s sustain clock, so the tier-tightening modal arrives as confirmation of something the user has been watching rather than as an ambush.
- **Heap health is merged, not replaced** (`maxOf(heapStatus, pressureStatus)`). Heap exhaustion did not stop being a way to die.
- **Heap bounded at 2 GB.**

## Ownership is by command line, never by descendants

This is the load-bearing decision. Measured on a real session, the descendant tree from the host JVM totals **7,858 MB**, of which **4,414 MB is the user's own work**: four `claude` CLIs started in terminal tabs, their Python/MCP children, a `cloudflared` tunnel. Charging those to BOSS would paint the bar red for a workload BOSS neither controls nor can release.

Parentage fails the other way too: two Chromium helpers on that machine had been reparented to pid 1, outside the descendant tree. Orphaned engine processes are a bug this indicator exists to surface. Both directions have tests.

## Why 2 GB, and why not `MaxRAM`

Eleven independent readings of this app's live heap - ten crash reports spanning several released versions plus a running session - peak at **478 MB** (100, 103, 151, 266, 282, 367, 385, 385, 417, 478 MB). 2 GB is over 4x that, and it is not a new number: 25% of 8 GB is what every machine at or below the Ultra Lite threshold already runs with, so if it were too small for real work the smallest supported configuration would already be failing.

`-XX:MaxRAM=16g -XX:MaxRAMPercentage=25` was the first attempt and is **wrong**. `MaxRAM` *replaces* the physical-memory figure rather than capping it, verified on a 128 GB host where `-XX:MaxRAM=512g` yields a 128 GB `MaxHeapSize`. It would have handed an 8 GB machine a 4 GB heap, half its RAM. No static flag pair expresses `min(percentage, ceiling)` and jpackage bakes `java-options` in as fixed strings, so a flat `-Xmx` it is.

Resolved `MaxHeapSize`, verified per simulated machine size:

| RAM | today | after |
|---|---|---|
| 4 GB | 1.00 GB | 2.00 GB |
| 8 GB | 2.00 GB | 2.00 GB |
| 16 GB | 4.00 GB | 2.00 GB |
| 128 GB | 29.97 GB | 2.00 GB |

The 4 GB row is the one direction that loosens, and the thing to revisit if a very small machine ever reports heap trouble.

## Verification

- Full desktop suite: **2,550 tests, 0 failures**. 19 new tests.
- `detekt` + `ktlintCheck` green.
- **Mutation-checked, not just green**: dropping the `isNotEmpty()` guard in `classify` (which would claim every process on the machine) and reverting `memoryStatus` to heap-only each fail the suite; restoring each passes.
- **End-to-end against reality**: the live reading found 9 Chromium processes totalling 864 MB, against an independent `ps` sum of 926 MB over the same 9 taken minutes earlier - same structure, same order, normal drift. The count includes the two pid-1 orphans, which is the descendant walk's blind spot demonstrated on real processes.

## Known gap, not addressed here

On a machine at Ultra Lite (≤ 8 GB, which includes the 8 GB Windows case), `backgroundSamplingEnabled = false` means `PerformanceMonitor` never starts, so **no indicator is shown at all** - before or after this change. Making the pressure reading survive that tier is a change to tier semantics and a separate decision.