### PR TITLE
theme: add NVIDIA, and open on it by default on macOS and Linux

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettings.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.json.Json
 
 /**
  * Persisted host theme preference. `appThemeId` matches a [BossThemes] id
- * ("blueprint", "blueprint-light", "operator", "daylight", "clean"). Stored at
- * ~/.boss/app-theme-settings.json.
+ * ("blueprint", "blueprint-light", "operator", "daylight", "clean", "nvidia").
+ * Stored at ~/.boss/app-theme-settings.json.
  *
  * Note that `BossConsoleRust` reads and writes this same file, so its
  * `ThemeId::DEFAULT` must stay in lockstep with [BossThemes.DEFAULT_ID] - a

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/theme/AppThemeSettings.kt
@@ -12,9 +12,13 @@ import kotlinx.serialization.json.Json
  * Note that `BossConsoleRust` reads and writes this same file, so its
  * `ThemeId::DEFAULT` must stay in lockstep with [BossThemes.DEFAULT_ID] - a
  * settings file that omits `appThemeId` means "the default", and the two apps
- * would otherwise disagree about which theme that is. Windows now opens on
- * [BossThemes.WINDOWS_DEFAULT_ID] instead, but only when there is no file at
- * all; see [decodeOrDefaults] for why the two cases are not the same.
+ * would otherwise disagree about which theme that is. That lockstep is on
+ * [BossThemes.DEFAULT_ID] alone; the *platform* first-run defaults
+ * ([BossThemes.UNIX_DEFAULT_ID] on macOS and Linux,
+ * [BossThemes.WINDOWS_DEFAULT_ID] on Windows) apply only when there is no file
+ * at all, and see [decodeOrDefaults] for why those two absences are not the
+ * same thing. Rust has no `nvidia` variant yet, so a file this host writes
+ * naming it resolves there through `ThemeId::from_id(..).unwrap_or(DEFAULT)`.
  */
 @Serializable
 data class AppThemeSettings(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/theme/AppThemeDefaultsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/theme/AppThemeDefaultsTest.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.utils.SystemUtils
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**
@@ -17,9 +18,36 @@ import kotlin.test.assertTrue
  */
 class AppThemeDefaultsTest {
     @Test
-    fun `windows opens light and every other platform keeps the dark default`() {
+    fun `windows opens light and mac and linux open on the unix default`() {
         assertEquals(BossThemes.WINDOWS_DEFAULT_ID, BossThemes.defaultIdFor(isWindows = true))
-        assertEquals(BossThemes.DEFAULT_ID, BossThemes.defaultIdFor(isWindows = false))
+        assertEquals(BossThemes.UNIX_DEFAULT_ID, BossThemes.defaultIdFor(isWindows = false))
+    }
+
+    /**
+     * The Windows default is asserted as a *property* (light) because the request
+     * behind it was "light on Windows". This one is asserted as an *id*, because
+     * the request behind it named a theme: "make NVIDIA the default on mac". Every
+     * other test here routes through [BossThemes.UNIX_DEFAULT_ID] and so would
+     * still pass if the constant were re-pointed at any other dark theme - this is
+     * the only thing that pins which one.
+     */
+    @Test
+    fun `mac and linux open on nvidia specifically`() {
+        assertEquals("nvidia", BossThemes.UNIX_DEFAULT_ID)
+        assertEquals("nvidia", BossThemes.defaultIdFor(isWindows = false))
+    }
+
+    /**
+     * [BossThemes.DEFAULT_ID] is no longer any platform's first run, and that is
+     * the point: it is what a file saying `{}` means. If someone "tidies up" by
+     * re-pointing it at the new platform default, every user whose stored choice
+     * was written by the old `encodeDefaults = false` writer is silently
+     * re-skinned, on all three platforms at once.
+     */
+    @Test
+    fun `the class default is not what any platform opens with`() {
+        assertNotEquals(BossThemes.DEFAULT_ID, BossThemes.defaultIdFor(isWindows = false))
+        assertNotEquals(BossThemes.DEFAULT_ID, BossThemes.defaultIdFor(isWindows = true))
     }
 
     /**
@@ -35,7 +63,7 @@ class AppThemeDefaultsTest {
         assertTrue(windowsDefault.isLight, "Windows must open on a light theme")
         assertFalse(
             BossThemes.byId(BossThemes.defaultIdFor(isWindows = false)).isLight,
-            "the non-Windows default is unchanged and still dark",
+            "mac and Linux must open on a dark theme",
         )
     }
 
@@ -46,6 +74,7 @@ class AppThemeDefaultsTest {
 
         assertTrue(BossThemes.DEFAULT_ID in ids)
         assertTrue(BossThemes.WINDOWS_DEFAULT_ID in ids)
+        assertTrue(BossThemes.UNIX_DEFAULT_ID in ids)
     }
 
     @Test
@@ -63,7 +92,7 @@ class AppThemeDefaultsTest {
             AppThemeSettings.decodeOrDefaults(content = null, isWindows = true).appThemeId,
         )
         assertEquals(
-            BossThemes.DEFAULT_ID,
+            BossThemes.UNIX_DEFAULT_ID,
             AppThemeSettings.decodeOrDefaults(content = null, isWindows = false).appThemeId,
         )
     }
@@ -76,10 +105,18 @@ class AppThemeDefaultsTest {
      * light on the very next launch, with no way to make it stick.
      */
     @Test
-    fun `an existing file that omits the id keeps the dark default on windows`() {
+    fun `an existing file that omits the id keeps the class default on every platform`() {
         assertEquals(
             BossThemes.DEFAULT_ID,
             AppThemeSettings.decodeOrDefaults(content = "{}", isWindows = true).appThemeId,
+        )
+        // The same exposure the Windows default created, now live on macOS and
+        // Linux: `{}` is a mac user who deliberately picked Blueprint under the
+        // old writer, and resolving it from the platform default would flip them
+        // to NVIDIA on the very next launch with no way to make Blueprint stick.
+        assertEquals(
+            BossThemes.DEFAULT_ID,
+            AppThemeSettings.decodeOrDefaults(content = "{}", isWindows = false).appThemeId,
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/theme/BossThemesRegistryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/theme/BossThemesRegistryTest.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.plugin.ui.BossAppTheme
 import ai.rever.boss.plugin.ui.BossBlueprintColorScheme
 import ai.rever.boss.plugin.ui.BossBlueprintLightColorScheme
 import ai.rever.boss.plugin.ui.BossColorScheme
+import ai.rever.boss.plugin.ui.BossNvidiaColorScheme
 import ai.rever.boss.plugin.ui.BossThemeController
 import ai.rever.boss.plugin.ui.BossThemes
 import androidx.compose.ui.graphics.Color
@@ -77,6 +78,48 @@ class BossThemesRegistryTest {
         // Material factory, so a wrong flag is a functional bug, not cosmetics.
         assertTrue(luminance(dark.colors.ink) < 0.5, "blueprint's floor should be dark")
         assertTrue(luminance(light.colors.ink) > 0.5, "blueprint-light's floor should be light")
+    }
+
+    @Test
+    fun `nvidia carries the brand anchors`() {
+        // #76B900 is the whole point of the theme; if it drifts it is no longer
+        // an NVIDIA theme, just a green one. Black is the site's actual floor,
+        // and black-on-green is how the site draws its buttons.
+        assertEquals(Color(0xFF76B900), BossNvidiaColorScheme.signal, "NVIDIA green")
+        assertEquals(Color(0xFF000000), BossNvidiaColorScheme.ink, "nvidia.com is pure black")
+        assertEquals(Color(0xFF000000), BossNvidiaColorScheme.onSignal, "green button, black type")
+    }
+
+    /**
+     * The reason `nvidia` sets `signalText = signal` rather than inventing a
+     * twin. If someone darkens the brand green for a light variant and copies
+     * the value here, this fails before the aliasing test does and says why.
+     */
+    @Test
+    fun `nvidia green is legible as both a glyph and a fill`() {
+        val c = BossNvidiaColorScheme
+        assertEquals(c.signal, c.signalText, "NVIDIA green clears the text floor unaided")
+        surfaces(c).forEach { (name, bg) ->
+            assertTrue(
+                contrast(c.signal, bg) >= 4.5,
+                "nvidia: signal is only ${format(contrast(c.signal, bg))}:1 on $name",
+            )
+        }
+        assertTrue(
+            contrast(c.onSignal, c.signal) >= 4.5,
+            "nvidia: onSignal is only ${format(contrast(c.onSignal, c.signal))}:1 on the green fill",
+        )
+    }
+
+    @Test
+    fun `nvidia keeps ok clear of the brand green`() {
+        // With a green `signal`, an `ok` in the same hue makes a success chip
+        // read as a primary action. Distance is the invariant, not the hex.
+        val c = BossNvidiaColorScheme
+        assertTrue(
+            hueDistance(c.ok, c.signal) >= 40.0,
+            "nvidia: ok is only ${format(hueDistance(c.ok, c.signal))} deg from signal",
+        )
     }
 
     /**
@@ -208,6 +251,32 @@ class BossThemesRegistryTest {
     }
 
     private fun format(ratio: Double): String = ((ratio * 100).toInt() / 100.0).toString()
+
+    /** Shortest angular distance between two hues, in degrees. */
+    private fun hueDistance(
+        a: Color,
+        b: Color,
+    ): Double {
+        val delta = kotlin.math.abs(hue(a) - hue(b))
+        return min(delta, 360.0 - delta)
+    }
+
+    private fun hue(c: Color): Double {
+        val r = c.red.toDouble()
+        val g = c.green.toDouble()
+        val b = c.blue.toDouble()
+        val hi = maxOf(r, g, b)
+        val lo = minOf(r, g, b)
+        val span = hi - lo
+        if (span == 0.0) return 0.0
+        val h =
+            when (hi) {
+                r -> 60 * (((g - b) / span) % 6)
+                g -> 60 * (((b - r) / span) + 2)
+                else -> 60 * (((r - g) / span) + 4)
+            }
+        return if (h < 0) h + 360 else h
+    }
 
     /** WCAG 2.x relative luminance. */
     private fun luminance(c: Color): Double {

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -18,8 +18,9 @@ Three rules drive every token. When a choice is unclear, return here.
 2. **Exactly one signal.** One color means *live / active / now*: the primary
    action, the focused field, the selected tab, the cursor. Nothing else competes
    for it. A second color, `data`, carries links and data. *Which* hues those are
-   is the active theme's business - electric blue under **Blueprint** (the
-   default), amber and cyan under **Operator** - but a theme never gets three.
+   is the active theme's business - NVIDIA green under **NVIDIA** (what macOS
+   and Linux open with), electric blue under **Blueprint**, amber and cyan under
+   **Operator** - but a theme never gets three.
 3. **Quiet everywhere else.** Surfaces separate by tint, not shadow. Borders are
    hairlines. Density is high and calm so your output is the loudest thing on
    screen.
@@ -44,20 +45,28 @@ a theme is one `BossAppTheme` plus one list entry.
 
 | Theme | id | | Identity |
 |-------|----|-|----------|
-| **Blueprint** | `blueprint` | dark | Electric blue on ink - matches [bossconsole.ai](https://bossconsole.ai). **The default on macOS and Linux.** |
+| **Blueprint** | `blueprint` | dark | Electric blue on ink - matches [bossconsole.ai](https://bossconsole.ai). **The class default** (what a settings file saying `{}` means). |
 | **Blueprint Light** | `blueprint-light` | light | The same blue, re-grounded on the site's `--paper`. **The default on Windows.** |
 | **Operator** | `operator` | dark | The original amber-on-ink identity |
 | **Daylight** | `daylight` | light | Clean light theme |
 | **Clean** | `clean` | dark | Neutral charcoal, steel-blue accent |
-| **NVIDIA** | `nvidia` | dark | NVIDIA green `#76B900` on black - the [nvidia.com](https://www.nvidia.com/en-us/) look |
+| **NVIDIA** | `nvidia` | dark | NVIDIA green `#76B900` on black - the [nvidia.com](https://www.nvidia.com/en-us/) look. **The default on macOS and Linux.** |
 
 The choice is explicit and persisted (`~/.boss/app-theme-settings.json`); the OS
 theme setting is never consulted.
 
-**The default is per-platform.** Windows opens on Blueprint Light, everything else
-on Blueprint. `BossThemes.defaultIdFor(isWindows)` is the only place that branches;
-`BossThemes.DEFAULT_ID` stays the *class* default, which is what an existing
-settings file means when it says nothing.
+**The default is per-platform.** macOS and Linux open on NVIDIA
+(`BossThemes.UNIX_DEFAULT_ID`), Windows on Blueprint Light
+(`BossThemes.WINDOWS_DEFAULT_ID`). `BossThemes.defaultIdFor(isWindows)` is the only
+place that branches; `BossThemes.DEFAULT_ID` stays the *class* default, which is
+what an existing settings file means when it says nothing, and is now no longer
+what any platform opens with.
+
+Windows and the Unix default differ in **brand**, not merely in value, which was
+not true while both were Blueprint. That is forced rather than chosen: NVIDIA has
+no light half to reach for, because `#76B900` is 2.4:1 on white and darkening it
+enough to clear the 3:1 component floor stops it being the brand green. Windows
+keeps the identity that does have both halves.
 
 **Who a default change re-skins.** `AppThemeSettingsManager` writes that file only
 from `select()` - `ensureInitialized()` resolves the id without saving. The file's
@@ -83,7 +92,7 @@ reaches nobody who has ever run the app.
 That property is why the four mirrors below have to agree on the default, not just
 on the palettes.
 
-#### Blueprint - the default palette
+#### Blueprint - the class-default palette
 
 Lifted from bossconsole.ai's stylesheet, or composited from it (a site alpha over
 the site's own floor). The site's hero mocks the app itself (`.console-frame` /
@@ -330,15 +339,22 @@ raw-palette names `chalk` / `mist` / `muted`.
 | Terminal defaults | BossTerm `…/settings/TerminalSettings.kt` (`activeThemeId = "boss-blueprint"`, and the fg/bg/selection defaults must match that theme) |
 | Terminal chrome tokens | BossTerm `…/settings/theme/UiTheme.kt` (`EXACT_TOKENS` - both BOSS identities skip derivation) |
 
-**Defaults:** the host default is `blueprint` (`BossThemes.DEFAULT_ID`) on macOS
+**Defaults:** the host default is `nvidia` (`BossThemes.UNIX_DEFAULT_ID`) on macOS
 and Linux and `blueprint-light` (`BossThemes.WINDOWS_DEFAULT_ID`) on Windows,
-resolved through `BossThemes.defaultIdFor(isWindows)`. The BossTerm default is
+resolved through `BossThemes.defaultIdFor(isWindows)`. `BossThemes.DEFAULT_ID` is
+still `blueprint` and is now the class default only. The BossTerm default is
 `boss-blueprint` (`DEFAULT_THEME_ID` / `TerminalSettings.activeThemeId`) on every
 platform, but that default is what standalone BossTerm opens with: inside BOSS the
 `terminal-tab` plugin's `ApplyHostThemeToTerminal()` pushes the host tokens into
 BossTerm's `ThemeManager` on every compose, so the terminal follows the host and a
 Windows first run comes up light throughout. Existing saved settings keep their
 current theme; only fresh installs pick up a new default.
+
+There is no `boss-nvidia` BossTerm builtin, and none is needed. The bridge's
+builtin match is restricted to `boss-` prefixed themes, so NVIDIA's pure-black
+`ink` does not collide with BossTerm's XTerm-derived `default` (also `#000000`);
+with no BOSS builtin at that floor the bridge synthesizes the terminal from the
+host tokens instead, which is what makes the shell come up green-on-black.
 
 **Four mirrors, one settings file.** The palettes exist in four places and they
 have to agree:

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -49,6 +49,7 @@ a theme is one `BossAppTheme` plus one list entry.
 | **Operator** | `operator` | dark | The original amber-on-ink identity |
 | **Daylight** | `daylight` | light | Clean light theme |
 | **Clean** | `clean` | dark | Neutral charcoal, steel-blue accent |
+| **NVIDIA** | `nvidia` | dark | NVIDIA green `#76B900` on black - the [nvidia.com](https://www.nvidia.com/en-us/) look |
 
 The choice is explicit and persisted (`~/.boss/app-theme-settings.json`); the OS
 theme setting is never consulted.

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossThemes.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossThemes.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
  * - **Operator** — the original amber-on-ink dark identity.
  * - **Daylight** — a clean light theme.
  * - **Clean** — a neutral charcoal theme with a calm steel-blue accent.
+ * - **NVIDIA** — NVIDIA green on black, lifted from nvidia.com.
  *
  * The active theme is held reactively in [BossThemeController]; [BossTheme] and
  * the legacy [BossColors] both read it, so selecting a theme re-skins the whole
@@ -99,6 +100,54 @@ val BossBlueprintLightColorScheme =
         alert = Color(0xFFD33B4A),
         onSignal = Color(0xFFFFFFFF),
         onData = Color(0xFFFFFFFF),
+    )
+
+/**
+ * NVIDIA — the green-on-black identity from nvidia.com.
+ *
+ * Like Blueprint, every value below is either a literal from the site's
+ * stylesheet (`clientlib-site.min.css`) or composited from it, and the comment
+ * on each line names the source. The surface ladder is the site's own grey
+ * ramp; the status colors are its category-tag ramp, because the site has no
+ * semantic status system of its own (see [ok] below).
+ *
+ * On [signal]: `#76b900` needs no [signalText] twin. It is 8.7:1 on black as a
+ * glyph *and* 8.7:1 against the black type it carries as a fill, which is
+ * exactly how the site uses it in both directions - `.nv-button .btn-content`
+ * is a green ground with `color:#000`, and the black footer sets
+ * `.page-footer-link-set__links > li > a { color: #76b900 }`. So a hairline of
+ * `signal` is legitimate here, the one thing Blueprint's KDoc rules out. What
+ * the site never does is put green on white (2.4:1), which is why there is no
+ * light half of this theme.
+ */
+val BossNvidiaColorScheme =
+    BossColorScheme(
+        // Surfaces: `.theme-dark { background-color: #000 }` and the grey ramp
+        // layered over it. The site's floor is genuinely pure black.
+        ink = Color(0xFF000000), // .theme-dark / .page-footer-wrapper
+        panel = Color(0xFF0C0C0C), // --color-gray-975, the dark card surface
+        raised = Color(0xFF1A1A1A), // dark modal body / the homepage's one grey band
+        line = Color(0xFF313131), // --color-gray-800, the dark-mode hairline
+        lineStrong = Color(0xFF4B4B4B), // --color-gray-700
+        // Text: the site runs very high contrast and carries hierarchy in size
+        // and weight, not color, so nothing here is dimmed for style.
+        textPrimary = Color(0xFFEEEEEE), // .theme-dark { color: #eee }
+        textSecondary = Color(0xFFCCCCCC), // --color-gray-200, nav + menu body copy
+        textMuted = Color(0xFF999999), // the site's muted-on-dark and disabled grey
+        signal = Color(0xFF76B900), // --color-nvidia-green
+        signalDim = Color(0xFF549A00), // .nv-nav-cta-primary:hover
+        signalWash = Color(0xFF19210B), // --color-nvidia-green at 12% over `panel`
+        signalText = Color(0xFF76B900), // = signal; 7.2:1 at its worst surface, no twin needed
+        data = Color(0xFF10B1FB), // the site's blue tag chip
+        // Not the brand green. The site never uses green as "success" - it has
+        // no status system at all, only a category-tag ramp - and with a green
+        // `signal` a same-hue success chip reads as a primary action. Teal sits
+        // 89 degrees off the brand's 82, so the two stay different words.
+        ok = Color(0xFF1DBBA4), // --color-teal-300
+        warn = Color(0xFFEF9100), // --color-yellow-300
+        alert = Color(0xFFFF8181), // --color-red-300 (red-500 #e52020 is 2.4:1 on black)
+        onSignal = Color(0xFF000000), // .nv-button .btn-content { background: #76b900; color: #000 }
+        onData = Color(0xFF000000),
     )
 
 /** Clean light theme. */
@@ -240,9 +289,18 @@ object BossThemes {
             colors = BossCleanColorScheme,
             material = darkMaterial(BossCleanColorScheme),
         )
+    val NVIDIA =
+        BossAppTheme(
+            id = "nvidia",
+            name = "NVIDIA",
+            blurb = "NVIDIA green on black - the nvidia.com look",
+            isLight = false,
+            colors = BossNvidiaColorScheme,
+            material = darkMaterial(BossNvidiaColorScheme),
+        )
 
     /** All selectable themes, in display order. */
-    val all: List<BossAppTheme> = listOf(BLUEPRINT, BLUEPRINT_LIGHT, OPERATOR, DAYLIGHT, CLEAN)
+    val all: List<BossAppTheme> = listOf(BLUEPRINT, BLUEPRINT_LIGHT, OPERATOR, DAYLIGHT, CLEAN, NVIDIA)
 
     /** The theme [DEFAULT_ID] names — resolved, never restated. */
     private val default: BossAppTheme get() = all.first { it.id == DEFAULT_ID }

--- a/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossThemes.kt
+++ b/plugin-platform/plugin-ui-core/src/commonMain/kotlin/ai/rever/boss/plugin/ui/BossThemes.kt
@@ -232,15 +232,45 @@ private fun lightMaterial(s: BossColorScheme): Colors =
     )
 
 object BossThemes {
+    /**
+     * The **class** default, and no longer any platform's first run.
+     *
+     * Since macOS and Linux moved to [UNIX_DEFAULT_ID] and Windows to
+     * [WINDOWS_DEFAULT_ID], nothing in [defaultIdFor] returns this. It survives
+     * because it still answers two questions neither platform constant does:
+     * what a settings file that omits `appThemeId` means (someone who chose
+     * Blueprint under the old `encodeDefaults = false` writer), and what
+     * [byId] falls back to for an id this build does not know.
+     *
+     * Which is exactly why it must NOT be re-pointed when a platform default
+     * moves: doing so would silently re-skin everyone whose stored choice was
+     * written as `{}`, on every platform at once.
+     */
     const val DEFAULT_ID = "blueprint"
 
     /**
-     * What Windows opens with. Blueprint Light rather than Daylight: it is the
-     * light half of the same identity [DEFAULT_ID] names, so the two platforms
-     * differ in value and not in brand, and Daylight carries a known contrast
-     * defect (its amber signal sits at 2.63:1 on its own near-white floor, under
-     * the 3:1 floor for UI components) that has no business being anyone's
-     * out-of-the-box look. `BossThemesRegistryTest` records that debt.
+     * What macOS and Linux open with.
+     *
+     * A first run on either now lands on the NVIDIA identity rather than on
+     * Blueprint. Only a first run reaches this - see [defaultIdFor] for which
+     * absences count as "has never chosen".
+     */
+    const val UNIX_DEFAULT_ID = "nvidia"
+
+    /**
+     * What Windows opens with. Blueprint Light rather than Daylight because
+     * Daylight carries a known contrast defect (its amber signal sits at 2.63:1
+     * on its own near-white floor, under the 3:1 floor for UI components) that
+     * has no business being anyone's out-of-the-box look;
+     * `BossThemesRegistryTest` records that debt.
+     *
+     * Note that Windows and [UNIX_DEFAULT_ID] now differ in **brand**, not just
+     * in value, which was not true while both halves were Blueprint. That is
+     * deliberate and it is forced: NVIDIA has no light half to reach for.
+     * `#76b900` is 2.4:1 on white, and darkening it far enough to clear the 3:1
+     * component floor stops it being the brand green - so pairing a light
+     * Windows default with the NVIDIA identity is not something a palette can
+     * fix. Windows keeps the identity that does have both halves.
      */
     const val WINDOWS_DEFAULT_ID = "blueprint-light"
 
@@ -319,11 +349,19 @@ object BossThemes {
      * CI leg. Callers resolve `isWindows` themselves: this module is
      * commonMain and has no business reading system properties.
      *
-     * [DEFAULT_ID] deliberately stays the *class* default. It is what an
-     * existing settings file means when it omits `appThemeId`, and only a
-     * first run with no file at all resolves through here.
+     * **Only a first run with no file at all resolves through here**, and that
+     * is the whole safety margin of a default move. `AppThemeSettingsManager`
+     * writes the settings file solely from `select()`, so the file's existence
+     * is the record that someone chose. A user who has never opened the picker
+     * has no file and *is* re-skinned by a change here - which is the intent -
+     * while a user who chose Blueprint keeps it, because their file names it
+     * (or, under the old writer, says `{}`, which resolves through
+     * [DEFAULT_ID] rather than through this).
+     *
+     * macOS and Linux share a branch because the boolean does: if they ever
+     * need to differ, this takes a platform enum rather than a second flag.
      */
-    fun defaultIdFor(isWindows: Boolean): String = if (isWindows) WINDOWS_DEFAULT_ID else DEFAULT_ID
+    fun defaultIdFor(isWindows: Boolean): String = if (isWindows) WINDOWS_DEFAULT_ID else UNIX_DEFAULT_ID
 }
 
 /**


### PR DESCRIPTION
Adds a sixth host theme, `nvidia`, and makes it what macOS and Linux open with. Windows is unchanged on Blueprint Light.

## The palette

Every value is a literal out of nvidia.com's stylesheet (`clientlib-site.min.css`) or composited from it, with the source named on each line, the same discipline Blueprint follows:

- surfaces are the site's grey ramp over a genuinely pure black floor: `#000000` then `--color-gray-975 #0C0C0C` then `#1A1A1A`, hairline `--color-gray-800 #313131`
- text is its `.theme-dark` ladder: `#EEEEEE` / `#CCCCCC` / `#999999`
- `signal` is `--color-nvidia-green #76B900`, `signalDim` is the nav CTA's hover `#549A00`
- status colors come from the site's category-tag ramp (`--color-teal-300`, `-yellow-300`, `-red-300`)

Two decisions the KDoc explains at length:

**`signalText` aliases `signal`.** `#76B900` is the rare accent needing no twin: 8.7:1 on black as a glyph *and* 8.7:1 against the black type it carries as a fill. That is how the site uses it in both directions, `.nv-button` being a green ground with `color:#000` while the black footer sets its link color to `#76B900`. So a hairline of `signal` is legitimate here, which is the one thing Blueprint's KDoc rules out.

**`ok` is teal, not green.** The site has no semantic status system at all, green is purely brand, so with a green `signal` a same-hue success chip reads as a primary action. Teal sits 89 degrees off the brand's 82.

**There is no light half, deliberately.** `#76B900` is 2.4:1 on white, and the site designs around exactly that by making green a fill, rule and underline color rather than a text color. Darkening it enough to clear the 3:1 component floor stops it being the brand green.

## The default move

One branch: `defaultIdFor`'s non-Windows arm returns a new `UNIX_DEFAULT_ID`. The reason it is only one branch is the part worth reviewing, because the obvious tidy-up is a bug.

`BossThemes.DEFAULT_ID` stays `"blueprint"` and is now no platform's first run. It still answers two questions neither platform constant does: what a settings file saying `{}` means, and what `byId` falls back to for an unknown id. `{}` on disk is someone who chose Blueprint under the old `encodeDefaults = false` writer, so re-pointing `DEFAULT_ID` at `nvidia` to make it consistent would silently re-skin every one of them, on all three platforms at once. `the class default is not what any platform opens with` fails if anyone tries, and the `{}` regression test now covers the non-Windows branch as well. That exposure used to be Windows-only and this change hands it to macOS and Linux too.

**Who this re-skins:** only users with no settings file, which is exactly "has never opened the theme picker". `AppThemeSettingsManager` writes solely from `select()` and `ensureInitialized()` resolves without persisting.

**Windows and the Unix default now differ in brand**, not just in value, which was not true while both halves were Blueprint. Forced rather than chosen, for the no-light-half reason above. Windows keeps the identity that has both.

## Checked rather than assumed

- **The terminal does not break.** NVIDIA's `ink` is pure black and so is BossTerm's XTerm-derived `default` builtin, and the bridge matches builtins by background. It is already guarded: the match is restricted to `boss-` prefixed ids, so there is no collision, and with no BOSS builtin at that floor the bridge synthesizes from host tokens. That is what makes the shell come up green on black.
- **No flash of the wrong identity.** `BossThemeController` starts at `DEFAULT_ID`, which on macOS is now no longer where it ends up, so this creates that risk on the majority platform for the first time. `ensureInitialized()` runs unconditionally in `main.kt` about a hundred lines before `application {}`, so the first frame is already correct.
- **No binary incompatibility.** `plugin-ui-core` is what every plugin links against, and the `BossTheme(typography)` incident broke about 15 plugins. This only adds a top-level `val` and members on `BossThemes`, changing no existing signature. Confirmed against a running host: 37 of 39 persisted plugins loaded, zero `binary incompat` / `NoSuchFieldError` / `NoSuchMethodError` lines.

## Tests

Four new tests, and each was checked against a mutation of the value it guards rather than trusted for going green:

| Mutation | Caught by |
|---|---|
| brand green drifts to a generic `#00B050` | `nvidia carries the brand anchors`, `nvidia keeps ok clear of the brand green` |
| white type on the green button | `nvidia green is legible as both a glyph and a fill` |
| `DEFAULT_ID` re-pointed at `nvidia` | `the class default is not what any platform opens with` |
| `UNIX_DEFAULT_ID` re-pointed at another dark theme | `mac and linux open on nvidia specifically` |

That last row exists because the mutation run exposed a real gap: every other test routes through the constant, so the id itself was unpinned. The Windows default is asserted as a property (`isLight`) because the request behind it was a property. This request named a theme, so the id is pinned.

The existing whole-registry WCAG sweeps now cover `nvidia` too.

Full `:composeApp:desktopTest`: **2597 tests, 0 failing**. ktlint and detekt clean.

**Verified on a real first run**, not only in tests: with the settings file deleted, the app comes up green on black and writes no file, which is the `ensureInitialized()` contract that nothing had previously covered.

## Known gap

`BossConsoleRust` mirrors these palettes and reads the same `~/.boss/app-theme-settings.json`. It has no `nvidia` variant, so `ThemeId::from_id` returns `None` and it falls back to Blueprint. Its `ThemeId::DEFAULT` still equals `DEFAULT_ID`, so the `{}` contract between the two hosts is intact; what diverges is first run and any explicitly stored `"nvidia"`. Worth closing in a follow-up now that this is a default rather than an opt-in.
