### PR TITLE
chrome: one source for every bar's metrics, and a budget that measures them

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -28,6 +28,7 @@ import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.handleTabDropResult
+import ai.rever.boss.layout.ChromeBudgetReadout
 import ai.rever.boss.plugin.api.LocalBookmarkDataProvider
 import ai.rever.boss.plugin.api.LocalProjectPath
 import ai.rever.boss.plugin.api.LocalSplitViewOperations
@@ -275,6 +276,10 @@ internal fun BossAppScaffold(
                 onSignOut = { state.showLogoutDialog = true },
             )
         }
+
+    // Renders nothing; reports what the chrome costs the page when BOSS_CHROME_BUDGET is set.
+    // Here rather than inside a bar so it still reports with every bar switched off.
+    ChromeBudgetReadout(appearance = appearance, focusMode = focusModeSettings)
 
     with(state.draggablePanelComponent) {
         Box(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -279,7 +279,15 @@ internal fun BossAppScaffold(
 
     // Renders nothing; reports what the chrome costs the page when BOSS_CHROME_BUDGET is set.
     // Here rather than inside a bar so it still reports with every bar switched off.
-    ChromeBudgetReadout(appearance = appearance, focusMode = focusModeSettings)
+    //
+    // Anything that provides LocalChromeDimens must sit ABOVE this call. Provide it lower - between
+    // here and the bars - and the readout reports Comfortable while the bars draw Compact, which is
+    // exactly the drift ChromeMetrics exists to make impossible.
+    ChromeBudgetReadout(
+        windowId = state.windowId,
+        appearance = appearance,
+        focusMode = focusModeSettings,
+    )
 
     with(state.draggablePanelComponent) {
         Box(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -11,6 +11,7 @@ import ai.rever.boss.components.plugin.registries.StatusBarRegistryImpl
 import ai.rever.boss.components.plugin.registries.owningPluginId
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.components.window_panel.components.main_window_panels.BossTabsComponent
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.mcp.McpToolRegistryImpl
 import ai.rever.boss.performance.PerformanceState
 import ai.rever.boss.plugin.api.PanelId
@@ -52,7 +53,7 @@ fun BossBottomBar(tabsComponent: BossTabsComponent? = null) {
     Divider(color = BossTheme.colors.line)
     HorizontalBar(
         modifier = Modifier.contextMenu(items = rememberBarContextMenuItems(ChromeBar.BOTTOM)),
-        height = 30.dp,
+        height = BossChrome.dimens.bottomBarHeight,
     ) {
         HorizontalBarRow {
             BossLeftBottomBar(tabsComponent)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTitleBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTitleBar.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.bars.horizontal
 
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,13 +13,12 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
 fun BossTitleBar(
     title: String = "Boss Console",
-    height: Dp = 26.dp,
+    height: Dp = BossChrome.dimens.titleBarHeight,
     onToggleMaximize: (() -> Unit)? = null,
 ) {
     HorizontalBar(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -22,6 +22,7 @@ import ai.rever.boss.git.GitBranchInfo
 import ai.rever.boss.git.GitOperationResult
 import ai.rever.boss.git.GitService
 import ai.rever.boss.git.GitStashInfo
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.platform.rememberDirectoryPicker
 import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
@@ -78,7 +79,7 @@ fun BossDraggableComponent.BossTopBar(
 ) {
     val items = rememberBarContextMenuItems(ChromeBar.TOP)
 
-    HorizontalBar(modifier = Modifier.contextMenu(items = items), height = 40.dp) {
+    HorizontalBar(modifier = Modifier.contextMenu(items = items), height = BossChrome.dimens.topBarHeight) {
         HorizontalBarRow(modifier = Modifier.fillMaxHeight().padding(start = 36.dp)) {
             BossTopLeftBar(workspaceManager, onApplyWorkspace, getCurrentWorkspace, onShowTopOfMind, onNewProject, onCloneProject)
             Spacer(modifier = Modifier.weight(1f))

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/vertical/BossLeftSideBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/vertical/BossLeftSideBar.kt
@@ -11,6 +11,7 @@ import ai.rever.boss.components.sidebar.SidebarIconRail
 import ai.rever.boss.components.sidebar.SidebarVisibilitySettings
 import ai.rever.boss.components.sidebar.SidebarVisibilitySettingsManager
 import ai.rever.boss.components.sidebar.computeSlotIconLimits
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.api.Panel.Companion.bottom
 import ai.rever.boss.plugin.api.Panel.Companion.left
 import ai.rever.boss.plugin.api.Panel.Companion.top
@@ -35,7 +36,7 @@ fun BossDraggableComponent.BossLeftSideBar() {
     val customizeOnThisBar = SidebarVisibilitySettings.isLeftSide(customizeSlotId)
 
     VerticalBar(
-        width = 40.dp,
+        width = BossChrome.dimens.stripWidth,
         // On the bar, not on the weighted Spacer below: the icons carry their own contextMenu and
         // consume the press first, so this fires on empty rail and nowhere else - the same
         // arrangement the top bar has had all along.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/vertical/BossRightSideBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/vertical/BossRightSideBar.kt
@@ -11,6 +11,7 @@ import ai.rever.boss.components.sidebar.SidebarIconRail
 import ai.rever.boss.components.sidebar.SidebarVisibilitySettings
 import ai.rever.boss.components.sidebar.SidebarVisibilitySettingsManager
 import ai.rever.boss.components.sidebar.computeSlotIconLimits
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.api.Panel.Companion.bottom
 import ai.rever.boss.plugin.api.Panel.Companion.right
 import ai.rever.boss.plugin.api.Panel.Companion.top
@@ -49,7 +50,7 @@ fun BossDraggableComponent.BossRightSideBar(
 
     VDivider()
     VerticalBar(
-        width = 40.dp,
+        width = BossChrome.dimens.stripWidth,
         // See BossLeftSideBar: attached to the bar so the whole strip answers, while the icons'
         // own menus still win on the icons themselves.
         modifier = Modifier.contextMenu(items = rememberBarContextMenuItems(ChromeBar.RIGHT_STRIP)),

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.components.plugin.AvailablePluginUpdate
 import ai.rever.boss.components.plugin.PluginBuildInfo
 import ai.rever.boss.components.plugin.PluginBuildTag
 import ai.rever.boss.components.plugin.registries.PanelMenuRegistryImpl
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.plugin.ui.BossThemeColors
@@ -159,7 +160,7 @@ fun BossPanelTopBar(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(28.dp)
+                .height(BossChrome.dimens.panelTopBarHeight)
                 .background(BossTheme.colors.raised)
                 .then(dragModifier)
                 .contextMenu(items = menuItems),

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -38,6 +38,7 @@ import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.icons.FileIcons
 import ai.rever.boss.keymap.KeymapSettingsManager
 import ai.rever.boss.keymap.model.TabSwitchMode
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.api.LocalIsPanelActive
 import ai.rever.boss.plugin.api.TabComponentWithUI
 import ai.rever.boss.plugin.api.TabEvent
@@ -353,7 +354,7 @@ fun BossTabsComponent.BossMainTabBar(
     val dropTarget = tabDragComponent?.dropTarget
 
     HorizontalBar(
-        height = 42.dp,
+        height = BossChrome.dimens.tabBarHeight,
         backgroundColor = BossTheme.colors.panel,
     ) {
         HorizontalBarRow(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -125,17 +125,6 @@ import kotlin.time.Clock
 private val bossMainWindowPanelLogger = BossLogger.forComponent("BossMainWindowPanel")
 
 /**
- * Width of the ring a panel reserves for its active-panel border.
- *
- * Named once because it is used twice and the two uses must agree exactly: the border is
- * drawn at this width and the content is inset by the same amount, so that a child which
- * Compose cannot draw over — a foreign native surface such as the HARDWARE_ACCELERATED
- * browser — has nowhere to cover it from. A padding smaller than the border leaves a
- * sliver the browser paints over; larger leaves a visible gap inside the border.
- */
-private val ACTIVE_PANEL_BORDER = 2.dp
-
-/**
  * Wrapper for BossTabButton that loads and displays favicons from cache
  * Uses shared rememberFaviconLoader composable for DRY and error handling
  */
@@ -876,6 +865,7 @@ fun BossTabsComponent.BossMainPanel(
     // Track the active panel state to force recomposition
     val activePanelId by splitViewState?.activePanelIdState ?: remember { mutableStateOf("") }
     val isActivePanel = activePanelId == currentPanelId
+    val panelBorder = BossChrome.dimens.panelBorderThickness
 
     Column(
         modifier =
@@ -930,10 +920,13 @@ fun BossTabsComponent.BossMainPanel(
                 // inactive panel look exactly as it did before the ring existed, and gives the
                 // active border something themed to sit on.
                 .background(BossTheme.colors.panel)
+                // Border width and content inset must agree exactly, which is why both read the one
+                // value; see ChromeDimens.panelBorderThickness for what goes wrong if they drift.
+                // It is also 4dp of every panel's height and width, so ChromeMetrics charges for it.
                 .border(
-                    ACTIVE_PANEL_BORDER,
+                    panelBorder,
                     if (isActivePanel) MaterialTheme.colors.primary.copy(alpha = 0.5f) else Color.Transparent,
-                ).padding(ACTIVE_PANEL_BORDER),
+                ).padding(panelBorder),
     ) {
         BossMainTabBar(
             splitViewState = splitViewState,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeBudgetReadout.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeBudgetReadout.kt
@@ -1,0 +1,75 @@
+package ai.rever.boss.layout
+
+import ai.rever.boss.focusmode.FocusModeSettings
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.WindowAppearanceSettings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.dp
+
+private val logger = BossLogger.forComponent("ChromeBudgetReadout")
+
+/** Set `BOSS_CHROME_BUDGET=1` to have each window report its chrome budget as it changes. */
+private const val ENV_FLAG = "BOSS_CHROME_BUDGET"
+
+/**
+ * Read once, not per composition: the flag is a developer's launch decision, and re-reading the
+ * environment on every recomposition of every window would be pure waste.
+ */
+private val readoutEnabled: Boolean by lazy {
+    System.getenv(ENV_FLAG)?.lowercase() in setOf("1", "true", "yes")
+}
+
+/**
+ * Reports what this window's chrome costs the page, for the developer measuring it.
+ *
+ * Renders nothing. Off unless `BOSS_CHROME_BUDGET=1`, so it costs a disabled `LaunchedEffect` and
+ * nothing else on a normal launch.
+ *
+ * This is a log line rather than a status-bar item on purpose: the configuration most worth
+ * measuring is the one with the bottom bar switched off, and a readout that lives in the bottom bar
+ * cannot report that. A visible readout belongs next to the density control in Settings, which is
+ * reachable whatever the chrome is doing — that arrives with the density setting itself.
+ */
+@Composable
+fun ChromeBudgetReadout(
+    appearance: WindowAppearanceSettings,
+    focusMode: FocusModeSettings,
+) {
+    if (!readoutEnabled) return
+
+    val dimens = BossChrome.dimens
+    val budget = ChromeMetrics.mainPanelBudget(appearance, focusMode, dimens)
+
+    // containerSize is the window's content area in px; on macOS that includes the area the traffic
+    // lights are drawn over, which is exactly the space the title row is reserving.
+    val containerSize = LocalWindowInfo.current.containerSize
+    val density = LocalDensity.current
+    val windowHeight = with(density) { containerSize.height.toDp() }
+    val windowWidth = with(density) { containerSize.width.toDp() }
+
+    LaunchedEffect(budget, windowHeight, windowWidth) {
+        if (windowHeight <= 0.dp || windowWidth <= 0.dp) return@LaunchedEffect
+
+        val heightPercent = budget.verticalFractionOf(windowHeight) * 100
+        val widthPercent = budget.horizontalFractionOf(windowWidth) * 100
+        logger.info(
+            LogCategory.UI,
+            "chrome budget: page gets ${heightPercent.format1()}% of height, ${widthPercent.format1()}% of width",
+            mapOf(
+                "windowDp" to "${windowWidth.value.toInt()}x${windowHeight.value.toInt()}",
+                "chromeVerticalDp" to budget.vertical.value.toInt(),
+                "chromeHorizontalDp" to budget.horizontal.value.toInt(),
+            ),
+        )
+    }
+}
+
+/** One decimal place, without pulling in a platform formatter this module would have to expect/actual. */
+private fun Float.format1(): String {
+    val scaled = (this * 10).toInt()
+    return "${scaled / 10}.${scaled % 10}"
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeBudgetReadout.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeBudgetReadout.kt
@@ -8,34 +8,71 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 private val logger = BossLogger.forComponent("ChromeBudgetReadout")
 
-/** Set `BOSS_CHROME_BUDGET=1` to have each window report its chrome budget as it changes. */
+/** Env var and system property that turn the readout on. See [chromeBudgetReadoutEnabled]. */
 private const val ENV_FLAG = "BOSS_CHROME_BUDGET"
+private const val PROPERTY_FLAG = "boss.chrome.budget"
+
+/**
+ * Whether the readout is on, given the raw [env] var and [property] values.
+ *
+ * Both are accepted, and a blank env var falls through to the property rather than shadowing it.
+ * That is not hypothetical tidiness: `BrowserAnalytics.telemetryEnabledFrom` carries a KDoc
+ * recording that the blank-env case was hit for real, which is why this rule is a named function
+ * with a test rather than an expression inlined into a `by lazy` that no test can reach.
+ *
+ * The property matters most for the way this flag actually gets used: `./gradlew run` makes an env
+ * var awkward to set, where `-Dboss.chrome.budget=1` just works.
+ */
+internal fun chromeBudgetReadoutEnabled(
+    env: String?,
+    property: String?,
+): Boolean {
+    val raw = env?.takeIf { it.isNotBlank() } ?: property
+    return raw?.trim()?.lowercase() in setOf("1", "true", "yes", "on")
+}
 
 /**
  * Read once, not per composition: the flag is a developer's launch decision, and re-reading the
  * environment on every recomposition of every window would be pure waste.
  */
 private val readoutEnabled: Boolean by lazy {
-    System.getenv(ENV_FLAG)?.lowercase() in setOf("1", "true", "yes")
+    chromeBudgetReadoutEnabled(System.getenv(ENV_FLAG), System.getProperty(PROPERTY_FLAG))
 }
+
+/**
+ * How coarsely the window size is tracked for logging.
+ *
+ * Keying the effect on the exact size emits a line per pixel of a drag-resize, which buries the one
+ * line the developer was watching for. The budget is what this exists to report, and it does not
+ * change while a window is dragged.
+ */
+private val SIZE_BUCKET = 50.dp
 
 /**
  * Reports what this window's chrome costs the page, for the developer measuring it.
  *
- * Renders nothing. Off unless `BOSS_CHROME_BUDGET=1`, so it costs a disabled `LaunchedEffect` and
- * nothing else on a normal launch.
+ * Renders nothing. Off unless `BOSS_CHROME_BUDGET=1` or `-Dboss.chrome.budget=1`, so it costs a
+ * disabled `LaunchedEffect` and nothing else on a normal launch.
  *
  * This is a log line rather than a status-bar item on purpose: the configuration most worth
  * measuring is the one with the bottom bar switched off, and a readout that lives in the bottom bar
  * cannot report that. A visible readout belongs next to the density control in Settings, which is
- * reachable whatever the chrome is doing — that arrives with the density setting itself.
+ * reachable whatever the chrome is doing - that arrives with the density setting itself.
+ *
+ * **Must be composed below whatever provides [LocalChromeDimens].** It resolves the metrics the same
+ * way the bars do, and the whole point of [ChromeMetrics] is that the measurement cannot drift from
+ * what is drawn. A provider sitting *between* this call and the bars would have it report
+ * `Comfortable` while the bars drew `Compact`, and the density setting would look like it did
+ * nothing.
  */
 @Composable
 fun ChromeBudgetReadout(
+    windowId: String?,
     appearance: WindowAppearanceSettings,
     focusMode: FocusModeSettings,
 ) {
@@ -51,7 +88,7 @@ fun ChromeBudgetReadout(
     val windowHeight = with(density) { containerSize.height.toDp() }
     val windowWidth = with(density) { containerSize.width.toDp() }
 
-    LaunchedEffect(budget, windowHeight, windowWidth) {
+    LaunchedEffect(windowId, budget, windowHeight.bucket(), windowWidth.bucket()) {
         if (windowHeight <= 0.dp || windowWidth <= 0.dp) return@LaunchedEffect
 
         val heightPercent = budget.verticalFractionOf(windowHeight) * 100
@@ -60,6 +97,8 @@ fun ChromeBudgetReadout(
             LogCategory.UI,
             "chrome budget: page gets ${heightPercent.format1()}% of height, ${widthPercent.format1()}% of width",
             mapOf(
+                // Without this, two open windows produce two indistinguishable lines.
+                "windowId" to (windowId ?: "unknown"),
                 "windowDp" to "${windowWidth.value.toInt()}x${windowHeight.value.toInt()}",
                 "chromeVerticalDp" to budget.vertical.value.toInt(),
                 "chromeHorizontalDp" to budget.horizontal.value.toInt(),
@@ -68,8 +107,13 @@ fun ChromeBudgetReadout(
     }
 }
 
-/** One decimal place, without pulling in a platform formatter this module would have to expect/actual. */
+private fun Dp.bucket(): Int = (value / SIZE_BUCKET.value).toInt()
+
+/**
+ * One decimal place, rounded rather than truncated, without pulling in a platform formatter this
+ * module would have to expect/actual for.
+ */
 private fun Float.format1(): String {
-    val scaled = (this * 10).toInt()
+    val scaled = (this * 10 + 0.5f).toInt()
     return "${scaled / 10}.${scaled % 10}"
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
@@ -40,9 +40,16 @@ enum class ChromeDensity {
  * @property bottomBarHeight The status bar.
  * @property stripWidth One icon rail's width. Floored by the icon buttons — see [MIN_STRIP_WIDTH].
  * @property panelTopBarHeight A `SidePanel` header. Note this is *not* part of the main panel's
- *   budget — a browser tab in the main panel never pays it (see `ChromeMetrics`).
- * @property dividerThickness The hairline between stacked bars. `Divider`'s own default, named here
- *   so the budget can account for it.
+ *   budget - a browser tab in the main panel never pays it (see `ChromeMetrics`).
+ * @property dividerThickness The hairline between stacked bars, and the width of the `VDivider` each
+ *   icon strip draws down its inner edge. `Divider`'s own default, named here so the budget can
+ *   account for it.
+ * @property panelBorderThickness Width of the ring every main panel reserves for its active-panel
+ *   border. The border is drawn at this width and the content inset by the same amount, so a child
+ *   Compose cannot draw over - a foreign native surface such as the HARDWARE_ACCELERATED browser -
+ *   has nowhere to cover it from. Smaller padding than border leaves a sliver the browser paints
+ *   over; larger leaves a visible gap inside the border. Not density-scaled: it answers to a
+ *   rendering artifact, not to taste, and 1.dp is invisible while 3.dp is a frame.
  */
 data class ChromeDimens(
     val titleBarHeight: Dp,
@@ -52,6 +59,7 @@ data class ChromeDimens(
     val stripWidth: Dp,
     val panelTopBarHeight: Dp,
     val dividerThickness: Dp = 1.dp,
+    val panelBorderThickness: Dp = 2.dp,
 ) {
     companion object {
         /**
@@ -65,13 +73,21 @@ data class ChromeDimens(
 
         /**
          * The floor for [tabBarHeight]: `NEW_TAB_BUTTON_SIZE` is 32.dp, so anything under 36 leaves
-         * the "+" button less than 2.dp of breathing room on each side.
+         * the "+" button less than 2.dp of breathing room on each side. `ChromeMetricsTest` pins
+         * this against that constant rather than trusting the arithmetic in this sentence.
          */
         val MIN_TAB_BAR = 36.dp
 
         /**
-         * The floor for [stripWidth]: `SidebarIconRail.RowPitch` is a 32.dp button plus padding, so
-         * a rail narrower than 36 starts squeezing the buttons against its edges.
+         * The floor for [stripWidth]: the rail's icon buttons are 32.dp square
+         * (`SidebarSlotContainer`), so a rail narrower than 36 squeezes them against its edges.
+         *
+         * Deliberately *not* `SidebarIconRail.RowPitch`, which an earlier version of this comment
+         * cited. That is a *vertical* pitch - "32dp button + 8dp vertical padding" - and says
+         * nothing about how wide the rail has to be. It happens to be 40 as well, which is exactly
+         * what makes citing it here a trap for whoever changes one and reads the other. The button
+         * size it is really floored by is a literal at its call site, so there is no constant to
+         * pin it to.
          */
         val MIN_STRIP_WIDTH = 36.dp
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
@@ -1,0 +1,143 @@
+package ai.rever.boss.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.serialization.Serializable
+
+/**
+ * How tightly the window's chrome bars are drawn.
+ *
+ * Separate from *which* bars are on screen, which is `WindowAppearanceSettings.showTopBar` and its
+ * neighbours. That answers "do I want this bar at all"; this answers "how much room may the bars I
+ * do want take". The two are independent on purpose: on a 13" laptop the useful answer is usually
+ * "all of them, but tighter", and per-bar switches alone cannot express it.
+ */
+@Serializable
+enum class ChromeDensity {
+    COMPACT,
+    COMFORTABLE,
+    SPACIOUS,
+}
+
+/**
+ * The heights and widths of every host chrome bar, resolved from a [ChromeDensity].
+ *
+ * These were literals in the seven files that draw the bars, which meant there was no single knob
+ * to turn and no way to state what the chrome costs. Read them through [BossChrome].dimens.
+ *
+ * Host chrome only. This deliberately does not live in `plugin-ui-core` alongside
+ * `BossTheme.colors` / `BossTheme.space`: plugins never draw the title bar, the tab bar or the icon
+ * strips, and that module carries binary-compatibility constraints for dynamically loaded plugins
+ * that host layout tokens have no business touching.
+ *
+ * @property titleBarHeight The "Boss Console" row. On macOS this is also what keeps window content
+ *   clear of the traffic lights, since the window sets `fullWindowContent` — see [MIN_TITLE_BAR].
+ * @property topBarHeight The action bar (workspace controls, run bar, search, settings).
+ * @property tabBarHeight The main panel's tab row. Floored by the new-tab button — see [MIN_TAB_BAR].
+ * @property bottomBarHeight The status bar.
+ * @property stripWidth One icon rail's width. Floored by the icon buttons — see [MIN_STRIP_WIDTH].
+ * @property panelTopBarHeight A `SidePanel` header. Note this is *not* part of the main panel's
+ *   budget — a browser tab in the main panel never pays it (see `ChromeMetrics`).
+ * @property dividerThickness The hairline between stacked bars. `Divider`'s own default, named here
+ *   so the budget can account for it.
+ */
+data class ChromeDimens(
+    val titleBarHeight: Dp,
+    val topBarHeight: Dp,
+    val tabBarHeight: Dp,
+    val bottomBarHeight: Dp,
+    val stripWidth: Dp,
+    val panelTopBarHeight: Dp,
+    val dividerThickness: Dp = 1.dp,
+) {
+    companion object {
+        /**
+         * The shipped title bar height, and the floor for it.
+         *
+         * macOS draws the traffic lights over the top-left of the content (the window sets
+         * `apple.awt.fullWindowContent`), so this row is what they sit in. 26.dp is what has
+         * shipped; going below it risks the buttons overlapping whatever is drawn beneath.
+         */
+        val MIN_TITLE_BAR = 26.dp
+
+        /**
+         * The floor for [tabBarHeight]: `NEW_TAB_BUTTON_SIZE` is 32.dp, so anything under 36 leaves
+         * the "+" button less than 2.dp of breathing room on each side.
+         */
+        val MIN_TAB_BAR = 36.dp
+
+        /**
+         * The floor for [stripWidth]: `SidebarIconRail.RowPitch` is a 32.dp button plus padding, so
+         * a rail narrower than 36 starts squeezing the buttons against its edges.
+         */
+        val MIN_STRIP_WIDTH = 36.dp
+
+        /** Today's shipped metrics. Changing these changes the app's default look. */
+        val Comfortable =
+            ChromeDimens(
+                titleBarHeight = 26.dp,
+                topBarHeight = 40.dp,
+                tabBarHeight = 42.dp,
+                bottomBarHeight = 30.dp,
+                stripWidth = 40.dp,
+                panelTopBarHeight = 28.dp,
+            )
+
+        /**
+         * As tight as the existing content allows, for short screens.
+         *
+         * Every value here is at or above the floor its content imposes ([MIN_TITLE_BAR],
+         * [MIN_TAB_BAR], [MIN_STRIP_WIDTH]); the title bar cannot shrink at all, since the shipped
+         * height is already its floor. Worth ~20.dp of window height over [Comfortable].
+         */
+        val Compact =
+            ChromeDimens(
+                titleBarHeight = MIN_TITLE_BAR,
+                // The tallest thing in the top bar is the 22.dp logo plus 2.dp of padding.
+                topBarHeight = 32.dp,
+                tabBarHeight = MIN_TAB_BAR,
+                bottomBarHeight = 24.dp,
+                stripWidth = MIN_STRIP_WIDTH,
+                panelTopBarHeight = 24.dp,
+            )
+
+        /** Roomier, for a large display where the height is not the scarce resource. */
+        val Spacious =
+            ChromeDimens(
+                titleBarHeight = 28.dp,
+                topBarHeight = 44.dp,
+                tabBarHeight = 46.dp,
+                bottomBarHeight = 34.dp,
+                stripWidth = 44.dp,
+                panelTopBarHeight = 30.dp,
+            )
+
+        fun of(density: ChromeDensity): ChromeDimens =
+            when (density) {
+                ChromeDensity.COMPACT -> Compact
+                ChromeDensity.COMFORTABLE -> Comfortable
+                ChromeDensity.SPACIOUS -> Spacious
+            }
+    }
+}
+
+/**
+ * The chrome metrics in force for this window.
+ *
+ * Defaults to [ChromeDimens.Comfortable] — the shipped values — so every bar renders exactly as it
+ * did before this existed even where nothing provides it.
+ */
+val LocalChromeDimens = staticCompositionLocalOf { ChromeDimens.Comfortable }
+
+/**
+ * Accessor for host chrome metrics, mirroring the `BossTheme.colors` / `BossTheme.space` pattern
+ * the design system already uses: `BossChrome.dimens.tabBarHeight`.
+ */
+object BossChrome {
+    val dimens: ChromeDimens
+        @Composable @ReadOnlyComposable
+        get() = LocalChromeDimens.current
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeMetrics.kt
@@ -50,24 +50,34 @@ object ChromeMetrics {
      * "how much room does the page get while I am reading it".
      *
      * Deliberately **excludes**:
-     * - `BossPanelTopBar` (`panelTopBarHeight`) — that is a `SidePanel` header. A browser tab in the
+     * - `BossPanelTopBar` (`panelTopBarHeight`) - that is a `SidePanel` header. A browser tab in the
      *   main panel never pays it, and counting it here overstated the cost of the main panel by
      *   28dp in the first draft of issue #239. Do not add it back.
-     * - `UpdateBanner` — present only when an update is waiting, and deliberately drawn even in
+     * - `UpdateBanner` - present only when an update is waiting, and deliberately drawn even in
      *   focus mode. Transient, so it does not belong in a steady-state budget.
-     * - Split view. Each additional panel adds its own tab bar; this measures a single panel, which
-     *   is the best case, so a real split is never *better* than this number says.
+     * - Split view. Each additional panel adds its own tab bar and its own border ring; this
+     *   measures a single panel, which is the best case, so a real split is never *better* than
+     *   this number says.
+     *
+     * [dimens] has no default on purpose. Once density is user-selectable, a defaulted
+     * `Comfortable` would mean "silently assume the user picked comfortable", and a caller that
+     * forgot the argument would get a plausible wrong answer with nothing to catch it.
      */
     fun mainPanelBudget(
         appearance: WindowAppearanceSettings,
         focusMode: FocusModeSettings,
-        dimens: ChromeDimens = ChromeDimens.Comfortable,
+        dimens: ChromeDimens,
     ): ChromeBudget {
         val divider = dimens.dividerThickness
 
         // Each bar carries its own divider: BossTitleBar and BossTopBar draw a trailing one,
         // BossBottomBar a leading one, and BossMainPanel draws one under the tab bar.
-        var vertical = 0.dp
+        //
+        // The panel's border ring is charged first because it is the one piece of this that no
+        // preference can switch off. BossMainPanel draws a border at panelBorderThickness and insets
+        // its content by the same amount, on all four sides, whether or not the panel is active - so
+        // it is twice the thickness off each axis and a browser tab never gets it back.
+        var vertical = dimens.panelBorderThickness * 2
 
         // Not gated on focus mode: the title row answers only to the appearance preference, since
         // on macOS it is what keeps content clear of the traffic lights.
@@ -84,12 +94,16 @@ object ChromeMetrics {
             vertical += dimens.bottomBarHeight + divider
         }
 
-        var horizontal = 0.dp
+        var horizontal = dimens.panelBorderThickness * 2
+
+        // Each strip draws a VDivider down its inner edge, inside the same AnimatedVisibility that
+        // gates the strip itself, so the hairline comes and goes with it exactly as the horizontal
+        // dividers do with their bars.
         if (appearance.showLeftStrip && !focusMode.hides(FocusModeEdge.LEFT)) {
-            horizontal += dimens.stripWidth
+            horizontal += dimens.stripWidth + divider
         }
         if (appearance.showRightStrip && !focusMode.hides(FocusModeEdge.RIGHT)) {
-            horizontal += dimens.stripWidth
+            horizontal += dimens.stripWidth + divider
         }
 
         return ChromeBudget(vertical = vertical, horizontal = horizontal)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeMetrics.kt
@@ -1,0 +1,97 @@
+package ai.rever.boss.layout
+
+import ai.rever.boss.focusmode.FocusModeEdge
+import ai.rever.boss.focusmode.FocusModeSettings
+import ai.rever.boss.window.WindowAppearanceSettings
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * What the window's chrome costs a browser tab, and what is left for the page.
+ *
+ * @property vertical Total height taken by bars above and below the content, dividers included.
+ * @property horizontal Total width taken by the icon strips.
+ */
+data class ChromeBudget(
+    val vertical: Dp,
+    val horizontal: Dp,
+) {
+    /**
+     * The share of [windowHeight] left for page content, 0f..1f.
+     *
+     * Returns 0f for a non-positive [windowHeight] — a window can be measured mid-layout, and a
+     * readout showing "0%" for one frame beats dividing by zero.
+     */
+    fun verticalFractionOf(windowHeight: Dp): Float =
+        if (windowHeight <= 0.dp) 0f else ((windowHeight - vertical) / windowHeight).coerceIn(0f, 1f)
+
+    /** The share of [windowWidth] left for page content, 0f..1f. See [verticalFractionOf]. */
+    fun horizontalFractionOf(windowWidth: Dp): Float =
+        if (windowWidth <= 0.dp) 0f else ((windowWidth - horizontal) / windowWidth).coerceIn(0f, 1f)
+}
+
+/**
+ * The chrome budget for a browser tab in the main panel.
+ *
+ * Exists because "the browser feels cramped" is otherwise unfalsifiable: there was no way to say
+ * from inside the app that the page gets 84.7% of the window, so any change here could only be
+ * argued rather than shown. The unit test pins the shipped defaults, so adding or resizing a bar
+ * without accounting for it fails a test rather than quietly costing a user another 30dp.
+ *
+ * Mirrors what `BossAppScaffold` actually draws, and is derived from the same two settings objects
+ * it gates on, so the two cannot drift apart silently.
+ */
+object ChromeMetrics {
+    /**
+     * Chrome around a browser tab in the main panel, in its steady state.
+     *
+     * "Steady state" means no hover-reveal: a bar that focus mode is clearing counts as absent even
+     * though sweeping the window edge brings it back temporarily. That is the honest number for
+     * "how much room does the page get while I am reading it".
+     *
+     * Deliberately **excludes**:
+     * - `BossPanelTopBar` (`panelTopBarHeight`) — that is a `SidePanel` header. A browser tab in the
+     *   main panel never pays it, and counting it here overstated the cost of the main panel by
+     *   28dp in the first draft of issue #239. Do not add it back.
+     * - `UpdateBanner` — present only when an update is waiting, and deliberately drawn even in
+     *   focus mode. Transient, so it does not belong in a steady-state budget.
+     * - Split view. Each additional panel adds its own tab bar; this measures a single panel, which
+     *   is the best case, so a real split is never *better* than this number says.
+     */
+    fun mainPanelBudget(
+        appearance: WindowAppearanceSettings,
+        focusMode: FocusModeSettings,
+        dimens: ChromeDimens = ChromeDimens.Comfortable,
+    ): ChromeBudget {
+        val divider = dimens.dividerThickness
+
+        // Each bar carries its own divider: BossTitleBar and BossTopBar draw a trailing one,
+        // BossBottomBar a leading one, and BossMainPanel draws one under the tab bar.
+        var vertical = 0.dp
+
+        // Not gated on focus mode: the title row answers only to the appearance preference, since
+        // on macOS it is what keeps content clear of the traffic lights.
+        if (appearance.showTitleBar) vertical += dimens.titleBarHeight + divider
+
+        if (appearance.showTopBar && !focusMode.hides(FocusModeEdge.TOP)) {
+            vertical += dimens.topBarHeight + divider
+        }
+
+        // The tab bar has no switch. It is the one piece of chrome a tabbed browser cannot drop.
+        vertical += dimens.tabBarHeight + divider
+
+        if (appearance.showBottomBar && !focusMode.hides(FocusModeEdge.BOTTOM)) {
+            vertical += dimens.bottomBarHeight + divider
+        }
+
+        var horizontal = 0.dp
+        if (appearance.showLeftStrip && !focusMode.hides(FocusModeEdge.LEFT)) {
+            horizontal += dimens.stripWidth
+        }
+        if (appearance.showRightStrip && !focusMode.hides(FocusModeEdge.RIGHT)) {
+            horizontal += dimens.stripWidth
+        }
+
+        return ChromeBudget(vertical = vertical, horizontal = horizontal)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
@@ -13,7 +13,8 @@ data class WindowAppearanceSettings(
      */
     val showTitleBar: Boolean = true,
     /**
-     * Whether the 40dp action bar at the top of the window is on screen.
+     * Whether the action bar at the top of the window is on screen. Its height comes from
+     * `ChromeDimens.topBarHeight`, so quoting a dp figure here would go stale.
      *
      * This and the three below are a *permanent* preference, and deliberately separate from focus
      * mode's per-edge `hide*` flags. Focus mode is a transient posture with hover-reveal strips to
@@ -28,11 +29,11 @@ data class WindowAppearanceSettings(
      * differ per platform.
      */
     val showTopBar: Boolean = true,
-    /** Whether the 30dp status bar at the bottom of the window is on screen. See [showTopBar]. */
+    /** Whether the status bar at the bottom of the window is on screen. See [showTopBar]. */
     val showBottomBar: Boolean = true,
-    /** Whether the left 40dp icon strip is on screen. See [showTopBar]. */
+    /** Whether the left icon strip is on screen. See [showTopBar]. */
     val showLeftStrip: Boolean = true,
-    /** Whether the right 40dp icon strip is on screen. See [showTopBar]. */
+    /** Whether the right icon strip is on screen. See [showTopBar]. */
     val showRightStrip: Boolean = true,
     /**
      * How tabs in the main (top) tab bar are sized.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeBudgetReadoutFlagTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeBudgetReadoutFlagTest.kt
@@ -1,0 +1,60 @@
+package ai.rever.boss.layout
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The readout's on/off rule.
+ *
+ * Pulled out of the `by lazy` that reads the environment so it can be asserted at all. The case
+ * worth having a test for is the blank env var: `BrowserAnalytics.telemetryEnabledFrom` records in
+ * its KDoc that a blank value shadowing a set property was hit for real in this repo, and a flag
+ * that reads two sources has no business rediscovering it.
+ */
+class ChromeBudgetReadoutFlagTest {
+    @Test
+    fun `off when neither source is set`() {
+        assertFalse(chromeBudgetReadoutEnabled(env = null, property = null))
+    }
+
+    @Test
+    fun `the env var turns it on`() {
+        listOf("1", "true", "yes", "on", "TRUE", "On").forEach { value ->
+            assertTrue(chromeBudgetReadoutEnabled(env = value, property = null), value)
+        }
+    }
+
+    @Test
+    fun `the system property turns it on`() {
+        // The reason this source exists: `./gradlew run` makes an env var awkward to set.
+        assertTrue(chromeBudgetReadoutEnabled(env = null, property = "1"))
+    }
+
+    @Test
+    fun `a blank env var falls through to the property instead of shadowing it`() {
+        listOf("", "   ").forEach { blank ->
+            assertTrue(
+                chromeBudgetReadoutEnabled(env = blank, property = "1"),
+                "a blank env var swallowed the property, which is the bug this rule exists to avoid",
+            )
+        }
+    }
+
+    @Test
+    fun `a set env var wins over the property`() {
+        assertFalse(chromeBudgetReadoutEnabled(env = "0", property = "1"))
+    }
+
+    @Test
+    fun `surrounding whitespace does not defeat it`() {
+        assertTrue(chromeBudgetReadoutEnabled(env = " 1 ", property = null))
+    }
+
+    @Test
+    fun `anything else is off`() {
+        listOf("0", "false", "no", "off", "maybe", "2").forEach { value ->
+            assertFalse(chromeBudgetReadoutEnabled(env = value, property = null), value)
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeMetricsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeMetricsTest.kt
@@ -1,0 +1,175 @@
+package ai.rever.boss.layout
+
+import ai.rever.boss.focusmode.FocusModeSettings
+import ai.rever.boss.window.WindowAppearanceSettings
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins what the window chrome costs a browser tab.
+ *
+ * The point of these numbers being in a test is that issue #239 is about a budget nobody was
+ * tracking: bar heights were literals in seven different files, so a bar could be added or grown
+ * without anyone noticing the page had lost another 30dp. Growing the chrome now means changing an
+ * assertion here and saying so.
+ *
+ * The reference window is a 13" MacBook Air at its default scaled resolution: 1470 x 956 pt, of
+ * which ~931 pt is window height once the macOS menu bar is subtracted.
+ */
+class ChromeMetricsTest {
+    private val airHeight = 931.dp
+    private val airWidth = 1470.dp
+
+    /** macOS defaults: title bar on, all four bars on, focus mode off. */
+    private val macDefaults = WindowAppearanceSettings(showTitleBar = true)
+
+    /** Windows/Linux defaults, which differ only in the title bar. */
+    private val nonMacDefaults = WindowAppearanceSettings(showTitleBar = false)
+
+    private val focusOff = FocusModeSettings(enabled = false)
+
+    @Test
+    fun `shipped macOS defaults cost 142dp and leave the page 84 percent`() {
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff)
+
+        // 27 title (26+1) + 41 top (40+1) + 43 tab (42+1) + 31 bottom (30+1)
+        assertEquals(142.dp, budget.vertical)
+        assertEquals(80.dp, budget.horizontal)
+        assertEquals(0.847f, budget.verticalFractionOf(airHeight), absoluteTolerance = 0.001f)
+        assertEquals(0.946f, budget.horizontalFractionOf(airWidth), absoluteTolerance = 0.001f)
+    }
+
+    @Test
+    fun `Windows and Linux defaults save the title row`() {
+        val budget = ChromeMetrics.mainPanelBudget(nonMacDefaults, focusOff)
+
+        assertEquals(115.dp, budget.vertical)
+        assertEquals(80.dp, budget.horizontal)
+    }
+
+    @Test
+    fun `compact density is worth 20dp of height over comfortable`() {
+        val comfortable = ChromeMetrics.mainPanelBudget(macDefaults, focusOff, ChromeDimens.Comfortable)
+        val compact = ChromeMetrics.mainPanelBudget(macDefaults, focusOff, ChromeDimens.Compact)
+
+        assertEquals(20.dp, comfortable.vertical - compact.vertical)
+        // 8 off each strip.
+        assertEquals(8.dp, comfortable.horizontal - compact.horizontal)
+    }
+
+    @Test
+    fun `focus mode clearing every edge leaves only the tab bar`() {
+        val focusOn =
+            FocusModeSettings(
+                enabled = true,
+                hideTopBar = true,
+                hideLeftSidebar = true,
+                hideRightSidebar = true,
+                hideBottomBar = true,
+            )
+
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOn)
+
+        // Title row survives: it answers to the appearance preference, not to focus mode.
+        assertEquals(27.dp + 43.dp, budget.vertical)
+        assertEquals(0.dp, budget.horizontal)
+    }
+
+    @Test
+    fun `focus mode enabled but hiding nothing changes nothing`() {
+        val idle =
+            FocusModeSettings(
+                enabled = true,
+                hideTopBar = false,
+                hideLeftSidebar = false,
+                hideRightSidebar = false,
+                hideBottomBar = false,
+            )
+
+        assertEquals(
+            ChromeMetrics.mainPanelBudget(macDefaults, focusOff),
+            ChromeMetrics.mainPanelBudget(macDefaults, idle),
+        )
+    }
+
+    @Test
+    fun `a hidden bar costs nothing even with focus mode off`() {
+        val leanest =
+            WindowAppearanceSettings(
+                showTitleBar = false,
+                showTopBar = false,
+                showBottomBar = false,
+                showLeftStrip = false,
+                showRightStrip = false,
+            )
+
+        val budget = ChromeMetrics.mainPanelBudget(leanest, focusOff)
+
+        // The tab bar has no switch, so this is the floor the current architecture can reach.
+        assertEquals(43.dp, budget.vertical)
+        assertEquals(0.dp, budget.horizontal)
+        assertTrue(budget.verticalFractionOf(airHeight) > 0.95f)
+    }
+
+    @Test
+    fun `the tab bar is never free`() {
+        // Whatever else is switched off, a tabbed browser keeps its tab row.
+        ChromeDensity.entries.forEach { density ->
+            val budget =
+                ChromeMetrics.mainPanelBudget(
+                    WindowAppearanceSettings(
+                        showTitleBar = false,
+                        showTopBar = false,
+                        showBottomBar = false,
+                        showLeftStrip = false,
+                        showRightStrip = false,
+                    ),
+                    focusOff,
+                    ChromeDimens.of(density),
+                )
+            assertEquals(ChromeDimens.of(density).tabBarHeight + 1.dp, budget.vertical, "density $density")
+        }
+    }
+
+    @Test
+    fun `a degenerate window size reports zero rather than dividing by zero`() {
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff)
+
+        assertEquals(0f, budget.verticalFractionOf(0.dp))
+        assertEquals(0f, budget.horizontalFractionOf((-10).dp))
+    }
+
+    @Test
+    fun `chrome taller than the window clamps to zero rather than going negative`() {
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff)
+
+        assertEquals(0f, budget.verticalFractionOf(100.dp))
+    }
+
+    @Test
+    fun `every compact metric respects the floor its content imposes`() {
+        val compact = ChromeDimens.Compact
+
+        assertTrue(compact.titleBarHeight >= ChromeDimens.MIN_TITLE_BAR)
+        assertTrue(compact.tabBarHeight >= ChromeDimens.MIN_TAB_BAR)
+        assertTrue(compact.stripWidth >= ChromeDimens.MIN_STRIP_WIDTH)
+    }
+
+    @Test
+    fun `density ordering is monotonic so compact is never the roomiest`() {
+        val compact = ChromeDimens.Compact
+        val comfortable = ChromeDimens.Comfortable
+        val spacious = ChromeDimens.Spacious
+
+        assertTrue(compact.topBarHeight < comfortable.topBarHeight)
+        assertTrue(comfortable.topBarHeight < spacious.topBarHeight)
+        assertTrue(compact.tabBarHeight < comfortable.tabBarHeight)
+        assertTrue(comfortable.tabBarHeight < spacious.tabBarHeight)
+        assertTrue(compact.bottomBarHeight < comfortable.bottomBarHeight)
+        assertTrue(comfortable.bottomBarHeight < spacious.bottomBarHeight)
+        assertTrue(compact.stripWidth < comfortable.stripWidth)
+        assertTrue(comfortable.stripWidth < spacious.stripWidth)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeMetricsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeMetricsTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.layout
 
+import ai.rever.boss.components.window_panel.components.main_window_panels.NEW_TAB_BUTTON_SIZE
 import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.window.WindowAppearanceSettings
 import androidx.compose.ui.unit.dp
@@ -30,23 +31,51 @@ class ChromeMetricsTest {
 
     private val focusOff = FocusModeSettings(enabled = false)
 
-    @Test
-    fun `shipped macOS defaults cost 142dp and leave the page 84 percent`() {
-        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff)
+    private val comfortable = ChromeDimens.Comfortable
 
-        // 27 title (26+1) + 41 top (40+1) + 43 tab (42+1) + 31 bottom (30+1)
-        assertEquals(142.dp, budget.vertical)
-        assertEquals(80.dp, budget.horizontal)
-        assertEquals(0.847f, budget.verticalFractionOf(airHeight), absoluteTolerance = 0.001f)
-        assertEquals(0.946f, budget.horizontalFractionOf(airWidth), absoluteTolerance = 0.001f)
+    /** Border ring plus content inset, off both axes, in every configuration. */
+    private val ring = comfortable.panelBorderThickness * 2
+
+    /** Everything a preference can switch off, switched off. */
+    private val leanest =
+        WindowAppearanceSettings(
+            showTitleBar = false,
+            showTopBar = false,
+            showBottomBar = false,
+            showLeftStrip = false,
+            showRightStrip = false,
+        )
+
+    @Test
+    fun `shipped macOS defaults cost 146dp and leave the page 84 percent`() {
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff, comfortable)
+
+        // 27 title (26+1) + 41 top (40+1) + 43 tab (42+1) + 31 bottom (30+1) + 4 ring
+        assertEquals(146.dp, budget.vertical)
+        // 41 per strip (40+1 divider) + 4 ring
+        assertEquals(86.dp, budget.horizontal)
+        assertEquals(0.843f, budget.verticalFractionOf(airHeight), absoluteTolerance = 0.001f)
+        assertEquals(0.941f, budget.horizontalFractionOf(airWidth), absoluteTolerance = 0.001f)
     }
 
     @Test
     fun `Windows and Linux defaults save the title row`() {
-        val budget = ChromeMetrics.mainPanelBudget(nonMacDefaults, focusOff)
+        val budget = ChromeMetrics.mainPanelBudget(nonMacDefaults, focusOff, comfortable)
 
-        assertEquals(115.dp, budget.vertical)
-        assertEquals(80.dp, budget.horizontal)
+        assertEquals(119.dp, budget.vertical)
+        assertEquals(86.dp, budget.horizontal)
+    }
+
+    @Test
+    fun `the panel border ring is charged in every configuration`() {
+        // BossMainPanel draws it whether or not the panel is active, and no preference switches it
+        // off, so it is the one part of the budget that is always present. Omitting it understated
+        // every figure here by 4dp on each axis until the review of #240 caught it.
+        val leanestPossible =
+            ChromeMetrics.mainPanelBudget(leanest, focusOff, comfortable)
+
+        assertTrue(leanestPossible.vertical >= ring)
+        assertEquals(ring, leanestPossible.horizontal)
     }
 
     @Test
@@ -55,7 +84,7 @@ class ChromeMetricsTest {
         val compact = ChromeMetrics.mainPanelBudget(macDefaults, focusOff, ChromeDimens.Compact)
 
         assertEquals(20.dp, comfortable.vertical - compact.vertical)
-        // 8 off each strip.
+        // 4 off each strip, 8 across both.
         assertEquals(8.dp, comfortable.horizontal - compact.horizontal)
     }
 
@@ -70,11 +99,11 @@ class ChromeMetricsTest {
                 hideBottomBar = true,
             )
 
-        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOn)
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOn, comfortable)
 
         // Title row survives: it answers to the appearance preference, not to focus mode.
-        assertEquals(27.dp + 43.dp, budget.vertical)
-        assertEquals(0.dp, budget.horizontal)
+        assertEquals(27.dp + 43.dp + ring, budget.vertical)
+        assertEquals(ring, budget.horizontal)
     }
 
     @Test
@@ -89,53 +118,38 @@ class ChromeMetricsTest {
             )
 
         assertEquals(
-            ChromeMetrics.mainPanelBudget(macDefaults, focusOff),
-            ChromeMetrics.mainPanelBudget(macDefaults, idle),
+            ChromeMetrics.mainPanelBudget(macDefaults, focusOff, comfortable),
+            ChromeMetrics.mainPanelBudget(macDefaults, idle, comfortable),
         )
     }
 
     @Test
     fun `a hidden bar costs nothing even with focus mode off`() {
-        val leanest =
-            WindowAppearanceSettings(
-                showTitleBar = false,
-                showTopBar = false,
-                showBottomBar = false,
-                showLeftStrip = false,
-                showRightStrip = false,
-            )
+        val budget = ChromeMetrics.mainPanelBudget(leanest, focusOff, comfortable)
 
-        val budget = ChromeMetrics.mainPanelBudget(leanest, focusOff)
-
-        // The tab bar has no switch, so this is the floor the current architecture can reach.
-        assertEquals(43.dp, budget.vertical)
-        assertEquals(0.dp, budget.horizontal)
-        assertTrue(budget.verticalFractionOf(airHeight) > 0.95f)
+        // The tab bar has no switch, so this plus the ring is the floor the architecture can reach.
+        assertEquals(43.dp + ring, budget.vertical)
+        assertEquals(ring, budget.horizontal)
+        assertTrue(budget.verticalFractionOf(airHeight) > 0.94f)
     }
 
     @Test
     fun `the tab bar is never free`() {
         // Whatever else is switched off, a tabbed browser keeps its tab row.
         ChromeDensity.entries.forEach { density ->
-            val budget =
-                ChromeMetrics.mainPanelBudget(
-                    WindowAppearanceSettings(
-                        showTitleBar = false,
-                        showTopBar = false,
-                        showBottomBar = false,
-                        showLeftStrip = false,
-                        showRightStrip = false,
-                    ),
-                    focusOff,
-                    ChromeDimens.of(density),
-                )
-            assertEquals(ChromeDimens.of(density).tabBarHeight + 1.dp, budget.vertical, "density $density")
+            val dimens = ChromeDimens.of(density)
+            val budget = ChromeMetrics.mainPanelBudget(leanest, focusOff, dimens)
+            assertEquals(
+                dimens.tabBarHeight + dimens.dividerThickness + dimens.panelBorderThickness * 2,
+                budget.vertical,
+                "density $density",
+            )
         }
     }
 
     @Test
     fun `a degenerate window size reports zero rather than dividing by zero`() {
-        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff)
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff, comfortable)
 
         assertEquals(0f, budget.verticalFractionOf(0.dp))
         assertEquals(0f, budget.horizontalFractionOf((-10).dp))
@@ -143,9 +157,38 @@ class ChromeMetricsTest {
 
     @Test
     fun `chrome taller than the window clamps to zero rather than going negative`() {
-        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff)
+        val budget = ChromeMetrics.mainPanelBudget(macDefaults, focusOff, comfortable)
 
         assertEquals(0f, budget.verticalFractionOf(100.dp))
+    }
+
+    @Test
+    fun `comfortable reproduces the literals it replaced`() {
+        // The 146dp aggregate above catches a regression but reports a total; this names the field
+        // that moved, and is the most direct statement of PR A's no-op claim.
+        assertEquals(
+            ChromeDimens(
+                titleBarHeight = 26.dp,
+                topBarHeight = 40.dp,
+                tabBarHeight = 42.dp,
+                bottomBarHeight = 30.dp,
+                stripWidth = 40.dp,
+                panelTopBarHeight = 28.dp,
+            ),
+            ChromeDimens.Comfortable,
+        )
+    }
+
+    @Test
+    fun `the tab bar floor really clears the new-tab button`() {
+        // MIN_TAB_BAR's KDoc derives itself from NEW_TAB_BUTTON_SIZE in prose. Bump that constant
+        // and the prose is quietly wrong with a green suite, so pin the relationship instead - the
+        // same discipline SidebarBottomActionsLayoutTest applies to the rail metrics.
+        assertTrue(
+            ChromeDimens.MIN_TAB_BAR >= NEW_TAB_BUTTON_SIZE + 4.dp,
+            "MIN_TAB_BAR ${ChromeDimens.MIN_TAB_BAR} leaves the ${NEW_TAB_BUTTON_SIZE} new-tab " +
+                "button less than 2dp a side",
+        )
     }
 
     @Test


### PR DESCRIPTION
PR A of three for #239. **A provable no-op on screen**: it adds the knob and the measurement, and changes nothing a user sees.

*Updated after review: the budget was understating itself. See "Corrections from review" below.*

## Why

`WindowAppearanceSettings` already lets a user switch the top bar, bottom bar and both icon strips off, and `FocusModeSettings` already clears them per edge. What neither can express is the answer a small laptop usually wants, which is *all* the chrome but tighter, because every bar's height was a literal in the file that drew it:

| | was | file |
|---|---|---|
| title bar | `26.dp` | `BossTitleBar.kt` |
| top bar | `40.dp` | `BossTopBar.kt` |
| main tab bar | `42.dp` | `BossMainWindowPanel.kt` |
| bottom bar | `30.dp` | `BossBottomBar.kt` |
| icon strips | `40.dp` x2 | `BossLeftSideBar.kt`, `BossRightSideBar.kt` |
| side panel header | `28.dp` | `BossPanelTopBar.kt` |
| panel border ring | `2.dp` | `BossMainWindowPanel.kt` |

Seven files, no knob, and nothing stopping the next bar from quietly taking another 30dp.

## What's here

**`chrome: one source for every bar's metrics`** - `ChromeDimens` holds the metrics, `ChromeDensity` selects a set, the bars read `BossChrome.dimens`. `COMFORTABLE` is today's values to the dp and is what `LocalChromeDimens` defaults to, so nothing moves. Nothing provides the local yet; `COMPACT` / `SPACIOUS` are defined and unreachable until PR C wires a setting.

**`chrome: measure what the chrome costs the page`** - `ChromeMetrics.mainPanelBudget` derives the budget from the same two settings objects the scaffold gates on, so the measurement cannot drift from what is drawn. `ChromeBudgetReadout` renders nothing and logs the budget under `BOSS_CHROME_BUDGET=1` or `-Dboss.chrome.budget=1`.

**`chrome: charge the budget for chrome it was not counting`** - the review fixes, below.

## Corrections from review

The first version of this PR measured 142dp / 80dp for macOS defaults. Both were low, and the numbers matter because `ChromeMetricsTest` pins them as the baseline PRs B and C get measured against:

- **Each icon strip draws a 1dp `VDivider`** down its inner edge (`BossLeftSideBar:87`, `BossRightSideBar:51`), inside the same `AnimatedVisibility` that gates the strip. The vertical side counted every divider and the horizontal side counted none.
- **The main panel reserves a 4dp ring on both axes, unconditionally.** `BossMainPanel` draws a border at 2dp and insets its content by the same 2dp so a foreign native surface has nowhere to cover it from, active panel or not.

So the shipped figure is **146dp vertical / 86dp horizontal**, and the floor the architecture can reach is 47dp rather than 43. The ring also moves to `ChromeDimens.panelBorderThickness`, so the budget now reads the same value the border does rather than a copy of it - its own KDoc already said it was "named once because it is used twice and the two uses must agree exactly".

Four smaller things from the same review: `mainPanelBudget`'s `dimens` default is gone (once density is selectable, a default means "silently assume comfortable"); `MIN_TAB_BAR` is pinned against `NEW_TAB_BUTTON_SIZE` rather than deriving from it in prose; `MIN_STRIP_WIDTH`'s rationale cited `SidebarIconRail.RowPitch`, which is a *vertical* pitch that happens to also be 40, so the comment now names what actually floors it; and the readout gained system-property support with the resolution rule factored out and tested, a window id, a 50dp size bucket instead of a line per pixel of drag-resize, and rounding instead of truncation.

## Two decisions worth reviewing

**The COMPACT numbers are floored by content, not guessed.** `MIN_TAB_BAR` is 36 because `NEW_TAB_BUTTON_SIZE` is 32 and a 34dp bar leaves the "+" one dp a side. The title bar gets no compact value at all: with `fullWindowContent` set on macOS, that row is what the traffic lights are drawn over, and 26dp is already its floor.

**`ChromeMetrics` excludes `BossPanelTopBar`.** That 28dp header belongs to `SidePanel`; a browser tab in the main panel never pays it. Counting it overstated the main panel by 28dp in my first draft of #239, so the exclusion is commented in the source. `UpdateBanner` (transient) and split view (each panel brings its own tab bar and ring, so one panel is the best case) are excluded for reasons given there too.

## Verification

- `:composeApp:desktopTest` - **2618 tests, 244 classes, 0 failures**. The no-op claim rests on this: `COMFORTABLE` reproducing today's values means no existing layout test moves.
- `ChromeMetricsTest` pins 146dp / 84.3%, the always-present ring, the 20dp compact saving, the focus-mode truth table, the 47dp floor, and `Comfortable` field-by-field against the literals it replaced.
- `ChromeBudgetReadoutFlagTest` covers the flag rule, including a blank env var falling through to the property rather than shadowing it - a bug `BrowserAnalytics.telemetryEnabledFrom` records this repo hitting for real.
- `:composeApp:ktlintCheck` and `:composeApp:detekt` clean.

## Note for whoever builds this fresh

A cold worktree failed `:boss-ui-sdk:compileKotlin` with ~100 "Unresolved reference" errors against `ai.rever.boss.ipc.proto.*` while the `boss-ipc` jar plainly contained the classes. `./gradlew :boss-ui-sdk:clean :boss-ipc:clean` then rebuilding fixed it: stale incremental state from a compile that ran before `generateProto`, not a code problem, and CI on `be6adf83` is green.

Closes nothing on its own; #239 stays open for PRs B and C.
