### PR TITLE
Retire the My Secrets panel in favour of Secret Manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,52 @@ deletes the jar it rejected - so an entry-only check made Retry close the dialog
 success with nothing installed, and silenced the prompt for every other dependent of that
 plugin. The check is an entry whose `jarPath` still exists.
 
+## Retiring a plugin into another one
+
+`RetiredPlugins.sweep()` uninstalls a plugin whose job another plugin has taken over. It runs at
+step 3c of `PluginStoreSetup.loadPersistedPlugins` - after `PluginJarReconciler`, so
+`installed.json`'s `jarPath` is trustworthy, and before step 4 reads it, so a retired plugin never
+registers a panel or an MCP tool on a machine where its replacement is present. It is `internal`
+and **startup-only**: `PluginArtifactCleanup.remove` deletes the jar without unloading anything,
+which is safe only before any plugin has loaded (`PluginRemoval` spells out the alternative -
+`NoClassDefFoundError` from code that is still running).
+
+There is no "already done" flag. The sweep keys on the plugin being installed, and removing the
+`installed.json` row is what makes the next launch a no-op.
+
+**It fails closed at every step, and each step is a bug someone would otherwise ship.** A wrong
+"yes" deletes a panel the user still needs, so all of these mean "not yet, wait for a launch that
+can prove it":
+
+| Refusal | Why |
+|---|---|
+| replacement not installed | the user would have no panel at all for what the retired one did |
+| replacement disabled | `setPluginEnabled` and a for-lack-of-access install both leave the row and the jar in place |
+| replacement's jar missing | `installPlugin` records a DISABLED entry for a plugin it then rejected and deleted |
+| replacement's version unparseable or absent | see below |
+| replacement older than `minReplacementVersion` | that version has not absorbed the retired plugin's work yet |
+| the retired plugin would be restored anyway | a bundled or system plugin is re-copied at step 1 or re-downloaded at step 2, so removing it is a copy-then-delete loop on every launch, notice included |
+
+**`satisfiesVersionFloor` cannot be used alone here.** It returns `true` for anything
+`SemanticVersion.parse` rejects - `dev`, `v1.2.17`, `1.2.x`, a trailing `-` or `+` - by design,
+because for gating an *update* an ungated update beats a wrongly gated one. The consequence here
+runs the other way, and a locally built or side-loaded jar whose manifest version is not strict
+semver is exactly the case that would delete the user's only secrets panel. So the version is
+parsed explicitly first; `plugin-dependency` is on composeApp's classpath for that one call
+(`plugin-updater` has it as `implementation`, so it is not transitive).
+
+**The restore veto is asked at the call site, not inside `RetiredPlugins`**, which keeps that
+object free of both the manager and the system-plugin service. It combines
+`PluginRemoval.removalVeto` (the bundled dir) with `PluginStoreSetup.systemPlugins` (the remote
+`system_plugins` table merged over the built-in fallback). `ALL` is a list someone will append to
+without reading the change that added it, so this is a runtime guard rather than a comment.
+
+**One notice per sweep, not per retirement.** `StatusMessageManager.showMessage` cancels the
+previous message, so announcing in the loop would show only the last removal - and the sweep is
+one-shot, so a missed notice means a panel vanished with no explanation ever. Each retirement's
+removal is also wrapped individually, so one failure cannot drop the rest or lose the ids already
+removed.
+
 ## Configuration
 
 Create `local.properties`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,24 @@ can prove it":
 | replacement's version unparseable or absent | see below |
 | replacement older than `minReplacementVersion` | that version has not absorbed the retired plugin's work yet |
 | the retired plugin would be restored anyway | a bundled or system plugin is re-copied at step 1 or re-downloaded at step 2, so removing it is a copy-then-delete loop on every launch, notice included |
+| its jars could not actually be removed | see below - the row must not outlive the file |
+
+**The row is dropped only once the jars are gone, and that ordering is the whole guard.**
+`PluginArtifactCleanup.remove` drops the `installed.json` row unconditionally and only *logs*
+whether the delete worked, which is right for the interactive uninstall (the Toolbox already
+deleted the file) and wrong here. `DefaultPlugin.loadExternalPlugins` scans the same plugin
+directory after the persisted pass, **in the same launch**, and installs every jar the manager
+does not know about. So a retirement that drops the row while a jar survives does not leak a
+file - it reinstalls the plugin in the session the user was just told it left, `PluginBuildProbe`
+writes a fresh row on load, and every launch after that sweeps and announces again. The
+copy-then-delete loop the bundled/system veto prevents, by another door.
+
+`purgeJarsFor` therefore deletes **by manifest id, not by the recorded path**: `jarPath` can be
+stale while a differently named jar for the same plugin is still in the directory, and artifact
+prefixes are prefixes of each other (`boss-plugin-terminal` matches
+`boss-plugin-terminal-tab-*.jar`). It re-lists rather than trusting the delete results, because a
+Windows lock makes `delete()` return false silently and an already-absent file returns false too -
+absence is the postcondition, not the delete count.
 
 **`satisfiesVersionFloor` cannot be used alone here.** It returns `true` for anything
 `SemanticVersion.parse` rejects - `dev`, `v1.2.17`, `1.2.x`, a trailing `-` or `+` - by design,
@@ -278,11 +296,21 @@ object free of both the manager and the system-plugin service. It combines
 `system_plugins` table merged over the built-in fallback). `ALL` is a list someone will append to
 without reading the change that added it, so this is a runtime guard rather than a comment.
 
+**Retirement is also a filter on what is *offered*, not only on what is installed.** Unlisting the
+store row is a manual database action outside this repo and outside CI, and until it happens the
+store keeps returning the plugin - so a user can install it, have the sweep remove it at the next
+launch, and install it again indefinitely. `RetiredPluginIds` (commonMain, because the wizard is
+desktopMain and the home tool grid is commonMain) is filtered wherever
+`PluginDependencyResolution.NOT_USER_INSTALLABLE` is, and `RetiredPluginsTest` pins it against
+`RetiredPlugins.ALL` so the two lists cannot drift.
+
 **One notice per sweep, not per retirement.** `StatusMessageManager.showMessage` cancels the
 previous message, so announcing in the loop would show only the last removal - and the sweep is
 one-shot, so a missed notice means a panel vanished with no explanation ever. Each retirement's
 removal is also wrapped individually, so one failure cannot drop the rest or lose the ids already
-removed.
+removed. `noticeFor` **groups by replacement**: the function only exists for the multi-removal
+case, which is exactly the case where two retirements can point at different replacements, and
+taking `first().replacementDisplayName` told the user their panel moved somewhere it did not.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,7 @@ Scoped deliberately: this covers the **Docker and Kubernetes plugins only**, bec
 ### Security & secrets
 | Plugin | What it does |
 |--------|--------------|
-| **[Secret Manager](https://github.com/risa-labs-inc/boss-plugin-secret-manager)** | Encrypted credential vault - website/username/password, notes, tags, 2FA, expiry. Row-level-scoped to you, browser auto-fill, and permission-gated `secret_*` MCP tools |
-| **[My Secrets](https://github.com/risa-labs-inc/boss-plugin-user-secret-list)** | Read-only view of your own and shared credentials |
+| **[Secret Manager](https://github.com/risa-labs-inc/boss-plugin-secret-manager)** | Encrypted credential vault - website/username/password, notes, tags, 2FA, expiry. Row-level-scoped to you, browser auto-fill, and permission-gated `secret_*` MCP tools. A second section lists what other people have shared with you, read-only |
 
 ### Productivity & admin
 | Plugin | What it does |
@@ -448,7 +447,7 @@ BOSS is developed in the open, end to end - the host app, the plugin platform, t
 - **Dev tools** - [codebase](https://github.com/risa-labs-inc/boss-plugin-codebase) · [console](https://github.com/risa-labs-inc/boss-plugin-console) · [git-status](https://github.com/risa-labs-inc/boss-plugin-git-status) · [git-log](https://github.com/risa-labs-inc/boss-plugin-git-log) · [run-configurations](https://github.com/risa-labs-inc/boss-plugin-run-configurations) · [performance](https://github.com/risa-labs-inc/boss-plugin-performance)
 - **Infrastructure** - [docker](https://github.com/risa-labs-inc/boss-plugin-docker) · [kubernetes](https://github.com/risa-labs-inc/boss-plugin-kubernetes)
 - **AI & automation** - [tool-creator](https://github.com/risa-labs-inc/boss-plugin-tool-creator) · [tool-evolver](https://github.com/risa-labs-inc/boss-plugin-tool-evolver) · [llmrpa](https://github.com/risa-labs-inc/boss-plugin-llmrpa) · [rpaengine](https://github.com/risa-labs-inc/boss-plugin-rpaengine) · [rparecorder](https://github.com/risa-labs-inc/boss-plugin-rparecorder)
-- **Security** - [secret-manager](https://github.com/risa-labs-inc/boss-plugin-secret-manager) · [user-secret-list](https://github.com/risa-labs-inc/boss-plugin-user-secret-list)
+- **Security** - [secret-manager](https://github.com/risa-labs-inc/boss-plugin-secret-manager)
 - **Productivity** - [bookmarks](https://github.com/risa-labs-inc/boss-plugin-bookmarks) · [downloads](https://github.com/risa-labs-inc/boss-plugin-downloads) · [topofmind](https://github.com/risa-labs-inc/boss-plugin-topofmind)
 - **Admin** - [admin-role-management](https://github.com/risa-labs-inc/boss-plugin-admin-role-management) · [role-creation](https://github.com/risa-labs-inc/boss-plugin-role-creation)
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -696,6 +696,11 @@ kotlin {
             implementation(projects.pluginPlatform.pluginLoader)
             implementation(projects.pluginPlatform.pluginRepository)
             implementation(projects.pluginPlatform.pluginUpdater)
+            // SemanticVersion, for RetiredPlugins: satisfiesVersionFloor (from pluginUpdater)
+            // fails OPEN on a version it cannot parse, which is right for gating an update and
+            // wrong for deciding whether to delete a plugin. One pure file; pluginUpdater has
+            // it as `implementation`, so it is not transitive.
+            implementation(projects.pluginPlatform.pluginDependency)
             // Plugin panel manager is now dynamic (loaded from boss_plugin as plugin-manager)
 
             // Tab type plugins are now loaded dynamically from boss_plugin:

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeToolCatalog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeToolCatalog.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.home
 
 import ai.rever.boss.components.plugin.PluginDependencyResolution
+import ai.rever.boss.components.plugin.RetiredPluginIds
 import ai.rever.boss.components.plugin.registries.RegistryAccess
 import ai.rever.boss.plugin.api.PanelId
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -166,6 +167,10 @@ object HomeToolCatalog {
                 // is an unload-all / swap / reload-all hot swap, which must not start from a tile
                 // in a grid; the runtime is refused by loadPlugin outright.
                 .filterNot { it.pluginId in PluginDependencyResolution.NOT_USER_INSTALLABLE }
+                // Nor a plugin another plugin has taken over. Unlisting the store row is a manual
+                // action outside CI, so until it happens the store still returns it - and a user
+                // could install it, have it swept away at the next launch, and install it again.
+                .filterNot { it.pluginId in RetiredPluginIds.ALL }
                 .filterNot { it.isService }
                 .filter { it.isCompatible }
                 // A plugin the user has no access to is hidden, not greyed. The host already hides

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -905,9 +905,6 @@ class DefaultPlugin(
         // DYNAMIC: Secret Manager panel - loaded from boss-plugin-secret-manager JAR
         // registerSecretManagerPlugin()
 
-        // DYNAMIC: User Secret List panel - loaded from boss-plugin-user-secret-list JAR
-        // registerUserSecretListPlugin()
-
         // ============================================================
         // TAB TYPE PLUGINS
         // ============================================================

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelIds.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelIds.kt
@@ -23,7 +23,6 @@ object PanelIds {
 
     // Admin/Security panels
     val SECRET_MANAGER = PanelId("secret-manager", 2)
-    val USER_SECRET_LIST = PanelId("user-secret-list", 2)
     val ADMIN_ROLE_MANAGEMENT = PanelId("admin-role-management", 2)
     val ROLE_CREATION = PanelId("role-creation", 2)
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
@@ -1,0 +1,24 @@
+package ai.rever.boss.components.plugin
+
+/**
+ * Plugins whose job another plugin has taken over, and which must therefore never be *offered*
+ * for install again.
+ *
+ * Separate from `RetiredPlugins` (desktopMain), which owns the uninstall of one already on disk.
+ * The ids live here because the surfaces that offer plugins are split across source sets: the
+ * first-run wizard is desktopMain, the home screen's tool grid is commonMain, and both filter
+ * `PluginDependencyResolution.NOT_USER_INSTALLABLE` in the same spirit.
+ *
+ * **Why the host filters at all, when the fix is a database row.** Unlisting the store row is a
+ * manual action outside this repo and outside CI. Until it happens - and it may never happen on a
+ * self-hosted store - the store still returns the plugin, so a user can install it, have it swept
+ * away with a notice at the next launch, install it again, and so on. Filtering here makes the
+ * retirement hold regardless of what the store says, which is what stops it being a one-way door
+ * in the wrong direction.
+ *
+ * `RetiredPluginsTest` pins this against `RetiredPlugins.ALL`, so a retirement added there
+ * without a matching entry here fails rather than quietly staying installable.
+ */
+object RetiredPluginIds {
+    val ALL: Set<String> = setOf("ai.rever.boss.plugin.dynamic.usersecretlist")
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.wizard.plugin
 
+import ai.rever.boss.components.plugin.RetiredPluginIds
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginWithSource
@@ -177,6 +178,10 @@ object PluginListProvider {
                             // cross-classloader IllegalAccessError.
                             .filter { it.plugin.type != ai.rever.boss.plugin.api.PluginType.SERVICE }
                             .filter { it.plugin.pluginId != ai.rever.boss.components.plugin.MicrokernelRuntime.PLUGIN_ID }
+                            // Nor a plugin another plugin has taken over: the store keeps
+                            // returning it until its row is unlisted by hand, and installing it
+                            // here only gets it swept away at the next launch.
+                            .filter { it.plugin.pluginId !in RetiredPluginIds.ALL }
                             .map { pws: PluginWithSource ->
                                 convertToWizardPluginInfo(pws.plugin)
                             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
@@ -43,7 +43,11 @@ object PluginListProvider {
             "ai.rever.boss.plugin.dynamic.terminal",
             "ai.rever.boss.plugin.dynamic.console",
             "ai.rever.boss.plugin.dynamic.fluck",
-            "ai.rever.boss.plugin.dynamic.usersecretlist",
+            // Was `usersecretlist` ("My Secrets") until that plugin was retired into
+            // secret-manager's "Shared with me" section. Installing the read-only half by
+            // default and never the half that can add a key was backwards anyway: AI provider
+            // settings live in secret-manager, so a default install could not configure AI.
+            "ai.rever.boss.plugin.dynamic.secretmanager",
             "ai.rever.boss.plugin.dynamic.downloads",
             "ai.rever.boss.plugin.dynamic.codebase",
             "ai.rever.boss.plugin.dynamic.bookmarks",
@@ -82,7 +86,12 @@ object PluginListProvider {
             "ai.rever.boss.plugin.dynamic.terminal" to PluginCategory.ESSENTIAL,
             "ai.rever.boss.plugin.dynamic.console" to PluginCategory.ESSENTIAL,
             "ai.rever.boss.plugin.dynamic.fluck" to PluginCategory.ESSENTIAL,
-            "ai.rever.boss.plugin.dynamic.usersecretlist" to PluginCategory.ESSENTIAL,
+            // Not an admin tool, despite living under ADMIN until 9.4.7 and PRODUCTIVITY
+            // after it. It is a per-user credential vault (every RPC behind it is
+            // auth.uid()-scoped), it is the only place anyone adds an AI provider key, and
+            // since the My Secrets panel was retired into it, it is the only secrets panel
+            // there is - so it takes that panel's place among the essentials.
+            "ai.rever.boss.plugin.dynamic.secretmanager" to PluginCategory.ESSENTIAL,
             "ai.rever.boss.plugin.dynamic.downloads" to PluginCategory.ESSENTIAL,
             "ai.rever.boss.plugin.dynamic.fluckbrowser" to PluginCategory.ESSENTIAL,
             "ai.rever.boss.plugin.dynamic.editortab" to PluginCategory.ESSENTIAL,
@@ -94,10 +103,6 @@ object PluginListProvider {
             // Productivity
             "ai.rever.boss.plugin.dynamic.bookmarks" to PluginCategory.PRODUCTIVITY,
             "ai.rever.boss.plugin.dynamic.topofmind" to PluginCategory.PRODUCTIVITY,
-            // Not an admin tool, despite living here until 9.4.7. It is a per-user
-            // credential vault (every RPC behind it is auth.uid()-scoped) and, since AI
-            // provider settings moved into it, the only place anyone adds their own key.
-            "ai.rever.boss.plugin.dynamic.secretmanager" to PluginCategory.PRODUCTIVITY,
             // Automation
             "ai.rever.boss.plugin.dynamic.llmrpa" to PluginCategory.AUTOMATION,
             "ai.rever.boss.plugin.dynamic.rparecorder" to PluginCategory.AUTOMATION,
@@ -127,7 +132,6 @@ object PluginListProvider {
             "ai.rever.boss.plugin.dynamic.adminrolemanagement" to Icons.Default.ManageAccounts,
             "ai.rever.boss.plugin.dynamic.rolecreation" to Icons.Default.AdminPanelSettings,
             "ai.rever.boss.plugin.dynamic.secretmanager" to Icons.Default.Key,
-            "ai.rever.boss.plugin.dynamic.usersecretlist" to Icons.Default.Key,
             "ai.rever.boss.plugin.dynamic.performance" to Icons.Default.AutoAwesome,
             "ai.rever.boss.plugin.dynamic.fluck" to Icons.Default.Psychology,
             "ai.rever.boss.plugin.dynamic.runconfigurations" to Icons.Default.PlayArrow,
@@ -301,9 +305,9 @@ object PluginListProvider {
                     category = PluginCategory.ESSENTIAL,
                 ),
                 WizardPluginInfo(
-                    id = "ai.rever.boss.plugin.dynamic.usersecretlist",
-                    name = "My Secrets",
-                    description = "View your secrets and shared credentials",
+                    id = "ai.rever.boss.plugin.dynamic.secretmanager",
+                    name = "Secret Manager",
+                    description = "Your credentials, what others share with you, and AI provider keys",
                     version = "1.0.0",
                     icon = Icons.Default.Key,
                     isDefault = true,
@@ -411,15 +415,6 @@ object PluginListProvider {
                     icon = Icons.Default.AdminPanelSettings,
                     isDefault = false,
                     category = PluginCategory.ADMIN,
-                ),
-                WizardPluginInfo(
-                    id = "ai.rever.boss.plugin.dynamic.secretmanager",
-                    name = "Secret Manager",
-                    description = "Your encrypted credential vault, and where you add AI provider keys",
-                    version = "1.0.0",
-                    icon = Icons.Default.Key,
-                    isDefault = false,
-                    category = PluginCategory.PRODUCTIVITY,
                 ),
             )
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -1357,7 +1357,34 @@ object PluginStoreSetup {
                 //     plugin should never register a panel or an MCP tool on a machine
                 //     where its replacement is present, and after reconcile because
                 //     installed.json's jarPath is only trustworthy once that has run.
-                runCatching { RetiredPlugins.sweep() }
+                // Both sources that would put a retired plugin back: a bundled jar is
+                // re-copied at step 1 and a system plugin re-downloaded at step 2, both of which
+                // have already run by the time the sweep does - so uninstalling one is a
+                // copy-then-delete loop on every launch. Asked here rather than inside
+                // RetiredPlugins, so that object needs neither the manager nor the
+                // system-plugin service.
+                val restoredAtNextLaunch = { pluginId: String ->
+                    val bundledVeto =
+                        PluginRemoval.removalVeto(
+                            pluginId,
+                            dynamicPluginManager.getBundledPluginsDirectory(),
+                        )
+                    when {
+                        bundledVeto != null -> {
+                            bundledVeto
+                        }
+
+                        systemPlugins.any { it.pluginId == pluginId } -> {
+                            "is a system plugin and would be reinstalled at the next launch"
+                        }
+
+                        else -> {
+                            null
+                        }
+                    }
+                }
+
+                runCatching { RetiredPlugins.sweep(restoredAtNextLaunch) }
                     .onSuccess { removed ->
                         if (removed.isNotEmpty()) {
                             logger.info(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -1357,34 +1357,29 @@ object PluginStoreSetup {
                 //     plugin should never register a panel or an MCP tool on a machine
                 //     where its replacement is present, and after reconcile because
                 //     installed.json's jarPath is only trustworthy once that has run.
-                // Both sources that would put a retired plugin back: a bundled jar is
-                // re-copied at step 1 and a system plugin re-downloaded at step 2, both of which
-                // have already run by the time the sweep does - so uninstalling one is a
-                // copy-then-delete loop on every launch. Asked here rather than inside
-                // RetiredPlugins, so that object needs neither the manager nor the
-                // system-plugin service.
+                // Both guards the sweep needs from the filesystem, as named functions in
+                // RetiredPluginArtifacts rather than lambdas nothing can test - a typo in either
+                // silently disables a guard instead of failing.
                 val restoredAtNextLaunch = { pluginId: String ->
-                    val bundledVeto =
-                        PluginRemoval.removalVeto(
-                            pluginId,
-                            dynamicPluginManager.getBundledPluginsDirectory(),
-                        )
-                    when {
-                        bundledVeto != null -> {
-                            bundledVeto
-                        }
-
-                        systemPlugins.any { it.pluginId == pluginId } -> {
-                            "is a system plugin and would be reinstalled at the next launch"
-                        }
-
-                        else -> {
-                            null
-                        }
-                    }
+                    restoredAtNextLaunchReason(
+                        pluginId = pluginId,
+                        bundledVeto =
+                            PluginRemoval.removalVeto(
+                                pluginId,
+                                dynamicPluginManager.getBundledPluginsDirectory(),
+                            ),
+                        systemPluginIds = systemPlugins.map { it.pluginId }.toSet(),
+                    )
+                }
+                val purgeArtifacts = { pluginId: String ->
+                    purgeJarsFor(
+                        pluginId = pluginId,
+                        pluginDir = _pluginDir,
+                        manifestIdOf = { readPluginManifest(it)?.pluginId },
+                    )
                 }
 
-                runCatching { RetiredPlugins.sweep(restoredAtNextLaunch) }
+                runCatching { RetiredPlugins.sweep(restoredAtNextLaunch, purgeArtifacts) }
                     .onSuccess { removed ->
                         if (removed.isNotEmpty()) {
                             logger.info(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginStoreSetup.kt
@@ -1352,6 +1352,30 @@ object PluginStoreSetup {
                 //     created below, so this has to precede all plugin loads.
                 dynamicPluginManager.initializeApiLayer(_pluginDir)
 
+                // 3c. Uninstall plugins another plugin has taken over. Here rather than
+                //     anywhere later because it must precede step 4's read: a retired
+                //     plugin should never register a panel or an MCP tool on a machine
+                //     where its replacement is present, and after reconcile because
+                //     installed.json's jarPath is only trustworthy once that has run.
+                runCatching { RetiredPlugins.sweep() }
+                    .onSuccess { removed ->
+                        if (removed.isNotEmpty()) {
+                            logger.info(
+                                LogCategory.SYSTEM,
+                                "Uninstalled retired plugins",
+                                mapOf("pluginIds" to removed.joinToString(",")),
+                            )
+                        }
+                    }.onFailure { e ->
+                        // Never fatal: failing to tidy up an obsolete plugin must not stop
+                        // every other plugin from loading.
+                        logger.warn(
+                            LogCategory.SYSTEM,
+                            "Retired-plugin sweep failed",
+                            mapOf("error" to (e.message ?: "unknown")),
+                        )
+                    }
+
                 // 4. Read persisted plugins (including bundled ones now in plugin dir)
                 PluginPersistence.getInstalledPlugins()
             }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPluginArtifacts.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPluginArtifacts.kt
@@ -1,0 +1,77 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
+import java.io.File
+
+/**
+ * The two questions `RetiredPlugins.sweep` asks about the filesystem, as functions rather than
+ * lambdas at the call site.
+ *
+ * Both were inline in `PluginStoreSetup`, where nothing could test them - and a typo in either
+ * silently disables a guard rather than failing. They live here, next to
+ * [PluginArtifactCleanup], because they are about the same directory.
+ */
+
+/**
+ * Deletes every jar in [pluginDir] whose manifest declares [pluginId], with its signature
+ * sidecar, and reports whether the directory is clean of that plugin afterwards.
+ *
+ * **Matching on the manifest id, not the recorded path or a filename prefix**, for two reasons.
+ * `PluginStoreSetup` already does exactly this when retiring an old system-plugin version, and
+ * for the same first reason: artifact prefixes can be prefixes of each other, so
+ * `boss-plugin-terminal` would match `boss-plugin-terminal-tab-*.jar`. The second is specific to
+ * a retirement: `installed.json`'s `jarPath` can be stale (the reconciler and the updater both
+ * rewrite paths) while a *differently named* jar for the same id is still in the directory. A
+ * delete keyed on the recorded path would report success and leave that one behind.
+ *
+ * **Why the return value matters at all.** `DefaultPlugin.loadExternalPlugins` scans this same
+ * directory after the persisted pass, in the same launch, and installs every jar it finds that
+ * the manager does not know about. So a retirement that drops the `installed.json` row while a
+ * jar survives does not merely leak a file: the scan reinstalls the plugin, `PluginBuildProbe`
+ * writes a fresh row on load, and the next launch sweeps, announces and fails again - forever.
+ * That is the copy-then-delete loop the bundled/system veto prevents, arriving by another door.
+ * The sweep therefore refuses the retirement outright when this returns false, leaving the row
+ * alone so the plugin keeps working and the next launch can retry.
+ *
+ * Deleting nothing is success: absence is the postcondition, not the delete count.
+ */
+internal fun purgeJarsFor(
+    pluginId: String,
+    pluginDir: File,
+    manifestIdOf: (File) -> String?,
+    deleteJar: (File) -> Boolean = { it.delete() },
+    deleteSidecar: (File) -> Unit = { runCatching { PluginSignatureSidecar.delete(it.absolutePath) } },
+): Boolean {
+    fun jars() =
+        pluginDir
+            .takeIf { it.isDirectory }
+            ?.listFiles()
+            ?.filter { it.isFile && it.name.endsWith(".jar") && manifestIdOf(it) == pluginId }
+            ?: emptyList()
+
+    jars().forEach { jar ->
+        deleteSidecar(jar)
+        deleteJar(jar)
+    }
+    // Re-listed rather than trusting the delete results: a Windows lock makes `delete()` return
+    // false silently, and a jar that was already gone returns false too. Absence is the question.
+    return jars().isEmpty()
+}
+
+/**
+ * Why [pluginId] would come back on its own after being uninstalled, or null if it would not.
+ *
+ * A bundled jar is re-copied by `copyBundledPluginsToPluginDir` and a system plugin
+ * re-downloaded by `ensureSystemPluginsInstalled`, both of which run *before* the sweep - so
+ * retiring one is a copy-then-delete loop on every launch, notice included.
+ */
+internal fun restoredAtNextLaunchReason(
+    pluginId: String,
+    bundledVeto: String?,
+    systemPluginIds: Set<String>,
+): String? =
+    when {
+        bundledVeto != null -> bundledVeto
+        pluginId in systemPluginIds -> "is a system plugin and would be reinstalled at the next launch"
+        else -> null
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
@@ -1,0 +1,165 @@
+package ai.rever.boss.plugin
+
+import ai.rever.boss.components.bars.horizontal.StatusMessageManager
+import ai.rever.boss.plugin.updater.satisfiesVersionFloor
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+
+/**
+ * Uninstalls a plugin whose job another plugin has taken over.
+ *
+ * A retired plugin cannot uninstall itself, and leaving it installed means the user keeps a
+ * panel that no longer does anything. The store listing can be unlisted so nobody *new*
+ * installs it, but that does nothing for the machines that already have it - which is every
+ * machine, when the retired plugin was a first-run default.
+ *
+ * The sweep runs once per launch, before any plugin is loaded, so a retired plugin never
+ * registers a panel or an MCP tool on a machine where its replacement is present. No
+ * "already done" flag is needed: the sweep keys on the plugin being installed, and removing
+ * it is what makes the next launch a no-op.
+ */
+object RetiredPlugins {
+    private val logger = BossLogger.forComponent("RetiredPlugins")
+
+    /** How long the "X is now part of Y" line sits in the status bar. */
+    private const val NOTICE_MS = 8_000L
+
+    /**
+     * A plugin that has been folded into another one.
+     *
+     * [minReplacementVersion] is the release of the replacement that actually absorbed the
+     * work. Without it this would uninstall the old plugin as soon as the *name* of the new one
+     * appeared in `installed.json`, including a version predating the absorption - so the user
+     * would lose both halves at once.
+     */
+    data class Retirement(
+        val pluginId: String,
+        val displayName: String,
+        val replacementId: String,
+        val replacementDisplayName: String,
+        val minReplacementVersion: String,
+    )
+
+    val ALL =
+        listOf(
+            // "My Secrets" and Secret Manager sat next to each other in the right sidebar
+            // reading the same vault, and both listed the caller's own secrets. Secret Manager
+            // now has two sections that partition it - what you can manage, and what other
+            // people shared with you - so this plugin ships a notice panel and nothing else.
+            //
+            // The version is the secret-manager release that has those sections. It has to
+            // name a real published release: too low and this deletes the user's only secrets
+            // panel on a machine whose Secret Manager predates the merge.
+            Retirement(
+                pluginId = "ai.rever.boss.plugin.dynamic.usersecretlist",
+                displayName = "My Secrets",
+                replacementId = "ai.rever.boss.plugin.dynamic.secretmanager",
+                replacementDisplayName = "Secret Manager",
+                minReplacementVersion = "1.2.17",
+            ),
+        )
+
+    /**
+     * Seams with production defaults, so the decision is testable without deleting a
+     * developer's own plugins or rewriting their `installed.json`. Mirrors
+     * [PluginArtifactCleanup.Hooks], which this delegates the actual removal to.
+     */
+    class Hooks(
+        val installed: (String) -> PluginPersistence.InstalledPluginEntry? = { id ->
+            PluginPersistence.getInstalledPlugin(id)
+        },
+        val jarExists: (String) -> Boolean = { path -> path.isNotBlank() && File(path).isFile },
+        val remove: (String, String) -> Unit = { id, jarPath -> PluginArtifactCleanup.remove(id, jarPath) },
+        val announce: (String) -> Unit = { message -> StatusMessageManager.showMessage(message, NOTICE_MS) },
+    )
+
+    /**
+     * Uninstalls every retired plugin whose replacement is installed and new enough.
+     *
+     * @return the plugin ids actually removed, for the caller to log.
+     */
+    fun sweep(
+        retirements: List<Retirement> = ALL,
+        hooks: Hooks = Hooks(),
+    ): List<String> = retirements.filter { retire(it, hooks) }.map { it.pluginId }
+
+    private fun retire(
+        retirement: Retirement,
+        hooks: Hooks,
+    ): Boolean {
+        val entry = hooks.installed(retirement.pluginId)
+        if (entry == null || !replacementIsReady(retirement, hooks)) return false
+
+        hooks.remove(retirement.pluginId, entry.jarPath)
+        logger.info(
+            LogCategory.SYSTEM,
+            "Uninstalled a retired plugin",
+            mapOf(
+                "pluginId" to retirement.pluginId,
+                "replacedBy" to retirement.replacementId,
+            ),
+        )
+        // Said out loud, because a panel the user has had since their first run disappearing
+        // with no explanation reads as a bug - or as lost secrets.
+        hooks.announce("${retirement.displayName} is now part of ${retirement.replacementDisplayName}")
+        return true
+    }
+
+    /**
+     * Whether the replacement can actually stand in for the retired plugin.
+     *
+     * **Fails closed at every step**, which is the opposite of [satisfiesVersionFloor]'s own
+     * default: that helper answers "true" for a blank or unparseable version because a *gated
+     * update* is worse than an ungated one. Here the consequence runs the other way - a wrong
+     * "yes" deletes the panel the user reads their shared credentials in - so an unknown
+     * version means "not ready" and the retirement waits for a launch that can prove it.
+     *
+     * The jar check is not paranoia: `installPlugin` records a DISABLED entry for a plugin it
+     * then rejected and deleted, so an entry alone does not mean the replacement can run. Same
+     * definition of "installed" as `PluginDependencyResolution.installedAndOnDisk`.
+     */
+    // Guard clauses: each refusal logs a different reason, and a reader debugging "why is the
+    // old panel still there" needs to know which one fired. Folding them into one condition
+    // would collapse three distinct answers into one. Same call as VersionFloor.kt's.
+    @Suppress("ReturnCount")
+    private fun replacementIsReady(
+        retirement: Retirement,
+        hooks: Hooks,
+    ): Boolean {
+        val replacement = hooks.installed(retirement.replacementId)
+        if (replacement == null) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Keeping a retired plugin: its replacement is not installed",
+                mapOf("pluginId" to retirement.pluginId, "replacementId" to retirement.replacementId),
+            )
+            return false
+        }
+        if (!hooks.jarExists(replacement.jarPath)) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Keeping a retired plugin: its replacement has an installed.json entry but no jar",
+                mapOf("pluginId" to retirement.pluginId, "jarPath" to replacement.jarPath),
+            )
+            return false
+        }
+        val version = replacement.installedVersion
+        val newEnough =
+            !version.isNullOrBlank() &&
+                satisfiesVersionFloor(required = retirement.minReplacementVersion, installed = version)
+        if (!newEnough) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Keeping a retired plugin: its replacement predates the version that absorbed it",
+                mapOf(
+                    "pluginId" to retirement.pluginId,
+                    "replacementVersion" to (version ?: "unknown"),
+                    "required" to retirement.minReplacementVersion,
+                ),
+            )
+            return false
+        }
+        return true
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
@@ -71,6 +71,10 @@ object RetiredPlugins {
             PluginPersistence.getInstalledPlugin(id)
         },
         val jarExists: (String) -> Boolean = { path -> path.isNotBlank() && File(path).isFile },
+        /**
+         * Drops the `installed.json` row (and the sidecar for the recorded path). Called only
+         * after `purgeArtifacts` confirmed the jars are gone - see [retire].
+         */
         val remove: (String, String) -> Unit = { id, jarPath -> PluginArtifactCleanup.remove(id, jarPath) },
         /** Called once per sweep, with every removal in one message. See [noticeFor]. */
         val announce: (String) -> Unit = { message -> StatusMessageManager.showMessage(message, NOTICE_MS) },
@@ -94,6 +98,7 @@ object RetiredPlugins {
      */
     internal fun sweep(
         restoredAtNextLaunch: (String) -> String?,
+        purgeArtifacts: (String) -> Boolean,
         retirements: List<Retirement> = ALL,
         hooks: Hooks = Hooks(),
     ): List<String> {
@@ -101,7 +106,7 @@ object RetiredPlugins {
         // ids already removed, which the caller logs.
         val removed =
             retirements.filter { retirement ->
-                runCatching { retire(retirement, restoredAtNextLaunch, hooks) }
+                runCatching { retire(retirement, restoredAtNextLaunch, purgeArtifacts, hooks) }
                     .onFailure { error ->
                         logger.warn(
                             LogCategory.SYSTEM,
@@ -122,12 +127,30 @@ object RetiredPlugins {
         return removed.map { it.pluginId }
     }
 
-    /** "X is now part of Y", or "X and Y are now part of Z" once there is more than one. */
-    private fun noticeFor(removed: List<Retirement>): String {
-        val names = removed.joinToString(" and ") { it.displayName }
-        val verb = if (removed.size == 1) "is" else "are"
-        return "$names $verb now part of ${removed.first().replacementDisplayName}"
-    }
+    /**
+     * One line for the whole sweep: "X is now part of Y", or "X and Y are now part of Z".
+     *
+     * **Grouped by replacement.** The function only exists for the multi-removal case, and that
+     * is exactly the case where two retirements can point at *different* replacements - joining
+     * the names and taking `first().replacementDisplayName` told the user their panel moved
+     * somewhere it did not. Latent while `ALL` has one entry, which is why it needs a test
+     * rather than a reading.
+     */
+    private fun noticeFor(removed: List<Retirement>): String =
+        removed
+            .groupBy { it.replacementDisplayName }
+            .entries
+            .joinToString("; ") { (replacement, group) ->
+                val names = group.map { it.displayName }
+                val joined =
+                    if (names.size == 1) {
+                        names.first()
+                    } else {
+                        // "A, B and C" rather than "A and B and C".
+                        names.dropLast(1).joinToString(", ") + " and " + names.last()
+                    }
+                "$joined ${if (group.size == 1) "is" else "are"} now part of $replacement"
+            }
 
     // Guard clauses, each logging a different reason. Same call as replacementIsReady below and
     // as VersionFloor.kt itself: a reader asking "why is the old panel still there" needs to know
@@ -136,6 +159,7 @@ object RetiredPlugins {
     private fun retire(
         retirement: Retirement,
         restoredAtNextLaunch: (String) -> String?,
+        purgeArtifacts: (String) -> Boolean,
         hooks: Hooks,
     ): Boolean {
         val entry = hooks.installed(retirement.pluginId) ?: return false
@@ -150,6 +174,21 @@ object RetiredPlugins {
             return false
         }
         if (!replacementIsReady(retirement, hooks)) return false
+
+        // The jars go first, and the row is only dropped once they are actually gone. Dropping
+        // the row while a jar survives is worse than doing nothing: DefaultPlugin's directory
+        // scan runs later in the *same* launch and installs any jar the manager does not know
+        // about, so the panel comes back in the session the user was just told it left, a fresh
+        // row is written on load, and every launch after that sweeps and announces again. See
+        // purgeJarsFor.
+        if (!purgeArtifacts(retirement.pluginId)) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Keeping a retired plugin: its jar could not be removed, so its row is left alone",
+                mapOf("pluginId" to retirement.pluginId, "jarPath" to entry.jarPath),
+            )
+            return false
+        }
 
         hooks.remove(retirement.pluginId, entry.jarPath)
         logger.info(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.plugin
 
 import ai.rever.boss.components.bars.horizontal.StatusMessageManager
+import ai.rever.boss.plugin.dependency.SemanticVersion
 import ai.rever.boss.plugin.updater.satisfiesVersionFloor
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -71,25 +72,84 @@ object RetiredPlugins {
         },
         val jarExists: (String) -> Boolean = { path -> path.isNotBlank() && File(path).isFile },
         val remove: (String, String) -> Unit = { id, jarPath -> PluginArtifactCleanup.remove(id, jarPath) },
+        /** Called once per sweep, with every removal in one message. See [noticeFor]. */
         val announce: (String) -> Unit = { message -> StatusMessageManager.showMessage(message, NOTICE_MS) },
     )
 
     /**
      * Uninstalls every retired plugin whose replacement is installed and new enough.
      *
+     * **Startup only, before any plugin is loaded.** [PluginArtifactCleanup.remove] deletes the
+     * jar without unloading anything, which is safe at step 3c of
+     * `PluginStoreSetup.loadPersistedPlugins` and nowhere else: pulling a jar out from under a
+     * live classloader is how you get `NoClassDefFoundError` from code that is still running.
+     * `internal` so the only caller stays inside this module.
+     *
+     * @param restoredAtNextLaunch why [pluginId] would come back on its own, or null if it
+     *   would not. A bundled or system plugin is re-copied or re-downloaded before this sweep
+     *   runs (steps 1 and 2), so uninstalling one turns into a copy-then-delete loop on every
+     *   launch, with the status-bar notice firing each time. See `PluginRemoval.removalVeto`,
+     *   which exists for the same hazard on the interactive path.
      * @return the plugin ids actually removed, for the caller to log.
      */
-    fun sweep(
+    internal fun sweep(
+        restoredAtNextLaunch: (String) -> String?,
         retirements: List<Retirement> = ALL,
         hooks: Hooks = Hooks(),
-    ): List<String> = retirements.filter { retire(it, hooks) }.map { it.pluginId }
+    ): List<String> {
+        // Per retirement, so one entry whose removal throws cannot drop the rest - or lose the
+        // ids already removed, which the caller logs.
+        val removed =
+            retirements.filter { retirement ->
+                runCatching { retire(retirement, restoredAtNextLaunch, hooks) }
+                    .onFailure { error ->
+                        logger.warn(
+                            LogCategory.SYSTEM,
+                            "Could not uninstall a retired plugin",
+                            mapOf(
+                                "pluginId" to retirement.pluginId,
+                                "error" to (error.message ?: "unknown"),
+                            ),
+                        )
+                    }.getOrDefault(false)
+            }
 
+        // One message for the whole sweep, not one per retirement: showMessage cancels the
+        // previous one, so announcing in the loop would show only the last.
+        if (removed.isNotEmpty()) {
+            hooks.announce(noticeFor(removed))
+        }
+        return removed.map { it.pluginId }
+    }
+
+    /** "X is now part of Y", or "X and Y are now part of Z" once there is more than one. */
+    private fun noticeFor(removed: List<Retirement>): String {
+        val names = removed.joinToString(" and ") { it.displayName }
+        val verb = if (removed.size == 1) "is" else "are"
+        return "$names $verb now part of ${removed.first().replacementDisplayName}"
+    }
+
+    // Guard clauses, each logging a different reason. Same call as replacementIsReady below and
+    // as VersionFloor.kt itself: a reader asking "why is the old panel still there" needs to know
+    // which check fired, and folding them into one condition collapses three answers into one.
+    @Suppress("ReturnCount")
     private fun retire(
         retirement: Retirement,
+        restoredAtNextLaunch: (String) -> String?,
         hooks: Hooks,
     ): Boolean {
-        val entry = hooks.installed(retirement.pluginId)
-        if (entry == null || !replacementIsReady(retirement, hooks)) return false
+        val entry = hooks.installed(retirement.pluginId) ?: return false
+
+        val wouldComeBack = restoredAtNextLaunch(retirement.pluginId)
+        if (wouldComeBack != null) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Keeping a retired plugin: it would be restored anyway",
+                mapOf("pluginId" to retirement.pluginId, "reason" to wouldComeBack),
+            )
+            return false
+        }
+        if (!replacementIsReady(retirement, hooks)) return false
 
         hooks.remove(retirement.pluginId, entry.jarPath)
         logger.info(
@@ -100,9 +160,6 @@ object RetiredPlugins {
                 "replacedBy" to retirement.replacementId,
             ),
         )
-        // Said out loud, because a panel the user has had since their first run disappearing
-        // with no explanation reads as a bug - or as lost secrets.
-        hooks.announce("${retirement.displayName} is now part of ${retirement.replacementDisplayName}")
         return true
     }
 
@@ -136,6 +193,18 @@ object RetiredPlugins {
             )
             return false
         }
+        if (!replacement.enabled) {
+            // The user can disable Secret Manager from the Toolbox, and installPlugin also
+            // records a DISABLED entry for a plugin hidden for lack of access - both leave the
+            // row and the jar in place. `enabled` is the only signal available here, since
+            // nothing has loaded yet.
+            logger.info(
+                LogCategory.SYSTEM,
+                "Keeping a retired plugin: its replacement is installed but disabled",
+                mapOf("pluginId" to retirement.pluginId, "replacementId" to retirement.replacementId),
+            )
+            return false
+        }
         if (!hooks.jarExists(replacement.jarPath)) {
             logger.warn(
                 LogCategory.SYSTEM,
@@ -145,8 +214,14 @@ object RetiredPlugins {
             return false
         }
         val version = replacement.installedVersion
+        // Parsed explicitly, because satisfiesVersionFloor answers TRUE for anything
+        // SemanticVersion cannot read - "dev", "v1.2.17", "1.2.x", a trailing "-" or "+" - by
+        // design: for update gating an ungated update beats a wrongly gated one. Here the
+        // consequence runs the other way, and a locally built or side-loaded jar whose manifest
+        // version is not strict semver is exactly the case that would lose both panels.
         val newEnough =
-            !version.isNullOrBlank() &&
+            version != null &&
+                SemanticVersion.parse(version) != null &&
                 satisfiesVersionFloor(required = retirement.minReplacementVersion, installed = version)
         if (!newEnough) {
             logger.info(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/HomeToolCatalogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/HomeToolCatalogTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.home
 
 import ai.rever.boss.components.plugin.PluginDependencyResolution
+import ai.rever.boss.components.plugin.RetiredPluginIds
 import ai.rever.boss.components.plugin.registries.RegistryAccess
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Extension
@@ -192,6 +193,21 @@ class HomeToolCatalogTest {
             tools.isEmpty(),
             "NOT_USER_INSTALLABLE ids must not reach a tile: the api plugin's install is an " +
                 "unload-all / swap / reload-all hot swap.",
+        )
+    }
+
+    @Test
+    fun `a retired plugin is never offered`() {
+        // Unlisting the store row is a manual action outside CI, so until it happens the store
+        // keeps returning the plugin - and a user could install it, have the startup sweep remove
+        // it, and install it again indefinitely. The filter is what makes the retirement hold
+        // regardless of what the store says.
+        val tools = build(store = RetiredPluginIds.ALL.map { storeRow(it) })
+
+        assertTrue(
+            tools.isEmpty(),
+            "a retired plugin reached a tile: installing it only gets it swept away at the " +
+                "next launch",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginArtifactsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginArtifactsTest.kt
@@ -1,0 +1,110 @@
+package ai.rever.boss.plugin
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The two filesystem guards, which were lambdas at the call site until nothing could reach them.
+ *
+ * Both fail silently when wrong: a mistyped id comparison disables the restore veto, and a delete
+ * keyed on the wrong thing reports success while leaving a jar the directory scan will reinstall.
+ */
+class RetiredPluginArtifactsTest {
+    @TempDir
+    lateinit var pluginDir: File
+
+    private val retired = "ai.rever.boss.plugin.dynamic.oldpanel"
+    private val other = "ai.rever.boss.plugin.dynamic.otherpanel"
+
+    private fun jar(
+        name: String,
+        declaring: String,
+    ): File = File(pluginDir, name).apply { writeText(declaring) }
+
+    /** The stand-in for reading a manifest: each fixture jar's body is the id it declares. */
+    private val manifestIdOf: (File) -> String? = { it.readText().ifBlank { null } }
+
+    @Test
+    fun `every jar declaring the id goes, whatever it is called`() {
+        // The case a path-keyed delete misses: installed.json's jarPath can be stale while a
+        // differently named jar for the same plugin is still in the directory.
+        val recorded = jar("boss-plugin-old-1.0.0.jar", retired)
+        val stray = jar("old-panel-hotfix.jar", retired)
+        val neighbour = jar("boss-plugin-other-1.0.0.jar", other)
+
+        val clean = purgeJarsFor(retired, pluginDir, manifestIdOf)
+
+        assertTrue(clean)
+        assertFalse(recorded.exists())
+        assertFalse(stray.exists(), "a second jar for the same plugin survived")
+        assertTrue(neighbour.exists(), "deleted another plugin's jar")
+    }
+
+    @Test
+    fun `a jar whose delete fails reports not clean`() {
+        // Windows holds a lock on a jar loaded earlier in the process and delete() returns false
+        // silently, which is why the answer is re-listed rather than taken from the delete result.
+        jar("boss-plugin-old-1.0.0.jar", retired)
+
+        val clean = purgeJarsFor(retired, pluginDir, manifestIdOf, deleteJar = { false })
+
+        assertFalse(clean, "a surviving jar was reported as removed")
+    }
+
+    @Test
+    fun `nothing to delete is success`() {
+        // Absence is the postcondition, not the delete count.
+        jar("boss-plugin-other-1.0.0.jar", other)
+
+        assertTrue(purgeJarsFor(retired, pluginDir, manifestIdOf))
+    }
+
+    @Test
+    fun `a missing plugin directory is not a crash`() {
+        assertTrue(purgeJarsFor(retired, File(pluginDir, "gone"), manifestIdOf))
+    }
+
+    @Test
+    fun `the sidecar goes with the jar`() {
+        // Reinstalling the same version reuses the filename, so a surviving signature meets fresh
+        // bytes and hard-fails that load - worse than being unsigned.
+        val target = jar("boss-plugin-old-1.0.0.jar", retired)
+        val sidecarsDeleted = mutableListOf<String>()
+
+        purgeJarsFor(retired, pluginDir, manifestIdOf, deleteSidecar = { sidecarsDeleted += it.name })
+
+        assertEquals(listOf(target.name), sidecarsDeleted)
+    }
+
+    @Test
+    fun `a bundled plugin is vetoed, and its reason is passed through`() {
+        assertEquals(
+            "ships with BOSS and would be restored at the next launch",
+            restoredAtNextLaunchReason(
+                pluginId = retired,
+                bundledVeto = "ships with BOSS and would be restored at the next launch",
+                systemPluginIds = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun `a system plugin is vetoed`() {
+        assertEquals(
+            "is a system plugin and would be reinstalled at the next launch",
+            restoredAtNextLaunchReason(retired, bundledVeto = null, systemPluginIds = setOf(retired)),
+        )
+    }
+
+    @Test
+    fun `an ordinary plugin is not vetoed`() {
+        assertEquals(
+            null,
+            restoredAtNextLaunchReason(retired, bundledVeto = null, systemPluginIds = setOf(other)),
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
@@ -1,0 +1,168 @@
+package ai.rever.boss.plugin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers when a retired plugin is uninstalled and, mostly, when it is not.
+ *
+ * Every "not" here is a case where removing it would take away the only panel the user has for
+ * the job: the replacement missing, the replacement's jar gone, or a replacement too old to have
+ * absorbed the retired plugin's work. The decision therefore fails closed at every step, which
+ * is the opposite of `satisfiesVersionFloor`'s own default, so it needs pinning rather than
+ * trusting.
+ */
+class RetiredPluginsTest {
+    private val removed = mutableListOf<String>()
+    private val announced = mutableListOf<String>()
+
+    private val retirement =
+        RetiredPlugins.Retirement(
+            pluginId = OLD,
+            displayName = "Old Panel",
+            replacementId = NEW,
+            replacementDisplayName = "New Panel",
+            minReplacementVersion = "1.2.17",
+        )
+
+    @Test
+    fun `retires when the replacement is installed and new enough`() {
+        val result = sweep(installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.17")))
+
+        assertEquals(listOf(OLD), result)
+        assertEquals(listOf(OLD), removed)
+        assertEquals(listOf("Old Panel is now part of New Panel"), announced)
+    }
+
+    @Test
+    fun `retires when the replacement is newer still`() {
+        val result = sweep(installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.3.0")))
+
+        assertEquals(listOf(OLD), result)
+    }
+
+    @Test
+    fun `keeps it when the replacement is not installed`() {
+        // The case that matters most: deleting the retired plugin here leaves the user with no
+        // panel at all for what it did.
+        val result = sweep(installed = mapOf(OLD to entry(OLD)))
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+        assertTrue(announced.isEmpty(), "announced a removal that did not happen")
+    }
+
+    @Test
+    fun `keeps it when the replacement predates the version that absorbed it`() {
+        // An entry naming the replacement is not enough - that version does not have the
+        // retired plugin's work in it yet, so both halves would be gone at once.
+        val result = sweep(installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.16")))
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+    }
+
+    @Test
+    fun `keeps it when the replacement's version is unknown`() {
+        // satisfiesVersionFloor answers TRUE for a blank version, by design: a gated update is
+        // worse than an ungated one. Here the consequence runs the other way, so an unknown
+        // version must read as "not ready" and wait for a launch that can prove otherwise.
+        val result = sweep(installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = null)))
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+    }
+
+    @Test
+    fun `keeps it when the replacement has a row but no jar`() {
+        // installPlugin records a DISABLED entry for a plugin it then rejected and deleted, so
+        // an entry alone does not mean the replacement can run.
+        val result =
+            sweep(
+                installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.17")),
+                jarExists = false,
+            )
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+    }
+
+    @Test
+    fun `does nothing when the retired plugin was never installed`() {
+        val result = sweep(installed = mapOf(NEW to entry(NEW, version = "1.2.17")))
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+    }
+
+    @Test
+    fun `the second launch is a no-op because the first removed the row`() {
+        // Why this needs no "already done" flag: the sweep keys on the plugin being installed,
+        // and PluginArtifactCleanup drops the installed.json row.
+        val installed = mutableMapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.17"))
+        val hooks =
+            RetiredPlugins.Hooks(
+                installed = { installed[it] },
+                jarExists = { true },
+                remove = { id, _ ->
+                    removed += id
+                    installed.remove(id)
+                },
+                announce = { announced += it },
+            )
+
+        assertEquals(listOf(OLD), RetiredPlugins.sweep(listOf(retirement), hooks))
+        assertEquals(emptyList(), RetiredPlugins.sweep(listOf(retirement), hooks))
+        assertEquals(listOf(OLD), removed, "the second sweep removed it again")
+    }
+
+    @Test
+    fun `the shipped retirement names the plugin the wizard no longer installs`() {
+        // Pins the pair rather than the mechanism: PluginListProvider dropped
+        // `usersecretlist` and put `secretmanager` among the defaults in the same change, and
+        // a retirement pointing somewhere else would silently uninstall the wrong plugin.
+        val shipped = RetiredPlugins.ALL.single()
+        assertEquals("ai.rever.boss.plugin.dynamic.usersecretlist", shipped.pluginId)
+        assertEquals("ai.rever.boss.plugin.dynamic.secretmanager", shipped.replacementId)
+        assertTrue(
+            shipped.pluginId !in
+                ai.rever.boss.components.wizard.plugin.PluginListProvider.DEFAULT_PLUGIN_IDS,
+            "the wizard still installs a plugin this sweep uninstalls at the next launch",
+        )
+        assertTrue(
+            shipped.replacementId in
+                ai.rever.boss.components.wizard.plugin.PluginListProvider.DEFAULT_PLUGIN_IDS,
+            "nothing takes the retired plugin's place in a fresh install",
+        )
+    }
+
+    private fun sweep(
+        installed: Map<String, PluginPersistence.InstalledPluginEntry>,
+        jarExists: Boolean = true,
+    ): List<String> =
+        RetiredPlugins.sweep(
+            retirements = listOf(retirement),
+            hooks =
+                RetiredPlugins.Hooks(
+                    installed = { installed[it] },
+                    jarExists = { jarExists },
+                    remove = { id, _ -> removed += id },
+                    announce = { announced += it },
+                ),
+        )
+
+    private fun entry(
+        pluginId: String,
+        version: String? = "1.0.0",
+    ) = PluginPersistence.InstalledPluginEntry(
+        pluginId = pluginId,
+        jarPath = "/plugins/$pluginId.jar",
+        installedVersion = version,
+    )
+
+    private companion object {
+        const val OLD = "ai.rever.boss.plugin.dynamic.oldpanel"
+        const val NEW = "ai.rever.boss.plugin.dynamic.newpanel"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
@@ -112,8 +112,8 @@ class RetiredPluginsTest {
                 announce = { announced += it },
             )
 
-        assertEquals(listOf(OLD), RetiredPlugins.sweep({ null }, listOf(retirement), hooks))
-        assertEquals(emptyList(), RetiredPlugins.sweep({ null }, listOf(retirement), hooks))
+        assertEquals(listOf(OLD), RetiredPlugins.sweep({ null }, { true }, listOf(retirement), hooks))
+        assertEquals(emptyList(), RetiredPlugins.sweep({ null }, { true }, listOf(retirement), hooks))
         assertEquals(listOf(OLD), removed, "the second sweep removed it again")
     }
 
@@ -186,6 +186,7 @@ class RetiredPluginsTest {
         val result =
             RetiredPlugins.sweep(
                 restoredAtNextLaunch = { null },
+                purgeArtifacts = { true },
                 retirements = listOf(retirement, second),
                 hooks =
                     RetiredPlugins.Hooks(
@@ -224,6 +225,7 @@ class RetiredPluginsTest {
 
         RetiredPlugins.sweep(
             restoredAtNextLaunch = { null },
+            purgeArtifacts = { true },
             retirements = listOf(retirement, second),
             hooks =
                 RetiredPlugins.Hooks(
@@ -235,6 +237,63 @@ class RetiredPluginsTest {
         )
 
         assertEquals(listOf("Old Panel and Second Panel are now part of New Panel"), announced)
+    }
+
+    @Test
+    fun `a jar that cannot be removed leaves the row alone and announces nothing`() {
+        // Dropping the row while a jar survives is worse than doing nothing: DefaultPlugin's
+        // directory scan runs later in the same launch and installs any jar the manager does not
+        // know about, so the panel returns in the session the user was told it left - and a fresh
+        // row on load means the next launch sweeps and announces again, forever.
+        val result =
+            sweep(
+                installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.17")),
+                purgeArtifacts = { false },
+            )
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty(), "the row was dropped while the jar was still there")
+        assertTrue(announced.isEmpty(), "announced a removal that did not happen")
+    }
+
+    @Test
+    fun `two removals with different replacements are each attributed correctly`() {
+        // noticeFor only exists for the multi-removal case, which is exactly the case where the
+        // replacements can differ - and joining the names while taking the first replacement told
+        // the user their panel moved somewhere it did not.
+        val second =
+            RetiredPlugins.Retirement(
+                pluginId = "ai.rever.boss.plugin.dynamic.secondold",
+                displayName = "Second Panel",
+                replacementId = "ai.rever.boss.plugin.dynamic.othernew",
+                replacementDisplayName = "Other Panel",
+                minReplacementVersion = "2.0.0",
+            )
+        val installed =
+            mapOf(
+                OLD to entry(OLD),
+                second.pluginId to entry(second.pluginId),
+                NEW to entry(NEW, version = "1.2.17"),
+                second.replacementId to entry(second.replacementId, version = "2.0.0"),
+            )
+
+        RetiredPlugins.sweep(
+            restoredAtNextLaunch = { null },
+            purgeArtifacts = { true },
+            retirements = listOf(retirement, second),
+            hooks =
+                RetiredPlugins.Hooks(
+                    installed = { installed[it] },
+                    jarExists = { true },
+                    remove = { id, _ -> removed += id },
+                    announce = { announced += it },
+                ),
+        )
+
+        assertEquals(
+            listOf("Old Panel is now part of New Panel; Second Panel is now part of Other Panel"),
+            announced,
+        )
     }
 
     @Test
@@ -257,14 +316,28 @@ class RetiredPluginsTest {
         )
     }
 
+    @Test
+    fun `every retirement is also filtered out of what the store offers`() {
+        // Two source sets, two lists: RetiredPlugins (desktopMain) uninstalls what is on disk,
+        // RetiredPluginIds (commonMain) is what the wizard and the home grid refuse to offer. A
+        // retirement added to one and not the other leaves the plugin installable, swept away at
+        // the next launch, and installable again - which is the loop the filter exists to stop.
+        assertEquals(
+            RetiredPlugins.ALL.map { it.pluginId }.toSet(),
+            ai.rever.boss.components.plugin.RetiredPluginIds.ALL,
+        )
+    }
+
     private fun sweep(
         installed: Map<String, PluginPersistence.InstalledPluginEntry>,
         jarExists: Boolean = true,
         restoredAtNextLaunch: (String) -> String? = { null },
+        purgeArtifacts: (String) -> Boolean = { true },
         remove: (String, String) -> Unit = { id, _ -> removed += id },
     ): List<String> =
         RetiredPlugins.sweep(
             restoredAtNextLaunch = restoredAtNextLaunch,
+            purgeArtifacts = purgeArtifacts,
             retirements = listOf(retirement),
             hooks =
                 RetiredPlugins.Hooks(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
@@ -112,9 +112,129 @@ class RetiredPluginsTest {
                 announce = { announced += it },
             )
 
-        assertEquals(listOf(OLD), RetiredPlugins.sweep(listOf(retirement), hooks))
-        assertEquals(emptyList(), RetiredPlugins.sweep(listOf(retirement), hooks))
+        assertEquals(listOf(OLD), RetiredPlugins.sweep({ null }, listOf(retirement), hooks))
+        assertEquals(emptyList(), RetiredPlugins.sweep({ null }, listOf(retirement), hooks))
         assertEquals(listOf(OLD), removed, "the second sweep removed it again")
+    }
+
+    @Test
+    fun `keeps it when the replacement's version cannot be parsed`() {
+        // satisfiesVersionFloor answers TRUE for anything SemanticVersion cannot read, by
+        // design: for gating an update, ungated beats wrongly gated. Here the consequence runs
+        // the other way, and these are the shapes a locally built or side-loaded jar actually
+        // has. Without the explicit parse each of them deletes the user's only secrets panel.
+        listOf("dev", "v1.2.17", "1.2.x", "1.0.0-", "1.0.0+", "latest").forEach { version ->
+            removed.clear()
+            announced.clear()
+
+            val result = sweep(installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = version)))
+
+            assertEquals(emptyList(), result, "retired against an unparseable version '$version'")
+            assertTrue(removed.isEmpty(), "removed against an unparseable version '$version'")
+        }
+    }
+
+    @Test
+    fun `keeps it when the replacement is installed but disabled`() {
+        // Two ways to get here, both real: the user disabled Secret Manager from the Toolbox, or
+        // installPlugin recorded a DISABLED entry for a plugin hidden for lack of access. Both
+        // leave the row and the jar in place, so without this the sweep deletes the retired
+        // panel and the replacement is not running either.
+        val result =
+            sweep(installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.17", enabled = false)))
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+    }
+
+    @Test
+    fun `keeps it when it would be restored at the next launch`() {
+        // A bundled jar is re-copied at step 1 and a system plugin re-downloaded at step 2, both
+        // before this sweep runs - so uninstalling one is a copy-then-delete loop on every
+        // launch, with the notice firing each time. `ALL` is a list someone will append to
+        // without reading the PR that added it.
+        val result =
+            sweep(
+                installed = mapOf(OLD to entry(OLD), NEW to entry(NEW, version = "1.2.17")),
+                restoredAtNextLaunch = { "ships with BOSS and would be restored at the next launch" },
+            )
+
+        assertEquals(emptyList(), result)
+        assertTrue(removed.isEmpty())
+        assertTrue(announced.isEmpty(), "announced a removal that did not happen")
+    }
+
+    @Test
+    fun `a retirement whose removal throws does not stop the others`() {
+        // sweep() logs and carries on: one entry failing must not drop the rest, or lose the ids
+        // already removed - which the caller logs.
+        val second =
+            RetiredPlugins.Retirement(
+                pluginId = "ai.rever.boss.plugin.dynamic.secondold",
+                displayName = "Second Panel",
+                replacementId = NEW,
+                replacementDisplayName = "New Panel",
+                minReplacementVersion = "1.2.17",
+            )
+        val installed =
+            mapOf(
+                OLD to entry(OLD),
+                second.pluginId to entry(second.pluginId),
+                NEW to entry(NEW, version = "1.2.17"),
+            )
+
+        val result =
+            RetiredPlugins.sweep(
+                restoredAtNextLaunch = { null },
+                retirements = listOf(retirement, second),
+                hooks =
+                    RetiredPlugins.Hooks(
+                        installed = { installed[it] },
+                        jarExists = { true },
+                        remove = { id, _ ->
+                            if (id == OLD) error("disk is on fire") else removed += id
+                        },
+                        announce = { announced += it },
+                    ),
+            )
+
+        assertEquals(listOf(second.pluginId), result)
+        assertEquals(listOf(second.pluginId), removed)
+    }
+
+    @Test
+    fun `two removals are announced in one message`() {
+        // StatusMessageManager.showMessage cancels the previous message, so announcing per
+        // retirement would show only the last - and the sweep is one-shot, so a missed notice
+        // means the panel vanished with no explanation ever.
+        val second =
+            RetiredPlugins.Retirement(
+                pluginId = "ai.rever.boss.plugin.dynamic.secondold",
+                displayName = "Second Panel",
+                replacementId = NEW,
+                replacementDisplayName = "New Panel",
+                minReplacementVersion = "1.2.17",
+            )
+        val installed =
+            mapOf(
+                OLD to entry(OLD),
+                second.pluginId to entry(second.pluginId),
+                NEW to entry(NEW, version = "1.2.17"),
+            )
+
+        RetiredPlugins.sweep(
+            restoredAtNextLaunch = { null },
+            retirements = listOf(retirement, second),
+            hooks =
+                RetiredPlugins.Hooks(
+                    installed = { installed[it] },
+                    jarExists = { true },
+                    remove = { id, _ -> removed += id },
+                    announce = { announced += it },
+                ),
+        )
+
+        assertEquals(listOf("Old Panel and Second Panel are now part of New Panel"), announced)
     }
 
     @Test
@@ -140,14 +260,17 @@ class RetiredPluginsTest {
     private fun sweep(
         installed: Map<String, PluginPersistence.InstalledPluginEntry>,
         jarExists: Boolean = true,
+        restoredAtNextLaunch: (String) -> String? = { null },
+        remove: (String, String) -> Unit = { id, _ -> removed += id },
     ): List<String> =
         RetiredPlugins.sweep(
+            restoredAtNextLaunch = restoredAtNextLaunch,
             retirements = listOf(retirement),
             hooks =
                 RetiredPlugins.Hooks(
                     installed = { installed[it] },
                     jarExists = { jarExists },
-                    remove = { id, _ -> removed += id },
+                    remove = remove,
                     announce = { announced += it },
                 ),
         )
@@ -155,9 +278,11 @@ class RetiredPluginsTest {
     private fun entry(
         pluginId: String,
         version: String? = "1.0.0",
+        enabled: Boolean = true,
     ) = PluginPersistence.InstalledPluginEntry(
         pluginId = pluginId,
         jarPath = "/plugins/$pluginId.jar",
+        enabled = enabled,
         installedVersion = version,
     )
 


### PR DESCRIPTION
Host half of a three-repo change:
- [secret-manager#20](https://github.com/risa-labs-inc/boss-plugin-secret-manager/pull/20) - the sections
- [user-secret-list#9](https://github.com/risa-labs-inc/boss-plugin-user-secret-list/pull/9) - the stand-down

**Pre-merge check:** `RetiredPlugins.ALL` names `minReplacementVersion = "1.2.17"`. Confirm that
is the secret-manager release that actually shipped the sections (the release bot bumps from
1.2.16 on merge) and correct it if the number differs. Too low and this uninstalls the user's only
secrets panel on a machine whose Secret Manager predates the merge.

## Why

"My Secrets" (`usersecretlist`) and Secret Manager sat next to each other in the right sidebar
reading the same vault, and **both listed the caller's own secrets**. Secret Manager now has two
sections that partition it, so the other plugin ships a notice panel and nothing else. That
leaves the host two jobs.

## 1. The wizard was installing the wrong one

`usersecretlist` was ESSENTIAL **and** a default; `secretmanager` was PRODUCTIVITY and not a
default. So a default install got the read-only half and never the half that can add a key -
and since AI provider settings live in secret-manager, that install could not configure AI at
all.

`DEFAULT_PLUGIN_IDS`, `PLUGIN_CATEGORIES`, the icon map and the hardcoded fallback
`WizardPluginInfo` list now all name `secretmanager`. It takes the retired plugin's **slot** in
the fallback list, so the essentials keep their order when the store lookup fails, and the old
`secretmanager` entry further down is removed so the wizard cannot offer it twice.

Also drops `PanelIds.USER_SECRET_LIST` (nothing referenced it) and the dead
`registerUserSecretListPlugin()` comment.

## 2. Existing installs

Unlisting the store row does nothing for a machine that already has the plugin - which is every
machine, when the plugin was a first-run default. `RetiredPlugins.sweep()` uninstalls it through
the existing `PluginArtifactCleanup` (jar + `.sig` sidecar + `installed.json` row).

**Where it runs:** `PluginStoreSetup.loadPersistedPlugins` step 3c. After reconcile, so
`installed.json`'s `jarPath` is trustworthy, and before step 4 reads it, so a retired plugin
never registers a panel or an MCP tool on a machine where its replacement is present. Wrapped in
`runCatching` - failing to tidy up an obsolete plugin must not stop every other plugin loading.

**No "already done" flag.** The sweep keys on the plugin being installed, and removing it is what
makes the next launch a no-op. Pinned by a test.

**It fails closed at every step, deliberately the opposite of `satisfiesVersionFloor`'s own
default.** That helper answers `true` for a blank or unparseable version because a gated update is
worse than an ungated one. Here the consequence runs the other way - a wrong "yes" deletes the
panel the user reads their shared credentials in - so all of these mean "not yet, wait for a
launch that can prove it":

| Case | Why it must not retire |
|---|---|
| replacement not installed | the user would have no panel at all for this |
| replacement has a row but no jar | `installPlugin` records a DISABLED entry for a plugin it then rejected and deleted |
| replacement version unknown/blank | cannot prove it has the sections |
| replacement older than `minReplacementVersion` | that version has not absorbed the retired plugin's work yet |

The removal is announced in the status bar ("My Secrets is now part of Secret Manager"), because a
panel the user has had since their first run disappearing with no explanation reads as lost
secrets.

## Testing

- `./gradlew :composeApp:desktopTest` - **2601 tests, 0 failures** (9 new).
- `./gradlew :composeApp:ktlintCheck detekt` - green. `replacementIsReady` carries
  `@Suppress("ReturnCount")` with a reason, matching `VersionFloor.kt`'s own suppression: each
  guard logs a different answer to "why is the old panel still there".

Mutation-verified, each failing only its intended test:

| Mutation | Fails |
|---|---|
| remove the version gate | *keeps it when the replacement's version is unknown* + *...predates the version that absorbed it* |
| keep the floor but trust a blank version | *keeps it when the replacement's version is unknown* |
| remove the jar-on-disk check | *keeps it when the replacement has a row but no jar* |

One test crosses the two halves of this PR deliberately: it asserts the retirement's `pluginId` is
**not** in `DEFAULT_PLUGIN_IDS` and its `replacementId` **is**, so a wizard that installs what the
next launch uninstalls cannot ship.

A stale `user-secret-list` entry in a saved sidebar layout is harmless -
`resolveRegisteredPanelId` returns null for an unregistered panel id.

## Not verified here

The end-to-end sweep against real files on disk. The decision is covered through injected hooks;
running the app with both plugins in `~/.boss_debug/plugins` and watching the old one disappear
after one launch is a manual check I have not done yet.