### PR TITLE
feat: show the active browser's renderer memory in the status strip

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -239,9 +239,19 @@ fun BossRightBottomBar() {
     if (showIndicator) {
         val snapshot = PerformanceState.currentSnapshot()
         val health = PerformanceState.currentHealth()
+        // Resolved here rather than in the sampler because it is per window: this strip should
+        // show the browser in THIS window, and a single sampled value would show one window's tab
+        // in the other's. Keyed on the snapshot so it is read once per sample rather than once
+        // per recomposition - all three lookups behind it are cheap, but the 15 s cadence should
+        // be explicit rather than incidental.
+        val activeBrowserBytes =
+            remember(snapshot, windowId) {
+                windowId?.let { PerformanceState.activeBrowserBytes(it) } ?: 0L
+            }
         PerformanceIndicator(
             snapshot = snapshot,
             health = health,
+            activeBrowserBytes = activeBrowserBytes,
             onClick = { PerformanceState.togglePerformancePanel() },
         )
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -241,9 +241,12 @@ fun BossRightBottomBar() {
         val health = PerformanceState.currentHealth()
         // Resolved here rather than in the sampler because it is per window: this strip should
         // show the browser in THIS window, and a single sampled value would show one window's tab
-        // in the other's. Keyed on the snapshot so it is read once per sample rather than once
-        // per recomposition - all three lookups behind it are cheap, but the 15 s cadence should
-        // be explicit rather than incidental.
+        // in the other's.
+        //
+        // Keyed on the snapshot, which arrives every `memorySampleIntervalMs` - 1 s by default,
+        // not the 15 s of ProcessFootprint.MEASURE_TTL_MS. Those are two different clocks: this
+        // re-reads about once a second, while the value behind it only changes every 15 s. The
+        // key is there to keep it off the recomposition path, not to match the sampler.
         val activeBrowserBytes =
             remember(snapshot, windowId) {
                 windowId?.let { PerformanceState.activeBrowserBytes(it) } ?: 0L

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.DisposableEffect
 fun PerformanceIndicator(
     snapshot: PerformanceSnapshot?,
     health: PerformanceHealth,
+    activeBrowserBytes: Long,
     onClick: () -> Unit,
 ) {
     // Before the null-return below, deliberately. Whole-process sampling is gated on this being
@@ -59,11 +60,14 @@ fun PerformanceIndicator(
     val memory = snapshot.memory
     val memoryText =
         memoryIndicatorText(
+            activeBrowserMB = activeBrowserBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
             footprintMB = if (memory.footprintKnown) memory.footprintMB else null,
             systemUsedMB = memory.systemUsedBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
             systemTotalMB = memory.systemTotalBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
-            heapUsedMB = memory.heapUsedMB,
-            heapMaxMB = memory.heapMaxMB,
+            heapFallback =
+                FormatUtils.formatMegabytes(memory.heapUsedMB, compact = true) +
+                    "/" +
+                    FormatUtils.formatMegabytes(memory.heapMaxMB, compact = true),
         )
     val cpuText = "${snapshot.cpu.processLoadPercent.toInt()}%"
 
@@ -83,11 +87,11 @@ fun PerformanceIndicator(
  * inputs really can be absent at runtime and neither may be rendered as a zero.
  */
 internal fun memoryIndicatorText(
+    activeBrowserMB: Float?,
     footprintMB: Float?,
     systemUsedMB: Float?,
     systemTotalMB: Float?,
-    heapUsedMB: Float,
-    heapMaxMB: Float,
+    heapFallback: String,
 ): String {
     val footprint = footprintMB?.let { FormatUtils.formatMegabytes(it, compact = true) }
     val machine =
@@ -97,13 +101,26 @@ internal fun memoryIndicatorText(
             null
         }
 
-    return when {
-        footprint != null && machine != null -> {
-            "$footprint · $machine"
+    // Nested in brackets rather than listed as a third peer, because it is literally a subset:
+    // that renderer is one of the Chromium processes already summed into the footprint. Shown
+    // beside it, a reader could add the two and get a number that means nothing.
+    //
+    // Only ever alongside a known footprint. A tab figure with no total to sit inside is not a
+    // smaller version of this feature, it is a number with no referent.
+    val withBrowser =
+        if (footprint != null && activeBrowserMB != null) {
+            "$footprint (${FormatUtils.formatMegabytes(activeBrowserMB, compact = true)} tab)"
+        } else {
+            footprint
         }
 
-        footprint != null -> {
-            footprint
+    return when {
+        withBrowser != null && machine != null -> {
+            "$withBrowser · $machine"
+        }
+
+        withBrowser != null -> {
+            withBrowser
         }
 
         machine != null -> {
@@ -111,9 +128,7 @@ internal fun memoryIndicatorText(
         }
 
         else -> {
-            FormatUtils.formatMegabytes(heapUsedMB, compact = true) +
-                "/" +
-                FormatUtils.formatMegabytes(heapMaxMB, compact = true)
+            heapFallback
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicator.kt
@@ -29,6 +29,13 @@ import androidx.compose.runtime.DisposableEffect
  * room the machine has left, and it is the one driving the colour - see `MemoryPressure` for the
  * thresholds and why they are shared with the memory-pressure watchdog.
  *
+ * The tab figure is biased in **both** directions and the two do not cancel. On macOS and
+ * Windows a renderer's RSS counts the whole shared Chromium framework, so it over-states the
+ * page; Linux `Pss` divides shared pages honestly. Against that, a page is not one process:
+ * cross-origin iframes are their own renderers under site isolation, and the GPU and network
+ * services hold page-attributable memory too, none of which is counted here. For a heavy site
+ * with third-party embeds - the case this figure exists for - it can materially under-state.
+ *
  * Each half degrades independently: an unreadable footprint leaves the machine pair, an
  * unreadable machine leaves the footprint, and losing both falls back to the old heap ratio,
  * which is always available.
@@ -37,7 +44,7 @@ import androidx.compose.runtime.DisposableEffect
 fun PerformanceIndicator(
     snapshot: PerformanceSnapshot?,
     health: PerformanceHealth,
-    activeBrowserBytes: Long,
+    activeBrowserBytes: Long = 0L,
     onClick: () -> Unit,
 ) {
     // Before the null-return below, deliberately. Whole-process sampling is gated on this being
@@ -64,10 +71,8 @@ fun PerformanceIndicator(
             footprintMB = if (memory.footprintKnown) memory.footprintMB else null,
             systemUsedMB = memory.systemUsedBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
             systemTotalMB = memory.systemTotalBytes.takeIf { it > 0L }?.let { it / (1024f * 1024f) },
-            heapFallback =
-                FormatUtils.formatMegabytes(memory.heapUsedMB, compact = true) +
-                    "/" +
-                    FormatUtils.formatMegabytes(memory.heapMaxMB, compact = true),
+            heapUsedMB = memory.heapUsedMB,
+            heapMaxMB = memory.heapMaxMB,
         )
     val cpuText = "${snapshot.cpu.processLoadPercent.toInt()}%"
 
@@ -86,12 +91,18 @@ fun PerformanceIndicator(
  * reader, and `SystemMemory` returns 0 for "unknown" on purpose rather than throwing, so both
  * inputs really can be absent at runtime and neither may be rendered as a zero.
  */
+@Suppress("LongParameterList")
+// Six, one over detekt's threshold. Collapsing the heap pair into a pre-formatted string was
+// tried and was worse in two ways: the caller then built that string on every recomposition to
+// use it only in the all-unknown branch, and the test for it degenerated into asserting a
+// literal against a default that was the same literal, so it could no longer fail.
 internal fun memoryIndicatorText(
     activeBrowserMB: Float?,
     footprintMB: Float?,
     systemUsedMB: Float?,
     systemTotalMB: Float?,
-    heapFallback: String,
+    heapUsedMB: Float,
+    heapMaxMB: Float,
 ): String {
     val footprint = footprintMB?.let { FormatUtils.formatMegabytes(it, compact = true) }
     val machine =
@@ -128,7 +139,9 @@ internal fun memoryIndicatorText(
         }
 
         else -> {
-            heapFallback
+            FormatUtils.formatMegabytes(heapUsedMB, compact = true) +
+                "/" +
+                FormatUtils.formatMegabytes(heapMaxMB, compact = true)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
@@ -37,6 +37,20 @@ expect object PerformanceState {
     fun setIndicatorMounted(mounted: Boolean)
 
     /**
+     * Resident memory of the renderer behind the browser on screen in [windowId], or 0.
+     *
+     * Resolved per window rather than sampled into the snapshot, for two reasons. The value is
+     * only ever drawn live in a status bar, so putting it in `MemoryMetrics` would persist a
+     * live-only figure into every one of the 10,000 retained history entries and into exported
+     * snapshots, where it means nothing. And it differs per window: a single sampled value would
+     * show one window's tab in the other window's strip.
+     *
+     * 0 means unknown - no browser on screen, a tab just switched, a renderer that has not
+     * committed a document yet - and must be rendered as absent, never as a zero.
+     */
+    fun activeBrowserBytes(windowId: String): Long
+
+    /**
      * Open the performance panel.
      */
     fun openPerformancePanel()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-private val panelLogger = BossLogger.forComponent("PerformanceState")
-
 /** The plugin that draws the Performance panel the status-bar indicator opens. */
 internal const val PERFORMANCE_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.performance"
 
@@ -37,6 +35,12 @@ private const val HOST_ID = "ai.rever.boss.host"
  * Desktop implementation of PerformanceState.
  * Uses PerformanceMonitor and PerformanceSettingsManager to provide state.
  */
+@Suppress("TooManyFunctions")
+// Over detekt's 11-function threshold. Suppressed rather than answered by moving whichever
+// member was easiest to move: the eviction that bought silence here also duplicated the logger
+// and put an unrelated function at file scope in a diff about renderer memory. If this object is
+// genuinely doing too much, the split worth making is a real one - the panel-plugin plumbing out
+// of a class about performance state - not one chosen by a lint threshold.
 actual object PerformanceState {
     private val logger = BossLogger.forComponent("PerformanceState")
     private val scope = CoroutineScope(Dispatchers.Main)
@@ -75,8 +79,12 @@ actual object PerformanceState {
     /**
      * Three lookups, none of which blocks or touches IPC.
      *
-     * `activeIn` reads two concurrent maps; `lastKnownRendererPid` is a volatile load pushed at
-     * navigation time; `lastReading` returns the sampler's last result without taking a new one.
+     * `activeIn` filters every registered entry and evaluates `isValid` on each - disposed,
+     * connection-dead, engine generation, `browser.isClosed` - so it is a handful of atomic reads
+     * per open browser surface rather than the two map lookups an earlier draft of this comment
+     * claimed. Still non-blocking, which is the property that matters here.
+     * `lastKnownRendererPid` is a volatile load pushed at navigation time; `lastReading` returns
+     * the sampler's last result without taking a new one.
      * That matters because the caller is a Compose pass - `ProcessFootprint.current()` would have
      * been wrong here, since it spawns `ps` once its TTL expires.
      *
@@ -87,6 +95,36 @@ actual object PerformanceState {
      * A dead pid resolves to unknown for free: `ProcessFootprint` drops departed pids from its
      * map each tick, so a lookup for one simply misses.
      */
+
+    /**
+     * Offer to install the panel's plugin when it is absent, returning whether it did.
+     *
+     * The status-bar indicator is drawn by the host, but the panel it opens is a plugin. Without
+     * this, clicking the indicator on an install that lacks that plugin emitted a panel event
+     * nothing was listening for: no panel, no dialog, no log line. A control that does nothing
+     * and says nothing is indistinguishable from a broken one.
+     *
+     * Reuses the install-time dependency prompt rather than adding a second dialog, so the offer
+     * comes with a working Install button. Both entry points are guarded, not just the toggle -
+     * the View menu reaches [openPerformancePanel] and would otherwise keep the silent failure.
+     *
+     * Fails **open**: with no active manager there is nothing to ask and nothing to install, so
+     * the panel event is emitted as before. A wiring gap must not be able to make the indicator
+     * unclickable on an install where the plugin is present.
+     */
+    private fun offerToInstallPanel(): Boolean {
+        val prompt =
+            DynamicPluginManager
+                .anyActiveManager()
+                ?.let { MissingDependencyReporter.installerFor(it) }
+                ?.let { performancePanelPrompt(it) }
+                ?: return false
+
+        logger.info(LogCategory.UI, "Performance panel requested but its plugin is not installed")
+        PluginDependencyEventBus.report(prompt)
+        return true
+    }
+
     actual fun activeBrowserBytes(windowId: String): Long {
         val pid =
             (ActiveBrowserRegistry.activeIn(windowId) as? BrowserHandleImpl)
@@ -180,33 +218,4 @@ internal fun performancePanelPrompt(installer: MissingDependencyInstaller): Miss
         // A click, so it is asked again even after the offer was dismissed once.
         userInitiated = true,
     )
-}
-
-/**
- * Offer to install the panel's plugin when it is absent, returning whether it did.
- *
- * The status-bar indicator is drawn by the host, but the panel it opens is a plugin. Without
- * this, clicking the indicator on an install that lacks that plugin emitted a panel event
- * nothing was listening for: no panel, no dialog, no log line. A control that does nothing
- * and says nothing is indistinguishable from a broken one.
- *
- * Reuses the install-time dependency prompt rather than adding a second dialog, so the offer
- * comes with a working Install button. Both entry points are guarded, not just the toggle -
- * the View menu reaches [openPerformancePanel] and would otherwise keep the silent failure.
- *
- * Fails **open**: with no active manager there is nothing to ask and nothing to install, so
- * the panel event is emitted as before. A wiring gap must not be able to make the indicator
- * unclickable on an install where the plugin is present.
- */
-private fun offerToInstallPanel(): Boolean {
-    val prompt =
-        DynamicPluginManager
-            .anyActiveManager()
-            ?.let { MissingDependencyReporter.installerFor(it) }
-            ?.let { performancePanelPrompt(it) }
-            ?: return false
-
-    panelLogger.info(LogCategory.UI, "Performance panel requested but its plugin is not installed")
-    PluginDependencyEventBus.report(prompt)
-    return true
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/PerformanceState.kt
@@ -8,6 +8,8 @@ import ai.rever.boss.components.plugin.MissingPluginDependency
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.browser.ActiveBrowserRegistry
+import ai.rever.boss.plugin.browser.BrowserHandleImpl
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -17,6 +19,8 @@ import androidx.compose.runtime.getValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+
+private val panelLogger = BossLogger.forComponent("PerformanceState")
 
 /** The plugin that draws the Performance panel the status-bar indicator opens. */
 internal const val PERFORMANCE_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.performance"
@@ -68,6 +72,28 @@ actual object PerformanceState {
         FootprintDisplay.setMounted(mounted)
     }
 
+    /**
+     * Three lookups, none of which blocks or touches IPC.
+     *
+     * `activeIn` reads two concurrent maps; `lastKnownRendererPid` is a volatile load pushed at
+     * navigation time; `lastReading` returns the sampler's last result without taking a new one.
+     * That matters because the caller is a Compose pass - `ProcessFootprint.current()` would have
+     * been wrong here, since it spawns `ps` once its TTL expires.
+     *
+     * The cast is confined to this one place. It is sound because `ActiveBrowserRegistry.register`
+     * has exactly one caller, `BrowserHandleImpl.Content()`, which passes itself; it stays a safe
+     * cast because a status-bar figure is not worth a ClassCastException if that ever changes.
+     *
+     * A dead pid resolves to unknown for free: `ProcessFootprint` drops departed pids from its
+     * map each tick, so a lookup for one simply misses.
+     */
+    actual fun activeBrowserBytes(windowId: String): Long {
+        val pid =
+            (ActiveBrowserRegistry.activeIn(windowId) as? BrowserHandleImpl)
+                ?.lastKnownRendererPid() ?: return 0L
+        return ProcessFootprint.lastReading()?.bytesByPid?.get(pid.toLong()) ?: 0L
+    }
+
     actual fun openPerformancePanel() {
         scope.launch {
             val focusedWindowId = WindowFocusManager.focusedWindowFlow.value
@@ -90,35 +116,6 @@ actual object PerformanceState {
             if (offerToInstallPanel()) return@launch
             PanelEventBus.togglePanel(PERFORMANCE_PANEL, sourceWindowId = focusedWindowId)
         }
-    }
-
-    /**
-     * Offer to install the panel's plugin when it is absent, returning whether it did.
-     *
-     * The status-bar indicator is drawn by the host, but the panel it opens is a plugin. Without
-     * this, clicking the indicator on an install that lacks that plugin emitted a panel event
-     * nothing was listening for: no panel, no dialog, no log line. A control that does nothing
-     * and says nothing is indistinguishable from a broken one.
-     *
-     * Reuses the install-time dependency prompt rather than adding a second dialog, so the offer
-     * comes with a working Install button. Both entry points are guarded, not just the toggle -
-     * the View menu reaches [openPerformancePanel] and would otherwise keep the silent failure.
-     *
-     * Fails **open**: with no active manager there is nothing to ask and nothing to install, so
-     * the panel event is emitted as before. A wiring gap must not be able to make the indicator
-     * unclickable on an install where the plugin is present.
-     */
-    private fun offerToInstallPanel(): Boolean {
-        val prompt =
-            DynamicPluginManager
-                .anyActiveManager()
-                ?.let { MissingDependencyReporter.installerFor(it) }
-                ?.let { performancePanelPrompt(it) }
-                ?: return false
-
-        logger.info(LogCategory.UI, "Performance panel requested but its plugin is not installed")
-        PluginDependencyEventBus.report(prompt)
-        return true
     }
 
     actual fun registerResourceProviders(
@@ -183,4 +180,33 @@ internal fun performancePanelPrompt(installer: MissingDependencyInstaller): Miss
         // A click, so it is asked again even after the offer was dismissed once.
         userInitiated = true,
     )
+}
+
+/**
+ * Offer to install the panel's plugin when it is absent, returning whether it did.
+ *
+ * The status-bar indicator is drawn by the host, but the panel it opens is a plugin. Without
+ * this, clicking the indicator on an install that lacks that plugin emitted a panel event
+ * nothing was listening for: no panel, no dialog, no log line. A control that does nothing
+ * and says nothing is indistinguishable from a broken one.
+ *
+ * Reuses the install-time dependency prompt rather than adding a second dialog, so the offer
+ * comes with a working Install button. Both entry points are guarded, not just the toggle -
+ * the View menu reaches [openPerformancePanel] and would otherwise keep the silent failure.
+ *
+ * Fails **open**: with no active manager there is nothing to ask and nothing to install, so
+ * the panel event is emitted as before. A wiring gap must not be able to make the indicator
+ * unclickable on an install where the plugin is present.
+ */
+private fun offerToInstallPanel(): Boolean {
+    val prompt =
+        DynamicPluginManager
+            .anyActiveManager()
+            ?.let { MissingDependencyReporter.installerFor(it) }
+            ?.let { performancePanelPrompt(it) }
+            ?: return false
+
+    panelLogger.info(LogCategory.UI, "Performance panel requested but its plugin is not installed")
+    PluginDependencyEventBus.report(prompt)
+    return true
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
@@ -54,6 +54,11 @@ import java.util.concurrent.TimeUnit
  * answers "what is BOSS holding"; the colour answers "is this machine in trouble". Conflating
  * them would inherit this bias into the alerting.
  */
+// Over detekt's 11-function threshold by one. Suppressed rather than paid for by exiling a
+// member to file scope, which is what an earlier revision did: it left `retainLive` as a
+// module-wide symbol whose name no longer said what it retained, for no reason a reader of this
+// file could see.
+@Suppress("TooManyFunctions")
 object ProcessFootprint {
     private val logger = BossLogger.forComponent("ProcessFootprint")
 
@@ -180,6 +185,20 @@ object ProcessFootprint {
      * frame. Null before the sampler's first successful read.
      */
     fun lastReading(): Reading? = cached
+
+    /**
+     * The owned-pid map carried into this tick, with the dead dropped.
+     *
+     * Dropping by liveness is what makes a departed process stop counting without any rescan: a
+     * closed browser tab's renderer is gone from `livePids` and therefore gone from the total on
+     * the very next tick. A full rescan starts from nothing instead, since it is about to
+     * reclassify everything anyway.
+     */
+    internal fun retainLive(
+        owned: Map<Long, Owner>,
+        livePids: Set<Long>,
+        fullRescan: Boolean,
+    ): Map<Long, Owner> = if (fullRescan) emptyMap() else owned.filterKeys { it in livePids }
 
     /**
      * Which pids need their command line read this tick.
@@ -408,17 +427,3 @@ object ProcessFootprint {
             }
         }.getOrNull()
 }
-
-/**
- * The owned-pid map carried into this tick, with the dead dropped.
- *
- * Dropping by liveness is what makes a departed process stop counting without any rescan: a
- * closed browser tab's renderer is gone from `livePids` and therefore gone from the total on
- * the very next tick. A full rescan starts from nothing instead, since it is about to
- * reclassify everything anyway.
- */
-internal fun retainLive(
-    owned: Map<Long, ProcessFootprint.Owner>,
-    livePids: Set<Long>,
-    fullRescan: Boolean,
-): Map<Long, ProcessFootprint.Owner> = if (fullRescan) emptyMap() else owned.filterKeys { it in livePids }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/performance/ProcessFootprint.kt
@@ -112,6 +112,18 @@ object ProcessFootprint {
         val browserBytes: Long,
         val pluginBytes: Long,
         val processCount: Int,
+        /**
+         * Bytes per owned pid, so one process can be reported on its own.
+         *
+         * Carried on the reading rather than kept as separate mutable state next to it, which
+         * would let a caller pair the sums from one sample with the per-pid map from another -
+         * a torn read that would surface as a tab figure exceeding the total it sits inside.
+         * Here the two cannot disagree, because they are the same object.
+         *
+         * The measurement already happens for every pid on every sample, so the detail is free:
+         * no extra `ps`, no second cadence.
+         */
+        val bytesByPid: Map<Long, Long> = emptyMap(),
     ) {
         val totalBytes: Long get() = hostBytes + browserBytes + pluginBytes
     }
@@ -160,6 +172,16 @@ object ProcessFootprint {
     }
 
     /**
+     * The last reading, without ever taking one.
+     *
+     * Deliberately distinct from [current]: that refreshes when its TTL has expired, and doing so
+     * spawns `ps`. This is for readers on paths that must never block - a Compose pass drawing the
+     * status strip - where triggering a subprocess would be a serious bug rather than a slow
+     * frame. Null before the sampler's first successful read.
+     */
+    fun lastReading(): Reading? = cached
+
+    /**
      * Which pids need their command line read this tick.
      *
      * Pure, so the incremental rule is testable without a process table. Everything on a full
@@ -171,20 +193,6 @@ object ProcessFootprint {
         knownPids: Set<Long>,
         fullRescan: Boolean,
     ): Set<Long> = if (fullRescan) livePids else livePids - knownPids
-
-    /**
-     * The owned-pid map carried into this tick, with the dead dropped.
-     *
-     * Dropping by liveness is what makes a departed process stop counting without any rescan: a
-     * closed browser tab's renderer is gone from `livePids` and therefore gone from the total on
-     * the very next tick. A full rescan starts from nothing instead, since it is about to
-     * reclassify everything anyway.
-     */
-    internal fun retainLive(
-        owned: Map<Long, Owner>,
-        livePids: Set<Long>,
-        fullRescan: Boolean,
-    ): Map<Long, Owner> = if (fullRescan) emptyMap() else owned.filterKeys { it in livePids }
 
     private fun read(nowMs: Long): Reading? =
         runCatching {
@@ -245,7 +253,7 @@ object ProcessFootprint {
                     Owner.PLUGIN -> plugin += bytes
                 }
             }
-            Reading(host, browser, plugin, memory.size)
+            Reading(host, browser, plugin, memory.size, memory)
         }.onFailure {
             logger.debug(LogCategory.SYSTEM, "Footprint reading failed: ${it.message}")
         }.getOrNull()
@@ -400,3 +408,17 @@ object ProcessFootprint {
             }
         }.getOrNull()
 }
+
+/**
+ * The owned-pid map carried into this tick, with the dead dropped.
+ *
+ * Dropping by liveness is what makes a departed process stop counting without any rescan: a
+ * closed browser tab's renderer is gone from `livePids` and therefore gone from the total on
+ * the very next tick. A full rescan starts from nothing instead, since it is about to
+ * reclassify everything anyway.
+ */
+internal fun retainLive(
+    owned: Map<Long, ProcessFootprint.Owner>,
+    livePids: Set<Long>,
+    fullRescan: Boolean,
+): Map<Long, ProcessFootprint.Owner> = if (fullRescan) emptyMap() else owned.filterKeys { it in livePids }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -588,7 +588,7 @@ internal class BrowserHandleImpl(
      * hole: a dead renderer's pid can be recycled by another Chromium helper of ours, and a stale
      * entry would then charge that process's memory to this tab, again plausibly.
      */
-    @Volatile private var rendererPid: Int? = null
+    private val rendererPid = RendererPid()
 
     /**
      * The renderer pid as of the last main-frame commit, or null when unknown.
@@ -597,7 +597,7 @@ internal class BrowserHandleImpl(
      * the first commit and after the renderer goes away, and callers must render it as absent
      * rather than as a zero.
      */
-    internal fun lastKnownRendererPid(): Int? = rendererPid
+    internal fun lastKnownRendererPid(): Int? = rendererPid.value
 
     /**
      * Whether this view is genuinely on screen: composed **and** in a window that is showing and
@@ -1095,10 +1095,24 @@ internal class BrowserHandleImpl(
                         visitTracker.leftTrackablePage(host)
                     }
 
+                    // One `mainFrame()` serving both the pid capture and the injection, so the
+                    // capture costs no round trip of its own.
+                    //
+                    // The capture sits OUTSIDE the URL gate below, and before the injection
+                    // rather than after it, because both of those are ways to keep a stale pid.
+                    // Injection is skipped for about:blank, so a tab navigating from a heavy
+                    // site to the dashboard would otherwise keep pointing at the old document's
+                    // renderer; and injection can throw partway, which would leave the previous
+                    // value in place. Either produces the "wrong number that looks right" the
+                    // whole design is built to avoid. Refreshing on every commit makes the only
+                    // failure mode "unknown".
+                    val frame = browser.mainFrame().orElse(null)
+                    rendererPid.onCommit(frame?.let { runCatching { it.renderProcess().pid() }.getOrNull() })
+
                     // Skip injection for about:blank pages (used for dashboard display)
                     // Only inject into actual web pages
-                    if (url.isNotEmpty() && url != "about:blank") {
-                        injectPageHelpers()
+                    if (frame != null && url.isNotEmpty() && url != "about:blank") {
+                        injectPageHelpers(frame)
                     }
                 }
             }
@@ -1170,10 +1184,14 @@ internal class BrowserHandleImpl(
                 }
             }
 
-        // Renderer gone. Forgetting the pid here is what keeps the status strip honest: Chromium
-        // recycles pids, so a retained one can later belong to a different helper of ours and
-        // that process's memory would be reported as this tab's - a wrong number that looks
-        // right. A fresh pid arrives on the next commit; until then the figure is absent.
+        // Renderer gone. Forgetting the pid here keeps the strip honest: Chromium recycles pids,
+        // so a retained one can later belong to a different helper of ours and that process's
+        // memory would be reported as this tab's.
+        //
+        // This covers *unexpected* death - a crash or a kill - not the ordinary process swap of
+        // a cross-site navigation, which fires no such event. The swap is covered by the commit
+        // that follows it, which is why the capture had to be moved out of the URL-gated
+        // injection path: between the two, every way the renderer can change is accounted for.
         subscriptions +=
             browser.on(RenderProcessTerminated::class.java) { event ->
                 logger.debug(
@@ -1181,7 +1199,7 @@ internal class BrowserHandleImpl(
                     "Renderer terminated",
                     mapOf("handleId" to id, "exitCode" to event.exitCode(), "status" to event.status().name),
                 )
-                rendererPid = null
+                rendererPid.onGone()
             }
 
         // Browser closed
@@ -1189,7 +1207,7 @@ internal class BrowserHandleImpl(
             browser.on(BrowserClosed::class.java) {
                 logger.debug(LogCategory.BROWSER, "Browser closed", mapOf("handleId" to id))
                 disposed.set(true)
-                rendererPid = null
+                rendererPid.onGone()
                 // Stop streaming: the underlying page is gone.
                 coBrowseCapturing = false
                 coBrowseSink = null
@@ -1593,8 +1611,8 @@ internal class BrowserHandleImpl(
      * target natively (see [setupContextMenuHandler]), and the trackers this used to
      * install could only ever answer for the main frame.
      */
-    private fun injectPageHelpers() {
-        browser.mainFrame().ifPresent { frame ->
+    private fun injectPageHelpers(frame: Frame) {
+        run {
             try {
                 // Inject Cmd+Click / Ctrl+Click handler for opening links in new tabs
                 frame.executeJavaScript<Unit>(BrowserJavaScripts.injectCmdClickHandler)
@@ -1603,11 +1621,6 @@ internal class BrowserHandleImpl(
                 FormFieldDetector.injectFormDetectionScript(createLockedBrowser())
 
                 injectInteractionCollector(frame)
-
-                // Free: the frame is already in hand, and both remaining hops are field reads.
-                // Re-derived on every commit rather than cached as a Frame, for the stale-pid
-                // reason spelled out on [rendererPid].
-                rendererPid = runCatching { frame.renderProcess().pid() }.getOrNull()
 
                 logger.debug(LogCategory.BROWSER, "Page helpers injected", mapOf("handleId" to id))
             } catch (e: Exception) {
@@ -3226,8 +3239,8 @@ internal class BrowserHandleImpl(
     }
 
     override fun dispose() {
-        rendererPid = null
         if (!disposed.compareAndSet(false, true)) return
+        rendererPid.onGone()
         // Shut the interaction bridge FIRST. Its only gate is this authority, and the
         // collector flushes on `pagehide` — which is precisely when this runs. Closing the
         // tracker first left a window between the two statements in which a batch arriving on

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -47,6 +47,7 @@ import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback
 import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
 import com.teamdev.jxbrowser.browser.event.BrowserClosed
 import com.teamdev.jxbrowser.browser.event.FaviconChanged
+import com.teamdev.jxbrowser.browser.event.RenderProcessTerminated
 import com.teamdev.jxbrowser.browser.event.TitleChanged
 import com.teamdev.jxbrowser.engine.Engine
 import com.teamdev.jxbrowser.event.Subscription
@@ -567,6 +568,36 @@ internal class BrowserHandleImpl(
      * Null until [Content] resolves one, and treated as "assume showing" while it is.
      */
     @Volatile private var frameStallHostWindow: Window? = null
+
+    /**
+     * OS pid of the Chromium renderer serving the last committed main-frame document, or null.
+     *
+     * Pushed at the events where it can change rather than pulled when someone asks, because the
+     * pull costs a blocking round trip and the push costs nothing. Of the chain
+     * `mainFrame -> renderProcess -> pid`, only `mainFrame()` is IPC; the other two are field
+     * reads. Capturing during [injectPageHelpers], which already holds the frame, therefore adds
+     * no round trip at all, and the reader gets a plain volatile load it can make from anywhere
+     * including a Compose layout pass.
+     *
+     * **Only the Int is kept, never the `Frame` or the `RenderProcess`.** Holding either across a
+     * navigation is a trap: `FrameImpl.renderProcess()` and `RenderProcess.pid()` carry no
+     * `checkNotClosed`, so a stale frame does not throw - it silently answers with the *previous*
+     * renderer's pid, which is a wrong number that looks entirely right.
+     *
+     * Cleared on renderer death, browser close and dispose. That is what closes the pid-reuse
+     * hole: a dead renderer's pid can be recycled by another Chromium helper of ours, and a stale
+     * entry would then charge that process's memory to this tab, again plausibly.
+     */
+    @Volatile private var rendererPid: Int? = null
+
+    /**
+     * The renderer pid as of the last main-frame commit, or null when unknown.
+     *
+     * Never blocks and never touches IPC - see [rendererPid]. Unknown is the honest answer before
+     * the first commit and after the renderer goes away, and callers must render it as absent
+     * rather than as a zero.
+     */
+    internal fun lastKnownRendererPid(): Int? = rendererPid
 
     /**
      * Whether this view is genuinely on screen: composed **and** in a window that is showing and
@@ -1139,11 +1170,26 @@ internal class BrowserHandleImpl(
                 }
             }
 
+        // Renderer gone. Forgetting the pid here is what keeps the status strip honest: Chromium
+        // recycles pids, so a retained one can later belong to a different helper of ours and
+        // that process's memory would be reported as this tab's - a wrong number that looks
+        // right. A fresh pid arrives on the next commit; until then the figure is absent.
+        subscriptions +=
+            browser.on(RenderProcessTerminated::class.java) { event ->
+                logger.debug(
+                    LogCategory.BROWSER,
+                    "Renderer terminated",
+                    mapOf("handleId" to id, "exitCode" to event.exitCode(), "status" to event.status().name),
+                )
+                rendererPid = null
+            }
+
         // Browser closed
         subscriptions +=
             browser.on(BrowserClosed::class.java) {
                 logger.debug(LogCategory.BROWSER, "Browser closed", mapOf("handleId" to id))
                 disposed.set(true)
+                rendererPid = null
                 // Stop streaming: the underlying page is gone.
                 coBrowseCapturing = false
                 coBrowseSink = null
@@ -1557,6 +1603,11 @@ internal class BrowserHandleImpl(
                 FormFieldDetector.injectFormDetectionScript(createLockedBrowser())
 
                 injectInteractionCollector(frame)
+
+                // Free: the frame is already in hand, and both remaining hops are field reads.
+                // Re-derived on every commit rather than cached as a Frame, for the stale-pid
+                // reason spelled out on [rendererPid].
+                rendererPid = runCatching { frame.renderProcess().pid() }.getOrNull()
 
                 logger.debug(LogCategory.BROWSER, "Page helpers injected", mapOf("handleId" to id))
             } catch (e: Exception) {
@@ -3175,6 +3226,7 @@ internal class BrowserHandleImpl(
     }
 
     override fun dispose() {
+        rendererPid = null
         if (!disposed.compareAndSet(false, true)) return
         // Shut the interaction bridge FIRST. Its only gate is this authority, and the
         // collector flushes on `pagehide` — which is precisely when this runs. Closing the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/RendererPid.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/RendererPid.kt
@@ -1,0 +1,43 @@
+package ai.rever.boss.plugin.browser
+
+/**
+ * The pid of the Chromium renderer serving a browser's current main-frame document.
+ *
+ * A holder rather than a bare `@Volatile var` on the handle, because this tiny state machine is
+ * the part of the per-tab memory figure that carries the actual hazard, and as a field on
+ * `BrowserHandleImpl` it could not be tested without a live browser and a real navigation.
+ *
+ * The hazard is that **being wrong here is silent**. Of the JxBrowser chain
+ * `mainFrame -> renderProcess -> pid`, neither of the last two carries a `checkNotClosed`, so a
+ * `Frame` read after a navigation does not throw - it answers with the *previous* renderer's pid.
+ * Chromium also recycles pids, so a value kept past its renderer's death can later name an
+ * unrelated helper of ours. Both produce a number that looks entirely reasonable and is charged
+ * to the wrong tab.
+ *
+ * So the rule this encodes is: only a commit may set a value, and anything that ends the
+ * renderer's life clears it. Unknown is always an acceptable answer - the strip simply omits the
+ * figure - and is always preferable to a plausible wrong one.
+ */
+internal class RendererPid {
+    @Volatile
+    private var pid: Int? = null
+
+    /** The current pid, or null when unknown. A plain volatile read, safe from any thread. */
+    val value: Int? get() = pid
+
+    /**
+     * A main-frame document committed on [pid].
+     *
+     * Accepts null and stores it, which is the point rather than an oversight: the caller passes
+     * null when the frame or the pid could not be read, and overwriting with "unknown" is what
+     * stops the previous document's renderer being reported for the new one.
+     */
+    fun onCommit(pid: Int?) {
+        this.pid = pid
+    }
+
+    /** The renderer, or the browser, is gone. */
+    fun onGone() {
+        pid = null
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicatorTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicatorTextTest.kt
@@ -19,8 +19,9 @@ class PerformanceIndicatorTextTest {
         footprintMB: Float? = 2.1f * gb,
         systemUsedMB: Float? = 70f * gb,
         systemTotalMB: Float? = 128f * gb,
-        heapFallback: String = "296MB/2.0GB",
-    ) = memoryIndicatorText(activeBrowserMB, footprintMB, systemUsedMB, systemTotalMB, heapFallback)
+        heapUsedMB: Float = 296f,
+        heapMaxMB: Float = 2f * gb,
+    ) = memoryIndicatorText(activeBrowserMB, footprintMB, systemUsedMB, systemTotalMB, heapUsedMB, heapMaxMB)
 
     // region the active browser figure
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicatorTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/bars/horizontal/PerformanceIndicatorTextTest.kt
@@ -15,12 +15,53 @@ class PerformanceIndicatorTextTest {
     private val gb = 1024f
 
     private fun text(
+        activeBrowserMB: Float? = null,
         footprintMB: Float? = 2.1f * gb,
         systemUsedMB: Float? = 70f * gb,
         systemTotalMB: Float? = 128f * gb,
-        heapUsedMB: Float = 296f,
-        heapMaxMB: Float = 2f * gb,
-    ) = memoryIndicatorText(footprintMB, systemUsedMB, systemTotalMB, heapUsedMB, heapMaxMB)
+        heapFallback: String = "296MB/2.0GB",
+    ) = memoryIndicatorText(activeBrowserMB, footprintMB, systemUsedMB, systemTotalMB, heapFallback)
+
+    // region the active browser figure
+
+    @Test
+    fun `the active tab is nested inside the total`() {
+        assertEquals("2.4GB (1.6GB tab) · 70/128GB", text(activeBrowserMB = 1.6f * gb, footprintMB = 2.4f * gb))
+    }
+
+    /**
+     * Brackets, not a third peer, because the renderer is one of the processes already summed
+     * into the footprint. Listed side by side, the two invite being added together.
+     */
+    @Test
+    fun `no browser reading leaves today's string untouched`() {
+        assertEquals("2.1GB · 70/128GB", text(activeBrowserMB = null))
+    }
+
+    /**
+     * A tab figure with no total to sit inside has no referent, so it is dropped rather than
+     * promoted to the front of the label.
+     */
+    @Test
+    fun `the tab figure is suppressed when the footprint is unknown`() {
+        assertEquals("70/128GB", text(activeBrowserMB = 1.6f * gb, footprintMB = null))
+    }
+
+    @Test
+    fun `the tab figure survives an unreadable machine`() {
+        assertEquals(
+            "2.4GB (1.6GB tab)",
+            text(activeBrowserMB = 1.6f * gb, footprintMB = 2.4f * gb, systemUsedMB = null, systemTotalMB = null),
+        )
+    }
+
+    @Test
+    fun `a small tab keeps its own unit rather than borrowing the total's`() {
+        // Unlike the machine pair, these two are not a ratio and are formatted independently.
+        assertEquals("2.4GB (180MB tab) · 70/128GB", text(activeBrowserMB = 180f, footprintMB = 2.4f * gb))
+    }
+
+    // endregion
 
     @Test
     fun `both readings show BOSS then the machine`() {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
@@ -138,14 +138,14 @@ class ProcessFootprintTest {
     fun `a departed process stops counting on the very next tick`() {
         // A closed tab's renderer must drop out without waiting for any rescan.
         val owned = mapOf(1L to ProcessFootprint.Owner.HOST, 42L to ProcessFootprint.Owner.BROWSER)
-        val retained = retainLive(owned, setOf(1L), fullRescan = false)
+        val retained = ProcessFootprint.retainLive(owned, setOf(1L), fullRescan = false)
         assertEquals(mapOf(1L to ProcessFootprint.Owner.HOST), retained)
     }
 
     @Test
     fun `a full rescan starts from nothing`() {
         val owned = mapOf(1L to ProcessFootprint.Owner.HOST)
-        assertEquals(emptyMap(), retainLive(owned, setOf(1L), fullRescan = true))
+        assertEquals(emptyMap(), ProcessFootprint.retainLive(owned, setOf(1L), fullRescan = true))
     }
 
     // endregion

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/performance/ProcessFootprintTest.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.performance
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Guards the ownership rule and the per-platform parsers in [ProcessFootprint].
@@ -137,14 +138,14 @@ class ProcessFootprintTest {
     fun `a departed process stops counting on the very next tick`() {
         // A closed tab's renderer must drop out without waiting for any rescan.
         val owned = mapOf(1L to ProcessFootprint.Owner.HOST, 42L to ProcessFootprint.Owner.BROWSER)
-        val retained = ProcessFootprint.retainLive(owned, setOf(1L), fullRescan = false)
+        val retained = retainLive(owned, setOf(1L), fullRescan = false)
         assertEquals(mapOf(1L to ProcessFootprint.Owner.HOST), retained)
     }
 
     @Test
     fun `a full rescan starts from nothing`() {
         val owned = mapOf(1L to ProcessFootprint.Owner.HOST)
-        assertEquals(emptyMap(), ProcessFootprint.retainLive(owned, setOf(1L), fullRescan = true))
+        assertEquals(emptyMap(), retainLive(owned, setOf(1L), fullRescan = true))
     }
 
     // endregion
@@ -180,6 +181,61 @@ class ProcessFootprintTest {
         assertEquals(true, FootprintDisplay.isOnScreen)
         FootprintDisplay.setMounted(false)
         assertEquals(false, FootprintDisplay.isOnScreen)
+    }
+
+    // endregion
+
+    // region per-pid detail
+
+    /**
+     * The map rides on the reading rather than beside it, so the sums and the detail can never
+     * come from different samples - a tab figure larger than the total it is nested inside is
+     * exactly what a torn read would look like on screen.
+     */
+    @Test
+    fun `a reading carries the bytes of each owned pid`() {
+        val reading = ProcessFootprint.Reading(1L, 2L, 3L, 2, mapOf(42L to 4096L))
+        assertEquals(4096L, reading.bytesByPid[42L])
+        assertEquals(6L, reading.totalBytes)
+    }
+
+    @Test
+    fun `an unmeasured pid is absent rather than zero`() {
+        // Absent and zero are different claims: one is "not one of ours, or not measured yet",
+        // the other would assert a process holding no memory.
+        val reading = ProcessFootprint.Reading(1L, 2L, 3L, 1, mapOf(42L to 4096L))
+        assertNull(reading.bytesByPid[99L])
+    }
+
+    @Test
+    fun `an older reading still deserialises without the map`() {
+        // Defaulted, so a Reading constructed the old way keeps working.
+        assertEquals(emptyMap(), ProcessFootprint.Reading(1L, 2L, 3L, 0).bytesByPid)
+    }
+
+    /**
+     * The invariant that actually catches a sampler which forgets to carry the map.
+     *
+     * The three constructor tests above pin the shape but would all pass if `read()` built its
+     * `Reading` without the detail, because they construct one by hand. This takes a real
+     * reading and holds the two halves against each other: every measured pid lands in exactly
+     * one bucket, so the per-pid values must sum to the totals and count to `processCount`.
+     *
+     * Returns early rather than failing when no reading is available - a machine or CI image
+     * where the process query cannot run is not evidence of a bug - so the mutation guard this
+     * provides is real locally and best-effort in CI.
+     */
+    @Test
+    fun `a real reading's per-pid detail agrees with its totals`() {
+        FootprintDisplay.setMounted(true)
+        try {
+            val reading = ProcessFootprint.current() ?: return
+            assertEquals(reading.processCount, reading.bytesByPid.size)
+            assertEquals(reading.totalBytes, reading.bytesByPid.values.sum())
+            assertTrue(reading.bytesByPid.isNotEmpty(), "this JVM is running, so at least one pid is ours")
+        } finally {
+            FootprintDisplay.setMounted(false)
+        }
     }
 
     // endregion

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/RendererPidTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/RendererPidTest.kt
@@ -1,0 +1,75 @@
+package ai.rever.boss.plugin.browser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Guards the renderer-pid lifecycle.
+ *
+ * This is the part of the per-tab memory figure that can be wrong *silently*. Neither
+ * `Frame.renderProcess()` nor `RenderProcess.pid()` carries a `checkNotClosed`, so a stale read
+ * answers with the previous document's renderer instead of throwing, and Chromium recycles pids,
+ * so a value kept past its renderer's death can name an unrelated helper. Both give a plausible
+ * number charged to the wrong tab, which no amount of downstream testing would catch.
+ *
+ * It lived as a `@Volatile` field on `BrowserHandleImpl` and was therefore untestable without a
+ * live browser and a real navigation - which is why it is a holder now.
+ */
+class RendererPidTest {
+    @Test
+    fun `unknown until a document commits`() {
+        assertNull(RendererPid().value)
+    }
+
+    @Test
+    fun `a commit records the renderer`() {
+        val pid = RendererPid()
+        pid.onCommit(2417)
+        assertEquals(2417, pid.value)
+    }
+
+    /**
+     * The about:blank case. Injection is skipped for it, so before the capture moved out of that
+     * gate a tab navigating from a heavy site to the dashboard kept reporting the old renderer.
+     * Overwriting with unknown is what makes the figure disappear instead of lying.
+     */
+    @Test
+    fun `a commit that could not read a pid clears the previous one`() {
+        val pid = RendererPid()
+        pid.onCommit(2417)
+        pid.onCommit(null)
+        assertNull(pid.value)
+    }
+
+    @Test
+    fun `a renderer going away clears it`() {
+        val pid = RendererPid()
+        pid.onCommit(2417)
+        pid.onGone()
+        assertNull(pid.value)
+    }
+
+    /**
+     * Clearing must not be terminal. A crashed renderer is replaced and the reload commits a new
+     * one; a holder that latched at unknown would leave that tab permanently unreported.
+     */
+    @Test
+    fun `a commit after a death records the new renderer`() {
+        val pid = RendererPid()
+        pid.onCommit(2417)
+        pid.onGone()
+        pid.onCommit(9001)
+        assertEquals(9001, pid.value)
+    }
+
+    @Test
+    fun `a cross-site swap replaces rather than accumulates`() {
+        // No event fires for an ordinary swap, so the following commit is the only thing that
+        // moves the pid off the previous renderer.
+        val pid = RendererPid()
+        pid.onCommit(2417)
+        pid.onCommit(2418)
+        assertEquals(2418, pid.value)
+    }
+}


### PR DESCRIPTION
## Why

The strip showed one lump for all of BOSS. On a real session that lump is dominated by one thing: measured live, Chromium renderers ranged from **99 MB to 1,637 MB**, so a single heavy page can be most of the footprint with nothing on screen saying so.

**Now:** `1.9GB (195MB tab) · 66/128GB 0%`

Nested rather than listed beside it, because the renderer is one of the processes *already summed into* the footprint. Side by side, a reader could add the two and get a number that means nothing.

## Almost none of this is new machinery

Two pieces existed and had never been connected:

- **`ActiveBrowserRegistry.activeIn(windowId)`** already answers "which browser is on screen in this window". So the tab-id ↔ handle gap that exists elsewhere in the codebase is routed around entirely - no bridge needed.
- **`ProcessFootprint`** already measures every Chromium process each sample and discarded the per-pid detail. Carrying it makes the figure **free**: no extra `ps`, no second cadence, nothing at all on Linux where it is a `/proc` read.

## The pid is pushed, not pulled

Of the chain `mainFrame -> renderProcess -> pid`, **only `mainFrame()` is IPC** - the other two are field reads (verified against the 9.4.1 bytecode). Capturing during `injectPageHelpers`, which already holds the frame, costs **no round trip**, and leaves the reader a volatile load safe from a Compose pass.

Pulling instead would have put a blocking call on `PerformanceMonitor`'s sampling loop. `syncCall` bounds what a dead browser *throws*, never how long a live-but-wedged one *takes* - one bad page could have frozen memory, CPU, GC and resource sampling for every window, indefinitely and silently. Routing through `syncCall` would also have let a cosmetic status figure latch `connectionDead` and permanently invalidate a browser handle.

**Only the `Int` is kept, never the `Frame` or `RenderProcess`.** Holding either across a navigation is a trap: neither `renderProcess()` nor `pid()` carries a `checkNotClosed`, so a stale frame does not throw - it answers with the *previous* renderer's pid, a wrong number that looks right. Cleared on `RenderProcessTerminated`, close and dispose, which also closes the **pid-reuse** hole (Chromium recycles pids; a retained one would later charge another helper's memory to this tab).

## Two smaller decisions

- The per-pid map rides **on `Reading`**, not beside it, so sums and detail cannot come from different samples. A torn read would surface as a tab figure *larger than the total it sits inside*.
- The value is resolved **per window in the bar**, not sampled into `MemoryMetrics`. It is drawn live and differs per window: in the snapshot it would persist a meaningless number into all 10,000 retained history entries and every export, and would show one window's tab in the other window's strip.

## Verification

**Against ground truth.** The strip read `195MB` for a pid the app resolved itself; `ps` agreed on that pid; and the pid was independently confirmed to be a `--type=renderer` process under the dev engine directory. Instrumentation showed every link resolving:

```
windowId=7c2ae73b…  handle=f6440ad2…  pid=2417
readingPids=2319,2320,2323,2325,2329,2330,2331,2417,2428
bytes=212008960
```

| on screen | strip |
|---|---|
| Home, no browser | `1.3GB · 64/128GB` |
| Google tab | `1.9GB (195MB tab) · 66/128GB` |

**Suite: 2,606 tests, 0 failures**; detekt + ktlint green.

**Mutation-checked**, both fail the suite and pass on restore:
- sampler dropping the per-pid map from `Reading`
- rendering a tab figure with no total to nest it in

The second guard needed a test that could actually catch it: the hand-constructed `Reading` cases would all have passed a sampler that forgot the map, so there is now an invariant test taking a *real* reading and holding `bytesByPid` against `processCount` and `totalBytes`.

## Limits, documented rather than papered over

- **A renderer can serve several tabs** (LITE caps at 4, ULTRA_LITE at 2; same-site navigations reuse). This is the renderer behind the tab, not the tab alone - which is why per-tab figures must never be summed.
- **macOS and Windows over-count**: a renderer's RSS includes the whole shared Chromium framework, so the figure overstates the page. Linux `Pss` divides shared pages honestly. Same bias already documented for the total.

Neither affects the colour, which still comes from machine free memory.