### PR TITLE
chrome: make the dimens real, and enforce that the bars read them

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -29,6 +29,7 @@ import ai.rever.boss.components.workspaces.extractCurrentWorkspace
 import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.focusmode.FocusModeSettings
 import ai.rever.boss.handleTabDropResult
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.layout.ChromeBudgetReadout
 import ai.rever.boss.plugin.api.LocalBookmarkDataProvider
 import ai.rever.boss.plugin.api.LocalProjectPath
@@ -281,13 +282,15 @@ internal fun BossAppScaffold(
     // Renders nothing; reports what the chrome costs the page when BOSS_CHROME_BUDGET is set.
     // Here rather than inside a bar so it still reports with every bar switched off.
     //
-    // Anything that provides LocalChromeDimens must sit ABOVE this call. Provide it lower - between
-    // here and the bars - and the readout reports Comfortable while the bars draw Compact, which is
-    // exactly the drift ChromeMetrics exists to make impossible.
+    // The metrics are read once here and handed to both the readout and the bars, so a provider
+    // installed anywhere above this line reaches them together. Resolving them separately inside the
+    // readout is what would let it report Comfortable while the bars drew Compact.
+    val chromeDimens = BossChrome.dimens
     ChromeBudgetReadout(
         windowId = state.windowId,
         appearance = appearance,
         focusMode = focusModeSettings,
+        dimens = chromeDimens,
     )
 
     with(state.draggablePanelComponent) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/auth/screens/PasskeyBrowserScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/auth/screens/PasskeyBrowserScreen.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.auth.screens
 
 import ai.rever.boss.components.bars.horizontal.HorizontalBar
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.DeepLinkHandler
 import ai.rever.boss.utils.logging.BossLogger
@@ -76,8 +77,10 @@ fun PasskeyBrowserScreen(
                 .fillMaxSize()
                 .background(BossTheme.colors.panel),
     ) {
-        // Title Bar - matches BossTitleBar
-        HorizontalBar(height = 26.dp) {
+        // Title Bar - matches BossTitleBar, and reads the same metric so it keeps matching. The
+        // literals here were copied from those bars; once ChromeDimens owns them, a copy is a copy
+        // that drifts the first time a density other than Comfortable is selected.
+        HorizontalBar(height = BossChrome.dimens.titleBarHeight) {
             Text(
                 text = "Boss Console",
                 color = BossTheme.colors.textPrimary,
@@ -90,10 +93,10 @@ fun PasskeyBrowserScreen(
                         .align(Alignment.Center),
             )
         }
-        Divider(color = BossTheme.colors.line)
+        Divider(color = BossTheme.colors.line, thickness = BossChrome.dimens.dividerThickness)
 
-        // Top bar - matches main BossTopBar structure
-        HorizontalBar(height = 40.dp) {
+        // Top bar - matches main BossTopBar structure. See above for why this is not a literal.
+        HorizontalBar(height = BossChrome.dimens.topBarHeight) {
             Row(
                 modifier =
                     Modifier
@@ -124,7 +127,7 @@ fun PasskeyBrowserScreen(
                 Spacer(modifier = Modifier.weight(1f))
             }
         }
-        Divider(color = BossTheme.colors.line)
+        Divider(color = BossTheme.colors.line, thickness = BossChrome.dimens.dividerThickness)
 
         // Browser content area
         Box(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun BossBottomBar(tabsComponent: BossTabsComponent? = null) {
-    Divider(color = BossTheme.colors.line)
+    Divider(color = BossTheme.colors.line, thickness = BossChrome.dimens.dividerThickness)
     HorizontalBar(
         modifier = Modifier.contextMenu(items = rememberBarContextMenuItems(ChromeBar.BOTTOM)),
         height = BossChrome.dimens.bottomBarHeight,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTitleBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTitleBar.kt
@@ -44,5 +44,5 @@ fun BossTitleBar(
                     .align(Alignment.Center),
         )
     }
-    Divider(color = BossTheme.colors.line)
+    Divider(color = BossTheme.colors.line, thickness = BossChrome.dimens.dividerThickness)
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -89,7 +89,7 @@ fun BossDraggableComponent.BossTopBar(
             BossTopRightBar(onShowSettings = onShowSettings, onShowSearch = onShowSearch, onSignOut = onSignOut)
         }
     }
-    Divider(color = BossTheme.colors.line)
+    Divider(color = BossTheme.colors.line, thickness = BossChrome.dimens.dividerThickness)
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/BossActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/BossActionButton.kt
@@ -330,7 +330,7 @@ fun BossActionButton(
                 .then(if (compact) Modifier.height(COMPACT_ROW_HEIGHT) else Modifier)
                 .run {
                     if (imageVector != null) {
-                        size(28.dp).hoverable(interactionSource)
+                        size(BOSS_ACTION_BUTTON_ICON_SIZE).hoverable(interactionSource)
                     } else {
                         hoverable(interactionSource)
                     }
@@ -369,3 +369,12 @@ private val COMPACT_GAP = 6.dp
 
 /** Row height in compact mode, matching the vertical bar's group headers and summary rows. */
 private val COMPACT_ROW_HEIGHT = 24.dp
+
+/**
+ * Rendered size of an icon-only action button.
+ *
+ * Named because it is the real floor on the top bar's height: `BossTopBar` and `BossTopRunBar` are
+ * built from these, so a top bar shorter than this clips them. `ChromeDimens.MIN_TOP_BAR` is pinned
+ * against it in `ChromeMetricsTest` rather than restating the number in prose.
+ */
+internal val BOSS_ACTION_BUTTON_ICON_SIZE = 28.dp

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dividers/VDivider.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dividers/VDivider.kt
@@ -1,20 +1,28 @@
 package ai.rever.boss.components.dividers
 
+import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
+/**
+ * The app's vertical hairline.
+ *
+ * Width comes from `ChromeDimens.dividerThickness` rather than a literal, because `ChromeMetrics`
+ * charges the budget for one of these down each icon strip's inner edge. A literal here made that
+ * token measurement-only: changing it moved the reported number and not a single pixel, which is
+ * the exact drift `ChromeMetrics` exists to prevent, inside `ChromeMetrics`.
+ */
 @Composable
 fun VDivider(modifier: Modifier = Modifier) {
     Divider(
         modifier =
             modifier
                 .fillMaxHeight()
-                .width(1.dp),
+                .width(BossChrome.dimens.dividerThickness),
         color = BossTheme.colors.line,
     )
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossMainWindowPanel.kt
@@ -1313,7 +1313,7 @@ fun BossTabsComponent.BossMainPanel(
                 tabDragComponent = tabDragComponent,
                 onTabDropResult = onTabDropResult,
             )
-            Divider(color = BossTheme.colors.line)
+            Divider(color = BossTheme.colors.line, thickness = BossChrome.dimens.dividerThickness)
             panelContent(Modifier.weight(1f).fillMaxWidth())
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeBudgetReadout.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeBudgetReadout.kt
@@ -33,8 +33,10 @@ internal fun chromeBudgetReadoutEnabled(
     property: String?,
 ): Boolean {
     val raw = env?.takeIf { it.isNotBlank() } ?: property
-    return raw?.trim()?.lowercase() in setOf("1", "true", "yes", "on")
+    return raw?.trim()?.lowercase() in TRUTHY
 }
+
+private val TRUTHY = setOf("1", "true", "yes", "on")
 
 /**
  * Read once, not per composition: the flag is a developer's launch decision, and re-reading the
@@ -64,21 +66,21 @@ private val SIZE_BUCKET = 50.dp
  * cannot report that. A visible readout belongs next to the density control in Settings, which is
  * reachable whatever the chrome is doing - that arrives with the density setting itself.
  *
- * **Must be composed below whatever provides [LocalChromeDimens].** It resolves the metrics the same
- * way the bars do, and the whole point of [ChromeMetrics] is that the measurement cannot drift from
- * what is drawn. A provider sitting *between* this call and the bars would have it report
- * `Comfortable` while the bars drew `Compact`, and the density setting would look like it did
- * nothing.
+ * [dimens] is a parameter rather than a `BossChrome.dimens` read inside this function, for the same
+ * reason [ChromeMetrics.mainPanelBudget] refuses a default for it. Resolving it here would silently
+ * report `Comfortable` if a provider were ever installed *between* this call and the bars, which is
+ * the natural place to put one; taking it as an argument makes the caller name it from the same
+ * scope that provides it.
  */
 @Composable
 fun ChromeBudgetReadout(
     windowId: String?,
     appearance: WindowAppearanceSettings,
     focusMode: FocusModeSettings,
+    dimens: ChromeDimens,
 ) {
     if (!readoutEnabled) return
 
-    val dimens = BossChrome.dimens
     val budget = ChromeMetrics.mainPanelBudget(appearance, focusMode, dimens)
 
     // containerSize is the window's content area in px; on macOS that includes the area the traffic
@@ -88,7 +90,10 @@ fun ChromeBudgetReadout(
     val windowHeight = with(density) { containerSize.height.toDp() }
     val windowWidth = with(density) { containerSize.width.toDp() }
 
-    LaunchedEffect(windowId, budget, windowHeight.bucket(), windowWidth.bucket()) {
+    // `windowHeight > 0.dp` is in the key list because bucket 0 covers both the degenerate
+    // mid-layout size and any real size under 50dp: without it, a window whose first real size
+    // landed in that bucket would never re-key and never log.
+    LaunchedEffect(windowId, budget, windowHeight > 0.dp, windowHeight.bucket(), windowWidth.bucket()) {
         if (windowHeight <= 0.dp || windowWidth <= 0.dp) return@LaunchedEffect
 
         val heightPercent = budget.verticalFractionOf(windowHeight) * 100

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/layout/ChromeDimens.kt
@@ -72,6 +72,16 @@ data class ChromeDimens(
         val MIN_TITLE_BAR = 26.dp
 
         /**
+         * The floor for [topBarHeight]: the bar is built from icon-only `BossActionButton`s at
+         * `BOSS_ACTION_BUTTON_ICON_SIZE`, so anything under 32 starts clipping them.
+         *
+         * An earlier version of the [Compact] comment said the tallest thing in the top bar was the
+         * 22.dp logo, which is not the binding constraint - the same species of mistake the
+         * [MIN_STRIP_WIDTH] KDoc warns about. Pinned in `ChromeMetricsTest` against the button size.
+         */
+        val MIN_TOP_BAR = 32.dp
+
+        /**
          * The floor for [tabBarHeight]: `NEW_TAB_BUTTON_SIZE` is 32.dp, so anything under 36 leaves
          * the "+" button less than 2.dp of breathing room on each side. `ChromeMetricsTest` pins
          * this against that constant rather than trusting the arithmetic in this sentence.
@@ -112,8 +122,7 @@ data class ChromeDimens(
         val Compact =
             ChromeDimens(
                 titleBarHeight = MIN_TITLE_BAR,
-                // The tallest thing in the top bar is the 22.dp logo plus 2.dp of padding.
-                topBarHeight = 32.dp,
+                topBarHeight = MIN_TOP_BAR,
                 tabBarHeight = MIN_TAB_BAR,
                 bottomBarHeight = 24.dp,
                 stripWidth = MIN_STRIP_WIDTH,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeDimensConventionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/layout/ChromeDimensConventionTest.kt
@@ -1,0 +1,125 @@
+package ai.rever.boss.layout
+
+import ai.rever.boss.testsupport.kotlinSourcesUnder
+import ai.rever.boss.testsupport.repoRoot
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Keeps the chrome bars reading [ChromeDimens] instead of literals.
+ *
+ * `ChromeMetricsTest` pins the arithmetic *given* a [ChromeDimens]. Nothing in it pins that the
+ * chrome actually drawn and the metrics measured are the same thing, and the system fails open in
+ * the direction that matters: a bar written next month as `HorizontalBar(height = 36.dp)` compiles,
+ * ships, and is silently missing from the budget. That is the exact failure issue #239 opens with,
+ * "a bar could be added or grown without anyone noticing".
+ *
+ * So this scans for it. `HorizontalBar` and `VerticalBar` are the only two ways a window chrome bar's
+ * extent gets set, which makes them a small enough surface to police textually.
+ *
+ * A convention test in the style of `NoRawDialogConventionTest` and `SettingsSearchIndexDriftTest`,
+ * and heuristic for the same reason: it cannot parse Kotlin. It reads the argument that follows the
+ * call, on the same line or the next few, which is how every call site in the tree is written.
+ */
+class ChromeDimensConventionTest {
+    private val barPrimitives =
+        mapOf(
+            "HorizontalBar(" to "height",
+            "VerticalBar(" to "width",
+        )
+
+    /**
+     * Files the scan skips.
+     *
+     * The two primitives declare the parameter they are scanned for, and this test quotes an
+     * offending call in its own KDoc as the example of what it catches - it found itself first.
+     */
+    private val skippedFiles =
+        setOf("HorizontalBar.kt", "VerticalBar.kt", "ChromeDimensConventionTest.kt")
+
+    private val literal = Regex("""=\s*\d+(\.\d+)?\.dp""")
+
+    @Test
+    fun `no chrome bar sets its own extent from a literal`() {
+        val offenders = mutableListOf<String>()
+
+        kotlinSourcesUnder(repoRoot(), "composeApp/src").forEach { file ->
+            if (file.name in skippedFiles) return@forEach
+            val lines = file.readLines()
+            lines.forEachIndexed { index, line ->
+                barPrimitives.forEach { (call, parameter) ->
+                    if (!line.contains(call)) return@forEach
+                    // The argument sits on this line or within the next few, before the lambda opens.
+                    val window = lines.subList(index, minOf(index + 6, lines.size)).joinToString("\n")
+                    val argument = Regex("""$parameter\s*=[^,)\n]*""").find(window)?.value ?: return@forEach
+                    if (literal.containsMatchIn(argument)) {
+                        offenders += "${file.name}:${index + 1}  $argument"
+                    }
+                }
+            }
+        }
+
+        if (offenders.isNotEmpty()) {
+            fail(
+                "these chrome bars set their extent from a literal instead of ChromeDimens, so they " +
+                    "are drawn but not measured (see ChromeMetrics):\n" + offenders.joinToString("\n"),
+            )
+        }
+    }
+
+    @Test
+    fun `the side panel header reads the metrics too`() {
+        // BossPanelTopBar sizes a Row directly rather than going through HorizontalBar, so the scan
+        // above cannot see it. It is in ChromeDimens (panelTopBarHeight) and excluded from the main
+        // panel's budget, so what matters here is only that it has not drifted back to a literal.
+        val file =
+            kotlinSourcesUnder(repoRoot(), "composeApp/src")
+                .single { it.name == "BossPanelTopBar.kt" }
+
+        assertTrue(
+            file.readText().contains("BossChrome.dimens.panelTopBarHeight"),
+            "BossPanelTopBar no longer reads its height from ChromeDimens",
+        )
+    }
+
+    @Test
+    fun `the panel border ring reads the metrics`() {
+        // The ring is 4dp off both axes of every main panel and no preference switches it off, so a
+        // literal here is 4dp the budget would claim and the panel would not spend, or vice versa.
+        val file =
+            kotlinSourcesUnder(repoRoot(), "composeApp/src")
+                .single { it.name == "BossMainWindowPanel.kt" }
+
+        assertTrue(
+            file.readText().contains("BossChrome.dimens.panelBorderThickness"),
+            "BossMainWindowPanel no longer reads its border ring from ChromeDimens",
+        )
+    }
+
+    @Test
+    fun `the hairline the budget charges for is the hairline that is drawn`() {
+        // dividerThickness was measurement-only at first: the budget added it seven times while
+        // VDivider hardcoded 1.dp and the horizontal dividers took Material's default. Changing the
+        // token moved the reported number and not one pixel.
+        val sources = kotlinSourcesUnder(repoRoot(), "composeApp/src")
+
+        assertTrue(
+            sources
+                .single { it.name == "VDivider.kt" }
+                .readText()
+                .contains("width(BossChrome.dimens.dividerThickness)"),
+            "VDivider is back to a literal width, so the strips' hairlines are charged but not drawn",
+        )
+
+        listOf("BossTopBar.kt", "BossBottomBar.kt", "BossMainWindowPanel.kt").forEach { name ->
+            assertTrue(
+                sources
+                    .single { it.name == name }
+                    .readText()
+                    .contains("thickness = BossChrome.dimens.dividerThickness"),
+                "$name draws a budgeted divider without the thickness the budget charges for",
+            )
+        }
+    }
+}


### PR DESCRIPTION
Follow-ups from the **second** review round on #240, which merged before these were ready. Straight onto `main`.

Two of these turn into user-visible wrong answers the moment PR C makes a density other than `Comfortable` reachable, so they are worth landing before it.

## `dividerThickness` was measurement-only

The budget adds it five times vertically and twice horizontally. Nothing drew with it: `VDivider` hardcoded `.width(1.dp)` and the horizontal dividers took Material's default thickness. So it was the one metric where changing the value moved the reported number and not a single pixel, which is precisely the drift `ChromeMetrics` exists to prevent, sitting inside `ChromeMetrics`.

`VDivider` and the four budgeted dividers read it now. No pixels move today: every density says `1.dp`.

## Nothing pinned that a bar reads the metrics at all

`ChromeMetricsTest` pins the arithmetic *given* a `ChromeDimens`. It cannot see whether the chrome drawn and the chrome measured are the same thing, and the system failed open in the direction that matters: a bar written next month as `HorizontalBar(height = 36.dp)` compiles, ships, and is silently absent from the budget. That is the exact failure #239 opens with, "a bar could be added or grown without anyone noticing".

`ChromeDimensConventionTest` scans for it, in the style of `NoRawDialogConventionTest`. `HorizontalBar` and `VerticalBar` are the only two ways a chrome bar's extent gets set, which makes the surface small enough to police textually. It also pins the panel ring, the side-panel header that sizes a `Row` directly, and the hairline case above.

**It found two offenders on its first run.** One was its own KDoc, quoting the call it catches. The other was real: `PasskeyBrowserScreen` hand-copies a 26dp title bar and a 40dp top bar, with comments reading "matches BossTitleBar" and "matches main BossTopBar structure". Copies, so they would have kept saying 26 and 40 the first time a user picked Compact while the chrome they claim to match moved. They read the metrics now, which is what those comments were always asserting.

## `MIN_TOP_BAR` joins the floors that are pinned rather than argued

The `Compact` KDoc said the tallest thing in the top bar was the 22dp logo. That is not the binding constraint: the bar is built from icon-only `BossActionButton`s, which render at 28dp. 32 clears them, so the number was right and its stated basis was not, which is the same species of mistake the `MIN_STRIP_WIDTH` KDoc goes out of its way to warn about. The button size is a named constant now and the floor is pinned against it.

## `ChromeBudgetReadout` takes `dimens` as a parameter

It is composed above the `Column` that holds the bars, and PR C's most natural place to provide `LocalChromeDimens` is around that `Column`, which is *below* it. The failure would have been silent: the readout reporting `Comfortable` while the bars drew `Compact`. `mainPanelBudget` already refuses a default for the same reason, so this holds the same line, and the scaffold reads the metrics once and hands them to both.

Two smaller ones: the truthy set is hoisted out of `chromeBudgetReadoutEnabled` rather than allocated per call, and the readout's effect keys on `windowHeight > 0.dp` as well as the size bucket, because bucket 0 covers both the degenerate mid-layout size and any real size under 50dp, so a window whose first real size landed there would never re-key and never log.

## Verification

- `:composeApp:desktopTest` - **2678 tests, 249 classes, 0 failures**.
- `ChromeDimensConventionTest` is 4 new tests; the rest of the suite is unchanged, which is the claim: no pixels move.
- `ktlintCheck` and `detekt` clean.
