### PR TITLE
Right-click a sidebar icon for the plugin's menu, and let the drag ghost sit on the pointer

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/DraggableActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/DraggableActionButton.kt
@@ -2,10 +2,13 @@ package ai.rever.boss.components.buttons
 
 import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.overlays.contextMenu
+import ai.rever.boss.components.plugin.panelMenuItems
+import ai.rever.boss.components.plugin.rememberPanelMenuActions
 import ai.rever.boss.components.sidebar.rememberSidebarSettingsMenuItems
 import ai.rever.boss.plugin.api.Panel
 import ai.rever.boss.plugin.api.Panel.Companion.opposite
 import ai.rever.boss.plugin.api.SidebarItem
+import ai.rever.boss.window.LocalWindowId
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -38,8 +41,20 @@ fun BossDraggableComponent.DraggableActionButton(
     var componentPositionInWindow by remember { mutableStateOf<Offset?>(null) }
     var pendingDragStartOffset by remember { mutableStateOf<Offset?>(null) }
 
-    // Right-click (long-press on touch) → "Sidebar settings"
-    val settingsMenuItems = rememberSidebarSettingsMenuItems()
+    // Right-click (long-press on touch) → this plugin's own menu, i.e. the one its panel header
+    // offers behind the "…" kebab, plus the sidebar's own settings row. The rail icon IS the plugin
+    // as far as the user is concerned, and it is the only handle the plugin has while its panel is
+    // closed - reloading, updating or uninstalling it used to mean opening the panel first.
+    val panelMenu =
+        panelMenuItems(
+            panelId = item.pluginContentId,
+            windowId = LocalWindowId.current,
+            actions = rememberPanelMenuActions(item.pluginContentId),
+            onOpenAsTab = { requestOpenAsTab(currentItem.pluginContentId) },
+            // No Minimize row: the icon's own click already toggles the panel, and this menu opens
+            // just as often while the panel is closed, where minimising means nothing.
+            trailingItems = rememberSidebarSettingsMenuItems(),
+        )
 
     // Log recomposition state
 
@@ -81,7 +96,7 @@ fun BossDraggableComponent.DraggableActionButton(
                     }
                 }.size(40.dp)
                 .alpha(if (isBeingDragged) 0f else 1f)
-                .contextMenu(items = settingsMenuItems)
+                .contextMenu(items = panelMenu)
                 .pointerInput(Unit) {
                     // Keep Unit key
                     detectDragGesturesAfterLongPress(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/DraggableActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/DraggableActionButton.kt
@@ -2,13 +2,12 @@ package ai.rever.boss.components.buttons
 
 import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.overlays.contextMenu
+import ai.rever.boss.components.plugin.panelMenuActions
 import ai.rever.boss.components.plugin.panelMenuItems
-import ai.rever.boss.components.plugin.rememberPanelMenuActions
 import ai.rever.boss.components.sidebar.rememberSidebarSettingsMenuItems
 import ai.rever.boss.plugin.api.Panel
 import ai.rever.boss.plugin.api.Panel.Companion.opposite
 import ai.rever.boss.plugin.api.SidebarItem
-import ai.rever.boss.window.LocalWindowId
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -48,8 +47,9 @@ fun BossDraggableComponent.DraggableActionButton(
     val panelMenu =
         panelMenuItems(
             panelId = item.pluginContentId,
-            windowId = LocalWindowId.current,
-            actions = rememberPanelMenuActions(item.pluginContentId),
+            actions = panelMenuActions(item.pluginContentId),
+            // currentItem, not item: a native menu on macOS is an OS window that outlives the
+            // composition that opened it, so the row acts on whatever the icon stands for by then.
             onOpenAsTab = { requestOpenAsTab(currentItem.pluginContentId) },
             // No Minimize row: the icon's own click already toggles the panel, and this menu opens
             // just as often while the panel is closed, where minimising means nothing.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/DraggableActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/buttons/DraggableActionButton.kt
@@ -40,22 +40,6 @@ fun BossDraggableComponent.DraggableActionButton(
     var componentPositionInWindow by remember { mutableStateOf<Offset?>(null) }
     var pendingDragStartOffset by remember { mutableStateOf<Offset?>(null) }
 
-    // Right-click (long-press on touch) → this plugin's own menu, i.e. the one its panel header
-    // offers behind the "…" kebab, plus the sidebar's own settings row. The rail icon IS the plugin
-    // as far as the user is concerned, and it is the only handle the plugin has while its panel is
-    // closed - reloading, updating or uninstalling it used to mean opening the panel first.
-    val panelMenu =
-        panelMenuItems(
-            panelId = item.pluginContentId,
-            actions = panelMenuActions(item.pluginContentId),
-            // currentItem, not item: a native menu on macOS is an OS window that outlives the
-            // composition that opened it, so the row acts on whatever the icon stands for by then.
-            onOpenAsTab = { requestOpenAsTab(currentItem.pluginContentId) },
-            // No Minimize row: the icon's own click already toggles the panel, and this menu opens
-            // just as often while the panel is closed, where minimising means nothing.
-            trailingItems = rememberSidebarSettingsMenuItems(),
-        )
-
     // Log recomposition state
 
     LaunchedEffect(componentPositionInWindow, pendingDragStartOffset) {
@@ -96,8 +80,26 @@ fun BossDraggableComponent.DraggableActionButton(
                     }
                 }.size(40.dp)
                 .alpha(if (isBeingDragged) 0f else 1f)
-                .contextMenu(items = panelMenu)
-                .pointerInput(Unit) {
+                // Right-click (long-press on touch) → this plugin's own menu, i.e. the one its
+                // panel header offers behind the "…" kebab, plus the sidebar's own settings row.
+                // The rail icon IS the plugin as far as the user is concerned, and it is the only
+                // handle the plugin has while its panel is closed - reloading, updating or
+                // uninstalling it used to mean opening the panel first.
+                //
+                // Built lazily: this modifier is on every plugin icon in the rail, and resolving
+                // the menu eagerly held five registry subscriptions per icon and re-queried every
+                // plugin's contributed items on every plugin load, for panels nobody had opened.
+                .contextMenu {
+                    panelMenuItems(
+                        panelId = currentItem.pluginContentId,
+                        actions = panelMenuActions(currentItem.pluginContentId),
+                        onOpenAsTab = { requestOpenAsTab(currentItem.pluginContentId) },
+                        // No Minimize row: the icon's own click already toggles the panel, and this
+                        // menu opens just as often while the panel is closed, where minimising
+                        // means nothing.
+                        trailingItems = rememberSidebarSettingsMenuItems(),
+                    )
+                }.pointerInput(Unit) {
                     // Keep Unit key
                     detectDragGesturesAfterLongPress(
                         onDragStart = { touchOffset ->

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/ContextMenu.kt
@@ -741,6 +741,25 @@ private fun SubMenuContent(
 fun Modifier.contextMenu(
     enabled: Boolean = true,
     items: List<ContextMenuItem>,
+): Modifier = contextMenu(enabled) { items }
+
+/**
+ * [contextMenu] for a menu that is expensive to build, e.g. one derived from several registries.
+ *
+ * [items] is composed only while the menu is actually open, so a caller that would otherwise hold
+ * flow subscriptions for a menu nobody has asked for pays nothing until the right-click. That is not
+ * a micro-optimisation where the caller is repeated: the sidebar rail attaches one of these to every
+ * plugin icon, and the eager form cost five `collectAsState` subscriptions per icon and re-queried
+ * every plugin's contributed items on every plugin load, for panels the user had never opened.
+ *
+ * The catch, for anyone writing a provider: it is composed inside the open-menu branch, so anything
+ * remembered in it dies when the menu closes - including a `rememberCoroutineScope`, which the menu
+ * closing on the very click that launched the work would then cancel. Work started from a menu row
+ * has to be owned by something that outlives the menu.
+ */
+fun Modifier.contextMenu(
+    enabled: Boolean = true,
+    items: @Composable () -> List<ContextMenuItem>,
 ): Modifier =
     composed {
         var showMenu by remember { mutableStateOf(false) }
@@ -751,7 +770,7 @@ fun Modifier.contextMenu(
 
         if (showMenu && enabled) {
             ContextMenu(
-                items = items,
+                items = items(),
                 offset = menuPosition,
                 onDismissRequest = { showMenu = false },
             )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/DraggingItemOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/DraggingItemOverlay.kt
@@ -32,20 +32,19 @@ fun BossDraggableComponent.DraggingItemOverlay() {
         // Calculate the current absolute position
         val currentPosition = startPosition + delta
 
-        // Calculate the offset to center the ghost icon on the pointer
-        val iconSizePx = with(LocalDensity.current) { GHOST_ICON_SIZE.toPx() }
-        val centeredOffset = Offset(currentPosition.x - iconSizePx / 2, currentPosition.y - iconSizePx / 2)
+        // Centred on the pointer: the icon is being carried, so the pointer holds its middle. The
+        // two paths take it from the same value rather than each doing the arithmetic - stated
+        // twice, they drift, and the drift shows up only in whichever rendering mode you are not in.
+        val hotspot = DpOffset(GHOST_ICON_SIZE / 2, GHOST_ICON_SIZE / 2)
+        val hotspotPx = with(LocalDensity.current) { Offset(hotspot.x.toPx(), hotspot.y.toPx()) }
 
         // Under HARDWARE the browser's native surface paints over the Compose scene, so this ghost
         // disappeared as soon as the drag crossed a page. OverlayGhost gives it its own
         // cursor-tracking window there; on OFF_SCREEN it is the same offset Box as before.
         OverlayGhost(
             size = DpSize(GHOST_ICON_SIZE, GHOST_ICON_SIZE),
-            // Centred on the pointer: the icon is being carried, so the pointer holds its middle.
-            // Same statement as centeredOffset below, in the units the ghost's own window needs.
-            hotspot = DpOffset(GHOST_ICON_SIZE / 2, GHOST_ICON_SIZE / 2),
-            // Position the ghost based on calculated absolute position, centered
-            windowOffset = { centeredOffset.round() },
+            hotspot = hotspot,
+            windowOffset = { (currentPosition - hotspotPx).round() },
         ) {
             Box(
                 modifier = Modifier.alpha(0.7f), // Apply transparency

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/DraggingItemOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/DraggingItemOverlay.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
@@ -40,6 +41,9 @@ fun BossDraggableComponent.DraggingItemOverlay() {
         // cursor-tracking window there; on OFF_SCREEN it is the same offset Box as before.
         OverlayGhost(
             size = DpSize(GHOST_ICON_SIZE, GHOST_ICON_SIZE),
+            // Centred on the pointer: the icon is being carried, so the pointer holds its middle.
+            // Same statement as centeredOffset below, in the units the ghost's own window needs.
+            hotspot = DpOffset(GHOST_ICON_SIZE / 2, GHOST_ICON_SIZE / 2),
             // Position the ghost based on calculated absolute position, centered
             windowOffset = { centeredOffset.round() },
         ) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -298,9 +298,9 @@ internal fun overlayCornerIsHeavyweight(): Boolean = routeOverlayHeavyweight(Ove
  * title-bar height), which reading the cursor avoids entirely.
  *
  * [hotspot] is the same placement stated in the only terms the heavyweight path can use: where the
- * POINTER sits inside the ghost, measured from its top-left. It must agree with [windowOffset] - the
- * two are one decision expressed twice, and a caller that changes one without the other gets a ghost
- * that jumps when the browser's rendering mode changes.
+ * POINTER sits inside the ghost, measured from its top-left. Both callers derive [windowOffset] from
+ * it rather than stating the placement twice: expressed twice they drift, and the drift is visible
+ * only in whichever rendering mode the person changing it is not running.
  */
 @Composable
 fun OverlayGhost(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/OverlayConfig.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -122,15 +123,17 @@ object OverlayConfig {
 
     /**
      * Platform-injected heavyweight GHOST renderer - a **content-sized**, non-focusable window of
-     * [size] that follows the cursor, offset by a gap so the pointer never lands on it.
+     * [size] that follows the cursor, with the pointer sitting at `hotspot` inside it.
      *
-     * The gap is load-bearing rather than cosmetic: the JVM has no portable click-through, so a
-     * ghost sitting under the cursor would swallow the drag that is moving it. Null until injected;
-     * callers fall back to drawing in place.
+     * The hotspot is what keeps the two paths agreeing about where a ghost is: the lightweight one
+     * positions itself in the caller's own coordinates, so without it the heavyweight ghost drifts
+     * off the pointer by however far the caller's own offset would have moved it. Null until
+     * injected; callers fall back to drawing in place.
      */
     var heavyweightGhost: (
         @Composable (
             size: DpSize,
+            hotspot: DpOffset,
             content: @Composable () -> Unit,
         ) -> Unit
     )? = null
@@ -293,16 +296,22 @@ internal fun overlayCornerIsHeavyweight(): Boolean = routeOverlayHeavyweight(Ove
  * ghost's own window has to be placed in SCREEN coordinates, and converting from a Compose offset
  * means going through the content pane rather than the window (via the window it is off by the
  * title-bar height), which reading the cursor avoids entirely.
+ *
+ * [hotspot] is the same placement stated in the only terms the heavyweight path can use: where the
+ * POINTER sits inside the ghost, measured from its top-left. It must agree with [windowOffset] - the
+ * two are one decision expressed twice, and a caller that changes one without the other gets a ghost
+ * that jumps when the browser's rendering mode changes.
  */
 @Composable
 fun OverlayGhost(
     size: DpSize,
+    hotspot: DpOffset,
     windowOffset: () -> IntOffset,
     content: @Composable () -> Unit,
 ) {
     val hw = OverlayConfig.heavyweightGhost
     if (routeOverlayHeavyweight(hw != null) && hw != null) {
-        hw(size) { content() }
+        hw(size, hotspot) { content() }
     } else {
         Box(modifier = Modifier.offset { windowOffset() }) { content() }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/TabDraggingOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/TabDraggingOverlay.kt
@@ -44,17 +44,13 @@ fun TabDraggableComponent.TabDraggingOverlay() {
 
     val currentPosition = startPosition + delta
 
-    // Offset to position the ghost tab with its left edge near the cursor
-    val density = LocalDensity.current
-    val tabWidthPx = with(density) { GHOST_WIDTH.toPx() }
-    val tabHeightPx = with(density) { GHOST_HEIGHT.toPx() }
-
-    // Position slightly offset from cursor so user can see where they're dropping
-    val offsetPosition =
-        Offset(
-            currentPosition.x - tabWidthPx / 4,
-            currentPosition.y - tabHeightPx / 2,
-        )
+    // Where the pointer sits inside the ghost card: a quarter in from the leading edge, vertically
+    // centred, so the drop point is visible beside it. Both paths take it from this one value -
+    // stated twice, they drift, and the drift shows up only in whichever rendering mode you are not
+    // in.
+    val hotspot = DpOffset(GHOST_WIDTH / 4, GHOST_HEIGHT / 2)
+    val hotspotPx = with(LocalDensity.current) { Offset(hotspot.x.toPx(), hotspot.y.toPx()) }
+    val offsetPosition = currentPosition - hotspotPx
 
     // OverlayGhost puts the ghost in its own cursor-tracking window under HARDWARE, where the
     // browser's native surface would otherwise paint over it - so the ghost used to vanish for
@@ -62,9 +58,7 @@ fun TabDraggableComponent.TabDraggingOverlay() {
     // it has always been.
     OverlayGhost(
         size = DpSize(GHOST_WIDTH, GHOST_HEIGHT),
-        // The same placement offsetPosition above expresses, from the ghost's corner instead of the
-        // cursor's: a quarter in from the leading edge, vertically centred.
-        hotspot = DpOffset(GHOST_WIDTH / 4, GHOST_HEIGHT / 2),
+        hotspot = hotspot,
         windowOffset = { IntOffset(offsetPosition.x.toInt(), offsetPosition.y.toInt()) },
     ) {
         Box(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/TabDraggingOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/overlays/TabDraggingOverlay.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -61,6 +62,9 @@ fun TabDraggableComponent.TabDraggingOverlay() {
     // it has always been.
     OverlayGhost(
         size = DpSize(GHOST_WIDTH, GHOST_HEIGHT),
+        // The same placement offsetPosition above expresses, from the ghost's corner instead of the
+        // cursor's: a quarter in from the leading edge, vertically centred.
+        hotspot = DpOffset(GHOST_WIDTH / 4, GHOST_HEIGHT / 2),
         windowOffset = { IntOffset(offsetPosition.x.toInt(), offsetPosition.y.toInt()) },
     ) {
         Box(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelMenuActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelMenuActions.kt
@@ -57,6 +57,9 @@ data class PanelMenuActions(
  * The actions available for [panelId], derived from the plugin registries and the current user's
  * RBAC snapshot.
  *
+ * Not a `remember`, deliberately and by name: the callbacks close over this composition's panel and
+ * window, so they are rebuilt each pass and nothing downstream should key on their identity.
+ *
  * Lives here rather than in the panel header because the header is no longer the only place that
  * offers them: the sidebar rail's icon is the same plugin, and right-clicking it has to reach the
  * same menu whether or not the panel is currently showing. Resolving it in one composable is what
@@ -68,7 +71,7 @@ data class PanelMenuActions(
  * one.
  */
 @Composable
-fun rememberPanelMenuActions(panelId: PanelId?): PanelMenuActions {
+fun panelMenuActions(panelId: PanelId?): PanelMenuActions {
     val windowId = LocalWindowId.current
     val pluginId = panelId?.let { LocalPanelPluginIdResolver.current(it) }
 
@@ -80,7 +83,7 @@ fun rememberPanelMenuActions(panelId: PanelId?): PanelMenuActions {
     // Uninstall is offered for every plugin panel and disabled for the ones the manager refuses to
     // unload, so a system plugin shows why the action is unavailable instead of hiding it.
     val uninstallable = LocalPluginUninstallable.current
-    val evolver = rememberEvolverActions(pluginId)
+    val evolver = evolverActions(pluginId)
     val buildInfo = pluginId?.let { pluginBuilds[it] }
 
     if (panelId == null || windowId == null) {
@@ -132,7 +135,7 @@ private data class EvolverActions(
  * (holds the permission, or is admin). Both dispatch evolver_open with the right section.
  */
 @Composable
-private fun rememberEvolverActions(pluginId: String?): EvolverActions {
+private fun evolverActions(pluginId: String?): EvolverActions {
     val registeredMcpTools by McpToolRegistryImpl.tools.collectAsState()
     val menuScope = rememberCoroutineScope()
     val logger = remember { BossLogger.forComponent("PanelMenu") }
@@ -187,12 +190,15 @@ private fun rememberEvolverActions(pluginId: String?): EvolverActions {
 @Composable
 fun panelMenuItems(
     panelId: PanelId?,
-    windowId: String?,
     actions: PanelMenuActions,
     onOpenAsTab: (() -> Unit)? = null,
     onMinimize: (() -> Unit)? = null,
     trailingItems: List<ContextMenuItem> = emptyList(),
 ): List<ContextMenuItem> {
+    // The window is read here rather than taken as a parameter: [panelMenuActions] reads the same
+    // local for the built-in rows, and two sources for one window is a way for the built-ins and the
+    // contributed rows to end up addressed at different windows with nothing to catch it.
+    val windowId = LocalWindowId.current
     val contributions by PanelMenuRegistryImpl.contributions.collectAsState()
     val access by PanelMenuRegistryImpl.access.collectAsState()
     val pluginEntries =
@@ -222,9 +228,10 @@ fun panelMenuItems(
         addContributedRows(pluginEntries, panelId, windowId)
         onMinimize?.let { add(row("Minimize", Icons.Outlined.Remove, it)) }
         if (trailingItems.isNotEmpty()) {
-            // Only a separator when there is something to separate: a panel that offers no actions
-            // of its own would otherwise open its menu with a divider as the first row.
-            if (isNotEmpty()) add(ContextMenuItem(isDivider = true))
+            // Only a separator when there is something to separate, and never a second one: a panel
+            // that offers no actions of its own would otherwise open its menu with a divider as the
+            // first row, and one that ends in a divider would show two rules in a row.
+            if (isNotEmpty() && !last().isDivider) add(ContextMenuItem(isDivider = true))
             addAll(trailingItems)
         }
     }
@@ -262,16 +269,24 @@ private fun MutableList<ContextMenuItem>.addBuildRows(actions: PanelMenuActions)
     add(ContextMenuItem(isDivider = true))
 }
 
-/** The plugin's own contributed rows, after the built-ins and behind a divider. */
+/**
+ * The plugin's own contributed rows, after the built-ins and behind a divider.
+ *
+ * The disabled ones are dropped BEFORE the divider is decided. Deciding on `entries` and skipping
+ * inside the loop leaves a contribution whose items are all disabled adding a divider with nothing
+ * under it - and on the rail that divider then satisfies the "is there anything to separate" guard
+ * for the trailing rows, so the menu shows two rules in a row and then "Sidebar settings".
+ */
 private fun MutableList<ContextMenuItem>.addContributedRows(
     entries: List<Pair<PanelMenuContribution, PanelMenuItem>>,
     panelId: PanelId?,
     windowId: String?,
 ) {
-    if (entries.isEmpty() || panelId == null) return
+    if (panelId == null) return
+    val visible = entries.filter { (_, item) -> item.enabled }
+    if (visible.isEmpty()) return
     add(ContextMenuItem(isDivider = true))
-    for ((contribution, item) in entries) {
-        if (!item.enabled) continue
+    for ((contribution, item) in visible) {
         add(
             row(item.label, item.icon, {
                 PanelMenuRegistryImpl.onItemClick(contribution, panelId, item.id, windowId)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelMenuActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelMenuActions.kt
@@ -1,0 +1,281 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.components.bars.horizontal.StatusMessageManager
+import ai.rever.boss.components.overlays.ContextMenuItem
+import ai.rever.boss.components.plugin.registries.PanelMenuRegistryImpl
+import ai.rever.boss.mcp.EvolverContract
+import ai.rever.boss.mcp.McpToolRegistryImpl
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelMenuContribution
+import ai.rever.boss.plugin.api.PanelMenuItem
+import ai.rever.boss.plugin.sandbox.PanelSandboxRegistry
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.LocalWindowId
+import ai.rever.boss.window.MenuActionsHandler
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BugReport
+import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.outlined.DeleteOutline
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.MonitorHeart
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Remove
+import androidx.compose.material.icons.outlined.Tab
+import androidx.compose.material.icons.outlined.Upgrade
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Everything the panel menu can do to one plugin panel, resolved from the host's registries.
+ *
+ * A null callback means "not offered here": the panel has no resolvable window, the plugin exposes
+ * no evolver tools to this user, and so on. Every consumer treats null as "leave the row out", so a
+ * row named as an imperative never appears while silently doing nothing.
+ */
+data class PanelMenuActions(
+    val pluginId: String? = null,
+    val buildInfo: PluginBuildInfo? = null,
+    val updateAvailable: AvailablePluginUpdate? = null,
+    val installStoreVersion: (() -> Unit)? = null,
+    val reloadPanel: (() -> Unit)? = null,
+    val checkForUpdates: (() -> Unit)? = null,
+    val openEvolver: (() -> Unit)? = null,
+    val reportIssue: (() -> Unit)? = null,
+    val uninstallPlugin: (() -> Unit)? = null,
+    val uninstallEnabled: Boolean = false,
+)
+
+/**
+ * The actions available for [panelId], derived from the plugin registries and the current user's
+ * RBAC snapshot.
+ *
+ * Lives here rather than in the panel header because the header is no longer the only place that
+ * offers them: the sidebar rail's icon is the same plugin, and right-clicking it has to reach the
+ * same menu whether or not the panel is currently showing. Resolving it in one composable is what
+ * keeps the two from drifting - each registry is collected rather than read once, so a hot reload,
+ * an update landing or a role change re-derives both at the same moment.
+ *
+ * Everything is left out when there is no panel to act on, or no window to route through:
+ * `LocalWindowId` is null outside a tracked window, and every one of these actions is addressed to
+ * one.
+ */
+@Composable
+fun rememberPanelMenuActions(panelId: PanelId?): PanelMenuActions {
+    val windowId = LocalWindowId.current
+    val pluginId = panelId?.let { LocalPanelPluginIdResolver.current(it) }
+
+    // Plugin update availability for this panel's owning plugin (host-compatible updates only), and
+    // which build it is running. Collected, so the rows track a hot reload or an update landing.
+    val availableUpdates by PluginUpdateRegistry.updates.collectAsState()
+    val pluginBuilds by PluginBuildRegistry.builds.collectAsState()
+
+    // Uninstall is offered for every plugin panel and disabled for the ones the manager refuses to
+    // unload, so a system plugin shows why the action is unavailable instead of hiding it.
+    val uninstallable = LocalPluginUninstallable.current
+    val evolver = rememberEvolverActions(pluginId)
+    val buildInfo = pluginId?.let { pluginBuilds[it] }
+
+    if (panelId == null || windowId == null) {
+        return PanelMenuActions(pluginId = pluginId, buildInfo = buildInfo)
+    }
+
+    return PanelMenuActions(
+        pluginId = pluginId,
+        buildInfo = buildInfo,
+        updateAvailable = pluginId?.let { availableUpdates[it] },
+        installStoreVersion =
+            if (buildInfo?.isTagged == true) {
+                { MenuActionsHandler.triggerInstallStoreVersion(windowId, panelId) }
+            } else {
+                null
+            },
+        reloadPanel = {
+            // Clear the sandbox's consecutive-error count first: a reload replaces the code that was
+            // failing, so carrying its error tally over would leave a freshly loaded plugin one
+            // fault away from being quarantined.
+            PanelSandboxRegistry.getSandbox(panelId)?.resetHealth()
+            MenuActionsHandler.triggerReloadPlugin(windowId, panelId)
+        },
+        checkForUpdates = { MenuActionsHandler.triggerCheckPluginUpdates(windowId, panelId) },
+        openEvolver = evolver.openEvolver,
+        reportIssue = evolver.reportIssue,
+        uninstallPlugin =
+            if (pluginId != null) {
+                { MenuActionsHandler.triggerUninstallPlugin(windowId, panelId) }
+            } else {
+                null
+            },
+        uninstallEnabled = pluginId != null && uninstallable(pluginId),
+    )
+}
+
+/** The two Tool Evolver rows, which are gated differently from everything else. */
+private data class EvolverActions(
+    val openEvolver: (() -> Unit)? = null,
+    val reportIssue: (() -> Unit)? = null,
+)
+
+/**
+ * The evolver rows for [pluginId], gated via the (RBAC-filtered) MCP registry, with no compile-time
+ * coupling to the plugin.
+ *
+ * "Report Issue" shows whenever the plugin is active (evolver_open is ungated). "Open Evolver" shows
+ * only when the permission-gated evolver_evolve tool is exposed, i.e. the current user may evolve
+ * (holds the permission, or is admin). Both dispatch evolver_open with the right section.
+ */
+@Composable
+private fun rememberEvolverActions(pluginId: String?): EvolverActions {
+    val registeredMcpTools by McpToolRegistryImpl.tools.collectAsState()
+    val menuScope = rememberCoroutineScope()
+    val logger = remember { BossLogger.forComponent("PanelMenu") }
+
+    if (pluginId == null) return EvolverActions()
+
+    val dispatch: (String?, String) -> Unit = { section, failLabel ->
+        menuScope.launch {
+            val args =
+                buildJsonObject {
+                    put(EvolverContract.ARG_PLUGIN_ID, pluginId)
+                    if (section != null) put(EvolverContract.ARG_SECTION, section)
+                }.toString()
+            val result = McpToolRegistryImpl.invoke(EvolverContract.OPEN_TOOL, args)
+            if (result.isError) {
+                logger.warn(
+                    LogCategory.UI,
+                    "$failLabel failed",
+                    mapOf("pluginId" to pluginId, "error" to result.text),
+                )
+                StatusMessageManager.showMessage("$failLabel failed: ${result.text}", durationMs = 5000)
+            }
+        }
+    }
+
+    val exposes = { tool: String -> registeredMcpTools.any { it.definition.name == tool } }
+    return EvolverActions(
+        openEvolver = if (exposes(EvolverContract.EVOLVE_TOOL)) ({ dispatch(null, "Open Evolver") }) else null,
+        reportIssue =
+            if (exposes(EvolverContract.OPEN_TOOL)) {
+                { dispatch(EvolverContract.SECTION_ISSUE, "Report Issue") }
+            } else {
+                null
+            },
+    )
+}
+
+/**
+ * One menu definition for a plugin panel, shared by the header's "…" kebab, the header's right-click
+ * menu and the sidebar rail icon's right-click menu, so none of the three can offer a different set.
+ *
+ * Plugin-contributed items (PanelMenuRegistry) render between the built-ins and [onMinimize]; the
+ * registry map and the RBAC snapshot trigger a re-query, so they track plugin lifecycle and role
+ * changes. Contributions change their item set by re-registering (items() must stay cheap - see
+ * PanelMenuContribution).
+ *
+ * [onOpenAsTab] and [onMinimize] are the two rows that depend on where the menu was opened rather
+ * than on the plugin, so they are passed in: the rail has no panel on screen to minimize.
+ * [trailingItems] is for rows that belong to the surface rather than to the panel, e.g. the rail's
+ * "Sidebar settings".
+ */
+@Composable
+fun panelMenuItems(
+    panelId: PanelId?,
+    windowId: String?,
+    actions: PanelMenuActions,
+    onOpenAsTab: (() -> Unit)? = null,
+    onMinimize: (() -> Unit)? = null,
+    trailingItems: List<ContextMenuItem> = emptyList(),
+): List<ContextMenuItem> {
+    val contributions by PanelMenuRegistryImpl.contributions.collectAsState()
+    val access by PanelMenuRegistryImpl.access.collectAsState()
+    val pluginEntries =
+        if (panelId != null) {
+            remember(panelId, contributions, access) {
+                PanelMenuRegistryImpl.itemsFor(panelId)
+            }
+        } else {
+            emptyList()
+        }
+
+    return buildList {
+        addBuildRows(actions)
+        // "Reload Panel" is the user-facing name for what is really a reload of the owning plugin:
+        // the jar is unloaded and re-read, and every window's slots for it are reset. Named for the
+        // thing the user is pointing at, since this menu belongs to one panel.
+        actions.reloadPanel?.let { add(row("Reload Panel", Icons.Outlined.Refresh, it)) }
+        actions.checkForUpdates?.let { add(row("Check for Updates", Icons.Outlined.Upgrade, it)) }
+        actions.openEvolver?.let { add(row("Open Evolver", Icons.Outlined.MonitorHeart, it)) }
+        actions.reportIssue?.let { add(row("Report Issue", Icons.Outlined.BugReport, it)) }
+        onOpenAsTab?.let { add(row("Open as Tab", Icons.Outlined.Tab, it)) }
+        // Shown for every plugin panel, disabled for the ones the manager refuses to unload (system
+        // plugins), so the action's absence is never mistaken for the feature missing.
+        actions.uninstallPlugin?.let {
+            add(row("Uninstall Plugin", Icons.Outlined.DeleteOutline, it).copy(enabled = actions.uninstallEnabled))
+        }
+        addContributedRows(pluginEntries, panelId, windowId)
+        onMinimize?.let { add(row("Minimize", Icons.Outlined.Remove, it)) }
+        if (trailingItems.isNotEmpty()) {
+            // Only a separator when there is something to separate: a panel that offers no actions
+            // of its own would otherwise open its menu with a divider as the first row.
+            if (isNotEmpty()) add(ContextMenuItem(isDivider = true))
+            addAll(trailingItems)
+        }
+    }
+}
+
+private fun row(
+    text: String,
+    icon: ImageVector?,
+    onClick: () -> Unit,
+) = ContextMenuItem(text = text, icon = icon, onClick = onClick)
+
+/**
+ * Which build is running, first and clickable, for a plugin that is not on the released version.
+ *
+ * The version has to be the item's TEXT rather than a badge widget: with no trailing icon this menu
+ * is native-representable, so on macOS it renders as a real NSMenu, whose items carry a label, an
+ * enabled flag and a rasterised leading icon - but nothing that is a widget, which is what a badge
+ * would need.
+ *
+ * Both rows are gated on the action existing, not merely on the build being tagged:
+ * [PanelMenuActions.installStoreVersion] is null whenever the panel has no resolvable window, and a
+ * row named as an imperative that silently does nothing is a worse failure than no row at all. The
+ * tag itself is inert in exactly that case.
+ */
+private fun MutableList<ContextMenuItem>.addBuildRows(actions: PanelMenuActions) {
+    val installStoreVersion = actions.installStoreVersion ?: return
+    val taggedBuild = actions.buildInfo?.takeIf { it.isTagged } ?: return
+
+    add(row("Version ${taggedBuild.displayVersion}", Icons.Outlined.Info, installStoreVersion))
+    // The way back to the released build, named as the action it is. The version row above already
+    // carries it, but that row reads as a statement of fact, so the only discoverable route was
+    // clicking the tag - and the tag is a 9sp pill that is the first thing to run out of room once
+    // the panel narrows.
+    add(row("Install Store Version", Icons.Outlined.CloudDownload, installStoreVersion))
+    add(ContextMenuItem(isDivider = true))
+}
+
+/** The plugin's own contributed rows, after the built-ins and behind a divider. */
+private fun MutableList<ContextMenuItem>.addContributedRows(
+    entries: List<Pair<PanelMenuContribution, PanelMenuItem>>,
+    panelId: PanelId?,
+    windowId: String?,
+) {
+    if (entries.isEmpty() || panelId == null) return
+    add(ContextMenuItem(isDivider = true))
+    for ((contribution, item) in entries) {
+        if (!item.enabled) continue
+        add(
+            row(item.label, item.icon, {
+                PanelMenuRegistryImpl.onItemClick(contribution, panelId, item.id, windowId)
+            }),
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelMenuActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PanelMenuActions.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.vector.ImageVector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -66,9 +68,11 @@ data class PanelMenuActions(
  * keeps the two from drifting - each registry is collected rather than read once, so a hot reload,
  * an update landing or a role change re-derives both at the same moment.
  *
- * Everything is left out when there is no panel to act on, or no window to route through:
- * `LocalWindowId` is null outside a tracked window, and every one of these actions is addressed to
- * one.
+ * Everything is left out when there is no panel to act on, no window to route through, or no plugin
+ * behind the panel. All three are load-bearing: `LocalWindowId` is null outside a tracked window,
+ * and every handler in `BossAppMenuActionEffects` resolves the panel's plugin and gives up silently
+ * when it cannot - so a panel with no resolvable plugin would otherwise show Reload Panel and Check
+ * for Updates as rows that do nothing at all, which is what this file's own rule rules out.
  */
 @Composable
 fun panelMenuActions(panelId: PanelId?): PanelMenuActions {
@@ -86,14 +90,14 @@ fun panelMenuActions(panelId: PanelId?): PanelMenuActions {
     val evolver = evolverActions(pluginId)
     val buildInfo = pluginId?.let { pluginBuilds[it] }
 
-    if (panelId == null || windowId == null) {
+    if (panelId == null || windowId == null || pluginId == null) {
         return PanelMenuActions(pluginId = pluginId, buildInfo = buildInfo)
     }
 
     return PanelMenuActions(
         pluginId = pluginId,
         buildInfo = buildInfo,
-        updateAvailable = pluginId?.let { availableUpdates[it] },
+        updateAvailable = availableUpdates[pluginId],
         installStoreVersion =
             if (buildInfo?.isTagged == true) {
                 { MenuActionsHandler.triggerInstallStoreVersion(windowId, panelId) }
@@ -110,15 +114,22 @@ fun panelMenuActions(panelId: PanelId?): PanelMenuActions {
         checkForUpdates = { MenuActionsHandler.triggerCheckPluginUpdates(windowId, panelId) },
         openEvolver = evolver.openEvolver,
         reportIssue = evolver.reportIssue,
-        uninstallPlugin =
-            if (pluginId != null) {
-                { MenuActionsHandler.triggerUninstallPlugin(windowId, panelId) }
-            } else {
-                null
-            },
-        uninstallEnabled = pluginId != null && uninstallable(pluginId),
+        uninstallPlugin = { MenuActionsHandler.triggerUninstallPlugin(windowId, panelId) },
+        uninstallEnabled = uninstallable(pluginId),
     )
 }
+
+private val menuLogger = BossLogger.forComponent("PanelMenu")
+
+/**
+ * Where work started from a menu row runs.
+ *
+ * NOT a `rememberCoroutineScope`: the menu is composed only while it is open (see the deferred
+ * `Modifier.contextMenu`), and it closes on the very click that starts this work - so a scope owned
+ * by the menu would cancel the MCP call before it returned, and the row would do nothing with no
+ * error to show for it. Supervised, so one failed dispatch cannot take the next one down with it.
+ */
+private val menuActionScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 /** The two Tool Evolver rows, which are gated differently from everything else. */
 private data class EvolverActions(
@@ -137,13 +148,11 @@ private data class EvolverActions(
 @Composable
 private fun evolverActions(pluginId: String?): EvolverActions {
     val registeredMcpTools by McpToolRegistryImpl.tools.collectAsState()
-    val menuScope = rememberCoroutineScope()
-    val logger = remember { BossLogger.forComponent("PanelMenu") }
 
     if (pluginId == null) return EvolverActions()
 
     val dispatch: (String?, String) -> Unit = { section, failLabel ->
-        menuScope.launch {
+        menuActionScope.launch {
             val args =
                 buildJsonObject {
                     put(EvolverContract.ARG_PLUGIN_ID, pluginId)
@@ -151,7 +160,7 @@ private fun evolverActions(pluginId: String?): EvolverActions {
                 }.toString()
             val result = McpToolRegistryImpl.invoke(EvolverContract.OPEN_TOOL, args)
             if (result.isError) {
-                logger.warn(
+                menuLogger.warn(
                     LogCategory.UI,
                     "$failLabel failed",
                     mapOf("pluginId" to pluginId, "error" to result.text),

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/registries/PanelMenuRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/registries/PanelMenuRegistryImpl.kt
@@ -83,11 +83,12 @@ object PanelMenuRegistryImpl : AccessGatedRegistry {
      *
      * Called wherever a panel menu is BUILT, which is not the same as opened -
      * matching what `PanelMenuContribution.items` already promises callers. The
-     * panel header builds one per composition, and since BossConsole#253 so does
-     * every sidebar rail icon, including panels that have never been opened. Each
-     * is memoised on (panelId, contributions, access), so this runs on plugin
-     * lifecycle and role changes rather than per frame - but `items()` must stay
-     * cheap, and is now called more often than "when a menu opens" suggested.
+     * panel header builds one per composition whether or not anyone opens it;
+     * the sidebar rail icon builds one only while its right-click menu is up,
+     * which is why that menu is passed to `Modifier.contextMenu` as a provider
+     * rather than a list. Each is memoised on (panelId, contributions, access),
+     * so this runs on plugin lifecycle and role changes rather than per frame.
+     * `items()` must still be cheap.
      */
     fun itemsFor(panelId: PanelId): List<Pair<PanelMenuContribution, PanelMenuItem>> {
         val access = _access.value

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/registries/PanelMenuRegistryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/registries/PanelMenuRegistryImpl.kt
@@ -79,8 +79,15 @@ object PanelMenuRegistryImpl : AccessGatedRegistry {
     /**
      * Resolve the visible menu items for [panelId]: query each targeting
      * contribution (outside any lock, crash-isolated), RBAC-filter, sort by
-     * [PanelMenuItem.order]. Called when a menu opens — contributions must
-     * keep `items()` cheap.
+     * [PanelMenuItem.order].
+     *
+     * Called wherever a panel menu is BUILT, which is not the same as opened -
+     * matching what `PanelMenuContribution.items` already promises callers. The
+     * panel header builds one per composition, and since BossConsole#253 so does
+     * every sidebar rail icon, including panels that have never been opened. Each
+     * is memoised on (panelId, contributions, access), so this runs on plugin
+     * lifecycle and role changes rather than per frame - but `items()` must stay
+     * cheap, and is now called more often than "when a menu opens" suggested.
      */
     fun itemsFor(panelId: PanelId): List<Pair<PanelMenuContribution, PanelMenuItem>> {
         val access = _access.value

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
@@ -2,11 +2,11 @@ package ai.rever.boss.components.window_panel.components
 
 import ai.rever.boss.components.buttons.BossActionButton
 import ai.rever.boss.components.overlays.ContextMenu
+import ai.rever.boss.components.overlays.ContextMenuItem
 import ai.rever.boss.components.overlays.contextMenu
-import ai.rever.boss.components.plugin.AvailablePluginUpdate
 import ai.rever.boss.components.plugin.PanelMenuActions
-import ai.rever.boss.components.plugin.PluginBuildInfo
 import ai.rever.boss.components.plugin.PluginBuildTag
+import ai.rever.boss.components.plugin.panelMenuActions
 import ai.rever.boss.components.plugin.panelMenuItems
 import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.api.PanelId
@@ -43,20 +43,17 @@ private val UpdateBadgeColor: Color get() = BossThemeColors.SuccessColor
 fun BossPanelTopBar(
     title: String?,
     isHovered: Boolean,
-    onReloadPlugin: (() -> Unit)? = null,
+    /**
+     * What this panel's plugin can be told to do, from [panelMenuActions].
+     *
+     * One parameter rather than ten pass-throughs, because unpacking it here and repacking it for
+     * the menu is the drift this type exists to remove: a field added to [PanelMenuActions] would
+     * reach the rail and silently not the header until someone threaded another argument.
+     */
+    actions: PanelMenuActions = PanelMenuActions(),
     onOpenAsTab: (() -> Unit)? = null,
-    onCheckForUpdates: (() -> Unit)? = null,
-    onOpenEvolver: (() -> Unit)? = null,
-    onReportIssue: (() -> Unit)? = null,
-    onUninstallPlugin: (() -> Unit)? = null,
-    uninstallEnabled: Boolean = true,
     onMinimize: () -> Unit,
-    updateAvailable: AvailablePluginUpdate? = null,
-    onUpdateClick: (() -> Unit)? = null,
-    buildInfo: PluginBuildInfo? = null,
-    onBuildTagClick: (() -> Unit)? = null,
     panelId: PanelId? = null,
-    windowId: String? = null,
     dragModifier: Modifier = Modifier,
     content: (@Composable () -> Unit)? = null,
 ) {
@@ -65,19 +62,7 @@ fun BossPanelTopBar(
     val menuItems =
         panelMenuItems(
             panelId = panelId,
-            windowId = windowId,
-            actions =
-                PanelMenuActions(
-                    buildInfo = buildInfo,
-                    updateAvailable = updateAvailable,
-                    installStoreVersion = onBuildTagClick,
-                    reloadPanel = onReloadPlugin,
-                    checkForUpdates = onCheckForUpdates,
-                    openEvolver = onOpenEvolver,
-                    reportIssue = onReportIssue,
-                    uninstallPlugin = onUninstallPlugin,
-                    uninstallEnabled = uninstallEnabled,
-                ),
+            actions = actions,
             onOpenAsTab = onOpenAsTab,
             onMinimize = onMinimize,
         )
@@ -121,85 +106,114 @@ fun BossPanelTopBar(
             // Next to the name, not out at the edge: the tag qualifies which build of this panel you
             // are looking at, so it belongs with the thing it qualifies. Not hover-gated - a panel
             // running unreleased code should say so whether or not the pointer is over it.
-            if (buildInfo?.isTagged == true) {
+            if (actions.buildInfo?.isTagged == true) {
                 Spacer(modifier = Modifier.width(6.dp))
                 PluginBuildTag(
-                    info = buildInfo,
-                    onClick = onBuildTagClick,
+                    info = actions.buildInfo,
+                    onClick = actions.installStoreVersion,
                 )
             }
         }
 
-        // "Update available" badge — always visible (not hover-gated) when a compatible update
-        // exists for this plugin. Clicking it prompts to update.
-        if (updateAvailable != null) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+        UpdateBadge(actions)
+
+        HeaderControls(
+            isHovered = isHovered,
+            menuItems = menuItems,
+            onMinimize = onMinimize,
+            content = content,
+        )
+    }
+}
+
+/**
+ * The "update available" badge, shown whenever a host-compatible update exists for this panel's
+ * plugin.
+ *
+ * Not hover-gated, unlike the controls beside it: an update the user can take is worth saying while
+ * the pointer is elsewhere. Clicking it goes to the same place "Check for Updates" does.
+ */
+@Composable
+private fun RowScope.UpdateBadge(actions: PanelMenuActions) {
+    val updateAvailable = actions.updateAvailable ?: return
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier
+                .padding(end = 4.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .clickable { actions.checkForUpdates?.invoke() }
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Upgrade,
+            contentDescription = "Update available: v${updateAvailable.currentVersion} → v${updateAvailable.newVersion}",
+            tint = UpdateBadgeColor,
+            modifier = Modifier.size(14.dp),
+        )
+        Spacer(modifier = Modifier.width(3.dp))
+        Text(
+            text = "Update",
+            color = UpdateBadgeColor,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+/**
+ * The trailing controls: the caller's own [content], the "…" kebab and Minimize.
+ *
+ * Hover-gated as a group, and the kebab keeps the group up while its menu is open - otherwise moving
+ * the pointer into the menu takes the button that opened it away.
+ */
+@Composable
+private fun RowScope.HeaderControls(
+    isHovered: Boolean,
+    menuItems: List<ContextMenuItem>,
+    onMinimize: () -> Unit,
+    content: (@Composable () -> Unit)?,
+) {
+    var showMenu by remember { mutableStateOf(false) }
+    val buttonHeightRef = remember { intArrayOf(0) }
+
+    AnimatedVisibility(
+        visible = isHovered || showMenu,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Row(modifier = Modifier.padding(end = 2.dp)) {
+            content?.invoke()
+
+            // More button - opens the same menu as right-click
+            Box(
                 modifier =
-                    Modifier
-                        .padding(end = 4.dp)
-                        .clip(RoundedCornerShape(4.dp))
-                        .clickable { onUpdateClick?.invoke() }
-                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                    Modifier.onGloballyPositioned { coordinates ->
+                        buttonHeightRef[0] = coordinates.size.height
+                    },
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Upgrade,
-                    contentDescription = "Update available: v${updateAvailable.currentVersion} → v${updateAvailable.newVersion}",
-                    tint = UpdateBadgeColor,
-                    modifier = Modifier.size(14.dp),
-                )
-                Spacer(modifier = Modifier.width(3.dp))
-                Text(
-                    text = "Update",
-                    color = UpdateBadgeColor,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.Medium,
-                )
-            }
-        }
-
-        // State for dropdown menu (moved outside AnimatedVisibility to be accessible in condition)
-        var showMenu by remember { mutableStateOf(false) }
-        val buttonHeightRef = remember { intArrayOf(0) }
-
-        AnimatedVisibility(
-            visible = isHovered || showMenu, // Keep visible while menu is open
-            enter = fadeIn(),
-            exit = fadeOut(),
-        ) {
-            Row(modifier = Modifier.padding(end = 2.dp)) {
-                content?.invoke()
-
-                // More button — opens the same menu as right-click
-                Box(
-                    modifier =
-                        Modifier.onGloballyPositioned { coordinates ->
-                            buttonHeightRef[0] = coordinates.size.height
-                        },
-                ) {
-                    BossActionButton(
-                        imageVector = Icons.Outlined.MoreVert,
-                        text = "More",
-                        color = BossThemeColors.TextPrimary,
-                        onClick = { showMenu = true },
-                    )
-
-                    if (showMenu) {
-                        ContextMenu(
-                            items = menuItems,
-                            offset = IntOffset(0, buttonHeightRef[0]),
-                            onDismissRequest = { showMenu = false },
-                        )
-                    }
-                }
-
                 BossActionButton(
-                    imageVector = Icons.Outlined.Remove,
-                    text = "Minimize",
+                    imageVector = Icons.Outlined.MoreVert,
+                    text = "More",
                     color = BossThemeColors.TextPrimary,
-                    onClick = onMinimize,
+                    onClick = { showMenu = true },
                 )
+
+                if (showMenu) {
+                    ContextMenu(
+                        items = menuItems,
+                        offset = IntOffset(0, buttonHeightRef[0]),
+                        onDismissRequest = { showMenu = false },
+                    )
+                }
             }
+
+            BossActionButton(
+                imageVector = Icons.Outlined.Remove,
+                text = "Minimize",
+                color = BossThemeColors.TextPrimary,
+                onClick = onMinimize,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBar.kt
@@ -2,12 +2,12 @@ package ai.rever.boss.components.window_panel.components
 
 import ai.rever.boss.components.buttons.BossActionButton
 import ai.rever.boss.components.overlays.ContextMenu
-import ai.rever.boss.components.overlays.ContextMenuItem
 import ai.rever.boss.components.overlays.contextMenu
 import ai.rever.boss.components.plugin.AvailablePluginUpdate
+import ai.rever.boss.components.plugin.PanelMenuActions
 import ai.rever.boss.components.plugin.PluginBuildInfo
 import ai.rever.boss.components.plugin.PluginBuildTag
-import ai.rever.boss.components.plugin.registries.PanelMenuRegistryImpl
+import ai.rever.boss.components.plugin.panelMenuItems
 import ai.rever.boss.layout.BossChrome
 import ai.rever.boss.plugin.api.PanelId
 import ai.rever.boss.plugin.ui.BossTheme
@@ -22,15 +22,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.BugReport
-import androidx.compose.material.icons.outlined.CloudDownload
-import androidx.compose.material.icons.outlined.DeleteOutline
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material.icons.outlined.MonitorHeart
 import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Remove
-import androidx.compose.material.icons.outlined.Tab
 import androidx.compose.material.icons.outlined.Upgrade
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -67,94 +60,27 @@ fun BossPanelTopBar(
     dragModifier: Modifier = Modifier,
     content: (@Composable () -> Unit)? = null,
 ) {
-    // Plugin-contributed menu items for this panel (PanelMenuRegistry). The
-    // registry map and RBAC snapshot trigger a re-query, so items track
-    // plugin lifecycle and role changes. Contributions change their item set
-    // by re-registering (items() must stay cheap — see PanelMenuContribution).
-    val contributions by PanelMenuRegistryImpl.contributions.collectAsState()
-    val access by PanelMenuRegistryImpl.access.collectAsState()
-    val pluginEntries =
-        if (panelId != null) {
-            remember(panelId, contributions, access) {
-                PanelMenuRegistryImpl.itemsFor(panelId)
-            }
-        } else {
-            emptyList()
-        }
-
-    // One menu definition, shared by the "…" kebab and the right-click context menu,
-    // so both offer identical options. Plugin items render between the
-    // built-ins and Minimize.
+    // One menu definition, shared by the "…" kebab, the right-click context menu here and the
+    // sidebar rail icon's right-click menu, so all three offer identical options. See panelMenuItems.
     val menuItems =
-        buildList {
-            // Which build is running, first and clickable, for a plugin that is not on the released
-            // version. The version has to be the item's TEXT rather than a badge widget: with no
-            // trailing icon this menu is native-representable, so on macOS it renders as a real
-            // NSMenu, whose items carry a label, an enabled flag and a rasterised leading icon -
-            // but nothing that is a widget, which is what a badge would need.
-            //
-            // Both rows are gated on the action existing, not merely on the build being tagged:
-            // onBuildTagClick is null whenever the panel has no resolvable window (LocalWindowId
-            // defaults to null), and a row named as an imperative that silently does nothing is a
-            // worse failure than no row at all. The tag itself is inert in exactly that case.
-            val installStoreVersion = onBuildTagClick
-            val taggedBuild = buildInfo?.takeIf { it.isTagged }
-            if (taggedBuild != null && installStoreVersion != null) {
-                add(
-                    ContextMenuItem(
-                        text = "Version ${taggedBuild.displayVersion}",
-                        icon = Icons.Outlined.Info,
-                        onClick = installStoreVersion,
-                    ),
-                )
-                // The way back to the released build, named as the action it is. The version row
-                // above already carries it, but that row reads as a statement of fact, so the only
-                // discoverable route was clicking the tag - and the tag is a 9sp pill that is the
-                // first thing to run out of room once the panel narrows.
-                add(
-                    ContextMenuItem(
-                        text = "Install Store Version",
-                        icon = Icons.Outlined.CloudDownload,
-                        onClick = installStoreVersion,
-                    ),
-                )
-                add(ContextMenuItem(isDivider = true))
-            }
-            // "Reload Panel" is the user-facing name for what is really a reload of the owning
-            // plugin: the jar is unloaded and re-read, and every window's slots for it are reset.
-            // Named for the thing the user is pointing at, since this menu belongs to one panel.
-            onReloadPlugin?.let { cb ->
-                add(ContextMenuItem(text = "Reload Panel", icon = Icons.Outlined.Refresh, onClick = cb))
-            }
-            onCheckForUpdates?.let { cb -> add(ContextMenuItem(text = "Check for Updates", icon = Icons.Outlined.Upgrade, onClick = cb)) }
-            onOpenEvolver?.let { cb -> add(ContextMenuItem(text = "Open Evolver", icon = Icons.Outlined.MonitorHeart, onClick = cb)) }
-            onReportIssue?.let { cb -> add(ContextMenuItem(text = "Report Issue", icon = Icons.Outlined.BugReport, onClick = cb)) }
-            onOpenAsTab?.let { cb -> add(ContextMenuItem(text = "Open as Tab", icon = Icons.Outlined.Tab, onClick = cb)) }
-            // Shown for every plugin panel, disabled for the ones the manager refuses to unload
-            // (system plugins), so the action's absence is never mistaken for the feature missing.
-            onUninstallPlugin?.let { cb ->
-                add(
-                    ContextMenuItem(
-                        text = "Uninstall Plugin",
-                        icon = Icons.Outlined.DeleteOutline,
-                        enabled = uninstallEnabled,
-                        onClick = cb,
-                    ),
-                )
-            }
-            if (pluginEntries.isNotEmpty() && panelId != null) {
-                add(ContextMenuItem(isDivider = true))
-                for ((contribution, item) in pluginEntries) {
-                    if (!item.enabled) continue
-                    add(
-                        ContextMenuItem(text = item.label, icon = item.icon, onClick = {
-                            PanelMenuRegistryImpl.onItemClick(contribution, panelId, item.id, windowId)
-                        }),
-                    )
-                }
-            }
-            add(ContextMenuItem(text = "Minimize", icon = Icons.Outlined.Remove, onClick = onMinimize))
-        }
+        panelMenuItems(
+            panelId = panelId,
+            windowId = windowId,
+            actions =
+                PanelMenuActions(
+                    buildInfo = buildInfo,
+                    updateAvailable = updateAvailable,
+                    installStoreVersion = onBuildTagClick,
+                    reloadPanel = onReloadPlugin,
+                    checkForUpdates = onCheckForUpdates,
+                    openEvolver = onOpenEvolver,
+                    reportIssue = onReportIssue,
+                    uninstallPlugin = onUninstallPlugin,
+                    uninstallEnabled = uninstallEnabled,
+                ),
+            onOpenAsTab = onOpenAsTab,
+            onMinimize = onMinimize,
+        )
 
     Row(
         modifier =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
@@ -3,7 +3,7 @@ package ai.rever.boss.components.window_panel.components.side_panel
 import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.plugin.DynamicPluginManager
-import ai.rever.boss.components.plugin.rememberPanelMenuActions
+import ai.rever.boss.components.plugin.panelMenuActions
 import ai.rever.boss.components.registery.PanelComponentStore
 import ai.rever.boss.components.window_panel.components.BossPanelTopBar
 import ai.rever.boss.plugin.api.Panel
@@ -13,7 +13,6 @@ import ai.rever.boss.plugin.sandbox.ui.PluginErrorBoundary
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
-import ai.rever.boss.window.LocalWindowId
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.hoverable
@@ -65,11 +64,10 @@ fun BossDraggableComponent.SidePanel(
                 .hoverable(interactionSource),
     ) {
         val title = component?.panelInfo?.displayName ?: "Default title" // getPanelTitle(panel)
-        val windowId = LocalWindowId.current
 
         // Everything this panel's menu can do, resolved once and shared with the sidebar rail's
-        // icon menu - see rememberPanelMenuActions.
-        val actions = rememberPanelMenuActions(pluginContentId)
+        // icon menu - see panelMenuActions.
+        val actions = panelMenuActions(pluginContentId)
 
         // Drag the panel by its header: reorder/move between sidebar slots, or drop on
         // the central area to open it as a main tab. Reuses the sidebar drag system.
@@ -96,25 +94,15 @@ fun BossDraggableComponent.SidePanel(
         BossPanelTopBar(
             title = title,
             isHovered = isHovered,
-            onReloadPlugin = actions.reloadPanel,
+            actions = actions,
             onOpenAsTab =
                 pluginContentId?.let { panelId ->
                     { requestPromoteToTab(panelId) }
                 },
-            onCheckForUpdates = actions.checkForUpdates,
-            onOpenEvolver = actions.openEvolver,
-            onReportIssue = actions.reportIssue,
-            onUninstallPlugin = actions.uninstallPlugin,
-            uninstallEnabled = actions.uninstallEnabled,
             onMinimize = {
                 setPanelVisible(panel, false)
             },
-            updateAvailable = actions.updateAvailable,
-            onUpdateClick = actions.checkForUpdates,
-            buildInfo = actions.buildInfo,
-            onBuildTagClick = actions.installStoreVersion,
             panelId = pluginContentId,
-            windowId = windowId,
             dragModifier = headerDragModifier,
         )
         Divider(color = BossTheme.colors.line)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/side_panel/SidePanel.kt
@@ -3,14 +3,9 @@ package ai.rever.boss.components.window_panel.components.side_panel
 import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.plugin.DynamicPluginManager
-import ai.rever.boss.components.plugin.LocalPanelPluginIdResolver
-import ai.rever.boss.components.plugin.LocalPluginUninstallable
-import ai.rever.boss.components.plugin.PluginBuildRegistry
-import ai.rever.boss.components.plugin.PluginUpdateRegistry
+import ai.rever.boss.components.plugin.rememberPanelMenuActions
 import ai.rever.boss.components.registery.PanelComponentStore
 import ai.rever.boss.components.window_panel.components.BossPanelTopBar
-import ai.rever.boss.mcp.EvolverContract
-import ai.rever.boss.mcp.McpToolRegistryImpl
 import ai.rever.boss.plugin.api.Panel
 import ai.rever.boss.plugin.sandbox.PanelSandboxRegistry
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
@@ -19,7 +14,6 @@ import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.window.LocalWindowId
-import ai.rever.boss.window.MenuActionsHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.hoverable
@@ -30,7 +24,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -43,8 +36,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 @Composable
 fun BossDraggableComponent.SidePanel(
@@ -76,87 +67,9 @@ fun BossDraggableComponent.SidePanel(
         val title = component?.panelInfo?.displayName ?: "Default title" // getPanelTitle(panel)
         val windowId = LocalWindowId.current
 
-        // Plugin update availability for this panel's owning plugin (host-compatible updates only).
-        val pluginId = pluginContentId?.let { LocalPanelPluginIdResolver.current(it) }
-        val availableUpdates by PluginUpdateRegistry.updates.collectAsState()
-        val updateForPlugin = pluginId?.let { availableUpdates[it] }
-
-        // Which build this panel's plugin is running. Collected (not read once) so the tag appears
-        // the moment a hot reload lands, without the panel having to be reopened.
-        val pluginBuilds by PluginBuildRegistry.builds.collectAsState()
-        val buildForPlugin = pluginId?.let { pluginBuilds[it] }
-        val installStoreVersion: (() -> Unit)? =
-            if (pluginContentId != null && windowId != null && buildForPlugin?.isTagged == true) {
-                { MenuActionsHandler.triggerInstallStoreVersion(windowId, pluginContentId) }
-            } else {
-                null
-            }
-
-        // Uninstall is offered for every plugin panel and disabled for the ones the manager refuses
-        // to unload, so a system plugin shows why the action is unavailable instead of hiding it.
-        val uninstallable = LocalPluginUninstallable.current
-        val uninstallPlugin: (() -> Unit)? =
-            if (pluginContentId != null && windowId != null && pluginId != null) {
-                { MenuActionsHandler.triggerUninstallPlugin(windowId, pluginContentId) }
-            } else {
-                null
-            }
-        val uninstallEnabled = pluginId != null && uninstallable(pluginId)
-        val checkForUpdates: (() -> Unit)? =
-            if (pluginContentId != null && windowId != null) {
-                { MenuActionsHandler.triggerCheckPluginUpdates(windowId, pluginContentId) }
-            } else {
-                null
-            }
-
-        // Tool Evolver menu items, gated via the (RBAC-filtered) MCP registry —
-        // no compile-time coupling to the plugin. "Report Issue" shows whenever the
-        // plugin is active (evolver_open is ungated). "Open Evolver" shows only when
-        // the permission-gated evolver_evolve tool is exposed — i.e. the current
-        // user may evolve (holds the permission, or is admin). Both dispatch
-        // evolver_open with the right section.
-        val registeredMcpTools by McpToolRegistryImpl.tools.collectAsState()
-        val menuScope = rememberCoroutineScope()
-        val evolverLogger = remember { BossLogger.forComponent("SidePanel") }
-        val evolverOpenAvailable =
-            pluginId != null &&
-                registeredMcpTools.any { it.definition.name == EvolverContract.OPEN_TOOL }
-        val evolveAvailable =
-            pluginId != null &&
-                registeredMcpTools.any { it.definition.name == EvolverContract.EVOLVE_TOOL }
-        val dispatchEvolverOpen: (String?, String) -> Unit = { section, failLabel ->
-            val id = pluginId
-            if (id != null) {
-                menuScope.launch {
-                    val args =
-                        buildJsonObject {
-                            put(EvolverContract.ARG_PLUGIN_ID, id)
-                            if (section != null) put(EvolverContract.ARG_SECTION, section)
-                        }.toString()
-                    val result = McpToolRegistryImpl.invoke(EvolverContract.OPEN_TOOL, args)
-                    if (result.isError) {
-                        evolverLogger.warn(
-                            LogCategory.UI,
-                            "$failLabel failed",
-                            mapOf("pluginId" to id, "error" to result.text),
-                        )
-                        StatusMessageManager.showMessage("$failLabel failed: ${result.text}", durationMs = 5000)
-                    }
-                }
-            }
-        }
-        val openEvolver: (() -> Unit)? =
-            if (evolveAvailable) {
-                { dispatchEvolverOpen(null, "Open Evolver") }
-            } else {
-                null
-            }
-        val reportIssue: (() -> Unit)? =
-            if (evolverOpenAvailable) {
-                { dispatchEvolverOpen(EvolverContract.SECTION_ISSUE, "Report Issue") }
-            } else {
-                null
-            }
+        // Everything this panel's menu can do, resolved once and shared with the sidebar rail's
+        // icon menu - see rememberPanelMenuActions.
+        val actions = rememberPanelMenuActions(pluginContentId)
 
         // Drag the panel by its header: reorder/move between sidebar slots, or drop on
         // the central area to open it as a main tab. Reuses the sidebar drag system.
@@ -183,36 +96,23 @@ fun BossDraggableComponent.SidePanel(
         BossPanelTopBar(
             title = title,
             isHovered = isHovered,
-            onReloadPlugin =
-                pluginContentId?.let { panelId ->
-                    windowId?.let { wId ->
-                        {
-                            // Clear the sandbox's consecutive-error count first: a reload replaces
-                            // the code that was failing, so carrying its error tally over would
-                            // leave a freshly loaded plugin one fault away from being quarantined.
-                            // This was the only thing the removed "Restart Panel" item did that
-                            // reloading did not, and it is the half worth keeping.
-                            PanelSandboxRegistry.getSandbox(panelId)?.resetHealth()
-                            MenuActionsHandler.triggerReloadPlugin(wId, panelId)
-                        }
-                    }
-                },
+            onReloadPlugin = actions.reloadPanel,
             onOpenAsTab =
                 pluginContentId?.let { panelId ->
                     { requestPromoteToTab(panelId) }
                 },
-            onCheckForUpdates = checkForUpdates,
-            onOpenEvolver = openEvolver,
-            onReportIssue = reportIssue,
-            onUninstallPlugin = uninstallPlugin,
-            uninstallEnabled = uninstallEnabled,
+            onCheckForUpdates = actions.checkForUpdates,
+            onOpenEvolver = actions.openEvolver,
+            onReportIssue = actions.reportIssue,
+            onUninstallPlugin = actions.uninstallPlugin,
+            uninstallEnabled = actions.uninstallEnabled,
             onMinimize = {
                 setPanelVisible(panel, false)
             },
-            updateAvailable = updateForPlugin,
-            onUpdateClick = checkForUpdates,
-            buildInfo = buildForPlugin,
-            onBuildTagClick = installStoreVersion,
+            updateAvailable = actions.updateAvailable,
+            onUpdateClick = actions.checkForUpdates,
+            buildInfo = actions.buildInfo,
+            onBuildTagClick = actions.installStoreVersion,
             panelId = pluginContentId,
             windowId = windowId,
             dragModifier = headerDragModifier,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
@@ -163,12 +163,19 @@ private fun placeGhost(
 
 /**
  * Where a ghost of [size] goes for a cursor at ([cursorX], [cursorY]): hung off the pointer by
- * [hotspot], and inside the working area of whichever monitor the pointer is on.
+ * [hotspot], and pulled back onto a monitor if that would put it somewhere there is no screen.
  *
- * The clamp is the whole of the screen handling now, and it is what keeps a ghost near an edge from
- * spilling onto a taskbar, a dock, or the next display. It is allowed to move the pointer off the
- * hotspot, which is the right trade: an offset ghost is worse than an exactly-placed one, and both
- * are far better than one that is half off the screen.
+ * The clamp exists for the edges of the desktop - a dock, a taskbar, the outside of the rightmost
+ * display - and it is the one thing allowed to move the ghost off its hotspot. So it is asked only
+ * when the ghost would actually land off-screen: **a ghost that fits inside the union of the
+ * monitors is left exactly on the pointer**, which is what keeps a drag across the seam between two
+ * displays from yanking the card up to its hotspot's width sideways and snapping it back on the
+ * other side. Clamping to the monitor the cursor happens to be on cannot tell the two cases apart -
+ * spilling onto the next display is free, spilling onto a dock is what this is for.
+ *
+ * Coverage is tested by the ghost's corners rather than by area: monitors are rectangles laid out in
+ * a grid, so a rectangle whose four corners are all on some screen spans at worst a seam between
+ * them, which is exactly the case being allowed.
  *
  * Pure so the placement can be pinned by a test, which is the only part of this reachable without a
  * display.
@@ -182,14 +189,34 @@ internal fun clampGhostToScreens(
 ): Pair<Int, Int> {
     val x = cursorX - hotspot.x
     val y = cursorY - hotspot.y
+    // Nothing known to clamp against, or nothing to clamp: the ghost stays on the pointer.
+    if (screens.isEmpty() || screens.covers(x, y, size)) return Pair(x, y)
+
     val screen =
         screens.firstOrNull { it.contains(cursorX, cursorY) }
-            ?: screens.firstOrNull()
-            ?: return Pair(x, y)
+            ?: screens.first()
     return Pair(
         pinInside(x, size.width, screen[0], screen[2]),
         pinInside(y, size.height, screen[1], screen[3]),
     )
+}
+
+/** Whether every corner of the ghost at ([x], [y]) sits on some monitor's working area. */
+private fun List<IntArray>.covers(
+    x: Int,
+    y: Int,
+    size: IntSize,
+): Boolean {
+    // The far edges are exclusive, matching contains(): a ghost ending exactly on the boundary is
+    // inside, and one pixel past it is not.
+    val corners =
+        listOf(
+            x to y,
+            x + size.width - 1 to y,
+            x to y + size.height - 1,
+            x + size.width - 1 to y + size.height - 1,
+        )
+    return corners.all { (cx, cy) -> any { it.contains(cx, cy) } }
 }
 
 /** Whether this `[x, y, width, height]` rect holds the point ([x], [y]). */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.window.rememberWindowState
 import java.awt.GraphicsEnvironment
 import java.awt.MouseInfo
 import java.awt.Rectangle
-import java.awt.Toolkit
 
 /**
  * Heavyweight drag-ghost host for HARDWARE_ACCELERATED browser mode.
@@ -114,6 +113,13 @@ fun HeavyweightGhost(
  * frame on top of the frame the cursor read is already old. Both callbacks run on the EDT, which is
  * where `setLocation` has to be called from. The state is the fallback for the frames before the
  * window exists.
+ *
+ * That leaves two things that can place this window, so they must not disagree: Compose installs a
+ * `componentMoved` listener that writes the moved position straight back into [state], which keeps
+ * it in step with every `setLocation` here. It is worth knowing that this is what makes the split
+ * safe - if that write-back ever goes away, anything that re-applies [WindowState.position] would
+ * teleport the ghost back to where the drag started, and this loop would only correct it on the
+ * next pointer move.
  */
 @Composable
 private fun FollowCursor(
@@ -163,19 +169,22 @@ private fun placeGhost(
 
 /**
  * Where a ghost of [size] goes for a cursor at ([cursorX], [cursorY]): hung off the pointer by
- * [hotspot], and pulled back onto a monitor if that would put it somewhere there is no screen.
+ * [hotspot], and pulled back onto a monitor only if that would hang it off the edge of the desktop.
  *
- * The clamp exists for the edges of the desktop - a dock, a taskbar, the outside of the rightmost
- * display - and it is the one thing allowed to move the ghost off its hotspot. So it is asked only
- * when the ghost would actually land off-screen: **a ghost that fits inside the union of the
+ * The clamp is the one thing allowed to move the ghost off its hotspot, and it exists for exactly
+ * one case: a ghost half outside every display is half invisible for the rest of the drag. So it is
+ * asked only when the ghost would actually land there. **A ghost that fits inside the union of the
  * monitors is left exactly on the pointer**, which is what keeps a drag across the seam between two
  * displays from yanking the card up to its hotspot's width sideways and snapping it back on the
  * other side. Clamping to the monitor the cursor happens to be on cannot tell the two cases apart -
- * spilling onto the next display is free, spilling onto a dock is what this is for.
+ * spilling onto the next display is free.
  *
  * Coverage is tested by the ghost's corners rather than by area: monitors are rectangles laid out in
  * a grid, so a rectangle whose four corners are all on some screen spans at worst a seam between
- * them, which is exactly the case being allowed.
+ * them, which is exactly the case being allowed. And it is tested against [screenRects], which is
+ * full display bounds rather than working areas - a reserved strip is still a place with a screen
+ * under it, and treating a dock or a menu bar as "no screen" put the seam artifact back in a band
+ * along the top and bottom of every display.
  *
  * Pure so the placement can be pinned by a test, which is the only part of this reachable without a
  * display.
@@ -243,8 +252,16 @@ private fun pinInside(
 ): Int = at.coerceIn(origin, (origin + available - extent).coerceAtLeast(origin))
 
 /**
- * Every monitor's working area as `[x, y, width, height]`, i.e. bounds minus insets (taskbar, dock,
- * menu bar). Read once per ghost: monitors do not come and go mid-drag.
+ * Every monitor's FULL bounds as `[x, y, width, height]`. Read once per ghost: monitors do not come
+ * and go mid-drag.
+ *
+ * Bounds rather than the working area (bounds minus dock, taskbar and menu bar), which is what this
+ * used to subtract. A working area answers "where may a window be placed", and a drag ghost is not
+ * being placed - it is a transient always-on-top overlay tracking the pointer, and the pointer goes
+ * over the dock like anything else. Subtracting the insets made those reserved strips read as "no
+ * screen here", so a ghost whose far corner reached into the menu-bar strip of the display next
+ * door was treated as off the desktop and yanked back onto the cursor's monitor: the seam artifact
+ * this is meant to avoid, restored in a band the height of a menu bar. See [clampGhostToScreens].
  */
 private fun screenRects(): List<IntArray> =
     runCatching {
@@ -253,12 +270,6 @@ private fun screenRects(): List<IntArray> =
             .screenDevices
             .map { device ->
                 val bounds: Rectangle = device.defaultConfiguration.bounds
-                val insets = Toolkit.getDefaultToolkit().getScreenInsets(device.defaultConfiguration)
-                intArrayOf(
-                    bounds.x + insets.left,
-                    bounds.y + insets.top,
-                    bounds.width - insets.left - insets.right,
-                    bounds.height - insets.top - insets.bottom,
-                )
+                intArrayOf(bounds.x, bounds.y, bounds.width, bounds.height)
             }
     }.getOrDefault(emptyList())

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/overlays/HeavyweightGhost.kt
@@ -5,30 +5,27 @@ import ai.rever.boss.window.BossWindowIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import java.awt.GraphicsEnvironment
 import java.awt.MouseInfo
 import java.awt.Rectangle
 import java.awt.Toolkit
-
-/**
- * How far from the cursor the ghost sits - below-right normally, above-left at a screen edge (see
- * [clampGhostToScreens]).
- *
- * NOT cosmetic. A non-focusable AWT window still receives mouse events, and the JVM has no portable
- * click-through, so a ghost drawn under the pointer would swallow the drag that is moving it and the
- * drop would never land. The gap keeps the pointer outside the window for the whole drag. It also
- * matches [SwingTooltip], which places itself off the cursor for the same reason.
- */
-private const val GHOST_GAP_PX = 16
 
 /**
  * Heavyweight drag-ghost host for HARDWARE_ACCELERATED browser mode.
@@ -42,6 +39,18 @@ private const val GHOST_GAP_PX = 16
  * parent-sized ghost window would cover the whole app and eat the pointer events that constitute the
  * drag, ending it the moment it began.
  *
+ * [hotspot] is where the POINTER sits inside the ghost, so this window lands exactly where the
+ * lightweight ghost does: centred under the cursor for the sidebar icon, a quarter in from the
+ * leading edge for a tab card. It used to be placed 16px below-right of the cursor instead, on the
+ * theory that a window under the pointer would swallow the drag that is moving it (the JVM has no
+ * portable click-through, and a non-focusable AWT window still receives mouse events). Measured on
+ * macOS, that is not what happens for a ghost of this kind: the press that starts the drag lands on
+ * the source window first and takes the implicit mouse grab, after which a 22x22 always-on-top
+ * window centred on the cursor receives NOTHING - every drag event and the release still go to the
+ * source. The gap only mattered for a ghost that is already up when the button goes down, which
+ * neither of ours is (both appear after a long press or a drag threshold). What the gap did do was
+ * park the ghost ~27px diagonally off the pointer, which reads as an icon that is not being carried.
+ *
  * Position is read from [MouseInfo] on the frame clock rather than from the caller's Compose
  * coordinates. Two reasons: the cursor is authoritative for something that follows the cursor, and
  * converting window coordinates to screen coordinates has to go through the CONTENT PANE rather than
@@ -51,6 +60,7 @@ private const val GHOST_GAP_PX = 16
 @Composable
 fun HeavyweightGhost(
     size: DpSize,
+    hotspot: DpOffset,
     content: @Composable () -> Unit,
 ) {
     val screens = remember { screenRects() }
@@ -58,42 +68,16 @@ fun HeavyweightGhost(
     // the frame loop below correct it shows the ghost at the top-left corner for one frame, which
     // reads as a flicker at the start of every drag.
     val initial =
-        remember(size, screens) {
+        remember(size, hotspot, screens) {
             val cursor = runCatching { MouseInfo.getPointerInfo()?.location }.getOrNull()
-            clampGhostToScreens(
-                cursorX = cursor?.x ?: 0,
-                cursorY = cursor?.y ?: 0,
-                width = size.width.value.toInt(),
-                height = size.height.value.toInt(),
-                screens = screens,
-            )
+            placeGhost(cursor?.x ?: 0, cursor?.y ?: 0, size, hotspot, screens)
         }
     val state =
         rememberWindowState(size = size, position = WindowPosition(initial.first.dp, initial.second.dp))
 
-    // Drive from the frame clock, not from recomposition: the ghost has to keep up with the pointer
-    // whether or not anything it reads has changed, and the caller's drag state lives in a different
-    // subtree. Only assign when the point actually moves - each assignment is a native setLocation,
-    // and a still pointer should cost nothing.
-    LaunchedEffect(size) {
-        var last: Pair<Int, Int>? = initial
-        while (true) {
-            withFrameNanos { }
-            val cursor = runCatching { MouseInfo.getPointerInfo()?.location }.getOrNull() ?: continue
-            val placed =
-                clampGhostToScreens(
-                    cursorX = cursor.x,
-                    cursorY = cursor.y,
-                    width = size.width.value.toInt(),
-                    height = size.height.value.toInt(),
-                    screens = screens,
-                )
-            if (placed != last) {
-                last = placed
-                state.position = WindowPosition(placed.first.dp, placed.second.dp)
-            }
-        }
-    }
+    // The AWT window, once it exists. See FollowCursor for why it is moved directly.
+    var awtWindow by remember { mutableStateOf<java.awt.Window?>(null) }
+    FollowCursor(size, hotspot, screens, initial, state) { awtWindow }
 
     Window(
         onCloseRequest = {},
@@ -107,6 +91,10 @@ fun HeavyweightGhost(
     ) {
         EnsureOverlayWindowTransparent(window, kind = "ghost")
         ApplyBossWindowIcon(window)
+        DisposableEffect(window) {
+            awtWindow = window
+            onDispose { awtWindow = null }
+        }
         Box(modifier = Modifier.fillMaxSize()) {
             content()
         }
@@ -114,14 +102,73 @@ fun HeavyweightGhost(
 }
 
 /**
- * Where a ghost of [width] x [height] goes for a cursor at ([cursorX], [cursorY]): offset from the
- * pointer, and inside the working area of whichever monitor the pointer is on.
+ * Keeps the ghost window on the cursor for as long as it is composed.
  *
- * Below-right by default. When that would spill off an edge the ghost **flips to the other side of
- * the cursor** rather than being pulled back across it - pulling back is what a plain clamp does, and
- * near the right edge it slides the window under the pointer, which is exactly the state
- * [GHOST_GAP_PX] exists to prevent. Flipping keeps the pointer outside the ghost on every edge, so
- * the gap guarantee holds everywhere and not just mid-screen.
+ * Driven from the frame clock, not from recomposition: the ghost has to keep up with the pointer
+ * whether or not anything it reads has changed, and the caller's drag state lives in a different
+ * subtree. Only assigns when the point actually moves - each assignment is a native setLocation,
+ * and a still pointer should cost nothing.
+ *
+ * [window] is moved directly rather than through [WindowState.position]: assigning snapshot state
+ * inside `withFrameNanos` is only applied by the NEXT frame, so the ghost trailed the pointer by a
+ * frame on top of the frame the cursor read is already old. Both callbacks run on the EDT, which is
+ * where `setLocation` has to be called from. The state is the fallback for the frames before the
+ * window exists.
+ */
+@Composable
+private fun FollowCursor(
+    size: DpSize,
+    hotspot: DpOffset,
+    screens: List<IntArray>,
+    initial: Pair<Int, Int>,
+    state: WindowState,
+    window: () -> java.awt.Window?,
+) {
+    LaunchedEffect(size, hotspot) {
+        var last: Pair<Int, Int>? = initial
+        while (true) {
+            withFrameNanos { }
+            val cursor = runCatching { MouseInfo.getPointerInfo()?.location }.getOrNull() ?: continue
+            val placed = placeGhost(cursor.x, cursor.y, size, hotspot, screens)
+            if (placed != last) {
+                last = placed
+                val awt = window()
+                if (awt != null) {
+                    awt.setLocation(placed.first, placed.second)
+                } else {
+                    state.position = WindowPosition(placed.first.dp, placed.second.dp)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * [clampGhostToScreens] in the units the caller has: dp, which AWT reports 1:1 as logical pixels.
+ */
+private fun placeGhost(
+    cursorX: Int,
+    cursorY: Int,
+    size: DpSize,
+    hotspot: DpOffset,
+    screens: List<IntArray>,
+): Pair<Int, Int> =
+    clampGhostToScreens(
+        cursorX = cursorX,
+        cursorY = cursorY,
+        size = IntSize(size.width.value.toInt(), size.height.value.toInt()),
+        hotspot = IntOffset(hotspot.x.value.toInt(), hotspot.y.value.toInt()),
+        screens = screens,
+    )
+
+/**
+ * Where a ghost of [size] goes for a cursor at ([cursorX], [cursorY]): hung off the pointer by
+ * [hotspot], and inside the working area of whichever monitor the pointer is on.
+ *
+ * The clamp is the whole of the screen handling now, and it is what keeps a ghost near an edge from
+ * spilling onto a taskbar, a dock, or the next display. It is allowed to move the pointer off the
+ * hotspot, which is the right trade: an offset ghost is worse than an exactly-placed one, and both
+ * are far better than one that is half off the screen.
  *
  * Pure so the placement can be pinned by a test, which is the only part of this reachable without a
  * display.
@@ -129,17 +176,19 @@ fun HeavyweightGhost(
 internal fun clampGhostToScreens(
     cursorX: Int,
     cursorY: Int,
-    width: Int,
-    height: Int,
+    size: IntSize,
+    hotspot: IntOffset,
     screens: List<IntArray>,
 ): Pair<Int, Int> {
+    val x = cursorX - hotspot.x
+    val y = cursorY - hotspot.y
     val screen =
         screens.firstOrNull { it.contains(cursorX, cursorY) }
             ?: screens.firstOrNull()
-            ?: return Pair(cursorX + GHOST_GAP_PX, cursorY + GHOST_GAP_PX)
+            ?: return Pair(x, y)
     return Pair(
-        flipOrClamp(cursorX, width, screen[0], screen[2]),
-        flipOrClamp(cursorY, height, screen[1], screen[3]),
+        pinInside(x, size.width, screen[0], screen[2]),
+        pinInside(y, size.height, screen[1], screen[3]),
     )
 }
 
@@ -150,35 +199,21 @@ private fun IntArray.contains(
 ): Boolean = x >= this[0] && x < this[0] + this[2] && y >= this[1] && y < this[1] + this[3]
 
 /**
- * One axis of the placement: [cursor] + gap, flipped to `cursor - gap - extent` when that does not
- * fit, and clamped only if NEITHER side does.
+ * One axis of the placement: [at], kept inside `[origin, origin + available]` for an extent of
+ * [extent].
  *
- * Both candidates are tested against both ends of the range, not just the far one. A cursor that is
- * outside the monitor entirely - which happens when a display is unplugged mid-drag and the cached
- * rects no longer describe where the pointer is - otherwise passes the far-edge test trivially and
- * the ghost is placed thousands of pixels off-screen, invisible for the rest of the drag.
- *
- * The final `coerceIn` is the neither-side-fits case, i.e. a ghost bigger than the monitor. It uses
- * `coerceAtLeast(origin)` on the upper bound because an inverted range makes `coerceIn` throw, and an
- * exception here would take the whole drag gesture down with it.
+ * The `coerceAtLeast(origin)` on the upper bound is the ghost-bigger-than-the-monitor case: an
+ * inverted range makes `coerceIn` throw, and an exception here would take the whole drag gesture
+ * down with it. A cursor that is outside the monitor entirely - which happens when a display is
+ * unplugged mid-drag and the cached rects no longer describe where the pointer is - is pulled back
+ * onto the monitor by the same clamp rather than being left thousands of pixels off-screen.
  */
-private fun flipOrClamp(
-    cursor: Int,
+private fun pinInside(
+    at: Int,
     extent: Int,
     origin: Int,
     available: Int,
-): Int {
-    val limit = origin + available
-
-    fun fits(candidate: Int) = candidate >= origin && candidate + extent <= limit
-    val after = cursor + GHOST_GAP_PX
-    val before = cursor - GHOST_GAP_PX - extent
-    return when {
-        fits(after) -> after
-        fits(before) -> before
-        else -> after.coerceIn(origin, (limit - extent).coerceAtLeast(origin))
-    }
-}
+): Int = at.coerceIn(origin, (origin + available - extent).coerceAtLeast(origin))
 
 /**
  * Every monitor's working area as `[x, y, width, height]`, i.e. bounds minus insets (taskbar, dock,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -591,9 +591,9 @@ fun main(args: Array<String>) {
         ai.rever.boss.components.overlays
             .HeavyweightHud(alignment, hudContent)
     }
-    ai.rever.boss.components.overlays.OverlayConfig.heavyweightGhost = { size, ghostContent ->
+    ai.rever.boss.components.overlays.OverlayConfig.heavyweightGhost = { size, hotspot, ghostContent ->
         ai.rever.boss.components.overlays
-            .HeavyweightGhost(size, ghostContent)
+            .HeavyweightGhost(size, hotspot, ghostContent)
     }
     ai.rever.boss.components.overlays.OverlayConfig.heavyweightCorner = {
         alignment,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
@@ -2,24 +2,24 @@ package ai.rever.boss.components.overlays
 
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
  * Where a heavyweight drag ghost's window is placed.
  *
- * Two properties matter and only one of them is cosmetic.
+ * The property that matters is that THE POINTER SITS ON THE HOTSPOT: a drag ghost is the thing the
+ * pointer is carrying, so its own window has to land exactly where the lightweight ghost draws
+ * itself in Compose coordinates. It used to be pushed 16px below-right of the cursor instead, to
+ * keep the pointer outside a window that has no click-through - measured on macOS, an always-on-top
+ * window that appears AFTER the press takes no mouse events at all (the source window holds the
+ * implicit grab), so that gap bought nothing and cost ~27px of visible detachment.
  *
- * The load-bearing one is that the POINTER STAYS OUTSIDE THE GHOST. A non-focusable AWT window still
- * receives mouse events, and the JVM has no portable click-through, so a ghost window under the
- * pointer swallows the drag that is moving it: the ghost follows the cursor and the drop never lands.
- * That is why the placement flips to the other side of the cursor at a screen edge instead of being
- * pulled back across it, and why nearly every case below re-asserts the invariant.
- *
- * The other is the CLAMP, which keeps the ghost on the monitor the pointer is on rather than spilling
- * over a taskbar or onto the wrong display.
+ * The other property is the CLAMP, which keeps the ghost on the monitor the pointer is on rather
+ * than spilling over a taskbar or onto the wrong display. It is the one thing allowed to move the
+ * ghost off its hotspot.
  */
 class HeavyweightGhostPlacementTest {
     private companion object {
@@ -29,58 +29,74 @@ class HeavyweightGhostPlacementTest {
         /** The same, plus a second monitor to its right whose origin is NOT (0, 0). */
         val DUAL = SINGLE + listOf(intArrayOf(1920, 0, 1280, 800))
 
+        /** A tab card, carried a quarter in from its leading edge and vertically centred. */
         const val GHOST_W = 180
         const val GHOST_H = 32
+        const val HOT_X = GHOST_W / 4
+        const val HOT_Y = GHOST_H / 2
     }
 
     private fun place(
         x: Int,
         y: Int,
         screens: List<IntArray> = SINGLE,
-    ) = clampGhostToScreens(cursorX = x, cursorY = y, width = GHOST_W, height = GHOST_H, screens = screens)
-
-    /** The invariant the gap exists for: a pointer inside the ghost eats its own drag. */
-    private fun assertPointerOutside(
-        cursorX: Int,
-        cursorY: Int,
-        placed: Pair<Int, Int>,
-    ) {
-        val (gx, gy) = placed
-        val inside = cursorX >= gx && cursorX < gx + GHOST_W && cursorY >= gy && cursorY < gy + GHOST_H
-        assertFalse(inside, "pointer ($cursorX, $cursorY) landed inside the ghost at $placed")
-    }
+    ) = clampGhostToScreens(
+        cursorX = x,
+        cursorY = y,
+        size = IntSize(GHOST_W, GHOST_H),
+        hotspot = IntOffset(HOT_X, HOT_Y),
+        screens = screens,
+    )
 
     @Test
-    fun `mid-screen, the ghost sits below-right of the cursor`() {
+    fun `mid-screen, the pointer lands exactly on the ghost's hotspot`() {
         val placed = place(600, 400)
-        assertTrue(placed.first > 600 && placed.second > 400, "expected below-right, got $placed")
-        assertPointerOutside(600, 400, placed)
+        assertEquals(Pair(600 - HOT_X, 400 - HOT_Y), placed)
     }
 
     @Test
-    fun `at the right edge it flips to the cursor's left rather than sliding under it`() {
-        // This is the case a plain clamp gets wrong. Clamping to (1920 - 180) = 1740 with the cursor at
-        // 1900 puts the pointer inside the ghost, which would stall the drag in the last 180px of the
-        // screen. Flipping puts the ghost entirely left of the cursor instead.
+    fun `a carried ghost holds the pointer inside itself, which is the point of the hotspot`() {
+        // The reversal, stated as a test: this is exactly what the old gap existed to prevent, and
+        // what makes the ghost read as being carried rather than trailing behind the cursor.
+        val (gx, gy) = place(600, 400)
+        val inside = 600 >= gx && 600 < gx + GHOST_W && 400 >= gy && 400 < gy + GHOST_H
+        assertTrue(inside, "pointer should sit on the ghost it is dragging")
+    }
+
+    @Test
+    fun `a centred icon ghost is centred on the cursor`() {
+        // The sidebar rail's ghost: 22dp square, carried by its middle.
+        val placed =
+            clampGhostToScreens(
+                cursorX = 600,
+                cursorY = 400,
+                size = IntSize(22, 22),
+                hotspot = IntOffset(11, 11),
+                screens = SINGLE,
+            )
+        assertEquals(Pair(589, 389), placed)
+    }
+
+    @Test
+    fun `at the right edge the ghost is pulled back onto the screen`() {
+        // The clamp wins over the hotspot here: half a ghost hanging off the display is worse than
+        // a ghost the pointer is no longer centred on.
         val placed = place(1900, 400)
-        assertTrue(placed.first + GHOST_W <= 1900, "ghost should end left of the cursor, got $placed")
-        assertTrue(placed.first >= 0, "ghost should stay on screen, got $placed")
-        assertPointerOutside(1900, 400, placed)
+        assertEquals(1920 - GHOST_W, placed.first)
     }
 
     @Test
-    fun `at the bottom edge it flips above the cursor, clear of the menu-bar-adjusted floor`() {
+    fun `at the bottom edge it is pulled up clear of the menu-bar-adjusted floor`() {
         val placed = place(600, 1070)
-        assertTrue(placed.second + GHOST_H <= 1070, "ghost should end above the cursor, got $placed")
-        assertPointerOutside(600, 1070, placed)
+        assertEquals(25 + 1055 - GHOST_H, placed.second)
     }
 
     @Test
-    fun `a bottom edge that still fits below the cursor is left below it`() {
-        // Only flip when it is actually needed: 25 + 1055 = 1080 is the floor, and a cursor at 1000
-        // leaves room for 16 + 32 underneath.
+    fun `an edge that still fits is left exactly on the hotspot`() {
+        // Only clamp when it is actually needed: 25 + 1055 = 1080 is the floor, and a cursor at 1000
+        // leaves room for the half of the card that hangs below it.
         val placed = place(600, 1000)
-        assertEquals(1016, placed.second)
+        assertEquals(1000 - HOT_Y, placed.second)
     }
 
     @Test
@@ -89,42 +105,52 @@ class HeavyweightGhostPlacementTest {
         // monitor back to x < 1920, i.e. onto the wrong display entirely.
         val placed = place(2000, 300, DUAL)
         assertTrue(placed.first >= 1920, "ghost jumped back to the primary monitor: $placed")
-        assertPointerOutside(2000, 300, placed)
     }
 
     @Test
     fun `the second monitor's own origin is respected, not treated as zero`() {
         // Cursor at the second monitor's top-left. An axis computed from width/height without adding
-        // the monitor's origin would place the ghost at (16, 16) on the PRIMARY screen.
+        // the monitor's origin would place the ghost on the PRIMARY screen.
         val placed = place(1920, 0, DUAL)
-        assertEquals(Pair(1936, 16), placed)
+        assertEquals(Pair(1920, 0), placed)
     }
 
     @Test
     fun `a pointer on no known monitor is pulled back onto one, not left off-screen`() {
         // Monitors can be unplugged mid-drag, and the coordinates are then off every rect we cached.
-        // The near-edge half of the fit test is what catches this: a cursor far to the LEFT satisfies
-        // "does not run past the right edge" trivially, so testing only the far edge would leave the
-        // ghost thousands of pixels off-screen and invisible for the rest of the drag.
+        // Without the clamp the ghost would sit thousands of pixels off-screen, invisible for the
+        // rest of the drag.
         val placed = place(-5000, -5000, DUAL)
         assertEquals(Pair(0, 25), placed)
     }
 
     @Test
     fun `a ghost larger than the monitor pins inside it instead of inverting the range`() {
-        // Neither the offset nor the flip fits, so both axes fall through to the clamp. coerceIn throws
-        // on an inverted range, and an exception here would take the whole drag gesture down with it.
-        // 100 wide cannot hold 180, so x pins to the origin; 60 tall can hold 32, so y pins to 60 - 32.
+        // coerceIn throws on an inverted range, and an exception here would take the whole drag
+        // gesture down with it. 100 wide cannot hold 180, so x pins to the origin.
         val tiny = listOf(intArrayOf(0, 0, 100, 60))
-        val placed = clampGhostToScreens(cursorX = 50, cursorY = 30, width = GHOST_W, height = GHOST_H, screens = tiny)
-        assertEquals(Pair(0, 28), placed)
+        val placed =
+            clampGhostToScreens(
+                cursorX = 50,
+                cursorY = 30,
+                size = IntSize(GHOST_W, GHOST_H),
+                hotspot = IntOffset(HOT_X, HOT_Y),
+                screens = tiny,
+            )
+        assertEquals(Pair(0, 14), placed)
     }
 
     @Test
-    fun `with no monitors at all it still returns the offset point`() {
+    fun `with no monitors at all it still hangs the ghost off the pointer`() {
         val placed =
-            clampGhostToScreens(cursorX = 40, cursorY = 60, width = GHOST_W, height = GHOST_H, screens = emptyList())
-        assertEquals(Pair(56, 76), placed)
+            clampGhostToScreens(
+                cursorX = 40,
+                cursorY = 60,
+                size = IntSize(GHOST_W, GHOST_H),
+                hotspot = IntOffset(HOT_X, HOT_Y),
+                screens = emptyList(),
+            )
+        assertEquals(Pair(40 - HOT_X, 60 - HOT_Y), placed)
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
@@ -101,10 +101,19 @@ class HeavyweightGhostPlacementTest {
 
     @Test
     fun `the ghost is clamped to the monitor the pointer is on, not the primary one`() {
-        // The trap: clamping against the primary screen's rect would drag a ghost on the second
-        // monitor back to x < 1920, i.e. onto the wrong display entirely.
-        val placed = place(2000, 300, DUAL)
-        assertTrue(placed.first >= 1920, "ghost jumped back to the primary monitor: $placed")
+        // The trap: clamping against the primary screen's rect would drag a ghost near the second
+        // monitor's right edge back to x < 1920, i.e. onto the wrong display entirely.
+        val placed = place(3190, 300, DUAL)
+        assertEquals(1920 + 1280 - GHOST_W, placed.first)
+    }
+
+    @Test
+    fun `crossing the seam between two monitors leaves the ghost on the pointer`() {
+        // The card is 180 wide and carried 45 in, so clamping to whichever monitor the cursor is on
+        // would yank it up to 45px sideways at the seam and snap it back on the other side - for a
+        // spill that costs nothing, since the next display is right there. It is left alone.
+        val placed = place(1930, 300, DUAL)
+        assertEquals(Pair(1930 - HOT_X, 300 - HOT_Y), placed)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/overlays/HeavyweightGhostPlacementTest.kt
@@ -17,14 +17,21 @@ import kotlin.test.assertTrue
  * window that appears AFTER the press takes no mouse events at all (the source window holds the
  * implicit grab), so that gap bought nothing and cost ~27px of visible detachment.
  *
- * The other property is the CLAMP, which keeps the ghost on the monitor the pointer is on rather
- * than spilling over a taskbar or onto the wrong display. It is the one thing allowed to move the
- * ghost off its hotspot.
+ * The other property is the CLAMP, which keeps a ghost at the edge of the desktop from hanging half
+ * off it. It is the one thing allowed to move the ghost off its hotspot, so it is asked only when
+ * the ghost would land where no display is - spilling onto the next monitor, or over a dock, costs
+ * nothing and is left alone.
  */
 class HeavyweightGhostPlacementTest {
     private companion object {
-        /** A single 1920x1080 monitor at the origin with a 25px menu bar. */
-        val SINGLE = listOf(intArrayOf(0, 25, 1920, 1055))
+        /**
+         * A single 1920x1080 monitor at the origin.
+         *
+         * Full bounds, not the working area: a ghost is an always-on-top overlay following the
+         * pointer, so a dock or a menu bar is somewhere it may pass over, not somewhere there is no
+         * screen. See screenRects.
+         */
+        val SINGLE = listOf(intArrayOf(0, 0, 1920, 1080))
 
         /** The same, plus a second monitor to its right whose origin is NOT (0, 0). */
         val DUAL = SINGLE + listOf(intArrayOf(1920, 0, 1280, 800))
@@ -78,7 +85,7 @@ class HeavyweightGhostPlacementTest {
     }
 
     @Test
-    fun `at the right edge the ghost is pulled back onto the screen`() {
+    fun `at the right edge of the desktop the ghost is pulled back onto the screen`() {
         // The clamp wins over the hotspot here: half a ghost hanging off the display is worse than
         // a ghost the pointer is no longer centred on.
         val placed = place(1900, 400)
@@ -86,15 +93,15 @@ class HeavyweightGhostPlacementTest {
     }
 
     @Test
-    fun `at the bottom edge it is pulled up clear of the menu-bar-adjusted floor`() {
-        val placed = place(600, 1070)
-        assertEquals(25 + 1055 - GHOST_H, placed.second)
+    fun `at the bottom edge it is pulled up clear of the floor`() {
+        val placed = place(600, 1075)
+        assertEquals(1080 - GHOST_H, placed.second)
     }
 
     @Test
     fun `an edge that still fits is left exactly on the hotspot`() {
-        // Only clamp when it is actually needed: 25 + 1055 = 1080 is the floor, and a cursor at 1000
-        // leaves room for the half of the card that hangs below it.
+        // Only clamp when it is actually needed: a cursor at 1000 leaves room for the half of the
+        // card that hangs below it.
         val placed = place(600, 1000)
         assertEquals(1000 - HOT_Y, placed.second)
     }
@@ -125,12 +132,22 @@ class HeavyweightGhostPlacementTest {
     }
 
     @Test
+    fun `the seam holds along the top of the displays too, not only mid-screen`() {
+        // The trap that a mid-screen seam case cannot see: with the WORKING area as the coverage
+        // test, a card whose left corners reached into the strip a menu bar occupies counted as off
+        // the desktop, so it was pulled fully onto the cursor's monitor - the seam artifact back
+        // again, in a band along the top of every display.
+        val placed = place(1930, 30, DUAL)
+        assertEquals(Pair(1930 - HOT_X, 30 - HOT_Y), placed)
+    }
+
+    @Test
     fun `a pointer on no known monitor is pulled back onto one, not left off-screen`() {
         // Monitors can be unplugged mid-drag, and the coordinates are then off every rect we cached.
         // Without the clamp the ghost would sit thousands of pixels off-screen, invisible for the
         // rest of the drag.
         val placed = place(-5000, -5000, DUAL)
-        assertEquals(Pair(0, 25), placed)
+        assertEquals(Pair(0, 0), placed)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelMenuActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelMenuActionsTest.kt
@@ -1,0 +1,164 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.mcp.EvolverContract
+import ai.rever.boss.mcp.McpToolRegistryImpl
+import ai.rever.boss.plugin.api.McpToolDefinition
+import ai.rever.boss.plugin.api.McpToolProvider
+import ai.rever.boss.plugin.api.McpToolResult
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.window.LocalWindowId
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * What a panel's menu is allowed to offer, which is the half of the shared menu that decides rather
+ * than draws.
+ *
+ * Every row here is gated on something a person cannot see: a window to route the action to, a
+ * plugin behind the panel, a build that is not the released one, an MCP tool the current user's role
+ * exposes. Getting a gate wrong does not look like a bug - it looks like a row that is present and
+ * does nothing, which is exactly what this file's rule exists to prevent, so the gates are asserted
+ * directly rather than through whichever surface happens to draw them.
+ */
+class PanelMenuActionsTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private companion object {
+        const val PLUGIN = "ai.rever.boss.plugin.dynamic.probe"
+        const val PROVIDER = "test:evolver"
+        val PANEL = PanelId("probe", 1)
+    }
+
+    @After
+    fun clearRegistries() {
+        McpToolRegistryImpl.unregisterProvider(PROVIDER)
+        PluginBuildRegistry.reset()
+    }
+
+    /** Expose [names] as MCP tools, the way the evolver plugin exposes its own. */
+    private fun exposeTools(vararg names: String) {
+        McpToolRegistryImpl.registerProvider(
+            object : McpToolProvider {
+                override val providerId = PROVIDER
+
+                override fun tools() =
+                    names.map { name ->
+                        McpToolDefinition(
+                            name = name,
+                            description = name,
+                            handler = { McpToolResult("ok") },
+                        )
+                    }
+            },
+        )
+    }
+
+    private fun resolve(
+        windowId: String? = "window-1",
+        pluginId: String? = PLUGIN,
+        uninstallable: Boolean = true,
+    ): PanelMenuActions {
+        var actions = PanelMenuActions()
+        compose.setContent {
+            CompositionLocalProvider(
+                LocalWindowId provides windowId,
+                LocalPanelPluginIdResolver provides { pluginId },
+                LocalPluginUninstallable provides { uninstallable },
+            ) {
+                actions = panelMenuActions(PANEL)
+            }
+        }
+        compose.waitForIdle()
+        return actions
+    }
+
+    private fun localBuild() =
+        PluginBuildInfo(
+            pluginId = PLUGIN,
+            displayName = "Probe",
+            version = "1.0.3",
+            signedBytes = false,
+            storeSourced = false,
+            reloadStamp = null,
+        )
+
+    @Test
+    fun `a resolvable plugin in a tracked window gets the standing actions`() {
+        val actions = resolve()
+
+        assertNotNull(actions.reloadPanel)
+        assertNotNull(actions.checkForUpdates)
+        assertNotNull(actions.uninstallPlugin)
+        assertTrue(actions.uninstallEnabled)
+    }
+
+    @Test
+    fun `outside a tracked window nothing is offered`() {
+        // LocalWindowId is null wherever the caller is not hosted in a tracked window, and every one
+        // of these actions is addressed to a window.
+        val actions = resolve(windowId = null)
+
+        assertNull(actions.reloadPanel)
+        assertNull(actions.checkForUpdates)
+        assertNull(actions.uninstallPlugin)
+    }
+
+    @Test
+    fun `a panel with no resolvable plugin is offered nothing either`() {
+        // Every handler in BossAppMenuActionEffects resolves the panel's plugin and returns quietly
+        // when it cannot, so Reload Panel and Check for Updates would be rows that do nothing at
+        // all. They used to be offered anyway, gated on the window alone.
+        val actions = resolve(pluginId = null)
+
+        assertNull(actions.reloadPanel)
+        assertNull(actions.checkForUpdates)
+        assertNull(actions.uninstallPlugin)
+    }
+
+    @Test
+    fun `a plugin the manager refuses to unload keeps the row, disabled`() {
+        val actions = resolve(uninstallable = false)
+
+        assertNotNull(actions.uninstallPlugin, "the row is shown so its absence is not read as a missing feature")
+        assertEquals(false, actions.uninstallEnabled)
+    }
+
+    @Test
+    fun `the store-version action appears only for a build that is not the released one`() {
+        assertNull(resolve().installStoreVersion, "nothing to go back to on the released build")
+
+        PluginBuildRegistry.put(localBuild())
+        val tagged = resolve()
+
+        assertNotNull(tagged.installStoreVersion)
+        assertEquals("1.0.3-debug", tagged.buildInfo?.displayVersion)
+    }
+
+    @Test
+    fun `the evolver rows follow the tools the registry exposes`() {
+        // The gate is the RBAC-filtered MCP registry rather than anything compiled in: evolver_open
+        // is ungated, so Report Issue tracks the plugin being active, while Open Evolver tracks the
+        // permission-gated evolver_evolve being exposed to this user at all.
+        val none = resolve()
+        assertNull(none.reportIssue)
+        assertNull(none.openEvolver)
+
+        exposeTools(EvolverContract.OPEN_TOOL)
+        val openOnly = resolve()
+        assertNotNull(openOnly.reportIssue)
+        assertNull(openOnly.openEvolver, "a user who may not evolve is not offered the evolver")
+
+        exposeTools(EvolverContract.OPEN_TOOL, EvolverContract.EVOLVE_TOOL)
+        val both = resolve()
+        assertNotNull(both.reportIssue)
+        assertNotNull(both.openEvolver)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelMenuItemsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PanelMenuItemsTest.kt
@@ -1,0 +1,182 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.components.overlays.ContextMenuItem
+import ai.rever.boss.components.plugin.registries.PanelMenuRegistryImpl
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelMenuContribution
+import ai.rever.boss.plugin.api.PanelMenuItem
+import ai.rever.boss.window.LocalWindowId
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The one menu definition behind the panel header's kebab, the header's right-click menu and the
+ * sidebar rail icon's right-click menu.
+ *
+ * Asserted as a LIST rather than through a drawn menu, because what goes wrong here is structural
+ * and invisible to a "does this row exist" check: a divider with nothing under it, two rules in a
+ * row, a disabled row that is actually enabled, an order that puts the build rows somewhere other
+ * than first. The rendering of these rows is covered by BossPanelTopBarMenuTest and
+ * SidebarIconMenuTest.
+ */
+class PanelMenuItemsTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private companion object {
+        const val CONTRIBUTION = "test:menu"
+        val PANEL = PanelId("probe", 1)
+
+        /** What the rail passes as its trailing rows. */
+        val SIDEBAR_ROW = listOf(ContextMenuItem(text = "Sidebar settings"))
+    }
+
+    @After
+    fun clearRegistry() {
+        PanelMenuRegistryImpl.unregister(CONTRIBUTION)
+    }
+
+    private fun contribute(vararg items: PanelMenuItem) {
+        PanelMenuRegistryImpl.register(
+            object : PanelMenuContribution {
+                override val contributionId = CONTRIBUTION
+                override val targetPanels = setOf(PANEL.panelId)
+
+                override fun items(panelId: PanelId) = items.toList()
+
+                override fun onItemClick(
+                    panelId: PanelId,
+                    itemId: String,
+                    windowId: String?,
+                ) = Unit
+            },
+        )
+    }
+
+    private fun build(
+        actions: PanelMenuActions = PanelMenuActions(),
+        onOpenAsTab: (() -> Unit)? = null,
+        onMinimize: (() -> Unit)? = null,
+        trailingItems: List<ContextMenuItem> = emptyList(),
+    ): List<ContextMenuItem> {
+        var items: List<ContextMenuItem> = emptyList()
+        compose.setContent {
+            CompositionLocalProvider(LocalWindowId provides "window-1") {
+                items =
+                    panelMenuItems(
+                        panelId = PANEL,
+                        actions = actions,
+                        onOpenAsTab = onOpenAsTab,
+                        onMinimize = onMinimize,
+                        trailingItems = trailingItems,
+                    )
+            }
+        }
+        compose.waitForIdle()
+        return items
+    }
+
+    private fun taggedBuild() =
+        PluginBuildInfo(
+            pluginId = "p",
+            displayName = "Probe",
+            version = "1.0.3",
+            signedBytes = false,
+            storeSourced = false,
+            reloadStamp = null,
+        )
+
+    private fun List<ContextMenuItem>.labels() = filter { !it.isDivider }.map { it.text }
+
+    @Test
+    fun `the build rows come first and Minimize last, which is what the header shows`() {
+        val items =
+            build(
+                actions =
+                    PanelMenuActions(
+                        buildInfo = taggedBuild(),
+                        installStoreVersion = {},
+                        reloadPanel = {},
+                        checkForUpdates = {},
+                    ),
+                onOpenAsTab = {},
+                onMinimize = {},
+            )
+
+        assertEquals(
+            listOf(
+                "Version 1.0.3-debug",
+                "Install Store Version",
+                "Reload Panel",
+                "Check for Updates",
+                "Open as Tab",
+                "Minimize",
+            ),
+            items.labels(),
+        )
+    }
+
+    @Test
+    fun `an action that is not offered leaves no row behind`() {
+        // Every callback null is the no-window case, and the menu is then only what the caller adds.
+        val items = build(trailingItems = SIDEBAR_ROW)
+
+        assertEquals(listOf("Sidebar settings"), items.labels())
+        assertFalse(items.first().isDivider, "nothing to separate, so no leading rule")
+    }
+
+    @Test
+    fun `an unremovable plugin's uninstall row is present and disabled`() {
+        val items =
+            build(actions = PanelMenuActions(uninstallPlugin = {}, uninstallEnabled = false))
+
+        val uninstall = items.single { it.text == "Uninstall Plugin" }
+        assertFalse(uninstall.enabled, "a system plugin's row is shown so its absence is not read as a missing feature")
+    }
+
+    @Test
+    fun `a contribution whose items are all disabled adds neither a row nor a divider`() {
+        // The regression: the divider was decided from the raw entry list and the disabled items
+        // dropped inside the loop, so this left a rule with nothing under it.
+        contribute(PanelMenuItem(id = "a", label = "Run Diagnostics", enabled = false))
+
+        val items = build(actions = PanelMenuActions(reloadPanel = {}))
+
+        assertEquals(listOf("Reload Panel"), items.labels())
+        assertTrue(items.none { it.isDivider }, "an empty contribution should add no rule: $items")
+    }
+
+    @Test
+    fun `a contribution with something enabled gets its divider`() {
+        contribute(
+            PanelMenuItem(id = "a", label = "Hidden", enabled = false),
+            PanelMenuItem(id = "b", label = "Run Diagnostics"),
+        )
+
+        val items = build(actions = PanelMenuActions(reloadPanel = {}), onMinimize = {})
+
+        assertEquals(listOf("Reload Panel", "Run Diagnostics", "Minimize"), items.labels())
+        assertEquals(1, items.count { it.isDivider })
+    }
+
+    @Test
+    fun `the trailing rows never follow a second rule`() {
+        // The reported shape, end to end: an all-disabled contribution used to add a rule, which
+        // then counted as "something to separate" for the rail's trailing row - so the menu ended
+        // in two rules and then "Sidebar settings".
+        contribute(PanelMenuItem(id = "a", label = "Hidden", enabled = false))
+
+        val items = build(actions = PanelMenuActions(reloadPanel = {}), trailingItems = SIDEBAR_ROW)
+
+        val adjacent = items.zipWithNext().any { (a, b) -> a.isDivider && b.isDivider }
+        assertFalse(adjacent, "two dividers in a row: $items")
+        assertEquals(listOf("Reload Panel", "Sidebar settings"), items.labels())
+        assertEquals("Sidebar settings", items.last().text)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/sidebar/SidebarIconMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/sidebar/SidebarIconMenuTest.kt
@@ -22,12 +22,15 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.rightClick
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
  * What right-clicking a plugin's icon in the sidebar rail offers.
@@ -100,7 +103,7 @@ class SidebarIconMenuTest {
         windowId: String? = WINDOW,
         pluginId: String? = null,
         uninstallable: Boolean = true,
-    ) {
+    ): BossDraggableComponent {
         val model = BossDraggableComponent(PanelRegistry())
         val item = SidebarItem(PANEL, Icons.Default.Extension, LABEL)
         compose.setContent {
@@ -114,6 +117,7 @@ class SidebarIconMenuTest {
                 }
             }
         }
+        return model
     }
 
     private fun openMenu() {
@@ -122,7 +126,7 @@ class SidebarIconMenuTest {
 
     @Test
     fun `the icon's menu offers the plugin's own actions, not only the sidebar's`() {
-        showIcon()
+        showIcon(pluginId = PLUGIN)
         openMenu()
 
         compose.onNodeWithText("Reload Panel").assertExists()
@@ -185,8 +189,36 @@ class SidebarIconMenuTest {
     }
 
     @Test
+    fun `a panel with no resolvable plugin is offered no plugin rows`() {
+        // Every one of them routes through the owning plugin, and the handlers give up quietly when
+        // it cannot be resolved - so the rows would be present and inert. Only the sidebar's own
+        // row and Open as Tab, which needs no plugin, are left.
+        showIcon(pluginId = null)
+        openMenu()
+
+        compose.onNodeWithText("Reload Panel").assertDoesNotExist()
+        compose.onNodeWithText("Check for Updates").assertDoesNotExist()
+        compose.onNodeWithText("Uninstall Plugin").assertDoesNotExist()
+        compose.onNodeWithText("Open as Tab").assertExists()
+    }
+
+    @Test
+    fun `Open as Tab focuses the tab already hosting the panel instead of promoting a second`() {
+        // requestOpenAsTab's guard, at the new call site: addTab does not dedupe on TabInfo.id, so a
+        // second promote would leave two tabs rendering one cached panel component.
+        val model = showIcon(pluginId = PLUGIN)
+        model.markHostedAsTab(PANEL)
+        openMenu()
+
+        compose.onNodeWithText("Open as Tab").performClick()
+
+        assertEquals(PANEL, model.pendingFocusHostedTab)
+        assertNull(model.pendingPromoteToTab, "a second promote would double-compose the panel")
+    }
+
+    @Test
     fun `the sidebar's own row survives, after the plugin's`() {
-        showIcon()
+        showIcon(pluginId = PLUGIN)
         openMenu()
 
         compose.onNodeWithText("Sidebar settings").assertExists()
@@ -196,7 +228,7 @@ class SidebarIconMenuTest {
     fun `no Minimize row, since the menu opens just as often with the panel closed`() {
         // The icon's own click already toggles the panel. A Minimize row would be the only item in
         // this menu that silently does nothing for the state the rail is most often in.
-        showIcon()
+        showIcon(pluginId = PLUGIN)
         openMenu()
 
         compose.onNodeWithText("Minimize").assertDoesNotExist()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/sidebar/SidebarIconMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/sidebar/SidebarIconMenuTest.kt
@@ -3,9 +3,16 @@ package ai.rever.boss.components.sidebar
 import ai.rever.boss.components.buttons.DraggableActionButton
 import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.overlays.NativeContextMenuTestOverride
+import ai.rever.boss.components.plugin.LocalPanelPluginIdResolver
+import ai.rever.boss.components.plugin.LocalPluginUninstallable
+import ai.rever.boss.components.plugin.PluginBuildInfo
+import ai.rever.boss.components.plugin.PluginBuildRegistry
+import ai.rever.boss.components.plugin.registries.PanelMenuRegistryImpl
 import ai.rever.boss.plugin.api.Panel.Companion.left
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelMenuContribution
+import ai.rever.boss.plugin.api.PanelMenuItem
 import ai.rever.boss.plugin.api.PanelRegistry
 import ai.rever.boss.plugin.api.SidebarItem
 import ai.rever.boss.window.LocalWindowId
@@ -26,9 +33,10 @@ import org.junit.Test
  * What right-clicking a plugin's icon in the sidebar rail offers.
  *
  * The rail icon is the only handle a plugin has while its panel is closed, and it used to offer a
- * one-item menu ("Sidebar settings") - reloading, updating or opening a plugin meant opening its
- * panel first just to reach the header's "…" kebab. These pin that the icon now opens the panel's
- * own menu, and that the sidebar's row is still there behind it.
+ * one-item menu ("Sidebar settings") - reloading, updating or uninstalling a plugin meant opening
+ * its panel first just to reach the header's "…" kebab. These pin that the icon now opens the
+ * panel's own menu, including the rows that only exist for a resolvable plugin, and that the
+ * sidebar's own row is still there behind it.
  */
 class SidebarIconMenuTest {
     @get:Rule
@@ -37,6 +45,9 @@ class SidebarIconMenuTest {
     private companion object {
         const val LABEL = "Probe"
         const val WINDOW = "window-1"
+        const val PLUGIN = "ai.rever.boss.plugin.dynamic.probe"
+        const val CONTRIBUTION = "$PLUGIN:menu"
+        val PANEL = PanelId("probe", 1)
     }
 
     /**
@@ -50,15 +61,54 @@ class SidebarIconMenuTest {
     }
 
     @After
-    fun clearOverride() {
+    fun clearRegistries() {
         NativeContextMenuTestOverride.enabled = null
+        PluginBuildRegistry.reset()
+        PanelMenuRegistryImpl.unregister(CONTRIBUTION)
     }
 
-    private fun showIcon(windowId: String? = WINDOW) {
+    /** A build that is not the released one, so the version rows apply. */
+    private fun localBuild() =
+        PluginBuildInfo(
+            pluginId = PLUGIN,
+            displayName = LABEL,
+            version = "1.0.3",
+            signedBytes = false,
+            storeSourced = false,
+            reloadStamp = null,
+        )
+
+    /** A contribution whose items this test controls, targeting this panel only. */
+    private fun contribute(vararg items: PanelMenuItem) {
+        PanelMenuRegistryImpl.register(
+            object : PanelMenuContribution {
+                override val contributionId = CONTRIBUTION
+                override val targetPanels = setOf(PANEL.panelId)
+
+                override fun items(panelId: PanelId) = items.toList()
+
+                override fun onItemClick(
+                    panelId: PanelId,
+                    itemId: String,
+                    windowId: String?,
+                ) = Unit
+            },
+        )
+    }
+
+    private fun showIcon(
+        windowId: String? = WINDOW,
+        pluginId: String? = null,
+        uninstallable: Boolean = true,
+    ) {
         val model = BossDraggableComponent(PanelRegistry())
-        val item = SidebarItem(PanelId("probe", 1), Icons.Default.Extension, LABEL)
+        val item = SidebarItem(PANEL, Icons.Default.Extension, LABEL)
         compose.setContent {
-            CompositionLocalProvider(LocalWindowId provides windowId) {
+            CompositionLocalProvider(
+                LocalWindowId provides windowId,
+                LocalPanelPluginIdResolver provides { pluginId },
+                LocalPluginUninstallable provides { uninstallable },
+            ) {
                 with(model) {
                     DraggableActionButton(item = item, slot = left.top.top)
                 }
@@ -78,6 +128,60 @@ class SidebarIconMenuTest {
         compose.onNodeWithText("Reload Panel").assertExists()
         compose.onNodeWithText("Check for Updates").assertExists()
         compose.onNodeWithText("Open as Tab").assertExists()
+    }
+
+    @Test
+    fun `a resolvable plugin brings its uninstall row to the rail`() {
+        // Everything gated on the OWNING PLUGIN rather than on the panel: without a resolver the
+        // menu still has rows, so asserting only the ones above would pass with this half missing.
+        showIcon(pluginId = PLUGIN)
+        openMenu()
+
+        compose.onNodeWithText("Uninstall Plugin").assertExists()
+    }
+
+    @Test
+    fun `an unremovable plugin's uninstall row is still shown, not hidden`() {
+        // Same rule as the header: hiding it for a system plugin reads as the feature missing. That
+        // it is inert is asserted where the flag is visible, in PanelMenuItemsTest - the drawn row
+        // greys out rather than carrying disabled semantics.
+        showIcon(pluginId = PLUGIN, uninstallable = false)
+        openMenu()
+
+        compose.onNodeWithText("Uninstall Plugin").assertExists()
+    }
+
+    @Test
+    fun `a local build brings both version rows to the rail`() {
+        PluginBuildRegistry.put(localBuild())
+        showIcon(pluginId = PLUGIN)
+        openMenu()
+
+        compose.onNodeWithText("Version 1.0.3-debug").assertExists()
+        compose.onNodeWithText("Install Store Version").assertExists()
+    }
+
+    @Test
+    fun `the plugin's contributed rows reach the rail too`() {
+        contribute(PanelMenuItem(id = "diagnose", label = "Run Diagnostics"))
+        showIcon(pluginId = PLUGIN)
+        openMenu()
+
+        compose.onNodeWithText("Run Diagnostics").assertExists()
+    }
+
+    @Test
+    fun `a contribution with nothing enabled contributes no row`() {
+        // The divider used to be decided before the disabled items were dropped, so an all-disabled
+        // contribution left a rule with nothing under it - and on the rail that rule then counted as
+        // "something to separate", so the menu ended in two rules and then "Sidebar settings". The
+        // divider count itself is asserted in PanelMenuItemsTest, where the list is visible.
+        contribute(PanelMenuItem(id = "diagnose", label = "Run Diagnostics", enabled = false))
+        showIcon(pluginId = PLUGIN)
+        openMenu()
+
+        compose.onNodeWithText("Run Diagnostics").assertDoesNotExist()
+        compose.onNodeWithText("Sidebar settings").assertExists()
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/sidebar/SidebarIconMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/sidebar/SidebarIconMenuTest.kt
@@ -1,0 +1,112 @@
+package ai.rever.boss.components.sidebar
+
+import ai.rever.boss.components.buttons.DraggableActionButton
+import ai.rever.boss.components.model.BossDraggableComponent
+import ai.rever.boss.components.overlays.NativeContextMenuTestOverride
+import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.Panel.Companion.top
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelRegistry
+import ai.rever.boss.plugin.api.SidebarItem
+import ai.rever.boss.window.LocalWindowId
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.rightClick
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * What right-clicking a plugin's icon in the sidebar rail offers.
+ *
+ * The rail icon is the only handle a plugin has while its panel is closed, and it used to offer a
+ * one-item menu ("Sidebar settings") - reloading, updating or opening a plugin meant opening its
+ * panel first just to reach the header's "…" kebab. These pin that the icon now opens the panel's
+ * own menu, and that the sidebar's row is still there behind it.
+ */
+class SidebarIconMenuTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private companion object {
+        const val LABEL = "Probe"
+        const val WINDOW = "window-1"
+    }
+
+    /**
+     * The rows are found as Compose nodes, so this must run against the drawn menu. A native menu is
+     * an OS window with no Compose tree, which would make these fail on macOS and pass on CI for a
+     * reason unrelated to what they assert.
+     */
+    @Before
+    fun useDrawnMenu() {
+        NativeContextMenuTestOverride.enabled = false
+    }
+
+    @After
+    fun clearOverride() {
+        NativeContextMenuTestOverride.enabled = null
+    }
+
+    private fun showIcon(windowId: String? = WINDOW) {
+        val model = BossDraggableComponent(PanelRegistry())
+        val item = SidebarItem(PanelId("probe", 1), Icons.Default.Extension, LABEL)
+        compose.setContent {
+            CompositionLocalProvider(LocalWindowId provides windowId) {
+                with(model) {
+                    DraggableActionButton(item = item, slot = left.top.top)
+                }
+            }
+        }
+    }
+
+    private fun openMenu() {
+        compose.onNodeWithContentDescription(LABEL).performMouseInput { rightClick() }
+    }
+
+    @Test
+    fun `the icon's menu offers the plugin's own actions, not only the sidebar's`() {
+        showIcon()
+        openMenu()
+
+        compose.onNodeWithText("Reload Panel").assertExists()
+        compose.onNodeWithText("Check for Updates").assertExists()
+        compose.onNodeWithText("Open as Tab").assertExists()
+    }
+
+    @Test
+    fun `the sidebar's own row survives, after the plugin's`() {
+        showIcon()
+        openMenu()
+
+        compose.onNodeWithText("Sidebar settings").assertExists()
+    }
+
+    @Test
+    fun `no Minimize row, since the menu opens just as often with the panel closed`() {
+        // The icon's own click already toggles the panel. A Minimize row would be the only item in
+        // this menu that silently does nothing for the state the rail is most often in.
+        showIcon()
+        openMenu()
+
+        compose.onNodeWithText("Minimize").assertDoesNotExist()
+    }
+
+    @Test
+    fun `outside a tracked window the panel rows are left out rather than shown inert`() {
+        // LocalWindowId defaults to null wherever the rail is not hosted in a tracked window, and
+        // every one of these actions routes through a window. A row named as an imperative that
+        // does nothing is worse than no row.
+        showIcon(windowId = null)
+        openMenu()
+
+        compose.onNodeWithText("Reload Panel").assertDoesNotExist()
+        compose.onNodeWithText("Sidebar settings").assertExists()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarLayoutTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.window_panel.components
 
+import ai.rever.boss.components.plugin.PanelMenuActions
 import ai.rever.boss.components.plugin.PluginBuildInfo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.width
@@ -73,9 +74,8 @@ class BossPanelTopBarLayoutTest {
                 BossPanelTopBar(
                     title = title,
                     isHovered = true,
+                    actions = PanelMenuActions(buildInfo = buildInfo, installStoreVersion = {}),
                     onMinimize = {},
-                    buildInfo = buildInfo,
-                    onBuildTagClick = {},
                 )
             }
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/components/BossPanelTopBarMenuTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.window_panel.components
 
 import ai.rever.boss.components.overlays.NativeContextMenuTestOverride
+import ai.rever.boss.components.plugin.PanelMenuActions
 import ai.rever.boss.components.plugin.PluginBuildInfo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -70,12 +71,15 @@ class BossPanelTopBarMenuTest {
             BossPanelTopBar(
                 title = TITLE,
                 isHovered = true,
-                onReloadPlugin = { reloaded++ },
-                onUninstallPlugin = { uninstalled++ },
-                uninstallEnabled = uninstallEnabled,
+                actions =
+                    PanelMenuActions(
+                        buildInfo = buildInfo,
+                        installStoreVersion = if (withTagAction) ({ tagClicked++ }) else null,
+                        reloadPanel = { reloaded++ },
+                        uninstallPlugin = { uninstalled++ },
+                        uninstallEnabled = uninstallEnabled,
+                    ),
                 onMinimize = {},
-                buildInfo = buildInfo,
-                onBuildTagClick = if (withTagAction) ({ tagClicked++ }) else null,
             )
         }
     }


### PR DESCRIPTION
Two things about the sidebar rail's plugin icons, reported together.

## Right-click offered one row

The icon is the only handle a plugin has while its panel is closed, and its right-click menu was a single "Sidebar settings". Everything the plugin can actually be told to do - Reload Panel, Check for Updates, Install Store Version, Open Evolver, Report Issue, Uninstall Plugin, plus whatever the plugin contributes through `PanelMenuRegistry` - was behind the panel header's kebab, so reaching any of it meant opening the panel first.

The header's menu now comes from `panelMenuItems()` with its actions resolved by `rememberPanelMenuActions()`, both shared with the rail, so the kebab, the header's right-click menu and the icon's right-click menu cannot drift. `SidePanel` and `BossPanelTopBar` lose the derivation they used to carry.

Two rows are per-site rather than per-plugin:

- **Open as Tab** goes through `requestOpenAsTab`, so a plugin already hosted in a tab is focused rather than promoted a second time over the same cached component.
- **No Minimize** on the rail: the icon's own click already toggles the panel, and this menu opens just as often while the panel is closed, where the row would be the only one that silently does nothing.

"Sidebar settings" stays, after a divider. Outside a tracked window (`LocalWindowId` null) the panel rows are left out rather than shown inert.

## The drag ghost rode ~27px off the pointer

Under HARDWARE the ghost is its own cursor-tracking window, and it was placed 16px below-right of the cursor. For a 22dp icon that puts its centre ~27px diagonally from the pointer supposedly carrying it - while the lightweight path centred the same icon exactly on the pointer. The two paths disagreed, and the heavyweight one is what every platform runs since #128.

The gap was defensive rather than measured: the JVM has no portable click-through, so a window under the pointer was assumed to swallow the drag moving it. **Measured on macOS** with a Robot-driven drag, that is not what happens to a ghost that appears *after* the press - the source window holds the implicit mouse grab, and a 22x22 always-on-top window centred on the cursor received **zero** events while the source kept all 121 drag events and the release. Both ghosts here appear after a long press or a drag threshold, so the case the gap protected does not arise. (With the ghost already up *before* the press, it does take the whole gesture - which is why this is scoped to drag ghosts.)

`OverlayGhost` now takes the cursor hotspot, and both callers state the placement their lightweight path already draws: centred for the rail icon, a quarter in from the leading edge for a tab card. Screen handling reduces to the clamp that keeps a ghost near an edge on its own monitor. The window is also moved with `setLocation` directly rather than through `WindowState.position`, which is only applied by the next frame - a frame of lag on top of the frame the cursor read is already old.

## Tests

- `SidebarIconMenuTest` (new, 4 cases): the icon's menu offers the plugin's actions, keeps the sidebar row behind a divider, has no Minimize, and drops the panel rows outside a tracked window. Verified to fail against the old one-row menu.
- `HeavyweightGhostPlacementTest` rewritten around the hotspot invariant, keeping the multi-monitor, edge, unplugged-display and oversized-ghost cases.
- Full `:composeApp:desktopTest` green: 2820 tests, 0 failures. `ktlintCheck` + `detekt` clean.

Not covered by measurement: the grab behaviour was verified on macOS only. Windows and X11 use the same implicit-capture model, but if a drag ever proves flaky there, the hotspot is one parameter per caller to back off.