### PR TITLE
Offer to install the plugin a settings section needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,34 @@ deletes the jar it rejected - so an entry-only check made Retry close the dialog
 success with nothing installed, and silenced the prompt for every other dependent of that
 plugin. The check is an entry whose `jarPath` still exists.
 
+### A settings section can offer to install the plugin that serves it
+
+Three sections render a panel that belongs to a plugin - `Settings > AI Providers` (secret-manager),
+`Editor` and `Language servers` (both editor-tab). All three used to say "isn't loaded yet" for
+every reason there was no panel, which is true of exactly one of them. A plugin that was never
+installed, or that the user switched off, does not arrive however long they look at it.
+
+`PluginSettingsUnavailableNotice` now tells the four apart and offers an Install button for the one
+case where that is the answer. It leans on `MissingPluginOffer`, so no second install path exists:
+the press raises the host's own `MissingDependencyDialog`, which names the plugin **from the store**
+and shows the id it will install by, rather than installing on the button's say-so.
+
+**`pluginSectionAbsence` asks `isDisabled` before `installed`, and that order is the feature.**
+`MissingPluginOffer.isInstalled` counts a disabled plugin as installed - it is on disk, and
+`MissingDependencyInstaller` documents that deliberately - so the other order puts an Install button
+in front of a user who simply switched the plugin off, and pressing it downloads a jar they already
+have and changes nothing. That exact bug has shipped here once already with the bookmarks shelf. It
+is a pure function so the order is pinned by a test rather than by the reading order of a `when`,
+and reversing it fails *disabled is decided before installed*.
+
+**The notice gates on `MissingPluginOffer.isInstalled`, not on "can I reach the API".** Those are
+different questions and they disagree exactly when the plugin is installed but not running - which
+is the state where a button that appears does nothing. Same rule the tab bar's bookmarks shelf
+states.
+
+`null` from `isInstalled` means the question cannot be answered here (no active manager, no injected
+installer factory), and it must not become an offer: the section falls back to the neutral wait.
+
 ## Retiring a plugin into another one
 
 `RetiredPlugins.sweep()` uninstalls a plugin whose job another plugin has taken over. It runs at

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,13 +250,29 @@ case where that is the answer. It leans on `MissingPluginOffer`, so no second in
 the press raises the host's own `MissingDependencyDialog`, which names the plugin **from the store**
 and shows the id it will install by, rather than installing on the button's say-so.
 
-**`pluginSectionAbsence` asks `isDisabled` before `installed`, and that order is the feature.**
-`MissingPluginOffer.isInstalled` counts a disabled plugin as installed - it is on disk, and
-`MissingDependencyInstaller` documents that deliberately - so the other order puts an Install button
-in front of a user who simply switched the plugin off, and pressing it downloads a jar they already
-have and changes nothing. That exact bug has shipped here once already with the bookmarks shelf. It
-is a pure function so the order is pinned by a test rather than by the reading order of a `when`,
-and reversing it fails *disabled is decided before installed*.
+**`PluginState.DISABLED` is not one state, and that is why the decision is a pure function.**
+`DynamicPluginManager` writes it for at least three unrelated reasons - `disablePlugin`, a
+registration that failed as binary incompatible (`:1118`), and a plugin hidden because the user
+lacks access (`:1120`, `:2293`) - and "enable it in the Toolbox" is true for only the first. So
+`pluginSectionAbsence` takes the crash registry's `isIncompatible` and the manager's
+`getInaccessiblePlugins()` alongside the state, and its **order is load-bearing twice**:
+
+- permissions are asked **first**, because an inaccessible plugin is recorded DISABLED too, and
+  telling that user to switch it on points them at a row that is not listed for them;
+- `isIncompatible` and DISABLED are asked **before** `installed`, because
+  `MissingPluginOffer.isInstalled` counts both as installed (the jar is on disk, which
+  `MissingDependencyInstaller` documents deliberately) - so the other order offers an Install button
+  to someone whose problem a download cannot fix. That exact bug has shipped here once already with
+  the bookmarks shelf.
+
+All three orderings are mutation-verified: reversing each one fails a named test.
+
+**The section supplies exactly one fact the manager cannot answer**, `servesNoPanel` - the API is
+registered but this version has no panel for that section. Without it a loaded plugin reported
+"isn't loaded yet" forever. Everything else, permissions included, is derived from the plugin id, so
+a new section gets the whole behaviour by naming its plugin. An earlier version took the permissions
+as a parameter and only one of the three sections passed it, which left the other two telling a user
+who cannot access the plugin to go and switch it on.
 
 **The notice gates on `MissingPluginOffer.isInstalled`, not on "can I reach the API".** Those are
 different questions and they disagree exactly when the plugin is installed but not running - which
@@ -265,6 +281,18 @@ states.
 
 `null` from `isInstalled` means the question cannot be answered here (no active manager, no injected
 installer factory), and it must not become an offer: the section falls back to the neutral wait.
+
+**Known: the consent dialog opens over the main window, not the Settings window.** `SettingsWindow`
+is composed inside the main window's subtree and opts *its own* dialogs out of heavyweight overlay
+routing precisely so they do not open centred on the main window - but the dependency dialog is
+raised through `PluginDependencyEventBus` and composed by `BossAppDialogs`, outside that opt-out. It
+is always-on-top so it is not lost, just not where the press happened. Routing it would mean the
+prompt carrying a window id, which is the same change `MissingDependencyPrompt` already records as
+not built for the two-window case.
+
+**A raised offer is not a shown dialog.** `PluginDependencyEventBus.report` drops silently when a
+prompt for that plugin is already queued, so `offerIfMissing` returning true is not proof anything
+appeared. The press therefore logs whatever happens, matching the bookmarks shelf's call site.
 
 ## Retiring a plugin into another one
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/llm/LlmProviderAPIAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/llm/LlmProviderAPIAccess.kt
@@ -66,38 +66,6 @@ object LlmProviderAPIAccess {
         return remember(registryVersion) { getProvider() }
     }
 
-    /**
-     * The permissions the current user is missing for the plugin that owns AI provider
-     * settings, or an empty list when permissions are not why it is absent.
-     *
-     * `DynamicPluginManager` does not merely hide a plugin the user cannot access - it
-     * skips `register()` entirely, so the API is never contributed and this class's
-     * [getProvider] returns null. That is indistinguishable from "not installed" and
-     * "still starting up" at this layer, and the Settings section used to report all
-     * three as "isn't loaded yet" - which for the permission case is simply false: it
-     * will never load, and nothing told the user what to ask an admin for.
-     *
-     * Observes `pluginStates` rather than a permission flow because that is the public
-     * one, and it is written on exactly the transitions that matter: a plugin moving
-     * into or out of `hiddenPlugins` updates its state.
-     */
-    @Composable
-    fun rememberMissingPermissions(): List<String> {
-        val plugin = cachedDefaultPlugin ?: return emptyList()
-        val manager = plugin.dynamicPluginManager
-        val states by manager.pluginStates.collectAsState()
-        return remember(states) {
-            manager
-                .getInaccessiblePlugins()
-                .firstOrNull { it.pluginId == SECRET_MANAGER_PLUGIN_ID }
-                ?.missingPermissions
-                .orEmpty()
-        }
-    }
-
-    /** The plugin that owns AI provider settings. Also the credential vault. */
-    private const val SECRET_MANAGER_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.secretmanager"
-
     // ==================== Composable Bridges (Settings) ====================
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BossEditorSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BossEditorSettings.kt
@@ -22,10 +22,7 @@ fun BossEditorSettings() {
         PluginSettingsUnavailableNotice(
             what = "Editor settings",
             pluginName = "Code Editor",
-            pluginId = EDITOR_TAB_PLUGIN_ID,
+            pluginId = SettingsPluginIds.EDITOR_TAB,
         )
     }
 }
-
-/** The plugin that bundles BossEditor and serves both editor sections. */
-internal const val EDITOR_TAB_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.editortab"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BossEditorSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/BossEditorSettings.kt
@@ -19,6 +19,13 @@ fun BossEditorSettings() {
     if (provider != null) {
         provider.EditorSettingsPanel(modifier = Modifier.fillMaxSize())
     } else {
-        PluginSettingsUnavailableNotice("Editor settings are provided by the Code Editor plugin, which isn't loaded yet.")
+        PluginSettingsUnavailableNotice(
+            what = "Editor settings",
+            pluginName = "Code Editor",
+            pluginId = EDITOR_TAB_PLUGIN_ID,
+        )
     }
 }
+
+/** The plugin that bundles BossEditor and serves both editor sections. */
+internal const val EDITOR_TAB_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.editortab"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LLMProvidersSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LLMProvidersSettings.kt
@@ -21,25 +21,18 @@ import androidx.compose.ui.Modifier
 @Composable
 fun LLMProvidersSettings() {
     val provider = LlmProviderAPIAccess.rememberProvider()
-    // supportsSettingsPanel distinguishes "no panel" from "blank panel": the API's panel
-    // member has a default no-op, so a plugin that registers without overriding it would
-    // otherwise render an empty section with no explanation.
-    val missingPermissions = LlmProviderAPIAccess.rememberMissingPermissions()
+    // supportsSettingsPanel distinguishes "no panel" from "blank panel": the API's panel member
+    // has a default no-op, so a plugin that registers without overriding it would otherwise
+    // render an empty section with no explanation. It is the one fact the notice cannot look up
+    // for itself, so it is passed; everything else it derives from the plugin id.
     if (provider != null && provider.supportsSettingsPanel) {
         provider.LlmProviderSettingsPanel(modifier = Modifier.fillMaxSize())
     } else {
-        // One notice for every reason there is no panel. It tells the four apart - never
-        // installed, switched off, still starting, or inaccessible - and offers to install the
-        // plugin in the one case where that is the answer. The permission case is passed in
-        // rather than derived there because only this section can ask it.
         PluginSettingsUnavailableNotice(
             what = "AI provider settings",
             pluginName = "Secret Manager",
-            pluginId = SECRET_MANAGER_PLUGIN_ID,
-            missingPermissions = missingPermissions,
+            pluginId = SettingsPluginIds.SECRET_MANAGER,
+            servesNoPanel = provider != null,
         )
     }
 }
-
-/** The plugin that owns AI provider settings. Also the credential vault. */
-private const val SECRET_MANAGER_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.secretmanager"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LLMProvidersSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LLMProvidersSettings.kt
@@ -27,17 +27,19 @@ fun LLMProvidersSettings() {
     val missingPermissions = LlmProviderAPIAccess.rememberMissingPermissions()
     if (provider != null && provider.supportsSettingsPanel) {
         provider.LlmProviderSettingsPanel(modifier = Modifier.fillMaxSize())
-    } else if (missingPermissions.isNotEmpty()) {
-        // Not a loading state. The host skips register() for a plugin the user cannot
-        // access, so this section will stay empty until an admin grants the permission.
-        // Naming it is the difference between a dead end and an actionable one.
-        PluginSettingsUnavailableNotice(
-            "AI provider settings are provided by the Secret Manager plugin, which you do not have " +
-                "access to. Ask an administrator to grant: ${missingPermissions.joinToString(", ")}.",
-        )
     } else {
+        // One notice for every reason there is no panel. It tells the four apart - never
+        // installed, switched off, still starting, or inaccessible - and offers to install the
+        // plugin in the one case where that is the answer. The permission case is passed in
+        // rather than derived there because only this section can ask it.
         PluginSettingsUnavailableNotice(
-            "AI provider settings are provided by the Secret Manager plugin, which isn't loaded yet.",
+            what = "AI provider settings",
+            pluginName = "Secret Manager",
+            pluginId = SECRET_MANAGER_PLUGIN_ID,
+            missingPermissions = missingPermissions,
         )
     }
 }
+
+/** The plugin that owns AI provider settings. Also the credential vault. */
+private const val SECRET_MANAGER_PLUGIN_ID = "ai.rever.boss.plugin.dynamic.secretmanager"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LspSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LspSettings.kt
@@ -23,7 +23,7 @@ fun LspSettings() {
         PluginSettingsUnavailableNotice(
             what = "Language-server settings",
             pluginName = "Code Editor",
-            pluginId = EDITOR_TAB_PLUGIN_ID,
+            pluginId = SettingsPluginIds.EDITOR_TAB,
         )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LspSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/LspSettings.kt
@@ -20,6 +20,10 @@ fun LspSettings() {
     if (provider != null) {
         provider.LspSettingsPanel(modifier = Modifier.fillMaxSize())
     } else {
-        PluginSettingsUnavailableNotice("Language-server settings are provided by the Code Editor plugin, which isn't loaded yet.")
+        PluginSettingsUnavailableNotice(
+            what = "Language-server settings",
+            pluginName = "Code Editor",
+            pluginId = EDITOR_TAB_PLUGIN_ID,
+        )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsence.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsence.kt
@@ -1,21 +1,41 @@
 package ai.rever.boss.components.settings.sections
 
+import ai.rever.boss.plugin.api.PluginState
+
 /**
  * Why a plugin-backed settings section has nothing to render.
  *
- * The four are worth separating because only one of them is a wait. The section used to report
- * all of them as "isn't loaded yet", which for three of the four is simply false: a plugin that
- * was never installed, or that the user switched off, will not arrive however long they look at
- * it.
+ * Every member is a different sentence and a different thing to do about it, which is the whole
+ * point: the sections used to report all of these as "isn't loaded yet", and that is true of
+ * exactly one of them. A plugin that was never installed, that the user switched off, that the
+ * host rejected, or that they cannot access, does not arrive however long they look at it.
+ *
+ * **`PluginState.DISABLED` alone is not enough to tell them apart.** `DynamicPluginManager` writes
+ * it for at least three unrelated reasons - `disablePlugin`, a registration that failed as binary
+ * incompatible, and a plugin hidden because the user lacks access - and "enable it in the Toolbox"
+ * is only true for the first. The other two send the user to look for a row that either needs an
+ * update or is not listed for them at all.
  */
 internal enum class PluginSectionAbsence {
     /** Not on this machine. The only case that gets an Install button. */
     NOT_INSTALLED,
 
-    /** Installed, and switched off. It will never register until the user turns it back on. */
+    /** The user switched it off. It will not register until they turn it back on. */
     DISABLED,
 
-    /** Present and on its way: startup registration is asynchronous. The honest wait. */
+    /** The host rejected it as binary incompatible. It needs a newer build, not a switch. */
+    INCOMPATIBLE,
+
+    /** The user cannot access it, so the host never calls `register()`. An admin has to act. */
+    NO_ACCESS,
+
+    /** Loaded, and this version serves no panel for this section. It needs an update. */
+    NO_PANEL,
+
+    /** The host recorded a load failure. Not a wait either. */
+    FAILED,
+
+    /** Present and on its way: startup registration is asynchronous. The one honest wait. */
     STARTING,
 
     /** Not answerable here - no active manager, or the installer factory is not wired yet. */
@@ -23,28 +43,108 @@ internal enum class PluginSectionAbsence {
 }
 
 /**
- * Which absence a plugin is in, as a pure function of the two facts that decide it.
+ * Which absence a plugin is in, as a pure function of everything that decides it.
  *
- * **The order is the whole thing.** `isInstalled` counts a disabled plugin as installed - it is
- * on disk, and `MissingDependencyInstaller` documents that deliberately, because offering to
- * install something already on disk downloads a jar the user already has and still leaves the
- * feature dead. So DISABLED has to be asked first, or a user who switched a plugin off is shown
- * an Install button that does nothing. That is not hypothetical: `MissingPluginOffer.isInstalled`
- * records the same failure happening with the bookmarks plugin.
+ * **The order is the whole thing**, and two steps of it are load-bearing:
  *
- * A separate function from the composable because it is the one decision here worth testing, and
- * a composable that reads two global singletons is not reachable from a unit test.
+ * - `missingPermissions` is asked **first**. An inaccessible plugin is also recorded DISABLED, so
+ *   asking the state first tells a user to switch on a plugin that is not listed for them.
+ * - `isIncompatible` and `isDisabled` are asked **before** `installed`. `MissingPluginOffer
+ *   .isInstalled` counts both as installed - the jar is on disk, and `MissingDependencyInstaller`
+ *   documents that deliberately - so the other order puts an Install button in front of someone
+ *   whose problem a download cannot fix, and pressing it fetches a jar they already have. That is
+ *   not hypothetical: `MissingPluginOffer.isInstalled` records the same mistake shipping here with
+ *   the bookmarks shelf.
  *
- * @param installed the Install button's own predicate ([MissingPluginOffer.isInstalled]), where
- *   null means "cannot answer" - which is different from "no" and must not become an offer.
+ * A separate function from the composable because this is the decision worth testing, and a
+ * composable that reads three global singletons is not reachable from a unit test.
+ *
+ * @param installed the Install button's own predicate ([ai.rever.boss.components.plugin
+ *   .MissingPluginOffer.isInstalled]), where null means "cannot answer" - which is different from
+ *   "no" and must not become an offer
+ * @param state the manager's recorded state, or null when it has no entry for this plugin
+ * @param isIncompatible whether the host recorded it as binary incompatible
+ * @param missingPermissions non-empty when the user cannot access it at all
+ * @param servesNoPanel true when the plugin's API is present but serves no panel for this section,
+ *   which only the section can know - it is the one input the manager cannot answer
  */
 internal fun pluginSectionAbsence(
     installed: Boolean?,
-    isDisabled: Boolean,
+    state: PluginState?,
+    isIncompatible: Boolean,
+    missingPermissions: List<String>,
+    servesNoPanel: Boolean,
 ): PluginSectionAbsence =
     when {
-        isDisabled -> PluginSectionAbsence.DISABLED
+        missingPermissions.isNotEmpty() -> PluginSectionAbsence.NO_ACCESS
+        isIncompatible -> PluginSectionAbsence.INCOMPATIBLE
+        state == PluginState.DISABLED -> PluginSectionAbsence.DISABLED
         installed == false -> PluginSectionAbsence.NOT_INSTALLED
+        state == PluginState.ERROR -> PluginSectionAbsence.FAILED
+        servesNoPanel -> PluginSectionAbsence.NO_PANEL
         installed == true -> PluginSectionAbsence.STARTING
         else -> PluginSectionAbsence.UNKNOWN
     }
+
+/**
+ * What the section says, as a pure function so the wording of each case is pinned too.
+ *
+ * `when (absence)` over the enum rather than a chain of `==`: a member added without a sentence
+ * should be a compile error, not a silent fall-through to "isn't loaded yet", which is the failure
+ * this whole type exists to end.
+ *
+ * @param what a **plural** noun phrase for the thing the user came here for ("AI provider
+ *   settings", "Editor settings"), because every sentence below reads "$what are provided by"
+ */
+internal fun pluginSectionMessage(
+    absence: PluginSectionAbsence,
+    what: String,
+    pluginName: String,
+    missingPermissions: List<String>,
+): String {
+    val provided = "$what are provided by the $pluginName plugin"
+    return when (absence) {
+        PluginSectionAbsence.NOT_INSTALLED -> {
+            "$provided, which is not installed."
+        }
+
+        PluginSectionAbsence.DISABLED -> {
+            "$provided, which is installed but switched off. Enable it in the Toolbox."
+        }
+
+        PluginSectionAbsence.INCOMPATIBLE -> {
+            "$provided, which this version of BOSS could not load. Update it in the Toolbox."
+        }
+
+        PluginSectionAbsence.NO_ACCESS -> {
+            "$provided, which you do not have access to. " +
+                "Ask an administrator to grant: ${missingPermissions.joinToString(", ")}."
+        }
+
+        PluginSectionAbsence.NO_PANEL -> {
+            "$provided, and the installed version does not provide this panel. " +
+                "Update it in the Toolbox."
+        }
+
+        PluginSectionAbsence.FAILED -> {
+            "$provided, which failed to load. See the BOSS log for why."
+        }
+
+        PluginSectionAbsence.STARTING, PluginSectionAbsence.UNKNOWN -> {
+            "$provided, which isn't loaded yet."
+        }
+    }
+}
+
+/**
+ * Whether the section offers to install the plugin.
+ *
+ * One expression, named, because it is asked in two places that must agree - the button's
+ * visibility and what the press does - and because it is the single cell of the matrix where a
+ * download is the answer.
+ */
+internal fun pluginSectionOffersInstall(absence: PluginSectionAbsence): Boolean {
+    // A block body, not an expression one: ktlint wants the expression on the signature's line
+    // and detekt then calls that line too long. This is the shape both accept.
+    return absence == PluginSectionAbsence.NOT_INSTALLED
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsence.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsence.kt
@@ -1,0 +1,50 @@
+package ai.rever.boss.components.settings.sections
+
+/**
+ * Why a plugin-backed settings section has nothing to render.
+ *
+ * The four are worth separating because only one of them is a wait. The section used to report
+ * all of them as "isn't loaded yet", which for three of the four is simply false: a plugin that
+ * was never installed, or that the user switched off, will not arrive however long they look at
+ * it.
+ */
+internal enum class PluginSectionAbsence {
+    /** Not on this machine. The only case that gets an Install button. */
+    NOT_INSTALLED,
+
+    /** Installed, and switched off. It will never register until the user turns it back on. */
+    DISABLED,
+
+    /** Present and on its way: startup registration is asynchronous. The honest wait. */
+    STARTING,
+
+    /** Not answerable here - no active manager, or the installer factory is not wired yet. */
+    UNKNOWN,
+}
+
+/**
+ * Which absence a plugin is in, as a pure function of the two facts that decide it.
+ *
+ * **The order is the whole thing.** `isInstalled` counts a disabled plugin as installed - it is
+ * on disk, and `MissingDependencyInstaller` documents that deliberately, because offering to
+ * install something already on disk downloads a jar the user already has and still leaves the
+ * feature dead. So DISABLED has to be asked first, or a user who switched a plugin off is shown
+ * an Install button that does nothing. That is not hypothetical: `MissingPluginOffer.isInstalled`
+ * records the same failure happening with the bookmarks plugin.
+ *
+ * A separate function from the composable because it is the one decision here worth testing, and
+ * a composable that reads two global singletons is not reachable from a unit test.
+ *
+ * @param installed the Install button's own predicate ([MissingPluginOffer.isInstalled]), where
+ *   null means "cannot answer" - which is different from "no" and must not become an offer.
+ */
+internal fun pluginSectionAbsence(
+    installed: Boolean?,
+    isDisabled: Boolean,
+): PluginSectionAbsence =
+    when {
+        isDisabled -> PluginSectionAbsence.DISABLED
+        installed == false -> PluginSectionAbsence.NOT_INSTALLED
+        installed == true -> PluginSectionAbsence.STARTING
+        else -> PluginSectionAbsence.UNKNOWN
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSettingsUnavailableNotice.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSettingsUnavailableNotice.kt
@@ -2,9 +2,11 @@ package ai.rever.boss.components.settings.sections
 
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MissingPluginOffer
-import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
 import ai.rever.boss.plugin.ui.BossPrimaryButton
 import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,78 +22,83 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+private val logger = BossLogger.forComponent("PluginSettingsNotice")
+
 /**
  * Shown in a settings section whose panel is served by a plugin that has not registered its API.
  *
- * It says which of the four reasons applies, and when the plugin is genuinely absent it offers to
- * install it - the host can, which is the point: it resolves the id against the store, downloads
- * the jar and loads it, none of which a plugin can do for itself. Pressing Install raises the
- * host's own consent dialog (`MissingDependencyDialog`), which names the plugin from the **store**
- * and shows the id it will install by, rather than installing on this button's say-so.
+ * It says which of [PluginSectionAbsence]'s reasons applies, and when the plugin is genuinely
+ * absent it offers to install it - the host can, which is the point: it resolves the id against
+ * the store, downloads the jar and loads it, none of which a plugin can do for itself. Pressing
+ * Install raises the host's own consent dialog (`MissingDependencyDialog`), which names the plugin
+ * from the **store** and shows the id it will install by, rather than installing on this button's
+ * say-so.
  *
- * @param what the thing the user came here for, e.g. "AI provider settings"
+ * **Everything except [servesNoPanel] is derived from [pluginId]**, so a section gets the whole
+ * behaviour by naming its plugin. An earlier version took the missing permissions as a parameter
+ * and only one of the three sections passed it, which left the other two telling a user who cannot
+ * access the plugin to go and switch it on.
+ *
+ * **Known: the consent dialog opens over the main window, not this one.** `SettingsWindow` is
+ * composed inside the main window's subtree and opts *its own* dialogs out of heavyweight overlay
+ * routing for exactly this reason, but the dependency dialog is raised through
+ * `PluginDependencyEventBus` and composed by `BossAppDialogs`, outside that opt-out. It is
+ * always-on-top so it is not lost, but it appears centred on the main window rather than where the
+ * press happened. Routing it would mean the prompt carrying a window id - the same change
+ * `MissingDependencyPrompt` already records as not built, for the two-window case.
+ *
+ * @param what a **plural** noun phrase, e.g. "AI provider settings" - see [pluginSectionMessage]
  * @param pluginName the plugin's display name, for the sentence and the button
- * @param pluginId the id the host installs by
- * @param missingPermissions non-empty when the user cannot access the plugin at all, which is a
- *   different dead end: the host skips `register()` for an inaccessible plugin, so the API is
- *   never contributed and no amount of installing or waiting will help.
+ * @param pluginId the id the host installs by, and the id every other fact is looked up under
+ * @param servesNoPanel true when the plugin's API is present but this version serves no panel for
+ *   this section. The one input the manager cannot answer, so the section has to.
  */
 @Composable
 internal fun PluginSettingsUnavailableNotice(
     what: String,
     pluginName: String,
     pluginId: String,
-    missingPermissions: List<String> = emptyList(),
+    servesNoPanel: Boolean = false,
 ) {
-    val absence = rememberPluginSectionAbsence(pluginId)
-    var offerDeclined by remember(pluginId) { mutableStateOf(false) }
+    val facts = rememberPluginSectionFacts(pluginId, servesNoPanel)
+    // Keyed on the absence as well as the plugin, so the line cannot outlive the state that
+    // produced it. Keyed on the plugin alone, pressing Install just as the plugin arrived left
+    // "could not start the install" sitting under "isn't loaded yet", with no press left to clear
+    // it - the button it belongs to having disappeared.
+    var offerNotRaised by remember(pluginId, facts.absence) { mutableStateOf(false) }
 
     Column(
         modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Text(
-            text =
-                when {
-                    // Checked before the absence: an inaccessible plugin is skipped at
-                    // register() whether or not it is installed, so "install it" would send the
-                    // user to fix the wrong thing.
-                    missingPermissions.isNotEmpty() -> {
-                        "$what are provided by the $pluginName plugin, which you do not have access to. " +
-                            "Ask an administrator to grant: ${missingPermissions.joinToString(", ")}."
-                    }
-
-                    absence == PluginSectionAbsence.NOT_INSTALLED -> {
-                        "$what are provided by the $pluginName plugin, which is not installed."
-                    }
-
-                    absence == PluginSectionAbsence.DISABLED -> {
-                        "$what are provided by the $pluginName plugin, which is installed but " +
-                            "switched off. Enable it in the Toolbox."
-                    }
-
-                    else -> {
-                        "$what are provided by the $pluginName plugin, which isn't loaded yet."
-                    }
-                },
+            text = pluginSectionMessage(facts.absence, what, pluginName, facts.missingPermissions),
             color = BossTheme.colors.textMuted,
             fontSize = 13.sp,
         )
 
-        if (missingPermissions.isEmpty() && absence == PluginSectionAbsence.NOT_INSTALLED) {
+        if (pluginSectionOffersInstall(facts.absence)) {
             BossPrimaryButton(
                 text = "Install $pluginName",
                 onClick = {
-                    // False means there was nothing to offer after all - the plugin arrived
-                    // between the render and the press, or the installer factory is not wired.
-                    // Saying so beats a button that swallows the press: the panel replaces this
-                    // notice by itself in the first case, and the second is a real dead end.
-                    offerDeclined = !MissingPluginOffer.offerIfMissing(pluginId)
+                    // False means there was nothing to offer after all: the plugin arrived between
+                    // the render and the press, or the installer factory is not wired. Note that
+                    // true is not proof a dialog appeared either - the bus drops a report for a
+                    // plugin already queued - which is why the failure is logged as well as shown.
+                    val raised = MissingPluginOffer.offerIfMissing(pluginId)
+                    offerNotRaised = !raised
+                    if (!raised) {
+                        logger.warn(
+                            LogCategory.UI,
+                            "Settings offered to install a plugin and nothing was raised",
+                            mapOf("pluginId" to pluginId, "absence" to facts.absence.name),
+                        )
+                    }
                 },
             )
         }
 
-        if (offerDeclined) {
+        if (offerNotRaised) {
             Text(
                 text = "Could not start the install here. Install $pluginName from the Toolbox.",
                 color = BossTheme.colors.textMuted,
@@ -101,30 +108,49 @@ internal fun PluginSettingsUnavailableNotice(
     }
 }
 
+/** The absence and the permissions behind it, resolved together so they cannot disagree. */
+private data class PluginSectionFacts(
+    val absence: PluginSectionAbsence,
+    val missingPermissions: List<String>,
+)
+
 /**
  * Recomputed whenever any plugin's state changes, so the notice follows the plugin.
  *
  * Observing `pluginStates` is what makes Install self-clearing: the install lands, the manager
  * updates, this recomposes, and the section swaps to the real panel without the user reopening
- * Settings. It is also the signal for enabling or disabling the plugin elsewhere.
+ * Settings. It is also the signal for the plugin being enabled or disabled elsewhere, and for the
+ * access re-check that moves one in or out of `hiddenPlugins`.
  */
 @Composable
-private fun rememberPluginSectionAbsence(pluginId: String): PluginSectionAbsence {
+private fun rememberPluginSectionFacts(
+    pluginId: String,
+    servesNoPanel: Boolean,
+): PluginSectionFacts {
     // Same shape as the tab bar's bookmarks shelf, deliberately: a `?: return` before a
     // `collectAsState` would make the observation itself conditional on a global that can change
     // between compositions.
-    val states =
-        DynamicPluginManager
-            .anyActiveManager()
-            ?.pluginStates
-            ?.collectAsState()
-            ?.value
-    return remember(states, pluginId) {
-        pluginSectionAbsence(
-            // The Install button's own predicate, so the sentence and the button can never
-            // disagree about whether the plugin is here.
-            installed = MissingPluginOffer.isInstalled(pluginId),
-            isDisabled = states?.get(pluginId)?.state == PluginState.DISABLED,
+    val manager = DynamicPluginManager.anyActiveManager()
+    val states = manager?.pluginStates?.collectAsState()?.value
+    return remember(states, pluginId, servesNoPanel) {
+        val missingPermissions =
+            manager
+                ?.getInaccessiblePlugins()
+                ?.firstOrNull { it.pluginId == pluginId }
+                ?.missingPermissions
+                .orEmpty()
+        PluginSectionFacts(
+            absence =
+                pluginSectionAbsence(
+                    // The Install button's own predicate, so the sentence and the button can never
+                    // disagree about whether the plugin is here.
+                    installed = MissingPluginOffer.isInstalled(pluginId),
+                    state = states?.get(pluginId)?.state,
+                    isIncompatible = PluginCrashRegistry.isIncompatible(pluginId),
+                    missingPermissions = missingPermissions,
+                    servesNoPanel = servesNoPanel,
+                ),
+            missingPermissions = missingPermissions,
         )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSettingsUnavailableNotice.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/PluginSettingsUnavailableNotice.kt
@@ -1,27 +1,130 @@
 package ai.rever.boss.components.settings.sections
 
+import ai.rever.boss.components.plugin.DynamicPluginManager
+import ai.rever.boss.components.plugin.MissingPluginOffer
+import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.ui.BossPrimaryButton
 import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 /**
- * Shown in a settings section whose panel is served by a plugin that hasn't
- * registered its API (not installed yet, still loading, or an older version).
+ * Shown in a settings section whose panel is served by a plugin that has not registered its API.
+ *
+ * It says which of the four reasons applies, and when the plugin is genuinely absent it offers to
+ * install it - the host can, which is the point: it resolves the id against the store, downloads
+ * the jar and loads it, none of which a plugin can do for itself. Pressing Install raises the
+ * host's own consent dialog (`MissingDependencyDialog`), which names the plugin from the **store**
+ * and shows the id it will install by, rather than installing on this button's say-so.
+ *
+ * @param what the thing the user came here for, e.g. "AI provider settings"
+ * @param pluginName the plugin's display name, for the sentence and the button
+ * @param pluginId the id the host installs by
+ * @param missingPermissions non-empty when the user cannot access the plugin at all, which is a
+ *   different dead end: the host skips `register()` for an inaccessible plugin, so the API is
+ *   never contributed and no amount of installing or waiting will help.
  */
 @Composable
-internal fun PluginSettingsUnavailableNotice(message: String) {
-    Text(
-        text = message,
-        color = BossTheme.colors.textMuted,
-        fontSize = 13.sp,
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp),
-    )
+internal fun PluginSettingsUnavailableNotice(
+    what: String,
+    pluginName: String,
+    pluginId: String,
+    missingPermissions: List<String> = emptyList(),
+) {
+    val absence = rememberPluginSectionAbsence(pluginId)
+    var offerDeclined by remember(pluginId) { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text =
+                when {
+                    // Checked before the absence: an inaccessible plugin is skipped at
+                    // register() whether or not it is installed, so "install it" would send the
+                    // user to fix the wrong thing.
+                    missingPermissions.isNotEmpty() -> {
+                        "$what are provided by the $pluginName plugin, which you do not have access to. " +
+                            "Ask an administrator to grant: ${missingPermissions.joinToString(", ")}."
+                    }
+
+                    absence == PluginSectionAbsence.NOT_INSTALLED -> {
+                        "$what are provided by the $pluginName plugin, which is not installed."
+                    }
+
+                    absence == PluginSectionAbsence.DISABLED -> {
+                        "$what are provided by the $pluginName plugin, which is installed but " +
+                            "switched off. Enable it in the Toolbox."
+                    }
+
+                    else -> {
+                        "$what are provided by the $pluginName plugin, which isn't loaded yet."
+                    }
+                },
+            color = BossTheme.colors.textMuted,
+            fontSize = 13.sp,
+        )
+
+        if (missingPermissions.isEmpty() && absence == PluginSectionAbsence.NOT_INSTALLED) {
+            BossPrimaryButton(
+                text = "Install $pluginName",
+                onClick = {
+                    // False means there was nothing to offer after all - the plugin arrived
+                    // between the render and the press, or the installer factory is not wired.
+                    // Saying so beats a button that swallows the press: the panel replaces this
+                    // notice by itself in the first case, and the second is a real dead end.
+                    offerDeclined = !MissingPluginOffer.offerIfMissing(pluginId)
+                },
+            )
+        }
+
+        if (offerDeclined) {
+            Text(
+                text = "Could not start the install here. Install $pluginName from the Toolbox.",
+                color = BossTheme.colors.textMuted,
+                fontSize = 12.sp,
+            )
+        }
+    }
+}
+
+/**
+ * Recomputed whenever any plugin's state changes, so the notice follows the plugin.
+ *
+ * Observing `pluginStates` is what makes Install self-clearing: the install lands, the manager
+ * updates, this recomposes, and the section swaps to the real panel without the user reopening
+ * Settings. It is also the signal for enabling or disabling the plugin elsewhere.
+ */
+@Composable
+private fun rememberPluginSectionAbsence(pluginId: String): PluginSectionAbsence {
+    // Same shape as the tab bar's bookmarks shelf, deliberately: a `?: return` before a
+    // `collectAsState` would make the observation itself conditional on a global that can change
+    // between compositions.
+    val states =
+        DynamicPluginManager
+            .anyActiveManager()
+            ?.pluginStates
+            ?.collectAsState()
+            ?.value
+    return remember(states, pluginId) {
+        pluginSectionAbsence(
+            // The Install button's own predicate, so the sentence and the button can never
+            // disagree about whether the plugin is here.
+            installed = MissingPluginOffer.isInstalled(pluginId),
+            isDisabled = states?.get(pluginId)?.state == PluginState.DISABLED,
+        )
+    }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SettingsPluginIds.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/SettingsPluginIds.kt
@@ -1,0 +1,22 @@
+package ai.rever.boss.components.settings.sections
+
+/**
+ * The plugins that serve a settings section.
+ *
+ * One place, because each id is asked twice for different things - which plugin's absence the
+ * section explains, and which plugin the Install button downloads - and a drift between the two
+ * would have a section describe one plugin while offering to install another, with nothing
+ * failing. Two sections already share the editor id for the same reason.
+ *
+ * These ids also appear in `SystemPluginManifestService` and the first-run wizard's
+ * `PluginListProvider`. Those copies predate this and answer different questions (what to bundle,
+ * what to offer at first run); folding all of them into one holder is worth doing and is a wider
+ * change than this one.
+ */
+internal object SettingsPluginIds {
+    /** Owns AI provider settings, and the credential vault they are stored in. */
+    const val SECRET_MANAGER = "ai.rever.boss.plugin.dynamic.secretmanager"
+
+    /** Bundles BossEditor, and serves both the editor and language-server sections. */
+    const val EDITOR_TAB = "ai.rever.boss.plugin.dynamic.editortab"
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsenceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsenceTest.kt
@@ -1,0 +1,70 @@
+package ai.rever.boss.components.settings.sections
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Which of the four reasons a plugin-backed settings section has no panel, which decides whether
+ * it offers an Install button.
+ *
+ * The ordering test is the one that matters. `MissingPluginOffer.isInstalled` counts a **disabled**
+ * plugin as installed - it is on disk, and the installer documents that deliberately - so asking
+ * `installed` before `isDisabled` puts an Install button in front of a user who simply switched the
+ * plugin off. Pressing it downloads a jar they already have and changes nothing. The same mistake
+ * has already shipped once here with the bookmarks plugin, which is why it is pinned rather than
+ * left to the reading order of a `when`.
+ */
+class PluginSectionAbsenceTest {
+    @Test
+    fun `a plugin that is not installed is the one case that gets an offer`() {
+        assertEquals(
+            PluginSectionAbsence.NOT_INSTALLED,
+            pluginSectionAbsence(installed = false, isDisabled = false),
+        )
+    }
+
+    @Test
+    fun `an installed plugin that has not registered yet is starting, not missing`() {
+        // Registration is asynchronous, so this is the honest wait - and the only one of the four
+        // where "isn't loaded yet" was ever true.
+        assertEquals(
+            PluginSectionAbsence.STARTING,
+            pluginSectionAbsence(installed = true, isDisabled = false),
+        )
+    }
+
+    @Test
+    fun `a disabled plugin is disabled, not starting`() {
+        // It reads as installed, and it will never register. Reported as STARTING the section
+        // says "isn't loaded yet" forever at a user who switched it off themselves.
+        assertEquals(
+            PluginSectionAbsence.DISABLED,
+            pluginSectionAbsence(installed = true, isDisabled = true),
+        )
+    }
+
+    @Test
+    fun `disabled is decided before installed, so no Install button appears for it`() {
+        // The ordering, stated as its own case: whatever `installed` says, a disabled plugin must
+        // never reach NOT_INSTALLED, because that is the only value that draws the button.
+        assertEquals(
+            PluginSectionAbsence.DISABLED,
+            pluginSectionAbsence(installed = false, isDisabled = true),
+        )
+        assertEquals(
+            PluginSectionAbsence.DISABLED,
+            pluginSectionAbsence(installed = null, isDisabled = true),
+        )
+    }
+
+    @Test
+    fun `cannot answer is not the same as no`() {
+        // Null means no active manager or no injected installer factory - before startup finishes,
+        // and in tests. Treating it as "not installed" would offer to install something that may
+        // well be there, from a state where the install could not run anyway.
+        assertEquals(
+            PluginSectionAbsence.UNKNOWN,
+            pluginSectionAbsence(installed = null, isDisabled = false),
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsenceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/settings/sections/PluginSectionAbsenceTest.kt
@@ -1,70 +1,160 @@
 package ai.rever.boss.components.settings.sections
 
+import ai.rever.boss.plugin.api.PluginState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
- * Which of the four reasons a plugin-backed settings section has no panel, which decides whether
- * it offers an Install button.
+ * Why a plugin-backed settings section has no panel, and what it may offer about it.
  *
- * The ordering test is the one that matters. `MissingPluginOffer.isInstalled` counts a **disabled**
- * plugin as installed - it is on disk, and the installer documents that deliberately - so asking
- * `installed` before `isDisabled` puts an Install button in front of a user who simply switched the
- * plugin off. Pressing it downloads a jar they already have and changes nothing. The same mistake
- * has already shipped once here with the bookmarks plugin, which is why it is pinned rather than
- * left to the reading order of a `when`.
+ * The precedence tests are the ones that matter, because every one of them is a case where the
+ * section would otherwise give advice that cannot work:
+ *
+ * - `MissingPluginOffer.isInstalled` counts a **disabled** or **rejected** plugin as installed -
+ *   the jar is on disk - so asking `installed` first puts an Install button in front of a user
+ *   whose problem a download cannot fix. That has already shipped here once, with the bookmarks
+ *   shelf.
+ * - `DynamicPluginManager` records a plugin **hidden for lack of access** as `DISABLED` too, so
+ *   asking the state first tells a user to switch on a plugin that is not listed for them.
  */
 class PluginSectionAbsenceTest {
+    private fun absence(
+        installed: Boolean? = true,
+        state: PluginState? = PluginState.LOADED,
+        isIncompatible: Boolean = false,
+        missingPermissions: List<String> = emptyList(),
+        servesNoPanel: Boolean = false,
+    ) = pluginSectionAbsence(installed, state, isIncompatible, missingPermissions, servesNoPanel)
+
     @Test
     fun `a plugin that is not installed is the one case that gets an offer`() {
-        assertEquals(
-            PluginSectionAbsence.NOT_INSTALLED,
-            pluginSectionAbsence(installed = false, isDisabled = false),
-        )
+        assertEquals(PluginSectionAbsence.NOT_INSTALLED, absence(installed = false, state = null))
     }
 
     @Test
     fun `an installed plugin that has not registered yet is starting, not missing`() {
-        // Registration is asynchronous, so this is the honest wait - and the only one of the four
-        // where "isn't loaded yet" was ever true.
-        assertEquals(
-            PluginSectionAbsence.STARTING,
-            pluginSectionAbsence(installed = true, isDisabled = false),
-        )
+        // Registration is asynchronous, so this is the honest wait - and the only case where
+        // "isn't loaded yet" was ever true.
+        assertEquals(PluginSectionAbsence.STARTING, absence())
     }
 
     @Test
-    fun `a disabled plugin is disabled, not starting`() {
-        // It reads as installed, and it will never register. Reported as STARTING the section
-        // says "isn't loaded yet" forever at a user who switched it off themselves.
-        assertEquals(
-            PluginSectionAbsence.DISABLED,
-            pluginSectionAbsence(installed = true, isDisabled = true),
-        )
+    fun `a disabled plugin is disabled, not starting and not missing`() {
+        assertEquals(PluginSectionAbsence.DISABLED, absence(state = PluginState.DISABLED))
     }
 
     @Test
     fun `disabled is decided before installed, so no Install button appears for it`() {
-        // The ordering, stated as its own case: whatever `installed` says, a disabled plugin must
-        // never reach NOT_INSTALLED, because that is the only value that draws the button.
+        // Whatever `installed` says, a switched-off plugin must never reach NOT_INSTALLED,
+        // because that is the only value that draws the button.
         assertEquals(
             PluginSectionAbsence.DISABLED,
-            pluginSectionAbsence(installed = false, isDisabled = true),
+            absence(installed = false, state = PluginState.DISABLED),
         )
         assertEquals(
             PluginSectionAbsence.DISABLED,
-            pluginSectionAbsence(installed = null, isDisabled = true),
+            absence(installed = null, state = PluginState.DISABLED),
         )
     }
 
     @Test
-    fun `cannot answer is not the same as no`() {
-        // Null means no active manager or no injected installer factory - before startup finishes,
-        // and in tests. Treating it as "not installed" would offer to install something that may
-        // well be there, from a state where the install could not run anyway.
+    fun `a rejected plugin needs an update, not an install and not a switch`() {
+        // Binary-incompatible: the host records DISABLED and the installer deletes the jar it
+        // rejected. Both other readings send the user somewhere that cannot help.
         assertEquals(
-            PluginSectionAbsence.UNKNOWN,
-            pluginSectionAbsence(installed = null, isDisabled = false),
+            PluginSectionAbsence.INCOMPATIBLE,
+            absence(state = PluginState.DISABLED, isIncompatible = true),
         )
+        assertEquals(
+            PluginSectionAbsence.INCOMPATIBLE,
+            absence(installed = false, state = null, isIncompatible = true),
+        )
+    }
+
+    @Test
+    fun `no access wins over every other reason`() {
+        // An inaccessible plugin is recorded DISABLED as well, so this has to be asked first or
+        // the user is told to enable something that is not listed for them. It also outranks
+        // NOT_INSTALLED: installing it again would not grant the permission.
+        assertEquals(
+            PluginSectionAbsence.NO_ACCESS,
+            absence(state = PluginState.DISABLED, missingPermissions = listOf("secret.read")),
+        )
+        assertEquals(
+            PluginSectionAbsence.NO_ACCESS,
+            absence(installed = false, state = null, missingPermissions = listOf("secret.read")),
+        )
+        assertEquals(
+            PluginSectionAbsence.NO_ACCESS,
+            absence(isIncompatible = true, missingPermissions = listOf("secret.read")),
+        )
+    }
+
+    @Test
+    fun `a loaded plugin whose version serves no panel is not still loading`() {
+        // The API is present, so the plugin is loaded and accessible - it just has no panel for
+        // this section. Reported as STARTING it says "isn't loaded yet" forever about something
+        // that is loaded.
+        assertEquals(PluginSectionAbsence.NO_PANEL, absence(servesNoPanel = true))
+    }
+
+    @Test
+    fun `a load failure is not a wait either`() {
+        assertEquals(PluginSectionAbsence.FAILED, absence(state = PluginState.ERROR))
+    }
+
+    @Test
+    fun `cannot answer is not the same as no`() {
+        // Null means no active manager or no injected installer factory - before startup
+        // finishes, and in tests. Treating it as "not installed" would offer to install
+        // something that may well be there, from a state where the install could not run.
+        assertEquals(PluginSectionAbsence.UNKNOWN, absence(installed = null, state = null))
+    }
+
+    @Test
+    fun `only a missing plugin is offered for install`() {
+        // Asserted over every member rather than the one, so a member added later has to decide
+        // this deliberately instead of inheriting it.
+        PluginSectionAbsence.entries.forEach { absence ->
+            assertEquals(
+                absence == PluginSectionAbsence.NOT_INSTALLED,
+                pluginSectionOffersInstall(absence),
+                "offersInstall disagrees for $absence",
+            )
+        }
+    }
+
+    @Test
+    fun `every absence has its own sentence`() {
+        // The failure this guards is a member falling through to a message written for another
+        // one, which is the whole defect the type exists to end.
+        val messages =
+            PluginSectionAbsence.entries.associateWith {
+                pluginSectionMessage(it, "Editor settings", "Code Editor", listOf("editor.read"))
+            }
+        messages.forEach { (absence, message) ->
+            assertTrue(
+                message.startsWith("Editor settings are provided by the Code Editor plugin"),
+                "$absence does not name the section and its plugin: $message",
+            )
+        }
+        // STARTING and UNKNOWN deliberately share the wait; everything else is distinct.
+        val distinct = messages.filterKeys { it != PluginSectionAbsence.UNKNOWN }.values.toSet()
+        assertEquals(PluginSectionAbsence.entries.size - 1, distinct.size, "two absences read alike")
+    }
+
+    @Test
+    fun `the no-access sentence names the permissions to ask for`() {
+        val message =
+            pluginSectionMessage(
+                PluginSectionAbsence.NO_ACCESS,
+                "AI provider settings",
+                "Secret Manager",
+                listOf("secret.read", "secret.write"),
+            )
+        assertTrue(message.contains("secret.read, secret.write"), message)
+        assertFalse(pluginSectionOffersInstall(PluginSectionAbsence.NO_ACCESS))
     }
 }


### PR DESCRIPTION
Three settings sections render a panel that belongs to a plugin:

| Section | Plugin |
|---|---|
| AI Providers | secret-manager |
| Editor | editor-tab |
| Language servers | editor-tab |

All three said **"isn't loaded yet"** for every reason there was no panel, which is true of exactly one of them. A plugin that was never installed, or that the user switched off, does not arrive however long they look at it - and nothing on screen said so, or offered a way out.

## What it does now

The notice tells the four reasons apart, and offers an Install button in the one case where that is the answer:

| State | What the section says | Button |
|---|---|---|
| not installed | "…which is not installed." | **Install \<plugin\>** |
| installed, switched off | "…which is installed but switched off. Enable it in the Toolbox." | none |
| installed, still registering | "…which isn't loaded yet." | none |
| user lacks the permission | "…which you do not have access to. Ask an administrator to grant: X." | none |

Installing is the host's to do, which is the point: it resolves an id against the store, downloads the jar and loads it - none of which a plugin can do for itself. This adds **no second install path**. It calls `MissingPluginOffer.offerIfMissing`, so the press raises the host's own `MissingDependencyDialog`, which names the plugin *from the store* and shows the id it will install by, rather than installing on this button's say-so.

## The ordering is the feature

`pluginSectionAbsence` asks `isDisabled` **before** `installed`.

`MissingPluginOffer.isInstalled` counts a disabled plugin as installed - it is on disk, and `MissingDependencyInstaller` documents that deliberately. So the other order puts an Install button in front of someone who simply switched the plugin off, and pressing it downloads a jar they already have and changes nothing.

That is not hypothetical. `MissingPluginOffer.isInstalled`'s own KDoc records it happening here already, "with the bookmarks plugin sitting installed-and-disabled behind an Install button". So the decision is a pure function pinned by a test rather than left to the reading order of a `when` - **mutation-verified**: swapping the two branches fails *disabled is decided before installed, so no Install button appears for it*.

Two smaller rules carried over from that shelf:

- **Gate on the Install button's own predicate**, not on "can I reach the API right now". Those disagree exactly when the plugin is installed but not running, which is the state where a button that appears does nothing.
- **`null` means "cannot tell", not "no".** Before startup wires the installer factory there is no manager to ask; treating that as absent would offer to install something that may well be there, from a state where the install could not run anyway.

Observing `pluginStates` is what makes the notice self-clearing: the install lands, the manager updates, the section swaps to the real panel without reopening Settings.

## Verification

- `./gradlew :composeApp:desktopTest` - **2867 cases, 0 failures** (5 new).
- `./gradlew ktlintCheck detekt` - clean.
- Mutation: reversing the two `when` branches fails the ordering test.

**Not verified on screen, and worth saying plainly.** All three plugins are installed on this machine, so the not-installed branch never renders here; and driving the app to Settings needs pointer input this environment cannot produce (no assistive access). What that leaves unproven is the visual result, not the logic: the predicate, the manager lookup and the `pluginStates` observation are all copied from the tab bar's bookmarks shelf, which ships this exact pattern in production, and the branch selection is unit-tested. Worth a look at Settings > AI Providers on a machine without secret-manager before this is relied on.