### PR TITLE
Drag the vertical tab bar's edge to resize it

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -965,6 +965,7 @@
     <ID>PackageNaming:TabMenuVisibilityReportTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:BookmarksDialogProviderImpl.kt$package ai.rever.boss.components.plugin.panels.left_top</ID>
     <ID>PackageNaming:BarMenuItems.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
+    <ID>PackageNaming:VerticalTabBarResizeHandle.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
     <ID>PackageNaming:BossMainWindowPanel.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
     <ID>PackageNaming:BossPanelTopBar.kt$package ai.rever.boss.components.window_panel.components</ID>
     <ID>PackageNaming:BossPanelTopBarLayoutTest.kt$package ai.rever.boss.components.window_panel.components</ID>
@@ -1006,6 +1007,7 @@
     <ID>PackageNaming:PaneGlyphTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:PaneTabStrip.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
     <ID>PackageNaming:PaneTabStripVisibilityTest.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:BarResizeTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:PaneZoomTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:PanelHostTab.kt$package ai.rever.boss.components.plugin.tab_types</ID>
     <ID>PackageNaming:PromoteSidebarToTab.kt$package ai.rever.boss.components.window_panel</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -14,6 +14,7 @@ import ai.rever.boss.components.window_panel.components.main_window_panels.BossM
 import ai.rever.boss.components.window_panel.components.main_window_panels.BossTabsComponent
 import ai.rever.boss.components.window_panel.components.main_window_panels.TabBarLayout
 import ai.rever.boss.components.window_panel.components.main_window_panels.TabBarRevealState
+import ai.rever.boss.components.window_panel.components.main_window_panels.VerticalTabBarResizeHandle
 import ai.rever.boss.components.window_panel.components.main_window_panels.WindowRevealedTabBarDrawer
 import ai.rever.boss.components.window_panel.components.main_window_panels.WindowVerticalTabBar
 import ai.rever.boss.components.window_panel.components.main_window_panels.createBossAppContext
@@ -40,6 +41,7 @@ import ai.rever.boss.topofmind.ActiveTab
 import ai.rever.boss.utils.extractFileName
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.window.WindowAppearanceSettingsManager
 import ai.rever.boss.window.WindowProjectStateRegistry
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -67,6 +69,9 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -85,6 +90,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 // Sealed class representing the split tree structure
@@ -1934,13 +1940,21 @@ private fun WindowBarRow(
             tabDragComponent = tabDragComponent,
             onTabDropResult = onTabDropResult,
         )
+
+    // The width being dragged, or null when nobody is dragging. Local for the length of the
+    // gesture and written to settings once, on release - see VerticalTabBarResizeHandle for why
+    // persisting each frame is the wrong shape.
+    var draggedWidth by remember { mutableStateOf<Float?>(null) }
+    val barWidthScope = rememberCoroutineScope()
+    val barWidth = draggedWidth?.dp ?: bar.width
+
     Row(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.hoverable(reveal.railHover, enabled = bar.hoverExpand && bar.railShown)) {
             WindowVerticalTabBar(
                 groups = groups,
                 listState = listState,
                 expansion = expansion,
-                width = bar.width,
+                width = barWidth,
                 collapsed = bar.railShown,
                 onToggleCollapse = rememberToggleCollapseAction(bar, reveal),
                 tabDragComponent = tabDragComponent,
@@ -1949,7 +1963,22 @@ private fun WindowBarRow(
                 onExitZoom = splitViewState::exitZoom,
             )
         }
-        VDivider()
+        VerticalTabBarResizeHandle(
+            // Not while the bar is a rail: the rail's width is a different number, and a drag
+            // that appeared to work would be moving one nothing on screen was showing.
+            enabled = !bar.railShown,
+            currentWidth = barWidth.value,
+            onPreview = { width -> draggedWidth = width },
+            onCommit = { width ->
+                draggedWidth = null
+                barWidthScope.launch {
+                    WindowAppearanceSettingsManager.updateSettings(
+                        WindowAppearanceSettingsManager.currentSettings.value
+                            .copy(tabBarVerticalWidth = width),
+                    )
+                }
+            },
+        )
         splitTree(Modifier.weight(1f).fillMaxHeight())
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarResizeHandle.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/VerticalTabBarResizeHandle.kt
@@ -1,0 +1,100 @@
+package ai.rever.boss.components.window_panel.components.main_window_panels
+
+import ai.rever.boss.components.dividers.VDivider
+import ai.rever.boss.platform.CursorUtil.cursorForHorizontalResize
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.window.TabBarVerticalWidthRange
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+
+/**
+ * How wide the grab strip is.
+ *
+ * A hairline is not a pointer target, so the divider is widened rather than overlaid. 6dp is a
+ * compromise the layout can absorb: it reads as a divider with a little air around it, and it
+ * costs the content 5dp.
+ *
+ * Overlaying a wider invisible band was the first attempt and it was wrong twice over. Laid out
+ * as a Row child it took 16dp of real width and painted nothing, so the unpainted native surface
+ * showed through as a white column. Aligned over the CONTENT side instead - the way
+ * BossResizablePanel does it inside a BoxWithConstraints - it would be dead under a browser pane,
+ * because JxBrowser composites its surface ABOVE the Compose scene and the pointer never reaches
+ * Compose there. Everything this touches has to be chrome the app itself paints.
+ */
+private val RESIZE_AREA = 6.dp
+
+@Composable
+internal fun VerticalTabBarResizeHandle(
+    enabled: Boolean,
+    currentWidth: Float,
+    onPreview: (Float) -> Unit,
+    onCommit: (Float) -> Unit,
+) {
+    if (!enabled) {
+        VDivider()
+        return
+    }
+
+    // rememberUpdatedState, because the gesture coroutine outlives the composition that started
+    // it: a drag begun before a recomposition would otherwise go on reporting to the callbacks
+    // captured when it started, and go on measuring from a width that has since moved.
+    val latestWidth by rememberUpdatedState(currentWidth)
+    val latestPreview by rememberUpdatedState(onPreview)
+    val latestCommit by rememberUpdatedState(onCommit)
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxHeight()
+                .width(RESIZE_AREA)
+                // Painted, not transparent. An unpainted strip is not "the background showing
+                // through": nothing in the Compose scene covers it, so what shows is the raw
+                // native window surface, which is white.
+                .background(BossTheme.colors.panel),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+                    .cursorForHorizontalResize()
+                    // pointerInput(Unit), so the gesture is not restarted by the width changing
+                    // under it - which it does on every frame of the drag this block reports.
+                    .pointerInput(Unit) {
+                        var startWidth = latestWidth
+                        var accumulated = 0f
+                        detectDragGestures(
+                            onDragStart = {
+                                startWidth = latestWidth
+                                accumulated = 0f
+                            },
+                            onDragEnd = { latestCommit(clampBarWidth(startWidth + accumulated.toDp().value)) },
+                            onDragCancel = { latestCommit(clampBarWidth(startWidth + accumulated.toDp().value)) },
+                        ) { change, dragAmount ->
+                            change.consume()
+                            accumulated += dragAmount.x
+                            latestPreview(clampBarWidth(startWidth + accumulated.toDp().value))
+                        }
+                    },
+        )
+        // The hairline stays where it always was, on the content side, so widening the grab area
+        // did not move the line the eye reads as the boundary.
+        VDivider()
+    }
+}
+
+/** A width the bar can actually be. The one place the range is applied to a dragged value. */
+internal fun clampBarWidth(dp: Float): Float = dp.coerceIn(TabBarVerticalWidthRange)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/BarResizeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/BarResizeTest.kt
@@ -1,0 +1,70 @@
+package ai.rever.boss.components.window_panel
+
+import ai.rever.boss.components.window_panel.components.main_window_panels.clampBarWidth
+import ai.rever.boss.window.TabBarVerticalWidthRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the arithmetic behind dragging the vertical bar's edge.
+ *
+ * The handle recomputes the width from where the drag STARTED plus the total travel, rather than
+ * adding each delta to the current width. Those are the same thing until the width clamps, and
+ * then they are not: an accumulator keeps taking deltas the width cannot follow, so dragging back
+ * does nothing until the pointer returns past wherever it stopped tracking. That is a bug you can
+ * only feel, never see in a screenshot, which is why the sums are pinned here.
+ */
+class BarResizeTest {
+    private val min = TabBarVerticalWidthRange.start
+    private val max = TabBarVerticalWidthRange.endInclusive
+
+    /** What the handle computes: start width plus total travel, clamped. */
+    private fun widthAfter(
+        start: Float,
+        travel: Float,
+    ) = clampBarWidth(start + travel)
+
+    @Test
+    fun `the width follows the pointer`() {
+        assertEquals(240f, widthAfter(200f, 40f))
+        assertEquals(160f, widthAfter(200f, -40f))
+        assertEquals(200f, widthAfter(200f, 0f))
+    }
+
+    @Test
+    fun `it stops at both ends of the allowed range`() {
+        assertEquals(max, widthAfter(300f, 500f))
+        assertEquals(min, widthAfter(140f, -500f))
+    }
+
+    @Test
+    fun `the width depends on total travel and nothing else`() {
+        // The whole reason the handle measures from the drag's start. Having been clamped in the
+        // middle of a gesture must leave no trace: once the pointer is back at a travel that maps
+        // inside the range, the width is that value exactly. An accumulator would have gone on
+        // adding deltas while pinned at the clamp, and the width would come back short by
+        // however far past the end the pointer had gone.
+        assertEquals(max, widthAfter(300f, 500f), "precondition: the middle of the drag clamps")
+        assertEquals(290f, widthAfter(300f, -10f), "back inside the range, at the exact width")
+
+        // Same total travel reached two different ways is the same width.
+        assertEquals(widthAfter(200f, 30f), widthAfter(200f, 80f - 50f))
+    }
+
+    @Test
+    fun `a width already inside the range is untouched`() {
+        listOf(min, min + 1f, 200f, max - 1f, max).forEach {
+            assertEquals(it, clampBarWidth(it), "clamping must not move a legal width")
+        }
+    }
+
+    @Test
+    fun `the range is the one the settings slider uses`() {
+        // Two controls for one number. If they clamped differently, the slider and the drag would
+        // disagree about how narrow the bar can be, and the bar would jump on the next drag.
+        assertTrue(min > 0f && max > min, "range must be sane: $min..$max")
+        assertEquals(min, clampBarWidth(0f))
+        assertEquals(max, clampBarWidth(10_000f))
+    }
+}


### PR DESCRIPTION
The vertical tab bar's width had a slider in Settings, which is the wrong place to
be when the thing you are judging is on screen next to it: you set a number, close
Settings, look, and go back. Its trailing edge is now a 6dp grab strip with a
resize cursor.

## Why 6dp of painted chrome, and not a wide invisible band

Both of the obvious implementations are wrong here, and the second one is wrong in
a way that only shows up under a browser pane.

**A transparent band laid out as a Row child paints nothing, and nothing is not
the background.** The first version was 16dp at `alpha(0f)`. It took real layout
width, and what showed through was the raw native window surface: a white column
down the middle of the app. There is nothing in the Compose scene behind that area
to see through to.

**A band overlaid on the content side is dead under a browser.**
`BossResizablePanel` puts its grab area over the neighbouring content, offset
inside a `BoxWithConstraints`, and that works for the side panel. Here the
neighbour is the split tree, and JxBrowser composites its surface ABOVE the
Compose scene - so a band over a browser pane would never see the pointer. Every
part of this has to be chrome the app itself paints, which is what fixes the width
at 6dp rather than the 16dp the side panel can afford.

The hairline stays on the content side, so widening the grab area did not move the
line the eye reads as the boundary.

## The gesture

**The drag previews and only the release persists.** `updateSettings` writes the
settings file and a drag reports on every frame; persisting each one puts a file
write behind every pixel and re-reads the bar's width from disk mid-gesture. The
Settings slider already solved this the same way, and the two controls now agree
on both the clamp and the write.

**The width is recomputed from where the drag started plus total travel**, not
accumulated delta by delta. Those are identical until the width hits either end of
`TabBarVerticalWidthRange`, and then they are not: an accumulator goes on taking
deltas the width cannot follow, so dragging back does nothing until the pointer
returns past wherever it stopped tracking. It is a bug you can only feel, never
see in a screenshot.

**Disabled while the bar is collapsed to its rail.** The rail's width is a
different number, so a drag there would appear to work while moving something
nothing on screen was showing.

## Verification

`./gradlew :composeApp:desktopTest detekt ktlintCheck` is green, rebased onto
current main.

`BarResizeTest` pins the arithmetic: the width follows the pointer, stops at both
ends of the range, and - the reason the start-based formula exists - depends only
on total travel, so being clamped mid-gesture leaves no trace.

The white-column bug was caught on screen and the fix confirmed the same way, by
screenshotting the boundary after the change. The **drag itself is not verified by
hand**: not the resize cursor, not that the width survives a restart, and not what
happens when the pointer crosses over a browser pane mid-drag. That last one is
the interesting case, since it is the same compositing constraint that ruled out
the overlay approach.
