### PR TITLE
One download center, in the bottom bar, with a dialog behind it

### DIFF
--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>LongParameterList:DownloadCenter.kt$DownloadCenter$( id: String, title: String, kind: TransferKind, detail: String? = null, onCancel: (() -&gt; Unit)? = null, owner: String? = null, )</ID>
     <ID>LongParameterList:StoreVersionInstaller.kt$StoreVersionInstaller$( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
     <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>
     <ID>ComplexCondition:BrowserHandleImpl.kt$BrowserHandleImpl$ch != '\u0000' &amp;&amp; !ch.isISOControl() &amp;&amp; !bool("ctrl") &amp;&amp; !bool("meta")</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>LongParameterList:StoreVersionInstaller.kt$StoreVersionInstaller$( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
     <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>
     <ID>ComplexCondition:BrowserHandleImpl.kt$BrowserHandleImpl$ch != '\u0000' &amp;&amp; !ch.isISOControl() &amp;&amp; !bool("ctrl") &amp;&amp; !bool("meta")</ID>
     <ID>ComplexCondition:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$isMacOSExecutable || isChromium || isSharedLib || isShellScript || hasNoExtension</ID>
@@ -1142,7 +1143,7 @@
     <ID>ReturnCount:SplitView.kt$SplitViewState$fun openUrlInActivePanel( url: String, title: String, forceNewTab: Boolean = false, )</ID>
     <ID>ReturnCount:SplitView.kt$SplitViewState$fun setActivePanel(panelId: String)</ID>
     <ID>ReturnCount:StoreVersionInstaller.kt$StoreVersionInstaller$private suspend fun activate( request: StoreVersionRequest, target: File, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, ): Result&lt;String&gt;</ID>
-    <ID>ReturnCount:StoreVersionInstaller.kt$StoreVersionInstaller$suspend fun install( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, ): Result&lt;String&gt;</ID>
+    <ID>ReturnCount:StoreVersionInstaller.kt$StoreVersionInstaller$suspend fun install( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, ): Result&lt;String&gt;</ID>
     <ID>ReturnCount:SupabasePasskeyService.kt$SupabasePasskeyService$suspend fun getUserPasskeys(userId: String): Result&lt;List&lt;PasskeyCredential&gt;&gt;</ID>
     <ID>ReturnCount:SupabasePasskeyService.kt$SupabasePasskeyService$suspend fun requestRegistrationChallenge( userId: String, displayName: String, authenticatorSelection: AuthenticatorSelectionCriteria?, ): Result&lt;PasskeyChallenge&gt;</ID>
     <ID>ReturnCount:TabDraggableComponent.kt$TabDraggableComponent$private fun checkEdgeScroll()</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -764,8 +764,10 @@ internal fun BossAppDialogs(state: BossAppState) {
                         // runCatching rather than a catch block: a throw instead of a failed
                         // Result would otherwise leave the dialog open with no message and an
                         // "Install" button, looking like the click did nothing. Cancellation is
-                        // rethrown - the install is detached and continues, so nothing went wrong
-                        // and there is no longer anywhere to report it to.
+                        // rethrown rather than reported, and means one of two things, neither of
+                        // them a fault: the window closed while the detached install carried on,
+                        // or the user cancelled the download from the bottom bar - in which case
+                        // the dependency really is still missing and this prompt is still true.
                         runCatching { prompt.installer.install(prompt.missing.missingPluginId) }
                             .getOrElse { error ->
                                 if (error is CancellationException) throw error

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -698,6 +698,20 @@ internal fun BossAppStartupEffects(state: BossAppState) {
         }
     }
 
+    // Keep the badges honest whoever applies an update. The registry used to be
+    // cleared only by the host's own update path, so a plugin updated from the
+    // Toolbox or from its update toast kept offering a version it was already
+    // running. Not gated on isFirstWindow: this outlives the window that started
+    // it only if some window is still collecting, and the reconcile is an
+    // idempotent filter, so several windows running it costs nothing.
+    LaunchedEffect(state.currentDefaultPlugin) {
+        val manager = state.currentDefaultPlugin?.dynamicPluginManager ?: return@LaunchedEffect
+        manager.pluginStates.collect { states ->
+            ai.rever.boss.components.plugin.PluginUpdateRegistry
+                .reconcile(states.mapValues { (_, info) -> info.manifest.version })
+        }
+    }
+
     // Monitor for layout changes to mark workspace as dirty and auto-save
     LaunchedEffect(splitViewState, workspaceManager) {
         var lastWorkspaceSnapshot: LayoutWorkspace? = null

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.app
 
 import ai.rever.boss.components.plugin.DefaultPlugin
+import ai.rever.boss.components.plugin.PluginUpdateRegistry
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
 import ai.rever.boss.components.plugin.tab_types.registerPanelHostTab
 import ai.rever.boss.components.registery.PanelComponentStoreRegistry
@@ -707,8 +708,7 @@ internal fun BossAppStartupEffects(state: BossAppState) {
     LaunchedEffect(state.currentDefaultPlugin) {
         val manager = state.currentDefaultPlugin?.dynamicPluginManager ?: return@LaunchedEffect
         manager.pluginStates.collect { states ->
-            ai.rever.boss.components.plugin.PluginUpdateRegistry
-                .reconcile(states.mapValues { (_, info) -> info.manifest.version })
+            PluginUpdateRegistry.reconcile(states.mapValues { (_, info) -> info.manifest.version })
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossBottomBar.kt
@@ -235,6 +235,11 @@ fun BossRightBottomBar() {
         )
     }
 
+    // Live download/update progress, and the way into the download dialog. Ahead of
+    // the performance indicator so a transfer sits next to the plugin status items
+    // it used to be one of, rather than at the far edge of the bar.
+    DownloadCenterStatusItem()
+
     // Performance indicator (shows memory/CPU usage)
     val showIndicator = PerformanceState.shouldShowIndicator()
     if (showIndicator) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/DownloadCenterStatusItem.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/DownloadCenterStatusItem.kt
@@ -1,0 +1,89 @@
+package ai.rever.boss.components.bars.horizontal
+
+import ai.rever.boss.components.dialogs.DownloadCenterDialog
+import ai.rever.boss.downloads.DownloadCenter
+import ai.rever.boss.downloads.overallProgress
+import ai.rever.boss.downloads.transferBarLabel
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Live transfer progress in the bottom bar, and the way into [DownloadCenterDialog].
+ *
+ * Renders nothing while nothing is in flight, so the bar stays clean. This used
+ * to be a widget the Toolbox plugin contributed, which is why every download the
+ * host itself started - an update from a panel badge, a missing dependency, the
+ * application's own update - happened with no visible progress at all.
+ *
+ * Per-window on purpose: the dialog opens in the window whose bar was clicked,
+ * and the transfers behind it are process-wide, so two windows can both have it
+ * open and see the same rows.
+ */
+@Composable
+fun DownloadCenterStatusItem() {
+    val transfers by DownloadCenter.transfers.collectAsState()
+    var showDialog by remember { mutableStateOf(false) }
+
+    if (transfers.isEmpty()) return
+
+    val infos = transfers.map { it.info }
+    val overall = overallProgress(infos)
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier
+                .clickable { showDialog = true }
+                .padding(horizontal = 8.dp),
+    ) {
+        Text(
+            text = transferBarLabel(infos),
+            fontSize = 11.sp,
+            color = BossTheme.colors.textSecondary,
+            maxLines = 1,
+        )
+        Spacer(Modifier.width(6.dp))
+        val barModifier =
+            Modifier
+                .width(72.dp)
+                .height(3.dp)
+                .clip(RoundedCornerShape(2.dp))
+        if (overall != null) {
+            LinearProgressIndicator(
+                progress = overall,
+                modifier = barModifier,
+                color = BossTheme.colors.signal,
+                backgroundColor = BossTheme.colors.signal.copy(alpha = 0.2f),
+            )
+        } else {
+            LinearProgressIndicator(
+                modifier = barModifier,
+                color = BossTheme.colors.signal,
+                backgroundColor = BossTheme.colors.signal.copy(alpha = 0.2f),
+            )
+        }
+    }
+
+    if (showDialog) {
+        DownloadCenterDialog(onDismiss = { showDialog = false })
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/DownloadCenterStatusItem.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/DownloadCenterStatusItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,6 +44,13 @@ fun DownloadCenterStatusItem() {
     val transfers by DownloadCenter.transfers.collectAsState()
     var showDialog by remember { mutableStateOf(false) }
 
+    // Reset here, not only inside the dialog: the early return below removes the
+    // dialog's subtree in the same recomposition that empties the list, so its own
+    // LaunchedEffect is disposed before it can dispatch and `showDialog` would stay
+    // true - the next download then pops the dialog open with nobody clicking.
+    LaunchedEffect(transfers.isEmpty()) {
+        if (transfers.isEmpty()) showDialog = false
+    }
     if (transfers.isEmpty()) return
 
     val infos = transfers.map { it.info }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/DownloadCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/DownloadCenterDialog.kt
@@ -182,7 +182,11 @@ private fun TransferActions(transfer: Transfer) {
             Text("Install", fontSize = 12.sp)
         }
     }
-    if (transfer.onCancel != null) {
+    // Rendered on the phase, not on the action's presence: `DownloadCenter.cancel`
+    // clears the action to make the press single-shot, so keying the button on it made
+    // Cancel VANISH when pressed and reappear a tick later on a row whose caller
+    // re-asserts its actions - exactly the moving target this comment argues against.
+    if (info.phase != TransferPhase.READY_TO_INSTALL || transfer.onCancel != null) {
         TextButton(
             onClick = { DownloadCenter.cancel(info.id) },
             enabled = info.cancellable,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/DownloadCenterDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/dialogs/DownloadCenterDialog.kt
@@ -1,0 +1,201 @@
+package ai.rever.boss.components.dialogs
+
+import ai.rever.boss.downloads.DownloadCenter
+import ai.rever.boss.downloads.Transfer
+import ai.rever.boss.downloads.transferStatusLine
+import ai.rever.boss.plugin.api.TransferPhase
+import ai.rever.boss.plugin.ui.BossAlertDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * What the bottom-bar progress item opens: every transfer in flight, with the
+ * controls that belong to each one.
+ *
+ * Closing it is "minimize", not "stop" - the transfers are owned by the center,
+ * not by this window's composition, so the only thing that ends one is its own
+ * Cancel. That is the whole reason the button says Minimize: a dialog whose
+ * close button reads Cancel next to a Cancel that means something else is how a
+ * user cancels a download they meant to keep.
+ */
+@Composable
+fun DownloadCenterDialog(onDismiss: () -> Unit) {
+    val transfers by DownloadCenter.transfers.collectAsState()
+
+    // Nothing left to show: the last transfer finished while the dialog was open.
+    // Closing beats an empty box the user then has to dismiss - from an effect,
+    // never inline, because onDismiss writes the caller's state and doing that
+    // during composition is what "Cannot mutate state during composition" means.
+    LaunchedEffect(transfers.isEmpty()) {
+        if (transfers.isEmpty()) onDismiss()
+    }
+    if (transfers.isEmpty()) return
+
+    BossAlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = if (transfers.size == 1) "Download" else "Downloads",
+                color = BossTheme.colors.textPrimary,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        text = {
+            Column(
+                modifier =
+                    Modifier
+                        .dialogScrollFence(ROWS_MAX_HEIGHT)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+                transfers.forEach { transfer ->
+                    TransferRow(transfer)
+                }
+                Text(
+                    text = "Transfers continue in the background.",
+                    color = BossTheme.colors.textMuted,
+                    fontSize = 11.sp,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onDismiss,
+                colors = ButtonDefaults.textButtonColors(contentColor = BossTheme.colors.signalText),
+            ) {
+                Text("Minimize", fontSize = 13.sp)
+            }
+        },
+        backgroundColor = BossTheme.colors.panel,
+        contentColor = BossTheme.colors.textPrimary,
+    )
+}
+
+/** One transfer: what it is, where it has got to, and what can be done to it. */
+@Composable
+private fun TransferRow(transfer: Transfer) {
+    val info = transfer.info
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = info.title,
+                    color = BossTheme.colors.textPrimary,
+                    fontSize = 13.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                info.detail?.let { detail ->
+                    Text(
+                        text = detail,
+                        color = BossTheme.colors.textMuted,
+                        fontSize = 11.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            TransferActions(transfer)
+        }
+
+        Spacer(Modifier.height(6.dp))
+
+        val barModifier =
+            Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp))
+        // A downloaded update draws a full bar, not an indeterminate one: it has
+        // finished downloading and is waiting on the user, and a bar still
+        // sweeping beside "Ready to install" says the opposite.
+        val fraction = info.progress ?: 1f.takeIf { info.phase == TransferPhase.READY_TO_INSTALL }
+        if (fraction != null) {
+            LinearProgressIndicator(
+                progress = fraction,
+                modifier = barModifier,
+                color = BossTheme.colors.signal,
+                backgroundColor = BossTheme.colors.raised,
+            )
+        } else {
+            LinearProgressIndicator(
+                modifier = barModifier,
+                color = BossTheme.colors.signal,
+                backgroundColor = BossTheme.colors.raised,
+            )
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        Text(
+            text = transferStatusLine(info),
+            color = BossTheme.colors.textSecondary,
+            fontSize = 11.sp,
+        )
+    }
+}
+
+/**
+ * Install (a downloaded app update) and Cancel, for one row.
+ *
+ * Cancel is rendered whenever the transfer has a cancel action and merely
+ * DISABLED outside the phases that can be abandoned, rather than hidden: a
+ * button that appears and vanishes as the phase turns over is a moving target,
+ * and its absence would read as "this cannot be stopped" rather than "it is too
+ * late to stop safely".
+ */
+@Composable
+private fun TransferActions(transfer: Transfer) {
+    val info = transfer.info
+    if (info.phase == TransferPhase.READY_TO_INSTALL && transfer.onInstall != null) {
+        TextButton(
+            onClick = { DownloadCenter.install(info.id) },
+            colors = ButtonDefaults.textButtonColors(contentColor = BossTheme.colors.signalText),
+        ) {
+            Text("Install", fontSize = 12.sp)
+        }
+    }
+    if (transfer.onCancel != null) {
+        TextButton(
+            onClick = { DownloadCenter.cancel(info.id) },
+            enabled = info.cancellable,
+            colors =
+                ButtonDefaults.textButtonColors(
+                    contentColor = BossTheme.colors.textSecondary,
+                    disabledContentColor = BossTheme.colors.textMuted,
+                ),
+        ) {
+            Text("Cancel", fontSize = 12.sp)
+        }
+    }
+}
+
+/** How tall the row list grows before it scrolls. */
+private val ROWS_MAX_HEIGHT = 260.dp

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -734,7 +734,10 @@ class DefaultPlugin(
     // same progress item and dialog as the host's (and the Toolbox stops needing
     // a status-bar widget of its own).
     override val downloadCenterProvider: DownloadCenterProvider by lazy {
-        DownloadCenterProviderImpl(pluginScope)
+        // Unprefixed: this is the host's own view. A plugin never gets this one -
+        // TrackingPluginContext hands out a prefixed view instead - and it lives on
+        // the center's process-wide scope rather than this per-window pluginScope.
+        DownloadCenterProviderImpl.forHost()
     }
 
     // Phase 4: Application event bus for state change events

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -34,6 +34,7 @@ import ai.rever.boss.components.plugin.providers.createSemanticTokenProvider
 import ai.rever.boss.components.plugin.providers.createUrlHistoryProvider
 import ai.rever.boss.components.plugin.providers.createZoomSettingsProvider
 import ai.rever.boss.components.plugin.tab_types.fluck.SecretChangeNotifier
+import ai.rever.boss.downloads.DownloadCenterProviderImpl
 import ai.rever.boss.git.GitDataProviderImpl
 import ai.rever.boss.plugin.api.ActiveTabData
 import ai.rever.boss.plugin.api.ActiveTabsProvider
@@ -47,6 +48,7 @@ import ai.rever.boss.plugin.api.ContextMenuProvider
 import ai.rever.boss.plugin.api.DashboardContentProvider
 import ai.rever.boss.plugin.api.DiagnosticEntry
 import ai.rever.boss.plugin.api.DiagnosticProvider
+import ai.rever.boss.plugin.api.DownloadCenterProvider
 import ai.rever.boss.plugin.api.EditorContentProvider
 import ai.rever.boss.plugin.api.FileNodeData
 import ai.rever.boss.plugin.api.FilePickerProvider
@@ -726,6 +728,13 @@ class DefaultPlugin(
     // Phase 4: Notification provider for plugin toasts/notifications
     override val notificationProvider: NotificationProvider by lazy {
         createNotificationProvider(pluginToastState)
+    }
+
+    // Bottom-bar download center, so a plugin's own long fetches show up in the
+    // same progress item and dialog as the host's (and the Toolbox stops needing
+    // a status-bar widget of its own).
+    override val downloadCenterProvider: DownloadCenterProvider by lazy {
+        DownloadCenterProviderImpl(pluginScope)
     }
 
     // Phase 4: Application event bus for state change events

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateRegistry.kt
@@ -71,6 +71,32 @@ object PluginUpdateRegistry {
     fun clear(pluginId: String) {
         _updates.update { it - pluginId }
     }
+
+    /**
+     * Drop entries for plugins that are no longer at the version the update was
+     * computed against.
+     *
+     * The badge and its "Update Available" prompt used to be cleared only by the
+     * host's OWN update path, so updating a plugin from the Toolbox (or from its
+     * update toast) left the badge offering a version that was already installed,
+     * and the prompt that badge opened offered to install it again.
+     *
+     * Compares against `currentVersion`, NOT `newVersion`, so no semver ordering
+     * is needed and a downgrade invalidates the entry too: what makes an entry
+     * stale is the plugin no longer being where the check found it. A plugin that
+     * is absent from [installedVersions] is left alone - plugins are all unloaded
+     * during an api hot swap, and treating that as "updated" would wipe every
+     * badge in the app.
+     */
+    fun reconcile(installedVersions: Map<String, String>) {
+        if (installedVersions.isEmpty()) return
+        _updates.update { map ->
+            map.filterNot { (pluginId, update) ->
+                val installed = installedVersions[pluginId]
+                installed != null && installed != update.currentVersion
+            }
+        }
+    }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
@@ -319,7 +319,13 @@ class TrackingPluginContext(
     // plugin reports are namespaced with its plugin id, and this is the only layer
     // that knows which plugin is asking. See DownloadCenterProviderImpl.idPrefix.
     override val downloadCenterProvider: DownloadCenterProvider? by lazy {
-        delegate.downloadCenterProvider?.let { DownloadCenterProviderImpl(delegate.pluginScope, idPrefix = pluginId) }
+        // A presence test, not a use: `?.let { }` discarding `it` read as if the
+        // delegate's instance were needed, and forced it into existence for nothing.
+        if (delegate.downloadCenterProvider == null) {
+            null
+        } else {
+            DownloadCenterProviderImpl.forPlugin(delegate.pluginScope, pluginId)
+        }
     }
     override val bookmarkDataProvider: BookmarkDataProvider? get() = delegate.bookmarkDataProvider
     override val workspaceDataProvider: WorkspaceDataProvider? get() = delegate.workspaceDataProvider

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
@@ -318,14 +318,12 @@ class TrackingPluginContext(
     // Download center (bottom-bar transfer progress). NOT a bare delegate: the ids a
     // plugin reports are namespaced with its plugin id, and this is the only layer
     // that knows which plugin is asking. See DownloadCenterProviderImpl.idPrefix.
-    override val downloadCenterProvider: DownloadCenterProvider? by lazy {
-        // A presence test, not a use: `?.let { }` discarding `it` read as if the
-        // delegate's instance were needed, and forced it into existence for nothing.
-        if (delegate.downloadCenterProvider == null) {
-            null
-        } else {
-            DownloadCenterProviderImpl.forPlugin(delegate.pluginScope, pluginId)
-        }
+    // The delegate's own provider is deliberately NOT read: reading the property is
+    // what forces it, so a presence test built one unread instance with its own
+    // collector per window. The center is a process-wide object, so a prefixed view
+    // of it is always available - there is nothing to test for.
+    override val downloadCenterProvider: DownloadCenterProvider by lazy {
+        DownloadCenterProviderImpl.forPlugin(pluginId)
     }
     override val bookmarkDataProvider: BookmarkDataProvider? get() = delegate.bookmarkDataProvider
     override val workspaceDataProvider: WorkspaceDataProvider? get() = delegate.workspaceDataProvider

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
@@ -11,6 +11,7 @@ import ai.rever.boss.plugin.api.ClipboardProvider
 import ai.rever.boss.plugin.api.ContextMenuProvider
 import ai.rever.boss.plugin.api.DashboardContentProvider
 import ai.rever.boss.plugin.api.DiagnosticProvider
+import ai.rever.boss.plugin.api.DownloadCenterProvider
 import ai.rever.boss.plugin.api.DownloadDataProvider
 import ai.rever.boss.plugin.api.EditorContentProvider
 import ai.rever.boss.plugin.api.FilePickerProvider
@@ -312,6 +313,9 @@ class TrackingPluginContext(
     // Service providers - delegate to underlying context
     override val performanceDataProvider: PerformanceDataProvider? get() = delegate.performanceDataProvider
     override val downloadDataProvider: DownloadDataProvider? get() = delegate.downloadDataProvider
+
+    // Download center (bottom-bar transfer progress) - delegate to underlying context
+    override val downloadCenterProvider: DownloadCenterProvider? get() = delegate.downloadCenterProvider
     override val bookmarkDataProvider: BookmarkDataProvider? get() = delegate.bookmarkDataProvider
     override val workspaceDataProvider: WorkspaceDataProvider? get() = delegate.workspaceDataProvider
     override val splitViewOperations: SplitViewOperations? get() = delegate.splitViewOperations

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.downloads.DownloadCenterProviderImpl
 import ai.rever.boss.plugin.api.ActiveTabsProvider
 import ai.rever.boss.plugin.api.ApplicationEventBus
 import ai.rever.boss.plugin.api.AuthDataProvider
@@ -314,8 +315,12 @@ class TrackingPluginContext(
     override val performanceDataProvider: PerformanceDataProvider? get() = delegate.performanceDataProvider
     override val downloadDataProvider: DownloadDataProvider? get() = delegate.downloadDataProvider
 
-    // Download center (bottom-bar transfer progress) - delegate to underlying context
-    override val downloadCenterProvider: DownloadCenterProvider? get() = delegate.downloadCenterProvider
+    // Download center (bottom-bar transfer progress). NOT a bare delegate: the ids a
+    // plugin reports are namespaced with its plugin id, and this is the only layer
+    // that knows which plugin is asking. See DownloadCenterProviderImpl.idPrefix.
+    override val downloadCenterProvider: DownloadCenterProvider? by lazy {
+        delegate.downloadCenterProvider?.let { DownloadCenterProviderImpl(delegate.pluginScope, idPrefix = pluginId) }
+    }
     override val bookmarkDataProvider: BookmarkDataProvider? get() = delegate.bookmarkDataProvider
     override val workspaceDataProvider: WorkspaceDataProvider? get() = delegate.workspaceDataProvider
     override val splitViewOperations: SplitViewOperations? get() = delegate.splitViewOperations

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
@@ -71,10 +71,25 @@ object DownloadCenter {
             // retry loop, so a caller that built the row and then lost the CAS runs
             // again with the row present - and a stale `true` would hand ownership to
             // two callers, whose `finally` blocks then delete each other's rows.
-            val exists = list.any { it.info.id == id }
-            created = !exists
-            if (exists) {
-                list
+            val existing = list.firstOrNull { it.info.id == id }
+            created = existing == null
+            if (existing != null) {
+                // Joining is for a fallback path nested inside ONE operation, where the
+                // row's Cancel belongs to the operation still running it. Two
+                // INDEPENDENT operations can also land here - the host keys plugin work
+                // by pluginId, so an "Install Store Version" concurrent with a
+                // dependency install of the same id shares a row - and there the row's
+                // Cancel would abandon whichever got there first while the user was
+                // looking at the other. Withdrawing it is the honest answer: neither
+                // can be cancelled without the other, so nothing offers to.
+                val joinedByAnother = onCancel != null && existing.onCancel !== onCancel
+                if (joinedByAnother) {
+                    list.map { t ->
+                        if (t.info.id == id) t.copy(onCancel = null, info = t.info.copy(cancellable = false)) else t
+                    }
+                } else {
+                    list
+                }
             } else {
                 list +
                     Transfer(
@@ -141,26 +156,57 @@ object DownloadCenter {
     }
 
     /**
-     * Run [id]'s cancel action, if it currently has one.
+     * Run [id]'s cancel action once, if it currently has one.
      *
-     * The row is NOT removed here: the cancelled work removes it through the
-     * same `finally` that a completed one does, so a cancel that loses a race
-     * with completion cannot leave a phantom row behind.
+     * Read and cleared in one update, so a second press cannot fire it again. The row
+     * survives a cancel - the work being cancelled removes it through the same
+     * `finally` a completed one uses, which can take a while on a slow socket - so
+     * without this the button stays clickable over a live-looking bar.
+     *
+     * A caller that re-asserts its actions per state (the app-update mirror does, on
+     * every progress tick) puts the action back, which is right: while bytes are still
+     * arriving the transfer really is still cancellable, and the underlying
+     * `cancelDownload` is idempotent. What this closes is the double click, where two
+     * presses land before anything has moved.
      */
     fun cancel(id: String) {
-        _transfers.value
-            .firstOrNull { it.info.id == id }
-            ?.takeIf { it.info.cancellable }
-            ?.onCancel
-            ?.invoke()
+        var action: (() -> Unit)? = null
+        _transfers.update { list ->
+            val target = list.firstOrNull { it.info.id == id }
+            // Assigned on every pass: `update` retries, and a stale action from a lost
+            // CAS would run after another thread had already taken it.
+            action = target?.onCancel?.takeIf { target.info.cancellable }
+            if (action == null) {
+                list
+            } else {
+                list.map { t ->
+                    if (t.info.id == id) t.copy(onCancel = null, info = t.info.copy(cancellable = false)) else t
+                }
+            }
+        }
+        action?.invoke()
     }
 
-    /** Run [id]'s install action, if it has one (a downloaded app update). */
+    /**
+     * Run [id]'s install action once, if it has one (a downloaded app update).
+     *
+     * Single-shot for a sharper reason than Cancel: the action is withdrawn only when
+     * the state reaches Installing, which is a background hop plus a collect plus a
+     * recomposition away, and the row still reads "Ready to install" under the cursor.
+     * Two quick clicks used to launch two elevated installs of the same artifact.
+     */
     fun install(id: String) {
-        _transfers.value
-            .firstOrNull { it.info.id == id }
-            ?.onInstall
-            ?.invoke()
+        var action: (() -> Unit)? = null
+        _transfers.update { list ->
+            val target = list.firstOrNull { it.info.id == id }
+            action = target?.onInstall
+            if (action == null) {
+                list
+            } else {
+                list.map { t -> if (t.info.id == id) t.copy(onInstall = null) else t }
+            }
+        }
+        action?.invoke()
     }
 
     /** Drop everything. Test-only; production rows are ended by their owners. */

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
@@ -3,6 +3,9 @@ package ai.rever.boss.downloads
 import ai.rever.boss.plugin.api.TransferInfo
 import ai.rever.boss.plugin.api.TransferKind
 import ai.rever.boss.plugin.api.TransferPhase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,6 +44,22 @@ data class Transfer(
 object DownloadCenter {
     /** The id the application's own update is tracked under. */
     const val APP_UPDATE_ID = "boss-app-update"
+
+    /**
+     * Where the per-plugin views of [transfers] are kept alive.
+     *
+     * The center's own, and NOT a plugin scope: `DefaultPlugin` is created per WINDOW
+     * and its `dispose()` cancels `pluginScope`, so a view built on the first window's
+     * scope froze - permanently, and for every plugin that resolved through it - the
+     * moment that window closed. This object is process-wide; so is this.
+     *
+     * Unconfined, so a derived view updates on the thread that changed the center
+     * rather than after a dispatch. The derivation is a list map, and the alternative
+     * hands a caller reading `transfers.value` right after its own `begin` the value
+     * from before it - which is exactly the question `.value` gets asked ("is this one
+     * busy?"), and is why these views are eager in the first place.
+     */
+    internal val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
 
     // Insertion-ordered: rows must not jump around in the dialog as progress ticks.
     private val _transfers = MutableStateFlow<List<Transfer>>(emptyList())

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
@@ -83,6 +83,7 @@ object DownloadCenter {
         kind: TransferKind,
         detail: String? = null,
         onCancel: (() -> Unit)? = null,
+        owner: String? = null,
     ): Boolean {
         var created = false
         _transfers.update { list ->
@@ -121,6 +122,7 @@ object DownloadCenter {
                                 phase = TransferPhase.PREPARING,
                                 progress = null,
                                 cancellable = onCancel != null,
+                                owner = owner,
                             ),
                         onCancel = onCancel,
                     )
@@ -143,7 +145,10 @@ object DownloadCenter {
             info =
                 t.info.copy(
                     phase = TransferPhase.DOWNLOADING,
-                    progress = fraction.coerceIn(0f, 1f),
+                    // Indeterminate rather than clamped for a non-finite value:
+                    // `coerceIn` propagates NaN, and NaN is what `bytes / length` gives
+                    // when the length is absent or zero - so it would reach the bar.
+                    progress = fraction.takeIf { it.isFinite() }?.coerceIn(0f, 1f),
                 ),
         )
     }
@@ -161,6 +166,12 @@ object DownloadCenter {
                 ),
         )
     }
+
+    /** Replace [id]'s detail line, or clear it. */
+    fun detail(
+        id: String,
+        text: String?,
+    ) = mutate(id) { it.copy(info = it.info.copy(detail = text)) }
 
     /** Replace [id]'s actions, e.g. when a finished download gains an Install. */
     fun setActions(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
@@ -67,10 +67,15 @@ object DownloadCenter {
     ): Boolean {
         var created = false
         _transfers.update { list ->
-            if (list.any { it.info.id == id }) {
+            // ASSIGNED on every pass, never only set: `update` is a compare-and-set
+            // retry loop, so a caller that built the row and then lost the CAS runs
+            // again with the row present - and a stale `true` would hand ownership to
+            // two callers, whose `finally` blocks then delete each other's rows.
+            val exists = list.any { it.info.id == id }
+            created = !exists
+            if (exists) {
                 list
             } else {
-                created = true
                 list +
                     Transfer(
                         info =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenter.kt
@@ -1,0 +1,197 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.plugin.api.TransferInfo
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * One in-flight transfer plus the actions only the host can perform.
+ *
+ * [info] is exactly what a plugin sees through `DownloadCenterProvider`; the two
+ * lambdas stay here because they close over host state (a download job, the
+ * update installer) that has no meaning across a plugin boundary.
+ */
+data class Transfer(
+    val info: TransferInfo,
+    val onCancel: (() -> Unit)? = null,
+    val onInstall: (() -> Unit)? = null,
+)
+
+/**
+ * Every long-running transfer in the app, in one place: plugin installs and
+ * updates (started by the host's own prompts or by the Toolbox), and the BOSS
+ * application update.
+ *
+ * This is the single source the bottom-bar progress item and its dialog read,
+ * which is the point of it - before it existed, the only visible progress was
+ * a widget the Toolbox plugin owned, so every download the host itself started
+ * happened silently.
+ *
+ * Not to be confused with the browser's file downloads (`DownloadDataProvider`
+ * and the `downloads` plugin). This one is about plugin jars and the app.
+ *
+ * Process-wide, like [ai.rever.boss.updater.UpdateManager]: a transfer outlives
+ * the window whose button started it, and every window's status bar shows the
+ * same set.
+ */
+object DownloadCenter {
+    /** The id the application's own update is tracked under. */
+    const val APP_UPDATE_ID = "boss-app-update"
+
+    // Insertion-ordered: rows must not jump around in the dialog as progress ticks.
+    private val _transfers = MutableStateFlow<List<Transfer>>(emptyList())
+    val transfers: StateFlow<List<Transfer>> = _transfers.asStateFlow()
+
+    /**
+     * Start tracking [id], or join the entry already tracking it.
+     *
+     * There is deliberately no `onInstall` here: an Install action only exists
+     * once something has finished downloading, which is a later fact about a row
+     * that already exists. [setActions] is where it arrives.
+     *
+     * @return true when this call created the entry. A caller that gets false is
+     *   nested inside an operation someone else owns and must NOT [end] it - the
+     *   fallback paths inside an install would otherwise tear down the row their
+     *   caller is still using.
+     */
+    fun begin(
+        id: String,
+        title: String,
+        kind: TransferKind,
+        detail: String? = null,
+        onCancel: (() -> Unit)? = null,
+    ): Boolean {
+        var created = false
+        _transfers.update { list ->
+            if (list.any { it.info.id == id }) {
+                list
+            } else {
+                created = true
+                list +
+                    Transfer(
+                        info =
+                            TransferInfo(
+                                id = id,
+                                title = title,
+                                detail = detail,
+                                kind = kind,
+                                phase = TransferPhase.PREPARING,
+                                progress = null,
+                                cancellable = onCancel != null,
+                            ),
+                        onCancel = onCancel,
+                    )
+            }
+        }
+        return created
+    }
+
+    /**
+     * Report download progress for [id]. Also moves the transfer into
+     * [TransferPhase.DOWNLOADING]: bytes arriving is what that phase means, and
+     * making it implicit means no caller can report progress on a row that still
+     * reads "Preparing" (and so refuses to offer Cancel).
+     */
+    fun progress(
+        id: String,
+        fraction: Float,
+    ) = mutate(id) { t ->
+        t.copy(
+            info =
+                t.info.copy(
+                    phase = TransferPhase.DOWNLOADING,
+                    progress = fraction.coerceIn(0f, 1f),
+                ),
+        )
+    }
+
+    /** Move [id] to [phase], dropping the progress fraction once it stops downloading. */
+    fun phase(
+        id: String,
+        phase: TransferPhase,
+    ) = mutate(id) { t ->
+        t.copy(
+            info =
+                t.info.copy(
+                    phase = phase,
+                    progress = if (phase == TransferPhase.DOWNLOADING) t.info.progress else null,
+                ),
+        )
+    }
+
+    /** Replace [id]'s actions, e.g. when a finished download gains an Install. */
+    fun setActions(
+        id: String,
+        onCancel: (() -> Unit)?,
+        onInstall: (() -> Unit)?,
+    ) = mutate(id) { it.copy(onCancel = onCancel, onInstall = onInstall) }
+
+    /** Stop tracking [id]. Idempotent, so it is safe in a `finally`. */
+    fun end(id: String) {
+        _transfers.update { list -> list.filterNot { it.info.id == id } }
+    }
+
+    /**
+     * Run [id]'s cancel action, if it currently has one.
+     *
+     * The row is NOT removed here: the cancelled work removes it through the
+     * same `finally` that a completed one does, so a cancel that loses a race
+     * with completion cannot leave a phantom row behind.
+     */
+    fun cancel(id: String) {
+        _transfers.value
+            .firstOrNull { it.info.id == id }
+            ?.takeIf { it.info.cancellable }
+            ?.onCancel
+            ?.invoke()
+    }
+
+    /** Run [id]'s install action, if it has one (a downloaded app update). */
+    fun install(id: String) {
+        _transfers.value
+            .firstOrNull { it.info.id == id }
+            ?.onInstall
+            ?.invoke()
+    }
+
+    /** Drop everything. Test-only; production rows are ended by their owners. */
+    internal fun reset() {
+        _transfers.value = emptyList()
+    }
+
+    /**
+     * Apply [block] to [id] and re-derive `cancellable` from the result, so that
+     * flag has exactly one definition: an action exists AND the transfer is not
+     * being installed.
+     *
+     * [TransferPhase.INSTALLING] is the one phase that cannot be abandoned -
+     * cancelling a jar swap mid-flight leaves the plugin unloaded, and an app
+     * install is file moves plus an elevated helper. Everything else can:
+     * a download is bytes, and a downloaded-but-uninstalled app update is a file
+     * to delete, which is exactly the "Install / Cancel" pair the dialog offers.
+     */
+    private fun mutate(
+        id: String,
+        block: (Transfer) -> Transfer,
+    ) {
+        _transfers.update { list ->
+            list.map { t ->
+                if (t.info.id != id) {
+                    t
+                } else {
+                    val next = block(t)
+                    next.copy(
+                        info =
+                            next.info.copy(
+                                cancellable = next.onCancel != null && next.info.phase != TransferPhase.INSTALLING,
+                            ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
@@ -5,7 +5,6 @@ import ai.rever.boss.plugin.api.TransferHandle
 import ai.rever.boss.plugin.api.TransferInfo
 import ai.rever.boss.plugin.api.TransferKind
 import ai.rever.boss.plugin.api.TransferPhase
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -19,11 +18,10 @@ import java.util.concurrent.ConcurrentHashMap
  * providers use: there is nothing platform-specific to reach for, the center is
  * already common, and an expect/actual pair here would only be ceremony.
  *
- * @param scope a long-lived scope (the plugin layer's) for the derived flow;
- *   the mapping is stateful so every plugin observing it shares one collector.
+ * The derived flow lives on [DownloadCenter.scope] - the center's own, because a
+ * plugin-layer scope belongs to one window and dies with it.
  */
 class DownloadCenterProviderImpl internal constructor(
-    scope: CoroutineScope,
     /**
      * Prefix for ids this instance reports, or null for the host's own transfers.
      *
@@ -41,7 +39,9 @@ class DownloadCenterProviderImpl internal constructor(
         DownloadCenter.transfers
             .map { list -> list.map { it.info.withoutPrefix(idPrefix) } }
             .stateIn(
-                scope = scope,
+                // The center's scope, not a caller's: see DownloadCenter.scope for the
+                // window-lifetime trap that hid behind "a long-lived scope".
+                scope = DownloadCenter.scope,
                 // Eagerly, so `.value` is truthful for a reader that never collects -
                 // WhileSubscribed would hand such a caller the stale initial value, and
                 // "is this one busy?" is exactly a `.value` question. The instance is
@@ -88,15 +88,16 @@ class DownloadCenterProviderImpl internal constructor(
          * Toolbox reload and `resetPluginInstances` - growing with reload count rather
          * than plugin count, each survivor remapping the whole transfer list per tick.
          *
-         * Safe to share because [scope] is the plugin LAYER's scope (DefaultPlugin's),
-         * not the unloading plugin's: a reload cannot cancel the collector another
-         * plugin's view depends on.
+         * Safe to cache because the view lives on [DownloadCenter.scope], which nothing
+         * cancels - a window closing or a plugin unloading cannot freeze another
+         * plugin's view.
          */
-        fun forPlugin(
-            scope: CoroutineScope,
-            pluginId: String,
-            // `it` is the prefix, which is the second parameter.
-        ): DownloadCenterProviderImpl = byPrefix.computeIfAbsent(pluginId) { DownloadCenterProviderImpl(scope, it) }
+        fun forPlugin(pluginId: String) = byPrefix.computeIfAbsent(pluginId) { DownloadCenterProviderImpl(it) }
+
+        /** The host's own view: unprefixed ids, one instance. */
+        fun forHost(): DownloadCenterProviderImpl = hostView
+
+        private val hostView by lazy { DownloadCenterProviderImpl(idPrefix = null) }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
@@ -23,14 +23,26 @@ import kotlinx.coroutines.flow.stateIn
  */
 class DownloadCenterProviderImpl(
     scope: CoroutineScope,
+    /**
+     * Prefix for ids this instance reports, or null for the host's own transfers.
+     *
+     * Without it the id space is one unnamespaced namespace shared by the host and
+     * every plugin, which is two bugs rather than one: two plugins both choosing
+     * `"update"` collide and hit the nested-begin rule by accident (the second is
+     * bound to a row it cannot remove, and its transfer never appears), and any
+     * plugin can address another's transfer - or the host's app update - to withdraw
+     * its Cancel, fake its progress, or fabricate a row. The prefix is stripped on
+     * the way out, so a plugin still matches its own work by the id it passed in.
+     */
+    private val idPrefix: String? = null,
 ) : DownloadCenterProvider {
     override val transfers: StateFlow<List<TransferInfo>> =
         DownloadCenter.transfers
-            .map { list -> list.map { it.info } }
+            .map { list -> list.map { it.info.withoutPrefix(idPrefix) } }
             .stateIn(
                 scope = scope,
                 started = SharingStarted.Eagerly,
-                initialValue = DownloadCenter.transfers.value.map { it.info },
+                initialValue = DownloadCenter.transfers.value.map { it.info.withoutPrefix(idPrefix) },
             )
 
     override fun begin(
@@ -40,8 +52,23 @@ class DownloadCenterProviderImpl(
         detail: String?,
         onCancel: (() -> Unit)?,
     ): TransferHandle {
-        val created = DownloadCenter.begin(id, title, kind, detail, onCancel)
-        return CenterHandle(id, ownsEntry = created)
+        val key = qualify(id)
+        val created = DownloadCenter.begin(key, title, kind, detail, onCancel)
+        return CenterHandle(key, ownsEntry = created)
+    }
+
+    private fun qualify(id: String): String = idPrefix?.let { "$it:$id" } ?: id
+
+    /**
+     * Show a plugin its own ids unprefixed, and leave everyone else's alone.
+     *
+     * A plugin asking "is this one busy?" compares against the id it passed to
+     * [begin]; it should not have to know the host qualified it. Other plugins' rows
+     * stay qualified, which is what makes them unmistakable for your own.
+     */
+    private fun TransferInfo.withoutPrefix(prefix: String?): TransferInfo {
+        val head = prefix?.plus(":") ?: return this
+        return if (id.startsWith(head)) copy(id = id.removePrefix(head)) else this
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
@@ -59,7 +59,10 @@ class DownloadCenterProviderImpl internal constructor(
         onCancel: (() -> Unit)?,
     ): TransferHandle {
         val key = qualify(id)
-        val created = DownloadCenter.begin(key, title, kind, detail, onCancel)
+        // The owner is this instance's prefix: null for the host's own view, the
+        // plugin id otherwise. It is what lets a plugin tell its row for `com.foo`
+        // from the host's row for `com.foo`, which the id alone cannot.
+        val created = DownloadCenter.begin(key, title, kind, detail, onCancel, owner = idPrefix)
         return CenterHandle(key, ownsEntry = created)
     }
 
@@ -114,6 +117,8 @@ class DownloadCenterProviderImpl internal constructor(
         override fun progress(fraction: Float) = DownloadCenter.progress(id, fraction)
 
         override fun phase(phase: TransferPhase) = DownloadCenter.phase(id, phase)
+
+        override fun detail(text: String?) = DownloadCenter.detail(id, text)
 
         override fun done() {
             if (ownsEntry) DownloadCenter.end(id)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
@@ -1,0 +1,66 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.plugin.api.DownloadCenterProvider
+import ai.rever.boss.plugin.api.TransferHandle
+import ai.rever.boss.plugin.api.TransferInfo
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The plugin-facing view of [DownloadCenter].
+ *
+ * Plain common code rather than the `createXxxProvider` expect/actual other
+ * providers use: there is nothing platform-specific to reach for, the center is
+ * already common, and an expect/actual pair here would only be ceremony.
+ *
+ * @param scope a long-lived scope (the plugin layer's) for the derived flow;
+ *   the mapping is stateful so every plugin observing it shares one collector.
+ */
+class DownloadCenterProviderImpl(
+    scope: CoroutineScope,
+) : DownloadCenterProvider {
+    override val transfers: StateFlow<List<TransferInfo>> =
+        DownloadCenter.transfers
+            .map { list -> list.map { it.info } }
+            .stateIn(
+                scope = scope,
+                started = SharingStarted.Eagerly,
+                initialValue = DownloadCenter.transfers.value.map { it.info },
+            )
+
+    override fun begin(
+        id: String,
+        title: String,
+        kind: TransferKind,
+        detail: String?,
+        onCancel: (() -> Unit)?,
+    ): TransferHandle {
+        val created = DownloadCenter.begin(id, title, kind, detail, onCancel)
+        return CenterHandle(id, ownsEntry = created)
+    }
+
+    /**
+     * A handle over one center entry.
+     *
+     * [ownsEntry] is the nested-begin rule: a caller that joined an existing
+     * transfer reports into it but must not remove it, or an inner fallback path
+     * would tear down the row its caller is still filling.
+     */
+    private class CenterHandle(
+        private val id: String,
+        private val ownsEntry: Boolean,
+    ) : TransferHandle {
+        override fun progress(fraction: Float) = DownloadCenter.progress(id, fraction)
+
+        override fun phase(phase: TransferPhase) = DownloadCenter.phase(id, phase)
+
+        override fun done() {
+            if (ownsEntry) DownloadCenter.end(id)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * The plugin-facing view of [DownloadCenter].
@@ -21,7 +22,7 @@ import kotlinx.coroutines.flow.stateIn
  * @param scope a long-lived scope (the plugin layer's) for the derived flow;
  *   the mapping is stateful so every plugin observing it shares one collector.
  */
-class DownloadCenterProviderImpl(
+class DownloadCenterProviderImpl internal constructor(
     scope: CoroutineScope,
     /**
      * Prefix for ids this instance reports, or null for the host's own transfers.
@@ -41,6 +42,11 @@ class DownloadCenterProviderImpl(
             .map { list -> list.map { it.info.withoutPrefix(idPrefix) } }
             .stateIn(
                 scope = scope,
+                // Eagerly, so `.value` is truthful for a reader that never collects -
+                // WhileSubscribed would hand such a caller the stale initial value, and
+                // "is this one busy?" is exactly a `.value` question. The instance is
+                // cached per prefix (see [forPlugin]), so this costs one collector per
+                // plugin rather than one per plugin LOAD.
                 started = SharingStarted.Eagerly,
                 initialValue = DownloadCenter.transfers.value.map { it.info.withoutPrefix(idPrefix) },
             )
@@ -69,6 +75,28 @@ class DownloadCenterProviderImpl(
     private fun TransferInfo.withoutPrefix(prefix: String?): TransferInfo {
         val head = prefix?.plus(":") ?: return this
         return if (id.startsWith(head)) copy(id = id.removePrefix(head)) else this
+    }
+
+    companion object {
+        private val byPrefix = ConcurrentHashMap<String, DownloadCenterProviderImpl>()
+
+        /**
+         * The instance for [pluginId], created once and reused.
+         *
+         * A fresh `TrackingPluginContext` is built on every plugin LOAD, so constructing
+         * one of these per context left an eager collector behind on each hot reload,
+         * Toolbox reload and `resetPluginInstances` - growing with reload count rather
+         * than plugin count, each survivor remapping the whole transfer list per tick.
+         *
+         * Safe to share because [scope] is the plugin LAYER's scope (DefaultPlugin's),
+         * not the unloading plugin's: a reload cannot cancel the collector another
+         * plugin's view depends on.
+         */
+        fun forPlugin(
+            scope: CoroutineScope,
+            pluginId: String,
+            // `it` is the prefix, which is the second parameter.
+        ): DownloadCenterProviderImpl = byPrefix.computeIfAbsent(pluginId) { DownloadCenterProviderImpl(scope, it) }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterText.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterText.kt
@@ -1,0 +1,94 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.plugin.api.TransferInfo
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+
+/**
+ * The wording for the download center's two surfaces, kept pure so tests pin it.
+ *
+ * Same reasoning as `engineDownloadStatus`: these strings are the only thing that
+ * tells the user which of several transfers is which, and a phase whose verb is
+ * wrong ("Installing" while an update is still downloading) is how a bar that
+ * looks stuck gets reported as a hang.
+ */
+
+/** The verb for one transfer, given where it has got to. */
+internal fun transferVerb(info: TransferInfo): String =
+    when (info.phase) {
+        TransferPhase.PREPARING, TransferPhase.DOWNLOADING -> {
+            "Downloading"
+        }
+
+        TransferPhase.INSTALLING -> {
+            if (info.kind == TransferKind.PLUGIN_UPDATE) "Updating" else "Installing"
+        }
+
+        TransferPhase.READY_TO_INSTALL -> {
+            "Ready to install"
+        }
+    }
+
+/**
+ * The status line under a row in the dialog, e.g. "Downloading 72%".
+ *
+ * A determinate percentage is shown only while downloading: the fraction is a
+ * download fraction, and repeating the last one next to "Installing" would read
+ * as an install that is 72% done and stuck there.
+ */
+internal fun transferStatusLine(info: TransferInfo): String {
+    val verb = transferVerb(info)
+    val percent = info.progress?.takeIf { info.phase == TransferPhase.DOWNLOADING }
+    return when {
+        info.phase == TransferPhase.READY_TO_INSTALL -> verb
+        percent != null -> "$verb ${(percent * 100).toInt()}%"
+        else -> "$verb…"
+    }
+}
+
+/**
+ * The bottom-bar label for everything in flight.
+ *
+ * Deliberately not "N plugins": the application's own update shares this bar
+ * with plugin transfers, so a count of plugins would be a lie exactly when two
+ * different kinds are running.
+ */
+internal fun transferBarLabel(items: List<TransferInfo>): String =
+    when (items.size) {
+        0 -> {
+            ""
+        }
+
+        1 -> {
+            val info = items.first()
+            val line = transferStatusLine(info)
+            // "Downloading 72% Toolbox" reads backwards, so the name goes between
+            // the verb and the number: "Downloading Toolbox 72%".
+            val verb = transferVerb(info)
+            line.replaceFirst(verb, "$verb ${info.title}")
+        }
+
+        else -> {
+            "${items.size} downloads…"
+        }
+    }
+
+/**
+ * The one fraction the bar can draw, or null when it must stay indeterminate.
+ *
+ * Determinate only when EVERY transfer knows its size: averaging a known 90%
+ * with an unknown would draw a bar that jumps backwards the moment the unknown
+ * one starts reporting.
+ */
+internal fun overallProgress(items: List<TransferInfo>): Float? {
+    // A downloaded update is finished as far as this bar is concerned. Left as
+    // null it would animate an indeterminate bar next to "Ready to install",
+    // which reads as work still happening.
+    val fractions =
+        items.map { it.progress ?: if (it.phase == TransferPhase.READY_TO_INSTALL) 1f else null }
+    return if (fractions.isEmpty() || fractions.any { it == null }) {
+        null
+    } else {
+        fractions.filterNotNull().average().toFloat()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterText.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/downloads/DownloadCenterText.kt
@@ -60,12 +60,18 @@ internal fun transferBarLabel(items: List<TransferInfo>): String =
         }
 
         1 -> {
+            // Composed from the parts rather than by rewriting the status line: the
+            // name goes between the verb and the number ("Downloading Toolbox 72%"),
+            // and a search-and-replace on the verb can be surprised by a title that
+            // happens to contain it.
             val info = items.first()
-            val line = transferStatusLine(info)
-            // "Downloading 72% Toolbox" reads backwards, so the name goes between
-            // the verb and the number: "Downloading Toolbox 72%".
             val verb = transferVerb(info)
-            line.replaceFirst(verb, "$verb ${info.title}")
+            val percent = info.progress?.takeIf { info.phase == TransferPhase.DOWNLOADING }
+            when {
+                info.phase == TransferPhase.READY_TO_INSTALL -> "$verb ${info.title}"
+                percent != null -> "$verb ${info.title} ${(percent * 100).toInt()}%"
+                else -> "$verb ${info.title}…"
+            }
         }
 
         else -> {
@@ -79,6 +85,12 @@ internal fun transferBarLabel(items: List<TransferInfo>): String =
  * Determinate only when EVERY transfer knows its size: averaging a known 90%
  * with an unknown would draw a bar that jumps backwards the moment the unknown
  * one starts reporting.
+ *
+ * An UNWEIGHTED mean, deliberately: a 200 KB jar and a 400 MB installer count
+ * equally, so the bar can sit near 50% while the large one does all the work.
+ * Weighting by size would need every transfer to report bytes rather than a
+ * fraction; this is an indicator, and the per-row bars in the dialog are where
+ * someone looks to see which one is moving.
  */
 internal fun overallProgress(items: List<TransferInfo>): Float? {
     // A downloaded update is finished as far as this bar is concerned. Left as

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirror.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirror.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.downloads.DownloadCenter
 import ai.rever.boss.plugin.api.TransferKind
 import ai.rever.boss.plugin.api.TransferPhase
 import kotlinx.coroutines.Job
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -53,11 +54,33 @@ object UpdateDownloadCenterMirror {
     private val job = AtomicReference<Job?>(null)
 
     /** Internal for the mapping test: the table above is the whole behaviour. */
+
+    /**
+     * The actions, allocated once per manager rather than per emission.
+     *
+     * Identity matters: `DownloadCenter.begin` decides "another operation joined" by
+     * comparing cancel actions by reference, and a fresh lambda every progress tick
+     * made that fire on every tick - withdrawing Cancel, having `setActions` put it
+     * straight back, and rebuilding the list three times where one would do. A guard
+     * that fires constantly for the one caller it does not mean is no guard at all.
+     */
+    private val actions = ConcurrentHashMap<UpdateManager, UpdateActions>()
+
+    private class UpdateActions(
+        manager: UpdateManager,
+    ) {
+        val cancelDownload: () -> Unit = { manager.cancelDownload() }
+        val discardDownload: () -> Unit = { manager.launchInBackground { manager.discardDownload() } }
+    }
+
+    private fun actionsFor(manager: UpdateManager) = actions.computeIfAbsent(manager) { UpdateActions(it) }
+
     internal fun publish(
         state: UpdateState,
         manager: UpdateManager,
     ) {
         val id = DownloadCenter.APP_UPDATE_ID
+        val acts = actionsFor(manager)
         when (state) {
             is UpdateState.Downloading -> {
                 DownloadCenter.begin(
@@ -65,7 +88,7 @@ object UpdateDownloadCenterMirror {
                     title = title(manager),
                     kind = TransferKind.APP_UPDATE,
                     detail = "Application update",
-                    onCancel = { manager.cancelDownload() },
+                    onCancel = acts.cancelDownload,
                 )
                 // Asserted, not left to begin: a row already exists when a second
                 // version is picked from the list while one sits ReadyToInstall, and
@@ -76,7 +99,7 @@ object UpdateDownloadCenterMirror {
                 // staged path.
                 DownloadCenter.setActions(
                     id = id,
-                    onCancel = { manager.cancelDownload() },
+                    onCancel = acts.cancelDownload,
                     onInstall = null,
                 )
                 DownloadCenter.progress(id, state.progress)
@@ -89,7 +112,7 @@ object UpdateDownloadCenterMirror {
                 val staged = state.downloadPath
                 DownloadCenter.setActions(
                     id = id,
-                    onCancel = { manager.launchInBackground { manager.discardDownload() } },
+                    onCancel = acts.discardDownload,
                     onInstall = { manager.launchInBackground { manager.installUpdate(staged) } },
                 )
                 DownloadCenter.phase(id, TransferPhase.READY_TO_INSTALL)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirror.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirror.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.downloads.DownloadCenter
 import ai.rever.boss.plugin.api.TransferKind
 import ai.rever.boss.plugin.api.TransferPhase
 import kotlinx.coroutines.Job
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Publishes the application's own update into [DownloadCenter], so it shares the
@@ -33,16 +34,23 @@ object UpdateDownloadCenterMirror {
      * download that is still going.
      */
     fun start(coordinator: UpdateCoordinator) {
-        if (job?.isActive == true) return
         val manager = coordinator.manager
-        job =
+        // compareAndSet rather than a check on a @Volatile: two windows starting at
+        // once would both pass check-then-act and launch a collector each, which is
+        // not the "every window may ask" this claims to be. The loser cancels the
+        // collector it launched. The expected value is the job we read rather than
+        // null, so a dead one (only app shutdown kills the scope) can be replaced
+        // instead of blocking every later start forever.
+        val existing = job.get()
+        if (existing?.isActive == true) return
+        val started =
             manager.launchInBackground {
                 manager.updateState.collect { state -> publish(state, manager) }
             }
+        if (!job.compareAndSet(existing, started)) started.cancel()
     }
 
-    @Volatile
-    private var job: Job? = null
+    private val job = AtomicReference<Job?>(null)
 
     /** Internal for the mapping test: the table above is the whole behaviour. */
     internal fun publish(
@@ -58,6 +66,18 @@ object UpdateDownloadCenterMirror {
                     kind = TransferKind.APP_UPDATE,
                     detail = "Application update",
                     onCancel = { manager.cancelDownload() },
+                )
+                // Asserted, not left to begin: a row already exists when a second
+                // version is picked from the list while one sits ReadyToInstall, and
+                // begin leaves an existing row alone. Without this the row keeps the
+                // ready-state actions - a Cancel that calls discardDownload() and
+                // early-returns because the state moved on, so the button renders
+                // enabled and does nothing, and an Install still holding the previous
+                // staged path.
+                DownloadCenter.setActions(
+                    id = id,
+                    onCancel = { manager.cancelDownload() },
+                    onInstall = null,
                 )
                 DownloadCenter.progress(id, state.progress)
             }
@@ -77,6 +97,9 @@ object UpdateDownloadCenterMirror {
 
             is UpdateState.Installing -> {
                 DownloadCenter.begin(id, title(manager), TransferKind.APP_UPDATE, "Application update")
+                // Both dropped: an Install left in place would offer a second elevated
+                // install of the artifact this one is already installing.
+                DownloadCenter.setActions(id, onCancel = null, onInstall = null)
                 DownloadCenter.phase(id, TransferPhase.INSTALLING)
             }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirror.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirror.kt
@@ -1,0 +1,98 @@
+package ai.rever.boss.updater
+
+import ai.rever.boss.downloads.DownloadCenter
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import kotlinx.coroutines.Job
+
+/**
+ * Publishes the application's own update into [DownloadCenter], so it shares the
+ * bottom-bar progress item and the dialog with every plugin transfer.
+ *
+ * A mirror rather than a second source: [UpdateManager.updateState] stays the one
+ * place the update's progress lives (the top banner reads the same flow), and this
+ * translates it. Two states writing the same row from different places is how a
+ * banner and a bar come to disagree about whether an install has started.
+ *
+ * The row carries the actions the state allows, and only those:
+ *
+ * | State | Row |
+ * |---|---|
+ * | `Downloading` | progress, Cancel |
+ * | `ReadyToInstall` | Install, Cancel (discards the staged file) |
+ * | `Installing` | no actions - file moves and an elevated helper, past abandoning |
+ * | anything else | no row |
+ */
+object UpdateDownloadCenterMirror {
+    /**
+     * Start mirroring. Idempotent: a second call is ignored, so every window may
+     * ask for it without N collectors racing to write one row.
+     *
+     * Runs on the manager's own scope, the same one the download runs on - a
+     * window's scope dies with its composition and would stop mirroring a
+     * download that is still going.
+     */
+    fun start(coordinator: UpdateCoordinator) {
+        if (job?.isActive == true) return
+        val manager = coordinator.manager
+        job =
+            manager.launchInBackground {
+                manager.updateState.collect { state -> publish(state, manager) }
+            }
+    }
+
+    @Volatile
+    private var job: Job? = null
+
+    /** Internal for the mapping test: the table above is the whole behaviour. */
+    internal fun publish(
+        state: UpdateState,
+        manager: UpdateManager,
+    ) {
+        val id = DownloadCenter.APP_UPDATE_ID
+        when (state) {
+            is UpdateState.Downloading -> {
+                DownloadCenter.begin(
+                    id = id,
+                    title = title(manager),
+                    kind = TransferKind.APP_UPDATE,
+                    detail = "Application update",
+                    onCancel = { manager.cancelDownload() },
+                )
+                DownloadCenter.progress(id, state.progress)
+            }
+
+            is UpdateState.ReadyToInstall -> {
+                DownloadCenter.begin(id, title(manager), TransferKind.APP_UPDATE, "Application update")
+                // Set after begin, not through it: a download that just finished
+                // already has a row, and begin leaves an existing one alone.
+                val staged = state.downloadPath
+                DownloadCenter.setActions(
+                    id = id,
+                    onCancel = { manager.launchInBackground { manager.discardDownload() } },
+                    onInstall = { manager.launchInBackground { manager.installUpdate(staged) } },
+                )
+                DownloadCenter.phase(id, TransferPhase.READY_TO_INSTALL)
+            }
+
+            is UpdateState.Installing -> {
+                DownloadCenter.begin(id, title(manager), TransferKind.APP_UPDATE, "Application update")
+                DownloadCenter.phase(id, TransferPhase.INSTALLING)
+            }
+
+            // Idle, UpToDate, CheckingForUpdates, UpdateAvailable, RestartRequired, Error.
+            // None of them is work in flight: an available update is an offer the banner
+            // and the dialog make, and a failure is reported there too - a row that
+            // stayed would be a progress bar for something that is not happening.
+            else -> {
+                DownloadCenter.end(id)
+            }
+        }
+    }
+
+    /** "BOSS v9.4.33" when a version is known, and just "BOSS" before any check named one. */
+    private fun title(manager: UpdateManager): String {
+        val version = manager.updateInfo.value?.latestVersion ?: return "BOSS"
+        return "BOSS v$version"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
@@ -36,6 +36,13 @@ class UpdateManager {
 
     private val _updateInfo = MutableStateFlow<UpdateInfo?>(null)
 
+    /**
+     * The update the current state is about, or null before any check found one.
+     * Read-only: [UpdateState.Downloading] carries a fraction and nothing else, so
+     * anything naming the download (the download center's row) needs this.
+     */
+    val updateInfo: StateFlow<UpdateInfo?> = _updateInfo.asStateFlow()
+
     // Whether the "update available" dialog should be visible.
     // Set when a check (auto or forced) surfaces a non-dismissed update.
     private val _showUpdateDialog = MutableStateFlow(false)
@@ -219,13 +226,60 @@ class UpdateManager {
     }
 
     /**
+     * The coroutine running the current download, so [cancelDownload] has
+     * something to cancel.
+     *
+     * @Volatile: written on the manager's scope and read from whichever thread
+     * the download center's Cancel arrives on.
+     */
+    @Volatile
+    private var downloadJob: Job? = null
+
+    /**
      * Launch [downloadUpdate] on the manager's own long-lived scope so the
      * download survives the window that started it — the update dialog lives
      * in one specific window, and closing that window must not cancel an
      * in-flight download.
      */
     fun downloadUpdateInBackground(updateInfo: UpdateInfo) {
-        launchInBackground { downloadUpdate(updateInfo) }
+        downloadJob = launchInBackground { downloadUpdate(updateInfo) }
+    }
+
+    /** As [downloadUpdateInBackground], for a specific version (upgrade or downgrade). */
+    fun downloadSpecificVersionInBackground(versionInfo: VersionInfo) {
+        downloadJob = launchInBackground { downloadSpecificVersion(versionInfo) }
+    }
+
+    /**
+     * Abandon the download in flight, if there is one.
+     *
+     * Only the download: an install is a sequence of file moves and an elevated
+     * helper, and stopping it half way is worse than finishing it. The download
+     * center enforces the same rule by only offering Cancel while downloading;
+     * this is the second half of it, so a caller that asks anyway is refused.
+     *
+     * The partial file is deleted by the service, which is the only layer that
+     * knows where it was staged.
+     */
+    fun cancelDownload() {
+        if (_updateState.value !is UpdateState.Downloading) return
+        downloadJob?.cancel()
+    }
+
+    /**
+     * Throw away an update that finished downloading but was not installed.
+     *
+     * Deletes the staged artifact rather than leaving it: it is the whole app,
+     * it sits in a restricted staging directory, and an update the user declined
+     * should not quietly occupy that much disk until the next one replaces it.
+     * The version stays on offer, so the banner can download it again.
+     */
+    suspend fun discardDownload() {
+        val state = _updateState.value
+        if (state !is UpdateState.ReadyToInstall) return
+        updateService.discardDownload(state.downloadPath)
+        _updateState.value =
+            _updateInfo.value?.let { UpdateState.UpdateAvailable(it) } ?: UpdateState.Idle
     }
 
     /**
@@ -254,6 +308,13 @@ class UpdateManager {
                 _updateState.value = UpdateState.Error(errorMsg)
                 UpdateResult.Error(errorMsg)
             }
+        } catch (e: CancellationException) {
+            // A cancellation is an answer, not a fault. Caught before the general
+            // clause below, which would otherwise turn the user's own Cancel into
+            // "Download failed: StandaloneCoroutine was cancelled" in the banner,
+            // and leave that error where the offer to update used to be.
+            _updateState.value = UpdateState.UpdateAvailable(updateInfo)
+            throw e
         } catch (e: Exception) {
             val errorMsg = "Download failed: ${e.message}"
             _updateState.value = UpdateState.Error(errorMsg)
@@ -293,6 +354,11 @@ class UpdateManager {
                 _updateState.value = UpdateState.Error(errorMsg)
                 UpdateResult.Error(errorMsg)
             }
+        } catch (e: CancellationException) {
+            // See downloadUpdate: back to whatever was on offer before, not an error.
+            _updateState.value =
+                _updateInfo.value?.let { UpdateState.UpdateAvailable(it) } ?: UpdateState.Idle
+            throw e
         } catch (e: Exception) {
             val errorMsg = "Download failed: ${e.message}"
             _updateState.value = UpdateState.Error(errorMsg)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
@@ -278,8 +278,14 @@ class UpdateManager {
         val state = _updateState.value
         if (state !is UpdateState.ReadyToInstall) return
         updateService.discardDownload(state.downloadPath)
+        // Idle unless there is genuinely a newer version to offer: after discarding a
+        // DOWNGRADE, `_updateInfo` holds the older version, and UpdateAvailable would
+        // put "Update v9.4.20 available" in the banner.
         _updateState.value =
-            _updateInfo.value?.let { UpdateState.UpdateAvailable(it) } ?: UpdateState.Idle
+            _updateInfo.value
+                ?.takeIf { it.isNewerVersionAvailable }
+                ?.let { UpdateState.UpdateAvailable(it) }
+                ?: UpdateState.Idle
     }
 
     /**
@@ -341,6 +347,12 @@ class UpdateManager {
                     sha256 = versionInfo.sha256,
                 )
 
+            // Published before the download starts, so anything naming it - the
+            // download center's row, and the state discardDownload restores - names the
+            // version actually on the wire. Only the check path used to write this, so
+            // downgrading to 9.4.20 showed a row reading "BOSS v9.4.34".
+            _updateInfo.value = updateInfo
+
             val downloadPath =
                 updateService.downloadUpdate(updateInfo) { progress ->
                     _updateState.value = UpdateState.Downloading(progress)
@@ -355,9 +367,13 @@ class UpdateManager {
                 UpdateResult.Error(errorMsg)
             }
         } catch (e: CancellationException) {
-            // See downloadUpdate: back to whatever was on offer before, not an error.
+            // See downloadUpdate: back to whatever was on offer before, not an error -
+            // and Idle rather than an "available" banner for a version that is older.
             _updateState.value =
-                _updateInfo.value?.let { UpdateState.UpdateAvailable(it) } ?: UpdateState.Idle
+                _updateInfo.value
+                    ?.takeIf { it.isNewerVersionAvailable }
+                    ?.let { UpdateState.UpdateAvailable(it) }
+                    ?: UpdateState.Idle
             throw e
         } catch (e: Exception) {
             val errorMsg = "Download failed: ${e.message}"

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateOwnership.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateOwnership.kt
@@ -154,6 +154,12 @@ class UpdateCoordinator internal constructor(
             logger.warn(LogCategory.SYSTEM, "Ignoring update start request after shutdown")
             return
         }
+
+        // Ahead of the auto-check gate on purpose: turning automatic checks off
+        // does not stop a MANUAL check from starting a download, and that download
+        // still belongs in the bottom bar. Idempotent, so every window may ask.
+        UpdateDownloadCenterMirror.start(this)
+
         if (!UpdateSettings.autoCheckEnabled) return
 
         val startedNow =
@@ -216,7 +222,10 @@ class UpdateCoordinator internal constructor(
 
     fun downloadSpecificVersionInBackground(versionInfo: VersionInfo) {
         if (isShutDown) return
-        manager.launchInBackground { manager.downloadSpecificVersion(versionInfo) }
+        // Through the manager's own launcher, which records the job: a download
+        // started from the version list is as cancellable as one started from the
+        // banner, and launching it here directly would leave nothing to cancel.
+        manager.downloadSpecificVersionInBackground(versionInfo)
     }
 
     fun installUpdateInBackground(downloadPath: String) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateService.kt
@@ -90,6 +90,16 @@ expect class UpdateService() {
 
     suspend fun installUpdate(downloadPath: String): InstallOutcome
 
+    /**
+     * Delete a staged download the user decided not to install.
+     *
+     * Containment is checked against the same staging directory the installer
+     * validates against: the path travels through [UpdateState] and is the only
+     * argument here, so a deletion that trusted it would be an arbitrary-file
+     * delete primitive rather than a cleanup.
+     */
+    fun discardDownload(downloadPath: String)
+
     fun getCurrentPlatform(): String
 
     fun getExpectedAssetName(version: Version): String

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginStoreVersionBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginStoreVersionBridge.kt
@@ -1,15 +1,20 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.downloads.DownloadCenter
 import ai.rever.boss.plugin.KeyedDetachedJobs
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.api.PluginUnloadIntent
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
 import ai.rever.boss.plugin.repository.shortFailureReason
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 
 /**
  * Desktop implementation of the store-version bridge.
@@ -96,20 +101,39 @@ actual object PluginStoreVersionBridge {
                             "The plugin store is not available. Check your connection and try again.",
                         ),
                     )
-            installer.install(
-                store = store,
-                request =
-                    StoreVersionRequest(
-                        pluginId = pluginId,
-                        version = version,
-                        sourceUrl = sourceUrl,
-                        runningJarPath = manager.getPluginInfo(pluginId)?.jarPath,
-                    ),
-                unload = { id -> manager.uninstallPlugin(id, force = true).map { } },
-                load = { path ->
-                    manager.installPlugin(path, enabled = true).map { it.state == PluginState.LOADED }
-                },
-            )
+            // The center's row is opened inside the detached job, so the Cancel it
+            // offers cancels THAT job - the one actually downloading. Cancelling the
+            // window's coroutine would only abandon the wait: the swap is detached
+            // precisely so closing a window cannot stop it mid-flight.
+            val job = currentCoroutineContext()[Job]
+            val ownsTransfer =
+                DownloadCenter.begin(
+                    id = pluginId,
+                    title = displayName,
+                    kind = TransferKind.PLUGIN_INSTALL,
+                    detail = "Store version v$version",
+                    onCancel = { job?.cancel() },
+                )
+            try {
+                installer.install(
+                    store = store,
+                    request =
+                        StoreVersionRequest(
+                            pluginId = pluginId,
+                            version = version,
+                            sourceUrl = sourceUrl,
+                            runningJarPath = manager.getPluginInfo(pluginId)?.jarPath,
+                        ),
+                    unload = { id -> manager.uninstallPlugin(id, force = true).map { } },
+                    load = { path ->
+                        manager.installPlugin(path, enabled = true).map { it.state == PluginState.LOADED }
+                    },
+                    onProgress = { DownloadCenter.progress(pluginId, it) },
+                    onInstalling = { DownloadCenter.phase(pluginId, TransferPhase.INSTALLING) },
+                )
+            } finally {
+                if (ownsTransfer) DownloadCenter.end(pluginId)
+            }
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -1,11 +1,19 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.downloads.DownloadCenter
 import ai.rever.boss.plugin.MissingDependencyReporter
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.api.PluginUnloadIntent
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import ai.rever.boss.plugin.loader.PluginSignatureSidecar
+import ai.rever.boss.plugin.updater.UpdateInfo
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import java.io.File
 
 /**
@@ -128,21 +136,32 @@ actual object PluginUpdateBridge {
         }
 
         val reporter = MissingDependencyReporter.forManager(manager)
+
+        val ownsTransfer = beginTransfer(pluginId, update, currentCoroutineContext()[Job])
         val result =
-            mgr.updatePlugin(
-                pluginId = pluginId,
-                downloadPath = targetPath,
-                unloadPlugin = { id -> manager.uninstallPlugin(id, force = true).map { } },
-                loadPlugin = { path ->
-                    manager.installPlugin(path).map { info ->
-                        // An update can add a dependency the installed version never declared,
-                        // and this path does not go through PluginLoaderDelegateImpl. Only for a
-                        // plugin that actually registered: `installPlugin` returns success with
-                        // `state = DISABLED` when registration failed as binary-incompatible.
-                        if (info.state == PluginState.LOADED) reporter.report(info.manifest)
-                    }
-                },
-            )
+            try {
+                mgr.updatePlugin(
+                    pluginId = pluginId,
+                    downloadPath = targetPath,
+                    unloadPlugin = { id -> manager.uninstallPlugin(id, force = true).map { } },
+                    loadPlugin = { path ->
+                        manager.installPlugin(path).map { info ->
+                            // An update can add a dependency the installed version never declared,
+                            // and this path does not go through PluginLoaderDelegateImpl. Only for a
+                            // plugin that actually registered: `installPlugin` returns success with
+                            // `state = DISABLED` when registration failed as binary-incompatible.
+                            if (info.state == PluginState.LOADED) reporter.report(info.manifest)
+                        }
+                    },
+                    onProgress = { DownloadCenter.progress(pluginId, it) },
+                    onInstalling = { DownloadCenter.phase(pluginId, TransferPhase.INSTALLING) },
+                )
+            } catch (e: CancellationException) {
+                discardPartialDownload(targetFile)
+                throw e
+            } finally {
+                if (ownsTransfer) DownloadCenter.end(pluginId)
+            }
         return if (result.isSuccess) {
             PluginUpdateRegistry.clear(pluginId)
             // Remove the previous version's JAR (and any other stale duplicates).
@@ -158,5 +177,50 @@ actual object PluginUpdateBridge {
         } else {
             Result.failure(result.exceptionOrNull() ?: Exception("Update failed"))
         }
+    }
+
+    /**
+     * Open this update's row in the bottom bar, cancellable while it is still bytes.
+     *
+     * Cancel is [job]'s: `performUpdate` runs inside whatever coroutine pressed the
+     * button, so cancelling that is what abandons the download. It stops being
+     * offered on its own once the swap starts, because the center withdraws Cancel
+     * for [ai.rever.boss.plugin.api.TransferPhase.INSTALLING].
+     *
+     * @return whether this call created the row, and so must end it.
+     */
+    private fun beginTransfer(
+        pluginId: String,
+        update: UpdateInfo,
+        job: Job?,
+    ): Boolean =
+        DownloadCenter.begin(
+            id = pluginId,
+            title = update.displayName,
+            kind = TransferKind.PLUGIN_UPDATE,
+            detail = "v${update.currentVersion} \u2192 v${update.newVersion}",
+            onCancel = { job?.cancel() },
+        )
+
+    /**
+     * Remove a jar a cancelled download left behind, and its signature sidecar.
+     *
+     * This path streams straight onto a version-named jar in the plugin directory
+     * (not a `.part` sibling, as the two store installers do), so a cancelled
+     * download leaves a truncated file at a name the next directory scan would try
+     * to load. Nothing else deletes it: the update never reached the reconciler.
+     *
+     * Both, and in that order: `PluginSignatureSidecar` is written next to the path
+     * the download was given, and a sidecar that outlives its jar meets the next
+     * download's fresh bytes and hard-fails the load - which is worse than being
+     * unsigned. Best-effort by design; a file that cannot be deleted here is
+     * reported, not raised, because the cancellation is what the caller is waiting on.
+     */
+    private fun discardPartialDownload(jar: File) {
+        runCatching { if (jar.exists()) jar.delete() }
+            .onFailure { e ->
+                logger.warn(LogCategory.SYSTEM, "Could not remove a cancelled update download: ${e.message}")
+            }
+        runCatching { PluginSignatureSidecar.delete(jar.absolutePath) }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -109,15 +109,10 @@ actual object PluginUpdateBridge {
             return Result.failure(DependentRestartDeclinedException(pluginId))
         }
 
-        // newVersion comes from the (remote) store manifest, and SemanticVersion.parse does NOT
-        // reject path separators in prerelease/build metadata — so sanitize the filename and verify
-        // the resolved path stays inside the plugin directory (no traversal out of it).
         val pluginDir = PluginStoreSetup.getPluginDir()
-        val safeName = "$pluginId-${update.newVersion}".replace(Regex("[^A-Za-z0-9._-]"), "_")
-        val targetFile = File(pluginDir, "$safeName.jar")
-        if (!targetFile.canonicalPath.startsWith(pluginDir.canonicalPath + File.separator)) {
-            return Result.failure(Exception("Refusing to download update outside the plugin directory"))
-        }
+        val targetFile =
+            downloadTargetIn(pluginDir, pluginId, update.newVersion)
+                ?: return Result.failure(Exception("Refusing to download update outside the plugin directory"))
         val targetPath = targetFile.absolutePath
 
         // Keep the jar this update is about to make unreachable, BEFORE anything downloads.
@@ -138,9 +133,7 @@ actual object PluginUpdateBridge {
         val reporter = MissingDependencyReporter.forManager(manager)
 
         val ownsTransfer = beginTransfer(pluginId, update, currentCoroutineContext()[Job])
-        // Whether the swap has begun, i.e. whether a cancellation is still safe to
-        // clean up after. Set from `onInstalling`, which fires between the last byte
-        // and the unload.
+        // Set from `onInstalling`; see discardPartialDownload for what it gates.
         var swapStarted = false
         val result =
             try {
@@ -164,11 +157,7 @@ actual object PluginUpdateBridge {
                     },
                 )
             } catch (e: CancellationException) {
-                // Only while it was still bytes. Past `onInstalling` the jar may already
-                // be loaded and recorded, and deleting it then leaves installed.json
-                // pointing at nothing for the next launch to fail on - a cancellation
-                // arriving late must not take the working install with it.
-                if (!swapStarted) discardPartialDownload(targetFile)
+                discardIfUnswapped(swapStarted, targetFile)
                 throw e
             } finally {
                 if (ownsTransfer) DownloadCenter.end(pluginId)
@@ -186,6 +175,7 @@ actual object PluginUpdateBridge {
             }
             Result.success(update.newVersion)
         } else {
+            discardIfUnswapped(swapStarted, targetFile)
             Result.failure(result.exceptionOrNull() ?: Exception("Update failed"))
         }
     }
@@ -214,12 +204,53 @@ actual object PluginUpdateBridge {
         )
 
     /**
+     * Where this update's jar goes, or null if that would leave [pluginDir].
+     *
+     * `newVersion` comes from the remote store manifest, and `SemanticVersion.parse`
+     * does NOT reject path separators in prerelease or build metadata - so the name is
+     * sanitised and the resolved path is checked, rather than trusted.
+     */
+    private fun downloadTargetIn(
+        pluginDir: File,
+        pluginId: String,
+        newVersion: String,
+    ): File? {
+        val safeName = "$pluginId-$newVersion".replace(Regex("[^A-Za-z0-9._-]"), "_")
+        val target = File(pluginDir, "$safeName.jar")
+        return target.takeIf { it.canonicalPath.startsWith(pluginDir.canonicalPath + File.separator) }
+    }
+
+    /**
+     * Discard the download unless the swap has begun.
+     *
+     * Both non-success paths need this, not only the cancellation: this is the one
+     * host update path that streams onto a scannable `<pluginId>-<version>.jar`
+     * rather than a `.part` sibling, and `reconcilePluginDir` runs only on success -
+     * so a mid-stream network failure leaves a truncated jar for the next launch to
+     * load with no cancellation anywhere in sight. The two store installers discard
+     * in both their failure branch and a catch; this one now matches.
+     *
+     * And not once the swap has begun: the jar may already be loaded and recorded,
+     * and deleting it then leaves `installed.json` pointing at nothing.
+     */
+    private fun discardIfUnswapped(
+        swapStarted: Boolean,
+        jar: File,
+    ) {
+        if (!swapStarted) discardPartialDownload(jar)
+    }
+
+    /**
      * Remove a jar a cancelled download left behind, and its signature sidecar.
      *
      * This path streams straight onto a version-named jar in the plugin directory
-     * (not a `.part` sibling, as the two store installers do), so a cancelled
-     * download leaves a truncated file at a name the next directory scan would try
-     * to load. Nothing else deletes it: the update never reached the reconciler.
+     * (not a `.part` sibling, as the two store installers do), so a cancelled or
+     * failed download leaves a truncated file at a name the next directory scan would
+     * try to load. Nothing else deletes it: the update never reached the reconciler.
+     *
+     * Only called while `swapStarted` is false. Past `onInstalling` the jar may
+     * already be loaded and recorded, and deleting it then leaves `installed.json`
+     * pointing at nothing for the next launch to fail on.
      *
      * Both, and in that order: `PluginSignatureSidecar` is written next to the path
      * the download was given, and a sidecar that outlives its jar meets the next

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginUpdateBridge.kt
@@ -138,6 +138,10 @@ actual object PluginUpdateBridge {
         val reporter = MissingDependencyReporter.forManager(manager)
 
         val ownsTransfer = beginTransfer(pluginId, update, currentCoroutineContext()[Job])
+        // Whether the swap has begun, i.e. whether a cancellation is still safe to
+        // clean up after. Set from `onInstalling`, which fires between the last byte
+        // and the unload.
+        var swapStarted = false
         val result =
             try {
                 mgr.updatePlugin(
@@ -154,10 +158,17 @@ actual object PluginUpdateBridge {
                         }
                     },
                     onProgress = { DownloadCenter.progress(pluginId, it) },
-                    onInstalling = { DownloadCenter.phase(pluginId, TransferPhase.INSTALLING) },
+                    onInstalling = {
+                        swapStarted = true
+                        DownloadCenter.phase(pluginId, TransferPhase.INSTALLING)
+                    },
                 )
             } catch (e: CancellationException) {
-                discardPartialDownload(targetFile)
+                // Only while it was still bytes. Past `onInstalling` the jar may already
+                // be loaded and recorded, and deleting it then leaves installed.json
+                // pointing at nothing for the next launch to fail on - a cancellation
+                // arriving late must not take the working install with it.
+                if (!swapStarted) discardPartialDownload(targetFile)
                 throw e
             } finally {
                 if (ownsTransfer) DownloadCenter.end(pluginId)
@@ -217,10 +228,18 @@ actual object PluginUpdateBridge {
      * reported, not raised, because the cancellation is what the caller is waiting on.
      */
     private fun discardPartialDownload(jar: File) {
-        runCatching { if (jar.exists()) jar.delete() }
-            .onFailure { e ->
-                logger.warn(LogCategory.SYSTEM, "Could not remove a cancelled update download: ${e.message}")
-            }
+        // Absence is the postcondition, not a delete that returned true: `delete()`
+        // returns false rather than throwing when a Windows lock holds the file, so
+        // runCatching alone never reported the case this warning exists for - and an
+        // already-absent file returns false too, which is success here.
+        val gone = runCatching { !jar.exists() || jar.delete() }.getOrDefault(false)
+        if (!gone) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "A cancelled update download could not be removed; the next launch would try to load it",
+                mapOf("path" to jar.absolutePath),
+            )
+        }
         runCatching { PluginSignatureSidecar.delete(jar.absolutePath) }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/StoreVersionInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/StoreVersionInstaller.kt
@@ -9,6 +9,8 @@ import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -109,6 +111,29 @@ internal class StoreVersionInstaller(
         // Past the point of no return: the swap can no longer be abandoned safely, so a
         // caller offering Cancel withdraws it here rather than after the unload.
         onInstalling?.invoke()
+
+        // And the work stops being cancellable, not just the button. Cancellation is
+        // cooperative: a Cancel pressed between the last progress tick and this line
+        // would otherwise throw out of `activate` - between the unload and the load -
+        // and leave the plugin gone with nothing in its place, which is what the
+        // detached scope and the withdrawn button both exist to prevent.
+        return withContext(NonCancellable) { promoteAndActivate(request, downloaded, target, unload, load) }
+    }
+
+    /**
+     * Move the verified download into place and swap the running plugin for it.
+     *
+     * Split from the download half so the whole swap runs under `NonCancellable` in
+     * one expression; see the call site for why it must.
+     */
+    private suspend fun promoteAndActivate(
+        request: StoreVersionRequest,
+        downloaded: String,
+        target: File,
+        unload: suspend (String) -> Result<Unit>,
+        load: suspend (String) -> Result<Boolean>,
+    ): Result<String> {
+        val version = request.version
 
         val moved = runCatching { hooks.promoteFiles(downloaded, target) }
         if (moved.isFailure) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/StoreVersionInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/StoreVersionInstaller.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.plugin.repository.PluginRepository
 import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CancellationException
 import java.io.File
 
 /**
@@ -79,6 +80,8 @@ internal class StoreVersionInstaller(
         request: StoreVersionRequest,
         unload: suspend (String) -> Result<Unit>,
         load: suspend (String) -> Result<Boolean>,
+        onProgress: ((Float) -> Unit)? = null,
+        onInstalling: (() -> Unit)? = null,
     ): Result<String> {
         val pluginId = request.pluginId
         val version = request.version
@@ -86,13 +89,26 @@ internal class StoreVersionInstaller(
         val part = File("${target.absolutePath}.part")
 
         val downloaded =
-            store
-                .downloadPlugin(pluginId, version, part.absolutePath)
-                .getOrElse { error ->
-                    hooks.discardFiles(part.absolutePath)
-                    logger.error(LogCategory.SYSTEM, "Could not download the store version", error = error)
-                    return failure("Could not download v$version: ${error.message ?: "unknown error"}")
-                }
+            try {
+                store
+                    .downloadPlugin(pluginId, version, part.absolutePath, onProgress)
+                    .getOrElse { error ->
+                        hooks.discardFiles(part.absolutePath)
+                        logger.error(LogCategory.SYSTEM, "Could not download the store version", error = error)
+                        return failure("Could not download v$version: ${error.message ?: "unknown error"}")
+                    }
+            } catch (e: CancellationException) {
+                // A cancelled download leaves a part file. It is ignored by the directory
+                // scan (the suffix is deliberately not .jar), so this is tidiness rather
+                // than safety - but a stale part file is what the next attempt truncates,
+                // and leaving it behind makes the plugin directory unreadable over time.
+                hooks.discardFiles(part.absolutePath)
+                throw e
+            }
+
+        // Past the point of no return: the swap can no longer be abandoned safely, so a
+        // caller offering Cancel withdraws it here rather than after the unload.
+        onInstalling?.invoke()
 
         val moved = runCatching { hooks.promoteFiles(downloaded, target) }
         if (moved.isFailure) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -18,8 +18,10 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -147,6 +149,8 @@ class StoreMissingDependencyInstaller(
         // Visible in the bottom bar like every other transfer, and cancellable while it
         // is still bytes. The row is opened inside the detached job (see `install`), so
         // its Cancel cancels the download rather than the window that asked for it.
+        // Whether the (uncancellable) promotion has run; see the catch below.
+        var promoted = false
         val job = currentCoroutineContext()[Job]
         val ownsTransfer =
             DownloadCenter.begin(
@@ -163,7 +167,19 @@ class StoreMissingDependencyInstaller(
                 }.fold(
                     onSuccess = { downloaded ->
                         DownloadCenter.phase(pluginId, TransferPhase.INSTALLING)
-                        promoteAndLoad(pluginId, downloaded, target, info)
+                        // NonCancellable, like the two swap paths: a Cancel pressed
+                        // between the last progress tick and here surfaces at the next
+                        // suspension point, which can be INSIDE the promotion. By then
+                        // the jar and its sidecar may have moved onto the final name -
+                        // so discarding the part file removes nothing, and a `.jar` sits
+                        // at a scannable name with no installed.json row. The next
+                        // launch's directory scan installs it, unvetted, because
+                        // `vetAndLoad` never ran. That is the exact harm the `.part`
+                        // suffix exists to prevent, reached by another door.
+                        withContext(NonCancellable) {
+                            promoted = true
+                            promoteAndLoad(pluginId, downloaded, target, info)
+                        }
                     },
                     onFailure = { error ->
                         discard(part.absolutePath)
@@ -173,6 +189,10 @@ class StoreMissingDependencyInstaller(
                 )
         } catch (e: CancellationException) {
             discard(part.absolutePath)
+            // The target only if the promotion never ran. Past it the jar may BE the
+            // installed plugin, with its installed.json row written - the same reason
+            // the host's update path gates its discard on `swapStarted`.
+            if (!promoted) discard(target.absolutePath)
             throw e
         } finally {
             if (ownsTransfer) DownloadCenter.end(pluginId)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstaller.kt
@@ -2,7 +2,10 @@ package ai.rever.boss.plugin
 
 import ai.rever.boss.components.plugin.MissingDependencyInstaller
 import ai.rever.boss.components.plugin.PluginDependencyResolution
+import ai.rever.boss.downloads.DownloadCenter
 import ai.rever.boss.plugin.api.PluginManifest
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
 import ai.rever.boss.plugin.loader.PluginManifestReader
 import ai.rever.boss.plugin.loader.PluginSignatureSidecar
 import ai.rever.boss.plugin.repository.PluginInfo
@@ -11,9 +14,12 @@ import ai.rever.boss.plugin.repository.shortFailureReason
 import ai.rever.boss.utils.atomicMoveFrom
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 import java.io.File
 
 /**
@@ -137,16 +143,40 @@ class StoreMissingDependencyInstaller(
         // is ignored by the directory scan rather than loaded. (`PluginInstallService` uses
         // `-downloading.jar`, which is scannable, and moves the jar without its sidecar.)
         val part = File("${target.absolutePath}.part")
-        return store
-            .downloadPlugin(pluginId, info.version, part.absolutePath)
-            .fold(
-                onSuccess = { downloaded -> promoteAndLoad(pluginId, downloaded, target, info) },
-                onFailure = { error ->
-                    discard(part.absolutePath)
-                    logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
-                    failure("Could not download ${info.displayName}: ${error.message ?: "unknown error"}")
-                },
+
+        // Visible in the bottom bar like every other transfer, and cancellable while it
+        // is still bytes. The row is opened inside the detached job (see `install`), so
+        // its Cancel cancels the download rather than the window that asked for it.
+        val job = currentCoroutineContext()[Job]
+        val ownsTransfer =
+            DownloadCenter.begin(
+                id = pluginId,
+                title = info.displayName.ifBlank { pluginId },
+                kind = TransferKind.PLUGIN_INSTALL,
+                detail = "Required by another plugin",
+                onCancel = { job?.cancel() },
             )
+        return try {
+            store
+                .downloadPlugin(pluginId, info.version, part.absolutePath) {
+                    DownloadCenter.progress(pluginId, it)
+                }.fold(
+                    onSuccess = { downloaded ->
+                        DownloadCenter.phase(pluginId, TransferPhase.INSTALLING)
+                        promoteAndLoad(pluginId, downloaded, target, info)
+                    },
+                    onFailure = { error ->
+                        discard(part.absolutePath)
+                        logger.error(LogCategory.SYSTEM, "Failed to download a plugin dependency", error = error)
+                        failure("Could not download ${info.displayName}: ${error.message ?: "unknown error"}")
+                    },
+                )
+        } catch (e: CancellationException) {
+            discard(part.absolutePath)
+            throw e
+        } finally {
+            if (ownsTransfer) DownloadCenter.end(pluginId)
+        }
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
@@ -299,6 +299,10 @@ actual class UpdateService {
                     is SocketTimeoutException -> "Network timeout: Download interrupted"
                     else -> e.message ?: "Unknown error"
                 }
+            // The partial goes here too, not only on the cancellation path: a dropped
+            // connection otherwise leaves a DMG's worth of disk occupied until the next
+            // attempt happens to overwrite it. Same asymmetry the plugin side closed.
+            runCatching { partial?.delete() }
             logger.error(LogCategory.NETWORK, "Error downloading update", mapOf("error" to errorMessage))
             null
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/updater/DesktopUpdateService.kt
@@ -18,6 +18,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -221,8 +222,14 @@ actual class UpdateService {
         assetSize: Long,
         sha256: String?,
         onProgress: (progress: Float) -> Unit,
-    ): String? =
-        try {
+    ): String? {
+        // Held outside the try so a cancellation can clean up the partial file. A
+        // cancelled download otherwise leaves a half-written installer in the staging
+        // directory under the exact name the next attempt checks for, and the next
+        // one deletes it before writing anyway - so the disk cost is silent until it
+        // is a whole DMG.
+        var partial: File? = null
+        return try {
             logger.info(LogCategory.SYSTEM, "Starting update download", mapOf("asset" to assetName, "size" to assetSize))
 
             // The asset name comes off the remote release row, and everything below
@@ -245,6 +252,7 @@ actual class UpdateService {
             if (downloadFile.exists()) {
                 downloadFile.delete()
             }
+            partial = downloadFile
 
             streamToFile(url, assetSize, downloadFile, onProgress)
 
@@ -276,6 +284,13 @@ actual class UpdateService {
                 logger.error(LogCategory.SYSTEM, "Download failed - file is empty or doesn't exist")
                 null
             }
+        } catch (e: CancellationException) {
+            // Caught ahead of the general clause, which would otherwise swallow it and
+            // return null - reporting the user's own Cancel as "Failed to download
+            // update" and leaving the partial file behind.
+            runCatching { partial?.delete() }
+            logger.info(LogCategory.SYSTEM, "Update download cancelled", mapOf("asset" to assetName))
+            throw e
         } catch (e: Exception) {
             val errorMessage =
                 when (e) {
@@ -287,6 +302,7 @@ actual class UpdateService {
             logger.error(LogCategory.NETWORK, "Error downloading update", mapOf("error" to errorMessage))
             null
         }
+    }
 
     /** Resolve the GitHub Releases asset URL for [version] — the download-time backup. */
     private suspend fun gitHubAssetUrlFor(version: Version): String? =
@@ -387,6 +403,44 @@ actual class UpdateService {
             // Ensure 100% is reported on completion, on the main thread.
             withContext(Dispatchers.Main) {
                 onProgress(1f)
+            }
+        }
+    }
+
+    actual fun discardDownload(downloadPath: String) {
+        val file = File(downloadPath)
+        // Containment first, exactly as the installer does before it touches an
+        // artifact: this path arrives from update state as a plain string, and a
+        // delete that trusted it would remove any file the user can write. A path
+        // that cannot be resolved is one that is already gone, so absence is the
+        // postcondition either way.
+        val realStagingDir = runCatching { defaultStagingDir().toPath().toRealPath() }.getOrNull()
+        val realPath = runCatching { file.toPath().toRealPath() }.getOrNull()
+        val contained =
+            realStagingDir != null &&
+                realPath != null &&
+                realPath != realStagingDir &&
+                realPath.startsWith(realStagingDir)
+        when {
+            realStagingDir == null || realPath == null -> {
+                Unit
+            }
+
+            !contained -> {
+                logger.error(
+                    LogCategory.SYSTEM,
+                    "Refusing to discard a download outside the staging directory",
+                    mapOf("expected" to realStagingDir.toString(), "actual" to realPath.toString()),
+                )
+            }
+
+            else -> {
+                val deleted = runCatching { file.delete() }.getOrDefault(false)
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "Discarded a downloaded update",
+                    mapOf("path" to file.absolutePath, "deleted" to deleted.toString()),
+                )
             }
         }
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginUpdateRegistryReconcileTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/PluginUpdateRegistryReconcileTest.kt
@@ -1,0 +1,82 @@
+package ai.rever.boss.components.plugin
+
+import org.junit.jupiter.api.AfterEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The badge has to go away when the update happens, whoever applied it.
+ *
+ * Before this, the registry was cleared only by the host's own update path, so a
+ * plugin updated from the Toolbox panel or from its update toast kept showing an
+ * "update available" badge - and the prompt that badge opens offered to install a
+ * version that was already running.
+ */
+class PluginUpdateRegistryReconcileTest {
+    @AfterEach
+    fun clean() {
+        PluginUpdateRegistry.updates.value.keys
+            .toList()
+            .forEach(PluginUpdateRegistry::clear)
+    }
+
+    private fun publish(
+        pluginId: String,
+        current: String,
+        new: String,
+    ) = PluginUpdateRegistry.put(AvailablePluginUpdate(pluginId, pluginId, current, new))
+
+    @Test
+    fun `an entry clears once the plugin is no longer at the version it was found on`() {
+        publish("a", current = "1.0.0", new = "1.1.0")
+
+        PluginUpdateRegistry.reconcile(mapOf("a" to "1.1.0"))
+
+        assertNull(PluginUpdateRegistry.updates.value["a"])
+    }
+
+    @Test
+    fun `a plugin still on the checked version keeps its badge`() {
+        publish("a", current = "1.0.0", new = "1.1.0")
+
+        PluginUpdateRegistry.reconcile(mapOf("a" to "1.0.0"))
+
+        assertNotNull(PluginUpdateRegistry.updates.value["a"])
+    }
+
+    @Test
+    fun `a downgrade invalidates the entry too`() {
+        // Comparing against currentVersion rather than newVersion means no semver
+        // ordering is needed: what makes the entry stale is the plugin having moved.
+        publish("a", current = "1.0.0", new = "1.1.0")
+
+        PluginUpdateRegistry.reconcile(mapOf("a" to "0.9.0"))
+
+        assertNull(PluginUpdateRegistry.updates.value["a"])
+    }
+
+    @Test
+    fun `plugins absent from the snapshot are left alone`() {
+        publish("a", current = "1.0.0", new = "1.1.0")
+
+        // Every plugin is unloaded during an api hot swap. Treating that as
+        // "updated" would wipe every badge in the app.
+        PluginUpdateRegistry.reconcile(emptyMap())
+        assertNotNull(PluginUpdateRegistry.updates.value["a"])
+
+        PluginUpdateRegistry.reconcile(mapOf("b" to "2.0.0"))
+        assertNotNull(PluginUpdateRegistry.updates.value["a"])
+    }
+
+    @Test
+    fun `other plugins are untouched`() {
+        publish("a", current = "1.0.0", new = "1.1.0")
+        publish("b", current = "2.0.0", new = "2.1.0")
+
+        PluginUpdateRegistry.reconcile(mapOf("a" to "1.1.0", "b" to "2.0.0"))
+
+        assertEquals(setOf("b"), PluginUpdateRegistry.updates.value.keys)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/StoreVersionInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/StoreVersionInstallerTest.kt
@@ -56,6 +56,7 @@ class StoreVersionInstallerTest {
             pluginId: String,
             version: String?,
             targetPath: String,
+            onProgress: ((Float) -> Unit)?,
         ): Result<String> {
             File(targetPath).writeText("store bytes")
             onDownload(targetPath)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImplTest.kt
@@ -1,0 +1,119 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.plugin.api.TransferKind
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The id prefix is a security boundary, not tidiness: without it any installed
+ * plugin could address the host's app-update row to withdraw its Cancel, fake its
+ * progress, or fabricate a row, and two plugins choosing `"update"` would collide.
+ *
+ * It has to be invisible to its owner, or it removes the only key a plugin can match
+ * its own work by - which is the feature the whole change exists for. Both halves
+ * are pinned here.
+ */
+class DownloadCenterProviderImplTest {
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+
+    @BeforeEach
+    @AfterEach
+    fun clean() = DownloadCenter.reset()
+
+    @AfterEach
+    fun stop() = scope.cancel()
+
+    private fun provider(prefix: String?) = DownloadCenterProviderImpl(scope, idPrefix = prefix)
+
+    @Test
+    fun `a plugin's id is qualified in the center`() {
+        provider("com.example.tools").begin("update", "Tools", TransferKind.PLUGIN_UPDATE)
+
+        assertEquals(
+            "com.example.tools:update",
+            DownloadCenter.transfers.value
+                .single()
+                .info.id,
+        )
+    }
+
+    @Test
+    fun `a plugin reads its own id back unqualified`() {
+        val plugin = provider("com.example.tools")
+        plugin.begin("update", "Tools", TransferKind.PLUGIN_UPDATE)
+
+        // Otherwise the plugin never learns what its row is called, and "is this one
+        // busy?" can never be answered.
+        assertEquals(listOf("update"), plugin.transfers.value.map { it.id })
+    }
+
+    @Test
+    fun `another plugin's row stays qualified and is not addressable`() {
+        provider("com.example.other").begin("update", "Other", TransferKind.PLUGIN_UPDATE)
+        val plugin = provider("com.example.tools")
+
+        assertEquals(listOf("com.example.other:update"), plugin.transfers.value.map { it.id })
+
+        // Naming it does not reach it: this opens the caller's OWN row instead.
+        plugin.begin("com.example.other:update", "Impostor", TransferKind.PLUGIN_INSTALL)
+        assertEquals(
+            setOf("com.example.other:update", "com.example.tools:com.example.other:update"),
+            DownloadCenter.transfers.value
+                .map { it.info.id }
+                .toSet(),
+        )
+    }
+
+    @Test
+    fun `a plugin cannot touch the host's app update`() {
+        DownloadCenter.begin(DownloadCenter.APP_UPDATE_ID, "BOSS v9.9.9", TransferKind.APP_UPDATE, onCancel = {})
+        DownloadCenter.progress(DownloadCenter.APP_UPDATE_ID, 0.5f)
+
+        val plugin = provider("com.example.tools")
+        val handle = plugin.begin(DownloadCenter.APP_UPDATE_ID, "Not BOSS", TransferKind.APP_UPDATE)
+        handle.phase(ai.rever.boss.plugin.api.TransferPhase.INSTALLING)
+        handle.done()
+
+        // The app update kept its progress, its phase and its Cancel; the plugin's
+        // attempt became a row of its own, which its own done() then removed.
+        val appRow = DownloadCenter.transfers.value.single { it.info.id == DownloadCenter.APP_UPDATE_ID }
+        assertEquals(0.5f, appRow.info.progress)
+        assertTrue(appRow.info.cancellable, "a plugin must not be able to withdraw the host's Cancel")
+    }
+
+    @Test
+    fun `a host row keyed by pluginId is visible to that plugin unchanged`() {
+        // This is the headline case: the host installs docker, and the Toolbox's own
+        // button for docker reads busy. It only works because host rows are unqualified.
+        DownloadCenter.begin("ai.rever.boss.plugin.dynamic.docker", "Docker", TransferKind.PLUGIN_INSTALL)
+
+        val toolbox = provider("ai.rever.boss.plugin.dynamic.pluginmanager")
+
+        assertEquals(listOf("ai.rever.boss.plugin.dynamic.docker"), toolbox.transfers.value.map { it.id })
+    }
+
+    @Test
+    fun `an unprefixed provider is the host's own view`() {
+        val host = provider(null)
+        host.begin("boss-app-update", "BOSS", TransferKind.APP_UPDATE)
+
+        assertEquals(
+            "boss-app-update",
+            DownloadCenter.transfers.value
+                .single()
+                .info.id,
+        )
+        assertNull(
+            DownloadCenter.transfers.value
+                .single()
+                .onCancel,
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterProviderImplTest.kt
@@ -1,9 +1,6 @@
 package ai.rever.boss.downloads
 
 import ai.rever.boss.plugin.api.TransferKind
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
@@ -21,16 +18,11 @@ import kotlin.test.assertTrue
  * are pinned here.
  */
 class DownloadCenterProviderImplTest {
-    private val scope = CoroutineScope(Dispatchers.Unconfined)
-
     @BeforeEach
     @AfterEach
     fun clean() = DownloadCenter.reset()
 
-    @AfterEach
-    fun stop() = scope.cancel()
-
-    private fun provider(prefix: String?) = DownloadCenterProviderImpl(scope, idPrefix = prefix)
+    private fun provider(prefix: String?) = DownloadCenterProviderImpl(idPrefix = prefix)
 
     @Test
     fun `a plugin's id is qualified in the center`() {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterStatusItemTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterStatusItemTest.kt
@@ -1,0 +1,87 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.components.bars.horizontal.DownloadCenterStatusItem
+import ai.rever.boss.plugin.api.TransferKind
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertTrue
+
+/**
+ * The bar itself, composed - not the strings, which [DownloadCenterTextTest] pins.
+ *
+ * Worth a screen because the thing that makes this widget correct is what it does
+ * when there is nothing to show: it sits in the middle of the status bar, so a
+ * version that composed an empty Row would push every item beside it sideways
+ * whenever a download finished, and no unit test would see that.
+ */
+class DownloadCenterStatusItemTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @After
+    fun clean() = DownloadCenter.reset()
+
+    @Test
+    fun `nothing is composed while nothing is in flight`() {
+        rule.setContent {
+            Row { DownloadCenterStatusItem() }
+        }
+
+        // Structural, not "no text saying Downloading": an item that composed an
+        // empty label and a zero-progress bar would pass that and still push every
+        // status-bar item beside it sideways whenever a download finished.
+        val children = rule.onRoot().fetchSemanticsNode().children
+        assertTrue(children.isEmpty(), "an empty center must draw nothing at all, not an empty row")
+    }
+
+    @Test
+    fun `a transfer appears and names itself`() {
+        rule.setContent {
+            Row { DownloadCenterStatusItem() }
+        }
+
+        rule.runOnIdle {
+            DownloadCenter.begin("p", "Docker", TransferKind.PLUGIN_INSTALL)
+            DownloadCenter.progress("p", 0.4f)
+        }
+
+        rule.onNodeWithText("Downloading Docker 40%").assertIsDisplayed()
+    }
+
+    @Test
+    fun `it goes away again when the transfer ends`() {
+        rule.setContent {
+            Row { DownloadCenterStatusItem() }
+        }
+
+        rule.runOnIdle {
+            DownloadCenter.begin("p", "Docker", TransferKind.PLUGIN_INSTALL)
+            DownloadCenter.progress("p", 0.4f)
+        }
+        rule.onNodeWithText("Downloading Docker 40%").assertIsDisplayed()
+
+        rule.runOnIdle { DownloadCenter.end("p") }
+
+        rule.onNodeWithText("Downloading Docker 40%").assertDoesNotExist()
+    }
+
+    @Test
+    fun `several transfers are counted rather than called plugins`() {
+        rule.setContent {
+            Row { DownloadCenterStatusItem() }
+        }
+
+        rule.runOnIdle {
+            DownloadCenter.begin("p", "Docker", TransferKind.PLUGIN_INSTALL)
+            DownloadCenter.begin(DownloadCenter.APP_UPDATE_ID, "BOSS v9.5.0", TransferKind.APP_UPDATE)
+        }
+
+        rule.onNodeWithText("2 downloads…").assertIsDisplayed()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterStatusItemTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterStatusItemTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertTrue
@@ -24,6 +25,8 @@ class DownloadCenterStatusItemTest {
     @get:Rule
     val rule = createComposeRule()
 
+    // Both, so the first test does not depend on every other class tidying up.
+    @Before
     @After
     fun clean() = DownloadCenter.reset()
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTest.kt
@@ -171,6 +171,72 @@ class DownloadCenterTest {
     }
 
     @Test
+    fun `a second press does nothing - both actions are single-shot`() {
+        var cancels = 0
+        var installs = 0
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_UPDATE, onCancel = { cancels++ })
+        DownloadCenter.setActions("p", onCancel = { cancels++ }, onInstall = { installs++ })
+        DownloadCenter.progress("p", 0.4f)
+
+        // The row keeps reading "Downloading" under the cursor until a background hop
+        // and a recomposition land, so two quick presses are one gesture away.
+        DownloadCenter.cancel("p")
+        DownloadCenter.cancel("p")
+        assertEquals(1, cancels)
+
+        DownloadCenter.phase("p", TransferPhase.READY_TO_INSTALL)
+        DownloadCenter.install("p")
+        DownloadCenter.install("p")
+        assertEquals(1, installs, "two elevated installs of one staged artifact")
+    }
+
+    @Test
+    fun `a second operation joining one row withdraws its Cancel`() {
+        var first = 0
+        var second = 0
+        DownloadCenter.begin("p", "Store version", TransferKind.PLUGIN_INSTALL, onCancel = {
+            first++
+            Unit
+        })
+        DownloadCenter.progress("p", 0.3f)
+
+        // The host keys plugin work by pluginId, so an "Install Store Version" and a
+        // dependency install of the same id land on one row. Cancel would abandon
+        // whichever got there first, while the user was looking at the other.
+        DownloadCenter.begin("p", "Dependency", TransferKind.PLUGIN_INSTALL, onCancel = {
+            second++
+            Unit
+        })
+
+        assertFalse(
+            DownloadCenter.transfers.value
+                .single()
+                .info.cancellable,
+        )
+        DownloadCenter.cancel("p")
+        assertEquals(0, first)
+        assertEquals(0, second)
+    }
+
+    @Test
+    fun `re-beginning with the same action is nesting, not joining`() {
+        var cancels = 0
+        val onCancel: () -> Unit = { cancels++ }
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL, onCancel = onCancel)
+        DownloadCenter.progress("p", 0.3f)
+
+        // A fallback path inside one operation passes the same action, and must not
+        // cost that operation its Cancel.
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL, onCancel = onCancel)
+
+        assertTrue(
+            DownloadCenter.transfers.value
+                .single()
+                .info.cancellable,
+        )
+    }
+
+    @Test
     fun `rows keep their insertion order as progress arrives`() {
         DownloadCenter.begin("a", "A", TransferKind.PLUGIN_INSTALL)
         DownloadCenter.begin("b", "B", TransferKind.PLUGIN_INSTALL)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTest.kt
@@ -1,0 +1,182 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The rules that keep one row honest: who owns it, when Cancel is offered, and
+ * what a nested operation is allowed to do to somebody else's entry.
+ *
+ * Each of these is a way the status bar can lie - a row that never leaves, a
+ * Cancel that corrupts a half-swapped plugin, or a fallback path removing the
+ * row its caller is still filling.
+ */
+class DownloadCenterTest {
+    @BeforeEach
+    @AfterEach
+    fun clean() = DownloadCenter.reset()
+
+    @Test
+    fun `begin creates one entry and nested begin joins it`() {
+        val outer = DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+        val inner = DownloadCenter.begin("p", "Plugin again", TransferKind.PLUGIN_UPDATE)
+
+        assertTrue(outer, "the first begin owns the entry")
+        assertFalse(inner, "a nested begin must not claim ownership")
+        assertEquals(1, DownloadCenter.transfers.value.size)
+        // The outer call's description wins: the inner one is a fallback inside it.
+        assertEquals(
+            "Plugin",
+            DownloadCenter.transfers.value
+                .single()
+                .info.title,
+        )
+    }
+
+    @Test
+    fun `progress moves the row into the downloading phase`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.progress("p", 0.42f)
+
+        val info =
+            DownloadCenter.transfers.value
+                .single()
+                .info
+        assertEquals(TransferPhase.DOWNLOADING, info.phase)
+        assertEquals(0.42f, info.progress)
+    }
+
+    @Test
+    fun `progress is clamped`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.progress("p", 3f)
+        assertEquals(
+            1f,
+            DownloadCenter.transfers.value
+                .single()
+                .info.progress,
+        )
+    }
+
+    @Test
+    fun `leaving the download phase drops the fraction`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.progress("p", 0.9f)
+        DownloadCenter.phase("p", TransferPhase.INSTALLING)
+
+        // Otherwise the row reads "Installing 90%" and sits there.
+        assertNull(
+            DownloadCenter.transfers.value
+                .single()
+                .info.progress,
+        )
+    }
+
+    @Test
+    fun `installing is the one phase that cannot be cancelled`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_UPDATE, onCancel = {})
+
+        DownloadCenter.progress("p", 0.5f)
+        assertTrue(
+            DownloadCenter.transfers.value
+                .single()
+                .info.cancellable,
+        )
+
+        DownloadCenter.phase("p", TransferPhase.INSTALLING)
+        assertFalse(
+            DownloadCenter.transfers.value
+                .single()
+                .info.cancellable,
+            "cancelling a jar swap would leave the plugin unloaded",
+        )
+
+        DownloadCenter.phase("p", TransferPhase.READY_TO_INSTALL)
+        assertTrue(
+            DownloadCenter.transfers.value
+                .single()
+                .info.cancellable,
+            "a downloaded update is a file to delete, so Cancel is offered again",
+        )
+    }
+
+    @Test
+    fun `a transfer with no cancel action is never cancellable`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.progress("p", 0.5f)
+        assertFalse(
+            DownloadCenter.transfers.value
+                .single()
+                .info.cancellable,
+        )
+    }
+
+    @Test
+    fun `cancel refuses while installing and runs otherwise`() {
+        var cancelled = 0
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_UPDATE, onCancel = { cancelled++ })
+
+        DownloadCenter.phase("p", TransferPhase.INSTALLING)
+        DownloadCenter.cancel("p")
+        assertEquals(0, cancelled, "the gate is enforced in the center, not only in the dialog")
+
+        DownloadCenter.progress("p", 0.1f)
+        DownloadCenter.cancel("p")
+        assertEquals(1, cancelled)
+    }
+
+    @Test
+    fun `cancel leaves the row for its owner to remove`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_UPDATE, onCancel = {})
+        DownloadCenter.progress("p", 0.1f)
+        DownloadCenter.cancel("p")
+
+        // The cancelled work removes it through the same finally a completed one
+        // uses; removing it here would race a transfer that finished first.
+        assertEquals(1, DownloadCenter.transfers.value.size)
+    }
+
+    @Test
+    fun `an Install action arrives after the row exists`() {
+        var installed = 0
+        DownloadCenter.begin("boss", "BOSS", TransferKind.APP_UPDATE)
+        // Not a begin parameter: an Install only exists once something has
+        // finished downloading, which is a later fact about an existing row.
+        DownloadCenter.setActions("boss", onCancel = null, onInstall = { installed++ })
+        DownloadCenter.phase("boss", TransferPhase.READY_TO_INSTALL)
+
+        DownloadCenter.install("boss")
+        assertEquals(1, installed)
+    }
+
+    @Test
+    fun `end is idempotent and untargeted calls are no-ops`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.end("p")
+        DownloadCenter.end("p")
+        // Safe in a finally, and safe after a transfer someone else already ended.
+        DownloadCenter.progress("p", 0.5f)
+        DownloadCenter.phase("p", TransferPhase.INSTALLING)
+        DownloadCenter.cancel("p")
+        DownloadCenter.install("p")
+
+        assertTrue(DownloadCenter.transfers.value.isEmpty())
+    }
+
+    @Test
+    fun `rows keep their insertion order as progress arrives`() {
+        DownloadCenter.begin("a", "A", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.begin("b", "B", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.progress("a", 0.5f)
+
+        // A map would let the dialog's rows swap places under the pointer.
+        assertEquals(listOf("a", "b"), DownloadCenter.transfers.value.map { it.info.id })
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTest.kt
@@ -237,6 +237,65 @@ class DownloadCenterTest {
     }
 
     @Test
+    fun `a non-finite fraction is indeterminate, not clamped`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL)
+
+        // bytes / length is NaN when the length is absent or zero, and coerceIn
+        // propagates NaN - straight to the progress bar.
+        DownloadCenter.progress("p", Float.NaN)
+        assertNull(
+            DownloadCenter.transfers.value
+                .single()
+                .info.progress,
+        )
+
+        DownloadCenter.progress("p", Float.POSITIVE_INFINITY)
+        assertNull(
+            DownloadCenter.transfers.value
+                .single()
+                .info.progress,
+        )
+
+        DownloadCenter.progress("p", 0.5f)
+        assertEquals(
+            0.5f,
+            DownloadCenter.transfers.value
+                .single()
+                .info.progress,
+        )
+    }
+
+    @Test
+    fun `detail can change as the steps do`() {
+        DownloadCenter.begin("p", "Plugin", TransferKind.PLUGIN_INSTALL, detail = "1 of 3")
+
+        DownloadCenter.detail("p", "2 of 3")
+        assertEquals(
+            "2 of 3",
+            DownloadCenter.transfers.value
+                .single()
+                .info.detail,
+        )
+
+        DownloadCenter.detail("p", null)
+        assertNull(
+            DownloadCenter.transfers.value
+                .single()
+                .info.detail,
+        )
+    }
+
+    @Test
+    fun `owner distinguishes a plugin's row from the host's for one plugin id`() {
+        DownloadCenter.begin("com.foo", "Foo", TransferKind.PLUGIN_INSTALL)
+        DownloadCenter.begin("tools:com.foo", "Foo", TransferKind.PLUGIN_INSTALL, owner = "tools")
+
+        // Two real downloads of the same plugin - one the host started, one a plugin
+        // did. The id alone cannot tell them apart once the prefix is stripped.
+        assertEquals(listOf(null, "tools"), DownloadCenter.transfers.value.map { it.info.owner })
+    }
+
+    @Test
     fun `rows keep their insertion order as progress arrives`() {
         DownloadCenter.begin("a", "A", TransferKind.PLUGIN_INSTALL)
         DownloadCenter.begin("b", "B", TransferKind.PLUGIN_INSTALL)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/downloads/DownloadCenterTextTest.kt
@@ -1,0 +1,95 @@
+package ai.rever.boss.downloads
+
+import ai.rever.boss.plugin.api.TransferInfo
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The bar and the dialog say what is happening in one line each, and that line is
+ * the only thing distinguishing two simultaneous transfers. Pinned here for the
+ * same reason `engineDownloadStatus` is: a wrong verb reads as a hang.
+ */
+class DownloadCenterTextTest {
+    private fun info(
+        id: String = "p",
+        title: String = "Toolbox",
+        kind: TransferKind = TransferKind.PLUGIN_INSTALL,
+        phase: TransferPhase = TransferPhase.DOWNLOADING,
+        progress: Float? = null,
+    ) = TransferInfo(id = id, title = title, kind = kind, phase = phase, progress = progress)
+
+    @Test
+    fun `a determinate download names its percentage`() {
+        assertEquals("Downloading 72%", transferStatusLine(info(progress = 0.725f)))
+    }
+
+    @Test
+    fun `an unknown size stays indeterminate`() {
+        assertEquals("Downloading…", transferStatusLine(info(progress = null)))
+    }
+
+    @Test
+    fun `an update says updating once it starts installing`() {
+        val updating = info(kind = TransferKind.PLUGIN_UPDATE, phase = TransferPhase.INSTALLING)
+        assertEquals("Updating…", transferStatusLine(updating))
+
+        val installing = info(kind = TransferKind.PLUGIN_INSTALL, phase = TransferPhase.INSTALLING)
+        assertEquals("Installing…", transferStatusLine(installing))
+    }
+
+    @Test
+    fun `a stale fraction is not shown next to a non-download phase`() {
+        // The fraction is a DOWNLOAD fraction: "Installing 90%" would read as an
+        // install that is 90% done and stuck.
+        val installing = info(phase = TransferPhase.INSTALLING, progress = 0.9f)
+        assertEquals("Installing…", transferStatusLine(installing))
+    }
+
+    @Test
+    fun `a downloaded update waits rather than reporting progress`() {
+        val ready = info(kind = TransferKind.APP_UPDATE, phase = TransferPhase.READY_TO_INSTALL)
+        assertEquals("Ready to install", transferStatusLine(ready))
+    }
+
+    @Test
+    fun `the bar names a single transfer`() {
+        assertEquals("Downloading Toolbox 40%", transferBarLabel(listOf(info(progress = 0.4f))))
+    }
+
+    @Test
+    fun `the bar counts several without calling them plugins`() {
+        // The application's own update shares this bar, so "2 plugins" would be a
+        // lie exactly when two kinds are running.
+        val items =
+            listOf(
+                info(id = "a", progress = 0.4f),
+                info(id = "boss", title = "BOSS v9.5.0", kind = TransferKind.APP_UPDATE, progress = 0.2f),
+            )
+        assertEquals("2 downloads…", transferBarLabel(items))
+    }
+
+    @Test
+    fun `overall progress needs every size to be known`() {
+        val known = listOf(info(id = "a", progress = 0.5f), info(id = "b", progress = 1f))
+        assertEquals(0.75f, overallProgress(known))
+
+        val mixed = listOf(info(id = "a", progress = 0.9f), info(id = "b", progress = null))
+        assertNull(overallProgress(mixed), "averaging in an unknown makes the bar jump backwards")
+    }
+
+    @Test
+    fun `a downloaded update counts as finished for the bar`() {
+        val ready = info(kind = TransferKind.APP_UPDATE, phase = TransferPhase.READY_TO_INSTALL)
+        // Otherwise the bar sweeps indeterminately beside "Ready to install".
+        assertEquals(1f, overallProgress(listOf(ready)))
+    }
+
+    @Test
+    fun `nothing in flight has no label and no bar`() {
+        assertEquals("", transferBarLabel(emptyList()))
+        assertNull(overallProgress(emptyList()))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/StoreMissingDependencyInstallerTest.kt
@@ -77,6 +77,7 @@ class StoreMissingDependencyInstallerTest {
             pluginId: String,
             version: String?,
             targetPath: String,
+            onProgress: ((Float) -> Unit)?,
         ): Result<String> {
             val target = File(targetPath)
             target.parentFile?.mkdirs()
@@ -563,6 +564,7 @@ class StoreMissingDependencyInstallerTest {
             pluginId: String,
             version: String?,
             targetPath: String,
+            onProgress: ((Float) -> Unit)?,
         ): Result<String> {
             downloads.incrementAndGet()
             // Long enough that a second, uncoalesced install would overlap this one.
@@ -597,6 +599,7 @@ class StoreMissingDependencyInstallerTest {
             pluginId: String,
             version: String?,
             targetPath: String,
+            onProgress: ((Float) -> Unit)?,
         ): Result<String> = error("offline")
 
         override fun getDownloadProgress(pluginId: String): Flow<Float>? = null

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/DiscardDownloadContainmentTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/DiscardDownloadContainmentTest.kt
@@ -1,0 +1,91 @@
+package ai.rever.boss.updater
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `discardDownload` takes a path out of update state and deletes it, so its
+ * containment check is the whole safety of the method: without it, a path that
+ * travelled through [UpdateState] is an arbitrary-file delete primitive running
+ * as the user.
+ *
+ * Same shape as the installer's own `validateDownloadFile` guard, which this
+ * mirrors deliberately - the two must agree on what the staging directory is.
+ */
+class DiscardDownloadContainmentTest {
+    @TempDir
+    lateinit var outside: File
+
+    private val service = UpdateService()
+
+    /** A real file inside the staging directory the installer validates against. */
+    private fun stagedFile(name: String): File {
+        val dir = createRestrictedDir(defaultStagingDir())
+        return File(dir, name).apply { writeText("installer bytes") }
+    }
+
+    @Test
+    fun `a staged artifact is deleted`() {
+        val staged = stagedFile("BOSS-9.9.9-test.dmg")
+
+        service.discardDownload(staged.absolutePath)
+
+        assertFalse(staged.exists(), "a download the user declined should not keep occupying the disk")
+    }
+
+    @Test
+    fun `a file outside the staging directory is refused`() {
+        val victim = File(outside, "important.txt").apply { writeText("not an update") }
+
+        service.discardDownload(victim.absolutePath)
+
+        assertTrue(victim.exists(), "the path arrives from UI state; deleting it unchecked deletes anything")
+    }
+
+    @Test
+    fun `a traversal out of the staging directory is refused`() {
+        val victim = File(outside, "important.txt").apply { writeText("not an update") }
+        val traversal = File(defaultStagingDir(), "../../${outside.name}/${victim.name}")
+
+        service.discardDownload(traversal.absolutePath)
+
+        assertTrue(victim.exists(), "a string prefix check would have passed this")
+    }
+
+    @Test
+    fun `a symlink inside staging pointing out is refused`() {
+        val victim = File(outside, "important.txt").apply { writeText("not an update") }
+        val dir = createRestrictedDir(defaultStagingDir())
+        val link = File(dir, "link-to-victim.dmg")
+        link.delete()
+        Files.createSymbolicLink(link.toPath(), victim.toPath())
+
+        service.discardDownload(link.absolutePath)
+
+        // toRealPath() resolves the link before comparing, so the target is what is
+        // checked - the reason the guard resolves both sides rather than comparing
+        // the paths it was given.
+        assertTrue(victim.exists(), "following a link out of staging would delete an arbitrary file")
+        link.delete()
+    }
+
+    @Test
+    fun `the staging directory itself is refused`() {
+        val dir = createRestrictedDir(defaultStagingDir())
+
+        service.discardDownload(dir.absolutePath)
+
+        assertTrue(dir.isDirectory, "an empty asset name resolves to the directory; deleting it is not a cleanup")
+    }
+
+    @Test
+    fun `an absent path is a no-op`() {
+        // Absence is the postcondition, so a path that is already gone is success
+        // rather than something to report.
+        service.discardDownload(File(defaultStagingDir(), "never-existed.dmg").absolutePath)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirrorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirrorTest.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.updater
 import ai.rever.boss.downloads.DownloadCenter
 import ai.rever.boss.plugin.api.TransferKind
 import ai.rever.boss.plugin.api.TransferPhase
+import ai.rever.boss.utils.Version
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
@@ -82,6 +83,16 @@ class UpdateDownloadCenterMirrorTest {
             UpdateState.CheckingForUpdates,
             UpdateState.RestartRequired,
             UpdateState.Error("boom"),
+            // The state a CANCELLED download lands in, so the one that most needs to
+            // retract the row - and the one this list originally missed.
+            UpdateState.UpdateAvailable(
+                UpdateInfo(
+                    available = true,
+                    currentVersion = Version.parse("9.4.33")!!,
+                    latestVersion = Version.parse("9.4.34")!!,
+                    releaseNotes = "",
+                ),
+            ),
         ).forEach { state ->
             UpdateDownloadCenterMirror.publish(UpdateState.Downloading(0.5f), manager)
             UpdateDownloadCenterMirror.publish(state, manager)

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirrorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/UpdateDownloadCenterMirrorTest.kt
@@ -1,0 +1,94 @@
+package ai.rever.boss.updater
+
+import ai.rever.boss.downloads.DownloadCenter
+import ai.rever.boss.plugin.api.TransferKind
+import ai.rever.boss.plugin.api.TransferPhase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The state-to-row mapping, which is the whole mirror.
+ *
+ * Worth pinning because both halves are easy to get subtly wrong in a way nobody
+ * sees until an update is actually running: a row left behind after a restart is
+ * required looks like a download that never finished, and an Install button
+ * offered while the installer is running is a second elevated install.
+ */
+class UpdateDownloadCenterMirrorTest {
+    private val manager = UpdateManager()
+
+    @BeforeEach
+    @AfterEach
+    fun clean() = DownloadCenter.reset()
+
+    private fun row() = DownloadCenter.transfers.value.singleOrNull()
+
+    @Test
+    fun `downloading publishes a cancellable row with progress`() {
+        UpdateDownloadCenterMirror.publish(UpdateState.Downloading(0.3f), manager)
+
+        val row = assertNotNull(row())
+        assertEquals(DownloadCenter.APP_UPDATE_ID, row.info.id)
+        assertEquals(TransferKind.APP_UPDATE, row.info.kind)
+        assertEquals(TransferPhase.DOWNLOADING, row.info.phase)
+        assertEquals(0.3f, row.info.progress)
+        assertTrue(row.info.cancellable)
+        assertNull(row.onInstall, "there is nothing to install until it has downloaded")
+    }
+
+    @Test
+    fun `progress updates the existing row rather than adding one`() {
+        UpdateDownloadCenterMirror.publish(UpdateState.Downloading(0.1f), manager)
+        UpdateDownloadCenterMirror.publish(UpdateState.Downloading(0.6f), manager)
+
+        assertEquals(1, DownloadCenter.transfers.value.size)
+        assertEquals(0.6f, row()?.info?.progress)
+    }
+
+    @Test
+    fun `a downloaded update offers Install and Cancel`() {
+        UpdateDownloadCenterMirror.publish(UpdateState.Downloading(0.9f), manager)
+        UpdateDownloadCenterMirror.publish(UpdateState.ReadyToInstall("/tmp/boss.dmg"), manager)
+
+        val row = assertNotNull(row())
+        assertEquals(TransferPhase.READY_TO_INSTALL, row.info.phase)
+        assertNotNull(row.onInstall)
+        // Cancel here discards the staged file, which is safe - unlike cancelling
+        // an install that has started.
+        assertTrue(row.info.cancellable)
+    }
+
+    @Test
+    fun `installing withdraws both actions`() {
+        UpdateDownloadCenterMirror.publish(UpdateState.ReadyToInstall("/tmp/boss.dmg"), manager)
+        UpdateDownloadCenterMirror.publish(UpdateState.Installing, manager)
+
+        val row = assertNotNull(row())
+        assertEquals(TransferPhase.INSTALLING, row.info.phase)
+        assertFalse(row.info.cancellable, "file moves plus an elevated helper are past abandoning")
+    }
+
+    @Test
+    fun `states that are not work in flight leave no row`() {
+        listOf(
+            UpdateState.Idle,
+            UpdateState.UpToDate,
+            UpdateState.CheckingForUpdates,
+            UpdateState.RestartRequired,
+            UpdateState.Error("boom"),
+        ).forEach { state ->
+            UpdateDownloadCenterMirror.publish(UpdateState.Downloading(0.5f), manager)
+            UpdateDownloadCenterMirror.publish(state, manager)
+            assertTrue(
+                DownloadCenter.transfers.value.isEmpty(),
+                "$state is not a transfer, so a progress row for it would be a lie",
+            )
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,7 +116,16 @@ intellij-platform = "243.21565.199"
 # exists**.
 #
 # Superset of 1.0.83: the field is additive with a "" default and nothing was withdrawn.
-boss-plugin-api = "1.0.84"
+#
+# 1.0.85 adds DownloadCenterProvider and PluginContext.downloadCenterProvider, the one place
+# every in-flight transfer is reported so the bottom bar can show all of them. The host needs it
+# to hand the Toolbox a center to report into: before it, the only visible download progress was
+# a status-bar widget that plugin owned, so every download the host started ran silently. Same
+# forced order as above: api first, then this, **and this pin 404s CI until that release exists**.
+#
+# Superset of 1.0.84: both additions are new declarations with a null default on PluginContext,
+# so nothing a host module or an installed plugin resolves has been withdrawn.
+boss-plugin-api = "1.0.85"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/plugin-platform/plugin-api-core/build.gradle.kts
+++ b/plugin-platform/plugin-api-core/build.gradle.kts
@@ -43,6 +43,10 @@ val fetchApiPluginJar =
                 rootDir.resolve("../boss_plugins/boss-plugin-api/build/libs/boss-plugin-api-$version.jar").absolutePath,
                 // Worktree layout: Boss/.worktrees/<name> + Boss/boss_plugins
                 rootDir.resolve("../../boss_plugins/boss-plugin-api/build/libs/boss-plugin-api-$version.jar").absolutePath,
+                // Where BossConsole worktrees actually live: Boss/BossConsole/.worktrees/<name>.
+                // Without this one a host worktree cannot see a locally built api jar at all, so
+                // every api-and-host change had to wait for the api release before it would compile.
+                rootDir.resolve("../../../boss_plugins/boss-plugin-api/build/libs/boss-plugin-api-$version.jar").absolutePath,
             )
         outputs.file(targetPath)
         doLast {

--- a/plugin-platform/plugin-repository/detekt-baseline.xml
+++ b/plugin-platform/plugin-repository/detekt-baseline.xml
@@ -3,7 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ForbiddenComment:PluginStoreClient.kt$PluginDetailResponse$// TODO: Implement proper timestamp parsing if needed</ID>
-    <ID>LongMethod:RemotePluginRepository.kt$RemotePluginRepository$override suspend fun downloadPlugin( pluginId: String, version: String?, targetPath: String, ): Result&lt;String&gt;</ID>
+    <ID>LongMethod:RemotePluginRepository.kt$RemotePluginRepository$override suspend fun downloadPlugin( pluginId: String, version: String?, targetPath: String, onProgress: ((Float) -&gt; Unit)?, ): Result&lt;String&gt;</ID>
     <ID>LongParameterList:RemotePluginRepository.kt$RemotePluginRepository$( sha256: String, signature: String?, pluginId: String, versionLabel: String, requestedVersion: String?, onVerificationFailure: () -&gt; Unit, )</ID>
     <ID>MaxLineLength:PluginStoreRealtimeService.kt$PluginStoreRealtimeService$logger.warn(LogCategory.NETWORK, "Plugins subscription lost, reconnecting in ${backoffMs}ms", error = e)</ID>
     <ID>MaxLineLength:PluginStoreRealtimeService.kt$PluginStoreRealtimeService$logger.warn(LogCategory.NETWORK, "Versions subscription lost, reconnecting in ${backoffMs}ms", error = e)</ID>
@@ -12,7 +12,7 @@
     <ID>ReturnCount:PluginDownloadCache.kt$PluginDownloadCache$fun getCachedJar( pluginId: String, version: String, expectedSha256: String, ): File?</ID>
     <ID>ReturnCount:PluginDownloadCache.kt$PluginDownloadCache$fun removeAllVersions(pluginId: String): Int</ID>
     <ID>ReturnCount:PluginRepositoryManager.kt$PluginRepositoryManager$private fun isNewerVersion( version1: String, version2: String, ): Boolean</ID>
-    <ID>ReturnCount:PluginRepositoryManager.kt$PluginRepositoryManager$suspend fun downloadPlugin( pluginId: String, version: String? = null, targetPath: String, ): Result&lt;String&gt;</ID>
+    <ID>ReturnCount:PluginRepositoryManager.kt$PluginRepositoryManager$suspend fun downloadPlugin( pluginId: String, version: String? = null, targetPath: String, onProgress: ((Float) -&gt; Unit)? = null, ): Result&lt;String&gt;</ID>
     <ID>ReturnCount:PluginStoreConfig.kt$PluginStoreConfig$private fun decodeIsAdmin(token: String?): Boolean</ID>
     <ID>ThrowsCount:RemotePluginRepository.kt$RemotePluginRepository$internal fun enforceStoreSignature( sha256: String, signature: String?, pluginId: String, versionLabel: String, requestedVersion: String?, onVerificationFailure: () -&gt; Unit, )</ID>
     <ID>TooGenericExceptionCaught:LocalPluginRepository.kt$LocalPluginRepository$e: Exception</ID>

--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepository.kt
@@ -66,12 +66,19 @@ interface PluginRepository {
      * @param pluginId The plugin ID
      * @param version The version to download (null for latest)
      * @param targetPath Path to save the downloaded JAR
+     * @param onProgress Called with the download fraction (0.0 to 1.0) as bytes
+     *   arrive. Pushed rather than polled through [getDownloadProgress]: that
+     *   flow only exists once a download has started, so a caller wanting to
+     *   show progress has to race it into existence. Every host install path
+     *   funnels through here, which is why the callback is here and not on one
+     *   of them.
      * @return Result with the path to the downloaded file
      */
     suspend fun downloadPlugin(
         pluginId: String,
         version: String? = null,
         targetPath: String,
+        onProgress: ((Float) -> Unit)? = null,
     ): Result<String>
 
     /**

--- a/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
+++ b/plugin-platform/plugin-repository/src/commonMain/kotlin/ai/rever/boss/plugin/repository/PluginRepositoryManager.kt
@@ -265,12 +265,14 @@ class PluginRepositoryManager {
      * @param pluginId The plugin ID
      * @param version The version to download (null for latest)
      * @param targetPath Path to save the downloaded JAR
+     * @param onProgress Called with the download fraction (0.0 to 1.0) as bytes arrive
      * @return Result with the path to the downloaded file
      */
     suspend fun downloadPlugin(
         pluginId: String,
         version: String? = null,
         targetPath: String,
+        onProgress: ((Float) -> Unit)? = null,
     ): Result<String> {
         // Find the plugin and its source. A lookup that FAILED is propagated as itself: reporting
         // "not found" here would re-create, one method along, exactly the wrong diagnosis that
@@ -288,7 +290,7 @@ class PluginRepositoryManager {
                     RepositoryException("Repository not found", pluginWithSource.source.repositoryId),
                 )
 
-        return repository.downloadPlugin(pluginId, version, targetPath)
+        return repository.downloadPlugin(pluginId, version, targetPath, onProgress)
     }
 
     /**

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/LocalPluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/LocalPluginRepository.kt
@@ -137,6 +137,7 @@ class LocalPluginRepository(
         pluginId: String,
         version: String?,
         targetPath: String,
+        onProgress: ((Float) -> Unit)?,
     ): Result<String> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -151,6 +152,11 @@ class LocalPluginRepository(
 
                 val targetFile = File(targetPath)
                 sourceJar.copyTo(targetFile, overwrite = true)
+
+                // A local copy is instant, but a caller showing progress still
+                // needs to be told it finished: without this its row would sit
+                // at "Downloading" until the phase after it moved on.
+                onProgress?.invoke(1f)
 
                 targetFile.absolutePath
             }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
@@ -14,6 +14,7 @@ import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -457,6 +458,11 @@ class RemotePluginRepository(
                     downloadProgress.remove(pluginId, progressFlow)
                 }
             }.onFailure { e ->
+                // A cancellation is not a download failure, and it must not arrive as
+                // one: `runCatching` catches Throwable, so a cancelled download used to
+                // come back as Result.failure and every caller above reported it as a
+                // fault - and stopped propagating, so nobody's cancellation handler ran.
+                if (e is CancellationException) throw e
                 logger.error(LogCategory.NETWORK, "Failed to download plugin", mapOf("pluginId" to pluginId), e)
             }
         }

--- a/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
+++ b/plugin-platform/plugin-repository/src/desktopMain/kotlin/ai/rever/boss/plugin/repository/remote/RemotePluginRepository.kt
@@ -310,6 +310,7 @@ class RemotePluginRepository(
         pluginId: String,
         version: String?,
         targetPath: String,
+        onProgress: ((Float) -> Unit)?,
     ): Result<String> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -348,6 +349,9 @@ class RemotePluginRepository(
                     )
                     cachedFile.copyTo(File(targetPath), overwrite = true)
                     PluginSignatureSidecar.persist(targetPath, downloadInfo.signature)
+                    // Nothing was fetched, but the caller's progress row exists and
+                    // would otherwise sit at 0% until the next phase moved it.
+                    onProgress?.invoke(1f)
                     return@runCatching targetPath
                 }
 
@@ -371,6 +375,11 @@ class RemotePluginRepository(
                         val channel = response.bodyAsChannel()
                         val totalBytes = response.headers[io.ktor.http.HttpHeaders.ContentLength]?.toLongOrNull() ?: downloadInfo.size
                         var downloadedBytes = 0L
+                        // The callback drives UI state that is copied on every write,
+                        // and an 8KB buffer means thousands of writes for one jar - so
+                        // it fires on whole-percent steps only. The flow keeps its
+                        // per-chunk resolution, which nothing re-renders.
+                        var lastPercent = -1
 
                         File(targetPath).outputStream().use { output ->
                             val buffer = ByteArray(8192)
@@ -380,7 +389,13 @@ class RemotePluginRepository(
                                     output.write(buffer, 0, bytes)
                                     downloadedBytes += bytes
                                     if (totalBytes > 0) {
-                                        progressFlow.value = downloadedBytes.toFloat() / totalBytes
+                                        val fraction = downloadedBytes.toFloat() / totalBytes
+                                        progressFlow.value = fraction
+                                        val percent = ((downloadedBytes * 100) / totalBytes).toInt()
+                                        if (percent != lastPercent) {
+                                            lastPercent = percent
+                                            onProgress?.invoke(fraction)
+                                        }
                                     }
                                 }
                             }
@@ -422,6 +437,7 @@ class RemotePluginRepository(
                     downloadCache.cacheJar(pluginId, downloadInfo.version, File(targetPath))
 
                     progressFlow.value = 1f
+                    onProgress?.invoke(1f)
 
                     logger.info(
                         LogCategory.NETWORK,

--- a/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginLookupFailureTest.kt
+++ b/plugin-platform/plugin-repository/src/desktopTest/kotlin/ai/rever/boss/plugin/repository/PluginLookupFailureTest.kt
@@ -179,6 +179,7 @@ class PluginLookupFailureTest {
             pluginId: String,
             version: String?,
             targetPath: String,
+            onProgress: ((Float) -> Unit)?,
         ): Result<String> = Result.failure(UnsupportedOperationException())
 
         override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
@@ -207,6 +208,7 @@ class PluginLookupFailureTest {
             pluginId: String,
             version: String?,
             targetPath: String,
+            onProgress: ((Float) -> Unit)?,
         ): Result<String> = Result.failure(UnsupportedOperationException())
 
         override fun getDownloadProgress(pluginId: String): Flow<Float>? = null

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
@@ -11,6 +11,7 @@ import ai.rever.boss.plugin.api.ClipboardProvider
 import ai.rever.boss.plugin.api.ContextMenuProvider
 import ai.rever.boss.plugin.api.DashboardContentProvider
 import ai.rever.boss.plugin.api.DiagnosticProvider
+import ai.rever.boss.plugin.api.DownloadCenterProvider
 import ai.rever.boss.plugin.api.DownloadDataProvider
 import ai.rever.boss.plugin.api.EditorContentProvider
 import ai.rever.boss.plugin.api.FilePickerProvider
@@ -101,6 +102,9 @@ class SandboxedPluginContext(
 
     override val downloadDataProvider: DownloadDataProvider?
         get() = delegate.downloadDataProvider
+
+    override val downloadCenterProvider: DownloadCenterProvider?
+        get() = delegate.downloadCenterProvider
 
     override val bookmarkDataProvider: BookmarkDataProvider?
         get() = delegate.bookmarkDataProvider

--- a/plugin-platform/plugin-updater/detekt-baseline.xml
+++ b/plugin-platform/plugin-updater/detekt-baseline.xml
@@ -2,12 +2,13 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>LongParameterList:PluginUpdateManager.kt$PluginUpdateManager$( pluginId: String, downloadPath: String, unloadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, loadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
     <ID>CyclomaticComplexMethod:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates(installedPlugins: Map&lt;String, String&gt;): UpdateCheckResult</ID>
     <ID>LongMethod:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates(installedPlugins: Map&lt;String, String&gt;): UpdateCheckResult</ID>
     <ID>NestedBlockDepth:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates(installedPlugins: Map&lt;String, String&gt;): UpdateCheckResult</ID>
     <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$private fun isNewerVersion( version1: String, version2: String, ): Boolean</ID>
     <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$private fun satisfiesFloor( required: String, installed: String, ): Boolean</ID>
-    <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$suspend fun updatePlugin( pluginId: String, downloadPath: String, unloadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, loadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, ): Result&lt;Unit&gt;</ID>
+    <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$suspend fun updatePlugin( pluginId: String, downloadPath: String, unloadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, loadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, ): Result&lt;Unit&gt;</ID>
     <ID>TooGenericExceptionCaught:PluginUpdateManager.kt$PluginUpdateManager$e: Exception</ID>
     <ID>TooManyFunctions:PluginUpdateManager.kt$PluginUpdateManager</ID>
   </CurrentIssues>

--- a/plugin-platform/plugin-updater/detekt-baseline.xml
+++ b/plugin-platform/plugin-updater/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ReturnCount:PluginUpdateManager.kt$PluginUpdateManager$private suspend fun swapPlugin( pluginId: String, update: UpdateInfo, downloadedPath: String, unloadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, loadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, ): Result&lt;Unit&gt;</ID>
     <ID>LongParameterList:PluginUpdateManager.kt$PluginUpdateManager$( pluginId: String, downloadPath: String, unloadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, loadPlugin: suspend (String) -&gt; Result&lt;Unit&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
     <ID>CyclomaticComplexMethod:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates(installedPlugins: Map&lt;String, String&gt;): UpdateCheckResult</ID>
     <ID>LongMethod:PluginUpdateManager.kt$PluginUpdateManager$suspend fun checkForUpdates(installedPlugins: Map&lt;String, String&gt;): UpdateCheckResult</ID>

--- a/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
+++ b/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
@@ -345,11 +345,15 @@ class PluginUpdateManager(
      *
      * @param pluginId Plugin to update
      * @param targetPath Path to download the update to
+     * @param onProgress Called with the download fraction (0.0 to 1.0) as bytes arrive.
+     *   The listener callbacks below only ever report 0f and 1f, which is enough to
+     *   know a download started but not enough to draw a bar.
      * @return Result with the downloaded file path
      */
     suspend fun downloadUpdate(
         pluginId: String,
         targetPath: String,
+        onProgress: ((Float) -> Unit)? = null,
     ): Result<String> {
         val update =
             _availableUpdates.value.find { it.pluginId == pluginId }
@@ -364,6 +368,7 @@ class PluginUpdateManager(
                     pluginId = pluginId,
                     version = update.newVersion,
                     targetPath = targetPath,
+                    onProgress = onProgress,
                 )
 
             if (result.isSuccess) {
@@ -397,6 +402,10 @@ class PluginUpdateManager(
      * @param downloadPath Path to download the new version
      * @param unloadPlugin Function to unload the old plugin
      * @param loadPlugin Function to load the new plugin
+     * @param onProgress Called with the download fraction (0.0 to 1.0) during step 1
+     * @param onInstalling Called once the download is done and the swap begins. The
+     *   caller uses it to withdraw its Cancel: from here on, cancelling would leave
+     *   the plugin unloaded.
      * @return Result indicating success or failure
      */
     suspend fun updatePlugin(
@@ -404,6 +413,8 @@ class PluginUpdateManager(
         downloadPath: String,
         unloadPlugin: suspend (String) -> Result<Unit>,
         loadPlugin: suspend (String) -> Result<Unit>,
+        onProgress: ((Float) -> Unit)? = null,
+        onInstalling: (() -> Unit)? = null,
     ): Result<Unit> {
         val update =
             _availableUpdates.value.find { it.pluginId == pluginId }
@@ -420,7 +431,7 @@ class PluginUpdateManager(
         )
 
         // Download new version
-        val downloadResult = downloadUpdate(pluginId, downloadPath)
+        val downloadResult = downloadUpdate(pluginId, downloadPath, onProgress)
         if (downloadResult.isFailure) {
             return Result.failure(downloadResult.exceptionOrNull() ?: Exception("Download failed"))
         }
@@ -430,6 +441,7 @@ class PluginUpdateManager(
         // Install
         _state.value = UpdateState.Installing(pluginId)
         listeners.forEach { it.onUpdateInstalling(pluginId) }
+        onInstalling?.invoke()
 
         // Unload old version
         val unloadResult = unloadPlugin(pluginId)

--- a/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
+++ b/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.plugin.repository.PluginRepositoryManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Callback interface for update events.
@@ -443,6 +445,28 @@ class PluginUpdateManager(
         listeners.forEach { it.onUpdateInstalling(pluginId) }
         onInstalling?.invoke()
 
+        // From here to the end of the load, NonCancellable. Cancellation is
+        // cooperative, so a Cancel pressed between the last progress tick and this
+        // point would otherwise throw out of `unloadPlugin` or `loadPlugin` and leave
+        // the plugin unloaded with nothing in its place - exactly the harm the caller
+        // withdraws its Cancel button to prevent. Withdrawing the button is necessary
+        // and not sufficient: the button is UI state, this is the work.
+        return withContext(NonCancellable) { swapPlugin(pluginId, update, downloadedPath, unloadPlugin, loadPlugin) }
+    }
+
+    /**
+     * Unload the old version and load [downloadedPath], reporting either outcome.
+     *
+     * Split out so the whole swap can run under `NonCancellable` in one expression;
+     * see the comment at the call site for why it must.
+     */
+    private suspend fun swapPlugin(
+        pluginId: String,
+        update: UpdateInfo,
+        downloadedPath: String,
+        unloadPlugin: suspend (String) -> Result<Unit>,
+        loadPlugin: suspend (String) -> Result<Unit>,
+    ): Result<Unit> {
         // Unload old version
         val unloadResult = unloadPlugin(pluginId)
         if (unloadResult.isFailure) {

--- a/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
+++ b/plugin-platform/plugin-updater/src/commonMain/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManager.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.plugin.logging.BossLogger
 import ai.rever.boss.plugin.logging.LogCategory
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginRepositoryManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -383,6 +384,13 @@ class PluginUpdateManager(
             }
 
             result
+        } catch (e: CancellationException) {
+            // Ahead of the general clause, and rethrown rather than reported: the user
+            // pressed Cancel. Reported as a failure it became "update failed:
+            // StandaloneCoroutine was cancelled" in the Toolbox, AND it stopped the
+            // cancellation propagating - so the caller's cleanup, which is what removes
+            // the truncated jar, never ran.
+            throw e
         } catch (e: Exception) {
             val error = e.message ?: "Download failed"
             _state.value = UpdateState.Failed(pluginId, error, e)

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateCancellationTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateCancellationTest.kt
@@ -1,0 +1,160 @@
+package ai.rever.boss.plugin.updater
+
+import ai.rever.boss.plugin.repository.PluginInfo
+import ai.rever.boss.plugin.repository.PluginRepository
+import ai.rever.boss.plugin.repository.PluginRepositoryManager
+import ai.rever.boss.plugin.repository.PluginSearchFilter
+import ai.rever.boss.plugin.repository.PluginSearchResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A cancelled download must arrive at the caller AS a cancellation.
+ *
+ * This is the shape of a bug that shipped past a review: `downloadUpdate` caught
+ * `Exception`, which includes `CancellationException`, and returned
+ * `Result.failure`. `updatePlugin` then RETURNED rather than throwing - so the
+ * caller's `catch (CancellationException)`, the thing that deletes the truncated jar
+ * from the plugin directory, could never run, and the user's own Cancel was reported
+ * to the Toolbox as "update failed: StandaloneCoroutine was cancelled".
+ *
+ * Both halves are asserted here, because either one alone re-breaks it.
+ */
+class PluginUpdateCancellationTest {
+    private val pluginId = "ai.rever.boss.plugin.dynamic.probe"
+
+    private fun manager(repository: PluginRepository): PluginUpdateManager {
+        val repos = PluginRepositoryManager().apply { addRepository(repository) }
+        return PluginUpdateManager(repositoryManager = repos, hostBossVersion = "9.9.9")
+    }
+
+    private fun candidate() =
+        PluginInfo(
+            pluginId = pluginId,
+            displayName = "Probe",
+            version = "2.0.0",
+        )
+
+    @Test
+    fun `a cancelled download propagates rather than becoming a failed result`() =
+        runTest {
+            val mgr = manager(CancellingRepository(candidate()))
+            mgr.checkForUpdates(mapOf(pluginId to "1.0.0"))
+
+            var cancelled = false
+            try {
+                mgr.downloadUpdate(pluginId, "/tmp/does-not-matter.jar")
+            } catch (_: CancellationException) {
+                cancelled = true
+            }
+
+            assertTrue(cancelled, "swallowed into Result.failure, the caller's cleanup never runs")
+        }
+
+    @Test
+    fun `a cancelled update is not reported to listeners as a failure`() =
+        runTest {
+            val mgr = manager(CancellingRepository(candidate()))
+            mgr.checkForUpdates(mapOf(pluginId to "1.0.0"))
+            val failures = mutableListOf<String>()
+            mgr.addListener(
+                object : UpdateListener {
+                    override fun onUpdateFailed(
+                        pluginId: String,
+                        error: String,
+                    ) {
+                        failures += error
+                    }
+                },
+            )
+
+            runCatching {
+                mgr.updatePlugin(
+                    pluginId = pluginId,
+                    downloadPath = "/tmp/does-not-matter.jar",
+                    unloadPlugin = { Result.success(Unit) },
+                    loadPlugin = { Result.success(Unit) },
+                )
+            }
+
+            // The user pressed Cancel. "update failed: StandaloneCoroutine was
+            // cancelled" is the wrong thing to put in front of them.
+            assertTrue(failures.isEmpty(), "reported as a failure: $failures")
+        }
+
+    @Test
+    fun `a real download failure is still reported`() =
+        runTest {
+            val mgr = manager(FailingRepository(candidate()))
+            mgr.checkForUpdates(mapOf(pluginId to "1.0.0"))
+            val failures = mutableListOf<String>()
+            mgr.addListener(
+                object : UpdateListener {
+                    override fun onUpdateFailed(
+                        pluginId: String,
+                        error: String,
+                    ) {
+                        failures += error
+                    }
+                },
+            )
+
+            val result = mgr.downloadUpdate(pluginId, "/tmp/does-not-matter.jar")
+
+            assertTrue(result.isFailure)
+            assertFalse(failures.isEmpty(), "a 404 is a failure and must stay one")
+        }
+}
+
+/** Cancels mid-download, the way a user pressing Cancel does. */
+private class CancellingRepository(
+    private val latest: PluginInfo,
+) : StubRepository(latest) {
+    override suspend fun downloadPlugin(
+        pluginId: String,
+        version: String?,
+        targetPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Result<String> = throw CancellationException("cancelled by the user")
+}
+
+/** Fails the way an unreachable asset does. */
+private class FailingRepository(
+    private val latest: PluginInfo,
+) : StubRepository(latest) {
+    override suspend fun downloadPlugin(
+        pluginId: String,
+        version: String?,
+        targetPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Result<String> = Result.failure(IllegalStateException("HTTP 404"))
+}
+
+/** Everything a [PluginUpdateManager] asks of a repository except the download. */
+private abstract class StubRepository(
+    private val latest: PluginInfo,
+) : PluginRepository {
+    override val id = "fake-remote"
+    override val name = "Fake Remote"
+    override val isLocal = false
+    override val isAvailable = true
+
+    override suspend fun listPlugins(): Result<List<PluginInfo>> = Result.success(listOf(latest))
+
+    override suspend fun searchPlugins(filter: PluginSearchFilter): Result<PluginSearchResult> =
+        Result.success(PluginSearchResult(listOf(latest), totalCount = 1))
+
+    override suspend fun getPlugin(pluginId: String): Result<PluginInfo?> =
+        Result.success(if (pluginId == latest.pluginId) latest else null)
+
+    override suspend fun getPluginVersions(pluginId: String): Result<List<PluginInfo>> =
+        Result.success(if (pluginId == latest.pluginId) listOf(latest) else emptyList())
+
+    override fun getDownloadProgress(pluginId: String): Flow<Float>? = null
+
+    override suspend fun refresh(): Result<Unit> = Result.success(Unit)
+}

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateCancellationTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateCancellationTest.kt
@@ -6,8 +6,11 @@ import ai.rever.boss.plugin.repository.PluginRepositoryManager
 import ai.rever.boss.plugin.repository.PluginSearchFilter
 import ai.rever.boss.plugin.repository.PluginSearchResult
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -87,6 +90,42 @@ class PluginUpdateCancellationTest {
         }
 
     @Test
+    fun `a cancel after the swap has started still completes the unload and load`() =
+        runTest {
+            val mgr = manager(SucceedingRepository(candidate()))
+            mgr.checkForUpdates(mapOf(pluginId to "1.0.0"))
+            var loaded = false
+
+            // The headline hazard: withdrawing the Cancel button is UI state, so the
+            // work has to stop being cancellable too. Here the unload cancels the very
+            // job the swap runs on - if the swap were cancellable, the plugin would be
+            // left unloaded with nothing in its place.
+            runCatching {
+                coroutineScope {
+                    mgr.updatePlugin(
+                        pluginId = pluginId,
+                        downloadPath = "/tmp/does-not-matter.jar",
+                        unloadPlugin = {
+                            this@coroutineScope.cancel()
+                            Result.success(Unit)
+                        },
+                        loadPlugin = {
+                            // A REAL suspension point, or the test proves nothing:
+                            // cancellation is cooperative, and a lambda that never
+                            // suspends never checks. Under NonCancellable this does not
+                            // throw, which is the whole point.
+                            yield()
+                            loaded = true
+                            Result.success(Unit)
+                        },
+                    )
+                }
+            }
+
+            assertTrue(loaded, "the load must still run, or the plugin is gone with nothing in its place")
+        }
+
+    @Test
     fun `a real download failure is still reported`() =
         runTest {
             val mgr = manager(FailingRepository(candidate()))
@@ -120,6 +159,18 @@ private class CancellingRepository(
         targetPath: String,
         onProgress: ((Float) -> Unit)?,
     ): Result<String> = throw CancellationException("cancelled by the user")
+}
+
+/** Downloads without incident, for the paths that are about the swap. */
+private class SucceedingRepository(
+    private val latest: PluginInfo,
+) : StubRepository(latest) {
+    override suspend fun downloadPlugin(
+        pluginId: String,
+        version: String?,
+        targetPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Result<String> = Result.success(targetPath)
 }
 
 /** Fails the way an unreachable asset does. */

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerBossVersionGateTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerBossVersionGateTest.kt
@@ -154,6 +154,7 @@ private class FakeRepository(
         pluginId: String,
         version: String?,
         targetPath: String,
+        onProgress: ((Float) -> Unit)?,
     ): Result<String> = Result.success(targetPath)
 
     override fun getDownloadProgress(pluginId: String): Flow<Float>? = null

--- a/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerCheckCompatTest.kt
+++ b/plugin-platform/plugin-updater/src/desktopTest/kotlin/ai/rever/boss/plugin/updater/PluginUpdateManagerCheckCompatTest.kt
@@ -108,6 +108,7 @@ private class FakeRemoteRepository(
         pluginId: String,
         version: String?,
         targetPath: String,
+        onProgress: ((Float) -> Unit)?,
     ): Result<String> = Result.success(targetPath)
 
     override fun getDownloadProgress(pluginId: String): Flow<Float>? = null


### PR DESCRIPTION
The only visible download progress in the app belonged to the Toolbox plugin: a status-bar widget fed by its own tracker. Everything the host downloaded was invisible - the "Update Available" prompt from a panel badge, "Install Store Version", a missing dependency, and the application's own update, which had a banner and nothing else. None of it could be cancelled, and none of it could be clicked.

`ai.rever.boss.downloads.DownloadCenter` is now the one place a transfer is reported, the bottom bar renders it, and clicking it opens the rows with their own controls: **Cancel** while it is still bytes, **Install** for a downloaded app update, and **Minimize**, which leaves everything running. The plugin-facing half is `DownloadCenterProvider` (api 1.0.85), so the Toolbox reports into the same center rather than drawing a second widget.

## Cancel had to be made real rather than cosmetic

- **`PluginRepository.downloadPlugin` takes an `onProgress` callback.** Every host install path already funnels through it, and `getDownloadProgress` is a flow that only exists once a download has started - a caller wanting a bar had to race it into existence.
- **A cancelled download deletes what it wrote.** `PluginUpdateBridge` streams onto a version-named jar in the plugin directory (the two store installers use `.part` siblings), so a partial file there is one the next directory scan tries to load.
- **`DesktopUpdateService` caught `CancellationException` in its general clause**, which turned the user's own Cancel into "Download failed" and left a half-written installer staged.

`TransferPhase.INSTALLING` is the only phase that withdraws Cancel: abandoning a jar swap leaves the plugin unloaded, while a downloaded-but-uninstalled app update is just a file to delete - which is why the same rule serves both the plugin rows and the app update's `Install / Cancel` pair.

## Update prompts stop going stale

`PluginUpdateRegistry.reconcile` drops a badge once the plugin is no longer at the version the check found it at - so updating from the Toolbox or from its toast clears the header badge and the "Update Available" alert the host would otherwise still offer. It compares against `currentVersion`, not `newVersion`, so no semver ordering is needed and a downgrade invalidates the entry too; a plugin absent from the snapshot is left alone, because every plugin is briefly unloaded during an api hot swap.

## Merge order

**api -> this -> Toolbox.** `boss-plugin-api = 1.0.85` is pinned here and CI 404s until that release exists, so risa-labs-inc/boss-plugin-api#41 goes first. The Toolbox (risa-labs-inc/boss-plugin-plugin-manager, branch `feature/download-center`) gates on `minBossVersion 9.4.34`, so it must not merge before this ships - v9.4.33 was tagged while this sat unmerged and does not carry the center.

One incidental fix: `plugin-api-core` gained a third sibling-jar candidate, so a BossConsole worktree under `BossConsole/.worktrees/` can resolve a locally built api jar. Without it an api-and-host change cannot compile locally until the api release exists.

## Verification

- `ktlintCheck` + `detekt` clean (four baseline keys re-signed after signature changes; two new `LongParameterList` entries)
- 2909 host desktop tests, 160 plugin-platform tests, all passing
- New: `DownloadCenterTest`, `DownloadCenterTextTest`, `DownloadCenterStatusItemTest` (Compose), `UpdateDownloadCenterMirrorTest`, `PluginUpdateRegistryReconcileTest`
- Run in a dev build against an isolated profile: api 1.0.85 resolves, the Toolbox loads under the new gates, and no `Status-bar item registered` line appears for it - the bar is the host's now

The empty-state assertion in `DownloadCenterStatusItemTest` is structural rather than text-based, and was checked by deleting the guard and watching it fail: a widget composing an empty label and a zero-progress bar would satisfy "no text saying Downloading" and still shove every status-bar item beside it sideways each time a download finished.