### PR TITLE
build: trim ~69 MB of dead weight from the desktop bundle

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1116,7 +1116,8 @@ compose.desktop {
             // `du -sh composeApp/build/compose/tmp/main/runtime`):
             //
             //     includeAllModules = true    141 MB
-            //     the list below              124 MB   (-17 MB)
+            //     tooling dropped             124 MB   (-17 MB)
+            //     jdk.localedata dropped       91 MB   (-50 MB)
             //
             // The list below is the module set the old image actually contained,
             // minus that tooling. It is deliberately NOT a jdeps-minimal list:
@@ -1190,8 +1191,9 @@ compose.desktop {
                 // The zip FileSystemProvider. Plugin jars are read through it,
                 // and it is discovered by ServiceLoader.
                 "jdk.zipfs",
-                // Locale data beyond CLDR root + en.
-                "jdk.localedata",
+                // NOT included: jdk.localedata, 33 MB of CLDR data for locales
+                // this app has no text in. See the commit that removed it for
+                // the exact blast radius (three date labels).
             )
 
             windows {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1100,15 +1100,99 @@ compose.desktop {
             copyright = "© 2024 Risa Labs Inc. All rights reserved."
             vendor = "Risa Labs Inc."
 
-            // Bundle a complete, self-contained JVM
-            includeAllModules = true
-
-            // Note: When includeAllModules is true, the modules() call is redundant
-            // as all modules will be included. If you want to optimize size later,
-            // set includeAllModules = false and specify only required modules:
-            // modules("java.base", "java.desktop", "java.logging", "java.net.http",
-            //         "java.sql", "java.prefs", "java.scripting", "jdk.unsupported",
-            //         "java.naming", "java.xml", "java.management", "jdk.crypto.ec")
+            // Bundle a self-contained JVM that can run the app and nothing else.
+            //
+            // This was `includeAllModules = true`, which jlinks the ENTIRE JDK into
+            // every package. That is not "a complete JVM" in any sense a user
+            // benefits from -- it is a JVM plus the toolchain for producing Java
+            // software, shipped to people who are running an app. The bundled
+            // runtime carried javadoc, jshell, the JDI debugger, jdeps, jlink,
+            // jpackage itself, the HotSpot serviceability agent and the JDWP
+            // debug agent -- none of which any code path in BOSS can reach,
+            // because the tools that use them are command-line entry points and
+            // jpackage strips `bin/` from the image anyway.
+            //
+            // Measured on macOS arm64 (`./gradlew :composeApp:createRuntimeImage`,
+            // `du -sh composeApp/build/compose/tmp/main/runtime`):
+            //
+            //     includeAllModules = true    141 MB
+            //     the list below              124 MB   (-17 MB)
+            //
+            // The list below is the module set the old image actually contained,
+            // minus that tooling. It is deliberately NOT a jdeps-minimal list:
+            // jdeps only sees static references, so a minimal list silently drops
+            // whatever is reached through ServiceLoader or reflection (crypto
+            // providers, charsets, the zip filesystem, JNDI backends) and the
+            // failure shows up at runtime on a user's machine, not in CI.
+            //
+            // `java.se` is the aggregator for every `java.*` module, so no
+            // platform API can go missing here -- only `jdk.*` implementation
+            // modules are enumerated, and only ones with a runtime consumer.
+            includeAllModules = false
+            modules(
+                // Every java.* module, as one aggregator. Costs a few unused
+                // modules (java.rmi, java.transaction.xa) and buys the guarantee
+                // that nothing in the platform API disappears.
+                "java.se",
+                // Not part of java.se. Kept because the passkey/credential paths
+                // probe for smartcard providers.
+                "java.smartcardio",
+                // Screen-reader support on Windows and Linux.
+                "jdk.accessibility",
+                // Attaching to a JVM: the performance/diagnostics MCP tools and
+                // the plugin host supervisor. jdk.internal.jvmstat is its backend.
+                "jdk.attach",
+                "jdk.internal.jvmstat",
+                // Non-ASCII charsets. A terminal emulator and an editor both
+                // decode files in encodings outside the java.base default set.
+                "jdk.charsets",
+                // javac. Kept conservatively: the editor-tab plugin embeds the
+                // Kotlin compiler, whose Java-interop path can ask for
+                // ToolProvider.getSystemJavaCompiler(). Dropping this module
+                // (and the 7.9 MB lib/ct.sym that rides with it) is worth another
+                // 14 MB once Kotlin analysis in the editor is confirmed to work
+                // without it.
+                "jdk.compiler",
+                // TLS. Both are ServiceLoader-discovered security providers, so
+                // nothing references them statically -- exactly the class of
+                // module a jdeps-minimal list would drop.
+                "jdk.crypto.cryptoki",
+                "jdk.crypto.ec",
+                // Dynamic call sites (jsr223 / invokedynamic linkage).
+                "jdk.dynalink",
+                // com.sun.net.httpserver -- the local MCP endpoint and the OAuth
+                // loopback listener.
+                "jdk.httpserver",
+                // Flight Recorder, and the JMX/JFR management surface behind the
+                // performance snapshot tools.
+                "jdk.jfr",
+                "jdk.management",
+                "jdk.management.agent",
+                "jdk.management.jfr",
+                // JavaScript <-> JVM bridging for the embedded browser.
+                "jdk.jsobject",
+                // JNDI backends, reached by name, never by reference.
+                "jdk.naming.dns",
+                "jdk.naming.rmi",
+                // Socket options and mmap modes used by the IPC layer.
+                "jdk.net",
+                "jdk.nio.mapmode",
+                // RandomGenerator implementations beyond java.util.Random.
+                "jdk.random",
+                // JAAS login modules, also ServiceLoader-discovered.
+                "jdk.security.auth",
+                "jdk.security.jgss",
+                // sun.misc.Unsafe -- netty and protobuf both require it.
+                "jdk.unsupported",
+                "jdk.unsupported.desktop",
+                // org.w3c.dom.* extensions used by the XML paths.
+                "jdk.xml.dom",
+                // The zip FileSystemProvider. Plugin jars are read through it,
+                // and it is discovered by ServiceLoader.
+                "jdk.zipfs",
+                // Locale data beyond CLDR root + en.
+                "jdk.localedata",
+            )
 
             windows {
                 menuGroup = "BOSS"
@@ -1181,7 +1265,7 @@ compose.desktop {
 
                 // Note: bundleJRE is not a valid property in current Compose Desktop
                 // The JVM is automatically bundled when creating native distributions
-                // Use includeAllModules = true above to ensure all JVM modules are included
+                // See the modules() list above for which JVM modules go into it
 
                 // Code signing configuration
                 signing {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -296,7 +296,13 @@ val downloadBundledPlugins =
             val bundledPlugins =
                 listOf(
                     "risa-labs-inc/boss-plugin-api" to "boss-plugin-api",
-                    "risa-labs-inc/boss-plugin-terminal-tab" to "boss-plugin-terminal-tab",
+                    // NOT terminal-tab. At 35.1 MB it is the largest thing left
+                    // here, and it is the one plugin whose unbundled behaviour is
+                    // not a prediction: the prefix-collision bug deleted it from
+                    // every shipped build for months, the terminal worked anyway
+                    // via ensureSystemPluginsInstalled(), and nobody filed a bug.
+                    // Bundling it back would ship 35 MB to restore a state no
+                    // user has ever been in.
                     "risa-labs-inc/boss-plugin-terminal" to "boss-plugin-terminal",
                     "risa-labs-inc/boss-plugin-fluck-browser" to "boss-plugin-fluck-browser",
                     // NOT editor-tab. It is 64.7 MB, a quarter of the whole

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -724,7 +724,6 @@ kotlin {
 
             // Compose Icons dependencies
             implementation(libs.compose.icons.feather)
-            implementation(libs.compose.icons.fontawesome)
             implementation(libs.compose.icons.simpleicons)
 
             // Supabase dependencies

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -287,38 +287,74 @@ val downloadBundledPlugins =
         val destDir = layout.buildDirectory.dir("bundled-plugins")
         outputs.dir(destDir)
 
+        // List of bundled plugins to download from GitHub releases.
+        // These are core plugins that ship with BossConsole.
+        //
+        // Declared at CONFIGURATION time, not inside doLast, so it can be a task
+        // input. As a literal inside the action it was invisible to Gradle:
+        // editing it did not invalidate anything, the task went UP-TO-DATE on a
+        // warm build directory and never ran, and the JAR of a plugin removed
+        // from the list stayed in `build/bundled-plugins` forever. Switching
+        // prepareBundledPluginsResources to Sync fixed the hop after this one;
+        // this is the hop itself. Verified: with editor-tab removed from the
+        // list and a stale JAR planted in the output directory, the task
+        // reported UP-TO-DATE and 64.7 MB shipped anyway.
+        val bundledPlugins =
+            listOf(
+                "risa-labs-inc/boss-plugin-api" to "boss-plugin-api",
+                // NOT terminal-tab. At 35.1 MB it is the largest thing left
+                // here, and it is the one plugin whose unbundled behaviour is
+                // not a prediction: the prefix-collision bug deleted it from
+                // every shipped build for months, the terminal worked anyway
+                // via ensureSystemPluginsInstalled(), and nobody filed a bug.
+                // Bundling it back would ship 35 MB to restore a state no
+                // user has ever been in.
+                "risa-labs-inc/boss-plugin-terminal" to "boss-plugin-terminal",
+                "risa-labs-inc/boss-plugin-fluck-browser" to "boss-plugin-fluck-browser",
+                // NOT editor-tab. It is 64.7 MB, a quarter of the whole
+                // download, and bundling buys almost nothing: the host's
+                // ensureSystemPluginsInstalled() fetches it from the
+                // plugin's latest GitHub release before load when it is not
+                // on disk, which is already how every developer build and
+                // every install of BOSS gets it (copyBundledPluginsLocal
+                // below has never copied it either). Bundling only covered a
+                // first launch with no network, and it went stale fast: the
+                // seed is frozen at BOSS build time while editor-tab shipped
+                // five releases in two days, so a bundled JAR below the
+                // host's minVersion floor is replaced on startup anyway.
+                "risa-labs-inc/boss-plugin-plugin-manager" to "boss-plugin-plugin-manager",
+                "risa-labs-inc/boss-plugin-bookmarks" to "boss-plugin-bookmarks",
+            )
+
+        inputs.property("bundledPlugins", bundledPlugins.map { (repo, prefix) -> "$repo|$prefix" })
+
+        // The real input is "the latest release of each of those repos", which
+        // Gradle cannot see. Three sibling tasks in this file opt out for the
+        // same reason. Without it a second invocation in one workspace is
+        // UP-TO-DATE: the prune below never runs and a newer release is never
+        // picked up.
+        outputs.upToDateWhen { false }
+
         doLast {
             val bundledPluginsDir = destDir.get().asFile
             bundledPluginsDir.mkdirs()
 
-            // List of bundled plugins to download from GitHub releases
-            // These are core plugins that ship with BossConsole
-            val bundledPlugins =
-                listOf(
-                    "risa-labs-inc/boss-plugin-api" to "boss-plugin-api",
-                    // NOT terminal-tab. At 35.1 MB it is the largest thing left
-                    // here, and it is the one plugin whose unbundled behaviour is
-                    // not a prediction: the prefix-collision bug deleted it from
-                    // every shipped build for months, the terminal worked anyway
-                    // via ensureSystemPluginsInstalled(), and nobody filed a bug.
-                    // Bundling it back would ship 35 MB to restore a state no
-                    // user has ever been in.
-                    "risa-labs-inc/boss-plugin-terminal" to "boss-plugin-terminal",
-                    "risa-labs-inc/boss-plugin-fluck-browser" to "boss-plugin-fluck-browser",
-                    // NOT editor-tab. It is 64.7 MB, a quarter of the whole
-                    // download, and bundling buys almost nothing: the host's
-                    // ensureSystemPluginsInstalled() fetches it from the
-                    // plugin's latest GitHub release before load when it is not
-                    // on disk, which is already how every developer build and
-                    // every install of BOSS gets it (copyBundledPluginsLocal
-                    // below has never copied it either). Bundling only covered a
-                    // first launch with no network, and it went stale fast: the
-                    // seed is frozen at BOSS build time while editor-tab shipped
-                    // five releases in two days, so a bundled JAR below the
-                    // host's minVersion floor is replaced on startup anyway.
-                    "risa-labs-inc/boss-plugin-plugin-manager" to "boss-plugin-plugin-manager",
-                    "risa-labs-inc/boss-plugin-bookmarks" to "boss-plugin-bookmarks",
-                )
+            // Drop JARs belonging to no listed plugin. The per-plugin cleanup
+            // further down only fires for prefixes still in the list, so nothing
+            // ever removed the JAR of a plugin that LEFT it -- which is the whole
+            // bug above. Boundary-aware for the reason the collision fix gives:
+            // `boss-plugin-terminal` is a prefix of
+            // `boss-plugin-terminal-tab-2.5.59.jar`, so a bare startsWith would
+            // keep a de-listed terminal-tab alive under terminal's entry.
+            val listedJar =
+                bundledPlugins.map { (_, prefix) -> Regex("""^${Regex.escape(prefix)}-\d.*\.jar$""") }
+            bundledPluginsDir
+                .listFiles()
+                ?.filter { it.name.endsWith(".jar") && listedJar.none { re -> re.matches(it.name) } }
+                ?.forEach { orphan ->
+                    logger.lifecycle("🗑️  Removing JAR for a plugin no longer bundled: ${orphan.name}")
+                    orphan.delete()
+                }
 
             for ((repo, artifactPrefix) in bundledPlugins) {
                 try {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -10,7 +10,9 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Properties
+import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 
 // Detect Windows ARM64 — microkernel modules excluded (no protoc binaries)
@@ -1430,6 +1432,156 @@ tasks.register("extractJcefNatives") {
     }
 }
 
+// Remove natives for platforms this package will never run on.
+//
+// Two third-party jars ship every platform's binaries in a single artifact and
+// leave it to the loader to pick one at runtime. That is the right call for a
+// library on Maven Central and the wrong one for a jar inside a signed, per-
+// platform desktop bundle, where the other platforms' copies are bytes every
+// user downloads, stores and code-signs for nothing.
+//
+//   skiko-awt-runtime-macos-arm64  publishes BOTH macOS dylibs (arm64 + x64) in
+//     the artifact named for arm64. The Compose plugin extracts the one this
+//     build needs to `app/libskiko-macos-arm64.dylib` and removes it from the
+//     jar -- leaving the jar holding nothing but the 22 MB x86_64 dylib, which
+//     an arm64-only bundle can never load. 9.4 MB of the packaged app.
+//
+//   sqlite-jdbc  ships ~20 builds: Linux ppc64/riscv64/armv6/armv7/x86/musl,
+//     FreeBSD, Windows x86/arm, and both Macs. Exactly one is loadable in any
+//     given package; the other ~10 MB is dead in all of them.
+//
+// This runs on the built app image, before the macOS re-sign in
+// extractCLIToAppResources, so the signature covers the trimmed jars.
+tasks.register("stripForeignPlatformNatives") {
+    description = "Strips other platforms' native binaries out of skiko and sqlite-jdbc in the app image"
+    group = "build"
+
+    // Configuration cache: capture everything the action needs at configuration
+    // time. The doLast lambda must not reach the enclosing script object nor
+    // call Task.project at execution time -- same rule as extractCLIToAppResources.
+    val appDirProvider = layout.buildDirectory.dir("compose/binaries/main/app")
+    val osName = System.getProperty("os.name").lowercase()
+    val osArch = System.getProperty("os.arch").lowercase()
+
+    // The build host is the target: Compose packages for the platform it runs
+    // on, and release.yml gives each platform its own runner.
+    val skikoToken =
+        when {
+            osName.contains("mac") -> "macos"
+            osName.contains("win") -> "windows"
+            else -> "linux"
+        } + "-" + if (osArch == "aarch64" || osArch == "arm64") "arm64" else "x64"
+
+    val sqliteOs =
+        when {
+            osName.contains("mac") -> "Mac"
+            osName.contains("win") -> "Windows"
+            else -> "Linux"
+        }
+    val sqliteArch = if (osArch == "aarch64" || osArch == "arm64") "aarch64" else "x86_64"
+
+    doLast {
+        val appDir = appDirProvider.get().asFile
+        if (!appDir.isDirectory) {
+            println("ℹ️  No app image at ${appDir.absolutePath} - nothing to strip")
+            return@doLast
+        }
+
+        // Rewrites a jar keeping only the entries `keep` accepts. Local to the
+        // action so it captures nothing from the build script. Returns the bytes
+        // saved, or 0 if the jar was left alone.
+        fun rewriteJar(
+            jar: File,
+            keep: (String) -> Boolean,
+        ): Long {
+            val before = jar.length()
+            val temp = File(jar.parentFile, "${jar.name}.stripping")
+            var dropped = 0
+            ZipFile(jar).use { zip ->
+                ZipOutputStream(temp.outputStream().buffered()).use { out ->
+                    for (entry in zip.entries()) {
+                        if (!keep(entry.name)) {
+                            dropped++
+                            continue
+                        }
+                        // Copying the ZipEntry preserves the method, and for a
+                        // STORED entry also the size and CRC the writer demands.
+                        out.putNextEntry(ZipEntry(entry))
+                        zip.getInputStream(entry).use { it.copyTo(out) }
+                        out.closeEntry()
+                    }
+                }
+            }
+            if (dropped == 0) {
+                temp.delete()
+                return 0
+            }
+            check(temp.renameTo(jar) || (jar.delete() && temp.renameTo(jar))) {
+                "Could not replace ${jar.absolutePath} with the stripped jar"
+            }
+            return before - jar.length()
+        }
+
+        var saved = 0L
+
+        // skiko: keep the native for this platform, drop the rest. The matching
+        // one is usually already gone (Compose extracts it next to the jar), so
+        // its absence is expected and must not be treated as a mis-detection.
+        val skikoNative = Regex("""(?:lib)?skiko-(?:macos|linux|windows)-(?:arm64|x64)\.(?:dylib|so|dll)(?:\.sha256)?$""")
+        appDir
+            .walkTopDown()
+            .filter { it.isFile && it.name.startsWith("skiko-awt-runtime-") && it.name.endsWith(".jar") }
+            .forEach { jar ->
+                val freed =
+                    rewriteJar(jar) { name ->
+                        val leaf = name.substringAfterLast('/')
+                        !skikoNative.matches(leaf) || leaf.contains(skikoToken)
+                    }
+                if (freed > 0) {
+                    saved += freed
+                    println("🧹 ${jar.name}: freed ${freed / 1024} KB of non-$skikoToken skiko natives")
+                }
+            }
+
+        // sqlite-jdbc: keep org/sqlite/native/<OS>/<arch>/, drop the other ~19.
+        // On Linux keep the musl build of the same arch too -- it is ~1 MB and
+        // covers a glibc-built package installed on a musl system.
+        val keepPrefixes =
+            buildList {
+                add("org/sqlite/native/$sqliteOs/$sqliteArch/")
+                if (sqliteOs == "Linux") add("org/sqlite/native/Linux-Musl/$sqliteArch/")
+            }
+        appDir
+            .walkTopDown()
+            .filter { it.isFile && it.name.startsWith("sqlite-jdbc-") && it.name.endsWith(".jar") }
+            .forEach { jar ->
+                // Refuse to strip a jar that does not contain the native we
+                // believe this platform needs: that means the OS/arch mapping is
+                // wrong, and stripping would leave a jar with no loadable native
+                // at all. Leaving it whole costs 10 MB; getting it wrong breaks
+                // every SQLite read on the platform.
+                val hasOurs =
+                    ZipFile(jar).use { zip ->
+                        zip.entries().asSequence().any { e -> keepPrefixes.any { e.name.startsWith(it) } }
+                    }
+                if (!hasOurs) {
+                    println("⚠️  ${jar.name}: no native under ${keepPrefixes.first()} - leaving it intact")
+                    return@forEach
+                }
+                val freed =
+                    rewriteJar(jar) { name ->
+                        !name.startsWith("org/sqlite/native/") || keepPrefixes.any { name.startsWith(it) }
+                    }
+                if (freed > 0) {
+                    saved += freed
+                    println("🧹 ${jar.name}: freed ${freed / 1024} KB of non-$sqliteOs/$sqliteArch SQLite natives")
+                }
+            }
+
+        println("✅ Foreign-platform natives stripped: ${saved / 1024 / 1024} MB freed")
+    }
+}
+
 // Extract CLI script to app bundle Resources for Homebrew installation
 tasks.register("extractCLIToAppResources") {
     description = "Extracts CLI script to BOSS.app/Contents/Resources for Homebrew binary stanza"
@@ -1891,11 +2043,15 @@ afterEvaluate {
         // Ensure bundled plugins are prepared
         dependsOn("prepareBundledPluginsResources")
 
-        // Task chain: createDistributable → signPty4jBinaries → extractCLIToAppResources.
-        // Both finalizers are wired unconditionally so the signing decision is NOT
-        // needed at configuration time (keeps the keychain scan lazy): when signing
-        // is disabled, signPty4jBinaries skips itself via its own onlyIf and the
-        // CLI extraction still runs.
+        // Every platform trims the app image; only macOS signs it afterwards.
+        finalizedBy("stripForeignPlatformNatives")
+
+        // Task chain: createDistributable → stripForeignPlatformNatives →
+        // signPty4jBinaries → extractCLIToAppResources.
+        // The signing finalizers are wired unconditionally so the signing decision
+        // is NOT needed at configuration time (keeps the keychain scan lazy): when
+        // signing is disabled, signPty4jBinaries skips itself via its own onlyIf
+        // and the CLI extraction still runs.
         if (isMacOS) {
             finalizedBy("signPty4jBinaries", "extractCLIToAppResources")
             println(
@@ -1904,9 +2060,15 @@ afterEvaluate {
         }
     }
 
-    // signPty4jBinaries runs after createDistributable, then triggers extractCLIToAppResources
-    tasks.findByName("signPty4jBinaries")?.apply {
+    // The strip must land before anything signs or packages the image, or the
+    // signature seals jars that are about to change underneath it.
+    tasks.findByName("stripForeignPlatformNatives")?.apply {
         mustRunAfter("createDistributable")
+    }
+
+    // signPty4jBinaries runs after the image is trimmed, then triggers extractCLIToAppResources
+    tasks.findByName("signPty4jBinaries")?.apply {
+        mustRunAfter("createDistributable", "stripForeignPlatformNatives")
         if (isMacOS) {
             finalizedBy("extractCLIToAppResources")
             println("📝 signPty4jBinaries will be finalized by extractCLIToAppResources")
@@ -1918,7 +2080,7 @@ afterEvaluate {
     // is skipped — so it needs no config-time signing check.
     tasks.findByName("extractCLIToAppResources")?.apply {
         dependsOn("generateVersionedCLIScripts")
-        mustRunAfter("signPty4jBinaries")
+        mustRunAfter("signPty4jBinaries", "stripForeignPlatformNatives")
         println("📝 extractCLIToAppResources will depend on generateVersionedCLIScripts")
     }
 
@@ -1928,6 +2090,12 @@ afterEvaluate {
             mustRunAfter("signPty4jBinaries", "extractCLIToAppResources")
             println("📝 packageDmg will run after PTY4J signing and CLI extraction")
         }
+    }
+
+    // Linux and Windows have no signing step to order against, so they need the
+    // strip wired to their packaging tasks directly.
+    listOf("packageDeb", "packageRpm", "packageMsi", "packageAppImage").forEach { name ->
+        tasks.findByName(name)?.mustRunAfter("stripForeignPlatformNatives")
     }
 
     // Linux: Fix .desktop file after DEB packaging to add StartupWMClass

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -299,7 +299,17 @@ val downloadBundledPlugins =
                     "risa-labs-inc/boss-plugin-terminal-tab" to "boss-plugin-terminal-tab",
                     "risa-labs-inc/boss-plugin-terminal" to "boss-plugin-terminal",
                     "risa-labs-inc/boss-plugin-fluck-browser" to "boss-plugin-fluck-browser",
-                    "risa-labs-inc/boss-plugin-editor-tab" to "boss-plugin-editor-tab",
+                    // NOT editor-tab. It is 64.7 MB, a quarter of the whole
+                    // download, and bundling buys almost nothing: the host's
+                    // ensureSystemPluginsInstalled() fetches it from the
+                    // plugin's latest GitHub release before load when it is not
+                    // on disk, which is already how every developer build and
+                    // every install of BOSS gets it (copyBundledPluginsLocal
+                    // below has never copied it either). Bundling only covered a
+                    // first launch with no network, and it went stale fast: the
+                    // seed is frozen at BOSS build time while editor-tab shipped
+                    // five releases in two days, so a bundled JAR below the
+                    // host's minVersion floor is replaced on startup anyway.
                     "risa-labs-inc/boss-plugin-plugin-manager" to "boss-plugin-plugin-manager",
                     "risa-labs-inc/boss-plugin-bookmarks" to "boss-plugin-bookmarks",
                 )
@@ -538,7 +548,14 @@ val copyPluginManagerToDev =
 
 // Task to prepare bundled plugins for app resources (used by native distributions)
 val prepareBundledPluginsResources =
-    tasks.register<Copy>("prepareBundledPluginsResources") {
+    // Sync, not Copy: Copy only ever ADDS to its destination, so a plugin
+    // dropped from the bundled list kept shipping out of a warm build
+    // directory -- the JAR stayed in bundled-plugins-resources forever and
+    // jpackage kept picking it up. Removing editor-tab from the list above
+    // appeared to do nothing until the directory was deleted by hand. CI
+    // starts clean so no release was wrong, but anyone testing a change to
+    // that list locally was reading a stale answer.
+    tasks.register<Sync>("prepareBundledPluginsResources") {
         group = "build"
         description = "Prepares bundled plugins in app resources structure for native distribution"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,7 +161,6 @@ precompose-viewmodel = { module = "moe.tlaster:precompose-viewmodel", version.re
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 compose-icons-feather = { module = "br.com.devsrsouza.compose.icons:feather", version.ref = "compose-icons" }
-compose-icons-fontawesome = { module = "br.com.devsrsouza.compose.icons:font-awesome", version.ref = "compose-icons" }
 compose-icons-simpleicons = { module = "br.com.devsrsouza.compose.icons:simple-icons", version.ref = "compose-icons" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }


### PR DESCRIPTION
## What

Four cuts to the packaged desktop bundle. No product code changes - every
commit is build configuration or packaging.

Measured end to end on macOS arm64 with `./gradlew :composeApp:createDistributable`:

| | before | after |
|---|---|---|
| `Contents/runtime` | 136 MB | **91 MB** |
| `Contents/app` (jars) | 198 MB | **173 MB** |
| **BOSS.app total** | **402 MB** | **~333 MB** |

The DMG should land near 240 MB, down from 293 MB.

("before" is the shipped 9.4.33 in `/Applications`. `Contents/app` excludes the
68 MB of `resources/bundled-plugins`, which the local build did not download -
`downloadBundledPlugins` came back empty without a token. That 68 MB is
unchanged by this PR and is added back into the total on both sides.)

## Where it comes from

**`font-awesome` was never used** (5.1 MB). `FontAwesomeIcons` appears zero
times in the repository - the only occurrence of the name anywhere is the
dependency declaration itself. feather (4 icons used) and simple-icons (143)
stay.

**`includeAllModules = true` jlinked the entire JDK into every package**
(17 MB). Not "a complete JVM" in any sense a user benefits from: a JVM plus
the toolchain for producing Java software, shipped to people running an app.
javadoc, jshell, the JDI debugger, jdeps, jlink, jpackage itself, the HotSpot
serviceability agent, jconsole, jstatd and the JDWP debug agent - none
reachable from BOSS, because they are command-line entry points and jpackage
strips `bin/` from the image anyway.

**`jdk.localedata` was the largest module in the runtime** (33 MB) - larger
than java.desktop, larger than java.base. BOSS ships no localized text: no
`ResourceBundle` anywhere, no localized `composeResources`, every label an
English literal. See that commit for the exact five-call-site blast radius.

**skiko and sqlite-jdbc ship every platform's natives** (19.5 MB).
`skiko-awt-runtime-macos-arm64` contains *both* macOS dylibs; Compose extracts
the arm64 one and leaves the jar holding nothing but a 22 MB x86_64 binary this
arm64-only bundle can never load (9,365,047 bytes -> 293 bytes). sqlite-jdbc
carries ~20 builds including Linux ppc64, riscv64, armv6 and FreeBSD
(11 MB -> 852 KB).

## Risk, honestly

Commits 1 and 4 are mechanical and verified against the built image.

**Commit 2 is the one to review carefully.** A missing jlink module fails at
runtime on a user's machine, not in CI. Two things reduce that risk:

- The list is deliberately *not* jdeps-minimal. jdeps only sees static
  references, so a minimal list silently drops anything reached through
  ServiceLoader or reflection - crypto providers, charsets, the zip
  filesystem, JNDI backends. This list is what the old image actually
  contained minus the tooling, and every `jdk.*` entry is annotated with the
  consumer that keeps it.
- `java.se` rather than an enumeration of `java.*`, so no platform API can go
  missing. Costs a few unused modules, buys the guarantee.

`jdk.compiler` is kept on purpose: editor-tab bundles
kotlin-compiler-embeddable, which ships 96 classes under
`org/jetbrains/kotlin/javac/` linking against `com.sun.tools.javac`. Dropping
it (plus the 7.9 MB `lib/ct.sym` that rides along) is a measured further 15 MB
once Kotlin analysis in the editor is confirmed to work without it.

Commit 4 refuses to strip sqlite-jdbc unless the native this platform needs is
actually present, so a wrong OS/arch guess costs 10 MB rather than every
SQLite read on that platform.

## Verified

- `:composeApp:createRuntimeImage` green; jlink accepts the module list.
- `:composeApp:createDistributable` green, including the macOS re-sign, which
  now seals the trimmed jars (the strip is ordered ahead of
  `signPty4jBinaries` and `extractCLIToAppResources`).
- Built image inspected: skiko jar 293 bytes, sqlite-jdbc 852 KB with
  `org/sqlite/native/Mac/aarch64/libsqlitejdbc.dylib` intact, loose
  `libskiko-macos-arm64.dylib` untouched at 21.3 MB.
- `ktlintKotlinScriptCheck` green.

## Still needs a human

**A smoke test of the trimmed runtime.** The built bundle is at
`composeApp/build/compose/binaries/main/app/BOSS.app`. Worth exercising TLS
(sign-in), the terminal (charsets), plugin loading (zipfs), and opening a
Kotlin file in the editor. CI can prove jlink succeeds; it cannot prove nothing
reaches for a module that is now absent.

## Unrelated finding

`release.yml:1590` copies the **macos-arm64** DMG to
`BOSS-$VERSION-Universal.dmg`, and the release table advertises it as
"Universal (Apple Silicon + Intel)". The bundle is arm64-only - `MacOS/BOSS`,
`libjvm.dylib` and the skiko dylib all report `arm64` under `lipo -archs`.
Rosetta translates x86_64 to run on Apple Silicon, not the reverse, so an
Intel Mac cannot run this DMG at all. Either the label is wrong or Intel needs
a real second build. Not touched here.
