### PR TITLE
fix: bundled plugins shipped a deleted terminal-tab and a thin fluck-browser

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -334,6 +334,11 @@ val downloadBundledPlugins =
         // UP-TO-DATE: the prune below never runs and a newer release is never
         // picked up.
         outputs.upToDateWhen { false }
+        // Read at configuration time so the doLast lambda does not call
+        // System.getenv under the configuration cache. `prepareBundledPluginsResources`
+        // only reaches this task when CI == "true", so in the path that produces a
+        // release this is always set; a developer invoking the task by hand is not.
+        val ciProvider = providers.environmentVariable("CI")
 
         doLast {
             val bundledPluginsDir = destDir.get().asFile
@@ -450,6 +455,37 @@ val downloadBundledPlugins =
                     logger.lifecycle("✅ Downloaded $jarFileName (version: $tagName, size: ${destFile.length()} bytes)")
                 } catch (e: Exception) {
                     logger.warn("⚠️  Failed to download bundled plugin from $repo: ${e.message}")
+                }
+            }
+
+            // Every path out of the loop above is a warn-and-continue: a release
+            // whose GitHub call 403s, whose repo has no release yet, or whose
+            // asset regex matches nothing produces a log line and a green build.
+            // That is how a missing terminal-tab and a thin fluck-browser both
+            // shipped for months -- nothing ever asserted the directory was
+            // complete. So assert it here.
+            val landed = bundledPluginsDir.listFiles()?.map { it.name }.orEmpty()
+            val missing =
+                bundledPlugins
+                    .map { (_, artifactPrefix) -> artifactPrefix }
+                    .filter { artifactPrefix ->
+                        val versioned = Regex("""^${Regex.escape(artifactPrefix)}-\d.*\.jar$""")
+                        landed.none { versioned.matches(it) }
+                    }
+
+            if (missing.isEmpty()) {
+                logger.lifecycle("✅ All ${bundledPlugins.size} bundled plugins present")
+            } else {
+                val summary =
+                    "Bundled plugins missing after download: ${missing.joinToString(", ")} " +
+                        "(present: ${landed.sorted().joinToString(", ").ifEmpty { "none" }})"
+                // On CI this is a release about to go out without plugins it
+                // promises, which is worse than a failed build. Locally it stays
+                // a warning: a developer may legitimately have no network.
+                if (ciProvider.orNull == "true") {
+                    error(summary)
+                } else {
+                    logger.warn("⚠️  $summary")
                 }
             }
         }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -373,15 +373,34 @@ val downloadBundledPlugins =
                     val tagNameMatch = Regex(""""tag_name"\s*:\s*"([^"]+)"""").find(responseText)
                     val tagName = tagNameMatch?.groupValues?.get(1) ?: "unknown"
 
-                    // Find the JAR download URL (look for browser_download_url ending in .jar)
-                    val jarUrlMatch = Regex(""""browser_download_url"\s*:\s*"([^"]+$artifactPrefix[^"]*\.jar)"""").find(responseText)
+                    // Find the JAR download URL.
+                    //
+                    // `findAll` + the `-thin.jar` filter, not `find`: a plugin
+                    // release publishes BOTH `<prefix>-<version>.jar` (what
+                    // buildPluginJar produces, with the plugin's dependencies
+                    // bundled) and `<prefix>-<version>-thin.jar` (the module's
+                    // bare `:jar` output, which is given that classifier purely
+                    // so it stops clobbering the real one). Whichever GitHub
+                    // happens to list first won here, and for fluck-browser that
+                    // was the thin one -- every shipped bundle through 9.4.33
+                    // contains `boss-plugin-fluck-browser-1.2.24-thin.jar`,
+                    // 1 MB of a 4 MB plugin, missing everything it needs to run.
+                    //
+                    // This is exactly PluginStoreSetup.pickPluginJarUrl, which
+                    // the host uses for the same decision and which
+                    // PluginStoreSetupMinVersionGateTest already guards against
+                    // picking a thin JAR. The two pickers must not disagree.
+                    val jarUrl =
+                        Regex(""""browser_download_url"\s*:\s*"([^"]+${Regex.escape(artifactPrefix)}[^"]*\.jar)"""")
+                            .findAll(responseText)
+                            .map { it.groupValues[1] }
+                            .firstOrNull { !it.endsWith("-thin.jar") }
 
-                    if (jarUrlMatch == null) {
+                    if (jarUrl == null) {
                         logger.warn("⚠️  No JAR asset found in release for $repo")
                         continue
                     }
 
-                    val jarUrl = jarUrlMatch.groupValues[1]
                     val jarFileName = jarUrl.substringAfterLast("/")
                     val destFile = File(bundledPluginsDir, jarFileName)
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -404,21 +404,40 @@ val downloadBundledPlugins =
                     val jarFileName = jarUrl.substringAfterLast("/")
                     val destFile = File(bundledPluginsDir, jarFileName)
 
+                    // Clean up other versions of THIS plugin.
+                    //
+                    // `startsWith(artifactPrefix)` is not a plugin-name boundary.
+                    // "boss-plugin-terminal" is a prefix of
+                    // "boss-plugin-terminal-tab-2.5.59.jar", and terminal is
+                    // processed one entry after terminal-tab in the list above --
+                    // so this deleted the 35 MB terminal plugin it had just
+                    // downloaded, logged it as an "old version", and finished
+                    // green. terminal-tab is absent from every shipped bundle.
+                    //
+                    // A plugin JAR is `<prefix>-<version>.jar`, so requiring the
+                    // version separator (a hyphen followed by a digit) is what
+                    // makes the prefix a boundary: "-tab-2.5.59.jar" does not
+                    // start with a digit, "-1.0.10.jar" does. A stale
+                    // `-thin.jar` still matches and is still cleaned up.
+                    //
+                    // Runs BEFORE the already-have-it check, and never touches
+                    // the file about to be kept: a directory left holding both
+                    // the real JAR and a thin one from before the previous
+                    // commit needs the thin one gone even on a no-op run.
+                    val ownVersionedJar = Regex("""^${Regex.escape(artifactPrefix)}-\d.*\.jar$""")
+                    bundledPluginsDir
+                        .listFiles()
+                        ?.filter { ownVersionedJar.matches(it.name) && it.name != jarFileName }
+                        ?.forEach { oldFile ->
+                            logger.lifecycle("🗑️  Removing old version: ${oldFile.name}")
+                            oldFile.delete()
+                        }
+
                     // Check if we already have this version
                     if (destFile.exists()) {
                         logger.lifecycle("✅ $jarFileName already exists (version: $tagName)")
                         continue
                     }
-
-                    // Clean up old versions of this plugin
-                    bundledPluginsDir
-                        .listFiles()
-                        ?.filter {
-                            it.name.startsWith(artifactPrefix) && it.name.endsWith(".jar")
-                        }?.forEach { oldFile ->
-                            logger.lifecycle("🗑️  Removing old version: ${oldFile.name}")
-                            oldFile.delete()
-                        }
 
                     // Download the JAR using curl
                     logger.lifecycle("⬇️  Downloading $jarFileName...")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -334,10 +334,18 @@ val downloadBundledPlugins =
         // UP-TO-DATE: the prune below never runs and a newer release is never
         // picked up.
         outputs.upToDateWhen { false }
-        // Read at configuration time so the doLast lambda does not call
-        // System.getenv under the configuration cache. `prepareBundledPluginsResources`
-        // only reaches this task when CI == "true", so in the path that produces a
-        // release this is always set; a developer invoking the task by hand is not.
+
+        // A Provider, not a captured value: `ciProvider.orNull` below is read at
+        // EXECUTION time, and what makes that configuration-cache safe is that
+        // Gradle tracks a Provider read as an input -- not that the value was
+        // captured early. (The sibling gate on `prepareBundledPluginsResources`
+        // still uses System.getenv at configuration time; the two agree today by
+        // different mechanisms, and only that one decides whether this task is in
+        // the graph at all.)
+        //
+        // `prepareBundledPluginsResources` only routes here when CI == "true", so
+        // the release path always has it set; a developer invoking this task by
+        // hand does not.
         val ciProvider = providers.environmentVariable("CI")
 
         doLast {
@@ -483,7 +491,7 @@ val downloadBundledPlugins =
                 // promises, which is worse than a failed build. Locally it stays
                 // a warning: a developer may legitimately have no network.
                 if (ciProvider.orNull == "true") {
-                    error(summary)
+                    throw GradleException(summary)
                 } else {
                     logger.warn("⚠️  $summary")
                 }


### PR DESCRIPTION
## What

`downloadBundledPlugins` picked the wrong JAR for one plugin and deleted
another one outright. Both are visible in shipped 9.4.33, and both builds
finished green.

Reproduced verbatim on `main` before touching anything -- this is the task's
own log:

```
📦 Fetching latest release for risa-labs-inc/boss-plugin-terminal-tab...
⬇️  Downloading boss-plugin-terminal-tab-2.5.59.jar...
📦 Fetching latest release for risa-labs-inc/boss-plugin-terminal...
🗑️  Removing old version: boss-plugin-terminal-tab-2.5.59.jar     ← bug 1
⬇️  Downloading boss-plugin-terminal-1.0.10.jar...
📦 Fetching latest release for risa-labs-inc/boss-plugin-fluck-browser...
⬇️  Downloading boss-plugin-fluck-browser-1.2.24-thin.jar...       ← bug 2
...
BUILD SUCCESSFUL
```

The directory that produces matches
`/Applications/BOSS.app/Contents/app/resources/bundled-plugins/` from the
released 9.4.33 exactly: six JARs, terminal-tab absent, fluck-browser thin.

## Bug 1 - terminal's cleanup eats terminal-tab

The "remove old versions" filter is `it.name.startsWith(artifactPrefix)`.
`"boss-plugin-terminal"` is a prefix of `"boss-plugin-terminal-tab-2.5.59.jar"`,
and terminal is the entry right after terminal-tab in the list. So every build
downloads the 35 MB terminal plugin and deletes it one iteration later, calling
it an "old version".

**The terminal has never been bundled.** A fresh install has to reach the
plugin store and pull 35 MB before it can open a terminal, which is the exact
thing bundling exists to avoid.

Fixed by requiring the version separator: a plugin JAR is
`<prefix>-<version>.jar`, so a hyphen followed by a digit is what makes the
prefix a boundary. `-tab-2.5.59.jar` does not start with a digit; `-1.0.10.jar`
does.

## Bug 2 - fluck-browser ships its thin JAR

A release publishes both `<prefix>-<version>.jar` (what `buildPluginJar`
produces, dependencies bundled) and `<prefix>-<version>-thin.jar` (the bare
`:jar` output, which carries that classifier only so it stops clobbering the
real one). The task used `Regex(...).find(...)`, taking whichever asset GitHub
listed first -- the thin one, 1 MB standing in for a 4 MB plugin.

The host already gets this right: `PluginStoreSetup.pickPluginJarUrl` uses
`findAll` plus `firstOrNull { !it.endsWith("-thin.jar") }`, and
`PluginStoreSetupMinVersionGateTest` guards it with two dedicated cases. Only
the Gradle-side picker disagreed, so **the JAR the store would refuse to
install is the one the installer shipped.** This makes the two rules identical.

## Third commit: why nobody noticed

Every path out of that loop is warn-and-continue, so nothing ever asserted the
directory was complete. Neither bug was subtle -- one of them logs the deletion
three lines after the download -- but nothing was reading, because nothing
failed.

The task now checks each entry produced a versioned JAR and reports what is
missing next to what landed. **On CI that is an error**, since
`prepareBundledPluginsResources` only routes here when `CI == "true"`, so the
CI path is exactly the path that cuts a release. Locally it stays a warning.

⚠️ **This can fail a release** if a plugin repo has no published release, so
adding a new plugin to the list now means publishing it first. That is the
intended trade, and it is the whole third commit if you would rather not take
it.

## Verified

Ran the task directly at each step (it only runs under `CI=true` in the normal
build path, so it needs invoking by hand).

After both fixes -- seven JARs where six landed before, no deletion line:

```
⬇️  Downloading boss-plugin-api-1.0.84.jar...
⬇️  Downloading boss-plugin-terminal-tab-2.5.59.jar...
⬇️  Downloading boss-plugin-terminal-1.0.10.jar...
⬇️  Downloading boss-plugin-fluck-browser-1.2.24.jar...
⬇️  Downloading boss-plugin-editor-tab-1.4.20.jar...
⬇️  Downloading boss-plugin-plugin-manager-1.9.21.jar...
⬇️  Downloading boss-plugin-bookmarks-2.1.10.jar...
✅ All 7 bundled plugins present
```

Cleanup still does its job. Planted a stale older version of each colliding
plugin plus a leftover thin JAR, then re-ran:

```
🗑️  Removing old version: boss-plugin-terminal-tab-2.4.0.jar
✅ boss-plugin-terminal-tab-2.5.59.jar already exists
🗑️  Removing old version: boss-plugin-terminal-0.9.0.jar
✅ boss-plugin-terminal-1.0.10.jar already exists
🗑️  Removing old version: boss-plugin-fluck-browser-1.2.24-thin.jar
✅ boss-plugin-fluck-browser-1.2.24.jar already exists
```

That last line is why the cleanup moved ahead of the already-have-it check: a
directory holding both the real JAR and a thin one from before this PR would
otherwise keep the thin one forever, because `continue` fired before any
cleanup ran.

Guard, both branches, by pointing one list entry at a repo that does not exist:

```
local     ⚠️  Bundled plugins missing after download: ... / BUILD SUCCESSFUL
CI=true   > Bundled plugins missing after download: ... / BUILD FAILED
```

`ktlintKotlinScriptCheck` green.

## Note

Touches the same file as #260 (bundle size) but a different region -- #260 is
in the `nativeDistributions` block and the post-`createDistributable` chain,
this is the download task at the top. They merge cleanly in either order.
