### PR TITLE
Wait for plugin UI to actually dispose before closing its classloader

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1304,7 +1304,20 @@ class DynamicPluginManager(
             force = force,
             waitForGC = waitForGC,
             closeTabsAcrossWindows = true,
-        )
+        ).also { outcome ->
+            // The teardown inside detached this plugin's sidebar panels so they would dispose
+            // while the loader was still open. If the unload then did not happen, nothing else
+            // puts them back: the plugin is still loaded, its panels are still registered, and no
+            // (re)install is coming to call notifyPanelsRefresh. Resuming here is what stops a
+            // refused uninstall from blanking a slot for the rest of the session, and a no-op
+            // when nothing was detached.
+            //
+            // Here rather than in the private overload because this is the entry point every
+            // user-facing unload takes (update, reload, remove). The other caller that tears
+            // tabs down globally is dispose(), which is the app shutting down - a panel that
+            // never comes back is exactly right there.
+            if (outcome.isFailure) notifyPanelsRefresh(pluginId)
+        }
 
     private suspend fun uninstallPlugin(
         pluginId: String,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/registery/PanelComponentStore.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/registery/PanelComponentStore.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.registery
 
+import ai.rever.boss.plugin.sandbox.PanelSandboxRegistry
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.mutableStateMapOf
@@ -17,6 +18,13 @@ class PanelComponentStore(
 
     // Get or create a component for a panel
     fun getOrCreateComponent(panelId: PanelId): PanelComponentWithUI? {
+        // Nothing for a plugin that is mid-unload. Called from composition by both panel hosts
+        // (SidePanel and the panel-host tab), so this is also what keeps a detached panel
+        // detached: without it the next frame would re-instantiate the component from factories
+        // that are about to be closed. See PanelComponentStoreRegistry.detachPanels.
+        val owner = PanelSandboxRegistry.getSandbox(panelId)?.pluginId
+        if (owner != null && PanelComponentStoreRegistry.isSuspended(owner)) return null
+
         // Return existing component if available
         activeComponents[panelId]?.let { return it }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/registery/PanelComponentStoreRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/registery/PanelComponentStoreRegistry.kt
@@ -1,5 +1,7 @@
 package ai.rever.boss.components.registery
 
+import ai.rever.boss.plugin.sandbox.PanelSandboxRegistry
+import androidx.compose.runtime.mutableStateMapOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 
@@ -51,5 +53,71 @@ object PanelComponentStoreRegistry {
             }
         }
         return reset
+    }
+
+    /**
+     * Plugins whose panels must not be composed right now.
+     *
+     * Snapshot state, and read from [PanelComponentStore.getOrCreateComponent] during
+     * composition, so suspending recomposes the open slots that are showing the plugin instead of
+     * leaving a stale component on screen.
+     */
+    private val suspendedPlugins = mutableStateMapOf<String, Unit>()
+
+    /** Whether [pluginId]'s panels are currently suspended. */
+    fun isSuspended(pluginId: String): Boolean = suspendedPlugins.containsKey(pluginId)
+
+    /**
+     * Take [pluginId]'s panels out of every window's composition and keep them out until
+     * [resumePanels].
+     *
+     * The unload path's panel counterpart of closing its tabs, and for the same reason: a panel
+     * left composed while the classloader closes runs its `onDispose` against a dead loader.
+     * Closing tabs was never enough - nothing else removes a panel before the unload, so the
+     * disposal wait could only expire (see PluginLoaderDelegateImpl.teardownPluginTabs).
+     *
+     * Suspending is what makes the removal stick: [SidePanel] and the panel-host tab both call
+     * [PanelComponentStore.getOrCreateComponent] *during* composition, so a bare
+     * `removeComponent` would be undone by the very next frame, which would re-instantiate the
+     * plugin's component from the factories that are about to go away.
+     *
+     * Deliberately NOT hiding the slot. The panel stays open and empty for the length of the
+     * unload, so a reload puts the new build back where the user left it - hiding it would need
+     * the far side to guess which slots to reopen, and #856 is the bug that comes from guessing.
+     *
+     * MUST run on the UI thread, like [resetPanels]: it mutates snapshot state that composition
+     * also reads.
+     *
+     * @return the number of cached components dropped, for logging.
+     */
+    fun detachPanels(pluginId: String): Int {
+        suspendedPlugins[pluginId] = Unit
+        var detached = 0
+        getAllStores().forEach { store ->
+            store.activeComponents.keys
+                .filter { PanelSandboxRegistry.getSandbox(it)?.pluginId == pluginId }
+                .forEach { panelId ->
+                    store.removeComponent(panelId)
+                    detached++
+                }
+        }
+        return detached
+    }
+
+    /**
+     * Let [pluginId]'s panels compose again.
+     *
+     * Every path that ends an unload calls this, whether or not the plugin came back: a suspension
+     * that outlives its unload is a slot that stays blank for the rest of the session, which is a
+     * worse failure than the stale component this replaced. See
+     * PluginLoaderDelegateImpl.refreshPluginPanels, which resumes before it resets.
+     */
+    fun resumePanels(pluginId: String) {
+        suspendedPlugins.remove(pluginId)
+    }
+
+    /** Test-only: drop every suspension. */
+    fun clearSuspensions() {
+        suspendedPlugins.clear()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -156,7 +156,11 @@ actual object PluginLoaderDelegateSetup {
                     ) = PluginCrashRegistry.recordRenderFault(pluginId, error, notify = false)
 
                     override suspend fun closeTabs(pluginId: String) {
-                        delegate.teardownPluginTabs(pluginId)
+                        // detachPanels = false: this is quarantine, not an unload. `disable`
+                        // below leaves the classloader open, so there is nothing to race - and
+                        // the plugin's panel is on screen showing the crash fallback, which is
+                        // where the user's Restart button lives. Detaching would blank it.
+                        delegate.teardownPluginTabs(pluginId, detachPanels = false)
                     }
 
                     override suspend fun disable(pluginId: String) = DynamicPluginManager.disableEverywhere(pluginId)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -585,9 +585,12 @@ class PluginLoaderDelegateImpl(
         // anything mounted" wait could never come true while one was open.
         val owners = sandboxed.map { (_, _, pluginId) -> pluginId }.toSet()
         if (tabs.isEmpty()) {
-            // Still waits: a plugin whose only surface is a sidebar panel has no tabs to close,
-            // and its boundary disposes on a later frame exactly like a tab's would.
-            awaitPluginUiDisposal(owners)
+            // Nothing to await, and the call that used to be here could never say otherwise:
+            // `owners` comes out of the same scan as `tabs`, so no tabs means no owners, and
+            // awaitDisposed returns immediately on an empty set. A panel-only plugin is NOT
+            // covered here - its panel is not in `owners` in either branch, and it stays mounted
+            // across a swap by design. Covering it would mean sourcing owners from
+            // PanelSandboxRegistry too, which is a change to what this waits for, not a comment.
             return 0
         }
         logger.info(
@@ -612,8 +615,16 @@ class PluginLoaderDelegateImpl(
     suspend fun teardownPluginTabs(pluginId: String): Int {
         val tabs = findOpenTabs(pluginId)
         if (tabs.isEmpty()) {
-            // No tabs is not "nothing to wait for": this plugin's sidebar panel is a boundary too,
-            // and its loader is about to close whether or not it had a tab open.
+            // No tabs is not "nothing to wait for": a surface of this plugin can be mounted with
+            // no tab open, and its loader is about to close either way.
+            //
+            // KNOWN GAP, sidebar panels. Nothing removes the panel before this runs - the
+            // registration drops in TrackingPluginContext.unregisterAll(), which happens inside
+            // the unload, after this has returned. So a plugin with a panel on screen waits the
+            // full timeout, logs a warning that reads like the fix failed, unloads anyway, and its
+            // panel still disposes against a closed loader. Closing that needs a panel-removal
+            // step ahead of this call. The wait is kept because it is correct for every other
+            // surface and errs toward waiting, which is the safe direction.
             awaitPluginUiDisposal(setOf(pluginId))
             return 0
         }
@@ -638,7 +649,9 @@ class PluginLoaderDelegateImpl(
      * runs the plugin's own onDispose lambdas, which cannot resolve once its classloader has gone.
      *
      * Hoisted out of [closeTabsOnEdt] because it is not about tabs: a plugin whose only surface is
-     * a sidebar panel has no tabs to close and the same race to lose.
+     * a sidebar panel has no tabs to close and the same race to lose. Note that it does not yet
+     * WIN that race for panels - see the known gap in [teardownPluginTabs] - the hoist is what
+     * makes fixing it a change at one call site rather than a restructure.
      */
     private suspend fun awaitPluginUiDisposal(pluginIds: Set<String>) {
         if (PluginUiMountRegistry.awaitDisposed(pluginIds, UI_DISPOSAL_TIMEOUT_MS)) return

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -606,25 +606,34 @@ class PluginLoaderDelegateImpl(
     }
 
     /**
-     * Close ONE plugin's open tabs across all windows on the EDT and wait.
-     * Invoked by the shared uninstall path (DynamicPluginManager) before the
-     * classloader closes, so update/reload/remove of a tab-hosting plugin
-     * (terminal-tab, editor-tab, fluck-browser) disposes its tab UI cleanly —
-     * same NoClassDefFoundError-avoidance as the API swap, one plugin at a time.
+     * Close ONE plugin's open tabs across all windows on the EDT, take its sidebar panels out of
+     * the composition, and wait for all of it to dispose.
+     *
+     * Invoked by the shared uninstall path (DynamicPluginManager) before the classloader closes,
+     * so update/reload/remove of a tab-hosting plugin (terminal-tab, editor-tab, fluck-browser)
+     * disposes its tab UI cleanly — same NoClassDefFoundError-avoidance as the API swap, one
+     * plugin at a time.
+     *
+     * Panels need the detach because nothing else removes them in time: the registration drops in
+     * TrackingPluginContext.unregisterAll(), which runs INSIDE the unload, after this has
+     * returned. Without it a plugin with a panel open could only ever time out here, and its
+     * panel disposed against a closed loader anyway - the exact fault this path exists to
+     * prevent. [PanelComponentStoreRegistry.detachPanels] has the mechanics.
+     *
+     * [detachPanels] is false for callers that are NOT about to close the classloader. Crash
+     * recovery is the one that matters: it closes tabs before disabling, `disable` leaves the
+     * loader open, and its panel is on screen showing the crash fallback with the Restart button
+     * the user needs. Detaching there would replace that with a blank slot to no purpose.
      */
-    suspend fun teardownPluginTabs(pluginId: String): Int {
+    suspend fun teardownPluginTabs(
+        pluginId: String,
+        detachPanels: Boolean = true,
+    ): Int {
         val tabs = findOpenTabs(pluginId)
+        if (detachPanels) detachPluginPanels(pluginId)
         if (tabs.isEmpty()) {
-            // No tabs is not "nothing to wait for": a surface of this plugin can be mounted with
-            // no tab open, and its loader is about to close either way.
-            //
-            // KNOWN GAP, sidebar panels. Nothing removes the panel before this runs - the
-            // registration drops in TrackingPluginContext.unregisterAll(), which happens inside
-            // the unload, after this has returned. So a plugin with a panel on screen waits the
-            // full timeout, logs a warning that reads like the fix failed, unloads anyway, and its
-            // panel still disposes against a closed loader. Closing that needs a panel-removal
-            // step ahead of this call. The wait is kept because it is correct for every other
-            // surface and errs toward waiting, which is the safe direction.
+            // No tabs is not "nothing to wait for": a sidebar panel is a boundary too, and with
+            // the detach above it now has a disposal to await rather than a timeout to burn.
             awaitPluginUiDisposal(setOf(pluginId))
             return 0
         }
@@ -649,9 +658,9 @@ class PluginLoaderDelegateImpl(
      * runs the plugin's own onDispose lambdas, which cannot resolve once its classloader has gone.
      *
      * Hoisted out of [closeTabsOnEdt] because it is not about tabs: a plugin whose only surface is
-     * a sidebar panel has no tabs to close and the same race to lose. Note that it does not yet
-     * WIN that race for panels - see the known gap in [teardownPluginTabs] - the hoist is what
-     * makes fixing it a change at one call site rather than a restructure.
+     * a sidebar panel has no tabs to close and the same race to lose. Panels reach this wait through
+     * [teardownPluginTabs]'s detach rather than through a tab close, which is why the wait is
+     * phrased in plugins and not in tabs.
      */
     private suspend fun awaitPluginUiDisposal(pluginIds: Set<String>) {
         if (PluginUiMountRegistry.awaitDisposed(pluginIds, UI_DISPOSAL_TIMEOUT_MS)) return
@@ -682,6 +691,11 @@ class PluginLoaderDelegateImpl(
         pluginId: String,
         panelIds: Set<PanelId>,
     ) {
+        // Resume FIRST, and before the empty check: this is the far side of every unload, and a
+        // plugin that did not come back (removed, or a failed reload) has no panels to reset but
+        // must still stop being suspended. Leaving it suspended would blank the slot for the rest
+        // of the session.
+        SwingUtilities.invokeLater { PanelComponentStoreRegistry.resumePanels(pluginId) }
         if (panelIds.isEmpty()) return
         SwingUtilities.invokeLater {
             val reset = PanelComponentStoreRegistry.resetPanels(panelIds)
@@ -695,6 +709,42 @@ class PluginLoaderDelegateImpl(
                     ),
                 )
             }
+        }
+    }
+
+    /**
+     * Take [pluginId]'s sidebar panels out of every window's composition, on the EDT.
+     *
+     * Blocking rather than fire-and-forget, unlike [refreshPluginPanels]: the caller awaits the
+     * disposal that this triggers, so returning before the state change had landed would just
+     * start the wait against a panel that was still composed.
+     */
+    @Suppress("TooGenericExceptionCaught") // A detach touches plugin code; a closed loader throws Error, not Exception.
+    private fun detachPluginPanels(pluginId: String) {
+        var detached = 0
+        runOnEdtAndWait {
+            detached =
+                try {
+                    PanelComponentStoreRegistry.detachPanels(pluginId)
+                } catch (t: Throwable) {
+                    logger.warn(
+                        LogCategory.SYSTEM,
+                        "Detaching sidebar panels before unload failed (continuing)",
+                        mapOf("pluginId" to pluginId),
+                        t,
+                    )
+                    0
+                }
+        }
+        if (detached > 0) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Detached sidebar panels before unload",
+                mapOf(
+                    "pluginId" to pluginId,
+                    "panels" to detached.toString(),
+                ),
+            )
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -567,16 +567,29 @@ class PluginLoaderDelegateImpl(
      * Sidebar panels re-register on reload; open tabs do not reopen.
      */
     suspend fun teardownAllPluginTabs(): Int {
-        val tabs =
+        val sandboxed =
             SplitViewStateRegistry.getAllStates().values.flatMap { state ->
                 state.getAllPanels().flatMap { panel ->
                     val component = panel.tabsComponent
                     component.tabsState.value.tabs
-                        .filter { tab -> TabSandboxRegistry.getSandbox(tab.typeId) != null }
-                        .map { tab -> component to tab.id }
+                        .mapNotNull { tab ->
+                            TabSandboxRegistry.getSandbox(tab.typeId)?.let { sandbox ->
+                                Triple(component, tab.id, sandbox.pluginId)
+                            }
+                        }
                 }
             }
-        if (tabs.isEmpty()) return 0
+        val tabs = sandboxed.map { (component, tabId, _) -> component to tabId }
+        // The plugins whose loaders the swap is about to close - the only ones worth waiting on.
+        // NOT every mounted plugin: sidebar panels stay up across a swap by design, so an "is
+        // anything mounted" wait could never come true while one was open.
+        val owners = sandboxed.map { (_, _, pluginId) -> pluginId }.toSet()
+        if (tabs.isEmpty()) {
+            // Still waits: a plugin whose only surface is a sidebar panel has no tabs to close,
+            // and its boundary disposes on a later frame exactly like a tab's would.
+            awaitPluginUiDisposal(owners)
+            return 0
+        }
         logger.info(
             LogCategory.SYSTEM,
             "Tearing down plugin tabs before API-layer swap",
@@ -585,6 +598,7 @@ class PluginLoaderDelegateImpl(
             ),
         )
         closeTabsOnEdt(pluginId = null, tabs = tabs)
+        awaitPluginUiDisposal(owners)
         return tabs.size
     }
 
@@ -597,7 +611,12 @@ class PluginLoaderDelegateImpl(
      */
     suspend fun teardownPluginTabs(pluginId: String): Int {
         val tabs = findOpenTabs(pluginId)
-        if (tabs.isEmpty()) return 0
+        if (tabs.isEmpty()) {
+            // No tabs is not "nothing to wait for": this plugin's sidebar panel is a boundary too,
+            // and its loader is about to close whether or not it had a tab open.
+            awaitPluginUiDisposal(setOf(pluginId))
+            return 0
+        }
         logger.info(
             LogCategory.SYSTEM,
             "Tearing down plugin tabs before unload",
@@ -607,7 +626,32 @@ class PluginLoaderDelegateImpl(
             ),
         )
         closeTabsOnEdt(pluginId, tabs)
+        awaitPluginUiDisposal(setOf(pluginId))
         return tabs.size
+    }
+
+    /**
+     * Wait for [pluginIds]' UI to actually leave the composition, before their loaders close.
+     *
+     * Closing a tab is not disposing it: `removeTabById` mutates the tab model on the EDT and
+     * returns, while Compose disposes the subtree on a LATER render frame - and that frame is what
+     * runs the plugin's own onDispose lambdas, which cannot resolve once its classloader has gone.
+     *
+     * Hoisted out of [closeTabsOnEdt] because it is not about tabs: a plugin whose only surface is
+     * a sidebar panel has no tabs to close and the same race to lose.
+     */
+    private suspend fun awaitPluginUiDisposal(pluginIds: Set<String>) {
+        if (PluginUiMountRegistry.awaitDisposed(pluginIds, UI_DISPOSAL_TIMEOUT_MS)) return
+        logger.warn(
+            LogCategory.SYSTEM,
+            "Plugin UI still mounted after teardown timeout - unloading anyway",
+            mapOf(
+                // The awaited plugins only. Listing every mounted plugin named ones that had
+                // nothing to do with this unload, which is what made the line unactionable.
+                "stillMounted" to PluginUiMountRegistry.stillMounted(pluginIds).toString(),
+                "timeoutMs" to UI_DISPOSAL_TIMEOUT_MS.toString(),
+            ),
+        )
     }
 
     /**
@@ -663,33 +707,6 @@ class PluginLoaderDelegateImpl(
                     )
                 }
             }
-        }
-
-        // Removing the tabs is not the same as disposing them, and the caller is about to close
-        // classloaders.
-        //
-        // removeTabById mutates the tab model on the EDT and returns; Compose disposes the subtree
-        // on a LATER render frame, and it is that frame which runs the plugin's own onDispose
-        // lambdas. Returning here left roughly one frame in which the loader closed first, and the
-        // plugin's teardown then could not resolve its own classes - the NoClassDefFoundError the
-        // classloader reports as "something still referenced the plugin after it was unloaded".
-        //
-        // Waiting on the boundary's own mounted/disposed signal is the fix. It is bounded: a
-        // window that is minimised or fully occluded may never draw, and hanging an unload on a
-        // frame that never comes would be worse than the fault, which the crash boundary contains.
-        val disposed = PluginUiMountRegistry.awaitDisposed(pluginId, UI_DISPOSAL_TIMEOUT_MS)
-        if (!disposed) {
-            logger.warn(
-                LogCategory.SYSTEM,
-                "Plugin UI still mounted after teardown timeout - unloading anyway",
-                mapOf(
-                    "pluginId" to (pluginId ?: "all"),
-                    "stillMounted" to
-                        PluginUiMountRegistry.mounted.value.keys
-                            .joinToString(),
-                    "timeoutMs" to UI_DISPOSAL_TIMEOUT_MS.toString(),
-                ),
-            )
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -24,6 +24,7 @@ import ai.rever.boss.plugin.loader.PluginUnloadException
 import ai.rever.boss.plugin.repository.remote.PluginStoreConfig
 import ai.rever.boss.plugin.sandbox.TabSandboxRegistry
 import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
+import ai.rever.boss.plugin.sandbox.ui.PluginUiMountRegistry
 import ai.rever.boss.utils.ApplicationRestarter
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
@@ -663,6 +664,33 @@ class PluginLoaderDelegateImpl(
                 }
             }
         }
+
+        // Removing the tabs is not the same as disposing them, and the caller is about to close
+        // classloaders.
+        //
+        // removeTabById mutates the tab model on the EDT and returns; Compose disposes the subtree
+        // on a LATER render frame, and it is that frame which runs the plugin's own onDispose
+        // lambdas. Returning here left roughly one frame in which the loader closed first, and the
+        // plugin's teardown then could not resolve its own classes - the NoClassDefFoundError the
+        // classloader reports as "something still referenced the plugin after it was unloaded".
+        //
+        // Waiting on the boundary's own mounted/disposed signal is the fix. It is bounded: a
+        // window that is minimised or fully occluded may never draw, and hanging an unload on a
+        // frame that never comes would be worse than the fault, which the crash boundary contains.
+        val disposed = PluginUiMountRegistry.awaitDisposed(pluginId, UI_DISPOSAL_TIMEOUT_MS)
+        if (!disposed) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Plugin UI still mounted after teardown timeout - unloading anyway",
+                mapOf(
+                    "pluginId" to (pluginId ?: "all"),
+                    "stillMounted" to
+                        PluginUiMountRegistry.mounted.value.keys
+                            .joinToString(),
+                    "timeoutMs" to UI_DISPOSAL_TIMEOUT_MS.toString(),
+                ),
+            )
+        }
     }
 
     override fun getInaccessiblePlugins(): List<InaccessiblePluginInfo> =
@@ -721,3 +749,11 @@ class PluginLoaderDelegateImpl(
         }
     }
 }
+
+/**
+ * How long an unload waits for Compose to finish disposing a plugin's UI.
+ *
+ * Generous for what it waits on - a render frame is ~16ms - and short enough that a window which
+ * is never going to draw does not hold up an unload. See `PluginUiMountRegistry.awaitDisposed`.
+ */
+private const val UI_DISPOSAL_TIMEOUT_MS = 2_000L

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/registery/PanelComponentStoreSuspensionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/registery/PanelComponentStoreSuspensionTest.kt
@@ -1,0 +1,254 @@
+package ai.rever.boss.components.registery
+
+import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.PanelComponentWithUI
+import ai.rever.boss.plugin.api.PanelId
+import ai.rever.boss.plugin.api.PanelInfo
+import ai.rever.boss.plugin.api.PanelRegistry
+import ai.rever.boss.plugin.sandbox.PanelSandboxRegistry
+import ai.rever.boss.plugin.sandbox.PluginSandbox
+import ai.rever.boss.plugin.sandbox.SandboxState
+import ai.rever.boss.plugin.sandbox.health.PluginHealthMetrics
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the panel half of the unload race.
+ *
+ * Closing a plugin's tabs was never enough: nothing removed its sidebar panel before the unload,
+ * so `teardownPluginTabs` could only burn its timeout and the panel disposed against a closed
+ * classloader anyway - the exact fault the wait exists to prevent.
+ * [PanelComponentStoreRegistry.detachPanels] is the missing step, and suspension is what makes it
+ * stick: both panel hosts call [PanelComponentStore.getOrCreateComponent] during composition, so a
+ * bare `removeComponent` is undone on the next frame.
+ *
+ * The failure these guard against is asymmetric. A panel that composes too long crashes an unload;
+ * a panel that stays suspended is blank for the rest of the session. So resume is tested on the
+ * paths that have no plugin left to come back, not just the happy one.
+ *
+ * Threading: production mutates this state on the UI thread (see the KDocs). These tests run
+ * off-EDT, which is safe because each owns its stores and no composition is reading them.
+ */
+class PanelComponentStoreSuspensionTest {
+    private val pluginId = "ai.rever.boss.plugin.dynamic.secretmanager"
+    private val otherPluginId = "ai.rever.boss.plugin.dynamic.terminaltab"
+
+    private val testIcon =
+        ImageVector
+            .Builder(
+                defaultWidth = 1.dp,
+                defaultHeight = 1.dp,
+                viewportWidth = 1f,
+                viewportHeight = 1f,
+            ).build()
+
+    private fun panelInfo(id: PanelId) =
+        object : PanelInfo {
+            override val id = id
+            override val displayName = "Test Panel"
+            override val icon = testIcon
+            override val defaultSlotPosition = left
+        }
+
+    private class FakePanelComponent(
+        override val panelInfo: PanelInfo,
+        ctx: ComponentContext,
+    ) : PanelComponentWithUI,
+        ComponentContext by ctx {
+        @Composable
+        override fun Content() = Unit
+    }
+
+    /** Enough of a sandbox to own a panel in [PanelSandboxRegistry]; only `pluginId` is read. */
+    private class FakeSandbox(
+        override val pluginId: String,
+    ) : PluginSandbox {
+        override val state: StateFlow<SandboxState> = MutableStateFlow(SandboxState.RUNNING)
+        override val healthMetrics: StateFlow<PluginHealthMetrics> = MutableStateFlow(PluginHealthMetrics())
+        override val sandboxScope = CoroutineScope(SupervisorJob())
+
+        override fun recordHeartbeat() = Unit
+
+        override fun recordSuccess() = Unit
+
+        override fun recordError(error: Throwable) = Unit
+
+        override suspend fun start() = Result.success(Unit)
+
+        override suspend fun stop() = Result.success(Unit)
+
+        override suspend fun restart() = Result.success(Unit)
+
+        override fun markUnhealthy() = Unit
+
+        override fun resetHealth() = Unit
+
+        override fun resetRestartAttempts() = Unit
+    }
+
+    private fun newContext(): ComponentContext = DefaultComponentContext(LifecycleRegistry())
+
+    private fun newStore(vararg ids: PanelId): PanelComponentStore {
+        val registry = PanelRegistry()
+        ids.forEach { id ->
+            registry.registerPanel(panelInfo(id)) { ctx, info -> FakePanelComponent(info, ctx) }
+        }
+        return PanelComponentStore(newContext(), registry)
+    }
+
+    private fun ownedPanel(
+        name: String,
+        owner: String,
+    ): PanelId {
+        val id = PanelId(name, 1)
+        PanelSandboxRegistry.register(id, FakeSandbox(owner))
+        return id
+    }
+
+    @BeforeTest
+    fun setUp() {
+        PanelSandboxRegistry.clear()
+        PanelComponentStoreRegistry.clearSuspensions()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        PanelSandboxRegistry.clear()
+        PanelComponentStoreRegistry.clearSuspensions()
+    }
+
+    @Test
+    fun `detaching drops the cached component and keeps it from coming back`() {
+        val id = ownedPanel("secrets", pluginId)
+        val store = newStore(id)
+        PanelComponentStoreRegistry.register("window-1", store)
+        assertNotNull(store.getOrCreateComponent(id), "precondition: the panel is open")
+
+        val detached = PanelComponentStoreRegistry.detachPanels(pluginId)
+
+        assertEquals(1, detached, "the open panel should have been detached")
+        assertFalse(store.activeComponents.containsKey(id), "and dropped from the store")
+        assertNull(
+            store.getOrCreateComponent(id),
+            "the next frame must NOT re-instantiate it - that is the whole point of suspending, " +
+                "since both panel hosts call getOrCreateComponent from composition",
+        )
+
+        PanelComponentStoreRegistry.unregister("window-1")
+    }
+
+    @Test
+    fun `resuming lets the panel come back, rebuilt rather than restored`() {
+        val id = ownedPanel("secrets", pluginId)
+        val store = newStore(id)
+        PanelComponentStoreRegistry.register("window-1", store)
+        val before = store.getOrCreateComponent(id)
+
+        PanelComponentStoreRegistry.detachPanels(pluginId)
+        PanelComponentStoreRegistry.resumePanels(pluginId)
+
+        val after = store.getOrCreateComponent(id)
+        assertNotNull(after, "resume must let the slot fill again")
+        assertNotSame(before, after, "and from the current factory - a reload is why we detached")
+
+        PanelComponentStoreRegistry.unregister("window-1")
+    }
+
+    @Test
+    fun `detaching one plugin leaves another plugin's panel alone`() {
+        val mine = ownedPanel("secrets", pluginId)
+        val theirs = ownedPanel("terminal", otherPluginId)
+        val store = newStore(mine, theirs)
+        PanelComponentStoreRegistry.register("window-1", store)
+        store.getOrCreateComponent(mine)
+        val untouched = store.getOrCreateComponent(theirs)
+
+        PanelComponentStoreRegistry.detachPanels(pluginId)
+
+        assertFalse(PanelComponentStoreRegistry.isSuspended(otherPluginId))
+        assertEquals(
+            untouched,
+            store.getOrCreateComponent(theirs),
+            "an unload of one plugin must not disturb another's panel - they share the store",
+        )
+
+        PanelComponentStoreRegistry.unregister("window-1")
+    }
+
+    @Test
+    fun `detaching reaches every window`() {
+        val id = ownedPanel("secrets", pluginId)
+        val storeA = newStore(id)
+        val storeB = newStore(id)
+        PanelComponentStoreRegistry.register("window-1", storeA)
+        PanelComponentStoreRegistry.register("window-2", storeB)
+        storeA.getOrCreateComponent(id)
+        storeB.getOrCreateComponent(id)
+
+        val detached = PanelComponentStoreRegistry.detachPanels(pluginId)
+
+        assertEquals(2, detached, "one unload, every window - the loader is process-wide")
+        assertFalse(storeA.activeComponents.containsKey(id))
+        assertFalse(storeB.activeComponents.containsKey(id))
+
+        PanelComponentStoreRegistry.unregister("window-1")
+        PanelComponentStoreRegistry.unregister("window-2")
+    }
+
+    @Test
+    fun `a panel with no sandbox is never suspended`() {
+        val id = PanelId("host-owned", 1)
+        val store = newStore(id)
+        PanelComponentStoreRegistry.register("window-1", store)
+        val hostPanel = store.getOrCreateComponent(id)
+
+        PanelComponentStoreRegistry.detachPanels(pluginId)
+
+        assertEquals(
+            hostPanel,
+            store.getOrCreateComponent(id),
+            "host panels have no owning plugin, so no unload can take them off screen",
+        )
+
+        PanelComponentStoreRegistry.unregister("window-1")
+    }
+
+    @Test
+    fun `resume works for a plugin that never came back`() {
+        val id = ownedPanel("secrets", pluginId)
+        val store = newStore(id)
+        PanelComponentStoreRegistry.register("window-1", store)
+        store.getOrCreateComponent(id)
+        PanelComponentStoreRegistry.detachPanels(pluginId)
+
+        // A remove, or a reload that failed: the plugin is gone, so nothing re-registers its
+        // panels. Resume still has to clear, or the slot is blank until the app restarts.
+        PanelSandboxRegistry.clear()
+        PanelComponentStoreRegistry.resumePanels(pluginId)
+
+        assertFalse(
+            PanelComponentStoreRegistry.isSuspended(pluginId),
+            "a suspension that outlives its unload blanks the slot for the rest of the session",
+        )
+        assertTrue(store.activeComponents.isEmpty(), "and the stale component stays gone")
+
+        PanelComponentStoreRegistry.unregister("window-1")
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -385,17 +385,12 @@ fun PluginErrorBoundary(
                 PluginCrashRegistry.recordCrash(pluginId, e)
             }
         }
-    // Mounted/disposed is recorded HERE rather than at the two call sites, because this boundary
-    // is what every plugin surface goes through - a tab, a sidebar panel, and whatever is added
-    // next. The unload path waits on it: Compose disposes a removed tab on a later frame, and that
-    // frame is what runs the plugin's own onDispose lambdas, which cannot resolve once its
-    // classloader has closed. See PluginUiMountRegistry.
+    // Unregistering the crash interceptor covers the WHOLE boundary, fallback included: it has to
+    // stay armed while the fallback is on screen, because Restart re-enters content() through this
+    // same boundary. Mount counting deliberately does NOT live here - it is in the content branch
+    // below, because the two have different lifetimes.
     DisposableEffect(pluginId) {
-        PluginUiMountRegistry.onMounted(pluginId)
-        onDispose {
-            PluginUiMountRegistry.onDisposed(pluginId)
-            crashRegistration?.invoke()
-        }
+        onDispose { crashRegistration?.invoke() }
     }
 
     // Check sandbox state — if DISABLED (e.g. binary incompatibility), show error
@@ -468,6 +463,26 @@ fun PluginErrorBoundary(
             },
         )
     } else {
+        // Mounted/disposed is recorded in THIS branch rather than above the if, because the
+        // registry answers one question - "is plugin code composed?" - and a boundary rendering
+        // the fallback composes none of it. Such a boundary has no plugin onDispose lambdas for
+        // the unload path to wait on, so counting it held the wait open for nothing: every unload
+        // of a crashed plugin paid the full timeout, on the path (crash recovery) that could least
+        // afford the delay. PluginRenderRecovery.registerMounted sits in this branch for the
+        // mirror-image reason; the two now agree on what "mounted" means.
+        //
+        // Recorded at the boundary rather than at the call sites because this is what every
+        // plugin surface goes through - a tab, a sidebar panel, and whatever is added next.
+        //
+        // FIRST in the branch and OUTSIDE CompositionLocalProvider, so it stays the outermost
+        // remember here: Compose dispatches observers inner-before-outer, so the count drops
+        // LAST, after the plugin's own onDispose lambdas have run. That ordering is the whole
+        // point of the registry - see its KDoc.
+        DisposableEffect(pluginId) {
+            PluginUiMountRegistry.onMounted(pluginId)
+            onDispose { PluginUiMountRegistry.onDisposed(pluginId) }
+        }
+
         // Note: Heartbeats are recorded automatically by the sandbox's heartbeat job
         // (InProcessPluginSandbox.startHeartbeatJob), so we don't need to record them here.
 

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginErrorBoundary.kt
@@ -385,8 +385,15 @@ fun PluginErrorBoundary(
                 PluginCrashRegistry.recordCrash(pluginId, e)
             }
         }
+    // Mounted/disposed is recorded HERE rather than at the two call sites, because this boundary
+    // is what every plugin surface goes through - a tab, a sidebar panel, and whatever is added
+    // next. The unload path waits on it: Compose disposes a removed tab on a later frame, and that
+    // frame is what runs the plugin's own onDispose lambdas, which cannot resolve once its
+    // classloader has closed. See PluginUiMountRegistry.
     DisposableEffect(pluginId) {
+        PluginUiMountRegistry.onMounted(pluginId)
         onDispose {
+            PluginUiMountRegistry.onDisposed(pluginId)
             crashRegistration?.invoke()
         }
     }

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistry.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistry.kt
@@ -1,0 +1,78 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * How much of each plugin's UI is currently mounted in a composition.
+ *
+ * This exists for ONE question, asked at exactly one moment: **has this plugin's UI actually been
+ * disposed yet?** - and the answer has to be true before its classloader closes.
+ *
+ * Closing a plugin's tabs is not that answer. Removing a tab mutates the tab model on the EDT and
+ * returns; Compose disposes the subtree on a LATER render frame, and it is that frame which runs
+ * the plugin's own `onDispose` lambdas. Unloading between the two resolves those lambdas against a
+ * closed loader, which is a `NoClassDefFoundError` the loader itself explains:
+ *
+ * > Plugin classloader for '...' is UNLOADED; refusing to resolve '...' against the host
+ * > classloader. Something still referenced the plugin after it was unloaded - that reference is
+ * > the bug.
+ *
+ * The reference in that message is the still-mounted composition. Waiting on this registry is how
+ * the unload path stops racing it.
+ *
+ * Counted rather than flagged, because one plugin can have several surfaces up at once - a tab in
+ * each of two windows, a tab and a sidebar panel - and they dispose independently.
+ */
+object PluginUiMountRegistry {
+    private val _mounted = MutableStateFlow<Map<String, Int>>(emptyMap())
+
+    /** Plugin id to the number of its boundaries currently mounted. Absent means none. */
+    val mounted: StateFlow<Map<String, Int>> = _mounted.asStateFlow()
+
+    /** A plugin boundary entered the composition. */
+    fun onMounted(pluginId: String) {
+        _mounted.update { it + (pluginId to (it[pluginId] ?: 0) + 1) }
+    }
+
+    /** A plugin boundary left the composition, for real - this runs from `onDispose`. */
+    fun onDisposed(pluginId: String) {
+        _mounted.update { current ->
+            val next = (current[pluginId] ?: 0) - 1
+            if (next <= 0) current - pluginId else current + (pluginId to next)
+        }
+    }
+
+    /** Whether any of [pluginId]'s UI is mounted, or any plugin's when null. */
+    fun isMounted(pluginId: String? = null): Boolean =
+        if (pluginId == null) _mounted.value.isNotEmpty() else _mounted.value.containsKey(pluginId)
+
+    /**
+     * Suspend until [pluginId]'s UI is fully disposed - or every plugin's, when null.
+     *
+     * Returns true when it got there, false on timeout. **The timeout is not a formality**: nothing
+     * guarantees a render frame will arrive. A minimised or fully occluded window may not draw at
+     * all, and blocking an unload on a frame that never comes would hang the app instead of risking
+     * a fault the crash boundary already contains. A caller that times out should say so and carry
+     * on.
+     */
+    suspend fun awaitDisposed(
+        pluginId: String? = null,
+        timeoutMillis: Long,
+    ): Boolean =
+        withTimeoutOrNull(timeoutMillis) {
+            _mounted.first { current ->
+                if (pluginId == null) current.isEmpty() else !current.containsKey(pluginId)
+            }
+            true
+        } ?: false
+
+    /** For tests, and for a headless host that never mounts anything. */
+    fun reset() {
+        _mounted.value = emptyMap()
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistry.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistry.kt
@@ -28,6 +28,12 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Counted rather than flagged, because one plugin can have several surfaces up at once - a tab in
  * each of two windows, a tab and a sidebar panel - and they dispose independently.
  *
+ * "Mounted" means **plugin code is composed**, not "a boundary exists". A boundary rendering the
+ * error fallback does not count: it composes none of the plugin, so it has no plugin `onDispose`
+ * lambdas for an unload to wait on, and counting it only made every unload of a crashed plugin pay
+ * the full timeout - worst on crash recovery, which closes tabs before disabling. That is why the
+ * registering effect lives in the boundary's content branch rather than above it.
+ *
  * **The count must drop LAST**, after the plugin's own `onDispose` lambdas have run, or this
  * reports "disposed" while the very lambdas the caller is waiting for are still to execute. That
  * holds today because the registering effect is the OUTERMOST one in the boundary and Compose

--- a/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistry.kt
+++ b/plugin-platform/plugin-sandbox/src/commonMain/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistry.kt
@@ -27,6 +27,18 @@ import kotlinx.coroutines.withTimeoutOrNull
  *
  * Counted rather than flagged, because one plugin can have several surfaces up at once - a tab in
  * each of two windows, a tab and a sidebar panel - and they dispose independently.
+ *
+ * **The count must drop LAST**, after the plugin's own `onDispose` lambdas have run, or this
+ * reports "disposed" while the very lambdas the caller is waiting for are still to execute. That
+ * holds today because the registering effect is the OUTERMOST one in the boundary and Compose
+ * dispatches remember observers in reverse slot order - inner before outer. It is written down
+ * because nothing enforces it: if that order ever inverted, this would go quiet and the fault would
+ * come back with no test failing.
+ *
+ * **Leak-tolerant, deliberately.** A boundary whose `onDispose` never runs pins its id here for the
+ * rest of the session, and every later unload of that plugin then pays the full timeout. That is
+ * the safe direction - waiting too long beats closing a loader too early - and the timeout warning
+ * names what is still mounted, which is what makes such a leak visible at all.
  */
 object PluginUiMountRegistry {
     private val _mounted = MutableStateFlow<Map<String, Int>>(emptyMap())
@@ -52,7 +64,16 @@ object PluginUiMountRegistry {
         if (pluginId == null) _mounted.value.isNotEmpty() else _mounted.value.containsKey(pluginId)
 
     /**
-     * Suspend until [pluginId]'s UI is fully disposed - or every plugin's, when null.
+     * Suspend until none of [pluginIds] has UI mounted.
+     *
+     * **Named plugins, not "everything".** The caller is about to close a specific set of
+     * classloaders, and those are the only surfaces whose disposal can race it. Waiting on every
+     * plugin instead would mean waiting on UI that is deliberately staying up: sidebar panels
+     * survive an API-layer swap by design and re-register on the far side, so an "is anything
+     * mounted" predicate could never come true while one was open - it would burn the whole
+     * timeout on every swap and log a warning that reads like the fix failed.
+     *
+     * An empty set returns immediately, which is the common case and must not pay the timeout.
      *
      * Returns true when it got there, false on timeout. **The timeout is not a formality**: nothing
      * guarantees a render frame will arrive. A minimised or fully occluded window may not draw at
@@ -61,17 +82,27 @@ object PluginUiMountRegistry {
      * on.
      */
     suspend fun awaitDisposed(
-        pluginId: String? = null,
+        pluginIds: Set<String>,
         timeoutMillis: Long,
-    ): Boolean =
-        withTimeoutOrNull(timeoutMillis) {
-            _mounted.first { current ->
-                if (pluginId == null) current.isEmpty() else !current.containsKey(pluginId)
-            }
+    ): Boolean {
+        if (pluginIds.isEmpty()) return true
+        return withTimeoutOrNull(timeoutMillis) {
+            _mounted.first { current -> pluginIds.none(current::containsKey) }
             true
         } ?: false
+    }
 
-    /** For tests, and for a headless host that never mounts anything. */
+    /** Which of [pluginIds] still have UI mounted, for a caller reporting a timeout. */
+    fun stillMounted(pluginIds: Set<String>): Map<String, Int> = _mounted.value.filterKeys(pluginIds::contains)
+
+    /**
+     * Empty the map. **Test-only, and process-wide.**
+     *
+     * Not concurrency-safe against a live composition: this module runs Compose UI tests in the
+     * same JVM, so a test that resets while another has a boundary mounted will drop that mount and
+     * the later dispose will decrement from zero. Reset in setUp/tearDown of tests that own what is
+     * mounted, and nowhere else.
+     */
     fun reset() {
         _mounted.value = emptyMap()
     }

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistryTest.kt
@@ -1,0 +1,123 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the signal the unload path waits on before closing a plugin's classloader.
+ *
+ * The bug it exists for: closing a plugin's tabs mutates the tab model on the EDT and returns,
+ * while Compose disposes the subtree on a LATER render frame - and that frame is what runs the
+ * plugin's own `onDispose` lambdas. Unloading in between leaves those lambdas unable to resolve
+ * their own classes, which surfaces as a `NoClassDefFoundError` blaming a reference that outlived
+ * the unload. Waiting on this registry is what closes that window.
+ *
+ * The timeout half is as load-bearing as the waiting half: a window that never draws would
+ * otherwise hang an unload forever.
+ */
+class PluginUiMountRegistryTest {
+    @BeforeTest
+    fun setUp() = PluginUiMountRegistry.reset()
+
+    @AfterTest
+    fun tearDown() = PluginUiMountRegistry.reset()
+
+    @Test
+    fun `a mounted plugin is mounted until it is disposed`() {
+        PluginUiMountRegistry.onMounted("terminal")
+
+        assertTrue(PluginUiMountRegistry.isMounted("terminal"))
+        assertTrue(PluginUiMountRegistry.isMounted(), "any plugin at all")
+
+        PluginUiMountRegistry.onDisposed("terminal")
+
+        assertFalse(PluginUiMountRegistry.isMounted("terminal"))
+        assertFalse(PluginUiMountRegistry.isMounted())
+    }
+
+    @Test
+    fun `surfaces are counted, not flagged`() {
+        // One plugin can have a tab in each of two windows, or a tab and a sidebar panel. They
+        // dispose independently, and the first one to go must not report the plugin as gone -
+        // which is exactly when the loader would close under the second.
+        PluginUiMountRegistry.onMounted("terminal")
+        PluginUiMountRegistry.onMounted("terminal")
+        PluginUiMountRegistry.onDisposed("terminal")
+
+        assertTrue(PluginUiMountRegistry.isMounted("terminal"), "one surface is still up")
+
+        PluginUiMountRegistry.onDisposed("terminal")
+        assertFalse(PluginUiMountRegistry.isMounted("terminal"))
+    }
+
+    @Test
+    fun `awaiting does not return until the last surface disposes`() =
+        runBlocking {
+            // Asserted as "had the dispose happened yet", not as "did it return true". The first
+            // version of this test only checked the return value, which is true whether the wait
+            // waited or returned instantly - so it passed against the very behaviour it was
+            // written to catch.
+            PluginUiMountRegistry.onMounted("terminal")
+            var disposeHappened = false
+
+            val waiter =
+                async {
+                    val reached = PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 5_000)
+                    reached to disposeHappened
+                }
+            delay(20)
+            disposeHappened = true
+            PluginUiMountRegistry.onDisposed("terminal")
+
+            val (reached, sawDispose) = waiter.await()
+            assertTrue(reached, "the wait must end on the dispose, not on the timeout")
+            assertTrue(sawDispose, "the wait returned before the surface had disposed")
+        }
+
+    @Test
+    fun `awaiting nothing returns immediately`() =
+        runBlocking {
+            // The common case: an unload with no plugin UI on screen must not pay the timeout.
+            assertTrue(PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 5_000))
+            assertTrue(PluginUiMountRegistry.awaitDisposed(null, timeoutMillis = 5_000))
+        }
+
+    @Test
+    fun `a surface that never disposes times out rather than hanging`() =
+        runBlocking {
+            // A window that is minimised or fully occluded may never draw another frame. Blocking
+            // an unload on it would be worse than the fault the crash boundary already contains.
+            PluginUiMountRegistry.onMounted("terminal")
+
+            assertFalse(PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 50))
+        }
+
+    @Test
+    fun `awaiting one plugin ignores another still on screen`() =
+        runBlocking {
+            // Unloading one plugin must not wait on an unrelated plugin's UI, which is not going
+            // anywhere and whose loader is not closing.
+            PluginUiMountRegistry.onMounted("editor")
+
+            assertTrue(PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 5_000))
+            assertFalse(PluginUiMountRegistry.awaitDisposed(null, timeoutMillis = 50), "but 'all' waits for it")
+        }
+
+    @Test
+    fun `disposing more than was mounted does not go negative`() {
+        // Compose can dispose a boundary whose mount this registry never saw - a composition that
+        // existed before a reset, for instance. Going negative would then hide a later real mount.
+        PluginUiMountRegistry.onDisposed("terminal")
+        PluginUiMountRegistry.onMounted("terminal")
+
+        assertTrue(PluginUiMountRegistry.isMounted("terminal"))
+        assertEquals(1, PluginUiMountRegistry.mounted.value["terminal"])
+    }
+}

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistryTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountRegistryTest.kt
@@ -69,7 +69,7 @@ class PluginUiMountRegistryTest {
 
             val waiter =
                 async {
-                    val reached = PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 5_000)
+                    val reached = PluginUiMountRegistry.awaitDisposed(setOf("terminal"), timeoutMillis = 5_000)
                     reached to disposeHappened
                 }
             delay(20)
@@ -85,8 +85,8 @@ class PluginUiMountRegistryTest {
     fun `awaiting nothing returns immediately`() =
         runBlocking {
             // The common case: an unload with no plugin UI on screen must not pay the timeout.
-            assertTrue(PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 5_000))
-            assertTrue(PluginUiMountRegistry.awaitDisposed(null, timeoutMillis = 5_000))
+            assertTrue(PluginUiMountRegistry.awaitDisposed(setOf("terminal"), timeoutMillis = 5_000))
+            assertTrue(PluginUiMountRegistry.awaitDisposed(setOf("terminal", "editor"), timeoutMillis = 5_000))
         }
 
     @Test
@@ -96,18 +96,43 @@ class PluginUiMountRegistryTest {
             // an unload on it would be worse than the fault the crash boundary already contains.
             PluginUiMountRegistry.onMounted("terminal")
 
-            assertFalse(PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 50))
+            assertFalse(PluginUiMountRegistry.awaitDisposed(setOf("terminal"), timeoutMillis = 50))
         }
 
     @Test
     fun `awaiting one plugin ignores another still on screen`() =
         runBlocking {
             // Unloading one plugin must not wait on an unrelated plugin's UI, which is not going
-            // anywhere and whose loader is not closing.
+            // anywhere and whose loader is not closing. This is what keeps a sidebar panel that
+            // deliberately survives an API swap from burning the whole timeout on every swap.
             PluginUiMountRegistry.onMounted("editor")
 
-            assertTrue(PluginUiMountRegistry.awaitDisposed("terminal", timeoutMillis = 5_000))
-            assertFalse(PluginUiMountRegistry.awaitDisposed(null, timeoutMillis = 50), "but 'all' waits for it")
+            assertTrue(PluginUiMountRegistry.awaitDisposed(setOf("terminal"), timeoutMillis = 5_000))
+            assertFalse(
+                PluginUiMountRegistry.awaitDisposed(setOf("terminal", "editor"), timeoutMillis = 50),
+                "a set that names the mounted plugin must wait for it",
+            )
+        }
+
+    @Test
+    fun `awaiting an empty set returns immediately`() =
+        runBlocking {
+            // An unload with no sandboxed surfaces at all. It must not pay the timeout, and it
+            // must not wait on unrelated plugins that happen to be mounted.
+            PluginUiMountRegistry.onMounted("editor")
+
+            assertTrue(PluginUiMountRegistry.awaitDisposed(emptySet(), timeoutMillis = 50))
+        }
+
+    @Test
+    fun `stillMounted reports only the plugins that were awaited`() =
+        runBlocking {
+            // The timeout warning is built from this. Listing every mounted plugin named ones with
+            // nothing to do with the unload, which is what made the line unactionable.
+            PluginUiMountRegistry.onMounted("terminal")
+            PluginUiMountRegistry.onMounted("editor")
+
+            assertEquals(mapOf("terminal" to 1), PluginUiMountRegistry.stillMounted(setOf("terminal")))
         }
 
     @Test

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountWiringTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountWiringTest.kt
@@ -1,0 +1,137 @@
+package ai.rever.boss.plugin.sandbox.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the WIRING, which the registry's own tests cannot see.
+ *
+ * `PluginUiMountRegistryTest` proves the registry counts and waits correctly. That is worth
+ * nothing if the boundary never calls it - the registry would stay empty, every wait would return
+ * instantly, and the whole fix would be inert while its unit tests stayed green. This mounts a real
+ * boundary and watches the count.
+ *
+ * It also pins the ordering the fix rests on: **the count must drop AFTER the plugin content's own
+ * onDispose has run.** If it dropped first, the unload would be told "disposed" while the very
+ * lambdas it is waiting for were still to execute - the original bug, restored, with nothing else
+ * in the suite noticing. Compose dispatches remember observers inner-first, so the boundary's
+ * effect (outermost) runs last; this test fails if that ever inverts.
+ */
+@OptIn(ExperimentalTestApi::class)
+class PluginUiMountWiringTest {
+    @BeforeTest
+    fun setUp() = PluginUiMountRegistry.reset()
+
+    @AfterTest
+    fun tearDown() = PluginUiMountRegistry.reset()
+
+    @Test
+    fun `a mounted boundary is counted, and stops being counted when it goes`() =
+        runComposeUiTest {
+            var mounted by mutableStateOf(true)
+            setContent {
+                Box(Modifier) {
+                    if (mounted) {
+                        BoundaryUnderTest { }
+                    }
+                }
+            }
+
+            waitForIdle()
+            assertTrue(PluginUiMountRegistry.isMounted(PLUGIN_ID), "the boundary did not register")
+
+            mounted = false
+            waitForIdle()
+            assertFalse(PluginUiMountRegistry.isMounted(PLUGIN_ID), "the boundary did not unregister")
+        }
+
+    @Test
+    fun `two boundaries for one plugin are counted separately`() =
+        runComposeUiTest {
+            // A tab and a sidebar panel, or a tab in each of two windows. The first to go must not
+            // report the plugin as gone - that is exactly when the loader would close under the
+            // second.
+            var second by mutableStateOf(true)
+            setContent {
+                Box(Modifier) {
+                    BoundaryUnderTest { }
+                    if (second) {
+                        BoundaryUnderTest { }
+                    }
+                }
+            }
+
+            waitForIdle()
+            assertEquals(2, PluginUiMountRegistry.mounted.value[PLUGIN_ID])
+
+            second = false
+            waitForIdle()
+            assertTrue(PluginUiMountRegistry.isMounted(PLUGIN_ID), "one surface is still up")
+            assertEquals(1, PluginUiMountRegistry.mounted.value[PLUGIN_ID])
+        }
+
+    @Test
+    fun `the count drops only after the plugin's own onDispose has run`() =
+        runComposeUiTest {
+            // The ordering the whole fix depends on. The content's onDispose stands in for a
+            // plugin's - the lambda that, in the real bug, could no longer resolve its own class.
+            var mounted by mutableStateOf(true)
+            var countWhenContentDisposed: Int? = null
+
+            setContent {
+                Box(Modifier) {
+                    if (mounted) {
+                        BoundaryUnderTest {
+                            DisposableEffect(Unit) {
+                                onDispose {
+                                    countWhenContentDisposed = PluginUiMountRegistry.mounted.value[PLUGIN_ID]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            waitForIdle()
+            mounted = false
+            waitForIdle()
+
+            assertEquals(
+                1,
+                countWhenContentDisposed,
+                "the registry said 'disposed' while the plugin's own onDispose was still to run - " +
+                    "an unload waiting on it would close the classloader too early",
+            )
+            assertFalse(PluginUiMountRegistry.isMounted(PLUGIN_ID), "and it must be zero afterwards")
+        }
+}
+
+/**
+ * The registering half of `PluginErrorBoundary`, mounted on its own.
+ *
+ * The real boundary needs a `PluginSandbox` and a crash interceptor; this is the DisposableEffect
+ * under test and nothing else, in the same position - outermost, around the content.
+ */
+@Composable
+private fun BoundaryUnderTest(content: @Composable () -> Unit) {
+    DisposableEffect(PLUGIN_ID) {
+        PluginUiMountRegistry.onMounted(PLUGIN_ID)
+        onDispose { PluginUiMountRegistry.onDisposed(PLUGIN_ID) }
+    }
+    content()
+}
+
+private const val PLUGIN_ID = "ai.rever.boss.plugin.dynamic.terminaltab"

--- a/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountWiringTest.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopTest/kotlin/ai/rever/boss/plugin/sandbox/ui/PluginUiMountWiringTest.kt
@@ -1,5 +1,8 @@
 package ai.rever.boss.plugin.sandbox.ui
 
+import ai.rever.boss.plugin.sandbox.PluginSandbox
+import ai.rever.boss.plugin.sandbox.SandboxState
+import ai.rever.boss.plugin.sandbox.health.PluginHealthMetrics
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -9,6 +12,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -21,8 +28,15 @@ import kotlin.test.assertTrue
  *
  * `PluginUiMountRegistryTest` proves the registry counts and waits correctly. That is worth
  * nothing if the boundary never calls it - the registry would stay empty, every wait would return
- * instantly, and the whole fix would be inert while its unit tests stayed green. This mounts a real
- * boundary and watches the count.
+ * instantly, and the whole fix would be inert while its unit tests stayed green.
+ *
+ * Two kinds of test live here, and the difference matters:
+ *
+ * - The `BoundaryUnderTest` tests use a **replica** of the registering effect. They pin the
+ *   ordering contract cheaply, but they would all still pass if the registration were deleted from
+ *   the real `PluginErrorBoundary` - they cannot see the wiring they are named for.
+ * - The `PluginErrorBoundary` tests drive the **real composable** through a fake sandbox. Those are
+ *   the ones that fail if the effect goes missing or moves out of the content branch.
  *
  * It also pins the ordering the fix rests on: **the count must drop AFTER the plugin content's own
  * onDispose has run.** If it dropped first, the unload would be told "disposed" while the very
@@ -117,13 +131,93 @@ class PluginUiMountWiringTest {
             )
             assertFalse(PluginUiMountRegistry.isMounted(PLUGIN_ID), "and it must be zero afterwards")
         }
+
+    @Test
+    fun `the real boundary registers while it is rendering plugin content`() =
+        runComposeUiTest {
+            var shown by mutableStateOf(true)
+            setContent {
+                if (shown) {
+                    PluginErrorBoundary(
+                        pluginId = PLUGIN_ID,
+                        sandbox = FakeSandbox(SandboxState.RUNNING),
+                        onRestart = {},
+                    ) { Box(Modifier) }
+                }
+            }
+            waitForIdle()
+            assertTrue(
+                PluginUiMountRegistry.isMounted(PLUGIN_ID),
+                "the real PluginErrorBoundary must register - if this fails while the " +
+                    "BoundaryUnderTest tests pass, the effect was deleted or moved and every " +
+                    "unload wait is now silently instant",
+            )
+
+            shown = false
+            waitForIdle()
+            assertFalse(PluginUiMountRegistry.isMounted(PLUGIN_ID), "and unregister when it goes")
+        }
+
+    @Test
+    fun `a boundary rendering the fallback is not counted`() =
+        runComposeUiTest {
+            setContent {
+                PluginErrorBoundary(
+                    pluginId = PLUGIN_ID,
+                    // DISABLED synthesises an error, so the boundary takes the fallback branch
+                    // without needing a real crash.
+                    sandbox = FakeSandbox(SandboxState.DISABLED),
+                    onRestart = {},
+                ) { Box(Modifier) }
+            }
+            waitForIdle()
+            assertFalse(
+                PluginUiMountRegistry.isMounted(PLUGIN_ID),
+                "a fallback composes no plugin code, so it has no plugin onDispose lambdas for an " +
+                    "unload to wait on - counting it made crash recovery pay the full timeout for " +
+                    "nothing",
+            )
+        }
+}
+
+/** Enough of a [PluginSandbox] to mount the real boundary; the boundary only reads `state`. */
+private class FakeSandbox(
+    state: SandboxState,
+) : PluginSandbox {
+    override val pluginId = PLUGIN_ID
+    override val state: StateFlow<SandboxState> = MutableStateFlow(state)
+    override val healthMetrics: StateFlow<PluginHealthMetrics> = MutableStateFlow(PluginHealthMetrics())
+    override val sandboxScope = CoroutineScope(SupervisorJob())
+
+    override fun recordHeartbeat() = Unit
+
+    override fun recordSuccess() = Unit
+
+    override fun recordError(error: Throwable) = Unit
+
+    override suspend fun start() = Result.success(Unit)
+
+    override suspend fun stop() = Result.success(Unit)
+
+    override suspend fun restart() = Result.success(Unit)
+
+    override fun markUnhealthy() = Unit
+
+    override fun resetHealth() = Unit
+
+    override fun resetRestartAttempts() = Unit
 }
 
 /**
  * The registering half of `PluginErrorBoundary`, mounted on its own.
  *
- * The real boundary needs a `PluginSandbox` and a crash interceptor; this is the DisposableEffect
- * under test and nothing else, in the same position - outermost, around the content.
+ * A replica, deliberately: these three tests are about Compose's dispatch ORDER, and a replica
+ * isolates that from everything else the real boundary drags in. It proves nothing about whether
+ * the real boundary registers at all - the `PluginErrorBoundary` tests above cover that, and the
+ * two are only meaningful together.
+ *
+ * Kept in the same position as the real one - outermost, around the content, inside the branch
+ * that renders plugin code.
  */
 @Composable
 private fun BoundaryUnderTest(content: @Composable () -> Unit) {


### PR DESCRIPTION
## What happened

A contained render fault during a startup API-layer hot swap, 87ms after the
teardown that exists to prevent it:

```
03:36:22.627  Tearing down plugin tabs before API-layer swap {tabs=2}
03:36:22.6xx  Unloading plugin x N          <- classloaders close
03:36:22.714  Contained render fault         <- on a render frame
03:36:24.665  API layer hot swap complete
```

```
java.lang.NoClassDefFoundError
  at ...ProperTerminalKt$ProperTerminal$...$inlined$onDispose$1.dispose(Effects.kt:74)
  at androidx.compose.runtime.CompositionImpl.dispose(Composition.kt:945)
  at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.disposeCurrentNodes(...)
Caused by: Plugin classloader for 'ai.rever.boss.plugin.dynamic.terminaltab' is
  UNLOADED; refusing to resolve '...' against the host classloader. Something
  still referenced the plugin after it was unloaded - that reference is the bug.
```

The loader named the bug. The reference was a composition that had not been
disposed yet.

## Why the existing teardown did not prevent it

`closeTabsOnEdt` did this:

```kotlin
runOnEdtAndWait { tabs.forEach { (component, tabId) -> component.removeTabById(tabId) } }
```

That waits for the tab MODEL mutation and returns. Compose disposes the subtree on
a later render frame, and that frame is what runs the plugin's own `onDispose`
lambdas. The loaders closed in the gap. The teardown was waiting for the wrong
thing - one frame early, every time.

A second route reaches the same place: a coroutine in `TabController.wireCwdTitle`
faulting the same way. Same cause, since that coroutine is tied to the composition
that had not been torn down.

## The fix

`PluginErrorBoundary` reports mounted/disposed into a new `PluginUiMountRegistry`,
and the teardown awaits it before returning to the caller that closes loaders.

The boundary is the right place because **every plugin surface already goes
through it** - a tab (`BossMainWindowPanel`) and a sidebar panel (`SidePanel`)
today, and whatever is added next - so no call site has to remember to register.

**Counted, not flagged.** One plugin can have several surfaces up at once: a tab in
each of two windows, or a tab and a panel. They dispose independently, and the
first one to go must not report the plugin as gone - which is precisely when the
loader would close under the second.

**Bounded at two seconds.** Nothing guarantees a frame arrives: a minimised or
fully occluded window may never draw, and hanging an unload on a frame that never
comes would be worse than a fault the crash boundary already contains. On timeout
it logs what is still mounted and proceeds.

## Verification

`./gradlew :composeApp:desktopTest :plugin-platform:plugin-sandbox:desktopTest detekt ktlintCheck`
is green - 3134 tests.

`PluginUiMountRegistryTest` covers: mounted until disposed; several surfaces
counted independently; the wait ending on the dispose rather than the timeout; an
unmounted plugin not paying the timeout at all; a surface that never disposes
timing out instead of hanging; and waiting on one plugin ignoring another's UI.

**One of those tests passed against the bug when first written.** It asserted that
awaiting returned `true` - which it does whether it waits or returns instantly. It
now asserts the dispose had actually happened by the time the wait returned, and
fails against the old behaviour along with the other two.

**Not reproduced on screen.** The trigger was an API-layer swap from 1.0.84 to
1.0.86; now that the api is current it will not swap again on demand. The
equivalent live check is to disable a tab-hosting plugin from Toolbox while one of
its tabs is open - that takes the same `teardownPluginTabs` path - and confirm no
contained fault is written to `~/.boss_debug/crash-reports/`. I did not run that
one because the plugin most convenient to test with hosts this session's terminal.
