### PR TITLE
fix(browser): page-helper injection deadlocked the JxBrowser RPC thread

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -94,6 +94,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -695,6 +696,43 @@ internal class BrowserHandleImpl(
                 },
         )
 
+    // Off-thread executor for the per-commit renderer-pid capture and page-helper injection.
+    //
+    // Same hazard the two above are built around, and the one place that was still running it
+    // unguarded. Both of those round trips were made straight from the NavigationFinished
+    // callback, which JxBrowser delivers on its RPC thread — the same thread that has to pump
+    // the reply. `executeJavaScript` there re-enters RpcThreadCallExecutor and parks on a queue
+    // only the thread it is blocking could drain, so the call can never be answered. Every later
+    // blocking call on that browser then waits behind it: the EDT freezes inside its own
+    // executeJavaScript, and the AppKit main thread freezes behind the EDT, taking the menu bar
+    // with it. A single unanswerable round trip is enough to hang the whole app.
+    //
+    // One thread, and daemon, for the reason contextMenuExecutor spells out: nothing can
+    // interrupt a call already inside executeJavaScript, so a wedged renderer costs one parked
+    // thread and later injections queue behind it.
+    private val pageInjectExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "boss-page-inject-$id").apply { isDaemon = true }
+        }
+    private val pageInjectDispatcher = pageInjectExecutor.asCoroutineDispatcher()
+
+    private val pageInjectScope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.Default +
+                CoroutineExceptionHandler { _, error ->
+                    logger.warn(LogCategory.BROWSER, "Page-helper injection failed", error = error)
+                },
+        )
+
+    /**
+     * The in-flight commit follow-up, swapped atomically.
+     *
+     * A redirect chain fires NavigationFinished repeatedly and only the document that finally
+     * sticks is worth injecting into, exactly as for [frameStallJob].
+     */
+    private val pageInjectJob = AtomicReference<Job?>(null)
+
     // Lock for thread-safe browser operations
     private val browserLock = ReentrantReadWriteLock()
 
@@ -1106,14 +1144,36 @@ internal class BrowserHandleImpl(
                     // value in place. Either produces the "wrong number that looks right" the
                     // whole design is built to avoid. Refreshing on every commit makes the only
                     // failure mode "unknown".
+                    //
+                    // `mainFrame()` is the one call still made here: it is what names the
+                    // document this commit is about, so reading it later would race the next
+                    // navigation. Everything after it is a blocking round trip and moves to
+                    // [pageInjectDispatcher] — see the note there for what running them on this
+                    // thread does.
                     val frame = browser.mainFrame().orElse(null)
-                    rendererPid.onCommit(frame?.let { runCatching { it.renderProcess().pid() }.getOrNull() })
+
+                    // Cleared synchronously, so the previous document's renderer is never the
+                    // answer for this one even while the real capture is still in flight. That
+                    // is the refresh-on-every-commit rule above, and "unknown" is the failure
+                    // mode RendererPid is built to prefer.
+                    rendererPid.onCommit(null)
 
                     // Skip injection for about:blank pages (used for dashboard display)
                     // Only inject into actual web pages
-                    if (frame != null && url.isNotEmpty() && url != "about:blank") {
-                        injectPageHelpers(frame)
-                    }
+                    val injectTarget = frame?.takeIf { url.isNotEmpty() && url != "about:blank" }
+                    val followUp =
+                        pageInjectScope.launch(pageInjectDispatcher) {
+                            val pid = frame?.let { runCatching { it.renderProcess().pid() }.getOrNull() }
+                            // A superseded commit must not write: by now the pid names a
+                            // document that is no longer current, which is precisely the
+                            // plausible-looking wrong number RendererPid exists to refuse. The
+                            // supersede below cannot interrupt a call already inside JxBrowser,
+                            // so the check has to happen here, after it returns.
+                            ensureActive()
+                            rendererPid.onCommit(pid)
+                            if (injectTarget != null) injectPageHelpers(injectTarget)
+                        }
+                    pageInjectJob.getAndSet(followUp)?.cancel()
                 }
             }
 
@@ -3302,6 +3362,13 @@ internal class BrowserHandleImpl(
         // exit, and interrupting it would buy nothing.
         contextMenuScope.cancel()
         contextMenuExecutor.shutdown()
+        // A pending commit follow-up outlives the tab otherwise, and its next act is a blocking
+        // round trip against a browser being torn down. shutdown() not shutdownNow(), for the
+        // reason the two above give: the thread is daemon and a call already inside JxBrowser
+        // cannot be interrupted, so interrupting would buy nothing.
+        pageInjectJob.getAndSet(null)?.cancel()
+        pageInjectScope.cancel()
+        pageInjectExecutor.shutdown()
         // Drop this browser's injectors, WITHOUT unclaiming the shared callback slot - that slot
         // belongs to BrowserInjectDispatcher on behalf of every registered injector, and removing
         // it here would tear down another feature's hook as a side effect of this teardown.


### PR DESCRIPTION
## The hang

BOSS freezes completely — window unresponsive, and the macOS menu bar won't even
drop down. It is a hard deadlock; the app never recovers.

Three threads, from a `jstack` of a hung 9.4.36:

```
"Browser Thread: f1891283-…"
  RpcThreadImpl$TaskRunner.processTasks          ← the RPC thread's task loop
   └ EventStream.dispatch → notifyObservers
      └ BrowserHandleImpl.setupEventListeners$lambda$1   (:1115)
         └ BrowserHandleImpl.injectPageHelpers           (:1618)
            └ FrameImpl.executeJavaScript → ServiceConnectionImpl.invoke
               └ RpcThreadCallExecutor.execute
                  └ RpcThreadImpl$TaskRunner.processTasks:175
                     └ LinkedBlockingQueue.take          ← PARKED FOREVER
```

`NavigationFinished` is delivered on JxBrowser's RPC thread. `injectPageHelpers`
makes a **blocking** `executeJavaScript` call from inside that callback, which
re-enters `RpcThreadCallExecutor` and blocks on a queue that only the very thread
it is blocking could drain. The reply can never arrive.

Once that thread is wedged, every response path for the browser is gone:

- `AWT-EventQueue-0` — parked in `executeJavaScript` (`:2206`) → **EDT dead, UI frozen**
- `boss-frame-probe-…` — parked in `readFrameBeacon` (`:767`)
- AppKit main thread — parked in a nested run loop under `-[NSMenu _sendMenuOpeningNotification:]`
  → `menuWillOpen:` → JNI → waiting on the dead EDT → **menu bar frozen**

`renderProcess().pid()`, two lines above the injection, is a blocking round trip
on that same thread and can wedge it the same way.

Not a recent regression — reproduced identically on 9.4.36 and on 9.4.33, and
`BrowserHandleImpl.kt` is unchanged between them.

## The fix

The file already solves this exact problem twice — `contextMenuExecutor` and
`frameProbeExecutor` both exist because a blocking JS round trip must not run on
the JxBrowser callback thread, and both document why. The commit path was the one
place still doing it unguarded. This applies the same pattern:

- both round trips move to a dedicated single daemon thread (`boss-page-inject-<id>`)
- the in-flight follow-up is superseded per commit, as `frameStallJob` does, so a
  redirect chain only injects into the document that sticks
- `shutdown()` not `shutdownNow()` in `dispose()`, for the reason the neighbours give

`RendererPid`'s invariant is preserved deliberately: the pid is cleared
synchronously on commit and written back off-thread only if that commit has not
been superseded. A stale renderer is never reported for a new document, and
"unknown" remains the only failure mode — which that class explicitly prefers over
a plausible wrong number.

## Verification

- `:composeApp:compileKotlinDesktop` clean — no new warnings
- `ktlintCheck` + `detekt` pass
- `:composeApp:desktopTest --tests "ai.rever.boss.plugin.browser.*"` passes
- patched `createDistributable` build launches with the EDT idle in
  `EventDispatchThread.pumpEvents` instead of parked in `executeJavaScript`

**Not verified:** I could not drive a real page load in the sandbox (no GUI
input), so the end-to-end "loads a page without hanging" path is untested by me.
Worth one manual pass before merge — open a tab, follow a redirect chain, confirm
a `boss-page-inject-*` thread appears and the UI stays live.

No regression test: exercising this needs a live browser and a real navigation,
the same constraint that got `RendererPid` extracted into its own testable class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)