### PR TITLE
The title bar is back on by default on macOS, and a tab's cross is always shown

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/TabFaviconChip.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/TabFaviconChip.kt
@@ -136,7 +136,14 @@ internal fun TabFaviconChip(
     // about a third of the tabs it can show - the density is the whole reason the strip exists.
     // The pointer is over the favicon when the cross appears to its RIGHT, so the chip under the
     // pointer never moves out from under it.
-    val showClose = onClose != null && hovered
+    // Always shown, not revealed on hover. A cross that appears under the pointer is a cross you
+    // cannot see before you go looking for it: closing a tab from the strip meant hovering each
+    // chip to find out whether it could be closed at all. It also made the chip change WIDTH on
+    // hover, so the strip reflowed under the pointer.
+    //
+    // The cost is real and accepted: every chip is now wider by the cross, so fewer fit before the
+    // strip scrolls. A pane with many tabs is exactly where closing one from here is most useful.
+    val showClose = onClose != null
 
     HoverTooltipBox(
         text = tab.title,
@@ -258,7 +265,7 @@ private fun Modifier.tabChipDrag(
     }
 
 /**
- * The cross beside a hovered chip.
+ * The cross beside a chip, whenever that chip can be closed.
  *
  * Its own click target rather than a gesture on the chip, because the chip already answers a
  * click by selecting the tab and a drag by picking it up. Sized to the chip so the two read as

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/window/WindowAppearanceSettings.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.window
 
+import ai.rever.boss.utils.SystemUtils
 import kotlinx.serialization.Serializable
 
 /**
@@ -10,12 +11,19 @@ data class WindowAppearanceSettings(
     /**
      * Whether to show the Boss Console title bar.
      *
-     * Off everywhere now, macOS included. On Windows and Linux it was always a plain bar above
-     * the content. On macOS it was something else: the window sets `apple.awt.fullWindowContent`,
-     * so the traffic lights are drawn OVER the content and this row existed to hold them - its own
-     * content is a centred title string. Reserving the window's full width to protect one 78dp
-     * corner is the wrong shape, so the clearance moved onto whichever column is leftmost. See
-     * `macTrafficLightInset`, which also names the one case that still wants the row.
+     * **On by default on macOS, off elsewhere.** On Windows and Linux it is a plain bar above the
+     * content and the OS draws its own frame. On macOS it is something else: the window sets
+     * `apple.awt.fullWindowContent`, so the close / minimise / zoom buttons are drawn OVER the
+     * content, and this row is what holds them.
+     *
+     * It was briefly off there too, with the clearance moved onto whichever column is leftmost
+     * (see `macTrafficLightInset`). That works only while a column is wide enough to hold a 78dp
+     * box: a collapsed tab bar is one 40dp rail, and the fallback for everything narrower was to
+     * draw this row anyway - so "off" was not a state a macOS window could reliably be in.
+     *
+     * The class default stays false, and macOS is switched on by `getDefaultSettings` for a fresh
+     * install and by the 1 -> 2 migration for an existing one. Flipping the class default instead
+     * would turn the row on for Windows and Linux too, whose files do not mention it either.
      */
     val showTitleBar: Boolean = false,
     /**
@@ -169,7 +177,7 @@ data class WindowAppearanceSettings(
 ) {
     companion object {
         /** Bump when a step is added to [WindowAppearanceMigrations.migrate]. */
-        const val CURRENT_SETTINGS_VERSION = 1
+        const val CURRENT_SETTINGS_VERSION = 2
     }
 }
 
@@ -208,6 +216,17 @@ object WindowAppearanceMigrations {
      * deliberately chose the value that used to be the default is indistinguishable from someone
      * who never touched it, and moves with everyone else.
      *
+     * **1 -> 2: the title bar comes back on macOS.** Turning it off there left the window with no
+     * reliable place for the traffic lights: the clearance moved onto the leftmost column, and a
+     * collapsed tab bar is a 40dp rail against a 78dp light box, so narrow configurations fell back
+     * to drawing the row regardless. A row that appears and disappears with the window's width is
+     * worse than one that is simply on. Windows and Linux are untouched - the row is an ordinary
+     * bar there and the OS draws its own frame.
+     *
+     * This step, like 0 -> 1, cannot tell somebody who deliberately switched the row off from
+     * somebody who never touched it: `encodeDefaults` is false, so the value that equals the class
+     * default is never written. Both move.
+     *
      * One thing this reasons over that it cannot actually see: it tests decoded VALUES, not what
      * the file said. A key that is absent decodes to the field's default, so a file written
      * before [WindowAppearanceSettings.showTopBar] existed is indistinguishable here from one
@@ -215,13 +234,20 @@ object WindowAppearanceMigrations {
      * belong on the new defaults anyway - but a future step that needs "absent" to differ from
      * "false" cannot get it from this signature, and will need the field to be nullable.
      */
-    fun migrate(loaded: WindowAppearanceSettings): WindowAppearanceSettings? {
+    fun migrate(
+        loaded: WindowAppearanceSettings,
+        isMacOs: Boolean = SystemUtils.isMacOS,
+    ): WindowAppearanceSettings? {
         if (loaded.settingsVersion >= WindowAppearanceSettings.CURRENT_SETTINGS_VERSION) return null
 
-        val onOldShippedDefaults = loaded.showTopBar && loaded.tabBarPosition == TabBarPosition.TOP
+        val onOldShippedDefaults =
+            loaded.settingsVersion < 1 && loaded.showTopBar && loaded.tabBarPosition == TabBarPosition.TOP
         return loaded.copy(
             showTopBar = if (onOldShippedDefaults) false else loaded.showTopBar,
             tabBarPosition = if (onOldShippedDefaults) TabBarPosition.LEFT else loaded.tabBarPosition,
+            // 1 -> 2, macOS only. A default flip cannot do this one: the class default has to stay
+            // false for Windows and Linux, whose files do not mention the field either.
+            showTitleBar = if (isMacOs) true else loaded.showTitleBar,
             settingsVersion = WindowAppearanceSettings.CURRENT_SETTINGS_VERSION,
         )
     }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowAppearanceSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/WindowAppearanceSettingsManager.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.window
 
 import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.SystemUtils
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import kotlinx.coroutines.Dispatchers
@@ -118,13 +119,17 @@ actual object WindowAppearanceSettingsManager {
     }
 
     actual fun getDefaultSettings(): WindowAppearanceSettings {
-        // No platform branch any more: the title row is off everywhere, macOS included, and the
-        // traffic lights are handled by insetting the leftmost column instead. See
-        // `macTrafficLightInset`.
+        // The title row is ON for macOS and off elsewhere. macOS draws the close / minimise / zoom
+        // buttons over the window's content (`apple.awt.fullWindowContent`), and this row is what
+        // holds them; on Windows and Linux the OS draws its own frame and the row is just a bar.
+        //
+        // The branch lives here rather than in the class default, which has to stay false so that
+        // a Windows or Linux file - which does not mention the field either - keeps the row off.
         //
         // Stamped current: a fresh file is already on this build's defaults and must not be
         // migrated on the next launch as though it were an older one.
         return WindowAppearanceSettings(
+            showTitleBar = SystemUtils.isMacOS,
             settingsVersion = WindowAppearanceSettings.CURRENT_SETTINGS_VERSION,
         )
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/tabs/TabChipCloseVisibilityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/tabs/TabChipCloseVisibilityTest.kt
@@ -1,0 +1,97 @@
+package ai.rever.boss.components.tabs
+
+// Deliberately not in the chip's own package: that one has underscores in its name, which detekt's
+// PackageNaming rule rejects for anything new. `internal` is module-wide, so the chip is reachable
+// from here regardless.
+import ai.rever.boss.components.window_panel.components.main_window_panels.TabFaviconChip
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabTypeId
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins that a closable chip shows its cross without being hovered.
+ *
+ * It used to appear on hover, which had two costs. The cross was invisible until you went looking
+ * for it, so whether a tab could be closed from the strip at all was not discoverable; and the chip
+ * changed WIDTH when it appeared, so the strip reflowed under the pointer that was reaching for it.
+ *
+ * A composition test rather than a unit one because "is it on screen" is the whole claim, and the
+ * old behaviour would pass any test that only asked whether a cross exists.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TabChipCloseVisibilityTest {
+    @Test
+    fun `a closable chip shows its cross with no hover`() =
+        runComposeUiTest {
+            setContent {
+                Row {
+                    TabFaviconChip(tab = TestTab("tab-1"), isActive = false, onClick = {}, onClose = {})
+                }
+            }
+
+            // Never hovered, never clicked - just mounted.
+            onNodeWithContentDescription(CLOSE_LABEL).assertExists()
+        }
+
+    @Test
+    fun `a chip that cannot be closed shows no cross`() =
+        runComposeUiTest {
+            setContent {
+                Row {
+                    TabFaviconChip(tab = TestTab("tab-1"), isActive = false, onClick = {})
+                }
+            }
+
+            onAllNodesWithContentDescription(CLOSE_LABEL).assertCountEquals(0)
+        }
+
+    @Test
+    fun `the cross closes its own tab`() =
+        runComposeUiTest {
+            var closed = 0
+            setContent {
+                Row {
+                    TabFaviconChip(tab = TestTab("tab-1"), isActive = false, onClick = {}, onClose = { closed++ })
+                }
+            }
+
+            onNodeWithContentDescription(CLOSE_LABEL).performClick()
+            assertEquals(1, closed)
+        }
+
+    @Test
+    fun `every closable chip in a strip shows one`() =
+        runComposeUiTest {
+            // The reason this matters: with hover-to-reveal, exactly one cross could be visible at
+            // a time - the one under the pointer.
+            setContent {
+                Row {
+                    repeat(3) { index ->
+                        TabFaviconChip(tab = TestTab("tab-$index"), isActive = index == 0, onClick = {}, onClose = {})
+                    }
+                }
+            }
+
+            onAllNodesWithContentDescription(CLOSE_LABEL).assertCountEquals(3)
+        }
+}
+
+private const val CLOSE_LABEL = "Close tab"
+
+private data class TestTab(
+    override val id: String,
+    override val typeId: TabTypeId = TabTypeId("chip-test", "test.plugin"),
+    override val title: String = "Chip Test Tab",
+) : TabInfo {
+    override val icon get() = Icons.Outlined.Language
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowAppearanceMigrationsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/window/WindowAppearanceMigrationsTest.kt
@@ -17,13 +17,13 @@ class WindowAppearanceMigrationsTest {
     @Test
     fun `a current file is left alone`() {
         val current = WindowAppearanceSettings(settingsVersion = WindowAppearanceSettings.CURRENT_SETTINGS_VERSION)
-        assertNull(WindowAppearanceMigrations.migrate(current))
+        assertNull(WindowAppearanceMigrations.migrate(current, isMacOs = false))
     }
 
     @Test
     fun `an install on the old shipped defaults is moved`() {
         val old = WindowAppearanceSettings(showTopBar = true, tabBarPosition = TabBarPosition.TOP, settingsVersion = 0)
-        val migrated = WindowAppearanceMigrations.migrate(old)!!
+        val migrated = WindowAppearanceMigrations.migrate(old, isMacOs = false)!!
 
         assertEquals(false, migrated.showTopBar)
         assertEquals(TabBarPosition.LEFT, migrated.tabBarPosition)
@@ -39,7 +39,7 @@ class WindowAppearanceMigrationsTest {
                 tabBarPosition = TabBarPosition.LEFT,
                 settingsVersion = 0,
             )
-        val migrated = WindowAppearanceMigrations.migrate(chosen)!!
+        val migrated = WindowAppearanceMigrations.migrate(chosen, isMacOs = false)!!
 
         assertEquals(true, migrated.showTopBar)
         assertEquals(TabBarPosition.LEFT, migrated.tabBarPosition)
@@ -53,7 +53,7 @@ class WindowAppearanceMigrationsTest {
                 tabBarPosition = TabBarPosition.TOP,
                 settingsVersion = 0,
             )
-        val migrated = WindowAppearanceMigrations.migrate(chosen)!!
+        val migrated = WindowAppearanceMigrations.migrate(chosen, isMacOs = false)!!
 
         assertEquals(false, migrated.showTopBar)
         assertEquals(TabBarPosition.TOP, migrated.tabBarPosition)
@@ -64,10 +64,10 @@ class WindowAppearanceMigrationsTest {
         // Otherwise the step re-runs on every launch and would keep re-deciding for someone who
         // moved back afterwards.
         val chosen = WindowAppearanceSettings(showTopBar = false, tabBarPosition = TabBarPosition.TOP)
-        val migrated = WindowAppearanceMigrations.migrate(chosen)!!
+        val migrated = WindowAppearanceMigrations.migrate(chosen, isMacOs = false)!!
 
         assertEquals(WindowAppearanceSettings.CURRENT_SETTINGS_VERSION, migrated.settingsVersion)
-        assertNull(WindowAppearanceMigrations.migrate(migrated))
+        assertNull(WindowAppearanceMigrations.migrate(migrated, isMacOs = false))
     }
 
     @Test
@@ -81,7 +81,7 @@ class WindowAppearanceMigrationsTest {
                 tabBarCollapsed = true,
                 settingsVersion = 0,
             )
-        val migrated = WindowAppearanceMigrations.migrate(old)!!
+        val migrated = WindowAppearanceMigrations.migrate(old, isMacOs = false)!!
 
         assertEquals(false, migrated.showBottomBar)
         assertEquals(260f, migrated.tabBarVerticalWidth)
@@ -94,5 +94,69 @@ class WindowAppearanceMigrationsTest {
 
         assertEquals(false, fresh.showTopBar)
         assertEquals(TabBarPosition.LEFT, fresh.tabBarPosition)
+    }
+
+    // --- 1 -> 2: the title bar comes back on macOS --------------------------------------------
+
+    @Test
+    fun `an existing macOS install gets the title bar back`() {
+        // The whole point of the step. A file written by 9.4.x does not mention showTitleBar at
+        // all - it equalled the class default, so `encodeDefaults = false` never wrote it - which
+        // means a default flip alone would leave this install with the row off for ever.
+        val existing = WindowAppearanceSettings(settingsVersion = 1)
+        val migrated = WindowAppearanceMigrations.migrate(existing, isMacOs = true)!!
+
+        assertTrue(migrated.showTitleBar)
+        assertEquals(WindowAppearanceSettings.CURRENT_SETTINGS_VERSION, migrated.settingsVersion)
+    }
+
+    @Test
+    fun `Windows and Linux keep the row off`() {
+        // The row is an ordinary bar there and the OS draws its own frame, so there is nothing for
+        // it to hold. This is why the class default stays false and the branch lives in the step.
+        val existing = WindowAppearanceSettings(settingsVersion = 1)
+        val migrated = WindowAppearanceMigrations.migrate(existing, isMacOs = false)!!
+
+        assertEquals(false, migrated.showTitleBar)
+    }
+
+    @Test
+    fun `the title-bar step does not re-decide the tab bar`() {
+        // A file already on version 1 has been through 0 -> 1. Someone who chose the top bar back
+        // must keep it: only the brand new step applies to them.
+        val chose =
+            WindowAppearanceSettings(
+                showTopBar = true,
+                tabBarPosition = TabBarPosition.TOP,
+                settingsVersion = 1,
+            )
+        val migrated = WindowAppearanceMigrations.migrate(chose, isMacOs = true)!!
+
+        assertTrue(migrated.showTopBar, "their top bar was taken away by a step that had already run")
+        assertEquals(TabBarPosition.TOP, migrated.tabBarPosition)
+        assertTrue(migrated.showTitleBar)
+    }
+
+    @Test
+    fun `a version 0 file gets both steps at once`() {
+        val ancient =
+            WindowAppearanceSettings(
+                showTopBar = true,
+                tabBarPosition = TabBarPosition.TOP,
+                settingsVersion = 0,
+            )
+        val migrated = WindowAppearanceMigrations.migrate(ancient, isMacOs = true)!!
+
+        assertEquals(false, migrated.showTopBar, "0 -> 1")
+        assertEquals(TabBarPosition.LEFT, migrated.tabBarPosition, "0 -> 1")
+        assertTrue(migrated.showTitleBar, "1 -> 2")
+    }
+
+    @Test
+    fun `migrating twice is a no-op`() {
+        val existing = WindowAppearanceSettings(settingsVersion = 1)
+        val once = WindowAppearanceMigrations.migrate(existing, isMacOs = true)!!
+
+        assertNull(WindowAppearanceMigrations.migrate(once, isMacOs = true), "the step must run at most once")
     }
 }


### PR DESCRIPTION
Two changes to the window chrome.

## The title bar is on by default on macOS

It was switched off there, with the traffic-light clearance moved onto whichever
column is leftmost. That works only while a column is wide enough to hold the
78x28dp light box - and a collapsed tab bar is one 40dp rail, so the fallback for
anything narrower was to draw the row anyway. "Off" was never a state a macOS
window could reliably be in: the row appeared and disappeared as a window was
dragged past the tab bar's auto-collapse width.

**It needs a migration, not a default flip.** The class default has to stay
`false`, because Windows and Linux keep the row off and their files do not mention
the field either - `encodeDefaults` is false, so a value equal to the class default
is never written, and flipping it would turn the row on everywhere.

- A fresh install gets the platform branch from `getDefaultSettings`.
- An existing install gets the new 1 -> 2 step, macOS only.

The step inherits the blindness the 0 -> 1 step already documents: a file records
*what* the value is, never *who* set it, so somebody who deliberately turned the row
off on macOS cannot be told apart from somebody who never touched it. Both move.
Stated rather than hidden, because it is the one group this change is wrong for.

Windows and Linux are untouched: the row is an ordinary bar there and the OS draws
its own frame, so there is nothing for it to hold.

## A tab's cross is always visible

The cross on a favicon chip appeared on hover. Two costs:

- It was invisible until the pointer found it, so whether a tab could be closed
  from the strip at all was not discoverable.
- The chip changed **width** when it appeared, so the strip reflowed under the very
  pointer that was reaching for the cross.

The cost of always showing it is real and accepted: every chip is wider, so fewer
fit before the strip scrolls - and a pane with many tabs is exactly where closing
one from the strip is most useful.

## Verification

`./gradlew :composeApp:desktopTest detekt ktlintCheck` is green - 3008 tests.

`WindowAppearanceMigrationsTest` gains five cases: an existing macOS install gets
the row back and is stamped current; Windows and Linux keep it off; the new step
does not re-decide the tab bar for someone already past 0 -> 1; a version 0 file
gets both steps at once; and migrating twice is a no-op. Existing cases now pass
`isMacOs` explicitly, so they no longer depend on the host that runs them.

`TabChipCloseVisibilityTest` mounts real chips: a closable one shows its cross with
no hover, a non-closable one shows none, the cross closes its own tab, and every
chip in a strip shows one - which the old behaviour could not do, since only the
chip under the pointer had a cross.

Both were checked by reverting: three migration tests fail against a step that does
nothing, and three chip tests fail against the hover gate.

**Not checked on screen.** The macOS default in particular is worth a look on a
real window, since what it changes is where the traffic lights sit.
