### PR TITLE
Make BOSS the default handler for links, markdown, shell scripts and code files

### DIFF
--- a/.github/workflows/build-chromium-branding.yml
+++ b/.github/workflows/build-chromium-branding.yml
@@ -304,6 +304,38 @@ jobs:
             /usr/libexec/PlistBuddy -c "Set :NSBluetoothPeripheralUsageDescription $BT_USAGE" "$MAIN_PLIST"
           echo "Added Bluetooth usage descriptions to Info.plist"
 
+          # The engine must not be a Launch Services candidate.
+          #
+          # This bundle is Chromium, so it inherits Chromium's CFBundleURLTypes
+          # (http, https, file) and CFBundleDocumentTypes (public.html, images,
+          # ...). Branded, it is also called "BOSS" with the id
+          # ai.rever.boss.browser - so macOS offered TWO indistinguishable
+          # entries named "BOSS" under "Default web browser", and picking the
+          # wrong one handed every link to a bare rendering engine that has no
+          # BOSS window, no tabs and no session. Measured on a real machine
+          # before this fix: http, https and public.html all resolved to
+          # ai.rever.boss.browser while the app itself (ai.rever.boss) sat
+          # there reporting "not the default browser".
+          #
+          # BOSS.app declares those types itself; the engine has no business
+          # doing so. Deleted here rather than in params.json because the
+          # branding tool copies Chromium's plist through and has no switch for
+          # it, and here for the same reason as the Bluetooth keys above: BEFORE
+          # the re-sign, or the edit breaks the seal.
+          /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$MAIN_PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Delete :CFBundleDocumentTypes" "$MAIN_PLIST" 2>/dev/null || true
+          # Assert the end state. Both deletes end in `|| true` (absent is fine,
+          # and a future engine may ship neither key), so without this a
+          # PlistBuddy that silently failed would republish the collision - the
+          # exact bug this step exists to remove.
+          for KEY in CFBundleURLTypes CFBundleDocumentTypes; do
+            if /usr/libexec/PlistBuddy -c "Print :$KEY" "$MAIN_PLIST" >/dev/null 2>&1; then
+              echo "::error::$KEY still present in the engine Info.plist; it would register as a browser"
+              exit 1
+            fi
+          done
+          echo "Removed CFBundleURLTypes and CFBundleDocumentTypes from the engine Info.plist"
+
           # Re-sign after modifications, PRESERVING identity + entitlements. A
           # bare ad-hoc `codesign --force --sign -` here used to strip the
           # Developer ID identity and every entitlement (JIT,
@@ -591,6 +623,38 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :NSBluetoothPeripheralUsageDescription string $BT_USAGE" "$MAIN_PLIST" 2>/dev/null || \
             /usr/libexec/PlistBuddy -c "Set :NSBluetoothPeripheralUsageDescription $BT_USAGE" "$MAIN_PLIST"
           echo "Added Bluetooth usage descriptions to Info.plist"
+
+          # The engine must not be a Launch Services candidate.
+          #
+          # This bundle is Chromium, so it inherits Chromium's CFBundleURLTypes
+          # (http, https, file) and CFBundleDocumentTypes (public.html, images,
+          # ...). Branded, it is also called "BOSS" with the id
+          # ai.rever.boss.browser - so macOS offered TWO indistinguishable
+          # entries named "BOSS" under "Default web browser", and picking the
+          # wrong one handed every link to a bare rendering engine that has no
+          # BOSS window, no tabs and no session. Measured on a real machine
+          # before this fix: http, https and public.html all resolved to
+          # ai.rever.boss.browser while the app itself (ai.rever.boss) sat
+          # there reporting "not the default browser".
+          #
+          # BOSS.app declares those types itself; the engine has no business
+          # doing so. Deleted here rather than in params.json because the
+          # branding tool copies Chromium's plist through and has no switch for
+          # it, and here for the same reason as the Bluetooth keys above: BEFORE
+          # the re-sign, or the edit breaks the seal.
+          /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$MAIN_PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Delete :CFBundleDocumentTypes" "$MAIN_PLIST" 2>/dev/null || true
+          # Assert the end state. Both deletes end in `|| true` (absent is fine,
+          # and a future engine may ship neither key), so without this a
+          # PlistBuddy that silently failed would republish the collision - the
+          # exact bug this step exists to remove.
+          for KEY in CFBundleURLTypes CFBundleDocumentTypes; do
+            if /usr/libexec/PlistBuddy -c "Print :$KEY" "$MAIN_PLIST" >/dev/null 2>&1; then
+              echo "::error::$KEY still present in the engine Info.plist; it would register as a browser"
+              exit 1
+            fi
+          done
+          echo "Removed CFBundleURLTypes and CFBundleDocumentTypes from the engine Info.plist"
 
           # Re-sign after modifications, PRESERVING identity + entitlements. A
           # bare ad-hoc `codesign --force --sign -` here used to strip the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -686,9 +686,141 @@ Linux) or a loopback port (Windows). Every request must present the token,
 "another instance is running" means something answered on the channel rather than
 a pid existing, and a descriptor nobody answers on is reclaimed.
 
+## Every OS open request becomes a `boss://` link
+
+Links and files arrive through four different doors and all four normalise to one
+deep link before anything else happens, via `fileDeepLinkFor` and
+`OsOpenArguments`:
+
+| Door | Platform | Handler |
+|---|---|---|
+| open-URI AppleEvent | macOS | `Desktop.setOpenURIHandler` |
+| open-file AppleEvent | macOS | `Desktop.setOpenFileHandler` |
+| a path or URL in `argv` | Windows, Linux | `DeepLinkHandler.processCommandLineArgs` |
+| a forward over the single-instance channel | all | `main.kt`, when the lock is held |
+
+The point of funnelling them is that `boss://file` and `boss://url` already carry
+the parts each new door would otherwise have to re-implement: path validation, the
+window resolve through `WindowFocusManager.resolveActionableWindowId`, and the
+`FileHandlerService` / `URLHandlerService` counters that stop the New Tab dialog
+destroying the tab being created during a cold start.
+
+Four things that were broken before this and are easy to break again:
+
+- **Nothing registered an open-file handler at all.** BOSS declared
+  `CFBundleDocumentTypes`, appeared in Finder's Open With menu, launched when a
+  file was double-clicked, and then did nothing with it. macOS discards the
+  AppleEvent once the queue drains with no handler set.
+- **`processCommandLineArgs` was gated on Windows.** Linux delivers a protocol URL
+  in `argv` too (`Exec=<app> %U`) and the JDK's X11 peer supports no
+  `APP_OPEN_URI` action, so a Linux user with BOSS as their default browser had
+  every cold-start link silently dropped.
+- **A CLI invocation must not be extracted as an open request.** `OsOpenArguments`
+  returns nothing when any argument names a `createBossCLI` subcommand, or
+  `boss file /tmp/x.md` opens the file twice. `OsOpenArgumentsTest` pins the
+  subcommand list against `BossCommand.kt`.
+- **A `file://` URL is not a path.** `Exec=%U` hands file managers' URLs over, and
+  `File(URI)` rejects any authority component, so `file://localhost/tmp/x` needs
+  the redundant host stripped before it resolves.
+
+`CLISecurityValidator` now has two path checks, and using the wrong one is a
+visible bug either way. `isValidOpenTargetPath` is for a file about to be **read**
+into the editor: NUL rejected, canonicalised, nothing else. `isValidPath` is for a
+path that may reach a **shell** and rejects `..`, `$`, `&`, `;`, `|` and a
+backtick - which are ordinary filename characters, so applying it to a file open
+meant `Q&A notes.md` could not be opened at all.
+
+## Default applications, and the engine bundle that stole them
+
+`boss-file-types.json` (in `composeApp/src/desktopMain/resources`) is the single
+source of truth for what BOSS can be made the default handler for: five
+categories over 83 extensions, which is exactly what `EditorLanguages.EXTENSIONS`
+can highlight. Three consumers read it and one test pins it:
+
+- `buildSrc/BossFileTypes` generates the `CFBundleURLTypes`,
+  `CFBundleDocumentTypes` and `UTExportedTypeDeclarations` blocks at build time.
+- `FileTypeCategories` serves the Settings screen and the registration calls.
+- `WindowsFileTypeHandler` and `LinuxFileTypeHandler` derive ProgIDs and MIME
+  associations from it.
+- `FileTypeCategoriesTest` asserts its extension set and its extension-to-language
+  map equal `EditorLanguages.EXTENSIONS`, so what BOSS offers to open cannot drift
+  from what it can render. (`buildSrc/BossFileTypesTest` checks the same thing by
+  regex, because `buildSrc` compiles first and cannot see the real object.)
+
+**Launch Services can only make an app the default for a *type*, never for an
+extension.** 31 of the 83 extensions resolve to a system UTI which BOSS claims
+as-is; the other 41 have no system UTI (`UTType(filenameExtension:)` answers with
+a `dyn.*` placeholder, which cannot be set as a default), so BOSS exports its own
+type for them, grouped by language. The per-extension answers in the resource are
+**measured, not derived**, and three of them are the reason: `.ts` resolves to
+`public.mpeg-2-transport-stream` (a video container), `.as` to
+`com.apple.applesingle-archive` (a binary archive) and `.edn` to `com.adobe.edn`.
+Claiming any of those would make BOSS the default application for a format it
+cannot open, so they are recorded as `rejectedSystemType` and get an exported type
+instead.
+
+**The engine bundle used to be a second app called "BOSS".**
+`~/.boss/boss-chromium/BOSS.app` is the branded JxBrowser engine, and being
+Chromium it inherited `CFBundleURLTypes` (http, https) and
+`CFBundleDocumentTypes` (`public.html`). Branded, its `CFBundleName` is also
+"BOSS" and its id is `ai.rever.boss.browser` - so System Settings offered two
+indistinguishable "BOSS" entries under Default web browser, and picking the wrong
+one handed every link to a bare rendering engine with no window, no tabs and no
+session. Measured on a real machine: http, https and `public.html` all resolved to
+`ai.rever.boss.browser` while the app itself reported "not the default browser".
+
+Both halves of the fix matter. `build-chromium-branding.yml` now deletes both keys
+from the engine's `Info.plist` before the re-sign (`EngineBundlePlistStripTest`
+pins that, including the ordering: after the re-sign the edit breaks the seal), so
+future engines are clean. And `DefaultHandlerState` is a three-way answer -
+`Ours` / `OurEngine` / `Other` - so an install already in the broken state is told
+what actually happened and offered a Repair rather than "BOSS is not your default
+browser", which is the wrong story to tell somebody who did set it.
+
+Launch Services is reached through `utils/mac/LaunchServices.kt`, bound with JNA.
+It replaced a `swift <tempfile>` shell-out per call, which needed Xcode installed
+and so could not work at all on most machines; the Swift scripts remain only as a
+fallback for URL schemes if `Native.load` fails.
+
+## A missing plugin no longer fails silently
+
+Browser, editor and terminal tabs are plugin-provided. `addTab` logged "Dropped
+tab - no factory registered for its type", returned -1, and every caller ignored
+it: with the browser plugin absent the OS could hand BOSS a link and nothing at
+all appeared, which is what "BOSS is my default browser and clicking a link does
+nothing" was.
+
+`SplitViewState.requireTabTypeThen` now gates every open on
+`TabTypeAvailability.require`, which:
+
+1. returns immediately when the type is registered (the normal case, so the fast
+   path does not suspend);
+2. otherwise **waits** through `awaitRegistryCondition` - at a cold start the
+   plugins have not registered yet, and prompting there would be a false alarm on
+   every launch, the same reason `WorkspaceApplier.awaitTabTypes` exists;
+3. only then raises a `MissingHandlerPluginPrompt` on `MissingHandlerPluginEventBus`,
+   whose delivery copies `PluginDependencyBus` deliberately: a `Channel` so exactly
+   one window asks, buffered so reporting never suspends the open, `trySend` so an
+   overflow is refused and logged rather than silently dropped;
+4. waits again, up to five minutes, for the plugin to register. **The dialog has no
+   success callback**: installing or enabling registers the tab type, which fires
+   the registry listeners, which completes this wait and performs the deferred
+   open. The file the user double-clicked appears by itself.
+
+It offers **Enable**, not Install, when the plugin is on disk and `DISABLED`.
+Installing something already installed cannot fix it, and both halves share
+`PluginDependencyResolution.installedAndOnDisk` so they cannot disagree about
+"installed" - the trap this repo's own AGENTS.md records as having broken the
+dependency prompt once already.
+
+`TabTypePlugins` maps a tab type to the plugin that provides it. It has to be a
+literal table: the mapping lives in each plugin's `plugin.json` and when the
+plugin is absent there is no manifest to read. It keys on the **type string**, not
+the whole `TabTypeId`, whose equality includes `pluginId` and `defaultOrder`.
+
 ## Documentation
 
-- [Core Subsystems](docs/SUBSYSTEMS.md) - Auth, UI, keyboard shortcuts, threading, default browser, runner, BossTerm
+- [Core Subsystems](docs/SUBSYSTEMS.md) - Auth, UI, keyboard shortcuts, threading, default applications, runner, BossTerm
 - [BossEditor](docs/BOSSEDITOR.md) - External editor dependency, LSP, PSI, editor features
 - [Application Features](docs/FEATURES.md) - Performance monitoring, dashboard, downloads, Chromium branding
 - [Keyboard Shortcuts](docs/KEYBOARD_SHORTCUTS.md) - Detailed shortcuts reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -777,6 +777,31 @@ future engines are clean. And `DefaultHandlerState` is a three-way answer -
 what actually happened and offered a Repair rather than "BOSS is not your default
 browser", which is the wrong story to tell somebody who did set it.
 
+**An existing install cannot be fixed by a version number.** The engine fix ships
+inside a *rebuild* of an already-published engine, so `version.txt` reads the same
+before and after and `ChromiumAutoDownloader.isChromiumInstalled`'s equality test
+short-circuits. So that function also asks the extracted bundle what it actually
+declares (`declaresBrowserTypes`): on macOS, an `Info.plist` still carrying
+`CFBundleURLTypes` or `CFBundleDocumentTypes` invalidates the directory and the
+existing download path replaces it. Three things about that check:
+
+- It sits beside the execute-bit check in the same function, which exists for the
+  same reason: catching a cached engine that is the right *version* and the wrong
+  *content*.
+- It is **bounded to one attempt per version** by a marker outside the engine
+  directory (`~/.boss/boss-chromium.types-repair`; a re-download replaces the
+  directory itself). Without it, an engine that still declares the keys after the
+  re-download - the rebuild never published, or published unrepaired - would
+  re-fetch ~160 MB on every launch, silently.
+- It **fails closed**: an unreadable or absent plist answers false, because
+  forcing a large download over a file we could not read is the worse mistake.
+  It matches `<key>NAME</key>` rather than the bare key name, so a comment or a
+  string value naming the key is not a declaration.
+
+`lsregister -u` on the engine bundle was tried first and does nothing: it returns
+0 and the bundle is still a candidate for `https` and `public.html` afterwards, so
+there is no download-free way to take it out of Launch Services.
+
 Launch Services is reached through `utils/mac/LaunchServices.kt`, bound with JNA.
 It replaced a `swift <tempfile>` shell-out per call, which needed Xcode installed
 and so could not work at all on most machines; the Swift scripts remain only as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -748,16 +748,40 @@ can highlight. Three consumers read it and one test pins it:
   regex, because `buildSrc` compiles first and cannot see the real object.)
 
 **Launch Services can only make an app the default for a *type*, never for an
-extension.** 31 of the 83 extensions resolve to a system UTI which BOSS claims
-as-is; the other 41 have no system UTI (`UTType(filenameExtension:)` answers with
-a `dyn.*` placeholder, which cannot be set as a default), so BOSS exports its own
-type for them, grouped by language. The per-extension answers in the resource are
+extension.** 42 of the 83 extensions resolve to a system UTI, which BOSS claims
+as-is - 31 distinct UTIs, since several extensions share one (`.cpp`, `.cc` and
+`.cxx` are all `public.c-plus-plus-source`). The other 41 have no system UTI
+(`UTType(filenameExtension:)` answers with a `dyn.*` placeholder, which cannot be
+set as a default), so BOSS exports its own type for them, grouped by language into
+24 declarations. The per-extension answers in the resource are
 **measured, not derived**, and three of them are the reason: `.ts` resolves to
 `public.mpeg-2-transport-stream` (a video container), `.as` to
 `com.apple.applesingle-archive` (a binary archive) and `.edn` to `com.adobe.edn`.
 Claiming any of those would make BOSS the default application for a format it
 cannot open, so they are recorded as `rejectedSystemType` and get an exported type
 instead.
+
+**Windows registration is one `reg import`, not hundreds of `reg add`s.**
+`WindowsRegistryScript` generates a `.reg` script and `WindowsFileTypeHandler`
+imports it in a single process; the status is one `reg query <FileExts> /s` parsed
+once. The per-`reg add` version ran on the order of 415 processes for a
+five-category "Set all" plus 83 more to read the status, each with its own
+timeout, from a Settings screen and from the first-run offer at startup.
+
+It also removes a quoting hazard rather than trying to get it right: the
+`shell\open\command` value is `"C:\path\BOSS.exe" "%1"`, a string that both
+begins and ends with a double quote, and Java's Windows `ProcessImpl` treats an
+argument in that shape as already quoted and passes it through unescaped - so
+`reg` would have stored only the exe path and treated `"%1"` as a stray token,
+killing the one write that makes a double-clicked file reach BOSS. That premise
+could not be verified on a mac (the JDK ships only the Unix `ProcessImpl`), which
+is itself a reason to prefer the form where the question cannot arise. In a `.reg`
+file the value is escaped by `regEscape` and never passes through a command line.
+
+**The three platform handlers share one fold.** `DefaultHandlerState.reduce` is
+the single definition of "BOSS only when every type in the category is BOSS, and
+`OurEngine` outranks `Other`". Each handler had its own copy; they agreed, which
+is the only reason nothing was broken, and a fourth copy would not have.
 
 **The engine bundle used to be a second app called "BOSS".**
 `~/.boss/boss-chromium/BOSS.app` is the branded JxBrowser engine, and being

--- a/buildSrc/src/main/kotlin/BossFileTypes.kt
+++ b/buildSrc/src/main/kotlin/BossFileTypes.kt
@@ -20,9 +20,10 @@ import java.io.File
  * ships in a plist.
  *
  * **Why two kinds of declaration.** Launch Services can only make an app the
- * default for a *type*, never for a bare extension. 31 of the 83 extensions
+ * default for a *type*, never for a bare extension. 42 of the 83 extensions
  * resolve to a system UTI (`public.python-script`, `net.daringfireball.markdown`
- * and so on) which BOSS claims as-is. The other 41 have no system UTI at all -
+ * and so on) which BOSS claims as-is; that is 31 *distinct* UTIs, because several
+ * extensions share one. The other 41 have no system UTI at all -
  * `UTType(filenameExtension:)` answers with a `dyn.*` placeholder, which cannot
  * be set as a default - so BOSS exports its own type for them, grouped by
  * language, exactly as other editors do for `.kt`, `.rs` and `.tsx`.
@@ -210,6 +211,26 @@ object BossFileTypes {
         val claimed = table.exportedTypes().flatMap { it.extensions }
         require(claimed.size == claimed.distinct().size) {
             "boss-file-types.json: two exported types claim the same extension"
+        }
+
+        // An exported language must live in exactly one category. The generator
+        // groups exported types by language across the WHOLE table, while the
+        // running app (FileTypeCategories.exportedTypeIdsFor) groups by language
+        // WITHIN a category. Those agree only while no language spans two
+        // categories; if one ever did, the single generated UTI would be listed
+        // under both, and claiming one category would silently make BOSS the
+        // default for the other's extensions too. Sibling of the check above:
+        // that one catches a duplicate extension, this catches a duplicate
+        // language.
+        val languagesPerCategory =
+            table.extensions
+                .filter { it.systemType == null }
+                .groupBy({ it.language }, { it.category })
+                .mapValues { (_, categories) -> categories.distinct() }
+        val spanning = languagesPerCategory.filterValues { it.size > 1 }
+        require(spanning.isEmpty()) {
+            "boss-file-types.json: exported language(s) span more than one category, " +
+                "which would make one UTI claim extensions in both: $spanning"
         }
     }
 

--- a/buildSrc/src/main/kotlin/BossFileTypes.kt
+++ b/buildSrc/src/main/kotlin/BossFileTypes.kt
@@ -1,0 +1,357 @@
+import groovy.json.JsonSlurper
+import java.io.File
+
+/**
+ * Generates the macOS `Info.plist` file-type declarations from
+ * `composeApp/src/desktopMain/resources/boss-file-types.json`.
+ *
+ * Lives in `buildSrc` rather than inline in `composeApp/build.gradle.kts` for
+ * the same reason [DebControl] does: the interesting part is a string transform
+ * with rules that are easy to get subtly wrong, and here it can be unit-tested
+ * (see `BossFileTypesTest`) without packaging a `.app` and reading its plist
+ * back.
+ *
+ * **Why generate it at all.** BOSS claims 83 extensions - every one its editor
+ * has a lexer for. Hand-writing that in the plist guarantees it drifts from
+ * `EditorLanguages`, which is the table that decides whether a file BOSS agreed
+ * to open can actually be highlighted; the KDoc on `EditorLanguages` already
+ * laments that "nothing enforces this at build time" for its sibling tables.
+ * One resource, one generator and one drift test closes that for the copy that
+ * ships in a plist.
+ *
+ * **Why two kinds of declaration.** Launch Services can only make an app the
+ * default for a *type*, never for a bare extension. 31 of the 83 extensions
+ * resolve to a system UTI (`public.python-script`, `net.daringfireball.markdown`
+ * and so on) which BOSS claims as-is. The other 41 have no system UTI at all -
+ * `UTType(filenameExtension:)` answers with a `dyn.*` placeholder, which cannot
+ * be set as a default - so BOSS exports its own type for them, grouped by
+ * language, exactly as other editors do for `.kt`, `.rs` and `.tsx`.
+ */
+object BossFileTypes {
+    /** Conformance for every type BOSS exports. `public.source-code` already conforms to `public.plain-text`. */
+    private const val SOURCE_CODE_CONFORMANCE = "public.source-code"
+
+    data class Category(
+        val id: String,
+        val displayName: String,
+        val description: String,
+        val schemes: List<String>,
+        val extraContentTypes: List<String>,
+        val mimeTypes: List<String>,
+        /**
+         * `LSHandlerRank` for the *system* types in this category.
+         *
+         * "Alternate" where the type belongs to somebody else - `public.html` is
+         * a browser's, and claiming to own it is both untrue and rude to the
+         * user's actual browser. "Default" where BOSS is a reasonable primary
+         * choice for a developer machine. Types BOSS exports itself are always
+         * "Owner", which is not a per-category decision.
+         */
+        val systemTypeRank: String,
+    )
+
+    data class Extension(
+        val ext: String,
+        val language: String,
+        val category: String,
+        /** The system UTI claimed for this extension, or null when BOSS exports its own type. */
+        val systemType: String?,
+        /** A system UTI this extension resolves to that BOSS deliberately refuses. Recorded, never claimed. */
+        val rejectedSystemType: String?,
+    )
+
+    data class Table(
+        val categories: List<Category>,
+        val languageNames: Map<String, String>,
+        val extensions: List<Extension>,
+        /**
+         * How the UTIs BOSS owns are named: `<prefix>.<language><suffix>`.
+         *
+         * Read from the resource rather than held as a constant here because the
+         * running app builds the same identifiers to ask Launch Services about
+         * them (`FileTypeCategories`), and the two must agree exactly - a
+         * mismatch is an app that declares `ai.rever.boss.kotlin-source` in its
+         * plist and then asks the OS about something else, which reports "not
+         * the default" forever and cannot be fixed by pressing the button.
+         */
+        val exportedTypePrefix: String,
+        val exportedTypeSuffix: String,
+    ) {
+        /** Distinct system UTIs claimed by [categoryId], plus that category's extension-less extras. */
+        fun systemTypesFor(categoryId: String): List<String> {
+            val category = categories.first { it.id == categoryId }
+            val fromExtensions =
+                extensions
+                    .filter { it.category == categoryId }
+                    .mapNotNull { it.systemType }
+            // Distinct, because several extensions share one UTI (.cpp/.cc/.cxx
+            // are all public.c-plus-plus-source) and a repeated entry in
+            // LSItemContentTypes is a plist that reads as a mistake.
+            return (fromExtensions + category.extraContentTypes).distinct()
+        }
+
+        /**
+         * Languages BOSS exports a type for, in the order they first appear, with
+         * the extensions each one claims.
+         *
+         * Grouped by language rather than one type per extension so the names
+         * Finder shows are meaningful ("Kotlin source", not 41 rows) - and so no
+         * two exported types can claim the same extension, which would leave
+         * Launch Services to pick between two of BOSS's own declarations.
+         */
+        fun exportedTypes(): List<ExportedType> =
+            extensions
+                .filter { it.systemType == null }
+                .groupBy { it.language }
+                .map { (language, rows) ->
+                    ExportedType(
+                        identifier = "$exportedTypePrefix.$language$exportedTypeSuffix",
+                        description = "${languageNames[language] ?: language} source",
+                        extensions = rows.map { it.ext },
+                        categoryId = rows.first().category,
+                    )
+                }
+
+        /** Every macOS type BOSS declares: claimed system UTIs plus its own. */
+        fun allContentTypes(): List<String> =
+            categories.flatMap { systemTypesFor(it.id) } + exportedTypes().map { it.identifier }
+    }
+
+    data class ExportedType(
+        val identifier: String,
+        val description: String,
+        val extensions: List<String>,
+        val categoryId: String,
+    )
+
+    /** Parses the shared resource. Throws with the offending file named, because a typo here breaks packaging. */
+    fun parse(json: String): Table {
+        @Suppress("UNCHECKED_CAST")
+        val root = JsonSlurper().parseText(json) as Map<String, Any?>
+
+        @Suppress("UNCHECKED_CAST")
+        val categories =
+            (root["categories"] as List<Map<String, Any?>>).map { entry ->
+                Category(
+                    id = entry.string("id"),
+                    displayName = entry.string("displayName"),
+                    description = entry.string("description"),
+                    schemes = entry.stringList("schemes"),
+                    extraContentTypes = entry.stringList("extraContentTypes"),
+                    mimeTypes = entry.stringList("mimeTypes"),
+                    systemTypeRank = entry.string("systemTypeRank"),
+                )
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        val extensions =
+            (root["extensions"] as List<Map<String, Any?>>).map { entry ->
+                Extension(
+                    ext = entry.string("ext"),
+                    language = entry.string("language"),
+                    category = entry.string("category"),
+                    systemType = entry["systemType"] as String?,
+                    rejectedSystemType = entry["rejectedSystemType"] as String?,
+                )
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        val languageNames = (root["languageNames"] as Map<String, String>)
+
+        val table =
+            Table(
+                categories = categories,
+                languageNames = languageNames,
+                extensions = extensions,
+                exportedTypePrefix = root.string("exportedTypePrefix"),
+                exportedTypeSuffix = root.string("exportedTypeSuffix"),
+            )
+        validate(table)
+        return table
+    }
+
+    fun parse(file: File): Table = parse(file.readText())
+
+    /**
+     * Refuses a table that would produce a broken plist.
+     *
+     * At configuration time, so a bad edit fails the build rather than shipping
+     * an app that claims a type it cannot open or silently claims nothing.
+     */
+    private fun validate(table: Table) {
+        val categoryIds = table.categories.map { it.id }.toSet()
+        require(categoryIds.size == table.categories.size) { "boss-file-types.json has duplicate category ids" }
+
+        table.extensions.forEach { row ->
+            require(row.category in categoryIds) {
+                "boss-file-types.json: extension .${row.ext} names unknown category '${row.category}'"
+            }
+            require(row.systemType == null || row.rejectedSystemType == null) {
+                "boss-file-types.json: extension .${row.ext} both claims and rejects a system type"
+            }
+            require(row.language in table.languageNames) {
+                "boss-file-types.json: extension .${row.ext} names language '${row.language}' with no display name"
+            }
+        }
+
+        val duplicateExtensions =
+            table.extensions
+                .groupingBy { it.ext }
+                .eachCount()
+                .filterValues { it > 1 }
+                .keys
+        require(duplicateExtensions.isEmpty()) { "boss-file-types.json has duplicate extensions: $duplicateExtensions" }
+
+        // An exported type claiming an extension another exported type also
+        // claims would leave Launch Services choosing between two of BOSS's own
+        // declarations for the same file. Grouping by language makes this
+        // impossible today; the check is here so a future grouping change cannot
+        // reintroduce it silently.
+        val claimed = table.exportedTypes().flatMap { it.extensions }
+        require(claimed.size == claimed.distinct().size) {
+            "boss-file-types.json: two exported types claim the same extension"
+        }
+    }
+
+    /**
+     * The `CFBundleDocumentTypes` array: what BOSS appears in "Open With" for
+     * and can be made the default for.
+     *
+     * One entry per category for the system types it claims, and one per
+     * exported language, so the names Finder shows read as file kinds rather
+     * than as one undifferentiated blob.
+     */
+    fun documentTypesXml(table: Table): String {
+        val entries = mutableListOf<String>()
+
+        table.categories.forEach { category ->
+            val systemTypes = table.systemTypesFor(category.id)
+            if (systemTypes.isNotEmpty()) {
+                entries += documentTypeEntry(category.displayName, systemTypes, category.systemTypeRank)
+            }
+        }
+
+        table.exportedTypes().forEach { exported ->
+            // Owner, because BOSS declares the type: nothing else on the machine
+            // has an opinion about ai.rever.boss.kotlin-source.
+            entries += documentTypeEntry(exported.description, listOf(exported.identifier), "Owner")
+        }
+
+        return buildString {
+            appendLine("<key>CFBundleDocumentTypes</key>")
+            appendLine("<array>")
+            entries.forEach { append(it) }
+            append("</array>")
+        }
+    }
+
+    private fun documentTypeEntry(
+        typeName: String,
+        contentTypes: List<String>,
+        handlerRank: String,
+    ): String =
+        buildString {
+            appendLine("    <dict>")
+            appendLine("        <key>CFBundleTypeName</key>")
+            appendLine("        <string>${escape(typeName)}</string>")
+            // Editor, not Viewer: BOSS opens these in an editor that can save
+            // them. The previous hand-written entry said Viewer for public.html,
+            // which told Finder BOSS could only look at it.
+            appendLine("        <key>CFBundleTypeRole</key>")
+            appendLine("        <string>Editor</string>")
+            appendLine("        <key>LSHandlerRank</key>")
+            appendLine("        <string>${escape(handlerRank)}</string>")
+            appendLine("        <key>LSItemContentTypes</key>")
+            appendLine("        <array>")
+            contentTypes.forEach { appendLine("            <string>${escape(it)}</string>") }
+            appendLine("        </array>")
+            appendLine("    </dict>")
+        }
+
+    /**
+     * The `UTExportedTypeDeclarations` array: the types BOSS invents for
+     * extensions macOS has never heard of.
+     *
+     * Without these, `.kt`, `.rs`, `.go` and 38 others have only a `dyn.*`
+     * placeholder UTI, and `LSSetDefaultRoleHandlerForContentType` cannot be
+     * given a `dyn.*` type - so "make BOSS the default for Kotlin files" had no
+     * type to name and could not be expressed at all.
+     */
+    fun exportedTypesXml(table: Table): String {
+        val exported = table.exportedTypes()
+        if (exported.isEmpty()) return ""
+
+        return buildString {
+            appendLine("<key>UTExportedTypeDeclarations</key>")
+            appendLine("<array>")
+            exported.forEach { type ->
+                appendLine("    <dict>")
+                appendLine("        <key>UTTypeIdentifier</key>")
+                appendLine("        <string>${escape(type.identifier)}</string>")
+                appendLine("        <key>UTTypeDescription</key>")
+                appendLine("        <string>${escape(type.description)}</string>")
+                appendLine("        <key>UTTypeConformsTo</key>")
+                appendLine("        <array>")
+                appendLine("            <string>$SOURCE_CODE_CONFORMANCE</string>")
+                appendLine("        </array>")
+                appendLine("        <key>UTTypeTagSpecification</key>")
+                appendLine("        <dict>")
+                appendLine("            <key>public.filename-extension</key>")
+                appendLine("            <array>")
+                type.extensions.forEach { appendLine("                <string>${escape(it)}</string>") }
+                appendLine("            </array>")
+                appendLine("        </dict>")
+                appendLine("    </dict>")
+            }
+            append("</array>")
+        }
+    }
+
+    /**
+     * The `CFBundleURLTypes` array: the URL schemes BOSS handles.
+     *
+     * `boss` is BOSS's own scheme and is not in the table; the rest come from the
+     * categories, so adding a scheme is a resource edit rather than a plist edit.
+     */
+    fun urlTypesXml(
+        table: Table,
+        ownScheme: String,
+        urlName: String,
+    ): String {
+        val schemes = listOf(ownScheme) + table.categories.flatMap { it.schemes }.distinct()
+        return buildString {
+            appendLine("<key>CFBundleURLTypes</key>")
+            appendLine("<array>")
+            appendLine("    <dict>")
+            appendLine("        <key>CFBundleURLName</key>")
+            appendLine("        <string>${escape(urlName)}</string>")
+            appendLine("        <key>CFBundleURLSchemes</key>")
+            appendLine("        <array>")
+            schemes.forEach { appendLine("            <string>${escape(it)}</string>") }
+            appendLine("        </array>")
+            appendLine("    </dict>")
+            append("</array>")
+        }
+    }
+
+    /**
+     * XML-escapes a plist string value.
+     *
+     * The inputs are ASCII identifiers from a controlled table, so this is not
+     * load-bearing today; it is here so that adding a language called `C++/CLI`
+     * or a description with an ampersand produces a valid plist instead of an app
+     * that will not launch.
+     */
+    private fun escape(value: String): String =
+        value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+
+    private fun Map<String, Any?>.string(key: String): String =
+        this[key] as? String
+            ?: error("boss-file-types.json: missing or non-string '$key' in $this")
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<String, Any?>.stringList(key: String): List<String> = (this[key] as? List<String>) ?: emptyList()
+}

--- a/buildSrc/src/test/kotlin/BossFileTypesTest.kt
+++ b/buildSrc/src/test/kotlin/BossFileTypesTest.kt
@@ -1,0 +1,302 @@
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the generated macOS file-type declarations.
+ *
+ * The plist is only assembled during `packageDmg` on a mac runner and only read
+ * by Launch Services, which reports nothing when a declaration is malformed - it
+ * just silently does not register the type. So the generator is verified here
+ * instead, including against the real resource the app ships.
+ *
+ * The drift test at the bottom is the important one: it is what stops what BOSS
+ * offers to open from diverging from what its editor can highlight.
+ */
+class BossFileTypesTest {
+    private val repoRoot = File("..").canonicalFile
+
+    private val resourceFile = File(repoRoot, "composeApp/src/desktopMain/resources/boss-file-types.json")
+
+    private val editorLanguagesFile =
+        File(
+            repoRoot,
+            "composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt",
+        )
+
+    private val table by lazy { BossFileTypes.parse(resourceFile) }
+
+    private fun minimalTable(extensions: String) =
+        """
+        {
+          "exportedTypePrefix": "ai.rever.boss",
+          "exportedTypeSuffix": "-source",
+          "categories": [
+            {"id": "source-code", "displayName": "Source", "description": "d",
+             "schemes": [], "extraContentTypes": [], "mimeTypes": [], "systemTypeRank": "Default"}
+          ],
+          "languageNames": {"kotlin": "Kotlin", "python": "Python"},
+          "extensions": [$extensions]
+        }
+        """.trimIndent()
+
+    // ---- the shipped resource ----
+
+    @Test
+    fun `the shipped resource parses`() {
+        assertTrue(resourceFile.isFile, "boss-file-types.json not found at ${resourceFile.absolutePath}")
+        assertTrue(table.extensions.isNotEmpty())
+        assertTrue(table.categories.isNotEmpty())
+    }
+
+    @Test
+    fun `every category is reachable and every extension names a real one`() {
+        val ids = table.categories.map { it.id }.toSet()
+        table.extensions.forEach { row ->
+            assertTrue(row.category in ids, ".${row.ext} names category '${row.category}'")
+        }
+        // A category with no extensions and no schemes claims nothing at all and
+        // would show in Settings as a row whose Set button does nothing.
+        table.categories.forEach { category ->
+            val claimsSomething =
+                category.schemes.isNotEmpty() ||
+                    category.extraContentTypes.isNotEmpty() ||
+                    table.extensions.any { it.category == category.id }
+            assertTrue(claimsSomething, "category '${category.id}' claims nothing")
+        }
+    }
+
+    @Test
+    fun `the three vetted system types are never claimed`() {
+        // These are the measurements that make the table worth having: .ts
+        // resolves to a video container, .as to a binary archive and .edn to an
+        // Adobe project format. Claiming any would make BOSS the default
+        // application for a format it cannot open.
+        val rejected = setOf("public.mpeg-2-transport-stream", "com.apple.applesingle-archive", "com.adobe.edn")
+        val claimed = table.categories.flatMap { table.systemTypesFor(it.id) }.toSet()
+        rejected.forEach { assertFalse(it in claimed, "$it must not be claimed") }
+
+        // And each of them still has to be openable, through an exported type.
+        val exportedExtensions = table.exportedTypes().flatMap { it.extensions }.toSet()
+        listOf("ts", "as", "edn").forEach {
+            assertTrue(it in exportedExtensions, ".$it must be covered by an exported type")
+        }
+    }
+
+    @Test
+    fun `no extension is claimed by two exported types`() {
+        val claimed = table.exportedTypes().flatMap { it.extensions }
+        assertEquals(claimed.distinct().size, claimed.size)
+    }
+
+    @Test
+    fun `no system type is repeated inside one document type entry`() {
+        table.categories.forEach { category ->
+            val types = table.systemTypesFor(category.id)
+            assertEquals(types.distinct().size, types.size, "duplicate content type in '${category.id}'")
+        }
+    }
+
+    // ---- generated XML ----
+
+    /**
+     * Wraps a fragment in a plist so a real XML parser can judge it.
+     *
+     * Concatenated, not `trimIndent()`ed with the fragment interpolated: the
+     * fragment's own lines start at column 0, which drags the common indent to
+     * zero and leaves the template's leading spaces in front of the `<?xml`
+     * prolog - an XML error, and the same trap the build file avoids the same
+     * way. Caught by these two tests failing when it was written that way.
+     */
+    private fun parseFragment(fragment: String) {
+        val document =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<plist version=\"1.0\"><dict>\n" +
+                fragment + "\n" +
+                "</dict></plist>"
+        DocumentBuilderFactory
+            .newInstance()
+            .newDocumentBuilder()
+            .parse(document.byteInputStream())
+    }
+
+    @Test
+    fun `generated blocks are well-formed XML`() {
+        parseFragment(BossFileTypes.documentTypesXml(table))
+        parseFragment(BossFileTypes.exportedTypesXml(table))
+        parseFragment(BossFileTypes.urlTypesXml(table, ownScheme = "boss", urlName = "ai.rever.boss"))
+    }
+
+    @Test
+    fun `every declared type appears in the document types block`() {
+        val xml = BossFileTypes.documentTypesXml(table)
+        table.allContentTypes().forEach { type ->
+            assertTrue("<string>$type</string>" in xml, "$type missing from CFBundleDocumentTypes")
+        }
+    }
+
+    @Test
+    fun `every exported type declares its extensions and conforms to source code`() {
+        val xml = BossFileTypes.exportedTypesXml(table)
+        table.exportedTypes().forEach { type ->
+            assertTrue("<string>${type.identifier}</string>" in xml)
+            type.extensions.forEach { ext ->
+                assertTrue("<string>$ext</string>" in xml, ".$ext missing from ${type.identifier}")
+            }
+        }
+        assertEquals(
+            table.exportedTypes().size,
+            Regex("public\\.source-code").findAll(xml).count(),
+            "each exported type needs exactly one conformance entry",
+        )
+    }
+
+    @Test
+    fun `document types are editors, never viewers`() {
+        // Viewer is what the hand-written entry said, and it told Finder BOSS
+        // could look at an .html file but not save it.
+        val xml = BossFileTypes.documentTypesXml(table)
+        assertFalse("<string>Viewer</string>" in xml)
+        assertTrue("<string>Editor</string>" in xml)
+    }
+
+    @Test
+    fun `exported types are owned and borrowed system types are not`() {
+        val xml = BossFileTypes.documentTypesXml(table)
+        // public.html belongs to a browser. Claiming Owner for it would be untrue.
+        val htmlEntry = xml.substringAfter("<string>Web pages</string>").substringBefore("</dict>")
+        assertTrue("<string>Alternate</string>" in htmlEntry, "web-pages should be an Alternate handler")
+        assertTrue("<string>Owner</string>" in xml, "BOSS's own types should be Owner")
+    }
+
+    @Test
+    fun `url types carry the boss scheme first and the table's schemes`() {
+        val xml = BossFileTypes.urlTypesXml(table, ownScheme = "boss", urlName = "ai.rever.boss")
+        assertTrue(xml.indexOf("<string>boss</string>") < xml.indexOf("<string>http</string>"))
+        assertTrue("<string>https</string>" in xml)
+    }
+
+    @Test
+    fun `an empty exported set produces no block rather than an empty array`() {
+        val onlySystemTypes =
+            BossFileTypes.parse(minimalTable("""{"ext": "py", "language": "python", "category": "source-code", "systemType": "public.python-script"}"""))
+        assertEquals("", BossFileTypes.exportedTypesXml(onlySystemTypes))
+    }
+
+    @Test
+    fun `special characters in a name cannot break the plist`() {
+        val withAmpersand =
+            BossFileTypes.parse(
+                """
+                {
+                  "exportedTypePrefix": "ai.rever.boss",
+                  "exportedTypeSuffix": "-source",
+                  "categories": [
+                    {"id": "source-code", "displayName": "A & B", "description": "d",
+                     "schemes": [], "extraContentTypes": ["public.text"], "mimeTypes": [], "systemTypeRank": "Default"}
+                  ],
+                  "languageNames": {"kotlin": "C++ <CLI> & friends"},
+                  "extensions": [{"ext": "kt", "language": "kotlin", "category": "source-code"}]
+                }
+                """.trimIndent(),
+            )
+        parseFragment(BossFileTypes.documentTypesXml(withAmpersand))
+        parseFragment(BossFileTypes.exportedTypesXml(withAmpersand))
+    }
+
+    // ---- validation ----
+
+    @Test
+    fun `an unknown category is refused`() {
+        assertFailsWith<IllegalArgumentException> {
+            BossFileTypes.parse(minimalTable("""{"ext": "kt", "language": "kotlin", "category": "nope"}"""))
+        }
+    }
+
+    @Test
+    fun `a language with no display name is refused`() {
+        assertFailsWith<IllegalArgumentException> {
+            BossFileTypes.parse(minimalTable("""{"ext": "kt", "language": "brainfuck", "category": "source-code"}"""))
+        }
+    }
+
+    @Test
+    fun `a duplicate extension is refused`() {
+        assertFailsWith<IllegalArgumentException> {
+            BossFileTypes.parse(
+                minimalTable(
+                    """{"ext": "kt", "language": "kotlin", "category": "source-code"},""" +
+                        """{"ext": "kt", "language": "python", "category": "source-code"}""",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `claiming and rejecting the same extension's type is refused`() {
+        assertFailsWith<IllegalArgumentException> {
+            BossFileTypes.parse(
+                minimalTable(
+                    """{"ext": "kt", "language": "kotlin", "category": "source-code",""" +
+                        """ "systemType": "public.x", "rejectedSystemType": "public.y"}""",
+                ),
+            )
+        }
+    }
+
+    // ---- the drift gate ----
+
+    @Test
+    fun `the table covers exactly the extensions EditorLanguages knows`() {
+        val editorLanguages = editorLanguageExtensions()
+        assertEquals(
+            editorLanguages.keys.sorted(),
+            table.extensions.map { it.ext }.sorted(),
+            "boss-file-types.json and EditorLanguages.EXTENSIONS disagree about which extensions exist. " +
+                "Adding a lexer means adding a row here, or BOSS will not offer to open the files it can now read; " +
+                "removing one and leaving the row means BOSS claims a file type it cannot highlight.",
+        )
+    }
+
+    @Test
+    fun `the table agrees with EditorLanguages about which language each extension is`() {
+        val editorLanguages = editorLanguageExtensions()
+        val disagreements =
+            table.extensions.mapNotNull { row ->
+                val expected = editorLanguages[row.ext]
+                if (expected != null && expected != row.language) {
+                    ".${row.ext}: EditorLanguages says '$expected', boss-file-types.json says '${row.language}'"
+                } else {
+                    null
+                }
+            }
+        assertTrue(disagreements.isEmpty(), disagreements.joinToString("\n"))
+    }
+
+    /**
+     * `EditorLanguages.EXTENSIONS`, read out of the source.
+     *
+     * A regex over Kotlin source is a poor way to read a map and it is the only
+     * way available here: `buildSrc` compiles before `composeApp` and cannot
+     * depend on it. The alternative was no gate at all, which is the state that
+     * let three copies of this table drift apart in the first place. The pattern
+     * is anchored to the `EXTENSIONS` block so `EXACT_NAMES` and `PREFIXED_NAMES`
+     * above it cannot leak in.
+     */
+    private fun editorLanguageExtensions(): Map<String, String> {
+        assertTrue(editorLanguagesFile.isFile, "EditorLanguages.kt not found at ${editorLanguagesFile.absolutePath}")
+        val source = editorLanguagesFile.readText()
+        val block =
+            source
+                .substringAfter("private val EXTENSIONS =", "")
+                .also { assertTrue(it.isNotEmpty(), "EXTENSIONS block not found; did EditorLanguages get restructured?") }
+        val pairs = Regex("\"([a-z0-9]+)\" to \"([a-z]+)\"").findAll(block)
+        val map = pairs.associate { it.groupValues[1] to it.groupValues[2] }
+        assertTrue(map.size > 50, "only ${map.size} extensions parsed out of EditorLanguages; the regex has gone stale")
+        return map
+    }
+}

--- a/buildSrc/src/test/kotlin/BossFileTypesTest.kt
+++ b/buildSrc/src/test/kotlin/BossFileTypesTest.kt
@@ -237,6 +237,51 @@ class BossFileTypesTest {
     }
 
     @Test
+    fun `an exported language spanning two categories is refused`() {
+        // The generator groups exported types by language across the WHOLE table
+        // while the app groups by language WITHIN a category, so a language in two
+        // categories would produce one UTI listed under both - and claiming one
+        // category would silently make BOSS the default for the other's
+        // extensions. Unreachable with today's data; this is what keeps it so.
+        val spanning =
+            """
+            {
+              "exportedTypePrefix": "ai.rever.boss",
+              "exportedTypeSuffix": "-source",
+              "categories": [
+                {"id": "source-code", "displayName": "Source", "description": "d",
+                 "schemes": [], "extraContentTypes": [], "mimeTypes": [], "systemTypeRank": "Default"},
+                {"id": "markdown", "displayName": "Markdown", "description": "d",
+                 "schemes": [], "extraContentTypes": [], "mimeTypes": [], "systemTypeRank": "Default"}
+              ],
+              "languageNames": {"kotlin": "Kotlin"},
+              "extensions": [
+                {"ext": "kt", "language": "kotlin", "category": "source-code"},
+                {"ext": "kts", "language": "kotlin", "category": "markdown"}
+              ]
+            }
+            """.trimIndent()
+        val failure = assertFailsWith<IllegalArgumentException> { BossFileTypes.parse(spanning) }
+        assertTrue(
+            failure.message.orEmpty().contains("span more than one category"),
+            "unexpected message: ${failure.message}",
+        )
+    }
+
+    @Test
+    fun `the shipped table keeps every exported language in one category`() {
+        val perLanguage =
+            table.extensions
+                .filter { it.systemType == null }
+                .groupBy({ it.language }, { it.category })
+                .mapValues { (_, categories) -> categories.distinct() }
+        assertTrue(
+            perLanguage.all { (_, categories) -> categories.size == 1 },
+            "exported languages span categories: ${perLanguage.filterValues { it.size > 1 }}",
+        )
+    }
+
+    @Test
     fun `claiming and rejecting the same extension's type is refused`() {
         assertFailsWith<IllegalArgumentException> {
             BossFileTypes.parse(

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -131,6 +131,21 @@ val macPrereleaseShortVersionKey: String =
 println("📦 Building BOSS Version: $appVersion")
 println("🔢 macOS CFBundleVersion (build id): $macBundleBuildVersion")
 
+// The file types BOSS can be made the default handler for, read from the same
+// resource the running app reads (see BossFileTypes and FileTypeCategories).
+// Feeds the generated CFBundleURLTypes / CFBundleDocumentTypes /
+// UTExportedTypeDeclarations blocks in nativeDistributions.macOS.infoPlist.
+//
+// Read through providers.fileContents, not File.readText(): a plain read at
+// configuration time is not a tracked configuration-cache input, so editing the
+// table would leave a cached configuration that still holds the old plist and an
+// app that claims types the resource no longer lists.
+val bossFileTypesJson =
+    providers
+        .fileContents(layout.projectDirectory.file("src/desktopMain/resources/boss-file-types.json"))
+        .asText
+val bossFileTypes: BossFileTypes.Table = BossFileTypes.parse(bossFileTypesJson.get())
+
 // Path to libs.versions.toml for reading JxBrowser version (single source of truth)
 val libsVersionsFile = layout.projectDirectory.file("../gradle/libs.versions.toml")
 
@@ -1439,7 +1454,26 @@ compose.desktop {
                 // again produced a plist with duplicate keys that only worked because the
                 // last declaration wins — the single-source DSL settings replace that.
                 infoPlist {
-                    extraKeysRawXml =
+                    // The URL schemes, document types and exported UTIs are
+                    // GENERATED from src/desktopMain/resources/boss-file-types.json
+                    // by buildSrc/BossFileTypes, not written here.
+                    //
+                    // What used to be here was one document type - public.html and
+                    // public.url, role Viewer - so BOSS could not be made the
+                    // default for a .md, a .sh or any of the 83 extensions its
+                    // editor has a lexer for. Launch Services can only make an app
+                    // the default for a *type*, and 41 of those extensions have no
+                    // system UTI at all, so the app has to export its own. That is
+                    // 28 document types and 24 exported types: generated, because
+                    // hand-writing it guarantees it drifts from EditorLanguages,
+                    // and a drift means BOSS agreeing to open a file it cannot
+                    // highlight or refusing one it can.
+                    //
+                    // Concatenated rather than interpolated into a trimIndent
+                    // block: trimIndent runs after interpolation and would
+                    // re-indent the generated XML by its own first line, which is
+                    // how a generated plist ends up with a mangled prolog.
+                    val staticKeys =
                         """
                         $macPrereleaseShortVersionKey
                         <key>NSCameraUsageDescription</key>
@@ -1450,34 +1484,15 @@ compose.desktop {
                         <string>BOSS uses Bluetooth to let you sign in with a passkey stored on your phone or tablet.</string>
                         <key>NSBluetoothPeripheralUsageDescription</key>
                         <string>BOSS uses Bluetooth to let you sign in with a passkey stored on your phone or tablet.</string>
-                        <key>CFBundleURLTypes</key>
-                        <array>
-                            <dict>
-                                <key>CFBundleURLName</key>
-                                <string>ai.rever.boss</string>
-                                <key>CFBundleURLSchemes</key>
-                                <array>
-                                    <string>boss</string>
-                                    <string>http</string>
-                                    <string>https</string>
-                                </array>
-                            </dict>
-                        </array>
-                        <key>CFBundleDocumentTypes</key>
-                        <array>
-                            <dict>
-                                <key>CFBundleTypeName</key>
-                                <string>HTML Document</string>
-                                <key>CFBundleTypeRole</key>
-                                <string>Viewer</string>
-                                <key>LSItemContentTypes</key>
-                                <array>
-                                    <string>public.html</string>
-                                    <string>public.url</string>
-                                </array>
-                            </dict>
-                        </array>
                         """.trimIndent()
+
+                    extraKeysRawXml =
+                        listOf(
+                            staticKeys,
+                            BossFileTypes.urlTypesXml(bossFileTypes, ownScheme = "boss", urlName = "ai.rever.boss"),
+                            BossFileTypes.documentTypesXml(bossFileTypes),
+                            BossFileTypes.exportedTypesXml(bossFileTypes),
+                        ).filter { it.isNotBlank() }.joinToString("\n")
                 }
             }
         }

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -1054,6 +1054,7 @@
     <ID>ReturnCount:CLICommandHandler.kt$CLICommandHandler$private suspend fun handleOpenFolder(folderPath: String)</ID>
     <ID>ReturnCount:CLIInstaller.kt$CLIInstaller$private fun installHomebrewStyle(): CLIInstallResult</ID>
     <ID>ReturnCount:CLIInstaller.kt$CLIInstaller$private fun updateShellConfig(): ShellConfigResult</ID>
+    <ID>ReturnCount:CLISecurityValidator.kt$CLISecurityValidator$fun isValidOpenTargetPath(path: String): Boolean</ID>
     <ID>ReturnCount:CLISecurityValidator.kt$CLISecurityValidator$fun isValidPath(path: String): Boolean</ID>
     <ID>ReturnCount:CLISecurityValidator.kt$CLISecurityValidator$fun normalizeAndValidateUrl(url: String): String?</ID>
     <ID>ReturnCount:ChromiumAutoDownloader.kt$ChromiumAutoDownloader$fun isChromiumInstalled(): Boolean</ID>
@@ -1103,11 +1104,12 @@
     <ID>ReturnCount:KeymapMatcher.kt$KeymapMatcher$fun match( event: KeyEvent, context: ShortcutContext, ): KeyBinding?</ID>
     <ID>ReturnCount:KeymapMatcher.kt$KeymapMatcher$private fun matchesBinding( event: KeyEvent, binding: KeyBinding, ): Boolean</ID>
     <ID>ReturnCount:LLMSettings.kt$LLMSettings$fun getApiKey(provider: LLMProvider): String?</ID>
-    <ID>ReturnCount:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$private fun getDefaultHandlers(): Map&lt;String, String&gt;</ID>
-    <ID>ReturnCount:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$private fun setDefaultHandlerForScheme(scheme: String): Boolean</ID>
+    <ID>ReturnCount:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$private fun getDefaultHandlersViaSwift(): Map&lt;String, String&gt;</ID>
+    <ID>ReturnCount:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$private fun setDefaultHandlerForSchemeViaSwift(scheme: String): Boolean</ID>
     <ID>ReturnCount:McpToolRegistryImpl.kt$McpToolRegistryCore$private fun permitted(def: McpToolDefinition): Boolean</ID>
     <ID>ReturnCount:MenuShortcutBridge.kt$MenuShortcutBridge$fun getKeyShortcut(actionId: String): androidx.compose.ui.input.key.KeyShortcut?</ID>
     <ID>ReturnCount:NewTabDialog.kt$private fun validateFilePath( path: String, basePath: String? = null, ): String?</ID>
+    <ID>ReturnCount:OsOpenArguments.kt$OsOpenArguments$fun deepLinksFrom( args: Array&lt;String&gt;, exists: (String) -&gt; Boolean = { File(it).isFile }, ): List&lt;String&gt;</ID>
     <ID>ReturnCount:PanelComponentStore.kt$PanelComponentStore$fun getOrCreateComponent(panelId: PanelId): PanelComponentWithUI?</ID>
     <ID>ReturnCount:PanelComponentStore.kt$PanelComponentStore$fun resetComponent(panelId: PanelId): Boolean</ID>
     <ID>ReturnCount:PasskeyAuthService.kt$PasskeyAuthService$suspend fun authenticateWithPasskey( email: String? = null, credentialId: String? = null, ): Result&lt;Unit&gt;</ID>
@@ -1135,16 +1137,17 @@
     <ID>ReturnCount:SessionManager.kt$SessionManager$suspend fun loadSession(): Result&lt;UserInfo?&gt;</ID>
     <ID>ReturnCount:ShortcutTestRunner.kt$ShortcutTestRunner$private fun validateKeyName(keyName: String): Pair&lt;Boolean, String&gt;</ID>
     <ID>ReturnCount:ShortcutTestRunner.kt$ShortcutTestRunner$suspend fun testShortcut(binding: KeyBinding): ShortcutTestResult</ID>
-    <ID>ReturnCount:SplitView.kt$SplitViewState$fun openUrlInActivePanel( url: String, title: String, forceNewTab: Boolean = false, )</ID>
     <ID>ReturnCount:SplitView.kt$SplitViewState$fun setActivePanel(panelId: String)</ID>
+    <ID>ReturnCount:SplitView.kt$SplitViewState$private fun openUrlInActivePanelNow( url: String, title: String, forceNewTab: Boolean, )</ID>
     <ID>ReturnCount:StoreVersionInstaller.kt$StoreVersionInstaller$private suspend fun activate( request: StoreVersionRequest, target: File, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, ): Result&lt;String&gt;</ID>
     <ID>ReturnCount:StoreVersionInstaller.kt$StoreVersionInstaller$suspend fun install( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, ): Result&lt;String&gt;</ID>
     <ID>ReturnCount:SupabasePasskeyService.kt$SupabasePasskeyService$suspend fun getUserPasskeys(userId: String): Result&lt;List&lt;PasskeyCredential&gt;&gt;</ID>
     <ID>ReturnCount:SupabasePasskeyService.kt$SupabasePasskeyService$suspend fun requestRegistrationChallenge( userId: String, displayName: String, authenticatorSelection: AuthenticatorSelectionCriteria?, ): Result&lt;PasskeyChallenge&gt;</ID>
     <ID>ReturnCount:TabDraggableComponent.kt$TabDraggableComponent$private fun checkEdgeScroll()</ID>
     <ID>ReturnCount:TabDraggableComponent.kt$TabDraggableComponent$private fun updateDropTarget()</ID>
+    <ID>ReturnCount:TabTypeAvailability.kt$TabTypeAvailability$private fun promptFor( typeId: TabTypeId, pluginId: String, purpose: String, ): MissingHandlerPluginPrompt?</ID>
+    <ID>ReturnCount:TabTypeAvailability.kt$TabTypeAvailability$suspend fun require( registry: TabRegistry, typeId: TabTypeId, purpose: String, bus: MissingHandlerPluginBus = MissingHandlerPluginEventBus, ): Boolean</ID>
     <ID>ReturnCount:TabUpdateRegistry.kt$TabUpdateRegistry$private fun resolveProvider( tabId: String, typeId: TabTypeId, ): TabUpdateProvider?</ID>
-    <ID>ReturnCount:URLHandlerService.kt$URLHandlerService$private fun isValidURL(url: String): Boolean</ID>
     <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$fun getCurrentApplicationPath(): String?</ID>
     <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$private fun detectLinuxDistroType(): String</ID>
     <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$private fun findInstalledAppViaSpotlight(): String?</ID>
@@ -1153,8 +1156,11 @@
     <ID>ReturnCount:UpdateInstaller.kt$UpdateInstaller$suspend fun installUpdate(downloadPath: String): InstallResult</ID>
     <ID>ReturnCount:UpdateInstaller.kt$internal fun realAppPathFor( path: String, appExists: (String) -&gt; Boolean, installedAppLookup: () -&gt; String?, ): String</ID>
     <ID>ReturnCount:UpdateManager.kt$UpdateManager$private suspend fun checkForUpdatesInternal(force: Boolean = false): UpdateResult</ID>
+    <ID>ReturnCount:UrlOpenValidation.kt$UrlOpenValidation$fun isOpenable(url: String): Boolean</ID>
+    <ID>ReturnCount:UrlOpenValidation.kt$UrlOpenValidation$private fun hostOf(authority: String): String?</ID>
     <ID>ReturnCount:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$fun extractMainDomain(url: String): String?</ID>
     <ID>ReturnCount:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private fun registerAsBrowserCandidate(): Boolean</ID>
+    <ID>ReturnCount:WindowsFileTypeHandler.kt$WindowsFileTypeHandler$fun register(category: FileTypeCategory): Boolean</ID>
     <ID>ReturnCount:WorkspacePlaceholders.kt$WorkspacePlaceholders$private fun getGitRemoteUrl(projectPath: String): String</ID>
     <ID>SpreadOperator:CrashHandler.kt$CrashHandler$(javaBin, *getRestartArgs())</ID>
     <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, *args.toTypedArray())</ID>
@@ -1211,6 +1217,8 @@
     <ID>TooGenericExceptionCaught:DashboardStatsManager.kt$DashboardStatsManager$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DeepLinkActionRegistryImpl.kt$DeepLinkActionRegistryImpl$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:DeepLinkHandler.kt$DeepLinkHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DefaultAppsManager.kt$DefaultAppsManager$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DefaultAppsSettingsManager.kt$DefaultAppsSettingsManager$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DefaultPlugin.kt$ApiActiveTabsProviderAdapter$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DefaultPlugin.kt$DefaultBackgroundTaskProvider$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DefaultPlugin.kt$DefaultCacheProvider$e: Exception</ID>
@@ -1257,6 +1265,7 @@
     <ID>TooGenericExceptionCaught:FilePickerProviderFactory.kt$DesktopFilePickerProvider$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FileSystemDataProviderImpl.kt$FileSystemDataProviderImpl$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FileSystemUtils.kt$FileSystemUtils$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FileTypeCategories.kt$FileTypeCategories$e: Exception</ID>
     <ID>TooGenericExceptionCaught:Fluck.kt$FluckTabComponent$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FluckEngine.kt$FluckEngine$e2: Exception</ID>
     <ID>TooGenericExceptionCaught:FluckEngine.kt$FluckEngine$e: Exception</ID>
@@ -1280,6 +1289,7 @@
     <ID>TooGenericExceptionCaught:LLMSettings.kt$LLMSettings$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LastSessionCoordinator.kt$LastSessionCoordinator$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LinuxDefaultBrowserHandler.kt$LinuxDefaultBrowserHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LinuxFileTypeHandler.kt$LinuxFileTypeHandler$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LockedBrowser.kt$LockedBrowser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MacOSCamera.kt$MacOSCamera$e: Exception</ID>
     <ID>TooGenericExceptionCaught:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler$e: Exception</ID>
@@ -1357,6 +1367,7 @@
     <ID>TooGenericExceptionCaught:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WindowAppearanceSettingsManager.kt$WindowAppearanceSettingsManager$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WindowsFileTypeHandler.kt$WindowsFileTypeHandler$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WindowsHelloAuth.kt$WindowsHelloAuth$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WindowsProtocolHandler.kt$WindowsProtocolHandler$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WorkspaceButton.desktop.kt$e: Exception</ID>
@@ -1407,7 +1418,9 @@
     <ID>TooManyFunctions:GlobalSearchDialog.kt$ai.rever.boss.components.dialogs.GlobalSearchDialog.kt</ID>
     <ID>TooManyFunctions:GlobalSearchService.kt$GlobalSearchService</ID>
     <ID>TooManyFunctions:LLMModelFetcher.kt$LLMModelFetcher</ID>
+    <ID>TooManyFunctions:LinuxDefaultBrowserHandler.kt$LinuxDefaultBrowserHandler</ID>
     <ID>TooManyFunctions:LogSanitizer.kt$LogSanitizer</ID>
+    <ID>TooManyFunctions:MacOSDefaultBrowserHandler.kt$MacOSDefaultBrowserHandler</ID>
     <ID>TooManyFunctions:McpToolRegistryImpl.kt$McpToolRegistryCore</ID>
     <ID>TooManyFunctions:MenuActionsHandler.kt$MenuActionsHandler</ID>
     <ID>TooManyFunctions:PasskeyDataMapper.kt$PasskeyDataMapper</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -255,6 +255,7 @@
     <ID>LongMethod:CrashReportService.kt$CrashReportService$private suspend fun submitViaProxy(report: CrashReport): ProxyResult</ID>
     <ID>LongMethod:CrossDeviceAuthenticationDialog.kt$@Composable fun CrossDeviceAuthenticationDialog( qrCodeUrl: String?, challenge: String?, sessionId: String? = null, onDismiss: () -&gt; Unit, onSuccess: () -&gt; Unit, onCreateFluckTab: ((FluckTabInfo) -&gt; Unit)? = null, )</ID>
     <ID>LongMethod:Dashboard.kt$@Composable fun Dashboard( onOpenFile: (String) -&gt; Unit, onOpenUrl: (String) -&gt; Unit, onOpenProject: (Project) -&gt; Unit, selectedProject: Project = Project("No Project", "", 0L), onNewTab: () -&gt; Unit, onNewTerminal: () -&gt; Unit, onNewWindow: () -&gt; Unit, onOpenProjectDialog: () -&gt; Unit, onOpenFileDialog: () -&gt; Unit, onNewProject: () -&gt; Unit, onApplySplitTemplate: (SplitTemplate) -&gt; Unit, onActivatePlugin: (String) -&gt; Unit, onShowSettings: (() -&gt; Unit)? = null, modifier: Modifier = Modifier, )</ID>
+    <ID>LongMethod:DefaultAppsSettings.kt$@Composable fun DefaultAppsSettings()</ID>
     <ID>LongMethod:DefaultBrowserSection.kt$@Composable fun DefaultBrowserSection()</ID>
     <ID>LongMethod:DefaultPlugin.kt$DefaultPlugin$private fun loadExternalPlugins()</ID>
     <ID>LongMethod:DefaultPlugin.kt$DefaultPlugin$private fun registerKernelPluginServices()</ID>
@@ -1109,7 +1110,7 @@
     <ID>ReturnCount:McpToolRegistryImpl.kt$McpToolRegistryCore$private fun permitted(def: McpToolDefinition): Boolean</ID>
     <ID>ReturnCount:MenuShortcutBridge.kt$MenuShortcutBridge$fun getKeyShortcut(actionId: String): androidx.compose.ui.input.key.KeyShortcut?</ID>
     <ID>ReturnCount:NewTabDialog.kt$private fun validateFilePath( path: String, basePath: String? = null, ): String?</ID>
-    <ID>ReturnCount:OsOpenArguments.kt$OsOpenArguments$fun deepLinksFrom( args: Array&lt;String&gt;, exists: (String) -&gt; Boolean = { File(it).isFile }, ): List&lt;String&gt;</ID>
+    <ID>ReturnCount:OsOpenArguments.kt$OsOpenArguments$fun deepLinksFrom( args: Array&lt;String&gt;, kindOf: (String) -&gt; OpenTargetKind = ::openTargetKindOf, ): List&lt;String&gt;</ID>
     <ID>ReturnCount:PanelComponentStore.kt$PanelComponentStore$fun getOrCreateComponent(panelId: PanelId): PanelComponentWithUI?</ID>
     <ID>ReturnCount:PanelComponentStore.kt$PanelComponentStore$fun resetComponent(panelId: PanelId): Boolean</ID>
     <ID>ReturnCount:PasskeyAuthService.kt$PasskeyAuthService$suspend fun authenticateWithPasskey( email: String? = null, credentialId: String? = null, ): Result&lt;Unit&gt;</ID>
@@ -1161,6 +1162,7 @@
     <ID>ReturnCount:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$fun extractMainDomain(url: String): String?</ID>
     <ID>ReturnCount:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private fun registerAsBrowserCandidate(): Boolean</ID>
     <ID>ReturnCount:WindowsFileTypeHandler.kt$WindowsFileTypeHandler$fun register(category: FileTypeCategory): Boolean</ID>
+    <ID>ReturnCount:WindowsRegistryScript.kt$WindowsRegistryScript$private fun userChoiceExtensionOf(keyLine: String): String?</ID>
     <ID>ReturnCount:WorkspacePlaceholders.kt$WorkspacePlaceholders$private fun getGitRemoteUrl(projectPath: String): String</ID>
     <ID>SpreadOperator:CrashHandler.kt$CrashHandler$(javaBin, *getRestartArgs())</ID>
     <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, *args.toTypedArray())</ID>
@@ -1288,6 +1290,7 @@
     <ID>TooGenericExceptionCaught:LLMProvidersSettings.kt$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LLMSettings.kt$LLMSettings$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LastSessionCoordinator.kt$LastSessionCoordinator$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LaunchServices.kt$LaunchServices$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:LinuxDefaultBrowserHandler.kt$LinuxDefaultBrowserHandler$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LinuxFileTypeHandler.kt$LinuxFileTypeHandler$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LockedBrowser.kt$LockedBrowser$e: Exception</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/BossApp.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/BossApp.kt
@@ -10,6 +10,7 @@ import ai.rever.boss.app.BossAppStartupEffects
 import ai.rever.boss.app.rememberBossAppState
 import ai.rever.boss.app.rememberFocusModeReveal
 import ai.rever.boss.components.registery.PanelRegistry
+import ai.rever.boss.filetypes.DefaultAppsOfferHost
 import ai.rever.boss.focusmode.FocusModeSettingsManager
 import ai.rever.boss.window.WindowAppearanceSettingsManager
 import androidx.compose.runtime.Composable
@@ -75,6 +76,14 @@ fun ComponentContext.BossApp(
             )
 
             BossAppDialogs(state)
+
+            // The one-time offer to make BOSS the default for links and code
+            // files. Composed here rather than inside BossAppDialogs because
+            // everything it touches - Launch Services, the Windows registry,
+            // xdg-mime - is desktopMain, so it is an expect/actual composable
+            // like AuthBrandSite. It raises nothing on the windows that are not
+            // the first, and nothing at all once the offer has been made.
+            DefaultAppsOfferHost(isFirstWindow = state.isFirstWindow)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppDialogs.kt
@@ -20,6 +20,8 @@ import ai.rever.boss.components.plugin.DependentRestartDeclinedException
 import ai.rever.boss.components.plugin.DependentRestartDialog
 import ai.rever.boss.components.plugin.DynamicPluginManager
 import ai.rever.boss.components.plugin.MissingDependencyDialog
+import ai.rever.boss.components.plugin.MissingHandlerPluginDialog
+import ai.rever.boss.components.plugin.MissingHandlerPluginEventBus
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.PluginLoadGateHost
 import ai.rever.boss.components.plugin.PluginLoadRemedyAccess
@@ -812,6 +814,65 @@ internal fun BossAppDialogs(state: BossAppState) {
         manager = state.currentDefaultPlugin?.dynamicPluginManager,
         remedyResolver = PluginLoadRemedyAccess.current(),
     )
+
+    // BOSS was asked to open something and the plugin that renders it is not
+    // running. Offer to install or enable it, rather than dropping the tab with
+    // only a log line - which is what "BOSS is my default browser and clicking a
+    // link does nothing" actually was.
+    state.pendingMissingHandlerPlugin?.let { prompt ->
+        MissingHandlerPluginDialog(
+            prompt = prompt,
+            working = state.resolvingMissingHandlerPlugin,
+            error = state.missingHandlerPluginError,
+            onDismiss = {
+                // An answer for the session, keyed by plugin: twelve files
+                // selected in Finder with no editor plugin is one question, and
+                // asking again for each would be the same question twelve times.
+                MissingHandlerPluginEventBus.decline(prompt.missing.pluginId)
+                state.pendingMissingHandlerPlugin = null
+                state.missingHandlerPluginError = null
+            },
+            onResolve = {
+                state.resolvingMissingHandlerPlugin = true
+                state.missingHandlerPluginError = null
+                coroutineScope.launch {
+                    try {
+                        // runCatching rather than a catch block, as the dependency
+                        // dialog does: a throw instead of a failed Result would
+                        // leave the dialog open with no message and a live button,
+                        // looking like the click did nothing. Cancellation is
+                        // rethrown - the work is detached and continues, so
+                        // nothing went wrong and there is nowhere to report it.
+                        runCatching { prompt.resolve() }
+                            .getOrElse { error ->
+                                if (error is CancellationException) throw error
+                                Result.failure(error)
+                            }.onSuccess {
+                                // Nothing else to do here: registering the tab
+                                // type fires the registry's change listeners,
+                                // which completes the wait in
+                                // TabTypeAvailability, which performs the open
+                                // that was deferred. The file the user
+                                // double-clicked appears by itself.
+                                state.pendingMissingHandlerPlugin = null
+                                state.missingHandlerPluginError = null
+                            }.onFailure { error ->
+                                // Keep the dialog up with the reason and a Retry:
+                                // dismissing on failure would look like it worked.
+                                state.missingHandlerPluginError =
+                                    error.message ?: "Could not start the plugin."
+                            }
+                    } finally {
+                        // Always, because `working` disables every button and
+                        // blocks dismissal: a throw here rather than a failed
+                        // Result would leave a modal that can only be escaped by
+                        // closing the window.
+                        state.resolvingMissingHandlerPlugin = false
+                    }
+                }
+            },
+        )
+    }
 
     // Directory picker for project selection (must be outside conditional for Compose)
     val directoryPicker =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -15,6 +15,7 @@ import ai.rever.boss.components.events.TerminalLinkEventBus
 import ai.rever.boss.components.events.URLEventBus
 import ai.rever.boss.components.events.WorkspaceEventBus
 import ai.rever.boss.components.plugin.DependentRestartEventBus
+import ai.rever.boss.components.plugin.MissingHandlerPluginEventBus
 import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.plugin.PluginDependencyEventBus
 import ai.rever.boss.components.plugin.resolveRegisteredPanelId
@@ -242,6 +243,31 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                 // window closing) leaves whatever is still in the channel for another window -
                 // though a prompt already received here and not yet shown does go with it.
                 snapshotFlow { state.pendingMissingPluginDependency }.first { it == null }
+            }
+    }
+
+    // BOSS was asked to open something - a link the OS handed over, a file
+    // double-clicked in Finder, a path dropped on a panel - and the plugin that
+    // renders it is not running. Without this the tab was silently dropped
+    // ("Dropped tab - no factory registered for its type") and the user saw
+    // nothing happen at all.
+    LaunchedEffect(windowId) {
+        MissingHandlerPluginEventBus.missingHandlers
+            .collect { prompt ->
+                // Declined since it was raised: two files can each raise a prompt
+                // for the same plugin before either is shown, and the second must
+                // not re-ask a question already answered. The bus filters at
+                // report time too; this covers the gap between the two.
+                if (MissingHandlerPluginEventBus.wasDeclined(prompt.missing.pluginId)) {
+                    return@collect
+                }
+                state.resolvingMissingHandlerPlugin = false
+                state.missingHandlerPluginError = null
+                state.pendingMissingHandlerPlugin = prompt
+                // Back-pressure rather than a queue, exactly as above: a second
+                // missing plugin waits in the channel instead of replacing a
+                // dialog someone is reading.
+                snapshotFlow { state.pendingMissingHandlerPlugin }.first { it == null }
             }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -261,6 +261,30 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
                 if (MissingHandlerPluginEventBus.wasDeclined(prompt.missing.pluginId)) {
                     return@collect
                 }
+                // Resolved on its own since it was raised: the plugin may have been
+                // installed from the Toolbox, or registration may simply have run
+                // past the first bounded wait. TabTypeAvailability's second wait
+                // then completes and the deferred open succeeds - and without this
+                // the queued dialog still appeared, offering to install a plugin
+                // that is now running. The dependency-bus collector guards the
+                // analogous case by re-checking isInstalled.
+                //
+                // Compared on the type STRING, not by looking up a TabTypeId:
+                // TabTypeId is a data class whose equality includes pluginId and
+                // defaultOrder, so a constructed one misses a type that is plainly
+                // registered - the trap panelid-defaultorder-silent-miss records.
+                val alreadyRegistered =
+                    state.tabRegistry.getAllTabTypes().any { candidate ->
+                        candidate.typeId.typeId == prompt.missing.tabTypeId
+                    }
+                if (alreadyRegistered) {
+                    logger.debug(
+                        LogCategory.UI,
+                        "Not asking about a tab-type plugin that has since registered",
+                        mapOf("plugin" to prompt.missing.pluginId, "tabType" to prompt.missing.tabTypeId),
+                    )
+                    return@collect
+                }
                 state.resolvingMissingHandlerPlugin = false
                 state.missingHandlerPluginError = null
                 state.pendingMissingHandlerPlugin = prompt

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -105,6 +105,19 @@ internal fun BossAppStartupEffects(state: BossAppState) {
         SplitViewStateRegistry.register(windowId, splitViewState)
     }
 
+    // Cancel the split state's deferred-open scope when the state itself goes.
+    //
+    // Keyed on `splitViewState` ALONE, deliberately. The obvious place for this
+    // was `SplitViewStateRegistry.unregister`, which is called from the big
+    // DisposableEffect below - and that one is keyed on seven values, only one of
+    // which is the split state. A change to any of the other six would have
+    // cancelled the scope of a state that is still live, after which every
+    // deferred open in that window silently did nothing for the rest of the
+    // session, with no error anywhere.
+    DisposableEffect(splitViewState) {
+        onDispose { splitViewState.dispose() }
+    }
+
     // Register this window's panel component store so the plugin reload path can
     // reset open sidebar panel slots across all windows (see PanelComponentStoreRegistry).
     // DisposableEffect (not LaunchedEffect like the registries below): a store

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppState.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.components.plugin.AvailablePluginUpdate
 import ai.rever.boss.components.plugin.DefaultPlugin
 import ai.rever.boss.components.plugin.DependentRestartPrompt
 import ai.rever.boss.components.plugin.MissingDependencyPrompt
+import ai.rever.boss.components.plugin.MissingHandlerPluginPrompt
 import ai.rever.boss.components.plugin.PluginUninstallPrompt
 import ai.rever.boss.components.plugin.StoreVersionPrompt
 import ai.rever.boss.components.plugin.providers.SplitViewOperationsImpl
@@ -146,6 +147,21 @@ internal class BossAppState(
         mutableStateOf<MissingDependencyPrompt?>(null)
     var installingMissingDependency by mutableStateOf(false)
     var missingDependencyError by mutableStateOf<String?>(null)
+
+    /**
+     * The plugin that would have rendered something BOSS was just asked to open,
+     * and is not running.
+     *
+     * Held separately from [pendingMissingPluginDependency] rather than sharing
+     * its three fields: the two prompts can be raised at once (installing a
+     * plugin whose dependency is absent, while a file the OS handed over waits on
+     * the editor plugin), and one set of fields would let the second overwrite
+     * the first's dialog mid-answer. Back-pressured the same way, per bus.
+     */
+    var pendingMissingHandlerPlugin by
+        mutableStateOf<MissingHandlerPluginPrompt?>(null)
+    var resolvingMissingHandlerPlugin by mutableStateOf(false)
+    var missingHandlerPluginError by mutableStateOf<String?>(null)
 
     /**
      * Plugins that would be restarted by an unload the user has not answered yet.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingHandlerPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingHandlerPlugin.kt
@@ -1,0 +1,153 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import java.util.concurrent.ConcurrentHashMap
+
+/** What the user has to do about a missing tab-type plugin. */
+enum class MissingHandlerRemedy {
+    /** The plugin is not on the machine. Download and load it. */
+    INSTALL,
+
+    /**
+     * The plugin is installed and switched off.
+     *
+     * A separate remedy, not a detail: offering to *install* something already on
+     * disk is both wrong and unactionable - `installPlugin` refuses with "Plugin
+     * already loaded" or reinstalls the same jar and changes nothing, because
+     * what is stopping it is the `installed.json` enabled flag. This is the same
+     * distinction `install-time-dependency-prompt` records as having broken the
+     * dependency prompt when the two halves disagreed about "installed".
+     */
+    ENABLE,
+}
+
+/**
+ * BOSS was asked to open something and the plugin that renders it is not running.
+ *
+ * @property purpose what the user was trying to do, in their terms ("Opening
+ *   README.md"). Carried rather than derived so the dialog can name the file the
+ *   OS handed over, which is the thing that makes the prompt make sense.
+ * @property capability what the plugin provides, from [TabTypePlugins.describe].
+ * @property tabTypeId the type that is missing, for logging and dedupe.
+ * @property pluginId the plugin to install or enable.
+ * @property remedy which of the two this is.
+ */
+data class MissingHandlerPlugin(
+    val purpose: String,
+    val capability: String,
+    val tabTypeId: String,
+    val pluginId: String,
+    val remedy: MissingHandlerRemedy,
+)
+
+/**
+ * A missing tab-type plugin plus the means to fix it.
+ *
+ * The installer travels with the event for the reason [MissingDependencyPrompt]
+ * documents: it is bound to the `DynamicPluginManager` that is missing the
+ * plugin, one per window, so the fix always lands in the manager that needs it.
+ *
+ * @property resolve performs the remedy. A suspending lambda rather than an
+ *   interface because the two remedies have nothing in common at the call site -
+ *   one downloads a jar through [MissingDependencyInstaller], the other flips a
+ *   flag through `DynamicPluginManager.enablePlugin` - and the dialog only needs
+ *   "do the thing, tell me if it worked".
+ * @property displayName resolves the plugin's store name, so the dialog can say
+ *   "Code Editor Tab" rather than `ai.rever.boss.plugin.dynamic.editortab`.
+ *   Returns null when the store cannot be reached, and the dialog then shows the
+ *   id: a prompt that appears late or not at all is worse than an ugly one.
+ */
+data class MissingHandlerPluginPrompt(
+    val missing: MissingHandlerPlugin,
+    val resolve: suspend () -> Result<Unit>,
+    val displayName: suspend () -> String?,
+)
+
+/**
+ * Carries a missing tab-type plugin from wherever an open was attempted to
+ * whichever window can ask about it.
+ *
+ * Deliberately a near-copy of [PluginDependencyBus] rather than a reuse of it.
+ * The two answer different questions - "a plugin you installed needs another
+ * plugin" against "the thing you just double-clicked needs a plugin" - and the
+ * text of the dependency dialog is specifically about a manifest declaration.
+ * What is copied is the delivery, because the reasons behind it apply unchanged:
+ *
+ * - a **`Channel`, not a `SharedFlow`**: a broadcast would put an identical
+ *   dialog in front of every open window and let each of them start the same
+ *   install.
+ * - **buffered**, so raising never suspends the code that was trying to open a
+ *   file, and a prompt raised before any window exists is asked as soon as one
+ *   appears rather than lost.
+ * - **`trySend` on a suspend-on-overflow channel**, so a full buffer refuses the
+ *   newest and says so, instead of a `DROP_OLDEST` that silently discards the one
+ *   the user is part-way through answering.
+ */
+open class MissingHandlerPluginBus {
+    private val logger = BossLogger.forComponent("MissingHandlerPluginBus")
+
+    /**
+     * Plugins the user has already declined, for this process only.
+     *
+     * Keyed by plugin id, not by the file that triggered it: declining once for
+     * `README.md` is an answer about the editor plugin, and asking again for the
+     * next file would be the same question. Not persisted, for the reason
+     * [PluginDependencyBus] gives: "not now" is an answer about now.
+     */
+    private val declined = ConcurrentHashMap.newKeySet<String>()
+
+    /** Plugins with a prompt already waiting, so the buffer is not spent on duplicates. */
+    private val queued = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * Buffer of 2, deliberately smaller than the dependency bus's 4.
+     *
+     * There are only four tab types the host opens, and a user selecting twelve
+     * files in Finder with no editor plugin produces one useful question, not
+     * twelve. `queued` collapses those to one; the buffer only has to hold a
+     * second *different* plugin (a link and a file arriving together).
+     */
+    private val prompts = Channel<MissingHandlerPluginPrompt>(capacity = 2)
+
+    val missingHandlers =
+        prompts
+            .receiveAsFlow()
+            // Freed on the way out rather than when the dialog is answered: the
+            // collector may decline to show a prompt whose plugin has since
+            // appeared, and a slot held for a prompt nobody will show is what
+            // `queued` exists to avoid.
+            .onEach { prompt -> queued.remove(prompt.missing.pluginId) }
+
+    fun decline(pluginId: String) {
+        declined.add(pluginId)
+    }
+
+    fun wasDeclined(pluginId: String): Boolean = pluginId in declined
+
+    /** Non-suspending, so the open path never waits on a UI. */
+    fun report(prompt: MissingHandlerPluginPrompt) {
+        val pluginId = prompt.missing.pluginId
+        if (wasDeclined(pluginId) || !queued.add(pluginId)) return
+        if (prompts.trySend(prompt).isFailure) {
+            queued.remove(pluginId)
+            logger.warn(
+                LogCategory.UI,
+                "Dropped a missing-handler prompt",
+                mapOf("plugin" to pluginId, "tabType" to prompt.missing.tabTypeId),
+            )
+        }
+    }
+
+    /** Test seam: forget this session's declines. */
+    internal fun resetForTest() {
+        declined.clear()
+        queued.clear()
+    }
+}
+
+/** The bus the host actually uses. */
+object MissingHandlerPluginEventBus : MissingHandlerPluginBus()

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingHandlerPluginDialog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/MissingHandlerPluginDialog.kt
@@ -1,0 +1,254 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * Offers to install or enable the plugin that would have rendered something BOSS
+ * was just asked to open.
+ *
+ * Separate from [MissingDependencyDialog] rather than a parameterisation of it:
+ * that one's copy is specifically about a plugin declaring a dependency in its
+ * manifest ("Flow needs the AI Gateway"), and the two questions differ in who is
+ * asking and what they were doing. Here the user double-clicked a file or clicked
+ * a link, and the sentence that makes sense names *that*.
+ *
+ * It also has a second verb. The dependency dialog only ever installs; this one
+ * offers **Enable** when the plugin is on disk and switched off, because
+ * installing something already installed cannot fix it.
+ *
+ * @param prompt the missing plugin plus the means to fix it
+ * @param working true while the install or enable is in flight
+ * @param error a failure from the last attempt, kept on screen with Retry
+ */
+@Composable
+fun MissingHandlerPluginDialog(
+    prompt: MissingHandlerPluginPrompt,
+    working: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onResolve: () -> Unit,
+) {
+    val missing = prompt.missing
+
+    // Show the id immediately and improve it if the store answers. Waiting would
+    // mean a dialog that appears late or not at all when the store is
+    // unreachable, which is exactly when the user most needs telling.
+    val resolvedName by
+        produceState(initialValue = missing.pluginId, missing.pluginId) {
+            runCatching { prompt.displayName() }
+                .getOrNull()
+                ?.takeIf { it.isNotBlank() }
+                ?.let { value = it }
+        }
+
+    BossDialog(
+        // Not dismissable while working: the install continues regardless, and a
+        // dialog that vanishes mid-download reads as "nothing happened".
+        onDismissRequest = { if (!working) onDismiss() },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = !working,
+                dismissOnClickOutside = !working,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .width(400.dp)
+                    .onKeyEvent { event ->
+                        val escape = event.type == KeyEventType.KeyDown && event.key == Key.Escape
+                        if (!working && escape) {
+                            onDismiss()
+                            true
+                        } else {
+                            false
+                        }
+                    },
+            shape = RoundedCornerShape(8.dp),
+            backgroundColor = BossTheme.colors.panel,
+            elevation = 8.dp,
+        ) {
+            MissingHandlerPluginBody(
+                missing = missing,
+                resolvedName = resolvedName,
+                working = working,
+                error = error,
+                onDismiss = onDismiss,
+                onResolve = onResolve,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MissingHandlerPluginBody(
+    missing: MissingHandlerPlugin,
+    resolvedName: String,
+    working: Boolean,
+    error: String?,
+    onDismiss: () -> Unit,
+    onResolve: () -> Unit,
+) {
+    val enabling = missing.remedy == MissingHandlerRemedy.ENABLE
+
+    Column(modifier = Modifier.padding(20.dp)) {
+        Text(
+            text = if (enabling) "Plugin is switched off" else "Plugin needed",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = BossTheme.colors.textPrimary,
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            // `purpose` is a file name or a URL the OS handed over and
+            // `resolvedName` comes from a store listing, so neither is allowed to
+            // grow the dialog or run on into something that reads like our own
+            // copy.
+            text =
+                if (enabling) {
+                    "${missing.purpose} needs $resolvedName, which is installed but switched off."
+                } else {
+                    "${missing.purpose} needs $resolvedName, the plugin that opens ${missing.capability}."
+                },
+            fontSize = 13.sp,
+            color = BossTheme.colors.textSecondary,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        // The plugin id, always, even once the store name resolves. For an
+        // install this is a consent dialog for downloading and running code, and
+        // the display name is the one string the least trustworthy party
+        // controls, so the identity the host will act on is shown alongside it.
+        Text(
+            text = missing.pluginId,
+            fontSize = 11.sp,
+            color = BossTheme.colors.textMuted,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        if (error != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = error,
+                fontSize = 12.sp,
+                color = BossTheme.colors.alert,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        MissingHandlerPluginActions(
+            enabling = enabling,
+            resolvedName = resolvedName,
+            working = working,
+            hasError = error != null,
+            onDismiss = onDismiss,
+            onResolve = onResolve,
+        )
+    }
+}
+
+@Composable
+private fun MissingHandlerPluginActions(
+    enabling: Boolean,
+    resolvedName: String,
+    working: Boolean,
+    hasError: Boolean,
+    onDismiss: () -> Unit,
+    onResolve: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (working) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(14.dp),
+                strokeWidth = 2.dp,
+                color = BossTheme.colors.signalText,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = if (enabling) "Enabling $resolvedName" else "Installing $resolvedName",
+                fontSize = 12.sp,
+                color = BossTheme.colors.textSecondary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        TextButton(
+            onClick = onDismiss,
+            enabled = !working,
+            colors =
+                ButtonDefaults.textButtonColors(
+                    contentColor = BossTheme.colors.textSecondary,
+                ),
+        ) {
+            Text("Not now")
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Button(
+            onClick = onResolve,
+            enabled = !working,
+            colors =
+                ButtonDefaults.buttonColors(
+                    backgroundColor = BossTheme.colors.signal,
+                    contentColor = BossTheme.colors.onSignal,
+                ),
+        ) {
+            Text(
+                when {
+                    hasError -> "Retry"
+                    enabling -> "Enable"
+                    else -> "Install"
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypeAvailability.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypeAvailability.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.components.bars.horizontal.StatusMessageManager
 import ai.rever.boss.plugin.api.PluginState
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.api.TabTypeId
@@ -63,6 +64,12 @@ object TabTypeAvailability {
 
         // Bounded wait for plugin startup. Without it, every file the OS queues
         // during a cold start would prompt.
+        //
+        // With a status message, because the wait is up to 15 seconds and the user
+        // has just double-clicked something: silence for 15 seconds looks exactly
+        // as dropped as the bug this whole path replaces, only slower. Shown for
+        // the wait only, and replaced by the dialog or the opened tab.
+        StatusMessageManager.showMessage("Waiting for the plugin that opens ${TabTypePlugins.describe(typeId)}...")
         val appearedOnItsOwn =
             awaitRegistryCondition(
                 registry::addChangeListener,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypeAvailability.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypeAvailability.kt
@@ -1,0 +1,220 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.PluginState
+import ai.rever.boss.plugin.api.TabRegistry
+import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.sandbox.ui.PluginCrashRegistry
+import ai.rever.boss.utils.awaitRegistryCondition
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+
+/**
+ * Makes sure the plugin that renders a tab type is running before something tries
+ * to open one, and offers to fix it when it is not.
+ *
+ * **The behaviour this replaces.** `BossMainWindowPanel.addTab` logs "Dropped tab
+ * - no factory registered for its type" and returns -1. Every caller ignored that
+ * return value, so with the browser plugin absent the OS could hand BOSS a link
+ * and *nothing at all* appeared - no tab, no error, no dialog. The user's report
+ * was "BOSS is my default browser and clicking a link does nothing", which is
+ * exactly what it looks like from outside.
+ *
+ * The wait matters as much as the prompt. At a cold start the plugins have not
+ * registered yet - `WorkspaceApplier.awaitTabTypes` exists for the same reason -
+ * so asking "is the editor plugin here?" the instant a queued file open drains
+ * would raise a false alarm on every launch. So: check, wait a bounded while,
+ * and only then conclude the plugin is genuinely absent.
+ */
+object TabTypeAvailability {
+    private val logger = BossLogger.forComponent("TabTypeAvailability")
+
+    /**
+     * How long to wait for the plugin after the user has been asked.
+     *
+     * Far longer than [ai.rever.boss.utils.PLUGIN_REGISTRATION_TIMEOUT_MS],
+     * because what is being waited on is different: the first wait is for plugin
+     * startup, this one is for a person to read a dialog, press Install and for a
+     * jar to download over whatever connection they have. Bounded rather than
+     * indefinite so a prompt nobody ever answers cannot pin the deferred open
+     * forever.
+     */
+    private const val USER_DECISION_TIMEOUT_MS = 5 * 60 * 1000L
+
+    /**
+     * True when [typeId] can be opened, waiting and prompting if it cannot.
+     *
+     * Suspends. Callers run it off the path that has to stay responsive - see
+     * `SplitViewState.requireTabTypeThen`, which launches it and performs the
+     * open in the continuation.
+     *
+     * @param purpose what the user was trying to do, for the dialog ("Opening
+     *   README.md"). Never a plugin id or a type id: the point of the prompt is to
+     *   connect the missing plugin to the thing the user just did.
+     * @param bus injected for tests.
+     */
+    suspend fun require(
+        registry: TabRegistry,
+        typeId: TabTypeId,
+        purpose: String,
+        bus: MissingHandlerPluginBus = MissingHandlerPluginEventBus,
+    ): Boolean {
+        if (registry.isRegistered(typeId)) return true
+
+        // Bounded wait for plugin startup. Without it, every file the OS queues
+        // during a cold start would prompt.
+        val appearedOnItsOwn =
+            awaitRegistryCondition(
+                registry::addChangeListener,
+                registry::removeChangeListener,
+            ) { registry.isRegistered(typeId) }
+        if (appearedOnItsOwn) return true
+
+        val pluginId = TabTypePlugins.pluginFor(typeId)
+        if (pluginId == null) {
+            // A plugin's own tab type that its plugin never registered. Nothing
+            // to offer: the host does not know who owns it, and guessing would
+            // offer to install the wrong thing.
+            logger.warn(
+                LogCategory.UI,
+                "Tab type is not registered and no plugin is known for it",
+                mapOf("tabType" to typeId.typeId, "purpose" to purpose),
+            )
+            return false
+        }
+
+        if (bus.wasDeclined(pluginId)) {
+            logger.debug(
+                LogCategory.UI,
+                "Not asking about a plugin the user declined this session",
+                mapOf("plugin" to pluginId),
+            )
+            return false
+        }
+
+        val prompt = promptFor(typeId, pluginId, purpose)
+        if (prompt == null) {
+            logger.warn(
+                LogCategory.UI,
+                "Cannot offer to fix a missing tab-type plugin",
+                mapOf("plugin" to pluginId, "tabType" to typeId.typeId),
+            )
+            return false
+        }
+
+        logger.info(
+            LogCategory.UI,
+            "Asking about a missing tab-type plugin",
+            mapOf("plugin" to pluginId, "tabType" to typeId.typeId, "remedy" to prompt.missing.remedy.name),
+        )
+        bus.report(prompt)
+
+        // The dialog does not call back. Installing or enabling the plugin
+        // registers the tab type, which fires the registry's change listeners,
+        // which completes this wait - so the file the user double-clicked opens
+        // as a consequence of the fix rather than needing a second attempt.
+        val resolved =
+            awaitRegistryCondition(
+                registry::addChangeListener,
+                registry::removeChangeListener,
+                timeoutMs = USER_DECISION_TIMEOUT_MS,
+            ) { registry.isRegistered(typeId) }
+
+        if (!resolved) {
+            logger.info(
+                LogCategory.UI,
+                "Giving up on a deferred open; the plugin never became available",
+                mapOf("plugin" to pluginId, "tabType" to typeId.typeId),
+            )
+        }
+        return resolved
+    }
+
+    /**
+     * Builds the prompt, choosing between Install and Enable, or null when
+     * neither can be offered.
+     *
+     * Null when there is no live `DynamicPluginManager` to act on - which happens
+     * during shutdown - because a dialog whose button cannot do anything is worse
+     * than no dialog.
+     */
+    private fun promptFor(
+        typeId: TabTypeId,
+        pluginId: String,
+        purpose: String,
+    ): MissingHandlerPluginPrompt? {
+        val manager = DynamicPluginManager.anyActiveManager() ?: return null
+
+        val installed =
+            PluginDependencyResolution.installedAndOnDisk(
+                states = manager.pluginStates.value,
+                // The same two predicates `MissingDependencyReporter.forManager`
+                // supplies, so this and the dependency prompt cannot disagree
+                // about what "installed" means - AGENTS.md records that
+                // disagreement having broken the dependency prompt once already.
+                exists = { File(it).isFile },
+                isIncompatible = { PluginCrashRegistry.isIncompatible(it) },
+            )
+
+        val info = manager.pluginStates.value[pluginId]
+        val remedy =
+            when {
+                // Installed and switched off: enabling is the fix, and installing
+                // would refuse ("Plugin already loaded") or rewrite the same jar
+                // and change nothing.
+                pluginId in installed && info?.state == PluginState.DISABLED -> {
+                    MissingHandlerRemedy.ENABLE
+                }
+
+                pluginId in installed -> {
+                    // Present, on disk, not disabled, and its tab type still is
+                    // not registered after the wait. Enabling is a no-op and
+                    // installing is wrong; there is nothing honest to offer, so
+                    // say so in the log rather than showing a button that cannot
+                    // work.
+                    logger.warn(
+                        LogCategory.UI,
+                        "Tab-type plugin is installed and not disabled but registered no tab type",
+                        mapOf("plugin" to pluginId, "state" to (info?.state?.name ?: "unknown")),
+                    )
+                    return null
+                }
+
+                else -> {
+                    MissingHandlerRemedy.INSTALL
+                }
+            }
+
+        val missing =
+            MissingHandlerPlugin(
+                purpose = purpose,
+                capability = TabTypePlugins.describe(typeId),
+                tabTypeId = typeId.typeId,
+                pluginId = pluginId,
+                remedy = remedy,
+            )
+
+        // The same installer the dependency prompt and the home tool grid use,
+        // through the factory `main.kt` injects. Null before startup finishes and
+        // in tests that never wire it, which is why INSTALL reports a failure the
+        // dialog can show rather than throwing.
+        val installer = MissingPluginOffer.installerFactory?.invoke(manager)
+
+        return MissingHandlerPluginPrompt(
+            missing = missing,
+            resolve = {
+                when (remedy) {
+                    MissingHandlerRemedy.ENABLE -> {
+                        manager.enablePlugin(pluginId)
+                    }
+
+                    MissingHandlerRemedy.INSTALL -> {
+                        installer?.install(pluginId)
+                            ?: Result.failure(IllegalStateException("The plugin store is not available."))
+                    }
+                }
+            },
+            displayName = { installer?.displayNameFor(pluginId) },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypePlugins.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypePlugins.kt
@@ -1,0 +1,67 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.TabTypeId
+
+/**
+ * Which plugin provides which tab type.
+ *
+ * The host needs this to answer "the OS just handed me a markdown file and there
+ * is no editor tab type - what do I offer to install?". It cannot be derived: the
+ * mapping lives in each plugin's `plugin.json` (`tab.typeId`), and when the
+ * plugin is absent there is no manifest to read. `TabTypeId` carries a `pluginId`
+ * field, but the constants the host opens tabs with (`FluckTabType.typeId` and
+ * friends, in the api artifact) leave it at the default, so it cannot be used
+ * either.
+ *
+ * A literal table, for the same reason `PluginDependencyResolution.NOT_USER_INSTALLABLE`
+ * holds the api plugin id as a literal: the value lives in another repository and
+ * nothing links the two at compile time. Getting an entry wrong is visible
+ * immediately - the dialog offers to install the wrong plugin - rather than
+ * silent.
+ *
+ * Only the four tab types the host itself opens are listed. A plugin that opens
+ * its own tab type does not come through here, because it is loaded by
+ * definition.
+ */
+object TabTypePlugins {
+    /** Browser tabs: `fluck-browser`. */
+    const val FLUCK_BROWSER = "ai.rever.boss.plugin.dynamic.fluckbrowser"
+
+    /** Code editor tabs: `editor-tab`. */
+    const val EDITOR_TAB = "ai.rever.boss.plugin.dynamic.editortab"
+
+    /** Terminal tabs: `terminal-tab`. */
+    const val TERMINAL_TAB = "ai.rever.boss.plugin.dynamic.terminaltab"
+
+    /** Notebook tabs: `jupyter-notebook`. */
+    const val JUPYTER_NOTEBOOK = "ai.rever.boss.plugin.dynamic.jupyternotebook"
+
+    private val byTypeId =
+        mapOf(
+            "fluck" to FLUCK_BROWSER,
+            "editor" to EDITOR_TAB,
+            "terminal" to TERMINAL_TAB,
+            "jupyter" to JUPYTER_NOTEBOOK,
+        )
+
+    /**
+     * The plugin that provides [typeId], or null for a type the host does not
+     * open itself.
+     *
+     * Keyed on the string, not the whole [TabTypeId]: `TabTypeId` is a data class
+     * whose equality includes `pluginId` and `defaultOrder`, and keying on it
+     * made a lookup miss for a type that was plainly registered - the same trap
+     * `panelid-defaultorder-silent-miss` records for panels.
+     */
+    fun pluginFor(typeId: TabTypeId): String? = byTypeId[typeId.typeId]
+
+    /** Human name for the thing a missing plugin would have opened, for the prompt's copy. */
+    fun describe(typeId: TabTypeId): String =
+        when (typeId.typeId) {
+            "fluck" -> "web pages"
+            "editor" -> "files in the editor"
+            "terminal" -> "terminals"
+            "jupyter" -> "notebooks"
+            else -> typeId.typeId
+        }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/language/EditorLanguages.kt
@@ -50,6 +50,22 @@ object EditorLanguages {
     }
 
     /**
+     * The extension-to-language table, for whoever has to stay in step with it.
+     *
+     * Exposed for exactly one reason: `boss-file-types.json` declares which file
+     * types BOSS asks the OS to make it the default for, and it must claim
+     * neither more nor less than what this table can highlight. Claiming more
+     * means BOSS agreeing to open a file it renders as plain text; claiming less
+     * means a language it *can* highlight that the OS never sends it.
+     * `FileTypeCategoriesTest` compares the two, which is the enforcement this
+     * class's own KDoc says nothing has.
+     *
+     * Read-only by construction: `EXTENSIONS` is an immutable `Map`, so this
+     * hands out no way to change it.
+     */
+    fun extensions(): Map<String, String> = EXTENSIONS
+
+    /**
      * Languages identified by file name rather than extension.
      *
      * Checked before extensions so that `Dockerfile.dev` is a Dockerfile rather than

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -6,6 +6,7 @@ import ai.rever.boss.components.model.TabDraggableComponent
 import ai.rever.boss.components.model.TabDropResult
 import ai.rever.boss.components.model.TabDropTarget
 import ai.rever.boss.components.overlays.OverlayCorner
+import ai.rever.boss.components.plugin.TabTypeAvailability
 import ai.rever.boss.components.plugin.disposePluginBrowsers
 import ai.rever.boss.components.plugin.tab_types.PanelHostTabInfo
 import ai.rever.boss.components.plugin.tab_types.fluck.FluckTabInfo
@@ -32,9 +33,12 @@ import ai.rever.boss.plugin.api.TabIcon
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
 import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
+import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
+import ai.rever.boss.plugin.tab.terminal.TerminalTabType
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.project.DefaultWorkingDirectory
 import ai.rever.boss.topofmind.ActiveTab
@@ -89,6 +93,10 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -197,6 +205,77 @@ class SplitViewState(
     private val windowId: String,
     initialTabsComponent: BossTabsComponent? = null,
 ) {
+    /**
+     * Scope for the deferred opens in [requireTabTypeThen].
+     *
+     * Window-lived and cancelled by [dispose], which `BossAppStartupEffects`
+     * calls from a `DisposableEffect` keyed on this state alone. What it holds is
+     * a wait of up to five minutes on a person answering a dialog, so closing the
+     * window has to abandon that rather than leave a coroutine holding a
+     * reference to a disposed window's panels.
+     *
+     * `Dispatchers.Main`: every continuation ends in an `addTab`, which touches
+     * Compose state.
+     */
+    private val openScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    /**
+     * Cancels the deferred opens. Called when this state leaves the composition.
+     *
+     * Deliberately NOT called from `SplitViewStateRegistry.unregister`, which was
+     * the first attempt: that runs from a `DisposableEffect` keyed on seven
+     * values, only one of which is this state, so a change to any of the other
+     * six would cancel a live window's scope and leave every later deferred open
+     * silently doing nothing.
+     */
+    internal fun dispose() {
+        openScope.cancel()
+    }
+
+    /**
+     * Runs [open] once [typeId]'s plugin is available, asking the user to install
+     * or enable it if it is not.
+     *
+     * Every open below goes through this, because the alternative is what shipped:
+     * `addTab` logs "Dropped tab - no factory registered for its type", returns
+     * -1, and every caller ignores it - so with the browser plugin absent the OS
+     * could hand BOSS a link and nothing whatsoever appeared.
+     *
+     * The fast path is synchronous in effect: [TabTypeAvailability.require]
+     * returns immediately when the type is registered, which is the normal case,
+     * and `launch` on `Dispatchers.Main` from the UI thread runs the continuation
+     * without yielding to another frame. The suspension only happens when there
+     * is genuinely something to wait for.
+     *
+     * @param purpose what the user was trying to do, for the dialog's copy.
+     */
+    private fun requireTabTypeThen(
+        typeId: TabTypeId,
+        purpose: String,
+        open: () -> Unit,
+    ) {
+        if (tabRegistry.isRegistered(typeId)) {
+            open()
+            return
+        }
+        openScope.launch {
+            if (!TabTypeAvailability.require(tabRegistry, typeId, purpose)) return@launch
+            // The wait can be five minutes long, because what it waits for is a
+            // person answering a dialog. Cancelling the scope is the primary
+            // guard; this is the one that survives a window teardown that did not
+            // reach it, rather than adding a tab to a panel tree nothing renders.
+            if (SplitViewStateRegistry.getState(windowId) !== this@SplitViewState) {
+                splitViewLogger.debug(
+                    LogCategory.UI,
+                    "Dropping a deferred open; its window is gone",
+                    mapOf("typeId" to typeId.typeId),
+                )
+                return@launch
+            }
+            open()
+        }
+    }
+
     // Root node of the split tree
     private var _rootNode =
         mutableStateOf<SplitNode>(
@@ -535,6 +614,15 @@ class SplitViewState(
         filePath: String,
         fileName: String,
     ) {
+        requireTabTypeThen(CodeEditorTabType.typeId, "Opening $fileName") {
+            openFileInEditorTabNow(filePath, fileName)
+        }
+    }
+
+    private fun openFileInEditorTabNow(
+        filePath: String,
+        fileName: String,
+    ) {
         val activeComponent = getActiveTabsComponent() ?: return
 
         // Check if file is already open in an editor tab in any panel
@@ -578,6 +666,16 @@ class SplitViewState(
         url: String,
         title: String,
         forceNewTab: Boolean = false,
+    ) {
+        requireTabTypeThen(FluckTabType.typeId, "Opening $title") {
+            openUrlInActivePanelNow(url, title, forceNewTab)
+        }
+    }
+
+    private fun openUrlInActivePanelNow(
+        url: String,
+        title: String,
+        forceNewTab: Boolean,
     ) {
         val activeComponent = getActiveTabsComponent()
 
@@ -654,23 +752,41 @@ class SplitViewState(
         command: String? = null,
         workingDirectory: String? = null,
     ) {
-        val activeComponent = getActiveTabsComponent()
+        requireTabTypeThen(TerminalTabType.typeId, "Opening a terminal") {
+            openTerminalInActivePanelNow(command, workingDirectory)
+        }
+    }
 
-        // Use provided working directory, or fall back to project path
+    /**
+     * Where a terminal opened in this window should start.
+     *
+     * Extracted from [openTerminalInActivePanelNow] to keep that function under
+     * the length limit once the availability gate split it in two; the rule it
+     * encodes is worth reading on its own anyway.
+     *
+     * `selectedOrNull` on the override too, not just `?:`. A run configuration
+     * with an unset working directory reaches here as "", which is not null, so
+     * it would pass straight through to the terminal service and land in the home
+     * directory - the thing this is meant to stop. Blank counts as absent, the
+     * same rule DefaultWorkingDirectory applies to a project path.
+     */
+    private fun terminalWorkingDirectory(workingDirectory: String?): String {
         val projectPath =
             WindowProjectStateRegistry
                 .get(windowId)
                 ?.selectedProject
                 ?.value
                 ?.path ?: ""
-        // selectedOrNull on the override too, not just `?:`. A run configuration with an unset
-        // working directory reaches here as "", which is not null, so it would pass straight
-        // through to the terminal service and land in the home directory - the thing this is
-        // meant to stop. Blank counts as absent, the same rule DefaultWorkingDirectory applies
-        // to a project path.
-        val terminalWorkingDir =
-            DefaultWorkingDirectory.selectedOrNull(workingDirectory)
-                ?: DefaultWorkingDirectory.resolve(projectPath)
+        return DefaultWorkingDirectory.selectedOrNull(workingDirectory)
+            ?: DefaultWorkingDirectory.resolve(projectPath)
+    }
+
+    private fun openTerminalInActivePanelNow(
+        command: String?,
+        workingDirectory: String?,
+    ) {
+        val activeComponent = getActiveTabsComponent()
+        val terminalWorkingDir = terminalWorkingDirectory(workingDirectory)
 
         // If no active component, this is likely the first terminal on app startup
         // Find any available panel to add the tab to

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/filetypes/DefaultAppsOffer.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/filetypes/DefaultAppsOffer.kt
@@ -1,0 +1,18 @@
+package ai.rever.boss.filetypes
+
+import androidx.compose.runtime.Composable
+
+/**
+ * The one-time offer to make BOSS the default for links and code files.
+ *
+ * `expect` because everything behind it - Launch Services, the Windows registry,
+ * `xdg-mime` - is `desktopMain`, while the window that has to show it is composed
+ * from `commonMain`. Same shape as `AuthBrandSite` and
+ * `rememberUpdateDialogOwnership`, which exist for the same reason.
+ *
+ * @param isFirstWindow only the first window offers. Two windows opening at once
+ *   would otherwise each raise a dialog about the same machine-wide setting, and
+ *   both would try to write it.
+ */
+@Composable
+internal expect fun DefaultAppsOfferHost(isFirstWindow: Boolean)

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLICommandHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLICommandHandler.kt
@@ -355,8 +355,12 @@ class CLICommandHandler private constructor() {
             return
         }
 
-        // Security validation
-        if (!CLISecurityValidator.isValidPath(file.absolutePath)) {
+        // Security validation. isValidOpenTargetPath, not isValidPath: this file
+        // is going to be read into an editor, never typed into a shell, and
+        // isValidPath's shell-metacharacter rules rejected legal filenames
+        // ("Q&A notes.md", anything under a directory with a `$` in it) so the
+        // open was dropped with nothing shown. See its KDoc.
+        if (!CLISecurityValidator.isValidOpenTargetPath(file.absolutePath)) {
             logger.warn(LogCategory.SYSTEM, "Invalid file path (security check failed)", mapOf("path" to file.absolutePath))
             return
         }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLISecurityValidator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLISecurityValidator.kt
@@ -55,6 +55,16 @@ object CLISecurityValidator {
     }
 
     /**
+     * Longest path BOSS will try to open.
+     *
+     * Well past any real filesystem limit (4096 on Linux, 1024 on macOS, 32767
+     * for a Windows extended path) and a bound on what a caller can make the app
+     * hold and canonicalise, since `boss://file` is reachable by any program that
+     * can ask the OS to open a URL.
+     */
+    private const val MAX_OPEN_TARGET_PATH_LENGTH = 32_768
+
+    /**
      * Validates a path that will be **read**, never handed to a shell.
      *
      * Separate from [isValidPath] because that one's rules are the right rules
@@ -77,6 +87,7 @@ object CLISecurityValidator {
      */
     fun isValidOpenTargetPath(path: String): Boolean {
         if (path.isBlank()) return false
+        if (path.length > MAX_OPEN_TARGET_PATH_LENGTH) return false
         if (path.contains('\u0000')) return false
 
         // canonicalFile resolves `..` and symlinks and throws on a path the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLISecurityValidator.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/CLISecurityValidator.kt
@@ -55,8 +55,52 @@ object CLISecurityValidator {
     }
 
     /**
+     * Validates a path that will be **read**, never handed to a shell.
+     *
+     * Separate from [isValidPath] because that one's rules are the right rules
+     * for a path that ends up inside a command line and the wrong rules for a
+     * file the user just double-clicked in Finder. `isValidPath` rejects any
+     * path containing `..`, `$`, `&`, `;`, `|` or a backtick, so a real file
+     * called `Q&A notes.md`, `pay$.sh` or anything under a directory with an
+     * ampersand in its name could not be opened at all - it failed the check and
+     * the open was dropped with a log line and no window.
+     *
+     * The dropped rules bought nothing on this path. There is no shell, so shell
+     * metacharacters are ordinary filename characters; and `..` cannot be a
+     * traversal defence when every caller may pass an absolute path anyway, so
+     * canonicalising is both stricter and correct. What remains is what actually
+     * matters: no NUL (which truncates the path in any native call underneath),
+     * and a path that resolves.
+     *
+     * Callers still check `exists()`, `isFile()` and `canRead()` afterwards;
+     * this decides only whether the string is a usable path at all.
+     */
+    fun isValidOpenTargetPath(path: String): Boolean {
+        if (path.isBlank()) return false
+        if (path.contains('\u0000')) return false
+
+        // canonicalFile resolves `..` and symlinks and throws on a path the
+        // filesystem cannot represent, which is the honest way to reject the
+        // shapes the `..` test was reaching for.
+        return try {
+            java.io
+                .File(path)
+                .canonicalFile
+            true
+        } catch (_: java.io.IOException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
+    }
+
+    /**
      * Validates file path for security.
      * Prevents path traversal attacks and other malicious patterns.
+     *
+     * For a path that is only going to be **read** (opening a file in the
+     * editor), use [isValidOpenTargetPath]: these rules assume the path may
+     * reach a shell and reject legal filenames that never would.
      */
     fun isValidPath(path: String): Boolean {
         // Check for null bytes

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/search/SettingsSearchEntries.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/search/SettingsSearchEntries.kt
@@ -250,6 +250,39 @@ private fun browserEntries() =
         group("Browser Profiles")
     }
 
+/**
+ * Default Apps has exactly one indexable label: its own section header.
+ *
+ * Everything inside it - the per-category rows and their Set buttons - is
+ * generated at runtime from `boss-file-types.json`, so no label appears as a
+ * literal in the source. `SettingsSearchIndexDriftTest` scans the sources, so
+ * indexing those rows made it (correctly) report seven entries naming settings
+ * that "no longer exist": a search result for them would navigate and highlight
+ * nothing, which reads as the search being broken.
+ *
+ * The keywords therefore carry the weight. They are the words somebody actually
+ * types when their links open in the wrong app - including the file extensions,
+ * since "how do I open .md in BOSS" is the question this page answers.
+ */
+private fun defaultAppsEntries() =
+    section(SettingsSection.DEFAULT_APPS) {
+        group(
+            "Default Apps",
+            "default browser",
+            "file association",
+            "open with",
+            "handler",
+            "markdown",
+            "md",
+            "shell script",
+            "sh",
+            "source code",
+            "http",
+            "https",
+            "html",
+        )
+    }
+
 private fun browserEngineEntries() =
     section(SettingsSection.BROWSER_ENGINE) {
         group("Current Engine")
@@ -480,6 +513,7 @@ private fun keymapEntries() =
 internal val builtInEntries: List<SettingsSearchEntry> by lazy {
     browserEntries() +
         browserEngineEntries() +
+        defaultAppsEntries() +
         runnerEntries() +
         workspaceEntries() +
         securityEntries() +

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultAppsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultAppsSettings.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.settings.shared.SettingsSection
 import ai.rever.boss.filetypes.ClaimOutcome
 import ai.rever.boss.filetypes.DefaultAppStatus
 import ai.rever.boss.filetypes.DefaultAppsManager
+import ai.rever.boss.filetypes.DefaultAppsSettingsManager
 import ai.rever.boss.filetypes.FileTypeCategory
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.DefaultHandlerState
@@ -50,7 +51,7 @@ import kotlinx.coroutines.launch
  * Settings > Default Apps: which file types and links BOSS opens.
  *
  * One row per category rather than per type, because BOSS claims 83 extensions
- * and 55 macOS UTIs and nobody sets 83 switches. See `boss-file-types.json` for
+ * and 56 macOS UTIs and nobody sets 83 switches. See `boss-file-types.json` for
  * the grouping and why it is a resource.
  *
  * The row that matters most is the one saying a **BOSS component** holds the
@@ -75,14 +76,22 @@ fun DefaultAppsSettings() {
     val scope = rememberCoroutineScope()
     val supported = remember { DefaultAppsManager.isSupported() }
 
+    var declined by remember { mutableStateOf<Set<String>>(emptySet()) }
+
     suspend fun refresh() {
         loading = true
         statuses = DefaultAppsManager.statuses()
+        declined = DefaultAppsSettingsManager.declinedCategories()
         loading = false
     }
 
     LaunchedEffect(Unit) {
-        if (supported) refresh() else loading = false
+        if (!supported) {
+            loading = false
+            return@LaunchedEffect
+        }
+        DefaultAppsSettingsManager.ensureLoaded()
+        refresh()
     }
 
     SettingsSection(
@@ -108,10 +117,16 @@ fun DefaultAppsSettings() {
             fun claim(
                 busyId: String,
                 what: String,
+                clearDeclineFor: Collection<String> = emptyList(),
                 block: suspend () -> ClaimOutcome,
             ) = scope.launch {
                 busyCategoryId = busyId
                 message = null
+                // Pressing Set on a row is the user changing their mind, so the
+                // refusal recorded when they dismissed the first-run offer has to
+                // go - otherwise "Set all" would keep skipping a category they
+                // have since asked for by hand.
+                if (clearDeclineFor.isNotEmpty()) DefaultAppsSettingsManager.clearDeclined(clearDeclineFor)
                 message = block().describe(what)
                 busyCategoryId = null
                 refresh()
@@ -123,9 +138,11 @@ fun DefaultAppsSettings() {
                     busyCategoryId = busyCategoryId,
                     loading = loading,
                     onSet = { status ->
-                        claim(status.category.id, status.category.displayName) {
-                            DefaultAppsManager.claim(status.category)
-                        }
+                        claim(
+                            busyId = status.category.id,
+                            what = status.category.displayName,
+                            clearDeclineFor = listOf(status.category.id),
+                        ) { DefaultAppsManager.claimOne(status.category) }
                     },
                 )
 
@@ -133,10 +150,11 @@ fun DefaultAppsSettings() {
 
                 SectionActions(
                     statuses = statuses,
+                    declined = declined,
                     busy = busyCategoryId != null,
                     onRefresh = { scope.launch { refresh() } },
-                    onSetAll = { unclaimed ->
-                        claim(busyId = "", what = "every type") { DefaultAppsManager.claimAll(unclaimed) }
+                    onSetAll = { toClaim ->
+                        claim(busyId = "", what = "every type") { DefaultAppsManager.claimAll(toClaim) }
                     },
                 )
 
@@ -197,11 +215,20 @@ private fun CategoryList(
 @Composable
 private fun SectionActions(
     statuses: List<DefaultAppStatus>,
+    declined: Set<String>,
     busy: Boolean,
     onRefresh: () -> Unit,
     onSetAll: (List<FileTypeCategory>) -> Unit,
 ) {
-    val unclaimed = statuses.filterNot { it.state.isOurs }.map { it.category }
+    // Refused categories are excluded, which is what DefaultAppsSettings'
+    // `declinedCategories` was documented to do and did not: "Set all" claimed
+    // exactly what the user had just said no to. A row's own Set button still
+    // works and clears the refusal.
+    val unclaimed =
+        statuses
+            .filterNot { it.state.isOurs }
+            .map { it.category }
+            .filterNot { it.id in declined }
 
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         TextButton(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultAppsSettings.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultAppsSettings.kt
@@ -1,0 +1,369 @@
+package ai.rever.boss.components.settings.sections
+
+import ai.rever.boss.components.settings.shared.SettingsSection
+import ai.rever.boss.filetypes.ClaimOutcome
+import ai.rever.boss.filetypes.DefaultAppStatus
+import ai.rever.boss.filetypes.DefaultAppsManager
+import ai.rever.boss.filetypes.FileTypeCategory
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.utils.DefaultHandlerState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Cancel
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+
+/**
+ * Settings > Default Apps: which file types and links BOSS opens.
+ *
+ * One row per category rather than per type, because BOSS claims 83 extensions
+ * and 55 macOS UTIs and nobody sets 83 switches. See `boss-file-types.json` for
+ * the grouping and why it is a resource.
+ *
+ * The row that matters most is the one saying a **BOSS component** holds the
+ * type. On any machine that installed BOSS before the engine bundle stopped
+ * declaring `CFBundleURLTypes`, `~/.boss/boss-chromium/BOSS.app` is a second app
+ * called "BOSS" in System Settings, and the default browser is very likely that
+ * one - so links open a bare Chromium with no BOSS window. "BOSS is not your
+ * default browser" was the old message and it was the wrong story to tell
+ * somebody who had set it.
+ */
+@Composable
+fun DefaultAppsSettings() {
+    var statuses by remember { mutableStateOf<List<DefaultAppStatus>>(emptyList()) }
+    var loading by remember { mutableStateOf(true) }
+
+    // "" while "Set all" runs, a category id while one row runs, null when idle.
+    // One field rather than two, so the disabled state cannot disagree with where
+    // the spinner is.
+    var busyCategoryId by remember { mutableStateOf<String?>(null) }
+    var message by remember { mutableStateOf<String?>(null) }
+
+    val scope = rememberCoroutineScope()
+    val supported = remember { DefaultAppsManager.isSupported() }
+
+    suspend fun refresh() {
+        loading = true
+        statuses = DefaultAppsManager.statuses()
+        loading = false
+    }
+
+    LaunchedEffect(Unit) {
+        if (supported) refresh() else loading = false
+    }
+
+    SettingsSection(
+        title = "Default Apps",
+        description = "Choose what BOSS opens when you click a link or double-click a file",
+    ) {
+        if (!supported) {
+            UnsupportedNotice()
+            return@SettingsSection
+        }
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = BossTheme.colors.ink,
+            shape = RoundedCornerShape(8.dp),
+            elevation = 0.dp,
+            border = BorderStroke(1.dp, BossTheme.colors.line),
+        ) {
+            // One helper for both buttons: mark busy, claim, report, refresh. The
+            // two differ only in what they claim and what the message calls it,
+            // and keeping the sequence in one place is what stops the busy flag
+            // and the spinner disagreeing.
+            fun claim(
+                busyId: String,
+                what: String,
+                block: suspend () -> ClaimOutcome,
+            ) = scope.launch {
+                busyCategoryId = busyId
+                message = null
+                message = block().describe(what)
+                busyCategoryId = null
+                refresh()
+            }
+
+            Column(modifier = Modifier.padding(16.dp)) {
+                CategoryList(
+                    statuses = statuses,
+                    busyCategoryId = busyCategoryId,
+                    loading = loading,
+                    onSet = { status ->
+                        claim(status.category.id, status.category.displayName) {
+                            DefaultAppsManager.claim(status.category)
+                        }
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                SectionActions(
+                    statuses = statuses,
+                    busy = busyCategoryId != null,
+                    onRefresh = { scope.launch { refresh() } },
+                    onSetAll = { unclaimed ->
+                        claim(busyId = "", what = "every type") { DefaultAppsManager.claimAll(unclaimed) }
+                    },
+                )
+
+                message?.let { text ->
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = text,
+                        color = BossTheme.colors.textSecondary,
+                        fontSize = 12.sp,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryList(
+    statuses: List<DefaultAppStatus>,
+    busyCategoryId: String?,
+    loading: Boolean,
+    onSet: (DefaultAppStatus) -> Unit,
+) {
+    if (loading && statuses.isEmpty()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp,
+                color = BossTheme.colors.signal,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Checking...", color = BossTheme.colors.textSecondary, fontSize = 14.sp)
+        }
+        return
+    }
+
+    statuses.forEachIndexed { index, status ->
+        if (index > 0) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Divider(color = BossTheme.colors.line)
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+        CategoryRow(
+            status = status,
+            busy = busyCategoryId == status.category.id,
+            // Disabled while ANY row is working, not just this one: the platform
+            // calls are not concurrent-safe against each other (Windows opens a
+            // Settings page, macOS walks 55 types) and two at once produces a
+            // result nobody can read.
+            enabled = busyCategoryId == null && !loading,
+            onSet = { onSet(status) },
+        )
+    }
+}
+
+@Composable
+private fun SectionActions(
+    statuses: List<DefaultAppStatus>,
+    busy: Boolean,
+    onRefresh: () -> Unit,
+    onSetAll: (List<FileTypeCategory>) -> Unit,
+) {
+    val unclaimed = statuses.filterNot { it.state.isOurs }.map { it.category }
+
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        TextButton(
+            onClick = onRefresh,
+            enabled = !busy,
+            colors = ButtonDefaults.textButtonColors(contentColor = BossTheme.colors.textSecondary),
+        ) {
+            Icon(Icons.Outlined.Refresh, contentDescription = "Refresh", modifier = Modifier.size(16.dp))
+            Spacer(modifier = Modifier.width(4.dp))
+            Text("Refresh", fontSize = 13.sp)
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(
+            onClick = { onSetAll(unclaimed) },
+            enabled = !busy && unclaimed.isNotEmpty(),
+            colors =
+                ButtonDefaults.buttonColors(
+                    backgroundColor = BossTheme.colors.signal,
+                    contentColor = BossTheme.colors.onSignal,
+                ),
+        ) {
+            Text(if (unclaimed.isEmpty()) "All set" else "Set all", fontSize = 13.sp)
+        }
+    }
+}
+
+@Composable
+private fun UnsupportedNotice() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        backgroundColor = BossTheme.colors.ink,
+        shape = RoundedCornerShape(8.dp),
+        elevation = 0.dp,
+        border = BorderStroke(1.dp, BossTheme.colors.line),
+    ) {
+        Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Outlined.Warning,
+                contentDescription = null,
+                tint = BossTheme.colors.textSecondary,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "BOSS cannot read or change default applications on this system.",
+                color = BossTheme.colors.textSecondary,
+                fontSize = 13.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryRow(
+    status: DefaultAppStatus,
+    busy: Boolean,
+    enabled: Boolean,
+    onSet: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = status.category.displayName,
+                color = BossTheme.colors.textPrimary,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = status.category.description,
+                color = BossTheme.colors.textMuted,
+                fontSize = 12.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            StatusLine(status.state)
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        if (busy) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                strokeWidth = 2.dp,
+                color = BossTheme.colors.signal,
+            )
+        } else {
+            TextButton(
+                onClick = onSet,
+                enabled = enabled && !status.state.isOurs,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = BossTheme.colors.signalText,
+                        disabledContentColor = BossTheme.colors.textMuted,
+                    ),
+            ) {
+                Text(
+                    // "Repair" when a BOSS component holds the type: the user did
+                    // set BOSS as their handler, they just got the wrong "BOSS",
+                    // and "Set" would suggest they had not tried.
+                    text =
+                        when (status.state) {
+                            is DefaultHandlerState.Ours -> "Default"
+                            is DefaultHandlerState.OurEngine -> "Repair"
+                            is DefaultHandlerState.Other -> "Set"
+                        },
+                    fontSize = 13.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusLine(state: DefaultHandlerState) {
+    val (icon, tint, text) =
+        when (state) {
+            is DefaultHandlerState.Ours -> {
+                Triple(Icons.Outlined.CheckCircle, BossTheme.colors.ok, "BOSS opens these")
+            }
+
+            is DefaultHandlerState.OurEngine -> {
+                Triple(
+                    Icons.Outlined.Warning,
+                    BossTheme.colors.alert,
+                    "A BOSS component is registered instead of BOSS itself, so these open with no BOSS window",
+                )
+            }
+
+            is DefaultHandlerState.Other -> {
+                Triple(
+                    Icons.Outlined.Cancel,
+                    BossTheme.colors.textSecondary,
+                    state.bundleId?.let { "Currently opened by $it" } ?: "No application is registered",
+                )
+            }
+        }
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(14.dp))
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = text,
+            color = tint,
+            fontSize = 12.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/** What to tell the user after a claim attempt. */
+private fun ClaimOutcome.describe(what: String): String =
+    when (this) {
+        is ClaimOutcome.Claimed -> "BOSS now opens $what."
+        is ClaimOutcome.NeedsUserAction -> instruction
+        is ClaimOutcome.Failed -> message
+    }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sidebar/SettingsSidebar.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sidebar/SettingsSidebar.kt
@@ -48,6 +48,11 @@ enum class SettingsSection(
         description = "Chromium engine version, downloads, and reinstall",
         icon = Icons.Outlined.Memory,
     ),
+    DEFAULT_APPS(
+        displayName = "Default Apps",
+        description = "Links, markdown, shell scripts and code files BOSS opens",
+        icon = Icons.Outlined.AppRegistration,
+    ),
     BOSS_EDITOR(
         displayName = "BossEditor",
         description = "Scroll behavior, code folding, and bracket matching",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/windows/SettingsWindow.kt
@@ -636,6 +636,10 @@ private fun SettingsContentArea(
                     BrowserEngineSettings()
                 }
 
+                SettingsSection.DEFAULT_APPS -> {
+                    DefaultAppsSettings()
+                }
+
                 SettingsSection.RUNNER -> {
                     RunnerSettings()
                 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/config/ChromiumAutoDownloader.kt
@@ -33,6 +33,11 @@ object ChromiumAutoDownloader {
     private val JXBROWSER_VERSION = VersionConstants.JXBROWSER_VERSION
     private const val VERSION_FILE = "version.txt"
 
+    /**
+     * Info.plist keys an engine bundle must not declare. See [declaresBrowserTypes].
+     */
+    private val BROWSER_TYPE_KEYS = listOf("CFBundleURLTypes", "CFBundleDocumentTypes")
+
     // Commit marker for staged installs: written strictly last by downloadChromium
     // (staged=true), required by promotePendingInstall. Guards against promoting a
     // staging dir whose executable.name/version.txt happen to exist (e.g. extracted
@@ -220,10 +225,105 @@ object ChromiumAutoDownloader {
                 logger.info(LogCategory.BROWSER, "Chromium executable missing execute permission, will re-download")
                 return false
             }
+
+            if (declaresBrowserTypes(dir.resolve("$executableName.app/Contents/Info.plist").toFile())) {
+                // Bounded to one attempt per version. Without this, an engine that
+                // still declares the keys after the re-download - the rebuild never
+                // published, or published unrepaired - would invalidate the
+                // directory on EVERY launch and re-fetch ~160 MB forever, silently.
+                // The marker lives outside the engine directory because a
+                // re-download replaces that whole directory.
+                if (repairAlreadyAttempted()) {
+                    logger.warn(
+                        LogCategory.BROWSER,
+                        "Chromium still registers itself as a browser after a re-download; keeping it",
+                        mapOf("version" to effectiveVersion),
+                    )
+                } else {
+                    recordRepairAttempt()
+                    logger.info(
+                        LogCategory.BROWSER,
+                        "Cached Chromium still registers itself as a browser, will re-download",
+                        mapOf("version" to effectiveVersion),
+                    )
+                    return false
+                }
+            }
         }
 
         return true
     }
+
+    /**
+     * Whether an extracted engine bundle still claims URL schemes or document
+     * types from the OS.
+     *
+     * **Why this is a content check and not a version check.** Engines built
+     * before `build-chromium-branding.yml` learned to strip these keys declare
+     * http, https, `file` and 17 document types (`public.html`, `public.text`,
+     * `com.adobe.pdf`, the image and video types, ...) under the id
+     * `ai.rever.boss.browser` and the name "BOSS". Launch Services then offers
+     * two indistinguishable "BOSS" entries for the default browser and puts the
+     * engine in Finder's Open With for a dozen file kinds, where choosing it
+     * launches a rendering engine with no window. See AGENTS.md.
+     *
+     * The version number cannot detect that. The fix ships inside a *rebuild* of
+     * an already-published engine, so `version.txt` reads the same before and
+     * after and [isValidChromiumDir]'s equality test short-circuits. Asking the
+     * bundle what it actually declares is the only thing that tells a repaired
+     * engine from the one it replaced, and it is self-limiting: once the clean
+     * engine is in place this answers false forever, on every version.
+     *
+     * Deliberately a substring test rather than a plist parse. The engine's
+     * `Info.plist` is XML (verified against a shipped 9.5.0 bundle), so
+     * `<key>NAME</key>` is exact and unambiguous, and the JDK has no binary-plist
+     * reader to fall back on. **Fails closed**: an unreadable or absent plist
+     * answers false, because forcing a ~160 MB download on a file we could not
+     * read would be the worse mistake - and a genuinely broken bundle is already
+     * caught by the executable checks above.
+     */
+
+    /** Marker recording that a browser-types re-download was already tried for a version. */
+    private fun repairMarker(): File = BossDirectories.resolve("boss-chromium.types-repair")
+
+    private fun repairAlreadyAttempted(): Boolean =
+        try {
+            repairMarker().takeIf { it.isFile }?.readText()?.trim() == effectiveVersion
+        } catch (e: Exception) {
+            logger.debug(
+                LogCategory.BROWSER,
+                "Could not read the repair marker",
+                mapOf("reason" to (e.message ?: "unknown")),
+            )
+            false
+        }
+
+    private fun recordRepairAttempt() {
+        try {
+            repairMarker().writeText(effectiveVersion)
+        } catch (e: Exception) {
+            // Logged, not fatal. The consequence of failing to write it is one
+            // extra download attempt on the next launch, not a broken engine.
+            logger.warn(LogCategory.BROWSER, "Could not record the repair marker", error = e)
+        }
+    }
+
+    internal fun declaresBrowserTypes(plist: File): Boolean =
+        try {
+            if (!plist.isFile) {
+                false
+            } else {
+                val text = plist.readText()
+                BROWSER_TYPE_KEYS.any { key -> text.contains("<key>$key</key>") }
+            }
+        } catch (e: Exception) {
+            logger.debug(
+                LogCategory.BROWSER,
+                "Could not read the engine Info.plist; assuming it is fine",
+                mapOf("reason" to (e.message ?: "unknown")),
+            )
+            false
+        }
 
     /**
      * Detect the current platform for download URL.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsManager.kt
@@ -1,0 +1,167 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.utils.DefaultHandlerState
+import ai.rever.boss.utils.LinuxDefaultBrowserHandler
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** A category and who currently owns it, for the Settings screen. */
+internal data class DefaultAppStatus(
+    val category: FileTypeCategory,
+    val state: DefaultHandlerState,
+)
+
+/** What happened when BOSS tried to claim a category. */
+internal sealed interface ClaimOutcome {
+    /** BOSS is now the handler for everything in the category. */
+    data object Claimed : ClaimOutcome
+
+    /**
+     * BOSS registered itself but the OS will not make it the default without the
+     * user: Windows since 10 forbids writing the choice, and macOS refuses when
+     * the app is not where Launch Services expects it.
+     *
+     * @property instruction what the user has to do, which differs per platform
+     *   and cannot be worded generically. Windows opens a Settings page and the
+     *   message points at it; macOS has no page for an arbitrary content type -
+     *   the route is Finder's Get Info - and telling a mac user to look in System
+     *   Settings would send them somewhere the option does not exist.
+     */
+    data class NeedsUserAction(
+        val instruction: String,
+    ) : ClaimOutcome
+
+    data class Failed(
+        val message: String,
+    ) : ClaimOutcome
+}
+
+/**
+ * Reads and sets the OS default handler for BOSS's file-type categories.
+ *
+ * The general form of [ai.rever.boss.utils.DefaultBrowserManager], which stays
+ * as the browser-only facade its Settings card and tests already use. This is
+ * what the new Default Apps screen talks to.
+ *
+ * Every call is suspending and runs on IO: on macOS a status is one native call
+ * per type (55 for the source-code category), on Windows it is a `reg query` per
+ * extension and on Linux an `xdg-mime` per MIME type. None of that belongs on the
+ * UI thread - see docs/THREADING.md.
+ */
+internal object DefaultAppsManager {
+    private val logger = BossLogger.forComponent("DefaultAppsManager")
+
+    private val osName = System.getProperty("os.name").lowercase()
+    private val isMacOS = osName.contains("mac")
+    private val isWindows = osName.contains("windows")
+
+    /**
+     * Whether this build can report or change defaults at all.
+     *
+     * False on macOS when the Launch Services binding could not be loaded: the
+     * screen then explains that instead of showing rows whose buttons do nothing.
+     */
+    fun isSupported(): Boolean =
+        FileTypeCategories.isAvailable() &&
+            when {
+                isMacOS -> MacOSFileTypeHandler.isAvailable()
+                else -> true
+            }
+
+    val categories: List<FileTypeCategory> get() = FileTypeCategories.categories
+
+    /** Status for every category, in the resource's order. */
+    suspend fun statuses(): List<DefaultAppStatus> =
+        withContext(Dispatchers.IO) {
+            categories.map { category -> DefaultAppStatus(category, statusOf(category)) }
+        }
+
+    private fun statusOf(category: FileTypeCategory): DefaultHandlerState =
+        try {
+            when {
+                isMacOS -> MacOSFileTypeHandler.statusOf(category)
+                isWindows -> WindowsFileTypeHandler.statusOf(category)
+                else -> LinuxFileTypeHandler.statusOf(category)
+            }
+        } catch (e: Exception) {
+            // A status is decoration; a throw here would take the Settings screen
+            // with it. Unknown is the honest answer and the screen shows it.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Could not read a default-handler status",
+                mapOf("category" to category.id),
+                e,
+            )
+            DefaultHandlerState.Other(null)
+        }
+
+    /**
+     * Claims [category] for BOSS.
+     *
+     * On Linux this also (re)writes the `.desktop` file through
+     * `LinuxDefaultBrowserHandler`, because `xdg-mime default` only associates a
+     * type the desktop entry already declares - so claiming a category without
+     * that step records an association that can never match a file.
+     */
+    suspend fun claim(category: FileTypeCategory): ClaimOutcome =
+        withContext(Dispatchers.IO) {
+            try {
+                when {
+                    isMacOS -> {
+                        if (MacOSFileTypeHandler.setDefault(category)) {
+                            ClaimOutcome.Claimed
+                        } else {
+                            // No System Settings page covers an arbitrary content
+                            // type, so this names the route that does exist.
+                            ClaimOutcome.NeedsUserAction(
+                                "macOS refused some of these. In Finder, select a file of that kind, " +
+                                    "press Command-I and use \"Open with\" then \"Change All\".",
+                            )
+                        }
+                    }
+
+                    isWindows -> {
+                        // Registering is all BOSS may do; Windows 10+ verifies a
+                        // hash on the UserChoice key and reverts anything written
+                        // directly, so the user finishes in Settings.
+                        WindowsFileTypeHandler.register(category)
+                        WindowsFileTypeHandler.openDefaultAppsSettings()
+                        ClaimOutcome.NeedsUserAction(
+                            "Windows does not let an app make itself the default. Settings has been opened: " +
+                                "choose BOSS under Default apps to finish.",
+                        )
+                    }
+
+                    else -> {
+                        LinuxDefaultBrowserHandler.ensureDesktopEntry()
+                        if (LinuxFileTypeHandler.setDefault(category)) {
+                            ClaimOutcome.Claimed
+                        } else {
+                            ClaimOutcome.NeedsUserAction(
+                                "Some associations were refused. Check that xdg-utils is installed, " +
+                                    "then set BOSS in your desktop's Default Applications.",
+                            )
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                logger.error(
+                    LogCategory.SYSTEM,
+                    "Could not claim a file-type category",
+                    mapOf("category" to category.id),
+                    e,
+                )
+                ClaimOutcome.Failed(e.message ?: "Could not change the default application.")
+            }
+        }
+
+    /** Claims several categories, reporting the worst outcome. */
+    suspend fun claimAll(categories: List<FileTypeCategory>): ClaimOutcome {
+        val outcomes = categories.map { claim(it) }
+        return outcomes.firstOrNull { it is ClaimOutcome.Failed }
+            ?: outcomes.firstOrNull { it is ClaimOutcome.NeedsUserAction }
+            ?: ClaimOutcome.Claimed
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsManager.kt
@@ -105,7 +105,7 @@ internal object DefaultAppsManager {
      * type the desktop entry already declares - so claiming a category without
      * that step records an association that can never match a file.
      */
-    suspend fun claim(category: FileTypeCategory): ClaimOutcome =
+    private suspend fun claim(category: FileTypeCategory): ClaimOutcome =
         withContext(Dispatchers.IO) {
             try {
                 when {
@@ -126,11 +126,16 @@ internal object DefaultAppsManager {
                         // Registering is all BOSS may do; Windows 10+ verifies a
                         // hash on the UserChoice key and reverts anything written
                         // directly, so the user finishes in Settings.
+                        //
+                        // Deliberately does NOT open Settings here. This runs once
+                        // per category and claimAll maps it over the selection, so
+                        // taking the five-category first-run offer launched
+                        // ms-settings:defaultapps five times. Opening it is the
+                        // batch's job, once - see openSettingsForUserAction.
                         WindowsFileTypeHandler.register(category)
-                        WindowsFileTypeHandler.openDefaultAppsSettings()
                         ClaimOutcome.NeedsUserAction(
-                            "Windows does not let an app make itself the default. Settings has been opened: " +
-                                "choose BOSS under Default apps to finish.",
+                            "Windows does not let an app make itself the default. " +
+                                "Choose BOSS under Default apps in the Settings window to finish.",
                         )
                     }
 
@@ -157,11 +162,48 @@ internal object DefaultAppsManager {
             }
         }
 
-    /** Claims several categories, reporting the worst outcome. */
+    /**
+     * Claims several categories, reporting the worst outcome, and opens the OS
+     * settings page at most once if any of them needs the user.
+     *
+     * An empty batch is [ClaimOutcome.Failed], not [ClaimOutcome.Claimed]:
+     * reporting "BOSS now opens every type" having claimed nothing is the kind of
+     * false success a third call site inherits without noticing. Both current
+     * callers guard on a non-empty list, so this is a guard rather than a
+     * behaviour change.
+     */
     suspend fun claimAll(categories: List<FileTypeCategory>): ClaimOutcome {
+        if (categories.isEmpty()) return ClaimOutcome.Failed("There was nothing to change.")
+
         val outcomes = categories.map { claim(it) }
-        return outcomes.firstOrNull { it is ClaimOutcome.Failed }
-            ?: outcomes.firstOrNull { it is ClaimOutcome.NeedsUserAction }
-            ?: ClaimOutcome.Claimed
+        val worst =
+            outcomes.firstOrNull { it is ClaimOutcome.Failed }
+                ?: outcomes.firstOrNull { it is ClaimOutcome.NeedsUserAction }
+                ?: ClaimOutcome.Claimed
+        if (worst is ClaimOutcome.NeedsUserAction) openSettingsForUserAction()
+        return worst
+    }
+
+    /**
+     * Claims one category and opens the settings page if it needs the user.
+     *
+     * The single-row entry point, so a row's Set button behaves like the batch
+     * without every caller having to remember the second step.
+     */
+    suspend fun claimOne(category: FileTypeCategory): ClaimOutcome {
+        val outcome = claim(category)
+        if (outcome is ClaimOutcome.NeedsUserAction) openSettingsForUserAction()
+        return outcome
+    }
+
+    /**
+     * Opens the OS page where the user finishes the job, on the platforms that
+     * have one. Called at most once per user action - see [claimAll].
+     */
+    private fun openSettingsForUserAction() {
+        if (isWindows) WindowsFileTypeHandler.openDefaultAppsSettings()
+        // macOS has no settings page for an arbitrary content type (the route is
+        // Finder's Get Info) and Linux has no single page at all, so on both the
+        // instruction text is the whole of the guidance.
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsOffer.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsOffer.desktop.kt
@@ -1,0 +1,351 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.plugin.ui.BossDialog
+import ai.rever.boss.plugin.ui.BossTheme
+import ai.rever.boss.utils.DefaultHandlerState
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.Checkbox
+import androidx.compose.material.CheckboxDefaults
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
+
+private val logger = BossLogger.forComponent("DefaultAppsOffer")
+
+/**
+ * Offers, once, to make BOSS the default for the categories it can open.
+ *
+ * **Three things it deliberately does not do.**
+ *
+ * It does not claim anything without a click. Taking over a machine's file
+ * associations on first launch is the behaviour that makes people distrust
+ * browsers, and the categories start checked only because the user is looking at
+ * a dialog whose whole subject is that question.
+ *
+ * It does not ask twice. `promptShown` is persisted the moment the dialog
+ * appears, not when it is answered - so a crash, a force quit or a window closed
+ * with the dialog up all count as asked. Being asked at every launch is worse
+ * than never discovering the setting, and Settings > Default Apps is always
+ * there.
+ *
+ * It does not appear when there is nothing to offer: no categories left to claim,
+ * or a platform where the status cannot be read at all.
+ */
+@Composable
+internal actual fun DefaultAppsOfferHost(isFirstWindow: Boolean) {
+    // Only the first window, and only when the offer has not been made. Read
+    // once: `shouldOfferPrompt` flips as soon as the dialog appears, and
+    // re-reading it would take the dialog away mid-decision.
+    val eligible = remember { isFirstWindow && DefaultAppsSettingsManager.shouldOfferPrompt() }
+    if (!eligible) return
+
+    var unclaimed by remember { mutableStateOf<List<DefaultAppStatus>>(emptyList()) }
+    var visible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        if (!DefaultAppsManager.isSupported()) return@LaunchedEffect
+        val statuses = DefaultAppsManager.statuses().filterNot { it.state.isOurs }
+        if (statuses.isEmpty()) {
+            // Everything is already BOSS's. Nothing to ask, and marking the
+            // prompt shown would be wrong: if the user later loses an
+            // association to another app, the offer is still worth making once.
+            logger.debug(LogCategory.SYSTEM, "Nothing to offer; BOSS already opens every category")
+            return@LaunchedEffect
+        }
+        unclaimed = statuses
+        visible = true
+        // Before the dialog is answered, deliberately. See the KDoc.
+        DefaultAppsSettingsManager.markPromptShown()
+    }
+
+    if (!visible) return
+
+    DefaultAppsOfferDialog(
+        unclaimed = unclaimed,
+        onClose = { visible = false },
+    )
+}
+
+@Composable
+private fun DefaultAppsOfferDialog(
+    unclaimed: List<DefaultAppStatus>,
+    onClose: () -> Unit,
+) {
+    var working by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    // Keyed on `unclaimed` so the selection is rebuilt if the offered set ever
+    // changes. Built with addAll rather than a spread, which would copy the array
+    // once more for nothing.
+    val selected =
+        remember(unclaimed) {
+            mutableStateListOf<String>().apply { addAll(unclaimed.map { it.category.id }) }
+        }
+    val scope = rememberCoroutineScope()
+
+    fun dismiss() {
+        // Everything on offer counts as declined, so a later "Set all" in
+        // Settings does not quietly claim what was just refused.
+        scope.launch { DefaultAppsSettingsManager.markDeclined(unclaimed.map { it.category.id }) }
+        onClose()
+    }
+
+    fun claim() {
+        working = true
+        error = null
+        scope.launch {
+            try {
+                val categories = unclaimed.filter { it.category.id in selected }.map { it.category }
+                val declined = unclaimed.map { it.category.id }.filterNot { it in selected }
+                if (declined.isNotEmpty()) DefaultAppsSettingsManager.markDeclined(declined)
+
+                when (val outcome = DefaultAppsManager.claimAll(categories)) {
+                    is ClaimOutcome.Claimed -> onClose()
+
+                    // Kept on screen: the user has something to do, and closing
+                    // the dialog would take the instruction away with it.
+                    is ClaimOutcome.NeedsUserAction -> error = outcome.instruction
+
+                    is ClaimOutcome.Failed -> error = outcome.message
+                }
+            } finally {
+                working = false
+            }
+        }
+    }
+
+    BossDialog(
+        onDismissRequest = { if (!working) dismiss() },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = !working,
+                dismissOnClickOutside = !working,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .width(460.dp)
+                    .onKeyEvent { event ->
+                        val escape = event.type == KeyEventType.KeyDown && event.key == Key.Escape
+                        if (!working && escape) {
+                            dismiss()
+                            true
+                        } else {
+                            false
+                        }
+                    },
+            shape = RoundedCornerShape(8.dp),
+            backgroundColor = BossTheme.colors.panel,
+            elevation = 8.dp,
+        ) {
+            OfferBody(
+                unclaimed = unclaimed,
+                selected = selected,
+                working = working,
+                error = error,
+                onToggle = { id, checked -> if (checked) selected.add(id) else selected.remove(id) },
+                onDismiss = { dismiss() },
+                onClaim = { claim() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun OfferBody(
+    unclaimed: List<DefaultAppStatus>,
+    selected: List<String>,
+    working: Boolean,
+    error: String?,
+    onToggle: (String, Boolean) -> Unit,
+    onDismiss: () -> Unit,
+    onClaim: () -> Unit,
+) {
+    // "Repair" whenever a BOSS component holds any of these, which is the state
+    // almost every existing install is in - and it needs different words, because
+    // the user very likely did set "BOSS" as their browser and got the wrong one
+    // of two entries with that name.
+    val repairing = unclaimed.any { it.state is DefaultHandlerState.OurEngine }
+
+    Column(modifier = Modifier.padding(20.dp)) {
+        Text(
+            text = if (repairing) "Finish setting up BOSS" else "Open these with BOSS?",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = BossTheme.colors.textPrimary,
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Text(
+            text =
+                if (repairing) {
+                    "Some of these are registered to a BOSS component rather than to BOSS itself, " +
+                        "so they open with no BOSS window. Repairing points them back at the app."
+                } else {
+                    "BOSS can open links and code files directly. You can change any of this later " +
+                        "in Settings > Default Apps."
+                },
+            fontSize = 13.sp,
+            color = BossTheme.colors.textSecondary,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(modifier = Modifier.height(14.dp))
+
+        unclaimed.forEach { status ->
+            CategoryCheckbox(
+                status = status,
+                checked = status.category.id in selected,
+                enabled = !working,
+                onCheckedChange = { checked -> onToggle(status.category.id, checked) },
+            )
+        }
+
+        error?.let { text ->
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = text,
+                fontSize = 12.sp,
+                color = BossTheme.colors.alert,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        OfferActions(
+            confirmLabel = if (repairing) "Repair" else "Use BOSS",
+            working = working,
+            canConfirm = selected.isNotEmpty(),
+            onDismiss = onDismiss,
+            onClaim = onClaim,
+        )
+    }
+}
+
+@Composable
+private fun OfferActions(
+    confirmLabel: String,
+    working: Boolean,
+    canConfirm: Boolean,
+    onDismiss: () -> Unit,
+    onClaim: () -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        if (working) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(14.dp),
+                strokeWidth = 2.dp,
+                color = BossTheme.colors.signalText,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = "Setting...", fontSize = 12.sp, color = BossTheme.colors.textSecondary)
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        TextButton(
+            onClick = onDismiss,
+            enabled = !working,
+            colors = ButtonDefaults.textButtonColors(contentColor = BossTheme.colors.textSecondary),
+        ) {
+            Text("Not now")
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Button(
+            onClick = onClaim,
+            enabled = !working && canConfirm,
+            colors =
+                ButtonDefaults.buttonColors(
+                    backgroundColor = BossTheme.colors.signal,
+                    contentColor = BossTheme.colors.onSignal,
+                ),
+        ) {
+            Text(confirmLabel)
+        }
+    }
+}
+
+@Composable
+private fun CategoryCheckbox(
+    status: DefaultAppStatus,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+            colors =
+                CheckboxDefaults.colors(
+                    checkedColor = BossTheme.colors.signal,
+                    uncheckedColor = BossTheme.colors.textMuted,
+                    checkmarkColor = BossTheme.colors.onSignal,
+                ),
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = status.category.displayName,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                color = BossTheme.colors.textPrimary,
+            )
+            Text(
+                text =
+                    if (status.state is DefaultHandlerState.OurEngine) {
+                        "Currently opened by a BOSS component with no window"
+                    } else {
+                        status.category.description
+                    },
+                fontSize = 11.sp,
+                color = BossTheme.colors.textMuted,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsOffer.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsOffer.desktop.kt
@@ -67,18 +67,24 @@ private val logger = BossLogger.forComponent("DefaultAppsOffer")
  */
 @Composable
 internal actual fun DefaultAppsOfferHost(isFirstWindow: Boolean) {
-    // Only the first window, and only when the offer has not been made. Read
-    // once: `shouldOfferPrompt` flips as soon as the dialog appears, and
-    // re-reading it would take the dialog away mid-decision.
-    val eligible = remember { isFirstWindow && DefaultAppsSettingsManager.shouldOfferPrompt() }
-    if (!eligible) return
+    if (!isFirstWindow) return
 
     var unclaimed by remember { mutableStateOf<List<DefaultAppStatus>>(emptyList()) }
     var visible by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         if (!DefaultAppsManager.isSupported()) return@LaunchedEffect
-        val statuses = DefaultAppsManager.statuses().filterNot { it.state.isOurs }
+        // After the load, not in a `remember`: before the file has been read
+        // `shouldOfferPrompt` answers from defaults and would offer a prompt that
+        // was already made and declined on a previous launch.
+        DefaultAppsSettingsManager.ensureLoaded()
+        if (!DefaultAppsSettingsManager.shouldOfferPrompt()) return@LaunchedEffect
+        val declined = DefaultAppsSettingsManager.declinedCategories()
+        val statuses =
+            DefaultAppsManager
+                .statuses()
+                .filterNot { it.state.isOurs }
+                .filterNot { it.category.id in declined }
         if (statuses.isEmpty()) {
             // Everything is already BOSS's. Nothing to ask, and marking the
             // prompt shown would be wrong: if the user later loses an

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsSettingsManager.kt
@@ -1,0 +1,112 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.plugin.pathutils.BossDirectories
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * What the user has already been asked about default applications.
+ *
+ * @property promptShown true once the one-time offer has been put in front of
+ *   them. The only thing that keeps this a one-time offer.
+ * @property declinedCategories categories they said no to. Kept so a later "Set
+ *   all" from Settings does not silently re-claim something they refused, and so
+ *   the offer can be narrowed rather than repeated.
+ */
+@Serializable
+internal data class DefaultAppsSettings(
+    val promptShown: Boolean = false,
+    val declinedCategories: Set<String> = emptySet(),
+)
+
+/**
+ * Persists the default-applications decisions in `~/.boss/default-apps.json`.
+ *
+ * Same shape as `ScrollbarSettingsManager` and the other settings managers:
+ * synchronous load at init, asynchronous save, defaults on any failure.
+ *
+ * **Persisted, unlike the missing-plugin declines.** Those are per-session
+ * because "not now" is an answer about now and a persisted one would leave no way
+ * to be asked again. This is the opposite: an offer to take over the user's file
+ * associations must be made once and never again unless they go looking for it.
+ * Being asked at every launch is precisely the behaviour that makes people
+ * distrust a browser.
+ */
+internal object DefaultAppsSettingsManager {
+    private val logger = BossLogger.forComponent("DefaultAppsSettingsManager")
+
+    private val settingsFile = BossDirectories.resolve("default-apps.json")
+
+    private val json =
+        Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        }
+
+    private val _settings = MutableStateFlow(DefaultAppsSettings())
+    val settings: StateFlow<DefaultAppsSettings> = _settings.asStateFlow()
+
+    init {
+        settingsFile.parentFile?.mkdirs()
+        load()
+    }
+
+    private fun load() {
+        try {
+            if (!settingsFile.exists()) return
+            _settings.value = json.decodeFromString<DefaultAppsSettings>(settingsFile.readText())
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Loaded default-apps settings",
+                mapOf("promptShown" to _settings.value.promptShown),
+            )
+        } catch (e: Exception) {
+            // Defaults, which means the prompt may be offered again. Better than
+            // the alternative failure direction: a corrupt file that silently
+            // suppressed the offer forever would leave no way to discover the
+            // feature at all.
+            logger.warn(LogCategory.SYSTEM, "Could not read default-apps settings", error = e)
+            _settings.value = DefaultAppsSettings()
+        }
+    }
+
+    /** True when the one-time offer has not been made yet. */
+    fun shouldOfferPrompt(): Boolean = !_settings.value.promptShown
+
+    suspend fun markPromptShown() {
+        update { it.copy(promptShown = true) }
+    }
+
+    suspend fun markDeclined(categoryIds: Collection<String>) {
+        update { it.copy(declinedCategories = it.declinedCategories + categoryIds) }
+    }
+
+    suspend fun clearDeclined(categoryIds: Collection<String>) {
+        update { it.copy(declinedCategories = it.declinedCategories - categoryIds.toSet()) }
+    }
+
+    private suspend fun update(transform: (DefaultAppsSettings) -> DefaultAppsSettings) {
+        _settings.value = transform(_settings.value)
+        save()
+    }
+
+    private suspend fun save() =
+        withContext(Dispatchers.IO) {
+            try {
+                settingsFile.parentFile?.mkdirs()
+                settingsFile.writeText(json.encodeToString(DefaultAppsSettings.serializer(), _settings.value))
+            } catch (e: Exception) {
+                // Logged, not surfaced: the decision has already taken effect in
+                // this session, and the only consequence of a failed write is
+                // being asked again next launch.
+                logger.warn(LogCategory.SYSTEM, "Could not save default-apps settings", error = e)
+            }
+        }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsSettingsManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/DefaultAppsSettingsManager.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -42,7 +45,14 @@ internal data class DefaultAppsSettings(
 internal object DefaultAppsSettingsManager {
     private val logger = BossLogger.forComponent("DefaultAppsSettingsManager")
 
-    private val settingsFile = BossDirectories.resolve("default-apps.json")
+    /**
+     * `internal var` so a test can point it at a temp file, matching
+     * `RecentBrowserPagesManager`. There is no other seam: the path is resolved
+     * from `BossDirectories`, and a round-trip test that wrote to the real
+     * `~/.boss/default-apps.json` would clobber the developer's own answer to the
+     * first-run prompt.
+     */
+    internal var settingsFile = BossDirectories.resolve("default-apps.json")
 
     private val json =
         Json {
@@ -53,13 +63,41 @@ internal object DefaultAppsSettingsManager {
     private val _settings = MutableStateFlow(DefaultAppsSettings())
     val settings: StateFlow<DefaultAppsSettings> = _settings.asStateFlow()
 
-    init {
-        settingsFile.parentFile?.mkdirs()
-        load()
+    @Volatile
+    private var loaded = false
+
+    private val loadMutex = Mutex()
+
+    /**
+     * Reads the file once, on IO. Every reader must await this first.
+     *
+     * There is deliberately no filesystem work in an `init` block. This object is
+     * reached from a composable, so an init doing `mkdirs` and `readText` put a
+     * file read on the UI thread at first-window composition - and
+     * [shouldOfferPrompt] read before the load would answer from defaults and
+     * offer a prompt that had already been made.
+     *
+     * Idempotent and safe from several windows at once; the mutex is what stops
+     * two first-launch windows both deciding the prompt has not been shown.
+     */
+    suspend fun ensureLoaded() {
+        if (loaded) return
+        loadMutex.withLock {
+            if (loaded) return@withLock
+            withContext(Dispatchers.IO) { load() }
+            loaded = true
+        }
+    }
+
+    /** Test seam: forget the cached load so the next [ensureLoaded] re-reads. */
+    internal fun resetForTest() {
+        loaded = false
+        _settings.value = DefaultAppsSettings()
     }
 
     private fun load() {
         try {
+            settingsFile.parentFile?.mkdirs()
             if (!settingsFile.exists()) return
             _settings.value = json.decodeFromString<DefaultAppsSettings>(settingsFile.readText())
             logger.debug(
@@ -77,8 +115,16 @@ internal object DefaultAppsSettingsManager {
         }
     }
 
-    /** True when the one-time offer has not been made yet. */
+    /**
+     * True when the one-time offer has not been made yet.
+     *
+     * Only meaningful after [ensureLoaded]; before it this reads the default and
+     * answers true for everybody.
+     */
     fun shouldOfferPrompt(): Boolean = !_settings.value.promptShown
+
+    /** Categories the user has refused, so nothing re-claims them behind their back. */
+    fun declinedCategories(): Set<String> = _settings.value.declinedCategories
 
     suspend fun markPromptShown() {
         update { it.copy(promptShown = true) }
@@ -93,7 +139,10 @@ internal object DefaultAppsSettingsManager {
     }
 
     private suspend fun update(transform: (DefaultAppsSettings) -> DefaultAppsSettings) {
-        _settings.value = transform(_settings.value)
+        // `update`, not a read-modify-write on `.value`: markPromptShown and
+        // markDeclined can run concurrently (the offer dialog records declines
+        // while marking itself shown), and the plain assignment loses one of them.
+        _settings.update(transform)
         save()
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/FileTypeCategories.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/FileTypeCategories.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
  * One group of things BOSS can be made the default handler for, as the Settings
  * screen and the registration code see it.
  *
- * Categories, not individual types: BOSS claims 83 extensions and 55 macOS UTIs,
+ * Categories, not individual types: BOSS claims 83 extensions and 56 macOS UTIs,
  * and a screen with 83 rows is not a screen anybody sets. What the user actually
  * decides is "should BOSS open my markdown" - five such decisions, each of which
  * expands to the list of types underneath it.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/FileTypeCategories.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/FileTypeCategories.kt
@@ -1,0 +1,165 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * One group of things BOSS can be made the default handler for, as the Settings
+ * screen and the registration code see it.
+ *
+ * Categories, not individual types: BOSS claims 83 extensions and 55 macOS UTIs,
+ * and a screen with 83 rows is not a screen anybody sets. What the user actually
+ * decides is "should BOSS open my markdown" - five such decisions, each of which
+ * expands to the list of types underneath it.
+ */
+@Serializable
+internal data class FileTypeCategory(
+    val id: String,
+    val displayName: String,
+    val description: String,
+    /** URL schemes, for the browser-shaped categories. Empty for file types. */
+    val schemes: List<String> = emptyList(),
+    /** macOS UTIs this category claims that no extension row names (`public.url`). */
+    val extraContentTypes: List<String> = emptyList(),
+    /** Linux MIME types, for `xdg-mime` and the `.desktop` file. */
+    val mimeTypes: List<String> = emptyList(),
+    val systemTypeRank: String = "Default",
+)
+
+/** One extension, and how macOS is asked about it. See `boss-file-types.json`. */
+@Serializable
+internal data class FileTypeExtension(
+    val ext: String,
+    val language: String,
+    val category: String,
+    /** The system UTI claimed as-is, or null when BOSS exports its own type for this extension. */
+    val systemType: String? = null,
+    /** A system UTI this extension resolves to that BOSS deliberately refuses. Recorded, never claimed. */
+    val rejectedSystemType: String? = null,
+)
+
+/** The parsed `boss-file-types.json`. */
+@Serializable
+internal data class FileTypeTable(
+    val exportedTypePrefix: String,
+    val exportedTypeSuffix: String,
+    val categories: List<FileTypeCategory>,
+    val languageNames: Map<String, String> = emptyMap(),
+    val extensions: List<FileTypeExtension>,
+    /** The resource's own documentation. Declared so it round-trips rather than being an unknown key. */
+    @SerialName("\$comment")
+    val comment: List<String> = emptyList(),
+) {
+    /**
+     * Every macOS type [categoryId] claims: the system UTIs its extensions
+     * resolve to, its extension-less extras, and the types BOSS exports itself.
+     *
+     * This is the list the "Set" button walks and the status check reduces over,
+     * so it must match what the plist declared exactly - hence the exported
+     * identifiers being built from the resource's own prefix and suffix rather
+     * than from a constant that could drift from `buildSrc/BossFileTypes`.
+     */
+    fun contentTypesFor(categoryId: String): List<String> {
+        val category = categories.firstOrNull { it.id == categoryId } ?: return emptyList()
+        val system =
+            extensions
+                .filter { it.category == categoryId }
+                .mapNotNull { it.systemType }
+        return (system + category.extraContentTypes + exportedTypeIdsFor(categoryId)).distinct()
+    }
+
+    /**
+     * The UTIs BOSS exports for [categoryId], one per language that has any
+     * extension without a system UTI.
+     *
+     * Grouped by language, identically to the generator: the plist declares
+     * `ai.rever.boss.kotlin-source` once for `.kt` and `.kts`, so asking about
+     * one identifier per extension would ask about types that do not exist.
+     */
+    fun exportedTypeIdsFor(categoryId: String): List<String> =
+        extensions
+            .filter { it.category == categoryId && it.systemType == null }
+            .map { it.language }
+            .distinct()
+            .map { language -> "$exportedTypePrefix.$language$exportedTypeSuffix" }
+
+    fun extensionsFor(categoryId: String): List<String> = extensions.filter { it.category == categoryId }.map { it.ext }
+
+    fun schemesFor(categoryId: String): List<String> = categories.firstOrNull { it.id == categoryId }?.schemes.orEmpty()
+
+    fun mimeTypesFor(categoryId: String): List<String> = categoryOrNull(categoryId)?.mimeTypes.orEmpty()
+
+    fun categoryOrNull(categoryId: String): FileTypeCategory? = categories.firstOrNull { it.id == categoryId }
+}
+
+/**
+ * Loads the shared file-type table from the classpath.
+ *
+ * Same resource `buildSrc/BossFileTypes` reads at build time to generate the
+ * macOS plist declarations, so the app cannot ask Launch Services about a type
+ * the bundle never declared - the failure mode that would produce is a Settings
+ * row that reports "not the default" forever and a button that cannot fix it.
+ *
+ * Parsed once, lazily. A parse failure yields an empty table and a logged error
+ * rather than a throw: this is read from the Settings screen and from startup
+ * detection, and neither should be able to take the app down over a resource
+ * problem. Every consumer treats an empty table as "no categories to offer",
+ * which shows an explanatory empty state instead of a broken one.
+ */
+internal object FileTypeCategories {
+    private const val RESOURCE_NAME = "boss-file-types.json"
+
+    private val logger = BossLogger.forComponent("FileTypeCategories")
+
+    private val json =
+        Json {
+            // The resource carries a "$comment" array documenting itself, and
+            // more fields will be added to it before every consumer is updated.
+            ignoreUnknownKeys = true
+        }
+
+    private val empty =
+        FileTypeTable(
+            exportedTypePrefix = "",
+            exportedTypeSuffix = "",
+            categories = emptyList(),
+            extensions = emptyList(),
+        )
+
+    val table: FileTypeTable by lazy { load() }
+
+    val categories: List<FileTypeCategory> get() = table.categories
+
+    /** True when the table loaded and has something to offer. */
+    fun isAvailable(): Boolean = table.categories.isNotEmpty()
+
+    private fun load(): FileTypeTable =
+        try {
+            val text =
+                FileTypeCategories::class.java.classLoader
+                    ?.getResourceAsStream(RESOURCE_NAME)
+                    ?.use { it.readBytes().decodeToString() }
+            if (text == null) {
+                logger.error(
+                    LogCategory.SYSTEM,
+                    "File-type table resource not found",
+                    mapOf("resource" to RESOURCE_NAME),
+                )
+                empty
+            } else {
+                json.decodeFromString<FileTypeTable>(text).also { parsed ->
+                    logger.debug(
+                        LogCategory.SYSTEM,
+                        "Loaded file-type table",
+                        mapOf("categories" to parsed.categories.size, "extensions" to parsed.extensions.size),
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            logger.error(LogCategory.SYSTEM, "Could not parse the file-type table", error = e)
+            empty
+        }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/LinuxFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/LinuxFileTypeHandler.kt
@@ -1,0 +1,124 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.utils.DefaultHandlerState
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.util.concurrent.TimeUnit
+
+/**
+ * Linux MIME associations for a [FileTypeCategory], through `xdg-mime`.
+ *
+ * The `.desktop` file itself is written by `LinuxDefaultBrowserHandler`, which
+ * owns it; this asks it to include every category's MIME types (see
+ * [allMimeTypes]) and then points each type at it.
+ *
+ * **Only MIME types freedesktop actually defines are listed** in
+ * `boss-file-types.json`. `xdg-mime default` accepts any string, and pointing it
+ * at an invented type such as `text/x-kotlin` silently records an association no
+ * file will ever match, because nothing maps `.kt` to that type. Making those
+ * work needs a `shared-mime-info` XML package installed alongside the app, which
+ * is a bigger change than this one and is not attempted: what a Linux user gets
+ * here is the schemes plus the languages the distribution already has types for.
+ */
+internal object LinuxFileTypeHandler {
+    private val logger = BossLogger.forComponent("LinuxFileTypeHandler")
+
+    private const val PROCESS_TIMEOUT_SECONDS = 15L
+
+    private const val DESKTOP_FILE_NAME = "boss.desktop"
+
+    /**
+     * Every MIME type across every category, for the `.desktop` `MimeType=` line.
+     *
+     * The desktop entry has to declare a type before `xdg-mime default` will
+     * associate it; declaring the union once is simpler than rewriting the
+     * desktop file per category, and harmless - declaring support is not the same
+     * as being the default.
+     */
+    fun allMimeTypes(): List<String> = FileTypeCategories.categories.flatMap { it.mimeTypes }.distinct()
+
+    /** Points every MIME type in [category] at BOSS. True when all of them were accepted. */
+    fun setDefault(category: FileTypeCategory): Boolean {
+        val mimeTypes = FileTypeCategories.table.mimeTypesFor(category.id)
+        if (mimeTypes.isEmpty()) return true
+
+        // fold rather than all, so one unknown type does not skip the rest.
+        val ok =
+            mimeTypes.fold(true) { acc, mimeType ->
+                runSucceeds(listOf("xdg-mime", "default", DESKTOP_FILE_NAME, mimeType)) && acc
+            }
+
+        logger.info(
+            LogCategory.SYSTEM,
+            if (ok) "Set Linux MIME associations" else "Some Linux MIME associations were refused",
+            mapOf("category" to category.id, "types" to mimeTypes.size),
+        )
+        return ok
+    }
+
+    /**
+     * Who owns [category] according to `xdg-mime query default`.
+     *
+     * There is no Linux equivalent of the engine-bundle collision, so the answer
+     * is only ever [DefaultHandlerState.Ours] or [DefaultHandlerState.Other]:
+     * the engine on Linux is a plain executable with no desktop entry, so it can
+     * never be a candidate.
+     */
+    fun statusOf(category: FileTypeCategory): DefaultHandlerState {
+        val mimeTypes = FileTypeCategories.table.mimeTypesFor(category.id)
+        if (mimeTypes.isEmpty()) return DefaultHandlerState.Other(null)
+
+        val states =
+            mimeTypes.map { mimeType ->
+                val owner = queryDefault(mimeType)
+                when {
+                    owner == null -> DefaultHandlerState.Other(null)
+                    owner.equals(DESKTOP_FILE_NAME, ignoreCase = true) -> DefaultHandlerState.Ours
+                    else -> DefaultHandlerState.Other(owner)
+                }
+            }
+
+        return if (states.all { it.isOurs }) DefaultHandlerState.Ours else states.first { !it.isOurs }
+    }
+
+    private fun queryDefault(mimeType: String): String? =
+        try {
+            val process =
+                ProcessBuilder("xdg-mime", "query", "default", mimeType)
+                    .redirectErrorStream(true)
+                    .start()
+            val output = process.inputStream.bufferedReader().use { it.readText().trim() }
+            if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                null
+            } else if (process.exitValue() != 0) {
+                null
+            } else {
+                output.ifEmpty { null }
+            }
+        } catch (e: Exception) {
+            // xdg-utils absent is normal on a minimal install, and it is the
+            // reason a status can be unknown rather than false.
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not query the MIME association",
+                mapOf("mimeType" to mimeType, "reason" to (e.message ?: "unknown")),
+            )
+            null
+        }
+
+    private fun runSucceeds(command: List<String>): Boolean =
+        try {
+            val process = ProcessBuilder(command).redirectErrorStream(true).start()
+            if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                logger.warn(LogCategory.SYSTEM, "xdg command timed out", mapOf("command" to command.joinToString(" ")))
+                false
+            } else {
+                process.exitValue() == 0
+            }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Could not run an xdg command", error = e)
+            false
+        }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/LinuxFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/LinuxFileTypeHandler.kt
@@ -3,6 +3,7 @@ package ai.rever.boss.filetypes
 import ai.rever.boss.utils.DefaultHandlerState
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 /**
@@ -78,7 +79,7 @@ internal object LinuxFileTypeHandler {
                 }
             }
 
-        return if (states.all { it.isOurs }) DefaultHandlerState.Ours else states.first { !it.isOurs }
+        return DefaultHandlerState.reduce(states)
     }
 
     private fun queryDefault(mimeType: String): String? =
@@ -87,14 +88,21 @@ internal object LinuxFileTypeHandler {
                 ProcessBuilder("xdg-mime", "query", "default", mimeType)
                     .redirectErrorStream(true)
                     .start()
-            val output = process.inputStream.bufferedReader().use { it.readText().trim() }
+            // Read on another thread so the waitFor timeout can actually fire.
+            // Reading to EOF first and waiting afterwards - which this did - means
+            // an xdg-mime that never closes stdout hangs forever and the 15 s bound
+            // is decorative.
+            val output =
+                CompletableFuture.supplyAsync {
+                    process.inputStream.bufferedReader().use { it.readText().trim() }
+                }
             if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
                 null
             } else if (process.exitValue() != 0) {
                 null
             } else {
-                output.ifEmpty { null }
+                output.get(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS).ifEmpty { null }
             }
         } catch (e: Exception) {
             // xdg-utils absent is normal on a minimal install, and it is the
@@ -109,7 +117,14 @@ internal object LinuxFileTypeHandler {
 
     private fun runSucceeds(command: List<String>): Boolean =
         try {
-            val process = ProcessBuilder(command).redirectErrorStream(true).start()
+            // DISCARD rather than redirectErrorStream(true) with nobody reading:
+            // an undrained pipe deadlocks the child as soon as it fills, and the
+            // timeout cannot rescue a child that never exits.
+            val process =
+                ProcessBuilder(command)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start()
             if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
                 logger.warn(LogCategory.SYSTEM, "xdg command timed out", mapOf("command" to command.joinToString(" ")))

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/MacOSFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/MacOSFileTypeHandler.kt
@@ -1,0 +1,77 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.utils.BOSS_MACOS_BUNDLE_ID
+import ai.rever.boss.utils.DefaultHandlerState
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.mac.LaunchServices
+
+/**
+ * Reads and writes the macOS default handler for a whole [FileTypeCategory].
+ *
+ * A category is several types - "Source code and config" is 31 system UTIs plus
+ * 24 BOSS exports - and Launch Services stores an answer per type, so both the
+ * status and the set are a fold over the list rather than one call.
+ */
+internal object MacOSFileTypeHandler {
+    private val logger = BossLogger.forComponent("MacOSFileTypeHandler")
+
+    /** Whether the native Launch Services calls can be made at all. */
+    fun isAvailable(): Boolean = LaunchServices.isAvailable()
+
+    /**
+     * Who owns [category] right now, reduced to one answer.
+     *
+     * [DefaultHandlerState.OurEngine] outranks [DefaultHandlerState.Other]
+     * whenever any type in the category is held by the Chromium engine bundle,
+     * because that is the answer with a one-click fix and the one the user needs
+     * to be told about. See [DefaultHandlerState].
+     */
+    fun statusOf(category: FileTypeCategory): DefaultHandlerState {
+        val table = FileTypeCategories.table
+        val owners =
+            table.schemesFor(category.id).map { LaunchServices.defaultHandlerForScheme(it) } +
+                table.contentTypesFor(category.id).map { LaunchServices.defaultHandlerForContentType(it) }
+
+        if (owners.isEmpty()) return DefaultHandlerState.Other(null)
+
+        val states = owners.map { DefaultHandlerState.of(it) }
+        return when {
+            states.all { it.isOurs } -> DefaultHandlerState.Ours
+            states.any { it is DefaultHandlerState.OurEngine } -> DefaultHandlerState.OurEngine
+            else -> states.first { !it.isOurs }
+        }
+    }
+
+    /**
+     * Claims every type and scheme in [category] for BOSS.
+     *
+     * @return true when the OS accepted all of them. A partial result is
+     *   reported as false and left in place rather than rolled back: the types it
+     *   did accept are ones the user asked for, and undoing them would hand the
+     *   file back to whatever had it with nothing gained.
+     */
+    fun setDefault(category: FileTypeCategory): Boolean {
+        val table = FileTypeCategories.table
+
+        // fold, not all: `all` short-circuits, so one refused type would skip
+        // every remaining one in the category and leave most of the user's
+        // request undone while reporting a single failure.
+        val schemesSet =
+            table.schemesFor(category.id).fold(true) { acc, scheme ->
+                LaunchServices.setDefaultHandlerForScheme(scheme, BOSS_MACOS_BUNDLE_ID) && acc
+            }
+        val typesSet =
+            table.contentTypesFor(category.id).fold(true) { acc, contentType ->
+                LaunchServices.setDefaultHandlerForContentType(contentType, BOSS_MACOS_BUNDLE_ID) && acc
+            }
+
+        val ok = schemesSet && typesSet
+        logger.info(
+            LogCategory.SYSTEM,
+            if (ok) "Claimed a file-type category" else "Could not claim every type in a category",
+            mapOf("category" to category.id),
+        )
+        return ok
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/MacOSFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/MacOSFileTypeHandler.kt
@@ -9,7 +9,7 @@ import ai.rever.boss.utils.mac.LaunchServices
 /**
  * Reads and writes the macOS default handler for a whole [FileTypeCategory].
  *
- * A category is several types - "Source code and config" is 31 system UTIs plus
+ * A category is several types - "Source code and config" is 26 system UTIs plus
  * 24 BOSS exports - and Launch Services stores an answer per type, so both the
  * status and the set are a fold over the list rather than one call.
  */
@@ -35,12 +35,7 @@ internal object MacOSFileTypeHandler {
 
         if (owners.isEmpty()) return DefaultHandlerState.Other(null)
 
-        val states = owners.map { DefaultHandlerState.of(it) }
-        return when {
-            states.all { it.isOurs } -> DefaultHandlerState.Ours
-            states.any { it is DefaultHandlerState.OurEngine } -> DefaultHandlerState.OurEngine
-            else -> states.first { !it.isOurs }
-        }
+        return DefaultHandlerState.reduce(owners.map { DefaultHandlerState.of(it) })
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsFileTypeHandler.kt
@@ -4,6 +4,8 @@ import ai.rever.boss.utils.DefaultHandlerState
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 /**
@@ -13,43 +15,40 @@ import java.util.concurrent.TimeUnit
  * `Capabilities\FileAssociations` entries for `.htm` and `.html` pointing at the
  * ProgID `BOSS` - and nothing ever created a ProgID called `BOSS`. A
  * `FileAssociations` value naming a ProgID that does not exist cannot resolve, so
- * BOSS never appeared as a candidate for those extensions in Settings, let alone
- * became the default. This creates a real ProgID per extension, which is what
- * makes the `FileAssociations` entry mean something.
+ * BOSS never appeared as a candidate for those extensions, let alone became the
+ * default. This creates a real ProgID per extension, which is what makes the
+ * `FileAssociations` entry mean something.
+ *
+ * **One process, not hundreds.** Registration is a generated `.reg` script
+ * imported in a single `reg import`, and the status is a single
+ * `reg query <FileExts> /s`. The per-`reg add` version ran roughly 415 processes
+ * for a five-category "Set all" and 83 more just to read the status, each with its
+ * own timeout, from a Settings screen and from the first-run offer at startup. See
+ * [WindowsRegistryScript], which also explains the quoting hazard the script form
+ * removes.
  *
  * **Setting the default is the user's, by design of the OS.** Since Windows 10,
- * writing the `UserChoice` key yourself is blocked (it carries a hash the shell
- * verifies, and a mismatch is reverted). So `register` prepares everything and
- * `openDefaultAppsSettings` takes the user to the one place that can finish it -
- * the same shape the existing browser flow already has.
+ * writing the `UserChoice` key yourself is blocked - it carries a hash the shell
+ * verifies, and a mismatch is reverted. So [register] prepares everything and
+ * [openDefaultAppsSettings] takes the user to the one place that can finish it,
+ * called once per user action by `DefaultAppsManager`.
  */
 internal object WindowsFileTypeHandler {
     private val logger = BossLogger.forComponent("WindowsFileTypeHandler")
 
-    private const val PROCESS_TIMEOUT_SECONDS = 15L
-
-    private const val CLASSES_KEY = """HKEY_CURRENT_USER\SOFTWARE\Classes"""
-
-    private const val CAPABILITIES_FILE_ASSOCIATIONS =
-        """HKEY_CURRENT_USER\SOFTWARE\Clients\StartMenuInternet\BOSS\Capabilities\FileAssociations"""
+    private const val PROCESS_TIMEOUT_SECONDS = 30L
 
     private const val FILE_EXTS_KEY =
-        """HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts"""
+        """HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts"""
+
+    /** The ProgID naming rule, in one place. See [WindowsRegistryScript.progIdFor]. */
+    internal fun progIdFor(extension: String): String = WindowsRegistryScript.progIdFor(extension)
 
     /**
-     * ProgID for an extension: `BOSS.md`, `BOSS.kt`.
+     * Writes the ProgIDs and capability entries for [category] in one `reg import`.
      *
-     * One per extension rather than one per category, because `FileAssociations`
-     * and `UserChoice` are both keyed by extension, and a shared ProgID would
-     * make "BOSS opens markdown" and "BOSS opens Kotlin" the same switch.
-     */
-    internal fun progIdFor(extension: String): String = "BOSS.${extension.lowercase()}"
-
-    /**
-     * Creates the ProgIDs and capability entries for [category].
-     *
-     * Idempotent (`reg add /f` overwrites), so it is safe to call on every
-     * attempt rather than tracking what was already written.
+     * Idempotent: `reg import` overwrites the values it names, so this is safe to
+     * call on every attempt rather than tracking what was already written.
      */
     fun register(category: FileTypeCategory): Boolean {
         val appPath = applicationPath()
@@ -61,82 +60,41 @@ internal object WindowsFileTypeHandler {
             return false
         }
 
-        val table = FileTypeCategories.table
-        val extensions = table.extensionsFor(category.id)
+        val extensions = FileTypeCategories.table.extensionsFor(category.id)
         if (extensions.isEmpty()) return true
 
-        var allSucceeded = true
-        extensions.forEach { extension ->
-            if (!registerExtension(extension, category.displayName, appPath)) allSucceeded = false
-        }
+        val script = WindowsRegistryScript.buildScript(extensions, appPath, category.displayName)
 
-        logger.info(
-            LogCategory.SYSTEM,
-            if (allSucceeded) {
-                "Registered Windows file associations"
-            } else {
-                "Registered Windows file associations with failures"
-            },
-            mapOf("category" to category.id, "extensions" to extensions.size),
-        )
-        return allSucceeded
-    }
+        var scriptFile: File? = null
+        return try {
+            // UTF-16LE with a BOM: that is what `reg import` requires of a
+            // "Windows Registry Editor Version 5.00" script. An ANSI file is
+            // mis-read rather than rejected loudly.
+            scriptFile =
+                File.createTempFile("boss-file-types", ".reg").apply {
+                    writeBytes(
+                        byteArrayOf(0xFF.toByte(), 0xFE.toByte()) + script.toByteArray(StandardCharsets.UTF_16LE),
+                    )
+                }
 
-    /**
-     * Writes the ProgID and capability entries for one extension.
-     *
-     * Extracted from [register] so that function stays readable: five `reg add`
-     * invocations per extension, each with its own reason, is not a loop body.
-     *
-     * @return true when every command succeeded. A partial result still leaves
-     *   the extension better off than before, so nothing is rolled back.
-     */
-    private fun registerExtension(
-        extension: String,
-        categoryDisplayName: String,
-        appPath: String,
-    ): Boolean {
-        val progId = progIdFor(extension)
-        val description = "$categoryDisplayName (BOSS)"
-        val commands =
-            listOf(
-                listOf("reg", "add", """$CLASSES_KEY\$progId""", "/ve", "/d", description, "/f"),
-                listOf("reg", "add", """$CLASSES_KEY\$progId\DefaultIcon""", "/ve", "/d", "$appPath,0", "/f"),
-                listOf(
-                    "reg",
-                    "add",
-                    """$CLASSES_KEY\$progId\shell\open\command""",
-                    "/ve",
-                    "/d",
-                    "\"$appPath\" \"%1\"",
-                    "/f",
-                ),
-                // An OpenWithProgids hint puts BOSS in the "Open with" list for the
-                // extension even before it is the default, which is how the user
-                // finds it in the Settings picker at all.
-                listOf(
-                    "reg",
-                    "add",
-                    """$CLASSES_KEY\.$extension\OpenWithProgids""",
-                    "/v",
-                    progId,
-                    "/t",
-                    "REG_NONE",
-                    "/f",
-                ),
-                listOf("reg", "add", CAPABILITIES_FILE_ASSOCIATIONS, "/v", ".$extension", "/d", progId, "/f"),
+            val imported = runSucceeds(listOf("reg", "import", scriptFile.absolutePath))
+            logger.info(
+                LogCategory.SYSTEM,
+                if (imported) {
+                    "Registered Windows file associations"
+                } else {
+                    "Could not import the file-association script"
+                },
+                mapOf("category" to category.id, "extensions" to extensions.size),
             )
-
-        return commands.fold(true) { acc, command ->
-            val ok = runSucceeds(command)
-            if (!ok) {
-                logger.warn(
-                    LogCategory.SYSTEM,
-                    "Registry command failed while registering a file association",
-                    mapOf("extension" to extension),
-                )
-            }
-            ok && acc
+            imported
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Could not write the file-association script", error = e)
+            false
+        } finally {
+            // Best effort. The script holds no secrets, but one temp file per
+            // attempt left in %TEMP% is untidy.
+            scriptFile?.delete()
         }
     }
 
@@ -144,18 +102,22 @@ internal object WindowsFileTypeHandler {
      * Who owns [category] according to the shell's per-extension `UserChoice`.
      *
      * Reduced the same way macOS is: BOSS only when every extension points at a
-     * BOSS ProgID. An extension with no `UserChoice` at all reads as
+     * BOSS ProgID. An extension with no `UserChoice` reads as
      * [DefaultHandlerState.Other] with a null id, which is honest - the shell has
-     * no recorded user preference, so the association falls back to whatever the
-     * machine defaults to.
+     * no recorded user preference, so the association falls back to the machine
+     * default.
      */
     fun statusOf(category: FileTypeCategory): DefaultHandlerState {
         val extensions = FileTypeCategories.table.extensionsFor(category.id)
         if (extensions.isEmpty()) return DefaultHandlerState.Other(null)
 
+        // One query over the whole FileExts tree, parsed once, instead of one
+        // process per extension.
+        val choices = userChoices()
+
         val states =
             extensions.map { extension ->
-                val progId = userChoiceProgId(extension)
+                val progId = choices[extension.lowercase()]
                 when {
                     progId == null -> DefaultHandlerState.Other(null)
                     progId.equals(progIdFor(extension), ignoreCase = true) -> DefaultHandlerState.Ours
@@ -163,11 +125,7 @@ internal object WindowsFileTypeHandler {
                 }
             }
 
-        return if (states.all { it.isOurs }) {
-            DefaultHandlerState.Ours
-        } else {
-            states.first { !it.isOurs }
-        }
+        return DefaultHandlerState.reduce(states)
     }
 
     /** Opens Settings > Default apps, the only place Windows lets the default actually change. */
@@ -177,33 +135,26 @@ internal object WindowsFileTypeHandler {
         runSucceeds(listOf("cmd", "/c", "start", "", "ms-settings:defaultapps"))
     }
 
-    private fun userChoiceProgId(extension: String): String? =
-        try {
-            val output =
-                runCapturing(
-                    listOf("reg", "query", """$FILE_EXTS_KEY\.$extension\UserChoice""", "/v", "ProgId"),
-                ) ?: return null
-            // reg query prints "    ProgId    REG_SZ    BOSS.md"
-            output
-                .lineSequence()
-                .firstOrNull { it.contains("ProgId", ignoreCase = true) }
-                ?.trim()
-                ?.split(Regex("\\s{2,}"))
-                ?.lastOrNull()
-                ?.trim()
-                ?.takeIf { it.isNotEmpty() }
-        } catch (e: Exception) {
-            logger.debug(
-                LogCategory.SYSTEM,
-                "Could not read the shell's file association",
-                mapOf("extension" to extension, "reason" to (e.message ?: "unknown")),
-            )
-            null
-        }
+    /** Every recorded `.ext -> ProgId` the shell holds, or empty when it cannot be read. */
+    private fun userChoices(): Map<String, String> =
+        runCapturing(listOf("reg", "query", FILE_EXTS_KEY, "/s"))
+            ?.let(WindowsRegistryScript::parseUserChoices)
+            ?: emptyMap()
 
+    /**
+     * Runs a command for its exit code, discarding its output.
+     *
+     * `DISCARD` rather than `redirectErrorStream(true)` with nobody reading: an
+     * undrained pipe deadlocks the child as soon as it fills, and the timeout
+     * below cannot rescue it because the child never exits.
+     */
     private fun runSucceeds(command: List<String>): Boolean =
         try {
-            val process = ProcessBuilder(command).redirectErrorStream(true).start()
+            val process =
+                ProcessBuilder(command)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start()
             if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
                 logger.warn(LogCategory.SYSTEM, "Registry command timed out", mapOf("command" to command.first()))
@@ -216,19 +167,35 @@ internal object WindowsFileTypeHandler {
             false
         }
 
+    /**
+     * Runs a command and returns its stdout, or null.
+     *
+     * The reader runs on another thread so the `waitFor` timeout can actually
+     * fire. Reading to EOF first and waiting afterwards - which this did - means a
+     * child that never closes stdout hangs forever and the timeout is decorative.
+     * `MacOSDefaultBrowserHandler` avoids the same trap the same way.
+     */
     private fun runCapturing(command: List<String>): String? =
         try {
-            val process = ProcessBuilder(command).redirectErrorStream(true).start()
-            val output = process.inputStream.bufferedReader().use { it.readText() }
+            val process =
+                ProcessBuilder(command)
+                    .redirectErrorStream(true)
+                    .start()
+            val output =
+                CompletableFuture.supplyAsync {
+                    process.inputStream.bufferedReader().use { it.readText() }
+                }
+
             if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
+                logger.warn(LogCategory.SYSTEM, "Registry query timed out", mapOf("command" to command.first()))
                 null
             } else if (process.exitValue() != 0) {
                 // A missing key exits non-zero, which is the common case here and
                 // not worth a warning.
                 null
             } else {
-                output
+                output.get(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             }
         } catch (e: Exception) {
             logger.debug(
@@ -244,8 +211,8 @@ internal object WindowsFileTypeHandler {
      *
      * Same resolution the browser registration uses, kept separate rather than
      * shared because that one is `private` and lives in a file about URL schemes;
-     * both would be better off in one place, which is a follow-up rather than
-     * part of this change.
+     * both would be better off in one place, which is a follow-up rather than part
+     * of this change.
      */
     private fun applicationPath(): String? =
         try {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsFileTypeHandler.kt
@@ -1,0 +1,270 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.utils.DefaultHandlerState
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Windows file associations for a [FileTypeCategory].
+ *
+ * **What was missing.** `WindowsDefaultBrowserHandler` wrote
+ * `Capabilities\FileAssociations` entries for `.htm` and `.html` pointing at the
+ * ProgID `BOSS` - and nothing ever created a ProgID called `BOSS`. A
+ * `FileAssociations` value naming a ProgID that does not exist cannot resolve, so
+ * BOSS never appeared as a candidate for those extensions in Settings, let alone
+ * became the default. This creates a real ProgID per extension, which is what
+ * makes the `FileAssociations` entry mean something.
+ *
+ * **Setting the default is the user's, by design of the OS.** Since Windows 10,
+ * writing the `UserChoice` key yourself is blocked (it carries a hash the shell
+ * verifies, and a mismatch is reverted). So `register` prepares everything and
+ * `openDefaultAppsSettings` takes the user to the one place that can finish it -
+ * the same shape the existing browser flow already has.
+ */
+internal object WindowsFileTypeHandler {
+    private val logger = BossLogger.forComponent("WindowsFileTypeHandler")
+
+    private const val PROCESS_TIMEOUT_SECONDS = 15L
+
+    private const val CLASSES_KEY = """HKEY_CURRENT_USER\SOFTWARE\Classes"""
+
+    private const val CAPABILITIES_FILE_ASSOCIATIONS =
+        """HKEY_CURRENT_USER\SOFTWARE\Clients\StartMenuInternet\BOSS\Capabilities\FileAssociations"""
+
+    private const val FILE_EXTS_KEY =
+        """HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts"""
+
+    /**
+     * ProgID for an extension: `BOSS.md`, `BOSS.kt`.
+     *
+     * One per extension rather than one per category, because `FileAssociations`
+     * and `UserChoice` are both keyed by extension, and a shared ProgID would
+     * make "BOSS opens markdown" and "BOSS opens Kotlin" the same switch.
+     */
+    internal fun progIdFor(extension: String): String = "BOSS.${extension.lowercase()}"
+
+    /**
+     * Creates the ProgIDs and capability entries for [category].
+     *
+     * Idempotent (`reg add /f` overwrites), so it is safe to call on every
+     * attempt rather than tracking what was already written.
+     */
+    fun register(category: FileTypeCategory): Boolean {
+        val appPath = applicationPath()
+        if (appPath == null) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Could not determine the executable path; cannot register file associations",
+            )
+            return false
+        }
+
+        val table = FileTypeCategories.table
+        val extensions = table.extensionsFor(category.id)
+        if (extensions.isEmpty()) return true
+
+        var allSucceeded = true
+        extensions.forEach { extension ->
+            if (!registerExtension(extension, category.displayName, appPath)) allSucceeded = false
+        }
+
+        logger.info(
+            LogCategory.SYSTEM,
+            if (allSucceeded) {
+                "Registered Windows file associations"
+            } else {
+                "Registered Windows file associations with failures"
+            },
+            mapOf("category" to category.id, "extensions" to extensions.size),
+        )
+        return allSucceeded
+    }
+
+    /**
+     * Writes the ProgID and capability entries for one extension.
+     *
+     * Extracted from [register] so that function stays readable: five `reg add`
+     * invocations per extension, each with its own reason, is not a loop body.
+     *
+     * @return true when every command succeeded. A partial result still leaves
+     *   the extension better off than before, so nothing is rolled back.
+     */
+    private fun registerExtension(
+        extension: String,
+        categoryDisplayName: String,
+        appPath: String,
+    ): Boolean {
+        val progId = progIdFor(extension)
+        val description = "$categoryDisplayName (BOSS)"
+        val commands =
+            listOf(
+                listOf("reg", "add", """$CLASSES_KEY\$progId""", "/ve", "/d", description, "/f"),
+                listOf("reg", "add", """$CLASSES_KEY\$progId\DefaultIcon""", "/ve", "/d", "$appPath,0", "/f"),
+                listOf(
+                    "reg",
+                    "add",
+                    """$CLASSES_KEY\$progId\shell\open\command""",
+                    "/ve",
+                    "/d",
+                    "\"$appPath\" \"%1\"",
+                    "/f",
+                ),
+                // An OpenWithProgids hint puts BOSS in the "Open with" list for the
+                // extension even before it is the default, which is how the user
+                // finds it in the Settings picker at all.
+                listOf(
+                    "reg",
+                    "add",
+                    """$CLASSES_KEY\.$extension\OpenWithProgids""",
+                    "/v",
+                    progId,
+                    "/t",
+                    "REG_NONE",
+                    "/f",
+                ),
+                listOf("reg", "add", CAPABILITIES_FILE_ASSOCIATIONS, "/v", ".$extension", "/d", progId, "/f"),
+            )
+
+        return commands.fold(true) { acc, command ->
+            val ok = runSucceeds(command)
+            if (!ok) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "Registry command failed while registering a file association",
+                    mapOf("extension" to extension),
+                )
+            }
+            ok && acc
+        }
+    }
+
+    /**
+     * Who owns [category] according to the shell's per-extension `UserChoice`.
+     *
+     * Reduced the same way macOS is: BOSS only when every extension points at a
+     * BOSS ProgID. An extension with no `UserChoice` at all reads as
+     * [DefaultHandlerState.Other] with a null id, which is honest - the shell has
+     * no recorded user preference, so the association falls back to whatever the
+     * machine defaults to.
+     */
+    fun statusOf(category: FileTypeCategory): DefaultHandlerState {
+        val extensions = FileTypeCategories.table.extensionsFor(category.id)
+        if (extensions.isEmpty()) return DefaultHandlerState.Other(null)
+
+        val states =
+            extensions.map { extension ->
+                val progId = userChoiceProgId(extension)
+                when {
+                    progId == null -> DefaultHandlerState.Other(null)
+                    progId.equals(progIdFor(extension), ignoreCase = true) -> DefaultHandlerState.Ours
+                    else -> DefaultHandlerState.Other(progId)
+                }
+            }
+
+        return if (states.all { it.isOurs }) {
+            DefaultHandlerState.Ours
+        } else {
+            states.first { !it.isOurs }
+        }
+    }
+
+    /** Opens Settings > Default apps, the only place Windows lets the default actually change. */
+    fun openDefaultAppsSettings() {
+        // Not through Desktop.browse: this is an ms-settings: URI, which the AWT
+        // Desktop refuses as an unsupported scheme on some JDK builds.
+        runSucceeds(listOf("cmd", "/c", "start", "", "ms-settings:defaultapps"))
+    }
+
+    private fun userChoiceProgId(extension: String): String? =
+        try {
+            val output =
+                runCapturing(
+                    listOf("reg", "query", """$FILE_EXTS_KEY\.$extension\UserChoice""", "/v", "ProgId"),
+                ) ?: return null
+            // reg query prints "    ProgId    REG_SZ    BOSS.md"
+            output
+                .lineSequence()
+                .firstOrNull { it.contains("ProgId", ignoreCase = true) }
+                ?.trim()
+                ?.split(Regex("\\s{2,}"))
+                ?.lastOrNull()
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        } catch (e: Exception) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not read the shell's file association",
+                mapOf("extension" to extension, "reason" to (e.message ?: "unknown")),
+            )
+            null
+        }
+
+    private fun runSucceeds(command: List<String>): Boolean =
+        try {
+            val process = ProcessBuilder(command).redirectErrorStream(true).start()
+            if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                logger.warn(LogCategory.SYSTEM, "Registry command timed out", mapOf("command" to command.first()))
+                false
+            } else {
+                process.exitValue() == 0
+            }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Could not run a registry command", error = e)
+            false
+        }
+
+    private fun runCapturing(command: List<String>): String? =
+        try {
+            val process = ProcessBuilder(command).redirectErrorStream(true).start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            if (!process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                null
+            } else if (process.exitValue() != 0) {
+                // A missing key exits non-zero, which is the common case here and
+                // not worth a warning.
+                null
+            } else {
+                output
+            }
+        } catch (e: Exception) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Could not query the registry",
+                mapOf("reason" to (e.message ?: "unknown")),
+            )
+            null
+        }
+
+    /**
+     * Path to the launcher a shell should run, or null when it cannot be found.
+     *
+     * Same resolution the browser registration uses, kept separate rather than
+     * shared because that one is `private` and lives in a file about URL schemes;
+     * both would be better off in one place, which is a follow-up rather than
+     * part of this change.
+     */
+    private fun applicationPath(): String? =
+        try {
+            val codeSource =
+                WindowsFileTypeHandler::class.java.protectionDomain.codeSource.location
+                    .toURI()
+                    .path
+            when {
+                codeSource.endsWith(".jar") -> {
+                    val launcher = File(codeSource).parentFile?.resolve("BOSS.exe")
+                    launcher?.takeIf { it.exists() }?.absolutePath
+                }
+
+                else -> {
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn(LogCategory.SYSTEM, "Could not resolve the executable path", error = e)
+            null
+        }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsRegistryScript.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsRegistryScript.kt
@@ -1,0 +1,169 @@
+package ai.rever.boss.filetypes
+
+/**
+ * Builds the `.reg` script that registers BOSS for a set of file extensions, and
+ * parses the shell's answer back out of `reg query` output.
+ *
+ * Pure, so both halves are testable without Windows - which matters more here
+ * than usual, because nobody developing on macOS will notice this breaking and
+ * the failure is silent (an association that exists but does not launch BOSS).
+ *
+ * **Why a script instead of `reg add` calls.** The previous version ran five
+ * `reg add` processes per extension, 83 extensions, five categories: on the order
+ * of 415 processes for one "Set all", each with its own 15 second ceiling, and 83
+ * more `reg query` processes just to read the status. `reg import` does the whole
+ * lot in one process.
+ *
+ * It also removes a quoting hazard rather than trying to get it right. The
+ * `shell\open\command` value has to be `"C:\path\BOSS.exe" "%1"` - a string that
+ * both begins and ends with a double quote. Java's Windows `ProcessImpl` treats
+ * an argument in that shape as already quoted and passes it through without
+ * escaping, so `reg` would see the value and `"%1"` as two separate tokens and
+ * store only the first. That is the single write that makes a double-clicked file
+ * actually reach BOSS. In a `.reg` file the value is escaped by [regEscape] and
+ * never passes through a command line at all, so the question does not arise.
+ */
+internal object WindowsRegistryScript {
+    /** `reg import` requires this exact header for a Unicode script. */
+    private const val HEADER = "Windows Registry Editor Version 5.00"
+
+    private const val CLASSES = """HKEY_CURRENT_USER\Software\Classes"""
+
+    private const val CAPABILITIES =
+        """HKEY_CURRENT_USER\Software\Clients\StartMenuInternet\BOSS\Capabilities\FileAssociations"""
+
+    private const val FILE_EXTS =
+        """HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts"""
+
+    /**
+     * ProgID for an extension: `BOSS.md`, `BOSS.kt`.
+     *
+     * One per extension rather than one per category, because `FileAssociations`
+     * and `UserChoice` are both keyed by extension - a shared ProgID would make
+     * "BOSS opens markdown" and "BOSS opens Kotlin" the same switch.
+     */
+    fun progIdFor(extension: String): String = "BOSS.${extension.lowercase()}"
+
+    /** The `FileExts` key whose `UserChoice` holds the shell's recorded answer for [extension]. */
+    fun userChoiceKey(extension: String): String = """$FILE_EXTS\.${extension.lowercase()}\UserChoice"""
+
+    /**
+     * Escapes a string for a `.reg` value.
+     *
+     * Backslashes double and quotes are backslash-escaped, which is what makes a
+     * Windows path safe to embed. Getting this wrong writes a broken command into
+     * the registry, so it is the one thing here with its own tests.
+     */
+    fun regEscape(value: String): String =
+        value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+
+    /**
+     * The full script for [extensions], all pointing at [appPath].
+     *
+     * @param categoryDisplayName shown by Explorer as the file kind, so it reads
+     *   as a description rather than a ProgID.
+     */
+    fun buildScript(
+        extensions: List<String>,
+        appPath: String,
+        categoryDisplayName: String,
+    ): String {
+        val exe = regEscape(appPath)
+        val description = regEscape("$categoryDisplayName (BOSS)")
+
+        return buildString {
+            appendLine(HEADER)
+            appendLine()
+            extensions.map { it.lowercase() }.distinct().forEach { extension ->
+                val progId = progIdFor(extension)
+
+                appendLine("""[$CLASSES\$progId]""")
+                appendLine("""@="$description"""")
+                appendLine()
+
+                appendLine("""[$CLASSES\$progId\DefaultIcon]""")
+                appendLine("""@="$exe,0"""")
+                appendLine()
+
+                appendLine("""[$CLASSES\$progId\shell\open\command]""")
+                // The value Explorer runs. Escaped, never shell-quoted.
+                appendLine("""@="\"$exe\" \"%1\""""")
+                appendLine()
+
+                // An OpenWithProgids hint puts BOSS in the "Open with" list for the
+                // extension even before it is the default, which is how the user
+                // finds it in the Settings picker at all. The empty REG_NONE value
+                // is the documented form.
+                appendLine("""[$CLASSES\.$extension\OpenWithProgids]""")
+                appendLine(""""$progId"=hex(0):""")
+                appendLine()
+
+                appendLine("""[$CAPABILITIES]""")
+                appendLine(""""".$extension"="$progId"""")
+                appendLine()
+            }
+        }
+    }
+
+    /**
+     * Pulls `.ext -> ProgId` out of a single `reg query <FileExts> /s` dump.
+     *
+     * One process for every extension instead of one each. `reg query /s` prints
+     * a key line, then indented `name<tab>type<tab>value` lines, so the parse is
+     * "remember the last key, and when a ProgId value appears under a
+     * `.ext\UserChoice` key, record it".
+     *
+     * Unparseable lines are skipped rather than failing the read: this drives a
+     * status display, and a shell that prints something unexpected should cost one
+     * unknown row, not the whole screen.
+     */
+    fun parseUserChoices(output: String): Map<String, String> {
+        val result = mutableMapOf<String, String>()
+        var extension: String? = null
+
+        output.lineSequence().forEach { raw ->
+            val line = raw.trim()
+            if (line.startsWith("HKEY_", ignoreCase = true)) {
+                extension = userChoiceExtensionOf(line)
+            } else {
+                val current = extension
+                val progId = if (current == null) null else progIdValueOf(line)
+                if (current != null && progId != null) result[current] = progId
+            }
+        }
+        return result
+    }
+
+    /**
+     * The extension a `FileExts\.md\UserChoice` key names, or null for any other
+     * key - including the extension key itself, whose `Progid` value is not the
+     * user's choice and must not be read as one.
+     */
+    private fun userChoiceExtensionOf(keyLine: String): String? {
+        val tail = keyLine.substringAfterLast("""\FileExts\""", "").takeIf { it.isNotEmpty() } ?: return null
+        val parts = tail.split('\\')
+        if (!parts.getOrNull(1).equals("UserChoice", ignoreCase = true)) return null
+        return parts
+            .getOrNull(0)
+            ?.removePrefix(".")
+            ?.lowercase()
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * The value of a `ProgId` line, or null when the line is something else.
+     *
+     * Split on runs of whitespace because the separator is tabs in some shells and
+     * spaces in others, and a ProgID never contains whitespace.
+     */
+    private fun progIdValueOf(valueLine: String): String? {
+        if (!valueLine.startsWith("ProgId", ignoreCase = true)) return null
+        return valueLine
+            .split(Regex("\\s{2,}|\\t+"))
+            .lastOrNull()
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() && !it.equals("ProgId", ignoreCase = true) }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/main.kt
@@ -25,6 +25,7 @@ import ai.rever.boss.project.DefaultWorkingDirectory
 import ai.rever.boss.services.passkey.PasskeyPlatformInit
 import ai.rever.boss.utils.DeepLinkHandler
 import ai.rever.boss.utils.DeepLinkOrigin
+import ai.rever.boss.utils.OsOpenArguments
 import ai.rever.boss.utils.SingleInstanceManager
 import ai.rever.boss.utils.SystemUtils
 import ai.rever.boss.utils.WindowsProtocolHandler
@@ -417,16 +418,19 @@ fun main(args: Array<String>) {
     if (!SingleInstanceManager.acquireLock()) {
         logger.info(LogCategory.SYSTEM, "Another BOSS instance is already running")
 
-        // Check if we have a deep link or URL to send to the existing instance
-        val deepLink =
-            args.firstOrNull {
-                it.startsWith("boss://") ||
-                    it.startsWith("http://") ||
-                    it.startsWith("https://")
-            }
+        // Everything the OS is asking this launch to open, as `boss://` links.
+        // File paths count, not only URL schemes: on Windows and Linux a
+        // double-clicked file arrives as a path in argv, and this branch used to
+        // ignore it and exit 0 with "No URL to send", so the file never opened
+        // while BOSS was running. See OsOpenArguments.
+        val deepLinks = OsOpenArguments.deepLinksFrom(args)
 
-        if (deepLink != null) {
-            logger.info(LogCategory.SYSTEM, "Sending URL to existing instance")
+        if (deepLinks.isNotEmpty()) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Sending open requests to existing instance",
+                mapOf("count" to deepLinks.size),
+            )
 
             // The origin is stated, not assumed: a `boss://` argument in this
             // process's argv is how the OS protocol handler delivers a URL
@@ -437,14 +441,14 @@ fun main(args: Array<String>) {
             // Try to send with retry logic (important for auth deep links during sign-in)
             // Note: runBlocking is acceptable here as this runs during pre-UI initialization,
             // before the Compose application starts. No UI thread exists yet to block.
-            var success = false
             val maxRetries = 3
-            for (attempt in 1..maxRetries) {
-                if (SingleInstanceManager.sendToExistingInstance(deepLink, DeepLinkOrigin.EXTERNAL)) {
-                    logger.info(LogCategory.SYSTEM, "URL sent successfully", mapOf("attempt" to attempt))
-                    success = true
-                    break
-                } else {
+
+            fun forward(link: String): Boolean {
+                for (attempt in 1..maxRetries) {
+                    if (SingleInstanceManager.sendToExistingInstance(link, DeepLinkOrigin.EXTERNAL)) {
+                        logger.info(LogCategory.SYSTEM, "URL sent successfully", mapOf("attempt" to attempt))
+                        return true
+                    }
                     logger.warn(
                         LogCategory.SYSTEM,
                         "Failed to send URL",
@@ -460,7 +464,13 @@ fun main(args: Array<String>) {
                         }
                     }
                 }
+                return false
             }
+
+            // Every link is attempted, and success means every one landed.
+            // `fold` rather than `all`, which would short-circuit and silently
+            // drop the rest of a multi-file selection after one failure.
+            val success = deepLinks.fold(true) { acc, link -> forward(link) && acc }
 
             if (success) {
                 exitProcess(0)
@@ -771,19 +781,21 @@ fun main(args: Array<String>) {
     // Parse CLI arguments if provided
     if (args.isNotEmpty()) {
         try {
-            // Check if args contain deep link protocols
-            val hasDeepLink =
-                args.any {
-                    it.startsWith("boss://") || it.startsWith("http://") || it.startsWith("https://")
-                }
+            // What the OS is asking this cold start to open: URL-scheme args as
+            // before, plus file paths, which Clikt cannot parse (it has `boss
+            // file <path>`, no bare-path argument) and used to fail on with a
+            // usage error - so a double-clicked file did nothing on a cold start.
+            val osOpenRequests = OsOpenArguments.deepLinksFrom(args)
 
-            // If it's a deep link, let DeepLinkHandler process it
-            // Otherwise, treat as CLI command
-            if (!hasDeepLink) {
+            if (osOpenRequests.isEmpty()) {
+                // Not an OS open request, so it is the operator's CLI.
                 logger.debug(LogCategory.SYSTEM, "Processing CLI arguments", mapOf("args" to args.joinToString(" ")))
                 createBossCLI().main(args)
                 // Commands are queued, continue with app initialization
             }
+            // Otherwise these are links and files the OS wants opened;
+            // `DeepLinkHandler.processCommandLineArgs` below is the single place
+            // that processes them, so nothing is opened twice.
         } catch (e: Exception) {
             logger.error(LogCategory.SYSTEM, "CLI error", error = e)
             // Don't exit - let the app start normally

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/URLHandlerService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/URLHandlerService.kt
@@ -215,44 +215,20 @@ actual object URLHandlerService {
     }
 
     /**
-     * Validate that a URL is acceptable for opening
+     * Validate that a URL is acceptable for opening.
      *
-     * Only allows http:// and https:// URLs for security.
-     *
-     * @param url The URL to validate
-     * @return true if the URL is valid and should be opened
+     * Delegates to [UrlOpenValidation], which is pure and tested. The rules used
+     * to live inline here and one of them was wrong: it required the host to
+     * contain a `.`, so `http://localhost:3000` was dropped with a log line and
+     * no tab, on an app whose users click that link more than any other.
      */
-    private fun isValidURL(url: String): Boolean {
-        // Only allow http and https URLs
-        if (!url.startsWith("http://") && !url.startsWith("https://")) {
-            return false
-        }
-
-        // Basic URL validation - must have at least a protocol and domain
+    private fun isValidURL(url: String): Boolean =
         try {
-            // Simple validation: check for protocol and domain separator
-            val protocolEnd = url.indexOf("://")
-            if (protocolEnd < 0) return false
-
-            val afterProtocol = url.substring(protocolEnd + 3)
-            if (afterProtocol.isEmpty()) return false
-
-            // Must have at least a domain name
-            val domainEnd = afterProtocol.indexOfAny(charArrayOf('/', '?', '#'))
-            val domain =
-                if (domainEnd >= 0) {
-                    afterProtocol.substring(0, domainEnd)
-                } else {
-                    afterProtocol
-                }
-
-            // Domain must not be empty and should contain at least one character
-            return domain.isNotEmpty() && domain.contains(".")
+            UrlOpenValidation.isOpenable(url)
         } catch (e: Exception) {
             logger.warn(LogCategory.BROWSER, "URL validation error", error = e)
-            return false
+            false
         }
-    }
 
     /**
      * Extract domain name from URL for display as tab title

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/URLHandlerService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/URLHandlerService.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.events.URLEventBus
 import ai.rever.boss.utils.WindowFocusManager
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.logging.LogSanitizer
 import androidx.compose.runtime.mutableStateOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -120,11 +121,13 @@ actual object URLHandlerService {
         var incremented = false
 
         try {
-            logger.debug(LogCategory.BROWSER, "Received URL", mapOf("url" to url))
+            // Masked, like every equivalent site in DeepLinkHandler. A URL the OS
+            // handed over can carry a token or a session id in its query.
+            logger.debug(LogCategory.BROWSER, "Received URL", mapOf("url" to LogSanitizer.maskUriParams(url)))
 
             // Validate URL
             if (!isValidURL(url)) {
-                logger.warn(LogCategory.BROWSER, "Invalid URL", mapOf("url" to url))
+                logger.warn(LogCategory.BROWSER, "Invalid URL", mapOf("url" to LogSanitizer.maskUriParams(url)))
                 return
             }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
@@ -83,6 +83,10 @@ internal object UrlOpenValidation {
     /** `:1234`, or `:` with nothing after it, which browsers accept as "default port". */
     private fun isValidPortSuffix(suffix: String): Boolean {
         if (!suffix.startsWith(':')) return false
-        return suffix.drop(1).all { it.isDigit() }
+        // `in '0'..'9'`, not Char.isDigit(): isDigit is true for every Unicode
+        // decimal digit, so ":٣३" (Arabic-Indic and Devanagari threes)
+        // validated as a port and the URL reached the browser. Verified with
+        // Character.isDigit on the JDK in use.
+        return suffix.drop(1).all { it in '0'..'9' }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/services/UrlOpenValidation.kt
@@ -1,0 +1,88 @@
+package ai.rever.boss.services
+
+/**
+ * Whether a URL the OS handed BOSS is one BOSS should open in a browser tab.
+ *
+ * Pure and separate from [URLHandlerService] so the rules can be tested without
+ * a window, a plugin or an event bus - the previous inline version had none of
+ * its behaviour covered, and one of its rules was wrong.
+ *
+ * **The rule that was wrong**: the host had to contain a `.`, which silently
+ * rejected `http://localhost:3000`. For an app whose users are developers, the
+ * single most common link they click is the one pointing at their own dev
+ * server, and BOSS dropped it with a "Invalid URL" line in the log and no tab.
+ * A dot is not what makes a host valid; it is not required by DNS (`localhost`,
+ * an intranet single-label name, a Docker service name) and it is not present in
+ * a bracketed IPv6 literal either.
+ *
+ * What is still enforced, because this input arrives from any program on the
+ * machine that can ask the OS to open a URL:
+ *
+ * - the scheme is http or https and nothing else. `file:`, `javascript:` and
+ *   `data:` in particular must never reach a browser tab from here.
+ * - there is an authority, and it is well formed: no spaces, no control
+ *   characters, no embedded credentials.
+ */
+internal object UrlOpenValidation {
+    private val ALLOWED_SCHEMES = listOf("http://", "https://")
+
+    /**
+     * Characters that must never appear in an authority.
+     *
+     * Tabs, newlines and NUL are covered by the `isISOControl` test at the call
+     * site; these are the printable ones that are not.
+     */
+    private val FORBIDDEN_IN_AUTHORITY = charArrayOf(' ', '\u00A0', '\\', '"', '<', '>')
+
+    fun isOpenable(url: String): Boolean {
+        val scheme = ALLOWED_SCHEMES.firstOrNull { url.startsWith(it, ignoreCase = true) } ?: return false
+
+        val afterScheme = url.substring(scheme.length)
+        // The authority ends at the first '/', '?' or '#'. Taken from the string
+        // rather than java.net.URI on purpose: URI.getHost() returns null for
+        // hosts it considers malformed (an underscore in a Docker service name,
+        // for one), which would reject links that browsers open fine.
+        val authorityEnd = afterScheme.indexOfAny(charArrayOf('/', '?', '#'))
+        val authority = if (authorityEnd >= 0) afterScheme.substring(0, authorityEnd) else afterScheme
+
+        if (authority.isEmpty()) return false
+        if (authority.any { it in FORBIDDEN_IN_AUTHORITY || it.isISOControl() }) return false
+
+        // Credentials in the authority are how a link disguises its real
+        // destination ("https://apple.com@evil.example"). Nothing BOSS does
+        // needs them, so they are refused rather than stripped.
+        if (authority.contains('@')) return false
+
+        val host = hostOf(authority) ?: return false
+        return host.isNotEmpty()
+    }
+
+    /**
+     * The host part of an authority, or null when the authority is malformed.
+     *
+     * Handles the bracketed IPv6 form (`[::1]:8080`) explicitly: splitting on
+     * the last colon would otherwise cut a bare IPv6 literal in half, and
+     * splitting on the first would take `::1` apart.
+     */
+    private fun hostOf(authority: String): String? {
+        if (authority.startsWith('[')) {
+            val close = authority.indexOf(']')
+            if (close < 0) return null
+            val host = authority.substring(1, close)
+            val rest = authority.substring(close + 1)
+            if (rest.isNotEmpty() && !isValidPortSuffix(rest)) return null
+            return host.ifEmpty { null }
+        }
+
+        val colon = authority.indexOf(':')
+        if (colon < 0) return authority
+        if (!isValidPortSuffix(authority.substring(colon))) return null
+        return authority.substring(0, colon).ifEmpty { null }
+    }
+
+    /** `:1234`, or `:` with nothing after it, which browsers accept as "default port". */
+    private fun isValidPortSuffix(suffix: String): Boolean {
+        if (!suffix.startsWith(':')) return false
+        return suffix.drop(1).all { it.isDigit() }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
@@ -98,6 +98,15 @@ internal fun routedDeepLinkHost(uri: String): DeepLinkHost? = deepLinkHostOf(uri
 internal fun fileDeepLinkFor(path: String): String = BOSS_SCHEME + "file?path=" + URLEncoder.encode(path, "UTF-8")
 
 /**
+ * The `boss://folder` link that opens [path] in the codebase panel.
+ *
+ * The counterpart of [fileDeepLinkFor] for a directory. Dropping a project folder
+ * on the app, or double-clicking one with BOSS as its handler, previously produced
+ * no link at all because the argv scan recognised only regular files.
+ */
+internal fun folderDeepLinkFor(path: String): String = BOSS_SCHEME + "folder?path=" + URLEncoder.encode(path, "UTF-8")
+
+/**
  * The window a [host]'s handler should act on: resolved through
  * [resolveWindowId] for hosts that resolve at dispatch, null for hosts that
  * resolve downstream when their queued command runs.

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DeepLinkHandler.kt
@@ -23,6 +23,7 @@ import java.awt.Desktop
 import java.io.File
 import java.net.URI
 import java.net.URLDecoder
+import java.net.URLEncoder
 
 private const val BOSS_SCHEME = "boss://"
 
@@ -81,6 +82,22 @@ private val deepLinkHostsByName: Map<String, DeepLinkHost> = DeepLinkHost.entrie
 internal fun routedDeepLinkHost(uri: String): DeepLinkHost? = deepLinkHostOf(uri)?.let { deepLinkHostsByName[it] }
 
 /**
+ * The `boss://file` link that opens [path].
+ *
+ * Every way the OS can ask BOSS to open a file - the macOS open-file
+ * AppleEvent, a path in `argv` on Windows and Linux, a path forwarded to an
+ * already-running instance - is turned into this one link, so all of them share
+ * the single validated, window-resolving, cold-start-queueing path that
+ * `boss://file` already had. The alternative was three more callers of
+ * `FileEventBus` each having to remember the `FileHandlerService` counter that
+ * stops the New Tab dialog destroying the tab being created.
+ *
+ * `URLEncoder` encodes a space as `+` and [DeepLinkHandler]'s decode side uses
+ * `URLDecoder`, which turns `+` back into a space, so the round trip is exact.
+ */
+internal fun fileDeepLinkFor(path: String): String = BOSS_SCHEME + "file?path=" + URLEncoder.encode(path, "UTF-8")
+
+/**
  * The window a [host]'s handler should act on: resolved through
  * [resolveWindowId] for hosts that resolve at dispatch, null for hosts that
  * resolve downstream when their queued command runs.
@@ -109,6 +126,54 @@ actual object DeepLinkHandler {
             isMacOS -> setupMacOSHandler()
             isWindows -> setupWindowsHandler()
             else -> setupDefaultHandler()
+        }
+        setupOpenFileHandler()
+    }
+
+    /**
+     * Registers the OS "open these files with BOSS" handler.
+     *
+     * Nothing registered one before, so BOSS declared `CFBundleDocumentTypes` in
+     * its Info.plist, appeared in Finder's Open With menu, launched when a file
+     * was double-clicked - and then did nothing at all with the file. macOS
+     * delivers a file open as an AppleEvent that reaches the JDK's
+     * `_AppEventHandler` and, with no handler set, is discarded once the queue
+     * is drained.
+     *
+     * Registered for macOS and the default branch, not Windows: Windows never
+     * sends this event and passes paths in `argv` instead, which `main.kt`
+     * handles. Calling it there is harmless but would claim support BOSS does
+     * not get.
+     */
+    private fun setupOpenFileHandler() {
+        if (isWindows || !Desktop.isDesktopSupported()) return
+        try {
+            Desktop.getDesktop().setOpenFileHandler { event ->
+                val files = event.files ?: emptyList()
+                logger.info(
+                    LogCategory.FILE,
+                    "Received open-file request from the OS",
+                    mapOf("count" to files.size),
+                )
+                // One deep link per file, because that is what the rest of the
+                // pipeline speaks: `boss://file` opens exactly one path, and
+                // selecting several files in Finder and hitting Enter is a
+                // single event carrying all of them.
+                files.forEach { file ->
+                    processDeepLink(fileDeepLinkFor(file.absolutePath), DeepLinkOrigin.EXTERNAL)
+                }
+            }
+            logger.info(LogCategory.SYSTEM, "OS open-file handler registered successfully")
+        } catch (e: UnsupportedOperationException) {
+            // Documented outcome on a platform whose Desktop has no APP_OPEN_FILE
+            // action. Not an error: it means files arrive some other way (argv).
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Desktop.setOpenFileHandler not supported on this platform",
+                mapOf("reason" to (e.message ?: "unsupported")),
+            )
+        } catch (e: Exception) {
+            logger.error(LogCategory.SYSTEM, "Failed to set up OS open-file handler", error = e)
         }
     }
 
@@ -207,17 +272,37 @@ actual object DeepLinkHandler {
     }
 
     /**
-     * Process command line arguments for deep links (needed for Windows)
+     * Processes links and file paths the OS asked BOSS to open through `argv`.
+     *
+     * **No longer Windows-only, and that gate was a real gap.** It ran under
+     * `if (isWindows)` because Windows delivers a protocol URL in `argv`. So does
+     * Linux: the generated `boss.desktop` uses `Exec=<app> %u`, and the JDK's X11
+     * Desktop peer supports no `APP_OPEN_URI` action, so `setOpenURIHandler` is
+     * never called there. Between the two, a Linux user who set BOSS as their
+     * default browser had every cold-start link silently dropped - argv held it,
+     * nothing read argv, and the URI handler that would have read it does not
+     * exist on that platform.
+     *
+     * macOS is unaffected either way: it delivers URLs and files as AppleEvents,
+     * so in practice these args hold neither, and running this costs one scan of
+     * an argv with nothing in it to find.
+     *
+     * Subsumes `WindowsProtocolHandler.extractDeepLinkFromArgs`, which was
+     * `args.firstOrNull { it.startsWith("boss://") }` - the same answer
+     * [OsOpenArguments] gives for that case, plus http/https and file paths, and
+     * all of them rather than the first.
      */
     fun processCommandLineArgs(args: Array<String>) {
-        if (isWindows) {
-            WindowsProtocolHandler.extractDeepLinkFromArgs(args)?.let { url ->
-                logger.info(LogCategory.SYSTEM, "Received deep link from command line", mapOf("uri" to LogSanitizer.maskUriParams(url)))
-                // A `boss://` argument on Windows is how the registered protocol
-                // handler delivers a URL somebody asked the OS to open, so it is
-                // external regardless of who launched the process.
-                processDeepLink(url, DeepLinkOrigin.EXTERNAL)
-            }
+        OsOpenArguments.deepLinksFrom(args).forEach { link ->
+            logger.info(
+                LogCategory.SYSTEM,
+                "Received deep link from command line",
+                mapOf("uri" to LogSanitizer.maskUriParams(link)),
+            )
+            // A link in this process's argv is how a registered protocol handler
+            // or a file association delivers something somebody asked the OS to
+            // open, so it is external regardless of who launched the process.
+            processDeepLink(link, DeepLinkOrigin.EXTERNAL)
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DefaultHandlerState.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DefaultHandlerState.kt
@@ -36,6 +36,27 @@ internal sealed interface DefaultHandlerState {
 
     companion object {
         /**
+         * Collapses per-type states into one, preferring the answer the user can
+         * act on.
+         *
+         * [OurEngine] outranks [Other] because it is the answer with a one-click
+         * fix, and it stays true and repairable whether one type in a category is
+         * affected or all of them. An empty collection is [Other] with no name:
+         * nothing to reduce is not "everything is fine".
+         *
+         * Lives here rather than in one of the three platform handlers, each of
+         * which had its own copy of this fold. They agreed, which is the only
+         * reason nothing was broken; a fourth copy would not have.
+         */
+        fun reduce(states: Collection<DefaultHandlerState>): DefaultHandlerState =
+            when {
+                states.isEmpty() -> Other(null)
+                states.all { it.isOurs } -> Ours
+                states.any { it is OurEngine } -> OurEngine
+                else -> states.first { !it.isOurs }
+            }
+
+        /**
          * Classifies a bundle id as reported by Launch Services.
          *
          * Case-insensitive, because bundle identifiers are: the OS will happily

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DefaultHandlerState.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DefaultHandlerState.kt
@@ -1,0 +1,54 @@
+package ai.rever.boss.utils
+
+/**
+ * Who currently owns a URL scheme or a file type, from BOSS's point of view.
+ *
+ * A boolean was the wrong shape and it produced a wrong message. On a machine
+ * where the branded Chromium engine had claimed http/https - which is the
+ * default outcome of every install that predates the branding fix, because both
+ * bundles are called "BOSS" and System Settings cannot distinguish them - the
+ * old `isDefaultBrowser(): Result<Boolean>` answered false, and the Settings
+ * card said "BOSS is not your default browser" to someone who had set it and
+ * whose links were being handed to a bare rendering engine. [OurEngine] exists
+ * so that case can be named and offered a repair instead.
+ */
+internal sealed interface DefaultHandlerState {
+    /** BOSS itself is registered. Nothing to do. */
+    data object Ours : DefaultHandlerState
+
+    /**
+     * A BOSS *component* is registered rather than BOSS: today only the
+     * Chromium engine bundle, [BOSS_MACOS_ENGINE_BUNDLE_ID].
+     *
+     * Distinct from [Other] because the fix is different. For [Other] the user
+     * chose another app and BOSS should ask; here nobody chose anything - two
+     * indistinguishable entries were offered and the wrong one was picked - so
+     * BOSS can simply take it back.
+     */
+    data object OurEngine : DefaultHandlerState
+
+    /** Some other application, or nothing at all when [bundleId] is null. */
+    data class Other(
+        val bundleId: String?,
+    ) : DefaultHandlerState
+
+    val isOurs: Boolean get() = this is Ours
+
+    companion object {
+        /**
+         * Classifies a bundle id as reported by Launch Services.
+         *
+         * Case-insensitive, because bundle identifiers are: the OS will happily
+         * return a differently-cased spelling of the id in an app's own
+         * Info.plist, and a case-sensitive comparison here would report BOSS as
+         * "some other app".
+         */
+        fun of(bundleId: String?): DefaultHandlerState =
+            when {
+                bundleId == null -> Other(null)
+                bundleId.equals(BOSS_MACOS_BUNDLE_ID, ignoreCase = true) -> Ours
+                bundleId.equals(BOSS_MACOS_ENGINE_BUNDLE_ID, ignoreCase = true) -> OurEngine
+                else -> Other(bundleId)
+            }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
@@ -92,6 +92,24 @@ object LinuxDefaultBrowserHandler {
         }
 
     /**
+     * Writes (or rewrites) `~/.local/share/applications/boss.desktop` and
+     * refreshes the desktop database.
+     *
+     * Exposed for the Default Apps screen, which claims a file-type category with
+     * `xdg-mime default`. That only associates a MIME type the desktop entry
+     * already declares in its `MimeType=` line, so a claim made without this
+     * having run records an association no file can ever match - it looks like it
+     * worked and does nothing.
+     *
+     * @return true when the entry is in place.
+     */
+    fun ensureDesktopEntry(): Boolean {
+        val created = createDesktopFile()
+        if (created) updateDesktopDatabase()
+        return created
+    }
+
+    /**
      * Get the current default web browser
      */
     private fun getDefaultWebBrowser(): String? =
@@ -131,6 +149,28 @@ object LinuxDefaultBrowserHandler {
 
             val iconPath = getIconPath()
 
+            // Every MIME type any file-type category claims, plus the three
+            // scheme handlers. Declared here because `xdg-mime default` will only
+            // associate a type the desktop entry already lists - see
+            // ensureDesktopEntry.
+            //
+            // Read from the shared table rather than hardcoded, so a category
+            // added to boss-file-types.json reaches Linux without a second edit.
+            // Falls back to the browser-only list if the table failed to load, so
+            // a resource problem cannot cost the user their default browser.
+            val mimeTypes =
+                buildList {
+                    add("x-scheme-handler/http")
+                    add("x-scheme-handler/https")
+                    add("x-scheme-handler/boss")
+                    addAll(
+                        ai.rever.boss.filetypes.LinuxFileTypeHandler
+                            .allMimeTypes(),
+                    )
+                    add("text/html")
+                    add("application/xhtml+xml")
+                }.distinct().joinToString(";", postfix = ";")
+
             val desktopContent =
                 """
                 [Desktop Entry]
@@ -138,11 +178,11 @@ object LinuxDefaultBrowserHandler {
                 Type=Application
                 Name=BOSS Console
                 Comment=Business Operating System + Simulation - Intelligent service automation platform
-                Exec=$appPath %u
+                Exec=$appPath %U
                 Icon=$iconPath
                 Terminal=false
-                Categories=Network;WebBrowser;
-                MimeType=x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/boss;text/html;application/xhtml+xml;
+                Categories=Network;WebBrowser;Development;TextEditor;
+                MimeType=$mimeTypes
                 StartupNotify=true
                 StartupWMClass=BOSS
                 """.trimIndent()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSAppIdentity.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSAppIdentity.kt
@@ -3,5 +3,23 @@ package ai.rever.boss.utils
 /** Bundle identifier shared by macOS runtime integrations. */
 internal const val BOSS_MACOS_BUNDLE_ID = "ai.rever.boss"
 
+/**
+ * Bundle identifier of the branded Chromium **engine**, not the app.
+ *
+ * `~/.boss/boss-chromium/BOSS.app` is a full Chromium app bundle produced by
+ * `build-chromium-branding.yml` from `chromium-branding/params.json`, where
+ * `mac.bundle.id` is this value and `mac.bundle.name` is "BOSS". Until that
+ * workflow learned to strip them, it also inherited Chromium's own
+ * `CFBundleURLTypes` (http, https) and `CFBundleDocumentTypes` (public.html),
+ * which made Launch Services offer **two** candidates called "BOSS" that no
+ * user could tell apart - and picking the wrong one handed every link to a bare
+ * rendering engine with no BOSS window in sight.
+ *
+ * Kept as a named constant rather than a literal at the comparison site because
+ * three places have to agree about it: the status check, the repair, and the
+ * copy that tells the user what happened.
+ */
+internal const val BOSS_MACOS_ENGINE_BUNDLE_ID = "ai.rever.boss.browser"
+
 /** Shipping app-bundle name used by the default `/Applications` fallback. */
 internal const val BOSS_MACOS_APP_BUNDLE_NAME = "BOSS.app"

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSDefaultBrowserHandler.kt
@@ -79,21 +79,17 @@ object MacOSDefaultBrowserHandler {
      * whether one scheme or all three are affected.
      */
     internal suspend fun browserHandlerState(): Result<DefaultHandlerState> =
-        browserHandlerStates().map { schemeStates ->
-            val contentTypeState = DefaultHandlerState.of(defaultHandlerForContentType(WEB_PAGE_CONTENT_TYPE))
-            reduce(schemeStates.values + contentTypeState)
-        }
-
-    /**
-     * Collapses per-target states into one, preferring the answer that tells the
-     * user something they can act on.
-     */
-    internal fun reduce(states: Collection<DefaultHandlerState>): DefaultHandlerState =
-        when {
-            states.isEmpty() -> DefaultHandlerState.Other(null)
-            states.all { it.isOurs } -> DefaultHandlerState.Ours
-            states.any { it is DefaultHandlerState.OurEngine } -> DefaultHandlerState.OurEngine
-            else -> states.first { !it.isOurs }
+        withContext(Dispatchers.IO) {
+            // Inside the IO block, not in a `Result.map` on the result of
+            // browserHandlerStates(). `map` is inline and runs on the CALLER's
+            // dispatcher after that withContext has already returned, so the
+            // content-type read - a native Launch Services call - was landing on
+            // Dispatchers.Main via DefaultBrowserSection's LaunchedEffect. Exactly
+            // what DefaultAppsManager's KDoc and docs/THREADING.md forbid.
+            browserHandlerStates().map { schemeStates ->
+                val contentTypeState = DefaultHandlerState.of(defaultHandlerForContentType(WEB_PAGE_CONTENT_TYPE))
+                DefaultHandlerState.reduce(schemeStates.values + contentTypeState)
+            }
         }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/MacOSDefaultBrowserHandler.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.utils
 
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
+import ai.rever.boss.utils.mac.LaunchServices
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.BufferedReader
@@ -15,41 +16,53 @@ private val logger = BossLogger.forComponent("MacOSDefaultBrowserHandler")
 /**
  * macOS-specific handler for default browser functionality
  *
- * Uses macOS APIs and system commands to:
- * - Check if BOSS is the default browser
+ * Uses Launch Services to:
+ * - Check who currently handles http/https
  * - Set BOSS as the default browser
+ *
+ * **Primary path is [LaunchServices]**, bound through JNA. The Swift scripts
+ * below remain as a fallback for the case where that binding fails, and only for
+ * URL schemes - a machine that cannot load CoreServices through JNA is odd
+ * enough that keeping a second implementation of every call would cost more than
+ * it buys. See [LaunchServices] for why the shell-out is no longer the primary
+ * path (it needs Xcode installed, which most users do not have).
  */
 object MacOSDefaultBrowserHandler {
     private const val PROCESS_TIMEOUT_SECONDS = 30L
 
+    /** The schemes "default browser" means. Both must point at BOSS for it to be true. */
+    private val BROWSER_SCHEMES = listOf("http", "https")
+
     /**
-     * Check if BOSS is currently the default browser on macOS
+     * The document type that travels with the browser role.
      *
-     * Uses a single Swift script with LSCopyDefaultHandlerForURLScheme to query
-     * both http and https handlers, avoiding double Swift JIT compilation overhead.
+     * Included in the check and the repair because the engine bundle claimed it
+     * too, and a machine where http/https point at BOSS while double-clicking an
+     * `.html` file still launches a bare Chromium is not fixed.
      */
-    suspend fun isDefaultBrowser(): Result<Boolean> =
+    private const val WEB_PAGE_CONTENT_TYPE = "public.html"
+
+    /**
+     * Who owns each browser scheme right now.
+     *
+     * Returned per scheme rather than reduced to one answer: http and https can
+     * genuinely disagree (Launch Services stores them separately, and setting
+     * one can succeed while the other fails), and the Settings card should not
+     * flatten that into a bare false.
+     */
+    internal suspend fun browserHandlerStates(): Result<Map<String, DefaultHandlerState>> =
         withContext(Dispatchers.IO) {
             try {
                 val handlers = getDefaultHandlers()
-                val httpDefault = handlers["http"]
-                val httpsDefault = handlers["https"]
+                val states = BROWSER_SCHEMES.associateWith { DefaultHandlerState.of(handlers[it]) }
 
                 logger.debug(
                     LogCategory.BROWSER,
                     "macOS default browser check",
-                    mapOf(
-                        "httpHandler" to (httpDefault ?: "none"),
-                        "httpsHandler" to (httpsDefault ?: "none"),
-                    ),
+                    states.mapValues { (_, state) -> state.toString() },
                 )
 
-                // BOSS is default if both schemes point to our bundle ID
-                val isDefault =
-                    BOSS_MACOS_BUNDLE_ID.equals(httpDefault, ignoreCase = true) &&
-                        BOSS_MACOS_BUNDLE_ID.equals(httpsDefault, ignoreCase = true)
-
-                Result.success(isDefault)
+                Result.success(states)
             } catch (e: Exception) {
                 logger.warn(LogCategory.BROWSER, "Error checking default browser on macOS", error = e)
                 Result.failure(e)
@@ -57,29 +70,68 @@ object MacOSDefaultBrowserHandler {
         }
 
     /**
+     * The single state for the browser role: [DefaultHandlerState.Ours] only
+     * when every scheme and the web-page content type point at BOSS.
+     *
+     * When they disagree, the *worst* answer wins, and [DefaultHandlerState.OurEngine]
+     * outranks [DefaultHandlerState.Other] - because "a BOSS component stole
+     * this" is the actionable thing to say, and it stays true and repairable
+     * whether one scheme or all three are affected.
+     */
+    internal suspend fun browserHandlerState(): Result<DefaultHandlerState> =
+        browserHandlerStates().map { schemeStates ->
+            val contentTypeState = DefaultHandlerState.of(defaultHandlerForContentType(WEB_PAGE_CONTENT_TYPE))
+            reduce(schemeStates.values + contentTypeState)
+        }
+
+    /**
+     * Collapses per-target states into one, preferring the answer that tells the
+     * user something they can act on.
+     */
+    internal fun reduce(states: Collection<DefaultHandlerState>): DefaultHandlerState =
+        when {
+            states.isEmpty() -> DefaultHandlerState.Other(null)
+            states.all { it.isOurs } -> DefaultHandlerState.Ours
+            states.any { it is DefaultHandlerState.OurEngine } -> DefaultHandlerState.OurEngine
+            else -> states.first { !it.isOurs }
+        }
+
+    /**
+     * Check if BOSS is currently the default browser on macOS
+     */
+    suspend fun isDefaultBrowser(): Result<Boolean> = browserHandlerState().map { it.isOurs }
+
+    /**
      * Set BOSS as the default browser on macOS
      *
-     * Uses LSSetDefaultHandlerForURLScheme via Swift script or system commands
+     * Claims http, https and `public.html`. Returns true when every one of them
+     * was accepted; false means the user has to finish the job in System
+     * Settings, which is opened for them.
      */
     suspend fun setAsDefaultBrowser(): Result<Boolean> =
         withContext(Dispatchers.IO) {
             try {
                 // First check if already default
-                val checkResult = isDefaultBrowser()
-                if (checkResult.isSuccess && checkResult.getOrNull() == true) {
+                val state = browserHandlerState()
+                if (state.getOrNull()?.isOurs == true) {
                     logger.info(LogCategory.BROWSER, "BOSS is already the default browser")
                     return@withContext Result.success(true)
                 }
 
-                // Try to set as default using Swift script
-                val setHttpResult = setDefaultHandlerForScheme("http")
-                val setHttpsResult = setDefaultHandlerForScheme("https")
+                // Sequenced with `fold`, not `all`, so a failure on http does not
+                // skip https: partial success is a real state here (the OS accepts
+                // them independently) and leaving one behind is worse than trying
+                // both and reporting the truth.
+                val schemesSet =
+                    BROWSER_SCHEMES.fold(true) { acc, scheme ->
+                        setDefaultHandlerForScheme(scheme) && acc
+                    }
+                val contentTypeSet = setDefaultHandlerForContentType(WEB_PAGE_CONTENT_TYPE)
 
-                if (setHttpResult && setHttpsResult) {
+                if (schemesSet && contentTypeSet) {
                     logger.info(LogCategory.BROWSER, "Successfully set BOSS as default browser on macOS")
                     Result.success(true)
                 } else {
-                    // If Swift approach fails, open System Preferences
                     logger.warn(LogCategory.BROWSER, "Could not set default programmatically, opening System Preferences")
                     openSystemPreferences()
                     Result.success(false)
@@ -90,21 +142,69 @@ object MacOSDefaultBrowserHandler {
             }
         }
 
+    /** Bundle id registered for the UTI [contentType], or null. Native path only. */
+    internal fun defaultHandlerForContentType(contentType: String): String? =
+        if (LaunchServices.isAvailable()) {
+            LaunchServices.defaultHandlerForContentType(contentType)
+        } else {
+            // No Swift fallback for content types on purpose: it would mean a
+            // second full implementation of the file-type feature for a case
+            // that only arises when CoreServices cannot be bound at all. Null
+            // reads as "unknown" and the UI says so.
+            logger.debug(
+                LogCategory.BROWSER,
+                "Launch Services unavailable, content type owner unknown",
+                mapOf("type" to contentType),
+            )
+            null
+        }
+
+    /** Registers BOSS for the UTI [contentType]. Native path only. */
+    internal fun setDefaultHandlerForContentType(contentType: String): Boolean =
+        LaunchServices.isAvailable() &&
+            LaunchServices.setDefaultHandlerForContentType(contentType, BOSS_MACOS_BUNDLE_ID)
+
     /**
-     * Get default handlers for both http and https schemes in a single Swift invocation.
+     * Get default handlers for every browser scheme.
      *
-     * Returns a map of scheme -> bundle ID. Uses one Swift process to avoid
-     * double JIT compilation overhead.
+     * Native when possible; one Swift process for all schemes otherwise, which
+     * is why the fallback is written as a batch rather than per scheme.
      */
     private fun getDefaultHandlers(): Map<String, String> {
+        if (LaunchServices.isAvailable()) {
+            return BROWSER_SCHEMES
+                .mapNotNull { scheme ->
+                    LaunchServices.defaultHandlerForScheme(scheme)?.let { scheme to it }
+                }.toMap()
+        }
+        return getDefaultHandlersViaSwift()
+    }
+
+    private fun setDefaultHandlerForScheme(scheme: String): Boolean =
+        if (LaunchServices.isAvailable()) {
+            LaunchServices.setDefaultHandlerForScheme(scheme, BOSS_MACOS_BUNDLE_ID)
+        } else {
+            setDefaultHandlerForSchemeViaSwift(scheme)
+        }
+
+    /**
+     * Fallback: query both handlers in a single Swift invocation.
+     *
+     * One process for all schemes, because each one pays a Swift front-end
+     * compile. Requires Xcode or the Command Line Tools; when `swift` is absent
+     * this returns an empty map and the caller reports "unknown" rather than
+     * "not default".
+     */
+    private fun getDefaultHandlersViaSwift(): Map<String, String> {
         val scriptFile = createTempFile("get_default_browser", ".swift").toFile()
         try {
+            val schemeList = BROWSER_SCHEMES.joinToString(", ") { "\"$it\"" }
             val swiftScript =
                 """
                 import Foundation
                 import ApplicationServices
 
-                for scheme in ["http", "https"] {
+                for scheme in [$schemeList] {
                     if let handler = LSCopyDefaultHandlerForURLScheme(scheme as CFString) {
                         print("\(scheme)=\(handler.takeRetainedValue() as String)")
                     }
@@ -150,10 +250,8 @@ object MacOSDefaultBrowserHandler {
         }
     }
 
-    /**
-     * Set default handler for a URL scheme using Swift script
-     */
-    private fun setDefaultHandlerForScheme(scheme: String): Boolean {
+    /** Fallback: set the default handler for a URL scheme using a Swift script. */
+    private fun setDefaultHandlerForSchemeViaSwift(scheme: String): Boolean {
         val scriptFile = createTempFile("set_default_browser", ".swift").toFile()
         try {
             val swiftScript =
@@ -215,7 +313,7 @@ object MacOSDefaultBrowserHandler {
      * Open System Settings (Ventura+) or System Preferences (Monterey and earlier)
      * to the Default Browser settings pane
      */
-    private fun openSystemPreferences() {
+    internal fun openSystemPreferences() {
         try {
             val url =
                 if (getMacOSMajorVersion() >= 13) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/OsOpenArguments.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/OsOpenArguments.kt
@@ -1,0 +1,136 @@
+package ai.rever.boss.utils
+
+import java.io.File
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * Turns the `argv` the OS launched BOSS with into `boss://` deep links.
+ *
+ * Windows and Linux do not send an open-file event: the shell and the desktop
+ * file hand the path to the process as an argument. Before this, `main.kt` looked
+ * only for args starting `boss://`, `http://` or `https://`, so a file path in
+ * `argv` reached one of two dead ends - a *running* instance logged "No URL to
+ * send" and `exitProcess(0)`, and a cold start handed the path to Clikt, which
+ * has no bare-path argument (only `boss file <path>`) and failed with a usage
+ * error. Double-clicking a file therefore did nothing on either platform, even
+ * with the association correctly registered.
+ *
+ * Pure, with the filesystem injected, so the interesting rule - telling a CLI
+ * invocation apart from an OS open request - is testable without a filesystem or
+ * a running app.
+ */
+internal object OsOpenArguments {
+    /** URL schemes that are already a link and pass through untouched. */
+    private val LINK_PREFIXES = listOf("boss://", "http://", "https://")
+
+    /**
+     * The subcommands `createBossCLI` registers.
+     *
+     * Their presence as the first non-flag argument means the operator is using
+     * the CLI, and this object must return nothing so Clikt gets the args
+     * intact. Without this test, `boss file /tmp/x.md` would be opened twice:
+     * once as an extracted deep link here and once by `BossFileCommand`.
+     *
+     * Kept in sync with `createBossCLI` by `OsOpenArgumentsTest`, which fails if
+     * a subcommand is added there and not here - the failure mode is a
+     * double-open, which is easy to miss and hard to attribute.
+     */
+    internal val CLI_SUBCOMMANDS = setOf("url", "workspace", "file", "folder", "terminal")
+
+    /**
+     * Deep links for everything in [args] the OS is asking BOSS to open, or an
+     * empty list when [args] is a CLI invocation, a flag-only launch, or empty.
+     *
+     * @param exists whether a path names a readable regular file. Injected for
+     *   tests; the caller passes the real filesystem. A path that does not exist
+     *   is deliberately **not** turned into a link: it is far more likely to be a
+     *   mistyped flag or a CLI argument this function does not know about than a
+     *   file worth opening, and `boss://file` would only log that it was missing.
+     */
+    fun deepLinksFrom(
+        args: Array<String>,
+        exists: (String) -> Boolean = { File(it).isFile },
+    ): List<String> {
+        if (args.isEmpty()) return emptyList()
+
+        // A CLI invocation is claimed by Clikt, whichever argument the
+        // subcommand sits at (`boss --flag file x` is still the CLI).
+        if (args.any { it in CLI_SUBCOMMANDS }) return emptyList()
+
+        return args.mapNotNull { arg ->
+            when {
+                LINK_PREFIXES.any { arg.startsWith(it, ignoreCase = true) } -> {
+                    arg
+                }
+
+                // Flags are never paths. Checked before `exists` because a file
+                // called `-n` in the working directory would otherwise turn a
+                // flag into an open request.
+                arg.startsWith("-") -> {
+                    null
+                }
+
+                // A local file as a URL. The Linux desktop entry uses `Exec=%U`,
+                // which is what lets it accept both links and files, and file
+                // managers hand `%U` a `file://` URL rather than a bare path - so
+                // without this the association would launch BOSS and open
+                // nothing, which is the bug this whole object exists to fix, one
+                // layer down.
+                arg.startsWith(FILE_URL_PREFIX, ignoreCase = true) -> {
+                    pathFromFileUrl(arg)
+                        ?.takeIf(exists)
+                        ?.let { fileDeepLinkFor(File(it).absolutePath) }
+                }
+
+                exists(arg) -> {
+                    fileDeepLinkFor(File(arg).absolutePath)
+                }
+
+                else -> {
+                    null
+                }
+            }
+        }
+    }
+
+    private const val FILE_URL_PREFIX = "file://"
+
+    /**
+     * The local path inside a `file://` URL, or null when it names another host.
+     *
+     * `file://host/path` is a remote path this process cannot open, and treating
+     * its host as the first path segment would silently open the wrong file. An
+     * empty host and `localhost` are both the local machine.
+     */
+    private fun pathFromFileUrl(url: String): String? =
+        try {
+            val uri = URI(url)
+            val host = uri.host
+            when {
+                host == null || host.isEmpty() -> {
+                    File(uri).absolutePath
+                }
+
+                // `File(URI)` rejects any URI with an authority component, so a
+                // `file://localhost/tmp/x` from a file manager has to have the
+                // redundant host removed before it can be turned into a path.
+                // Without this it landed in the IllegalArgumentException below
+                // and the file silently did not open.
+                host.equals("localhost", ignoreCase = true) -> {
+                    File(URI("file", null, uri.path, null, null)).absolutePath
+                }
+
+                // `file://somehost/path` is a path on another machine that this
+                // process cannot read. Dropping the host and opening the local
+                // path of the same name would open the wrong file.
+                else -> {
+                    null
+                }
+            }
+        } catch (_: IllegalArgumentException) {
+            null
+        } catch (_: URISyntaxException) {
+            null
+        }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/OsOpenArguments.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/OsOpenArguments.kt
@@ -38,25 +38,38 @@ internal object OsOpenArguments {
      */
     internal val CLI_SUBCOMMANDS = setOf("url", "workspace", "file", "folder", "terminal")
 
+    /** What a path on disk is, for deciding which deep link to build. */
+    internal enum class OpenTargetKind { FILE, DIRECTORY, ABSENT }
+
     /**
      * Deep links for everything in [args] the OS is asking BOSS to open, or an
      * empty list when [args] is a CLI invocation, a flag-only launch, or empty.
      *
-     * @param exists whether a path names a readable regular file. Injected for
-     *   tests; the caller passes the real filesystem. A path that does not exist
-     *   is deliberately **not** turned into a link: it is far more likely to be a
-     *   mistyped flag or a CLI argument this function does not know about than a
-     *   file worth opening, and `boss://file` would only log that it was missing.
+     * A **directory** becomes a `boss://folder` link rather than being dropped.
+     * `boss://folder` and `boss folder` both exist, dropping a project folder on
+     * the app is an obvious thing to do, and the previous file-only predicate made
+     * it silently do nothing.
+     *
+     * @param kindOf what a path names: a file, a directory, or nothing. Injected
+     *   for tests; the caller passes the real filesystem. A path that does not
+     *   exist is deliberately **not** turned into a link, because it is far more
+     *   likely a mistyped flag or an argument this function does not know about
+     *   than something worth opening.
      */
     fun deepLinksFrom(
         args: Array<String>,
-        exists: (String) -> Boolean = { File(it).isFile },
+        kindOf: (String) -> OpenTargetKind = ::openTargetKindOf,
     ): List<String> {
         if (args.isEmpty()) return emptyList()
 
-        // A CLI invocation is claimed by Clikt, whichever argument the
-        // subcommand sits at (`boss --flag file x` is still the CLI).
-        if (args.any { it in CLI_SUBCOMMANDS }) return emptyList()
+        // A CLI invocation is claimed by Clikt. Matched on the FIRST non-flag
+        // argument, which is both what the KDoc above describes and what Clikt
+        // actually parses. `args.any { it in CLI_SUBCOMMANDS }` matched at any
+        // position, so an OS open request whose path segment happened to be
+        // exactly `file`, `url`, `folder`, `terminal` or `workspace` was silently
+        // dropped as a CLI call.
+        val firstNonFlag = args.firstOrNull { !it.startsWith("-") }
+        if (firstNonFlag in CLI_SUBCOMMANDS) return emptyList()
 
         return args.mapNotNull { arg ->
             when {
@@ -64,35 +77,50 @@ internal object OsOpenArguments {
                     arg
                 }
 
-                // Flags are never paths. Checked before `exists` because a file
-                // called `-n` in the working directory would otherwise turn a
+                // Flags are never paths. Checked before the filesystem because a
+                // file called `-n` in the working directory would otherwise turn a
                 // flag into an open request.
                 arg.startsWith("-") -> {
                     null
                 }
 
-                // A local file as a URL. The Linux desktop entry uses `Exec=%U`,
+                // A local path as a URL. The Linux desktop entry uses `Exec=%U`,
                 // which is what lets it accept both links and files, and file
                 // managers hand `%U` a `file://` URL rather than a bare path - so
                 // without this the association would launch BOSS and open
                 // nothing, which is the bug this whole object exists to fix, one
                 // layer down.
                 arg.startsWith(FILE_URL_PREFIX, ignoreCase = true) -> {
-                    pathFromFileUrl(arg)
-                        ?.takeIf(exists)
-                        ?.let { fileDeepLinkFor(File(it).absolutePath) }
-                }
-
-                exists(arg) -> {
-                    fileDeepLinkFor(File(arg).absolutePath)
+                    pathFromFileUrl(arg)?.let { linkForPath(it, kindOf) }
                 }
 
                 else -> {
-                    null
+                    linkForPath(arg, kindOf)
                 }
             }
         }
     }
+
+    /** The real filesystem's answer. One stat, not two. */
+    internal fun openTargetKindOf(path: String): OpenTargetKind {
+        val file = File(path)
+        return when {
+            file.isDirectory -> OpenTargetKind.DIRECTORY
+            file.isFile -> OpenTargetKind.FILE
+            else -> OpenTargetKind.ABSENT
+        }
+    }
+
+    /** The deep link for a path, or null when it names nothing on disk. */
+    private fun linkForPath(
+        path: String,
+        kindOf: (String) -> OpenTargetKind,
+    ): String? =
+        when (kindOf(path)) {
+            OpenTargetKind.FILE -> fileDeepLinkFor(File(path).absolutePath)
+            OpenTargetKind.DIRECTORY -> folderDeepLinkFor(File(path).absolutePath)
+            OpenTargetKind.ABSENT -> null
+        }
 
     private const val FILE_URL_PREFIX = "file://"
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/mac/LaunchServices.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/mac/LaunchServices.kt
@@ -1,0 +1,202 @@
+package ai.rever.boss.utils.mac
+
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.platform.mac.CoreFoundation.CFStringRef
+
+/**
+ * The three Launch Services calls BOSS needs to read and write the OS's
+ * "which app opens this" answers, bound directly instead of shelled out to
+ * `swift`.
+ *
+ * **Why not the Swift scripts it replaces.** The previous implementation wrote a
+ * temporary `.swift` file and ran `swift <file>` for every query and every set.
+ * That needs Xcode or the Command Line Tools installed: on a machine with
+ * neither - which is most machines that are not a developer's own - the Settings
+ * card could only ever say "Error checking status" and the button could not work
+ * at all. It also paid a Swift front-end compile (hundreds of ms to seconds) per
+ * call, which was tolerable for one browser check and is not for a screen that
+ * reports a status per file-type category.
+ *
+ * **Deprecated but not gone.** `LSSetDefaultHandlerForURLScheme` and friends are
+ * marked deprecated since macOS 10.15 in favour of `NSWorkspace`, whose
+ * replacements are Objective-C instance methods on a shared object - reachable
+ * from JNA only through the Objective-C runtime, which is a substantially larger
+ * and more fragile surface than four C functions. The C functions are still
+ * exported and still work (verified against macOS 26); when they are finally
+ * removed, [isAvailable] starts answering false and callers fall back rather
+ * than crash.
+ *
+ * **Memory.** Every `LSCopy*` returns a +1 CFString that this object releases
+ * before handing back a Kotlin `String`, and every CFString it creates for an
+ * argument is released in a `finally`. Getting that wrong leaks a small
+ * allocation per call on a path the Settings screen can drive repeatedly.
+ */
+internal object LaunchServices {
+    private val logger = BossLogger.forComponent("LaunchServices")
+
+    /**
+     * `kLSRolesAll`. Declared as `-1` rather than `0xFFFFFFFF` because the
+     * parameter is a 32-bit `LSRolesMask` and JNA maps Kotlin `Int` to it
+     * directly; the two have the same bit pattern.
+     */
+    private const val ROLES_ALL = -1
+
+    /** `noErr`. Anything else from an `LSSet*` means the OS declined. */
+    private const val NO_ERR = 0
+
+    @Suppress("FunctionNaming", "FunctionName")
+    private interface CoreServices : Library {
+        fun LSCopyDefaultHandlerForURLScheme(scheme: CFStringRef): Pointer?
+
+        fun LSSetDefaultHandlerForURLScheme(
+            scheme: CFStringRef,
+            bundleId: CFStringRef,
+        ): Int
+
+        fun LSCopyDefaultRoleHandlerForContentType(
+            contentType: CFStringRef,
+            roles: Int,
+        ): Pointer?
+
+        fun LSSetDefaultRoleHandlerForContentType(
+            contentType: CFStringRef,
+            roles: Int,
+            bundleId: CFStringRef,
+        ): Int
+    }
+
+    /**
+     * The loaded framework, or null when it could not be bound.
+     *
+     * Resolved once and lazily: `Native.load` is not free, and on a
+     * non-macOS host it throws - so this must not run at class-init time on
+     * Windows or Linux merely because something imported the file.
+     */
+    private val coreServices: CoreServices? by lazy {
+        try {
+            Native.load("CoreServices", CoreServices::class.java)
+        } catch (e: UnsatisfiedLinkError) {
+            logger.warn(LogCategory.SYSTEM, "Could not bind CoreServices; Launch Services calls unavailable", error = e)
+            null
+        } catch (e: NoClassDefFoundError) {
+            // JNA missing from the runtime classpath entirely (a stripped build).
+            logger.warn(LogCategory.SYSTEM, "JNA unavailable; Launch Services calls unavailable", error = e)
+            null
+        }
+    }
+
+    /**
+     * Whether the native calls can be made at all.
+     *
+     * Callers use this to choose the fallback path rather than discovering the
+     * failure one silent null at a time.
+     */
+    fun isAvailable(): Boolean = coreServices != null
+
+    /** Bundle id currently registered for [scheme] (for example "http"), or null. */
+    fun defaultHandlerForScheme(scheme: String): String? =
+        withCFString(scheme) { cfScheme ->
+            val services = coreServices ?: return@withCFString null
+            copiedString { services.LSCopyDefaultHandlerForURLScheme(cfScheme) }
+        }
+
+    /** Bundle id currently registered for [contentType] (a UTI), or null. */
+    fun defaultHandlerForContentType(contentType: String): String? =
+        withCFString(contentType) { cfType ->
+            val services = coreServices ?: return@withCFString null
+            copiedString { services.LSCopyDefaultRoleHandlerForContentType(cfType, ROLES_ALL) }
+        }
+
+    /**
+     * Makes [bundleId] the handler for [scheme]. True when the OS accepted it.
+     *
+     * A false is not necessarily an error to escalate: the OS refuses when the
+     * bundle id is not registered (an app that was never launched from its final
+     * location), and the caller's answer to that is to send the user to System
+     * Settings, not to retry.
+     */
+    fun setDefaultHandlerForScheme(
+        scheme: String,
+        bundleId: String,
+    ): Boolean =
+        withCFString(scheme) { cfScheme ->
+            withCFString(bundleId) { cfBundle ->
+                val services = coreServices ?: return@withCFString false
+                val status = services.LSSetDefaultHandlerForURLScheme(cfScheme, cfBundle)
+                logStatus("scheme", scheme, bundleId, status)
+                status == NO_ERR
+            }
+        }
+
+    /** Makes [bundleId] the handler for the UTI [contentType]. True when the OS accepted it. */
+    fun setDefaultHandlerForContentType(
+        contentType: String,
+        bundleId: String,
+    ): Boolean =
+        withCFString(contentType) { cfType ->
+            withCFString(bundleId) { cfBundle ->
+                val services = coreServices ?: return@withCFString false
+                val status = services.LSSetDefaultRoleHandlerForContentType(cfType, ROLES_ALL, cfBundle)
+                logStatus("contentType", contentType, bundleId, status)
+                status == NO_ERR
+            }
+        }
+
+    private fun logStatus(
+        kind: String,
+        target: String,
+        bundleId: String,
+        status: Int,
+    ) {
+        if (status == NO_ERR) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Registered default handler",
+                mapOf(kind to target, "bundleId" to bundleId),
+            )
+        } else {
+            // OSStatus, not errno: worth recording verbatim, because the values
+            // that show up here (-10814 kLSApplicationNotFoundErr in particular)
+            // point at a different problem than "the call failed".
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Launch Services refused a default handler",
+                mapOf(kind to target, "bundleId" to bundleId, "status" to status),
+            )
+        }
+    }
+
+    /**
+     * Reads a `+1` CFString result and releases it.
+     *
+     * The `LSCopy*` naming is the Core Foundation ownership convention: the
+     * caller owns the returned string. Wrapping the pointer in a [CFStringRef]
+     * does not take ownership, so the release has to be explicit.
+     */
+    private inline fun copiedString(copy: () -> Pointer?): String? {
+        val pointer = copy() ?: return null
+        val ref = CFStringRef(pointer)
+        return try {
+            ref.stringValue()
+        } finally {
+            ref.release()
+        }
+    }
+
+    /** Runs [block] with [value] as a CFString, releasing it afterwards. */
+    private inline fun <T> withCFString(
+        value: String,
+        block: (CFStringRef) -> T,
+    ): T {
+        val ref = CFStringRef.createCFString(value)
+        return try {
+            block(ref)
+        } finally {
+            ref.release()
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/mac/LaunchServices.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/mac/LaunchServices.kt
@@ -86,6 +86,13 @@ internal object LaunchServices {
             // JNA missing from the runtime classpath entirely (a stripped build).
             logger.warn(LogCategory.SYSTEM, "JNA unavailable; Launch Services calls unavailable", error = e)
             null
+        } catch (e: Throwable) {
+            // isAvailable() is meant to be the gate that cannot itself fail. An
+            // unexpected JNA or linker problem must degrade to "unavailable"
+            // rather than propagate out of a lazy initialiser and take the
+            // Settings screen with it.
+            logger.warn(LogCategory.SYSTEM, "Unexpected failure binding CoreServices", error = e)
+            null
         }
     }
 
@@ -98,18 +105,22 @@ internal object LaunchServices {
     fun isAvailable(): Boolean = coreServices != null
 
     /** Bundle id currently registered for [scheme] (for example "http"), or null. */
-    fun defaultHandlerForScheme(scheme: String): String? =
-        withCFString(scheme) { cfScheme ->
-            val services = coreServices ?: return@withCFString null
+    fun defaultHandlerForScheme(scheme: String): String? {
+        // Hoisted above withCFString: reads unambiguously, and allocates no
+        // CFString at all when the framework is not bound.
+        val services = coreServices ?: return null
+        return withCFString(scheme) { cfScheme ->
             copiedString { services.LSCopyDefaultHandlerForURLScheme(cfScheme) }
         }
+    }
 
     /** Bundle id currently registered for [contentType] (a UTI), or null. */
-    fun defaultHandlerForContentType(contentType: String): String? =
-        withCFString(contentType) { cfType ->
-            val services = coreServices ?: return@withCFString null
+    fun defaultHandlerForContentType(contentType: String): String? {
+        val services = coreServices ?: return null
+        return withCFString(contentType) { cfType ->
             copiedString { services.LSCopyDefaultRoleHandlerForContentType(cfType, ROLES_ALL) }
         }
+    }
 
     /**
      * Makes [bundleId] the handler for [scheme]. True when the OS accepted it.
@@ -122,29 +133,34 @@ internal object LaunchServices {
     fun setDefaultHandlerForScheme(
         scheme: String,
         bundleId: String,
-    ): Boolean =
-        withCFString(scheme) { cfScheme ->
+    ): Boolean {
+        // Hoisted, which also removes a `return@withCFString false` whose label
+        // resolved to the inner of two nested `withCFString` calls: correct, but
+        // not something a reader should have to work out.
+        val services = coreServices ?: return false
+        return withCFString(scheme) { cfScheme ->
             withCFString(bundleId) { cfBundle ->
-                val services = coreServices ?: return@withCFString false
                 val status = services.LSSetDefaultHandlerForURLScheme(cfScheme, cfBundle)
                 logStatus("scheme", scheme, bundleId, status)
                 status == NO_ERR
             }
         }
+    }
 
     /** Makes [bundleId] the handler for the UTI [contentType]. True when the OS accepted it. */
     fun setDefaultHandlerForContentType(
         contentType: String,
         bundleId: String,
-    ): Boolean =
-        withCFString(contentType) { cfType ->
+    ): Boolean {
+        val services = coreServices ?: return false
+        return withCFString(contentType) { cfType ->
             withCFString(bundleId) { cfBundle ->
-                val services = coreServices ?: return@withCFString false
                 val status = services.LSSetDefaultRoleHandlerForContentType(cfType, ROLES_ALL, cfBundle)
                 logStatus("contentType", contentType, bundleId, status)
                 status == NO_ERR
             }
         }
+    }
 
     private fun logStatus(
         kind: String,

--- a/composeApp/src/desktopMain/resources/boss-file-types.json
+++ b/composeApp/src/desktopMain/resources/boss-file-types.json
@@ -1,0 +1,621 @@
+{
+  "$comment": [
+    "Single source of truth for the file types and URL schemes BOSS can be made the default handler for.",
+    "Read by three consumers and pinned by one test:",
+    "  1. buildSrc/BossFileTypes generates the macOS CFBundleDocumentTypes and UTExportedTypeDeclarations blocks from it at build time.",
+    "  2. FileTypeCategories (runtime) serves the Settings screen and the registration calls.",
+    "  3. WindowsFileAssociations / LinuxFileAssociations derive ProgIDs and MIME associations from it.",
+    "  BossFileTypesTest asserts the ext set and the ext-to-language map here equal EditorLanguages.EXTENSIONS,",
+    "  so what BOSS claims to open cannot drift from what its editor can actually highlight.",
+    "",
+    "systemType: the macOS UTI this extension resolves to, claimed as-is. Measured with UTType(filenameExtension:)",
+    "  on macOS 26, not guessed; absent means the extension has no system UTI (UTType reports a dyn.* placeholder),",
+    "  so BOSS exports its own type for it, grouped by language.",
+    "rejectedSystemType: the extension DOES resolve to a system UTI, and BOSS deliberately does not claim it.",
+    "  .ts resolves to public.mpeg-2-transport-stream (a video container), .as to com.apple.applesingle-archive",
+    "  (a binary archive) and .edn to com.adobe.edn (an Adobe project format). Claiming any of them would make",
+    "  BOSS the default application for a format it cannot open, so those three get an exported type instead.",
+    "  This is the reason the table records a measurement per extension rather than a rule: nothing about the",
+    "  extension itself tells you that .ts is video to Launch Services.",
+    "",
+    "exportedTypePrefix / exportedTypeSuffix build the UTIs BOSS owns: '<prefix>.<language><suffix>'.",
+    "  Here rather than in code because the generator (buildSrc) and the app (FileTypeCategories) must produce",
+    "  byte-identical identifiers - the app asks Launch Services about the very types the plist declared.",
+    "  Changing either value orphans every default a user has already set, so treat them as frozen."
+  ],
+  "exportedTypePrefix": "ai.rever.boss",
+  "exportedTypeSuffix": "-source",
+  "categories": [
+    {
+      "id": "web-links",
+      "displayName": "Web links",
+      "description": "http and https links from other apps",
+      "schemes": [
+        "http",
+        "https"
+      ],
+      "extraContentTypes": [],
+      "mimeTypes": [
+        "x-scheme-handler/http",
+        "x-scheme-handler/https"
+      ],
+      "systemTypeRank": "Alternate"
+    },
+    {
+      "id": "web-pages",
+      "displayName": "Web pages",
+      "description": "Local .html files and saved web locations",
+      "schemes": [],
+      "extraContentTypes": [
+        "public.url"
+      ],
+      "mimeTypes": [
+        "text/html",
+        "application/xhtml+xml"
+      ],
+      "systemTypeRank": "Alternate"
+    },
+    {
+      "id": "markdown",
+      "displayName": "Markdown",
+      "description": "README and .md files, with preview",
+      "schemes": [],
+      "extraContentTypes": [],
+      "mimeTypes": [
+        "text/markdown"
+      ],
+      "systemTypeRank": "Default"
+    },
+    {
+      "id": "shell-scripts",
+      "displayName": "Shell scripts",
+      "description": "Opens .sh, .bash and .zsh files in the editor; never runs them",
+      "schemes": [],
+      "extraContentTypes": [],
+      "mimeTypes": [
+        "application/x-shellscript",
+        "text/x-shellscript"
+      ],
+      "systemTypeRank": "Default"
+    },
+    {
+      "id": "source-code",
+      "displayName": "Source code and config",
+      "description": "Every language the BOSS editor can highlight",
+      "schemes": [],
+      "extraContentTypes": [],
+      "mimeTypes": [
+        "text/x-python",
+        "text/x-csrc",
+        "text/x-chdr",
+        "text/x-c++src",
+        "text/x-c++hdr",
+        "text/x-java-source",
+        "application/javascript",
+        "application/json",
+        "text/xml",
+        "text/css",
+        "text/x-ruby",
+        "application/x-php",
+        "text/x-perl",
+        "text/x-lua",
+        "text/x-go",
+        "text/x-scala",
+        "text/x-sql",
+        "text/x-makefile",
+        "text/x-diff",
+        "text/x-fortran",
+        "text/x-pascal",
+        "application/toml",
+        "application/x-yaml"
+      ],
+      "systemTypeRank": "Default"
+    }
+  ],
+  "languageNames": {
+    "kotlin": "Kotlin",
+    "java": "Java",
+    "javascript": "JavaScript",
+    "typescript": "TypeScript",
+    "python": "Python",
+    "json": "JSON",
+    "xml": "XML",
+    "html": "HTML",
+    "css": "CSS",
+    "markdown": "Markdown",
+    "toml": "TOML",
+    "groovy": "Gradle",
+    "swift": "Swift",
+    "c": "C",
+    "cpp": "C++",
+    "csharp": "C#",
+    "rust": "Rust",
+    "go": "Go",
+    "ruby": "Ruby",
+    "php": "PHP",
+    "perl": "Perl",
+    "lua": "Lua",
+    "bash": "Shell",
+    "yaml": "YAML",
+    "sql": "SQL",
+    "r": "R",
+    "scala": "Scala",
+    "dockerfile": "Dockerfile",
+    "makefile": "Makefile",
+    "properties": "Properties",
+    "diff": "Diff",
+    "batch": "Batch",
+    "clojure": "Clojure",
+    "latex": "LaTeX",
+    "lisp": "Lisp",
+    "tcl": "Tcl",
+    "fortran": "Fortran",
+    "d": "D",
+    "delphi": "Delphi",
+    "visualbasic": "Visual Basic",
+    "actionscript": "ActionScript",
+    "jsp": "JSP"
+  },
+  "extensions": [
+    {
+      "ext": "kt",
+      "language": "kotlin",
+      "category": "source-code"
+    },
+    {
+      "ext": "kts",
+      "language": "kotlin",
+      "category": "source-code"
+    },
+    {
+      "ext": "java",
+      "language": "java",
+      "category": "source-code",
+      "systemType": "com.sun.java-source"
+    },
+    {
+      "ext": "js",
+      "language": "javascript",
+      "category": "source-code",
+      "systemType": "com.netscape.javascript-source"
+    },
+    {
+      "ext": "jsx",
+      "language": "javascript",
+      "category": "source-code"
+    },
+    {
+      "ext": "mjs",
+      "language": "javascript",
+      "category": "source-code",
+      "systemType": "com.netscape.javascript-source"
+    },
+    {
+      "ext": "cjs",
+      "language": "javascript",
+      "category": "source-code"
+    },
+    {
+      "ext": "ts",
+      "language": "typescript",
+      "category": "source-code",
+      "rejectedSystemType": "public.mpeg-2-transport-stream"
+    },
+    {
+      "ext": "tsx",
+      "language": "typescript",
+      "category": "source-code",
+      "systemType": "com.microsoft.typescript"
+    },
+    {
+      "ext": "py",
+      "language": "python",
+      "category": "source-code",
+      "systemType": "public.python-script"
+    },
+    {
+      "ext": "pyw",
+      "language": "python",
+      "category": "source-code"
+    },
+    {
+      "ext": "json",
+      "language": "json",
+      "category": "source-code",
+      "systemType": "public.json"
+    },
+    {
+      "ext": "xml",
+      "language": "xml",
+      "category": "source-code",
+      "systemType": "public.xml"
+    },
+    {
+      "ext": "html",
+      "language": "html",
+      "category": "web-pages",
+      "systemType": "public.html"
+    },
+    {
+      "ext": "htm",
+      "language": "html",
+      "category": "web-pages",
+      "systemType": "public.html"
+    },
+    {
+      "ext": "css",
+      "language": "css",
+      "category": "source-code",
+      "systemType": "public.css"
+    },
+    {
+      "ext": "scss",
+      "language": "css",
+      "category": "source-code"
+    },
+    {
+      "ext": "sass",
+      "language": "css",
+      "category": "source-code"
+    },
+    {
+      "ext": "md",
+      "language": "markdown",
+      "category": "markdown",
+      "systemType": "net.daringfireball.markdown"
+    },
+    {
+      "ext": "markdown",
+      "language": "markdown",
+      "category": "markdown",
+      "systemType": "net.daringfireball.markdown"
+    },
+    {
+      "ext": "toml",
+      "language": "toml",
+      "category": "source-code",
+      "systemType": "public.toml"
+    },
+    {
+      "ext": "gradle",
+      "language": "groovy",
+      "category": "source-code"
+    },
+    {
+      "ext": "swift",
+      "language": "swift",
+      "category": "source-code",
+      "systemType": "public.swift-source"
+    },
+    {
+      "ext": "c",
+      "language": "c",
+      "category": "source-code",
+      "systemType": "public.c-source"
+    },
+    {
+      "ext": "h",
+      "language": "c",
+      "category": "source-code",
+      "systemType": "public.c-header"
+    },
+    {
+      "ext": "cpp",
+      "language": "cpp",
+      "category": "source-code",
+      "systemType": "public.c-plus-plus-source"
+    },
+    {
+      "ext": "cc",
+      "language": "cpp",
+      "category": "source-code",
+      "systemType": "public.c-plus-plus-source"
+    },
+    {
+      "ext": "cxx",
+      "language": "cpp",
+      "category": "source-code",
+      "systemType": "public.c-plus-plus-source"
+    },
+    {
+      "ext": "hpp",
+      "language": "cpp",
+      "category": "source-code",
+      "systemType": "public.c-plus-plus-header"
+    },
+    {
+      "ext": "cs",
+      "language": "csharp",
+      "category": "source-code"
+    },
+    {
+      "ext": "rs",
+      "language": "rust",
+      "category": "source-code"
+    },
+    {
+      "ext": "go",
+      "language": "go",
+      "category": "source-code"
+    },
+    {
+      "ext": "rb",
+      "language": "ruby",
+      "category": "source-code",
+      "systemType": "public.ruby-script"
+    },
+    {
+      "ext": "php",
+      "language": "php",
+      "category": "source-code",
+      "systemType": "public.php-script"
+    },
+    {
+      "ext": "pl",
+      "language": "perl",
+      "category": "source-code",
+      "systemType": "public.perl-script"
+    },
+    {
+      "ext": "pm",
+      "language": "perl",
+      "category": "source-code",
+      "systemType": "public.perl-script"
+    },
+    {
+      "ext": "lua",
+      "language": "lua",
+      "category": "source-code"
+    },
+    {
+      "ext": "sh",
+      "language": "bash",
+      "category": "shell-scripts",
+      "systemType": "public.shell-script"
+    },
+    {
+      "ext": "bash",
+      "language": "bash",
+      "category": "shell-scripts",
+      "systemType": "public.bash-script"
+    },
+    {
+      "ext": "zsh",
+      "language": "bash",
+      "category": "shell-scripts",
+      "systemType": "public.zsh-script"
+    },
+    {
+      "ext": "yml",
+      "language": "yaml",
+      "category": "source-code",
+      "systemType": "public.yaml"
+    },
+    {
+      "ext": "yaml",
+      "language": "yaml",
+      "category": "source-code",
+      "systemType": "public.yaml"
+    },
+    {
+      "ext": "sql",
+      "language": "sql",
+      "category": "source-code",
+      "systemType": "org.iso.sql"
+    },
+    {
+      "ext": "r",
+      "language": "r",
+      "category": "source-code",
+      "systemType": "com.apple.rez-source"
+    },
+    {
+      "ext": "scala",
+      "language": "scala",
+      "category": "source-code"
+    },
+    {
+      "ext": "dockerfile",
+      "language": "dockerfile",
+      "category": "source-code"
+    },
+    {
+      "ext": "mk",
+      "language": "makefile",
+      "category": "source-code",
+      "systemType": "public.make-source"
+    },
+    {
+      "ext": "mak",
+      "language": "makefile",
+      "category": "source-code",
+      "systemType": "public.make-source"
+    },
+    {
+      "ext": "properties",
+      "language": "properties",
+      "category": "source-code"
+    },
+    {
+      "ext": "ini",
+      "language": "properties",
+      "category": "source-code",
+      "systemType": "com.microsoft.ini"
+    },
+    {
+      "ext": "cfg",
+      "language": "properties",
+      "category": "source-code",
+      "systemType": "public.toml"
+    },
+    {
+      "ext": "env",
+      "language": "properties",
+      "category": "source-code"
+    },
+    {
+      "ext": "diff",
+      "language": "diff",
+      "category": "source-code",
+      "systemType": "public.patch-file"
+    },
+    {
+      "ext": "patch",
+      "language": "diff",
+      "category": "source-code",
+      "systemType": "public.patch-file"
+    },
+    {
+      "ext": "bat",
+      "language": "batch",
+      "category": "source-code"
+    },
+    {
+      "ext": "cmd",
+      "language": "batch",
+      "category": "source-code"
+    },
+    {
+      "ext": "clj",
+      "language": "clojure",
+      "category": "source-code"
+    },
+    {
+      "ext": "cljs",
+      "language": "clojure",
+      "category": "source-code"
+    },
+    {
+      "ext": "cljc",
+      "language": "clojure",
+      "category": "source-code"
+    },
+    {
+      "ext": "edn",
+      "language": "clojure",
+      "category": "source-code",
+      "rejectedSystemType": "com.adobe.edn"
+    },
+    {
+      "ext": "tex",
+      "language": "latex",
+      "category": "source-code"
+    },
+    {
+      "ext": "sty",
+      "language": "latex",
+      "category": "source-code"
+    },
+    {
+      "ext": "cls",
+      "language": "latex",
+      "category": "source-code"
+    },
+    {
+      "ext": "bib",
+      "language": "latex",
+      "category": "source-code"
+    },
+    {
+      "ext": "lisp",
+      "language": "lisp",
+      "category": "source-code"
+    },
+    {
+      "ext": "lsp",
+      "language": "lisp",
+      "category": "source-code"
+    },
+    {
+      "ext": "el",
+      "language": "lisp",
+      "category": "source-code"
+    },
+    {
+      "ext": "scm",
+      "language": "lisp",
+      "category": "source-code"
+    },
+    {
+      "ext": "tcl",
+      "language": "tcl",
+      "category": "source-code"
+    },
+    {
+      "ext": "f",
+      "language": "fortran",
+      "category": "source-code",
+      "systemType": "public.fortran-source"
+    },
+    {
+      "ext": "f90",
+      "language": "fortran",
+      "category": "source-code",
+      "systemType": "public.fortran-90-source"
+    },
+    {
+      "ext": "f95",
+      "language": "fortran",
+      "category": "source-code",
+      "systemType": "public.fortran-95-source"
+    },
+    {
+      "ext": "f03",
+      "language": "fortran",
+      "category": "source-code"
+    },
+    {
+      "ext": "for",
+      "language": "fortran",
+      "category": "source-code",
+      "systemType": "public.fortran-source"
+    },
+    {
+      "ext": "d",
+      "language": "d",
+      "category": "source-code"
+    },
+    {
+      "ext": "pas",
+      "language": "delphi",
+      "category": "source-code",
+      "systemType": "public.pascal-source"
+    },
+    {
+      "ext": "dpr",
+      "language": "delphi",
+      "category": "source-code"
+    },
+    {
+      "ext": "dfm",
+      "language": "delphi",
+      "category": "source-code"
+    },
+    {
+      "ext": "vb",
+      "language": "visualbasic",
+      "category": "source-code"
+    },
+    {
+      "ext": "vbs",
+      "language": "visualbasic",
+      "category": "source-code"
+    },
+    {
+      "ext": "as",
+      "language": "actionscript",
+      "category": "source-code",
+      "rejectedSystemType": "com.apple.applesingle-archive"
+    },
+    {
+      "ext": "jsp",
+      "language": "jsp",
+      "category": "source-code"
+    },
+    {
+      "ext": "jspx",
+      "language": "jsp",
+      "category": "source-code"
+    }
+  ]
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/cli/OpenTargetPathTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/cli/OpenTargetPathTest.kt
@@ -1,0 +1,72 @@
+package ai.rever.boss.cli
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [CLISecurityValidator.isValidOpenTargetPath], the check applied to a
+ * file BOSS is about to read into the editor.
+ *
+ * It exists because `isValidPath` - the right rules for a path that ends up in a
+ * shell command - refused ordinary filenames. A file called `Q&A notes.md` failed
+ * the shell-metacharacter test, so double-clicking it logged "Invalid file path
+ * (security check failed)" and nothing opened. No shell is involved on this path,
+ * so those characters are just characters.
+ */
+class OpenTargetPathTest {
+    @Test
+    fun `accepts filenames that isValidPath refused`() {
+        // Every one of these is a legal filename and every one was rejected.
+        listOf(
+            "/Users/me/Documents/Q&A notes.md",
+            "/Users/me/scripts/pay\$.sh",
+            "/Users/me/notes;draft.md",
+            "/Users/me/a|b.txt",
+            "/Users/me/back`tick`.md",
+            "/Users/me/notes..draft.md",
+        ).forEach { path ->
+            assertTrue(CLISecurityValidator.isValidOpenTargetPath(path), "should accept $path")
+            // The contrast is the point of having two functions.
+            assertFalse(CLISecurityValidator.isValidPath(path), "isValidPath was expected to refuse $path")
+        }
+    }
+
+    @Test
+    fun `accepts an ordinary absolute path`() {
+        assertTrue(CLISecurityValidator.isValidOpenTargetPath("/Users/me/project/src/Main.kt"))
+        // Parentheses are fine for both validators; listed here so the contrast
+        // above stays a list of characters isValidPath actually rejects.
+        assertTrue(CLISecurityValidator.isValidOpenTargetPath("/Users/me/Projects (2026)/README.md"))
+    }
+
+    @Test
+    fun `accepts a path containing dot-dot, which canonicalises away`() {
+        // `..` was refused as a traversal defence, which it never was on this
+        // path: the caller may pass any absolute path anyway, so the segment adds
+        // no reach. Canonicalising is both stricter and correct.
+        assertTrue(CLISecurityValidator.isValidOpenTargetPath("/Users/me/project/../project/README.md"))
+    }
+
+    @Test
+    fun `refuses a NUL byte`() {
+        // Truncates the path in any native call underneath, so the file that gets
+        // opened is not the file that was checked.
+        assertFalse(CLISecurityValidator.isValidOpenTargetPath("/Users/me/notes.md\u0000.png"))
+    }
+
+    @Test
+    fun `refuses blank input`() {
+        assertFalse(CLISecurityValidator.isValidOpenTargetPath(""))
+        assertFalse(CLISecurityValidator.isValidOpenTargetPath("   "))
+    }
+
+    @Test
+    fun `the shell-facing validator is unchanged`() {
+        // The terminal and folder paths still use isValidPath, and loosening it
+        // was never the intent - only splitting the two apart.
+        assertFalse(CLISecurityValidator.isValidPath("/tmp/a;rm -rf /"))
+        assertFalse(CLISecurityValidator.isValidPath("/tmp/../etc/passwd"))
+        assertTrue(CLISecurityValidator.isValidPath("/Users/me/project/src/Main.kt"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/MissingHandlerPluginBusTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/MissingHandlerPluginBusTest.kt
@@ -1,0 +1,144 @@
+package ai.rever.boss.components.plugin
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [MissingHandlerPluginBus].
+ *
+ * Its own class rather than the singleton, for the reason
+ * [PluginDependencyBus]'s KDoc gives: the shared buffer otherwise carries prompts
+ * between tests, which is the same coupling two windows would have.
+ */
+class MissingHandlerPluginBusTest {
+    private fun bus() = MissingHandlerPluginBus()
+
+    private fun prompt(
+        pluginId: String,
+        remedy: MissingHandlerRemedy = MissingHandlerRemedy.INSTALL,
+        purpose: String = "Opening README.md",
+    ) = MissingHandlerPluginPrompt(
+        missing =
+            MissingHandlerPlugin(
+                purpose = purpose,
+                capability = "files in the editor",
+                tabTypeId = "editor",
+                pluginId = pluginId,
+                remedy = remedy,
+            ),
+        resolve = { Result.success(Unit) },
+        displayName = { null },
+    )
+
+    @Test
+    fun `a reported prompt is delivered`() =
+        runBlocking {
+            val bus = bus()
+            bus.report(prompt("editor"))
+            val received = withTimeoutOrNull(1_000) { bus.missingHandlers.first() }
+            assertNotNull(received)
+            assertEquals("editor", received.missing.pluginId)
+        }
+
+    @Test
+    fun `a second prompt for the same plugin is not queued`() =
+        runBlocking {
+            val bus = bus()
+            bus.report(prompt("editor", purpose = "Opening a.md"))
+            bus.report(prompt("editor", purpose = "Opening b.md"))
+            bus.report(prompt("editor", purpose = "Opening c.md"))
+
+            // Twelve files selected in Finder with no editor plugin is one
+            // question, not twelve. The first is the one delivered.
+            val first = withTimeoutOrNull(1_000) { bus.missingHandlers.first() }
+            assertEquals("Opening a.md", first?.missing?.purpose)
+
+            // Nothing else is waiting.
+            val second = withTimeoutOrNull(200) { bus.missingHandlers.first() }
+            assertNull(second, "a duplicate must not occupy a buffer slot")
+        }
+
+    @Test
+    fun `a slot is freed once a prompt is taken, so the same plugin can ask again later`() {
+        // Block body, not `= runBlocking { ... }`, and that is load-bearing:
+        // `assertNotNull` returns the value it checked, so an expression-bodied
+        // test ending in one is inferred non-Unit, and JUnit 5 does not run a
+        // @Test method that returns a value - it is not reported as skipped
+        // either, it simply never appears. Two tests in this file were written
+        // that way and silently did not run.
+        runBlocking {
+            val bus = bus()
+            bus.report(prompt("editor"))
+            assertNotNull(withTimeoutOrNull(1_000) { bus.missingHandlers.first() })
+
+            // The user closed the dialog without answering (no decline recorded);
+            // the next file must be able to ask again.
+            bus.report(prompt("editor"))
+            assertNotNull(withTimeoutOrNull(1_000) { bus.missingHandlers.first() })
+        }
+    }
+
+    @Test
+    fun `two different plugins both get through`() =
+        runBlocking {
+            val bus = bus()
+            bus.report(prompt("editor"))
+            bus.report(prompt("browser"))
+            val first = withTimeoutOrNull(1_000) { bus.missingHandlers.first() }
+            val second = withTimeoutOrNull(1_000) { bus.missingHandlers.first() }
+            assertEquals(setOf("editor", "browser"), setOf(first?.missing?.pluginId, second?.missing?.pluginId))
+        }
+
+    @Test
+    fun `a declined plugin is never reported again this session`() =
+        runBlocking {
+            val bus = bus()
+            bus.decline("editor")
+            assertTrue(bus.wasDeclined("editor"))
+            bus.report(prompt("editor"))
+            assertNull(
+                withTimeoutOrNull(200) { bus.missingHandlers.first() },
+                "declining once must answer for the plugin, not for one file",
+            )
+        }
+
+    @Test
+    fun `declining one plugin does not silence another`() {
+        // Block body for the same reason as above.
+        runBlocking {
+            val bus = bus()
+            bus.decline("editor")
+            assertFalse(bus.wasDeclined("browser"))
+            bus.report(prompt("browser"))
+            assertNotNull(withTimeoutOrNull(1_000) { bus.missingHandlers.first() })
+        }
+    }
+
+    @Test
+    fun `the remedy travels with the prompt`() =
+        runBlocking {
+            val bus = bus()
+            bus.report(prompt("editor", remedy = MissingHandlerRemedy.ENABLE))
+            val received = withTimeoutOrNull(1_000) { bus.missingHandlers.first() }
+            // Install and Enable are different buttons doing different things;
+            // offering Install for a plugin already on disk cannot fix it.
+            assertEquals(MissingHandlerRemedy.ENABLE, received?.missing?.remedy)
+        }
+
+    @Test
+    fun `reporting never suspends, even past the buffer`() {
+        val bus = bus()
+        // Capacity is 2 and nothing is collecting. `report` uses trySend, so this
+        // must return rather than block the code that was trying to open a file.
+        // A DROP_OLDEST channel would accept all of these silently, which is why
+        // the overflow is refused and logged instead.
+        repeat(10) { index -> bus.report(prompt("plugin-$index")) }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/TabTypePluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/TabTypePluginsTest.kt
@@ -1,0 +1,62 @@
+package ai.rever.boss.components.plugin
+
+import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
+import ai.rever.boss.plugin.tab.fluck.FluckTabType
+import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
+import ai.rever.boss.plugin.tab.terminal.TerminalTabType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for [TabTypePlugins], the table that answers "which plugin renders this
+ * tab type" when the plugin is absent and there is no manifest to read.
+ */
+class TabTypePluginsTest {
+    @Test
+    fun `every tab type the host opens itself resolves to a plugin`() {
+        // If one of these returns null, the missing-plugin dialog cannot be
+        // offered for it and the tab is dropped silently again.
+        assertEquals(TabTypePlugins.FLUCK_BROWSER, TabTypePlugins.pluginFor(FluckTabType.typeId))
+        assertEquals(TabTypePlugins.EDITOR_TAB, TabTypePlugins.pluginFor(CodeEditorTabType.typeId))
+        assertEquals(TabTypePlugins.TERMINAL_TAB, TabTypePlugins.pluginFor(TerminalTabType.typeId))
+        assertEquals(TabTypePlugins.JUPYTER_NOTEBOOK, TabTypePlugins.pluginFor(JupyterTabInfo.TYPE_ID))
+    }
+
+    @Test
+    fun `the lookup keys on the type string, not the whole TabTypeId`() {
+        // TabTypeId is a data class whose equality includes pluginId and
+        // defaultOrder. Keying on the whole value made a lookup miss for a type
+        // that was plainly registered - the trap panelid-defaultorder-silent-miss
+        // records for panels. A TabTypeId built by a plugin with its own pluginId
+        // must still resolve.
+        val fromElsewhere = TabTypeId(typeId = "editor", pluginId = "some.other.plugin")
+        assertEquals(TabTypePlugins.EDITOR_TAB, TabTypePlugins.pluginFor(fromElsewhere))
+    }
+
+    @Test
+    fun `an unknown type resolves to nothing rather than a guess`() {
+        // A plugin's own tab type. Offering to install something would offer the
+        // wrong plugin.
+        assertNull(TabTypePlugins.pluginFor(TabTypeId("some-plugin-tab")))
+    }
+
+    @Test
+    fun `each type has copy for the dialog`() {
+        listOf(FluckTabType.typeId, CodeEditorTabType.typeId, TerminalTabType.typeId, JupyterTabInfo.TYPE_ID)
+            .forEach { typeId ->
+                val described = TabTypePlugins.describe(typeId)
+                assertNotNull(described)
+                // Not the raw type id: the sentence is "needs X, the plugin that
+                // opens <this>", and "fluck" is not something to say to a user.
+                assertEquals(false, described == typeId.typeId, "describe(${typeId.typeId}) returned the raw id")
+            }
+    }
+
+    @Test
+    fun `an unknown type falls back to its id rather than throwing`() {
+        assertEquals("weird-tab", TabTypePlugins.describe(TabTypeId("weird-tab")))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/EngineBundlePlistStripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/EngineBundlePlistStripTest.kt
@@ -60,17 +60,51 @@ class EngineBundlePlistStripTest {
     }
 
     @Test
-    fun `the deletes precede the re-sign, or they break the signature`() {
+    fun `the deletes precede the re-sign in every macOS job`() {
+        // Split per job before comparing. Comparing first-occurrence indices
+        // across the whole file constrained only the FIRST macOS job - while the
+        // test above exists precisely because patching one mac job and not the
+        // other is the expected mistake. So the ordering check has to be per job
+        // too, or it inherits the same blind spot it was written to cover.
+        val jobs = macJobSections()
+        assertEquals(2, jobs.size, "expected two macOS build jobs, found ${jobs.size}")
+
+        jobs.forEachIndexed { index, section ->
+            val delete = section.indexOf("""Delete :CFBundleURLTypes""")
+            val resign = section.indexOf("""Re-signing with identity""")
+            assertTrue(delete > 0, "macOS job $index has no CFBundleURLTypes delete")
+            assertTrue(resign > 0, "macOS job $index has no re-sign step")
+            assertTrue(
+                delete < resign,
+                "macOS job $index: the plist edit must come BEFORE the re-sign; after it, the edit breaks " +
+                    "the code signature and the engine fails codesign --verify (or worse, ships mis-signed)",
+            )
+        }
+    }
+
+    /**
+     * The workflow text split into one section per macOS build job.
+     *
+     * Keyed on the job headers rather than a line count so it survives edits
+     * elsewhere in the file.
+     */
+    private fun macJobSections(): List<String> {
         val text = workflow()
-        val firstDelete = text.indexOf("""Delete :CFBundleURLTypes""")
-        val firstResign = text.indexOf("""Re-signing with identity""")
-        assertTrue(firstDelete > 0, "no CFBundleURLTypes delete found")
-        assertTrue(firstResign > 0, "no re-sign step found")
-        assertTrue(
-            firstDelete < firstResign,
-            "the plist edit must come BEFORE the re-sign; after it, the edit breaks the code signature " +
-                "and the engine fails codesign --verify (or worse, ships mis-signed)",
-        )
+        val headers = listOf("  build-macos-arm64:", "  build-macos-x64:")
+        val starts = headers.map { text.indexOf(it) }
+        assertTrue(starts.all { it >= 0 }, "could not find both macOS job headers; were they renamed?")
+
+        // Each section runs to the start of the next top-level job, so a delete
+        // belonging to a later job cannot satisfy an earlier one.
+        val jobStarts =
+            Regex("""(?m)^  [a-z0-9-]+:$""")
+                .findAll(text)
+                .map { it.range.first }
+                .toList()
+        return starts.map { start ->
+            val end = jobStarts.firstOrNull { it > start } ?: text.length
+            text.substring(start, end)
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/EngineBundlePlistStripTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/EngineBundlePlistStripTest.kt
@@ -1,0 +1,88 @@
+package ai.rever.boss.config
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Asserts that the Chromium branding workflow strips the engine bundle's URL and
+ * document type declarations, and does it before the re-sign.
+ *
+ * A source-level assertion, for the same reason `WizardDependencyReportTest` is
+ * one: the workflow only runs on a mac runner against a downloaded JxBrowser
+ * archive, and what it produces is verified by Launch Services on a user's
+ * machine weeks later. The failure it guards is invisible and expensive - the
+ * engine re-registers as a second app called "BOSS" that claims http, https and
+ * `public.html`, System Settings offers two entries nobody can tell apart, and
+ * every link opens a bare Chromium with no BOSS window. That is exactly the bug
+ * this change exists to fix, and nothing else would notice it coming back.
+ */
+class EngineBundlePlistStripTest {
+    private val strippedKeys = listOf("CFBundleURLTypes", "CFBundleDocumentTypes")
+
+    private fun workflow(): String {
+        val root =
+            assertNotNull(
+                generateSequence(File("").absoluteFile) { it.parentFile }
+                    .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+                "could not locate the repository root",
+            )
+        val file = File(root, ".github/workflows/build-chromium-branding.yml")
+        assertTrue(file.isFile, "build-chromium-branding.yml not found at ${file.absolutePath}")
+        return file.readText()
+    }
+
+    @Test
+    fun `both plist keys are deleted from the engine bundle`() {
+        val text = workflow()
+        strippedKeys.forEach { key ->
+            assertTrue(
+                text.contains("""PlistBuddy -c "Delete :$key" "${'$'}MAIN_PLIST""""),
+                "the workflow must delete :$key from the engine's Info.plist",
+            )
+        }
+    }
+
+    @Test
+    fun `the deletes happen for every macOS architecture`() {
+        val text = workflow()
+        // Two mac jobs, arm64 and x64, with the same steps. Patching only one
+        // ships a clean engine on Apple Silicon and a colliding one on Intel.
+        strippedKeys.forEach { key ->
+            assertEquals(
+                2,
+                Regex("""PlistBuddy -c "Delete :$key"""").findAll(text).count(),
+                "expected the :$key delete in both macOS build jobs",
+            )
+        }
+    }
+
+    @Test
+    fun `the deletes precede the re-sign, or they break the signature`() {
+        val text = workflow()
+        val firstDelete = text.indexOf("""Delete :CFBundleURLTypes""")
+        val firstResign = text.indexOf("""Re-signing with identity""")
+        assertTrue(firstDelete > 0, "no CFBundleURLTypes delete found")
+        assertTrue(firstResign > 0, "no re-sign step found")
+        assertTrue(
+            firstDelete < firstResign,
+            "the plist edit must come BEFORE the re-sign; after it, the edit breaks the code signature " +
+                "and the engine fails codesign --verify (or worse, ships mis-signed)",
+        )
+    }
+
+    @Test
+    fun `the end state is asserted rather than assumed`() {
+        val text = workflow()
+        // Every PlistBuddy delete ends in `|| true`, because an absent key is
+        // fine. So without a check on the result, a delete that silently failed
+        // would republish the collision - and that is the whole failure this step
+        // exists to prevent.
+        assertTrue(
+            text.contains("""still present in the engine Info.plist"""),
+            "the workflow must fail the job when either key survives the delete",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/EngineDeclaresBrowserTypesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/EngineDeclaresBrowserTypesTest.kt
@@ -1,0 +1,118 @@
+package ai.rever.boss.config
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the content check that tells a repaired engine bundle from the one it
+ * replaced.
+ *
+ * This is the only thing that can: the fix ships inside a *rebuild* of an
+ * already-published engine, so `version.txt` reads `9.5.0` before and after and
+ * `isChromiumInstalled`'s version equality short-circuits. Without a content
+ * check, every existing install keeps the engine that declares http, https,
+ * `file` and 17 document types under the name "BOSS" forever.
+ */
+class EngineDeclaresBrowserTypesTest {
+    @TempDir
+    lateinit var dir: File
+
+    private fun plist(body: String): File {
+        val f = File(dir, "Info.plist")
+        f.writeText(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+            $body
+            </dict>
+            </plist>
+            """.trimIndent(),
+        )
+        return f
+    }
+
+    private fun check(file: File) = ChromiumAutoDownloader.declaresBrowserTypes(file)
+
+    @Test
+    fun `an engine claiming url schemes is stale`() {
+        assertTrue(
+            check(
+                plist(
+                    """
+                    <key>CFBundleIdentifier</key><string>ai.rever.boss.browser</string>
+                    <key>CFBundleURLTypes</key>
+                    <array><dict><key>CFBundleURLSchemes</key><array><string>http</string></array></dict></array>
+                    """.trimIndent(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `an engine claiming document types is stale`() {
+        assertTrue(
+            check(
+                plist(
+                    """
+                    <key>CFBundleDocumentTypes</key>
+                    <array><dict><key>LSItemContentTypes</key><array><string>public.html</string></array></dict></array>
+                    """.trimIndent(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `a repaired engine is not stale`() {
+        // What the fixed branding workflow produces: identity and the Bluetooth
+        // keys survive, the two browser-type keys are gone.
+        assertFalse(
+            check(
+                plist(
+                    """
+                    <key>CFBundleIdentifier</key><string>ai.rever.boss.browser</string>
+                    <key>CFBundleName</key><string>BOSS</string>
+                    <key>NSBluetoothAlwaysUsageDescription</key><string>passkeys</string>
+                    <key>CFBundleShortVersionString</key><string>9.5.0</string>
+                    """.trimIndent(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `the key name outside a key element does not count`() {
+        // Precision matters more than usual here: a false positive re-downloads
+        // ~160 MB, and before the one-attempt guard it would have done so on
+        // every launch. A comment or a string value naming the key is not a
+        // declaration.
+        assertFalse(
+            check(
+                plist(
+                    """
+                    <!-- CFBundleURLTypes was removed on purpose; see AGENTS.md -->
+                    <key>BossNote</key><string>CFBundleDocumentTypes</string>
+                    """.trimIndent(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `a missing plist fails closed`() {
+        // Answering true would force a large download over a file we could not
+        // read. A genuinely broken bundle is caught by the executable checks.
+        assertFalse(check(File(dir, "does-not-exist.plist")))
+    }
+
+    @Test
+    fun `a directory in place of the plist fails closed`() {
+        val asDir = File(dir, "Info.plist.d").apply { mkdirs() }
+        assertFalse(check(asDir))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/DefaultAppsSettingsManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/DefaultAppsSettingsManagerTest.kt
@@ -1,0 +1,105 @@
+package ai.rever.boss.filetypes
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Round-trip tests for the persisted default-apps decisions.
+ *
+ * `promptShown` is the only thing keeping the first-run offer to one appearance,
+ * and `declinedCategories` is what stops "Set all" re-claiming a refusal - both
+ * worth a test, and both previously untested.
+ */
+class DefaultAppsSettingsManagerTest {
+    @TempDir
+    lateinit var dir: File
+
+    private lateinit var original: File
+
+    @BeforeEach
+    fun pointAtTempFile() {
+        original = DefaultAppsSettingsManager.settingsFile
+        DefaultAppsSettingsManager.settingsFile = File(dir, "default-apps.json")
+        DefaultAppsSettingsManager.resetForTest()
+    }
+
+    @AfterEach
+    fun restore() {
+        DefaultAppsSettingsManager.settingsFile = original
+        DefaultAppsSettingsManager.resetForTest()
+    }
+
+    private fun reload() {
+        DefaultAppsSettingsManager.resetForTest()
+        runBlocking { DefaultAppsSettingsManager.ensureLoaded() }
+    }
+
+    @Test
+    fun `a fresh install offers the prompt`() {
+        reload()
+        assertTrue(DefaultAppsSettingsManager.shouldOfferPrompt())
+        assertTrue(DefaultAppsSettingsManager.declinedCategories().isEmpty())
+    }
+
+    @Test
+    fun `promptShown survives a reload, so the offer is made once`() {
+        runBlocking {
+            DefaultAppsSettingsManager.ensureLoaded()
+            DefaultAppsSettingsManager.markPromptShown()
+        }
+        reload()
+        assertFalse(DefaultAppsSettingsManager.shouldOfferPrompt())
+    }
+
+    @Test
+    fun `declines survive a reload and accumulate`() {
+        runBlocking {
+            DefaultAppsSettingsManager.ensureLoaded()
+            DefaultAppsSettingsManager.markDeclined(listOf("markdown"))
+            DefaultAppsSettingsManager.markDeclined(listOf("shell-scripts", "markdown"))
+        }
+        reload()
+        assertEquals(setOf("markdown", "shell-scripts"), DefaultAppsSettingsManager.declinedCategories())
+    }
+
+    @Test
+    fun `clearing a decline is what lets an explicit Set stick`() {
+        runBlocking {
+            DefaultAppsSettingsManager.ensureLoaded()
+            DefaultAppsSettingsManager.markDeclined(listOf("markdown", "shell-scripts"))
+            DefaultAppsSettingsManager.clearDeclined(listOf("markdown"))
+        }
+        reload()
+        assertEquals(setOf("shell-scripts"), DefaultAppsSettingsManager.declinedCategories())
+    }
+
+    @Test
+    fun `a corrupt file falls back to defaults rather than throwing`() {
+        DefaultAppsSettingsManager.settingsFile.writeText("{ this is not json")
+        reload()
+        // Defaults means the prompt may be offered again, which is the better
+        // failure direction: a corrupt file that suppressed it forever would leave
+        // no way to discover the feature.
+        assertTrue(DefaultAppsSettingsManager.shouldOfferPrompt())
+        assertTrue(DefaultAppsSettingsManager.declinedCategories().isEmpty())
+    }
+
+    @Test
+    fun `an unknown field does not empty the file`() {
+        // A future build adding a field must not make this build read an empty
+        // decision set - the strict-Json trap this repo records.
+        DefaultAppsSettingsManager.settingsFile.writeText(
+            """{"promptShown": true, "declinedCategories": ["markdown"], "somethingNew": 7}""",
+        )
+        reload()
+        assertFalse(DefaultAppsSettingsManager.shouldOfferPrompt())
+        assertEquals(setOf("markdown"), DefaultAppsSettingsManager.declinedCategories())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/FileTypeCategoriesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/FileTypeCategoriesTest.kt
@@ -1,0 +1,133 @@
+package ai.rever.boss.filetypes
+
+import ai.rever.boss.components.plugin.language.EditorLanguages
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the runtime half of the file-type table.
+ *
+ * `buildSrc/BossFileTypesTest` covers the generator and the plist it produces.
+ * This covers what the *app* does with the same resource, and one thing neither
+ * side can check alone: that the exported UTIs the app asks Launch Services about
+ * are the identifiers the plist actually declared. Those are built independently
+ * on the two sides - a mismatch would leave BOSS declaring
+ * `ai.rever.boss.kotlin-source` in its bundle and asking the OS about something
+ * else, which reports "not the default" forever and no button can fix.
+ */
+class FileTypeCategoriesTest {
+    private val table get() = FileTypeCategories.table
+
+    @Test
+    fun `the resource loads from the classpath`() {
+        assertTrue(FileTypeCategories.isAvailable(), "boss-file-types.json did not load")
+        assertTrue(table.categories.isNotEmpty())
+        assertTrue(table.extensions.isNotEmpty())
+    }
+
+    @Test
+    fun `the table covers exactly the extensions EditorLanguages knows`() {
+        // The anti-drift gate, from the app's side. Its sibling in buildSrc reads
+        // EditorLanguages out of the source with a regex because it compiles
+        // first; here the real object is on the classpath, so this is the
+        // stronger of the two and the one to trust.
+        assertEquals(
+            EditorLanguages.extensions().keys.sorted(),
+            table.extensions.map { it.ext }.sorted(),
+            "boss-file-types.json and EditorLanguages.EXTENSIONS disagree about which extensions exist",
+        )
+    }
+
+    @Test
+    fun `the table agrees with EditorLanguages about each extension's language`() {
+        val languages = EditorLanguages.extensions()
+        table.extensions.forEach { row ->
+            assertEquals(
+                languages[row.ext],
+                row.language,
+                "boss-file-types.json calls .${row.ext} '${row.language}'",
+            )
+        }
+    }
+
+    @Test
+    fun `exported type ids follow the resource's own naming`() {
+        // Read from the resource rather than reconstructed here, which is the
+        // point: both the generator and the app derive them from these two
+        // fields, so this test fails if either side invents its own.
+        table.categories.forEach { category ->
+            table.exportedTypeIdsFor(category.id).forEach { id ->
+                assertTrue(id.startsWith("${table.exportedTypePrefix}."), id)
+                assertTrue(id.endsWith(table.exportedTypeSuffix), id)
+            }
+        }
+    }
+
+    @Test
+    fun `one exported type per language, not one per extension`() {
+        // The plist declares `ai.rever.boss.kotlin-source` once for .kt and
+        // .kts. Asking about one id per extension would ask about types that do
+        // not exist.
+        val kotlinIds = table.exportedTypeIdsFor("source-code").filter { it.contains("kotlin") }
+        assertEquals(1, kotlinIds.size, "expected exactly one Kotlin type, got $kotlinIds")
+    }
+
+    @Test
+    fun `content types for a category include both claimed and exported types`() {
+        val sourceTypes = table.contentTypesFor("source-code")
+        // A claimed system UTI.
+        assertTrue("public.python-script" in sourceTypes, "expected the Python UTI among $sourceTypes")
+        // One BOSS exports.
+        assertTrue(sourceTypes.any { it.contains("kotlin") }, "expected a Kotlin type among $sourceTypes")
+        // No duplicates, since several extensions share one UTI.
+        assertEquals(sourceTypes.distinct().size, sourceTypes.size)
+    }
+
+    @Test
+    fun `the three vetted system types are never asked about`() {
+        // Measured facts, not guesses: .ts resolves to a video container, .as to
+        // a binary archive and .edn to an Adobe project format. Claiming any
+        // would make BOSS the default application for a format it cannot open.
+        val everyType = table.categories.flatMap { table.contentTypesFor(it.id) }.toSet()
+        listOf("public.mpeg-2-transport-stream", "com.apple.applesingle-archive", "com.adobe.edn").forEach {
+            assertFalse(it in everyType, "$it must never be claimed")
+        }
+    }
+
+    @Test
+    fun `the browser category claims the schemes and the web page category does not`() {
+        assertEquals(listOf("http", "https"), table.schemesFor("web-links"))
+        assertTrue(table.schemesFor("markdown").isEmpty())
+        assertTrue(table.schemesFor("source-code").isEmpty())
+    }
+
+    @Test
+    fun `every category has Linux MIME types or schemes to claim`() {
+        // A category with neither is a row in Settings whose Set button cannot do
+        // anything on Linux.
+        table.categories.forEach { category ->
+            val claimsSomething = category.mimeTypes.isNotEmpty() || category.schemes.isNotEmpty()
+            assertTrue(claimsSomething, "category '${category.id}' claims nothing on Linux")
+        }
+    }
+
+    @Test
+    fun `markdown and shell scripts claim their system types`() {
+        assertTrue("net.daringfireball.markdown" in table.contentTypesFor("markdown"))
+        val shell = table.contentTypesFor("shell-scripts")
+        assertTrue("public.shell-script" in shell)
+        assertTrue("public.bash-script" in shell)
+        assertTrue("public.zsh-script" in shell)
+    }
+
+    @Test
+    fun `an unknown category id answers empty rather than throwing`() {
+        // Read from a resource, so a stale id from a persisted setting must not
+        // take the Settings screen down.
+        assertTrue(table.contentTypesFor("no-such-category").isEmpty())
+        assertTrue(table.extensionsFor("no-such-category").isEmpty())
+        assertTrue(table.mimeTypesFor("no-such-category").isEmpty())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/WindowsRegistryScriptTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/WindowsRegistryScriptTest.kt
@@ -1,0 +1,159 @@
+package ai.rever.boss.filetypes
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the generated `.reg` script and the `reg query` parser.
+ *
+ * Both are pure string work driving a platform feature nobody developing on macOS
+ * will notice breaking, and the failure is silent: an association that exists but
+ * launches nothing. The `shell\open\command` value in particular is the single
+ * write that makes a double-clicked file reach BOSS.
+ */
+class WindowsRegistryScriptTest {
+    private val exe = """C:\Program Files\BOSS\BOSS.exe"""
+
+    private fun script(vararg extensions: String): String {
+        // Block body, not an expression body: ktlintFormat collapses the latter
+        // back onto one line, past detekt's 120-column limit.
+        return WindowsRegistryScript.buildScript(extensions.toList(), exe, "Markdown")
+    }
+
+    // ---- escaping ----
+
+    @Test
+    fun `backslashes are doubled and quotes escaped`() {
+        assertEquals("""C:\\Program Files\\BOSS\\BOSS.exe""", WindowsRegistryScript.regEscape(exe))
+        assertEquals("""a\"b""", WindowsRegistryScript.regEscape("""a"b"""))
+        // Order matters: escaping quotes first and then backslashes would double
+        // the backslash the quote escape just added.
+        assertEquals("""\\\"""", WindowsRegistryScript.regEscape("""\""""))
+    }
+
+    @Test
+    fun `a path with no special characters is unchanged`() {
+        assertEquals("C:/BOSS/BOSS.exe", WindowsRegistryScript.regEscape("C:/BOSS/BOSS.exe"))
+    }
+
+    // ---- the script ----
+
+    @Test
+    fun `the script carries the header reg import requires`() {
+        assertTrue(script("md").startsWith("Windows Registry Editor Version 5.00"))
+    }
+
+    @Test
+    fun `the open command is the exe followed by the file argument`() {
+        val text = script("md")
+        // This is the value the previous `reg add` form could not write reliably:
+        // both the exe and %1 quoted, inside an escaped .reg string.
+        assertTrue(
+            text.contains("""@="\"C:\\Program Files\\BOSS\\BOSS.exe\" \"%1\""""),
+            "the shell\\open\\command value is wrong:\n$text",
+        )
+    }
+
+    @Test
+    fun `each extension gets its own ProgID with all five entries`() {
+        val text = script("md")
+        listOf(
+            """[HKEY_CURRENT_USER\Software\Classes\BOSS.md]""",
+            """[HKEY_CURRENT_USER\Software\Classes\BOSS.md\DefaultIcon]""",
+            """[HKEY_CURRENT_USER\Software\Classes\BOSS.md\shell\open\command]""",
+            """[HKEY_CURRENT_USER\Software\Classes\.md\OpenWithProgids]""",
+            """"BOSS.md"=hex(0):""",
+            """".md"="BOSS.md"""",
+        ).forEach { fragment ->
+            assertTrue(text.contains(fragment), "missing from the script: $fragment")
+        }
+    }
+
+    @Test
+    fun `extensions are lowercased and de-duplicated`() {
+        val text = script("MD", "md", "Kt")
+        assertEquals(1, Regex("""\\BOSS\.md]""").findAll(text).count())
+        assertTrue(text.contains("""\BOSS.kt]"""))
+        assertFalse(text.contains("BOSS.MD"))
+    }
+
+    @Test
+    fun `the ProgID is per extension, not per category`() {
+        // FileAssociations and UserChoice are both keyed by extension, so a shared
+        // ProgID would make "BOSS opens markdown" and "BOSS opens Kotlin" one
+        // switch.
+        assertEquals("BOSS.md", WindowsRegistryScript.progIdFor("md"))
+        assertEquals("BOSS.kt", WindowsRegistryScript.progIdFor("KT"))
+    }
+
+    @Test
+    fun `the description names the category and BOSS`() {
+        assertTrue(script("md").contains("""@="Markdown (BOSS)""""))
+    }
+
+    @Test
+    fun `every extension in a real category ends up in the script`() {
+        val extensions = FileTypeCategories.table.extensionsFor("source-code")
+        assertTrue(extensions.size > 50, "expected the big category, got ${extensions.size}")
+        val text = WindowsRegistryScript.buildScript(extensions, exe, "Source code and config")
+        extensions.forEach { extension ->
+            assertTrue(
+                text.contains("""\BOSS.${extension.lowercase()}]"""),
+                ".$extension has no ProgID in the script",
+            )
+        }
+    }
+
+    // ---- the query parser ----
+
+    /** `reg query ... /s` output, in the shape reg.exe actually prints. */
+    private val regOutput =
+        """
+
+        HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.md
+            Progid    REG_SZ    Applications\notepad.exe
+
+        HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.md\OpenWithList
+            a    REG_SZ    notepad.exe
+
+        HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.md\UserChoice
+            Hash    REG_SZ    abcd1234=
+            ProgId    REG_SZ    BOSS.md
+
+        HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.kt\UserChoice
+            ProgId    REG_SZ    IntelliJ.kt
+
+        """.trimIndent()
+
+    @Test
+    fun `the parser reads UserChoice ProgIds and nothing else`() {
+        val choices = WindowsRegistryScript.parseUserChoices(regOutput)
+        assertEquals("BOSS.md", choices["md"])
+        assertEquals("IntelliJ.kt", choices["kt"])
+        // The `Progid` under the extension key itself is NOT the user's choice -
+        // reading it would report an association the shell does not honour.
+        assertEquals(2, choices.size, "unexpected extra entries: $choices")
+    }
+
+    @Test
+    fun `tab-separated output parses too`() {
+        val tabbed =
+            "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.sh\\UserChoice\n" +
+                "\tProgId\tREG_SZ\tBOSS.sh\n"
+        assertEquals("BOSS.sh", WindowsRegistryScript.parseUserChoices(tabbed)["sh"])
+    }
+
+    @Test
+    fun `empty and unparseable output yields nothing rather than throwing`() {
+        assertTrue(WindowsRegistryScript.parseUserChoices("").isEmpty())
+        assertTrue(WindowsRegistryScript.parseUserChoices("ERROR: The system was unable to find").isEmpty())
+        assertTrue(WindowsRegistryScript.parseUserChoices("ProgId    REG_SZ    Orphan.md").isEmpty())
+    }
+
+    @Test
+    fun `the userChoice key names the extension with its dot`() {
+        assertTrue(WindowsRegistryScript.userChoiceKey("MD").endsWith("""FileExts\.md\UserChoice"""))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/UrlOpenValidationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/UrlOpenValidationTest.kt
@@ -1,0 +1,91 @@
+package ai.rever.boss.services
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [UrlOpenValidation], the gate on every URL the OS hands BOSS.
+ *
+ * The rule that made this worth extracting: the previous inline version required
+ * the host to contain a `.`, so `http://localhost:3000` was refused with a log
+ * line and no tab. For an app whose users are developers, that is the link they
+ * click most.
+ */
+class UrlOpenValidationTest {
+    private fun accepts(url: String) = assertTrue(UrlOpenValidation.isOpenable(url), "should accept $url")
+
+    private fun refuses(url: String) = assertFalse(UrlOpenValidation.isOpenable(url), "should refuse $url")
+
+    @Test
+    fun `accepts a dev server on localhost`() {
+        accepts("http://localhost:3000")
+        accepts("http://localhost")
+        accepts("http://localhost:8080/api/health?x=1")
+        accepts("https://localhost:3000")
+    }
+
+    @Test
+    fun `accepts single-label and unusual but real hosts`() {
+        // An intranet name, a Docker Compose service name (underscores and all),
+        // and a machine name with no domain. java.net.URI rejects the underscore
+        // one, which is why the parser is hand-rolled.
+        accepts("http://wiki/start")
+        accepts("http://api_gateway:8080/")
+        accepts("http://build-server-07/job/1")
+    }
+
+    @Test
+    fun `accepts IP literals including bracketed IPv6`() {
+        accepts("http://127.0.0.1:5000")
+        accepts("http://[::1]:8080/x")
+        accepts("http://[fe80::1]")
+        accepts("https://[2001:db8::8a2e:370:7334]:443/path")
+    }
+
+    @Test
+    fun `accepts ordinary web URLs`() {
+        accepts("https://example.com")
+        accepts("https://www.example.com/a/b?c=d#e")
+        accepts("HTTPS://Example.COM/")
+    }
+
+    @Test
+    fun `refuses every scheme but http and https`() {
+        refuses("file:///etc/passwd")
+        refuses("javascript:alert(1)")
+        refuses("data:text/html,<script>alert(1)</script>")
+        refuses("boss://terminal?command=rm")
+        refuses("ftp://example.com")
+        refuses("example.com")
+        refuses("")
+    }
+
+    @Test
+    fun `refuses a missing or malformed authority`() {
+        refuses("http://")
+        refuses("http:///path")
+        refuses("http://:8080/")
+        refuses("http://[::1")
+        refuses("http://host:notaport/")
+    }
+
+    @Test
+    fun `refuses credentials in the authority`() {
+        // The classic disguised destination: this points at evil.example, not
+        // apple.com. Nothing BOSS does needs embedded credentials, so they are
+        // refused rather than stripped.
+        refuses("https://apple.com@evil.example/")
+        refuses("http://user:pass@example.com/")
+    }
+
+    @Test
+    fun `refuses whitespace and control characters in the authority`() {
+        refuses("http://exa mple.com")
+        refuses("http://example\ncom")
+        refuses("http://exa\u00A0mple.com")
+        refuses("http://exa\u0000mple.com")
+        refuses("http://exa<mple>.com")
+        refuses("http://exa\"mple.com")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DefaultHandlerStateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DefaultHandlerStateTest.kt
@@ -66,7 +66,7 @@ class DefaultHandlerStateTest {
 
     @Test
     fun `the worst answer wins when types in a category disagree`() {
-        val reduce = MacOSDefaultBrowserHandler::reduce
+        val reduce = DefaultHandlerState::reduce
 
         assertEquals(
             DefaultHandlerState.Ours,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DefaultHandlerStateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/DefaultHandlerStateTest.kt
@@ -1,0 +1,94 @@
+package ai.rever.boss.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [DefaultHandlerState], the three-way answer that replaced a boolean.
+ *
+ * The [DefaultHandlerState.OurEngine] case is the one this type exists for. On
+ * every machine that installed BOSS before `build-chromium-branding.yml` learned
+ * to strip them, `~/.boss/boss-chromium/BOSS.app` declares http, https and
+ * `public.html` and is also called "BOSS" - so System Settings offered two
+ * indistinguishable entries and the default browser is very likely the engine.
+ * The old boolean answered "not the default", which told a user who had set it
+ * that they had not.
+ */
+class DefaultHandlerStateTest {
+    @Test
+    fun `the app itself is ours`() {
+        assertEquals(DefaultHandlerState.Ours, DefaultHandlerState.of("ai.rever.boss"))
+        assertTrue(DefaultHandlerState.of("ai.rever.boss").isOurs)
+    }
+
+    @Test
+    fun `the chromium engine bundle is recognised as ours but not as us`() {
+        val state = DefaultHandlerState.of("ai.rever.boss.browser")
+        assertEquals(DefaultHandlerState.OurEngine, state)
+        // Crucially NOT ours: the whole point is that this state needs a repair,
+        // and reporting it as ours would leave the user with links that open a
+        // bare Chromium and a Settings screen saying everything is fine.
+        assertFalse(state.isOurs)
+    }
+
+    @Test
+    fun `another application is other, and names itself`() {
+        val state = DefaultHandlerState.of("com.apple.Safari")
+        assertEquals(DefaultHandlerState.Other("com.apple.Safari"), state)
+        assertFalse(state.isOurs)
+    }
+
+    @Test
+    fun `nothing registered is other with no name`() {
+        assertEquals(DefaultHandlerState.Other(null), DefaultHandlerState.of(null))
+    }
+
+    @Test
+    fun `bundle ids are compared case-insensitively`() {
+        // Launch Services returns the spelling from the app's own Info.plist,
+        // which need not match the constant's case. A case-sensitive comparison
+        // would report BOSS as some other app.
+        assertEquals(DefaultHandlerState.Ours, DefaultHandlerState.of("AI.Rever.Boss"))
+        assertEquals(DefaultHandlerState.OurEngine, DefaultHandlerState.of("AI.REVER.BOSS.BROWSER"))
+    }
+
+    @Test
+    fun `the engine id is not confused with the app id by prefix`() {
+        // `ai.rever.boss.browser` starts with `ai.rever.boss`. A `startsWith`
+        // comparison anywhere in this chain would call the engine "ours" and
+        // silently remove the repair.
+        assertEquals(DefaultHandlerState.OurEngine, DefaultHandlerState.of("ai.rever.boss.browser"))
+        val sibling = "ai.rever.boss.something"
+        assertEquals(DefaultHandlerState.Other(sibling), DefaultHandlerState.of(sibling))
+    }
+
+    @Test
+    fun `the worst answer wins when types in a category disagree`() {
+        val reduce = MacOSDefaultBrowserHandler::reduce
+
+        assertEquals(
+            DefaultHandlerState.Ours,
+            reduce(listOf(DefaultHandlerState.Ours, DefaultHandlerState.Ours)),
+        )
+        // OurEngine outranks Other, because it is the answer with a one-click
+        // fix and stays true whether one type or all of them are affected.
+        assertEquals(
+            DefaultHandlerState.OurEngine,
+            reduce(
+                listOf(
+                    DefaultHandlerState.Ours,
+                    DefaultHandlerState.Other("com.apple.Safari"),
+                    DefaultHandlerState.OurEngine,
+                ),
+            ),
+        )
+        assertEquals(
+            DefaultHandlerState.Other("com.apple.Safari"),
+            reduce(listOf(DefaultHandlerState.Ours, DefaultHandlerState.Other("com.apple.Safari"))),
+        )
+        // Nothing to reduce is not "everything is fine".
+        assertEquals(DefaultHandlerState.Other(null), reduce(emptyList()))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/OsOpenArgumentsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/OsOpenArgumentsTest.kt
@@ -17,14 +17,20 @@ import kotlin.test.assertTrue
  * be extracted, or the file opens twice.
  */
 class OsOpenArgumentsTest {
-    /** Pretend every path ending `.md` or `.kt` exists, nothing else does. */
-    private val exists: (String) -> Boolean = { it.endsWith(".md") || it.endsWith(".kt") }
+    /** Every path ending `.md` or `.kt` is a file, `/proj` is a directory, nothing else exists. */
+    private val kindOf: (String) -> OsOpenArguments.OpenTargetKind = { path ->
+        when {
+            path.endsWith(".md") || path.endsWith(".kt") -> OsOpenArguments.OpenTargetKind.FILE
+            path.trimEnd('/').endsWith("/proj") -> OsOpenArguments.OpenTargetKind.DIRECTORY
+            else -> OsOpenArguments.OpenTargetKind.ABSENT
+        }
+    }
 
-    private fun links(vararg args: String) = OsOpenArguments.deepLinksFrom(arrayOf(*args), exists)
+    private fun links(vararg args: String) = OsOpenArguments.deepLinksFrom(arrayOf(*args), kindOf)
 
     @Test
     fun `no args means nothing to open`() {
-        assertTrue(OsOpenArguments.deepLinksFrom(emptyArray(), exists).isEmpty())
+        assertTrue(OsOpenArguments.deepLinksFrom(emptyArray(), kindOf).isEmpty())
     }
 
     @Test
@@ -107,8 +113,14 @@ class OsOpenArgumentsTest {
 
     @Test
     fun `a percent-escaped file URL is decoded`() {
-        val existsSpaced: (String) -> Boolean = { it == "/tmp/my notes.md" }
-        val result = OsOpenArguments.deepLinksFrom(arrayOf("file:///tmp/my%20notes.md"), existsSpaced)
+        val spaced: (String) -> OsOpenArguments.OpenTargetKind = { path ->
+            if (path == "/tmp/my notes.md") {
+                OsOpenArguments.OpenTargetKind.FILE
+            } else {
+                OsOpenArguments.OpenTargetKind.ABSENT
+            }
+        }
+        val result = OsOpenArguments.deepLinksFrom(arrayOf("file:///tmp/my%20notes.md"), spaced)
         assertEquals(1, result.size)
         // Re-encoded for the deep link, so the space survives the round trip
         // rather than truncating the path.
@@ -128,7 +140,43 @@ class OsOpenArgumentsTest {
     fun `a file URL naming another host is refused`() {
         // A path on another machine. Dropping the host and opening the local path
         // of the same name would open the wrong file.
-        assertTrue(OsOpenArguments.deepLinksFrom(arrayOf("file://fileserver/tmp/notes.md")) { true }.isEmpty())
+        assertTrue(
+            OsOpenArguments
+                .deepLinksFrom(arrayOf("file://fileserver/tmp/notes.md")) { OsOpenArguments.OpenTargetKind.FILE }
+                .isEmpty(),
+        )
+    }
+
+    @Test
+    fun `a directory becomes a folder link`() {
+        // `boss://folder` and `boss folder` both exist, so dropping a project
+        // folder on the app should do something. The file-only predicate made it
+        // silently do nothing.
+        val result = links("/home/me/proj")
+        assertEquals(1, result.size)
+        assertTrue(result.single().startsWith("boss://folder?path="), result.single())
+        assertTrue(result.single().contains("proj"))
+    }
+
+    @Test
+    fun `a folder URL from a file manager becomes a folder link`() {
+        assertTrue(links("file:///home/me/proj").single().startsWith("boss://folder?path="))
+    }
+
+    @Test
+    fun `a subcommand name only counts as the first non-flag argument`() {
+        // `args.any { it in CLI_SUBCOMMANDS }` matched at ANY position, so an OS
+        // open request whose path happened to be exactly one of these names was
+        // dropped as a CLI call. The KDoc always said "first non-flag argument".
+        assertTrue(links("file", "/tmp/a.md").isEmpty(), "a real CLI call is still left to Clikt")
+        assertTrue(links("--verbose", "url", "https://example.com").isEmpty())
+
+        // ...but a path argument that merely equals a subcommand name is not one.
+        val kindWithOddName: (String) -> OsOpenArguments.OpenTargetKind = { path ->
+            if (path == "terminal") OsOpenArguments.OpenTargetKind.FILE else OsOpenArguments.OpenTargetKind.ABSENT
+        }
+        val result = OsOpenArguments.deepLinksFrom(arrayOf("/tmp/a.md", "terminal"), kindWithOddName)
+        assertEquals(1, result.size, "the second arg names a real file and should open: $result")
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/OsOpenArgumentsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/OsOpenArgumentsTest.kt
@@ -1,0 +1,165 @@
+package ai.rever.boss.utils
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [OsOpenArguments], which decides whether the `argv` BOSS launched
+ * with is the operator's CLI or the OS asking it to open something.
+ *
+ * The bug behind it: `main.kt` only recognised args starting `boss://`,
+ * `http://` or `https://`, so a file path (how Windows and Linux deliver a
+ * double-clicked file) reached one of two dead ends and nothing opened. The
+ * important rule here is the *other* direction - `boss file /tmp/x.md` must NOT
+ * be extracted, or the file opens twice.
+ */
+class OsOpenArgumentsTest {
+    /** Pretend every path ending `.md` or `.kt` exists, nothing else does. */
+    private val exists: (String) -> Boolean = { it.endsWith(".md") || it.endsWith(".kt") }
+
+    private fun links(vararg args: String) = OsOpenArguments.deepLinksFrom(arrayOf(*args), exists)
+
+    @Test
+    fun `no args means nothing to open`() {
+        assertTrue(OsOpenArguments.deepLinksFrom(emptyArray(), exists).isEmpty())
+    }
+
+    @Test
+    fun `url scheme args pass through untouched`() {
+        assertEquals(listOf("https://example.com/a"), links("https://example.com/a"))
+        assertEquals(listOf("http://localhost:3000"), links("http://localhost:3000"))
+        assertEquals(listOf("boss://terminal"), links("boss://terminal"))
+    }
+
+    @Test
+    fun `an existing file becomes a boss file link`() {
+        val result = links("/tmp/notes.md")
+        assertEquals(1, result.size)
+        assertTrue(result.single().startsWith("boss://file?path="), result.single())
+        assertTrue(result.single().contains("notes.md"))
+    }
+
+    @Test
+    fun `a path is absolutised, so a relative argument still resolves`() {
+        // A shell can hand over `notes.md` with the working directory implied,
+        // and the deep link is consumed elsewhere with no memory of that cwd.
+        val link = links("notes.md").single()
+        val path = link.substringAfter("boss://file?path=")
+        assertTrue(path.startsWith("%2F") || path.startsWith("/"), "expected an absolute path, got $path")
+    }
+
+    @Test
+    fun `a path that does not exist is not an open request`() {
+        // Far more likely a mistyped flag or an argument this function does not
+        // know about than a file worth opening.
+        assertTrue(links("/tmp/gone.txt").isEmpty())
+        assertTrue(links("something").isEmpty())
+    }
+
+    @Test
+    fun `flags are never paths`() {
+        assertTrue(links("--unregister-protocol").isEmpty())
+        assertTrue(links("-n").isEmpty())
+        // Checked before the filesystem: a file called "-h.md" in the working
+        // directory must not turn a flag into an open request.
+        assertTrue(links("-h.md").isEmpty())
+    }
+
+    @Test
+    fun `a CLI invocation is left entirely to Clikt`() {
+        // The whole point: extracting here as well would open the file twice,
+        // once from the deep link and once from BossFileCommand.
+        assertTrue(links("file", "/tmp/notes.md").isEmpty())
+        assertTrue(links("url", "https://example.com").isEmpty())
+        assertTrue(links("terminal", "-c", "ls").isEmpty())
+        assertTrue(links("folder", "/tmp").isEmpty())
+        assertTrue(links("workspace", "/tmp/notes.md").isEmpty())
+        // A subcommand behind a flag is still the CLI.
+        assertTrue(links("--verbose", "file", "/tmp/notes.md").isEmpty())
+    }
+
+    @Test
+    fun `a multi-file selection produces one link each`() {
+        val result = links("/tmp/a.md", "/tmp/b.kt")
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.startsWith("boss://file?path=") })
+    }
+
+    @Test
+    fun `mixed links and files all come through`() {
+        val result = links("https://example.com", "/tmp/a.md", "/tmp/gone.txt")
+        assertEquals(2, result.size)
+        assertEquals("https://example.com", result.first())
+    }
+
+    @Test
+    fun `a file URL from a Linux file manager becomes a file link`() {
+        // `Exec=%U` in the desktop entry is what lets BOSS accept links AND
+        // files, and file managers hand `%U` a file:// URL rather than a path.
+        val result = links("file:///tmp/notes.md")
+        assertEquals(1, result.size)
+        assertTrue(result.single().startsWith("boss://file?path="))
+        assertTrue(result.single().contains("notes.md"))
+    }
+
+    @Test
+    fun `a percent-escaped file URL is decoded`() {
+        val existsSpaced: (String) -> Boolean = { it == "/tmp/my notes.md" }
+        val result = OsOpenArguments.deepLinksFrom(arrayOf("file:///tmp/my%20notes.md"), existsSpaced)
+        assertEquals(1, result.size)
+        // Re-encoded for the deep link, so the space survives the round trip
+        // rather than truncating the path.
+        assertTrue(result.single().contains("my+notes.md") || result.single().contains("my%20notes.md"))
+    }
+
+    @Test
+    fun `a localhost file URL is treated as local`() {
+        // File(URI) rejects any authority component, so this used to fall into
+        // the exception path and the file silently did not open.
+        val result = links("file://localhost/tmp/notes.md")
+        assertEquals(1, result.size)
+        assertTrue(result.single().startsWith("boss://file?path="))
+    }
+
+    @Test
+    fun `a file URL naming another host is refused`() {
+        // A path on another machine. Dropping the host and opening the local path
+        // of the same name would open the wrong file.
+        assertTrue(OsOpenArguments.deepLinksFrom(arrayOf("file://fileserver/tmp/notes.md")) { true }.isEmpty())
+    }
+
+    @Test
+    fun `the CLI subcommand list matches the CLI`() {
+        // The failure mode when these drift is a double-open, which is easy to
+        // miss and hard to attribute - so it is pinned against the source that
+        // registers them.
+        val root =
+            assertNotNull(
+                generateSequence(File("").absoluteFile) { it.parentFile }
+                    .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+                "could not locate the repository root",
+            )
+        val source = File(root, "composeApp/src/desktopMain/kotlin/ai/rever/boss/cli/BossCommand.kt")
+        assertTrue(source.isFile, "BossCommand.kt not found at ${source.absolutePath}")
+
+        // The negative lookbehind excludes the root command, which is declared
+        // as `NoOpCliktCommand(name = "boss")` and whose text contains
+        // `CliktCommand(name = "boss")` as a substring. Without it the test
+        // demands a "boss" subcommand that does not exist.
+        val registered =
+            Regex("""(?<!NoOp)CliktCommand\(name\s*=\s*"([a-z-]+)"\)""")
+                .findAll(source.readText())
+                .map { it.groupValues[1] }
+                .toSet()
+        assertTrue(registered.isNotEmpty(), "no subcommand names parsed out of BossCommand.kt")
+        assertEquals(
+            registered.sorted(),
+            OsOpenArguments.CLI_SUBCOMMANDS.sorted(),
+            "OsOpenArguments.CLI_SUBCOMMANDS must list every subcommand createBossCLI registers, " +
+                "or an argument to that subcommand is opened twice",
+        )
+    }
+}

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -156,33 +156,57 @@ CoroutineScope(Dispatchers.IO).launch {
 - All platforms use same version from single source
 - Use `./gradlew showVersion` to see current version
 
-## Default Browser Support
+## Default Applications
 
-**Overview**: BOSS can be set as the default system browser to handle http:// and https:// URLs.
+**Overview**: BOSS can be made the default handler for http/https links and for
+the file types it opens: markdown, shell scripts, web pages and every language its
+editor can highlight.
 
 **Key Files**:
-- `DefaultBrowserManager.kt` (common/desktop) - Cross-platform interface
-- `MacOSDefaultBrowserHandler.kt` - macOS implementation
-- `WindowsDefaultBrowserHandler.kt` - Windows implementation
-- `LinuxDefaultBrowserHandler.kt` - Linux implementation
-- `URLHandlerService.kt` - Handles incoming http/https URLs
-- `DefaultBrowserSection.kt` - Settings UI
+- `boss-file-types.json` (`composeApp/src/desktopMain/resources`) - the single
+  source of truth: five categories, 83 extensions, the macOS UTIs each claims and
+  the Linux MIME types each maps to
+- `buildSrc/BossFileTypes.kt` - generates the `Info.plist` declarations from it
+- `FileTypeCategories.kt` - the runtime reader
+- `DefaultAppsManager.kt` - reads and sets defaults per category
+- `MacOSFileTypeHandler.kt` / `WindowsFileTypeHandler.kt` / `LinuxFileTypeHandler.kt`
+- `utils/mac/LaunchServices.kt` - the JNA binding to Launch Services
+- `DefaultHandlerState.kt` - `Ours` / `OurEngine` / `Other`
+- `DefaultAppsSettings.kt` - Settings > Default Apps
+- `DefaultAppsOffer.desktop.kt` - the one-time first-run offer
+- `DefaultBrowserManager.kt` + `DefaultBrowserSection.kt` - the browser-only
+  facade, still used by Settings > Browser
 
 **Platform Behavior**:
-- macOS: Automatic registration via Info.plist, Swift scripts
-- Windows: Registry keys, user must manually select in Settings
-- Linux: .desktop file with xdg-settings/xdg-mime
+- macOS: `LSSetDefaultRoleHandlerForContentType` / `LSSetDefaultHandlerForURLScheme`
+  through JNA, against types the bundle declares in `CFBundleDocumentTypes` and
+  `UTExportedTypeDeclarations`
+- Windows: per-extension ProgIDs under `HKCU\Software\Classes` plus
+  `Capabilities\FileAssociations`; the default itself can only be chosen by the
+  user in `ms-settings:defaultapps`, which BOSS opens
+- Linux: a `boss.desktop` entry declaring every MIME type, then `xdg-mime default`
+  per type
 
-**URL Handling Flow**:
-1. OS passes URL to BOSS via protocol handler
-2. `DeepLinkHandler` checks protocol
-3. If http/https: forwards to `URLHandlerService`
-4. If boss://: processes as authentication deep link
-5. Creates new browser tab in active window
+**Open Handling Flow**: every door the OS can use is normalised to a `boss://`
+link. See "Every OS open request becomes a `boss://` link" in `AGENTS.md` for the
+four doors and the four bugs that section records.
+
+1. OS passes a URL or a file to BOSS (AppleEvent on macOS, `argv` elsewhere)
+2. `DeepLinkHandler` / `OsOpenArguments` turn it into `boss://url` or `boss://file`
+3. `URLHandlerService` or `CLICommandHandler` validates and resolves a window
+4. `URLEventBus` / `FileEventBus` reach the window, which opens the tab
+5. If the plugin that renders that tab type is missing, `TabTypeAvailability`
+   offers to install or enable it rather than dropping the tab
 
 Anything arriving this way is tagged `DeepLinkOrigin.EXTERNAL`, since the OS
 accepts a URL from any program; only links BOSS's own CLI parsed out of `argv`
 are tagged `OPERATOR_CLI`. See the Deep Links section of `AGENTS.md`.
+
+**The collision worth knowing about**: the branded Chromium engine in
+`~/.boss/boss-chromium/BOSS.app` used to declare http, https and `public.html`
+itself, under the id `ai.rever.boss.browser` and the name "BOSS". Any install
+predating that fix is likely to have the engine as its default browser, which is
+why the status is three-way and the button says Repair. See AGENTS.md.
 
 ## Runner Terminal System
 


### PR DESCRIPTION
## The bug

The default http/https handler on a machine with BOSS installed was **`ai.rever.boss.browser`** - the branded Chromium engine in `~/.boss/boss-chromium/BOSS.app`, not the app (`ai.rever.boss`).

Being Chromium, that bundle inherited `CFBundleURLTypes` (http, https) and `CFBundleDocumentTypes` (`public.html`). Being branded, its `CFBundleName` is also **"BOSS"**. So macOS System Settings offered two indistinguishable "BOSS" entries under "Default web browser", the wrong one won, and every link launched a rendering engine with no window, no tabs and no session. Measured on a real machine before the fix:

```
scheme http     -> ai.rever.boss.browser
scheme https    -> ai.rever.boss.browser
uti public.html -> ai.rever.boss.browser
```

Meanwhile `MacOSDefaultBrowserHandler.isDefaultBrowser()` compared against `ai.rever.boss` and answered false, so the Settings card told a user who *had* set it that they had not.

Two more silent failures sat on top:

- Nothing ever called `Desktop.setOpenFileHandler`. BOSS declared `CFBundleDocumentTypes`, appeared in Finder's Open With menu, launched when a file was double-clicked, and then did nothing with the file.
- `addTab` logged `Dropped tab - no factory registered for its type`, returned -1, and every caller ignored it. With the browser plugin absent the OS could hand BOSS a link and nothing at all appeared.

## Links

- `build-chromium-branding.yml` deletes both plist keys from the engine's `Info.plist` **before** the re-sign (after it, the edit breaks the seal) and fails the job if either key survives. Both macOS jobs.
- `DefaultHandlerState` is three-way: `Ours` / `OurEngine` / `Other`. An install already in the broken state is told a BOSS *component* holds the type and offered **Repair**, which is a very different thing to say than "BOSS is not your default browser".
- Launch Services is reached through JNA (`utils/mac/LaunchServices.kt`), replacing a `swift <tempfile>` shell-out per call that needed Xcode installed and so could not work on most machines. The Swift scripts remain as a fallback for URL schemes only.
- `URLHandlerService.isValidURL` no longer requires a dot in the host, so `http://localhost:3000` opens instead of being dropped with a log line.

## Every OS open request becomes a `boss://` link

Four doors, one funnel, so path validation, the window resolve and the cold-start counters are not re-implemented per door:

| Door | Platform |
|---|---|
| open-URI AppleEvent | macOS |
| open-file AppleEvent | macOS |
| a path or URL in `argv` | Windows, Linux |
| a single-instance forward | all |

- `processCommandLineArgs` is no longer gated on Windows. Linux delivers a protocol URL in `argv` too (`Exec=%U`) and the JDK's X11 peer supports no `APP_OPEN_URI`, so a Linux user with BOSS as their default browser had **every cold-start link silently dropped**.
- `OsOpenArguments` returns nothing when any argument names a `createBossCLI` subcommand, or `boss file x.md` would be opened twice. `OsOpenArgumentsTest` pins the subcommand list against `BossCommand.kt`.
- It also decodes `file://` URLs, including `file://localhost/...`, which `File(URI)` rejects outright.
- `CLISecurityValidator.isValidOpenTargetPath` is new, for a file about to be **read** rather than typed into a shell. `isValidPath` rejects `..`, `$`, `&`, `;`, `|` and a backtick, so `Q&A notes.md` could not be opened at all.

## File types

`boss-file-types.json` is the single source of truth: five categories over the 83 extensions `EditorLanguages` can highlight. `buildSrc/BossFileTypes` generates the plist declarations, `FileTypeCategories` serves the runtime, and the Windows and Linux handlers derive ProgIDs and MIME associations from it. `FileTypeCategoriesTest` asserts its extension set and its extension-to-language map equal `EditorLanguages.EXTENSIONS`.

Launch Services can only make an app the default for a **type**, never an extension. 31 extensions resolve to a system UTI, which BOSS claims as-is; the other 41 have only a `dyn.*` placeholder, which cannot be set as a default, so BOSS exports its own type for them, grouped by language.

The per-extension answers are **measured, not derived**, and three of them are why:

| Extension | Resolves to | Claimed? |
|---|---|---|
| `.ts` | `public.mpeg-2-transport-stream` (a video container) | no |
| `.as` | `com.apple.applesingle-archive` (a binary archive) | no |
| `.edn` | `com.adobe.edn` (an Adobe project format) | no |

Claiming any would make BOSS the default application for a format it cannot open. They are recorded as `rejectedSystemType` and get an exported type instead.

Also: a new **Settings > Default Apps** section, and a one-time first-run offer that claims nothing without a click and never asks twice (`promptShown` persists when the dialog *appears*, so a force quit still counts as asked).

## Missing plugins

`SplitViewState.requireTabTypeThen` gates every open on `TabTypeAvailability.require`, which returns immediately when the type is registered, otherwise **waits** through `awaitRegistryCondition` (at a cold start the plugins have not registered yet, so prompting there would be a false alarm on every launch), and only then raises a prompt. It offers **Enable**, not Install, when the plugin is on disk and `DISABLED` - both halves share `PluginDependencyResolution.installedAndOnDisk` so they cannot disagree about "installed".

The dialog has no success callback: installing or enabling registers the tab type, which fires the registry listeners, which completes the wait and performs the deferred open. The file the user double-clicked appears by itself.

## Verification

- 63 new tests. 3076 desktop tests green, 37 `buildSrc` tests green, detekt and ktlint clean.
- Built a real unsigned app image and inspected the generated plist: `plutil -lint` OK, 28 document types, 24 exported UTIs over 41 extensions, 56 unique content types, **zero** `dyn.*` types, and none of the three rejected types.
- The JNA write path returns `noErr`, checked with a no-op (`boss` scheme to `ai.rever.boss`, already its value).
- Repaired a live machine out of band and confirmed `open https://example.com` produces a real BOSS browser tab.

## Rollout note

The engine plist fix reaches users only when a new `boss-chromium` engine is built and published; until then existing installs rely on the Repair path. And the markdown / shell-script / source-code categories can only be claimed once **this** build is installed, since Launch Services ignores a request naming an app that does not declare the type.
