### PR TITLE
Authenticate the bundled-plugin release lookups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,19 @@ env:
   SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   SUPABASE_FUNCTION_URL: ${{ secrets.SUPABASE_FUNCTION_URL }}
+  # `downloadBundledPlugins` asks api.github.com for the latest release of five
+  # bundled plugin repos. Unauthenticated that is 60 requests per hour PER IP,
+  # and GitHub-hosted runners share egress IPs - so the call 403s, the response
+  # carries no assets, and the task reports "No JAR asset found in release" for
+  # all five. That failed run 33058141756 twice, twelve minutes apart, while the
+  # identical unauthenticated request succeeded from a laptop: the releases were
+  # fine, the quota was not.
+  #
+  # Declared at WORKFLOW level, not on the build steps: six steps across five
+  # jobs run gradle, and adding it per step is how one gets missed. Authenticated
+  # requests get 5,000/hour, and the default GITHUB_TOKEN is enough because all
+  # five plugin repos are public - it needs no extra scope.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # boss-plugin-api-core resolves from GitHub Packages during every gradle
   # invocation; step-level GITHUB_TOKEN assignments still override this.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -363,6 +363,22 @@ val downloadBundledPlugins =
         // hand does not.
         val ciProvider = providers.environmentVariable("CI")
 
+        // A GitHub token, if the environment has one. Unauthenticated
+        // api.github.com is 60 requests per hour PER IP and GitHub-hosted
+        // runners share egress IPs, so five calls per build hit a 403 whose body
+        // carries no assets - which this task then reported as "No JAR asset
+        // found in release" for every plugin, twice in a row, while the same
+        // request succeeded from a laptop. Authenticated is 5,000/hour.
+        //
+        // A Provider for the same reason ciProvider is one: read at execution
+        // time and tracked by Gradle as an input. GH_TOKEN as well as
+        // GITHUB_TOKEN because that is what `gh` exports and a developer running
+        // this by hand is likely to have.
+        val githubTokenProvider =
+            providers
+                .environmentVariable("GITHUB_TOKEN")
+                .orElse(providers.environmentVariable("GH_TOKEN"))
+
         doLast {
             val bundledPluginsDir = destDir.get().asFile
             bundledPluginsDir.mkdirs()
@@ -388,14 +404,64 @@ val downloadBundledPlugins =
                 try {
                     logger.lifecycle("📦 Fetching latest release for $repo...")
 
-                    // Get latest release info from GitHub API using curl
+                    // Get latest release info from GitHub API using curl.
+                    //
+                    // The status code is appended on its own last line rather
+                    // than trusted from the exit code: `curl -s` without `-f`
+                    // exits 0 on a 403, so the old call could not tell a
+                    // rate-limit body from a release. Not `-f` alone either,
+                    // because the body of the error is what says WHICH failure
+                    // it was.
                     val apiUrl = "https://api.github.com/repos/$repo/releases/latest"
+                    val token = githubTokenProvider.orNull?.takeIf { it.isNotBlank() }
+                    val authHeader =
+                        if (token != null) listOf("-H", "Authorization: Bearer $token") else emptyList()
                     val curlProcess =
-                        ProcessBuilder("curl", "-s", "-H", "Accept: application/vnd.github.v3+json", apiUrl)
-                            .redirectErrorStream(true)
+                        ProcessBuilder(
+                            listOf("curl", "-s", "-w", "\n%{http_code}", "-H", "Accept: application/vnd.github.v3+json") +
+                                authHeader +
+                                listOf(apiUrl),
+                        ).redirectErrorStream(true)
                             .start()
-                    val responseText = curlProcess.inputStream.bufferedReader().readText()
+                    // Never log the command: it carries the token.
+                    val rawResponse = curlProcess.inputStream.bufferedReader().readText()
                     curlProcess.waitFor()
+
+                    val httpStatus = rawResponse.substringAfterLast('\n').trim()
+                    val responseText = rawResponse.substringBeforeLast('\n')
+
+                    if (httpStatus != "200") {
+                        // Say which failure it is. All three used to print "No
+                        // JAR asset found in release", which sent the last
+                        // investigation looking for a deleted Gradle task
+                        // instead of a quota.
+                        val apiMessage =
+                            Regex(""""message"\s*:\s*"([^"]{0,200})""").find(responseText)?.groupValues?.get(1)
+                        val hint =
+                            when {
+                                httpStatus in listOf("403", "429") && token == null -> {
+                                    "rate limited and no GITHUB_TOKEN was set (60 requests/hour per IP unauthenticated)"
+                                }
+
+                                httpStatus in listOf("403", "429") -> {
+                                    "rate limited even with a token"
+                                }
+
+                                httpStatus == "401" -> {
+                                    "the token was rejected"
+                                }
+
+                                httpStatus == "404" -> {
+                                    "no release, or the repository is unreachable"
+                                }
+
+                                else -> {
+                                    "unexpected status"
+                                }
+                            }
+                        logger.warn("⚠️  GitHub API returned $httpStatus for $repo - $hint${apiMessage?.let { ": $it" } ?: ""}")
+                        continue
+                    }
 
                     // Parse JSON to find the JAR asset
                     val tagNameMatch = Regex(""""tag_name"\s*:\s*"([^"]+)"""").find(responseText)
@@ -425,7 +491,9 @@ val downloadBundledPlugins =
                             .firstOrNull { !it.endsWith("-thin.jar") }
 
                     if (jarUrl == null) {
-                        logger.warn("⚠️  No JAR asset found in release for $repo")
+                        // Reached only on a 200, so this now means what it says:
+                        // the release really has no non-thin JAR for this prefix.
+                        logger.warn("⚠️  Release $tagName of $repo has no non-thin JAR asset for '$artifactPrefix'")
                         continue
                     }
 
@@ -470,10 +538,25 @@ val downloadBundledPlugins =
                     // Download the JAR using curl
                     logger.lifecycle("⬇️  Downloading $jarFileName...")
                     val downloadProcess =
-                        ProcessBuilder("curl", "-sL", "-o", destFile.absolutePath, jarUrl)
+                        ProcessBuilder("curl", "-fsSL", "-o", destFile.absolutePath, jarUrl)
                             .redirectErrorStream(true)
                             .start()
-                    downloadProcess.waitFor()
+                    val downloadOutput =
+                        downloadProcess.inputStream
+                            .bufferedReader()
+                            .readText()
+                            .trim()
+                    val downloadExit = downloadProcess.waitFor()
+
+                    // `-f` so curl fails on a non-2xx instead of writing the
+                    // error page into the file: without it a 404 left an HTML
+                    // body at a `.jar` name, which the completeness check below
+                    // then counted as present.
+                    if (downloadExit != 0) {
+                        logger.warn("⚠️  Could not download $jarFileName from $repo (curl exit $downloadExit) $downloadOutput")
+                        destFile.delete()
+                        continue
+                    }
 
                     logger.lifecycle("✅ Downloaded $jarFileName (version: $tagName, size: ${destFile.length()} bytes)")
                 } catch (e: Exception) {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/OsOpenArgumentsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/OsOpenArgumentsTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.utils
 
 import java.io.File
+import java.net.URLDecoder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -17,11 +18,22 @@ import kotlin.test.assertTrue
  * be extracted, or the file opens twice.
  */
 class OsOpenArgumentsTest {
-    /** Every path ending `.md` or `.kt` is a file, `/proj` is a directory, nothing else exists. */
-    private val kindOf: (String) -> OsOpenArguments.OpenTargetKind = { path ->
+    /**
+     * Every path ending `.md` or `.kt` is a file, one ending `proj` is a
+     * directory, nothing else exists.
+     *
+     * Separators are normalised before matching, and that is not cosmetic. For a
+     * bare path argument the predicate sees the raw string; for a `file://` URL it
+     * sees the path after `File(URI)` has normalised it, which on Windows means
+     * backslashes. A predicate written against `/proj` therefore matched the
+     * bare-path case and missed the URL case, and only on Windows - which is
+     * exactly how three of these tests passed locally and failed in CI.
+     */
+    private val kindOf: (String) -> OsOpenArguments.OpenTargetKind = { raw ->
+        val path = raw.replace('\\', '/').trimEnd('/')
         when {
             path.endsWith(".md") || path.endsWith(".kt") -> OsOpenArguments.OpenTargetKind.FILE
-            path.trimEnd('/').endsWith("/proj") -> OsOpenArguments.OpenTargetKind.DIRECTORY
+            path.endsWith("/proj") -> OsOpenArguments.OpenTargetKind.DIRECTORY
             else -> OsOpenArguments.OpenTargetKind.ABSENT
         }
     }
@@ -52,9 +64,14 @@ class OsOpenArgumentsTest {
     fun `a path is absolutised, so a relative argument still resolves`() {
         // A shell can hand over `notes.md` with the working directory implied,
         // and the deep link is consumed elsewhere with no memory of that cwd.
+        //
+        // Compared against File().absolutePath rather than asserting a leading
+        // slash: on Windows an absolute path starts `D:\`, which URL-encodes to
+        // `D%3A%5C` and satisfies neither `/` nor `%2F`.
         val link = links("notes.md").single()
-        val path = link.substringAfter("boss://file?path=")
-        assertTrue(path.startsWith("%2F") || path.startsWith("/"), "expected an absolute path, got $path")
+        val path = URLDecoder.decode(link.substringAfter("boss://file?path="), "UTF-8")
+        assertEquals(File("notes.md").absolutePath, path)
+        assertTrue(File(path).isAbsolute, "expected an absolute path, got $path")
     }
 
     @Test
@@ -113,8 +130,13 @@ class OsOpenArgumentsTest {
 
     @Test
     fun `a percent-escaped file URL is decoded`() {
+        // Matched on the decoded FILE NAME, not the whole path: `File(URI)`
+        // normalises `file:///tmp/...` differently per platform, so a literal
+        // POSIX path here never matched on Windows and the URL produced no link
+        // at all. The escape decoding is what this test is about, and the name
+        // carries it.
         val spaced: (String) -> OsOpenArguments.OpenTargetKind = { path ->
-            if (path == "/tmp/my notes.md") {
+            if (File(path).name == "my notes.md") {
                 OsOpenArguments.OpenTargetKind.FILE
             } else {
                 OsOpenArguments.OpenTargetKind.ABSENT
@@ -177,6 +199,26 @@ class OsOpenArgumentsTest {
         }
         val result = OsOpenArguments.deepLinksFrom(arrayOf("/tmp/a.md", "terminal"), kindWithOddName)
         assertEquals(1, result.size, "the second arg names a real file and should open: $result")
+    }
+
+    @Test
+    fun `a Windows-shaped path is recognised, on every platform`() {
+        // Pins the class of bug that made three of these tests fail only in CI:
+        // the predicate saw `D:\proj` for a file:// URL on Windows and matched
+        // against `/proj`. This runs everywhere, so a POSIX-only assumption fails
+        // on a laptop instead of on a Windows runner an hour later.
+        //
+        // Only the injected predicate is exercised, not the filesystem: a
+        // backslash path is not meaningful to File on Unix, so asserting on the
+        // resulting link would test the host OS rather than this code.
+        assertEquals(OsOpenArguments.OpenTargetKind.DIRECTORY, kindOf("""D:\home\me\proj"""))
+        assertEquals(OsOpenArguments.OpenTargetKind.DIRECTORY, kindOf("""D:\home\me\proj\"""))
+        assertEquals(OsOpenArguments.OpenTargetKind.FILE, kindOf("""D:\Users\me\notes.md"""))
+        assertEquals(OsOpenArguments.OpenTargetKind.ABSENT, kindOf("""D:\Users\me\notes.txt"""))
+
+        // And the POSIX shapes still resolve the same way.
+        assertEquals(OsOpenArguments.OpenTargetKind.DIRECTORY, kindOf("/home/me/proj"))
+        assertEquals(OsOpenArguments.OpenTargetKind.FILE, kindOf("/home/me/notes.md"))
     }
 
     @Test


### PR DESCRIPTION
## What broke

Release run [33058141756](https://github.com/risa-labs-inc/BossConsole/actions/runs/33058141756) failed `build-macos-arm64` at `:composeApp:downloadBundledPlugins`, **twice, twelve minutes apart**:

```
⚠️  No JAR asset found in release for risa-labs-inc/boss-plugin-api
⚠️  No JAR asset found in release for risa-labs-inc/boss-plugin-terminal
⚠️  No JAR asset found in release for risa-labs-inc/boss-plugin-fluck-browser
⚠️  No JAR asset found in release for risa-labs-inc/boss-plugin-plugin-manager
⚠️  No JAR asset found in release for risa-labs-inc/boss-plugin-bookmarks

> Bundled plugins missing after download: ... (present: none)
```

## The releases were fine; the quota was not

I ran the task's *exact* unauthenticated call and its *exact* asset regex against the live API from a laptop. All five resolve correctly, thin JAR properly skipped:

| repo | tag | chosen asset |
|---|---|---|
| boss-plugin-api | v1.0.86 | `boss-plugin-api-1.0.86.jar` |
| boss-plugin-terminal | v1.0.10 | `boss-plugin-terminal-1.0.10.jar` |
| boss-plugin-fluck-browser | v1.2.24 | `boss-plugin-fluck-browser-1.2.24.jar` (2 assets, `-thin` skipped) |
| boss-plugin-plugin-manager | v1.9.24 | `boss-plugin-plugin-manager-1.9.24.jar` |
| boss-plugin-bookmarks | v2.1.10 | `boss-plugin-bookmarks-2.1.10.jar` |

Same code, same request, works from one IP and fails from the runner's. Unauthenticated `api.github.com` is **60 requests/hour per IP** and GitHub-hosted runners share egress IPs. The 403 body carries no `assets`, so the regex matches nothing and the task reports it as a missing asset.

The completeness assertion at the end of that task was right to fail the build — its own comment predicts this case ("a release whose GitHub call 403s ... produces a log line and a green build ... So assert it here"). The bug is upstream of it.

## The fix

**Token at workflow level.** Six steps across five jobs run gradle; adding it per step is how one gets missed. The default `GITHUB_TOKEN` is enough — all five plugin repos are public, so it needs no extra scope — and authenticated gets 5,000/hour.

**Honest failure messages.** `curl -s` without `-f` exits 0 on a 403, so the status is now appended on its own line and checked. Four cases that all printed the same sentence are now distinct:

| status | message |
|---|---|
| 403/429, no token | `rate limited and no GITHUB_TOKEN was set (60 requests/hour per IP unauthenticated)` |
| 403/429, with token | `rate limited even with a token` |
| 401 | `the token was rejected` + the API's own message |
| 404 | `no release, or the repository is unreachable` |
| 200, no match | `Release <tag> of <repo> has no non-thin JAR asset for '<prefix>'` |

That wording matters: the old message sent an investigation looking for a Gradle task someone believed had been deleted for DMG-size reasons, rather than at a quota.

**`-f` on the asset download too.** Without it a non-2xx wrote the error page to the `.jar` path, and the completeness check then counted it as present.

The token is never logged — the command carrying it is not printed.

## Verified end to end against the live API

**With a valid token:**
```
✅ Downloaded boss-plugin-api-1.0.86.jar (1144531 bytes)
✅ Downloaded boss-plugin-terminal-1.0.10.jar (23285 bytes)
✅ Downloaded boss-plugin-fluck-browser-1.2.24.jar (4924725 bytes)
✅ Downloaded boss-plugin-plugin-manager-1.9.24.jar (1077729 bytes)
✅ Downloaded boss-plugin-bookmarks-2.1.10.jar (276231 bytes)
✅ All 5 bundled plugins present
BUILD SUCCESSFUL
```

**With a deliberately rejected token** (proving the message no longer lies):
```
⚠️  GitHub API returned 401 for risa-labs-inc/boss-plugin-api - the token was rejected: Bad credentials
   ... x5
> Bundled plugins missing after download: ... (present: none)
BUILD FAILED
```

ktlint and detekt clean. YAML parses.

## Release note

Re-running run 33058141756 cannot help — a re-run pins to the original SHA, which predates this fix. Once this merges, dispatch a **fresh** `release.yml`. `version.properties` on main is already at 9.5.1 from the failed run's bump, so a `patch` dispatch produces **9.5.2** and 9.5.1 is skipped; harmless, and it is never published (no tag, no release exists for it).
