### PR TITLE
Remove the duplicate GITHUB_TOKEN that broke release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,21 +84,17 @@ env:
   SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
   SUPABASE_FUNCTION_URL: ${{ secrets.SUPABASE_FUNCTION_URL }}
-  # `downloadBundledPlugins` asks api.github.com for the latest release of five
-  # bundled plugin repos. Unauthenticated that is 60 requests per hour PER IP,
-  # and GitHub-hosted runners share egress IPs - so the call 403s, the response
-  # carries no assets, and the task reports "No JAR asset found in release" for
-  # all five. That failed run 33058141756 twice, twelve minutes apart, while the
-  # identical unauthenticated request succeeded from a laptop: the releases were
-  # fine, the quota was not.
-  #
-  # Declared at WORKFLOW level, not on the build steps: six steps across five
-  # jobs run gradle, and adding it per step is how one gets missed. Authenticated
-  # requests get 5,000/hour, and the default GITHUB_TOKEN is enough because all
-  # five plugin repos are public - it needs no extra scope.
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # boss-plugin-api-core resolves from GitHub Packages during every gradle
   # invocation; step-level GITHUB_TOKEN assignments still override this.
+  #
+  # `downloadBundledPlugins` reads it too, for the api.github.com release lookups
+  # of the five bundled plugin repos: unauthenticated those are 60 requests per
+  # hour per IP and the macOS runner pool shares addresses, which 403'd and failed
+  # release run 33058141756 twice. It was already available here; the task simply
+  # never sent an Authorization header. Do NOT add a second GITHUB_TOKEN entry -
+  # a duplicate key in this mapping makes Actions refuse to start the workflow
+  # (startup_failure, zero jobs), and PyYAML will not catch it because it silently
+  # takes the last value.
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/WorkflowEnvKeysTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/config/WorkflowEnvKeysTest.kt
@@ -1,0 +1,162 @@
+package ai.rever.boss.config
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Asserts no workflow declares the same `env:` key twice.
+ *
+ * A duplicate key in a GitHub Actions mapping makes Actions refuse to start the
+ * workflow at all: `startup_failure`, zero jobs, and a run whose name is the file
+ * path because the `name:` field was never read. It took down release.yml on main
+ * and cost two dispatch attempts before anyone could see why.
+ *
+ * It reached main because **PyYAML accepts duplicate keys silently**, taking the
+ * last value - so `yaml.safe_load` on the file returned a valid document and the
+ * pre-merge check passed. Every YAML-parses check in this repo has that blind
+ * spot; this test is the one that does not.
+ *
+ * Scoped to `env:` blocks deliberately: that is where the failure happened, and
+ * where it will happen again, because an env block is a list of credentials that
+ * grows one line at a time and a newcomer cannot see the existing entries without
+ * reading past the comment blocks between them.
+ */
+class WorkflowEnvKeysTest {
+    private fun workflowsDir(): File {
+        val root =
+            assertNotNull(
+                generateSequence(File("").absoluteFile) { it.parentFile }
+                    .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+                "could not locate the repository root",
+            )
+        return File(root, ".github/workflows")
+    }
+
+    /**
+     * Keys declared in every `env:` block of [text], as (block start line, keys).
+     *
+     * Line-based rather than a YAML parse, for the reason above: the parsers
+     * available here are exactly the ones that do not see the problem. A block is
+     * the run of `  key: value` lines at one indentation directly under an `env:`
+     * line; comments and blank lines are skipped, and anything at a shallower
+     * indent or starting a list item ends the block.
+     */
+    private fun envBlocks(text: String): List<Pair<Int, List<String>>> {
+        val lines = text.split("\n")
+        val blocks = mutableListOf<Pair<Int, List<String>>>()
+
+        lines.forEachIndexed { index, line ->
+            val envIndent =
+                Regex("""^(\s*)env:\s*$""")
+                    .find(line)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.length ?: return@forEachIndexed
+            val keys = mutableListOf<String>()
+            var blockIndent: Int? = null
+
+            @Suppress("UNUSED_VARIABLE")
+            var cursor = index
+
+            // takeWhile then filter, rather than a loop with several jumps: the
+            // block ends at the first line that dedents or starts a list item,
+            // and everything after that is a per-line decision.
+            val body =
+                lines
+                    .drop(index + 1)
+                    .takeWhile { line ->
+                        val trimmed = line.trimStart()
+                        val indent = line.length - trimmed.length
+                        line.isBlank() ||
+                            trimmed.startsWith("#") ||
+                            (indent > envIndent && !trimmed.startsWith("- "))
+                    }.filterNot { it.isBlank() || it.trimStart().startsWith("#") }
+
+            body.forEach { current ->
+                val trimmed = current.trimStart()
+                val indent = current.length - trimmed.length
+                if (blockIndent == null) blockIndent = indent
+                if (indent == blockIndent) {
+                    Regex("""^([A-Za-z_][A-Za-z0-9_.-]*)\s*:""")
+                        .find(trimmed)
+                        ?.groupValues
+                        ?.get(1)
+                        ?.let(keys::add)
+                }
+            }
+            if (keys.isNotEmpty()) blocks.add(index + 1 to keys)
+        }
+        return blocks
+    }
+
+    @Test
+    fun `no workflow declares an env key twice`() {
+        val dir = workflowsDir()
+        assertTrue(dir.isDirectory, "no .github/workflows at ${dir.absolutePath}")
+        val workflows = dir.listFiles { f -> f.name.endsWith(".yml") || f.name.endsWith(".yaml") }.orEmpty()
+        assertTrue(workflows.isNotEmpty(), "no workflow files found")
+
+        val offences =
+            workflows.flatMap { file ->
+                envBlocks(file.readText()).flatMap { (line, keys) ->
+                    keys
+                        .groupingBy { it }
+                        .eachCount()
+                        .filterValues { it > 1 }
+                        .map { (key, count) -> "${file.name}:$line declares env key '$key' $count times" }
+                }
+            }
+
+        assertTrue(
+            offences.isEmpty(),
+            "A duplicate env key makes Actions refuse to start the workflow (startup_failure, zero jobs). " +
+                "PyYAML will not catch it - it takes the last value silently.\n" +
+                offences.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun `the detector actually catches a duplicate`() {
+        // Reverse-verified: without this, a detector that silently found nothing
+        // would pass forever and read as proof. The shape is the exact one that
+        // broke release.yml - two identical keys separated by a comment block.
+        val broken =
+            """
+            name: x
+            env:
+              GRADLE_OPTS: '-Dx'
+              GITHUB_TOKEN: ${'$'}{{ secrets.GITHUB_TOKEN }}
+              # a comment between them, which is how it went unnoticed
+              GITHUB_TOKEN: ${'$'}{{ secrets.GITHUB_TOKEN }}
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+            """.trimIndent()
+        val keys = envBlocks(broken).single().second
+        assertEquals(listOf("GRADLE_OPTS", "GITHUB_TOKEN", "GITHUB_TOKEN"), keys)
+        assertEquals(2, keys.count { it == "GITHUB_TOKEN" })
+    }
+
+    @Test
+    fun `a job-level env block is read separately from the workflow one`() {
+        // Two blocks, each with its own GITHUB_TOKEN, is legal: a step-level
+        // assignment overriding the workflow one is a documented pattern in
+        // release.yml. Only a repeat WITHIN one block is the error.
+        val legal =
+            """
+            env:
+              GITHUB_TOKEN: a
+            jobs:
+              build:
+                env:
+                  GITHUB_TOKEN: b
+                steps: []
+            """.trimIndent()
+        val blocks = envBlocks(legal)
+        assertEquals(2, blocks.size, "expected two separate env blocks, got $blocks")
+        blocks.forEach { (_, keys) -> assertEquals(keys.distinct(), keys) }
+    }
+}


### PR DESCRIPTION
## main cannot cut a release right now

#272 added a workflow-level `GITHUB_TOKEN` to `release.yml`. **One was already there**, eight lines below. A duplicate key in an Actions mapping makes Actions refuse to start the workflow:

| run | event | result |
|---|---|---|
| 33104769852 | workflow_dispatch | `startup_failure`, 0 jobs |
| 33104864099 | workflow_dispatch | `startup_failure`, 0 jobs |
| 33104535313 | push (merge) | `failure`, name shown as the file path |

The name showing as the path is the tell: Actions never got far enough to read `name:`.

## Two mistakes, mine

**The workflow half of #272 was never needed.** The existing entry's own comment says the token is there for every gradle invocation:

```yaml
  # boss-plugin-api-core resolves from GitHub Packages during every gradle
  # invocation; step-level GITHUB_TOKEN assignments still override this.
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

So `downloadBundledPlugins` had the token in its environment all along and simply never sent an `Authorization` header. The **task** change in #272 is the real and sufficient fix; the workflow change added nothing but the duplicate.

I concluded it was absent by grepping the build steps, then printing the top-level `env:` block through `head -8` — which cut off at exactly the line that had it. Truncated evidence read as absence.

**And it reached main because PyYAML accepts duplicate keys silently**, taking the last value:

```
>>> yaml.safe_load("env:\n  A: 1\n  A: 2\n")
{'env': {'A': 2}}       # no error
```

So the `yaml.safe_load` check I ran before pushing #272 passed. Every YAML-parses assertion in this repo has that same blind spot.

## The fix

Remove my duplicate, and extend the existing comment to name the second consumer and say not to add another entry.

Plus `WorkflowEnvKeysTest`: scans every workflow's `env:` blocks for a key declared twice **within one block**. Line-based rather than parsed, deliberately — the parsers available here are the ones that cannot see the problem.

- **Reverse-verified**: reintroducing the duplicate makes it fail. A detector that silently found nothing would otherwise pass forever and read as proof.
- Two *separate* blocks each declaring `GITHUB_TOKEN` stays legal, since a job- or step-level override is a documented pattern in this very file.

3114 desktop tests green, detekt and ktlint clean.

## After merging

`release.yml` starts again, and `downloadBundledPlugins` sends the header. Dispatch fresh:

```bash
gh workflow run release.yml --repo risa-labs-inc/BossConsole --ref main -f version_increment=patch
```

`version.properties` on main is 9.5.1, so that produces **9.5.2**.
