### PR TITLE
Offer "Set BOSS as Default App..." in the Help menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -783,6 +783,39 @@ the single definition of "BOSS only when every type in the category is BOSS, and
 `OurEngine` outranks `Other`". Each handler had its own copy; they agreed, which
 is the only reason nothing was broken, and a fourth copy would not have.
 
+**`Settings > Browser` reads that fold too, and used to hold a boolean instead.**
+`DefaultBrowserSection` is the older surface for the same two categories, and it
+flattened the answer to `Boolean?` - which cannot tell "Safari holds http" from
+"a BOSS component holds http". So on exactly the machines the three-way state
+exists for, it said "BOSS is not your default browser" while `Settings > Default
+Apps` reported `OurEngine` and offered a Repair: two screens, one machine,
+opposite stories, and the one a user reaches from `Settings > Browser` was the
+wrong one. It now renders all three states, offers **Repair** for `OurEngine`
+(the same claim call, relabelled, because setting and repairing are the same
+work), and **re-reads** the state after a successful set rather than assuming
+`Ours`. `browserHandlerState()` is not on the `expect` declaration:
+`DefaultHandlerState` is desktopMain and lifting it into commonMain to widen an
+interface with one implementation would be churn.
+
+**Windows counts schemes now, and could not before.** `web-links` is schemes with
+no extensions, and `WindowsFileTypeHandler` read only the per-extension
+`UserChoice` keys - so that row reported `Other` on every machine, including one
+where BOSS did hold http and https, and `register` returned early on "no
+extensions" without ever writing the `StartMenuInternet` entry that puts BOSS in
+the browser list its own settings page sends the user to. Both sides now consult
+`schemesFor`, through `WindowsDefaultBrowserHandler.schemeState` and
+`registerAsBrowserCandidate` rather than a second copy of those registry reads
+and writes. macOS always counted both. The `reg` calls cannot run on a mac or
+Linux runner, so what is pinned in a test is the data fact underneath
+(`FileTypeCategoriesTest`: `web-links` has schemes and no extensions, `web-pages`
+the reverse) - if that flips, the reason for reading both sides flips with it.
+
+`OurEngine` is unreachable on Windows and Linux, and that is a fact about those
+platforms rather than a gap: the second "BOSS" is a macOS `.app` that Launch
+Services indexes because it declares `CFBundleURLTypes`. Nothing registers the
+engine under `StartMenuInternet` or writes a desktop entry for it. The shared type
+is still used on all three so the card has one story to tell.
+
 **The engine bundle used to be a second app called "BOSS".**
 `~/.boss/boss-chromium/BOSS.app` is the branded JxBrowser engine, and being
 Chromium it inherited `CFBundleURLTypes` (http, https) and

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -404,7 +404,7 @@
     <ID>LongMethod:UserExistenceService.kt$UserExistenceService$suspend fun checkUserExists(email: String): Result&lt;UserExistence&gt;</ID>
     <ID>LongMethod:VersionSelectionDialog.kt$@Composable fun VersionSelectionDialog( currentVersion: Version, versions: List&lt;VersionInfo&gt;, isLoading: Boolean, error: String? = null, onVersionSelected: (VersionInfo) -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
     <ID>LongMethod:VersionSelectionDialog.kt$@Composable private fun VersionItem( versionInfo: VersionInfo, isCurrent: Boolean, isLatest: Boolean = false, onClick: () -&gt; Unit, )</ID>
-    <ID>LongMethod:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private fun registerAsBrowserCandidate(): Boolean</ID>
+    <ID>LongMethod:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$internal fun registerAsBrowserCandidate(): Boolean</ID>
     <ID>LongMethod:WizardComponents.kt$@Composable fun CheckboxCard( title: String, description: String, icon: ImageVector? = null, isChecked: Boolean, onCheckedChange: (Boolean) -&gt; Unit, enabled: Boolean = true, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:WizardComponents.kt$@Composable fun SelectionCard( title: String, description: String, icon: ImageVector? = null, isSelected: Boolean, onClick: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:WizardComponents.kt$@Composable fun WizardStepIndicator( currentStep: Int, totalSteps: Int, modifier: Modifier = Modifier, )</ID>
@@ -1160,7 +1160,7 @@
     <ID>ReturnCount:UrlOpenValidation.kt$UrlOpenValidation$fun isOpenable(url: String): Boolean</ID>
     <ID>ReturnCount:UrlOpenValidation.kt$UrlOpenValidation$private fun hostOf(authority: String): String?</ID>
     <ID>ReturnCount:WebsiteMatchingUtil.kt$WebsiteMatchingUtil$fun extractMainDomain(url: String): String?</ID>
-    <ID>ReturnCount:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$private fun registerAsBrowserCandidate(): Boolean</ID>
+    <ID>ReturnCount:WindowsDefaultBrowserHandler.kt$WindowsDefaultBrowserHandler$internal fun registerAsBrowserCandidate(): Boolean</ID>
     <ID>ReturnCount:WindowsFileTypeHandler.kt$WindowsFileTypeHandler$fun register(category: FileTypeCategory): Boolean</ID>
     <ID>ReturnCount:WindowsRegistryScript.kt$WindowsRegistryScript$private fun userChoiceExtensionOf(keyLine: String): String?</ID>
     <ID>ReturnCount:WorkspacePlaceholders.kt$WorkspacePlaceholders$private fun getGitRemoteUrl(projectPath: String): String</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/sidebar/SidebarSettingsMenuItems.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/sidebar/SidebarSettingsMenuItems.kt
@@ -16,8 +16,17 @@ import androidx.compose.runtime.remember
  * The section is passed by enum *name* ("SIDEBAR") because
  * `SettingsSection` lives in desktopMain and this helper is commonMain —
  * same convention as the "KEYMAP" literal used by the shortcut help
- * dialog. `SettingsWindow` falls back to its default section for names
- * it doesn't recognise, so a stale string degrades gracefully.
+ * dialog.
+ *
+ * A stale string does NOT degrade gracefully, so keep it in step with the
+ * enum. `resolveSettingsDeepLink` answers `Unresolved` for a name no
+ * section claims, and what that means depends on whether the window is
+ * already open: a *new* window defaults to FLUCK, but an *open* one is
+ * deliberately left exactly where the user had it. So the failure this
+ * literal invites is a menu entry that raises the settings window and
+ * does nothing else, with only a debug line to say why. Callers in
+ * desktopMain (`BossWindow`'s Help menu) name the enum instead and get a
+ * compile error; commonMain cannot.
  */
 @Composable
 fun rememberSidebarSettingsMenuItems(): List<ContextMenuItem> {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultBrowserSection.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/settings/sections/DefaultBrowserSection.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.components.settings.shared.SettingsSection
 import ai.rever.boss.plugin.ui.BossAlertDialog
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.utils.DefaultBrowserManager
+import ai.rever.boss.utils.DefaultHandlerState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -24,14 +25,30 @@ import kotlinx.coroutines.launch
  * Default Browser section for BOSS Console settings
  *
  * Allows users to:
- * - Check if BOSS is the default browser
- * - Set BOSS as the default browser
+ * - Check who currently handles http/https
+ * - Set BOSS as the default browser, or repair the case below
  * - View platform-specific instructions
+ *
+ * **It reads [DefaultHandlerState], not a boolean, for the same reason
+ * `Settings > Default Apps` does.** A machine that installed BOSS before the
+ * branded Chromium engine stopped declaring `CFBundleURLTypes` has a second app
+ * called "BOSS" holding http, https and `public.html`
+ * (`~/.boss/boss-chromium/BOSS.app`, id `ai.rever.boss.browser`), and links open
+ * a bare rendering engine with no window, no tabs and no session. Flattened to a
+ * boolean that is indistinguishable from Safari being the default, so this card
+ * said "BOSS is not your default browser" - the wrong story to tell somebody who
+ * did set it, and it sent them to a System Settings list with two identical BOSS
+ * entries where picking either looks the same.
+ *
+ * `Settings > Default Apps` has reported that case since it shipped. This card is
+ * the older surface for the same two categories and is the one a user reaches
+ * from `Settings > Browser`, so leaving it flattened meant the two screens
+ * contradicted each other about the same machine.
  */
 @Composable
 fun DefaultBrowserSection() {
     val platformName = DefaultBrowserManager.getPlatformName()
-    var isDefault by remember { mutableStateOf<Boolean?>(null) }
+    var state by remember { mutableStateOf<DefaultHandlerState?>(null) }
     var isLoading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var showSuccessDialog by remember { mutableStateOf(false) }
@@ -39,21 +56,28 @@ fun DefaultBrowserSection() {
 
     val coroutineScope = rememberCoroutineScope()
 
-    // Check status on mount
-    LaunchedEffect(Unit) {
+    // One read path for the mount, the Refresh button and the re-read after a
+    // successful set. It was three copies of the same fold, which is how the
+    // "assume success" line below got out of step with what the OS actually holds.
+    suspend fun refresh() {
         isLoading = true
         errorMessage = null
 
-        val result = DefaultBrowserManager.isDefaultBrowser()
+        val result = DefaultBrowserManager.browserHandlerState()
         isLoading = false
 
         result.fold(
-            onSuccess = { isDefault = it },
+            onSuccess = { state = it },
             onFailure = { error ->
                 errorMessage = error.message
-                isDefault = null
+                state = null
             },
         )
+    }
+
+    // Check status on mount
+    LaunchedEffect(Unit) {
+        refresh()
     }
 
     SettingsSection(
@@ -118,7 +142,25 @@ fun DefaultBrowserSection() {
                                 }
                             }
 
-                            isDefault == true -> {
+                            state is DefaultHandlerState.OurEngine -> {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(
+                                        Icons.Outlined.Warning,
+                                        contentDescription = "Needs repair",
+                                        tint = BossTheme.colors.alert,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = "A BOSS component holds this, so links open with no BOSS window",
+                                        color = BossTheme.colors.textPrimary,
+                                        fontSize = 14.sp,
+                                        fontWeight = FontWeight.Medium,
+                                    )
+                                }
+                            }
+
+                            state?.isOurs == true -> {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
                                         Icons.Outlined.CheckCircle,
@@ -136,7 +178,7 @@ fun DefaultBrowserSection() {
                                 }
                             }
 
-                            isDefault == false -> {
+                            state != null -> {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
                                         Icons.Outlined.Cancel,
@@ -160,23 +202,7 @@ fun DefaultBrowserSection() {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         // Refresh button
                         TextButton(
-                            onClick = {
-                                coroutineScope.launch {
-                                    isLoading = true
-                                    errorMessage = null
-
-                                    val result = DefaultBrowserManager.isDefaultBrowser()
-                                    isLoading = false
-
-                                    result.fold(
-                                        onSuccess = { isDefault = it },
-                                        onFailure = { error ->
-                                            errorMessage = error.message
-                                            isDefault = null
-                                        },
-                                    )
-                                }
-                            },
+                            onClick = { coroutineScope.launch { refresh() } },
                             colors = ButtonDefaults.textButtonColors(contentColor = BossTheme.colors.textSecondary),
                         ) {
                             Icon(
@@ -201,8 +227,12 @@ fun DefaultBrowserSection() {
                                     result.fold(
                                         onSuccess = { wasSetProgrammatically ->
                                             if (wasSetProgrammatically) {
-                                                // Successfully set programmatically (macOS/Linux)
-                                                isDefault = true
+                                                // Re-read rather than assume Ours. The call reports
+                                                // that every claim was accepted, which is not the
+                                                // same as the OS still holding it a moment later -
+                                                // and assuming was what let this card disagree with
+                                                // Default Apps about the same machine.
+                                                refresh()
                                                 showSuccessDialog = true
                                             } else {
                                                 // User action required (Windows)
@@ -215,7 +245,7 @@ fun DefaultBrowserSection() {
                                     )
                                 }
                             },
-                            enabled = !isLoading && isDefault != true,
+                            enabled = !isLoading && state?.isOurs != true,
                             colors =
                                 ButtonDefaults.textButtonColors(
                                     contentColor = BossTheme.colors.signalText,
@@ -231,13 +261,18 @@ fun DefaultBrowserSection() {
                                 Spacer(modifier = Modifier.width(4.dp))
                                 Text("Setting...", fontSize = 13.sp)
                             } else {
+                                val repairing = state is DefaultHandlerState.OurEngine
                                 Icon(
-                                    Icons.AutoMirrored.Outlined.OpenInNew,
-                                    contentDescription = "Set",
+                                    if (repairing) Icons.Outlined.Build else Icons.AutoMirrored.Outlined.OpenInNew,
+                                    contentDescription = if (repairing) "Repair" else "Set",
                                     modifier = Modifier.size(16.dp),
                                 )
                                 Spacer(modifier = Modifier.width(4.dp))
-                                Text("Set as Default", fontSize = 13.sp)
+                                // Same call either way: claiming http, https and public.html for
+                                // BOSS is what both setting and repairing amount to. Only the label
+                                // differs, because "Set as Default" reads as a no-op to somebody
+                                // who already set it and is looking at a card that says so.
+                                Text(if (repairing) "Repair" else "Set as Default", fontSize = 13.sp)
                             }
                         }
                     }
@@ -380,6 +415,22 @@ fun DefaultBrowserSection() {
                         fontSize = 13.sp,
                         lineHeight = 22.sp,
                     )
+                    // Only when a BOSS component holds the role: the list the user is
+                    // being sent to then contains TWO entries named BOSS, and picking
+                    // the wrong one repeats the state they are trying to leave. The
+                    // engine bundle stopped declaring these types, but an install that
+                    // has not re-downloaded the engine yet still shows both.
+                    if (state is DefaultHandlerState.OurEngine) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            "If two entries are both named BOSS, the one to pick is the application " +
+                                "itself, not the browser component. Reinstalling the browser engine in " +
+                                "Settings > Browser Engine removes the duplicate.",
+                            color = BossTheme.colors.textPrimary,
+                            fontSize = 12.sp,
+                        )
+                    }
+
                     Spacer(modifier = Modifier.height(12.dp))
                     Text(
                         "After completing these steps, click \"Refresh\" to verify.",

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsFileTypeHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/filetypes/WindowsFileTypeHandler.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.filetypes
 
 import ai.rever.boss.utils.DefaultHandlerState
+import ai.rever.boss.utils.WindowsDefaultBrowserHandler
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import java.io.File
@@ -60,8 +61,20 @@ internal object WindowsFileTypeHandler {
             return false
         }
 
+        // A category with schemes needs the `StartMenuInternet` registration as
+        // well, and `web-links` is schemes only - so returning early on "no
+        // extensions" meant claiming Web links from Settings > Default Apps opened
+        // the Windows settings page without ever making BOSS appear in the browser
+        // list it sends the user to.
+        val schemesRegistered =
+            if (FileTypeCategories.table.schemesFor(category.id).isEmpty()) {
+                true
+            } else {
+                WindowsDefaultBrowserHandler.registerAsBrowserCandidate()
+            }
+
         val extensions = FileTypeCategories.table.extensionsFor(category.id)
-        if (extensions.isEmpty()) return true
+        if (extensions.isEmpty()) return schemesRegistered
 
         val script = WindowsRegistryScript.buildScript(extensions, appPath, category.displayName)
 
@@ -109,13 +122,14 @@ internal object WindowsFileTypeHandler {
      */
     fun statusOf(category: FileTypeCategory): DefaultHandlerState {
         val extensions = FileTypeCategories.table.extensionsFor(category.id)
-        if (extensions.isEmpty()) return DefaultHandlerState.Other(null)
+        val schemes = FileTypeCategories.table.schemesFor(category.id)
+        if (extensions.isEmpty() && schemes.isEmpty()) return DefaultHandlerState.Other(null)
 
         // One query over the whole FileExts tree, parsed once, instead of one
         // process per extension.
-        val choices = userChoices()
+        val choices = if (extensions.isEmpty()) emptyMap() else userChoices()
 
-        val states =
+        val extensionStates =
             extensions.map { extension ->
                 val progId = choices[extension.lowercase()]
                 when {
@@ -125,7 +139,14 @@ internal object WindowsFileTypeHandler {
                 }
             }
 
-        return DefaultHandlerState.reduce(states)
+        // Schemes live under UrlAssociations, not FileExts, and `web-links` is
+        // schemes with NO extensions - so reading only the extension side reported
+        // Other on every machine, including one where BOSS held http and https.
+        // macOS has always counted both (MacOSFileTypeHandler reads
+        // `schemesFor` alongside the types); this is Windows catching up.
+        val schemeStates = schemes.map { WindowsDefaultBrowserHandler.schemeState(it) }
+
+        return DefaultHandlerState.reduce(extensionStates + schemeStates)
     }
 
     /** Opens Settings > Default apps, the only place Windows lets the default actually change. */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DefaultBrowserManager.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/DefaultBrowserManager.kt
@@ -27,6 +27,30 @@ actual object DefaultBrowserManager {
         }
 
     /**
+     * Who owns the browser role, as the three-way answer rather than a boolean.
+     *
+     * The boolean above cannot tell "another browser holds this" from "a BOSS
+     * component holds this", and those need opposite things said to the user: the
+     * second is what happens on every machine that installed BOSS before the
+     * branded Chromium engine stopped declaring `CFBundleURLTypes`, where
+     * `~/.boss/boss-chromium/BOSS.app` is a second app called BOSS and links open
+     * a bare rendering engine with no window. Telling that user "BOSS is not your
+     * default browser" is the wrong story - they did set it - and it points them
+     * at a System Settings list with two identical BOSS entries.
+     *
+     * Not on the `expect` declaration: [DefaultHandlerState] is desktopMain, and
+     * lifting it into commonMain to widen an interface with one desktop
+     * implementation would be churn. desktopMain callers see this directly.
+     */
+    internal suspend fun browserHandlerState(): Result<DefaultHandlerState> =
+        when {
+            isMacOS -> MacOSDefaultBrowserHandler.browserHandlerState()
+            isWindows -> WindowsDefaultBrowserHandler.browserHandlerState()
+            isLinux -> LinuxDefaultBrowserHandler.browserHandlerState()
+            else -> Result.failure(Exception("Unsupported platform: ${System.getProperty("os.name")}"))
+        }
+
+    /**
      * Set BOSS as the default system browser
      *
      * Platform-specific behavior:

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/LinuxDefaultBrowserHandler.kt
@@ -18,10 +18,14 @@ import java.io.InputStreamReader
  */
 object LinuxDefaultBrowserHandler {
     private val logger = BossLogger.forComponent("LinuxDefaultBrowserHandler")
+
+    /** The desktop entry that means BOSS, as `xdg-settings` reports it. */
+    private const val DESKTOP_FILE_NAME = "boss.desktop"
+
     private val DESKTOP_FILE_PATH =
         File(
             System.getProperty("user.home"),
-            ".local/share/applications/boss.desktop",
+            ".local/share/applications/$DESKTOP_FILE_NAME",
         )
 
     /**
@@ -29,17 +33,40 @@ object LinuxDefaultBrowserHandler {
      *
      * Uses xdg-settings to query default web browser
      */
-    suspend fun isDefaultBrowser(): Result<Boolean> =
+    suspend fun isDefaultBrowser(): Result<Boolean> = browserHandlerState().map { it.isOurs }
+
+    /**
+     * Who owns the browser role right now, as the three-way answer the Settings
+     * cards share.
+     *
+     * As on Windows, [DefaultHandlerState.OurEngine] cannot occur: the engine
+     * that stole the role on macOS is an `.app` bundle Launch Services indexes,
+     * and nothing writes a desktop entry for it here. A name that is not
+     * `boss.desktop` is another browser.
+     */
+
+    /**
+     * What an `xdg-settings` answer means, separated from the process call that
+     * produces it so the mapping can be tested.
+     *
+     * `xdg-settings` prints the desktop entry's file name; some environments echo
+     * it with different case, hence the case-insensitive comparison.
+     */
+    internal fun stateForDesktopEntry(desktopEntry: String?): DefaultHandlerState =
+        when {
+            desktopEntry == null -> DefaultHandlerState.Other(null)
+            desktopEntry.equals(DESKTOP_FILE_NAME, ignoreCase = true) -> DefaultHandlerState.Ours
+            else -> DefaultHandlerState.Other(desktopEntry)
+        }
+
+    internal suspend fun browserHandlerState(): Result<DefaultHandlerState> =
         withContext(Dispatchers.IO) {
             try {
                 val defaultBrowser = getDefaultWebBrowser()
 
                 logger.debug(LogCategory.BROWSER, "Linux default browser check", mapOf("defaultBrowser" to (defaultBrowser ?: "none")))
 
-                // BOSS is default if xdg-settings returns "boss.desktop"
-                val isDefault = defaultBrowser == "boss.desktop"
-
-                Result.success(isDefault)
+                Result.success(stateForDesktopEntry(defaultBrowser))
             } catch (e: Exception) {
                 logger.error(LogCategory.BROWSER, "Error checking default browser on Linux", error = e)
                 Result.failure(e)
@@ -305,7 +332,7 @@ object LinuxDefaultBrowserHandler {
                     "xdg-settings",
                     "set",
                     "default-web-browser",
-                    "boss.desktop",
+                    DESKTOP_FILE_NAME,
                 ).redirectErrorStream(true).start()
 
             val output =
@@ -344,7 +371,7 @@ object LinuxDefaultBrowserHandler {
                     ProcessBuilder(
                         "xdg-mime",
                         "default",
-                        "boss.desktop",
+                        DESKTOP_FILE_NAME,
                         mimeType,
                     ).redirectErrorStream(true).start()
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsDefaultBrowserHandler.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/utils/WindowsDefaultBrowserHandler.kt
@@ -25,35 +25,61 @@ object WindowsDefaultBrowserHandler {
     // Registry paths
     private const val START_MENU_KEY = "HKEY_CURRENT_USER\\SOFTWARE\\Clients\\StartMenuInternet\\BOSS"
     private const val REGISTERED_APPS = "HKEY_CURRENT_USER\\SOFTWARE\\RegisteredApplications"
-    private const val HTTP_USER_CHOICE =
-        "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice"
-    private const val HTTPS_USER_CHOICE =
-        "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\https\\UserChoice"
+    private const val URL_ASSOCIATIONS =
+        "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations"
+
+    /** The ProgId `registerAsBrowserCandidate` writes, and so the one that means BOSS. */
+    private const val BROWSER_PROG_ID = "BOSS"
+
+    /** The schemes "default browser" means. Both must point at BOSS for it to be true. */
+    private val BROWSER_SCHEMES = listOf("http", "https")
 
     /**
      * Check if BOSS is currently the default browser on Windows
      *
      * Queries registry UserChoice keys for http/https associations
      */
-    suspend fun isDefaultBrowser(): Result<Boolean> =
+    suspend fun isDefaultBrowser(): Result<Boolean> = browserHandlerState().map { it.isOurs }
+
+    /**
+     * Who owns the browser role right now, as the three-way answer the Settings
+     * cards share.
+     *
+     * [DefaultHandlerState.OurEngine] is unreachable here, and that is a fact
+     * about Windows rather than an omission: the second "BOSS" that stole the
+     * role on macOS is the branded Chromium **app bundle**, which Launch Services
+     * lists because it is an `.app` declaring `CFBundleURLTypes`. Nothing
+     * registers the engine under `StartMenuInternet` on Windows, so a ProgId that
+     * is not BOSS's is another vendor's browser. The state is still the shared
+     * type so the card has one story to tell on all three platforms.
+     */
+
+    /**
+     * What a `UserChoice` ProgId means, separated from the `reg query` that reads
+     * it so the mapping can be tested at all.
+     *
+     * Case-insensitive because the registry preserves whatever case wrote the
+     * value, and a case-sensitive comparison would report BOSS as another vendor.
+     */
+    internal fun stateForProgId(progId: String?): DefaultHandlerState =
+        when {
+            progId == null -> DefaultHandlerState.Other(null)
+            progId.equals(BROWSER_PROG_ID, ignoreCase = true) -> DefaultHandlerState.Ours
+            else -> DefaultHandlerState.Other(progId)
+        }
+
+    internal suspend fun browserHandlerState(): Result<DefaultHandlerState> =
         withContext(Dispatchers.IO) {
             try {
-                val httpDefault = getDefaultBrowserProgId("http")
-                val httpsDefault = getDefaultBrowserProgId("https")
+                val states = BROWSER_SCHEMES.associateWith { schemeState(it) }
 
                 logger.debug(
                     LogCategory.BROWSER,
                     "Windows default browser check",
-                    mapOf(
-                        "httpDefault" to (httpDefault ?: "none"),
-                        "httpsDefault" to (httpsDefault ?: "none"),
-                    ),
+                    states.mapValues { (_, state) -> state.toString() },
                 )
 
-                // BOSS is default if both schemes point to BOSS
-                val isDefault = httpDefault == "BOSS" && httpsDefault == "BOSS"
-
-                Result.success(isDefault)
+                Result.success(DefaultHandlerState.reduce(states.values))
             } catch (e: Exception) {
                 logger.error(LogCategory.BROWSER, "Error checking default browser on Windows", error = e)
                 Result.failure(e)
@@ -91,16 +117,27 @@ object WindowsDefaultBrowserHandler {
         }
 
     /**
+     * Who owns [scheme], blocking.
+     *
+     * Not suspending, because `WindowsFileTypeHandler.statusOf` is not either and
+     * needs this same answer: the `web-links` category is schemes with no
+     * extensions, so reading it through the extension path reported
+     * [DefaultHandlerState.Other] on every machine, including one where BOSS did
+     * hold http and https. Callers are responsible for being on IO - both are.
+     */
+    internal fun schemeState(scheme: String): DefaultHandlerState = stateForProgId(getDefaultBrowserProgId(scheme))
+
+    /**
      * Get the current default browser ProgId for a scheme
      */
-    private fun getDefaultBrowserProgId(scheme: String): String? {
-        return try {
-            val keyPath =
-                when (scheme) {
-                    "http" -> HTTP_USER_CHOICE
-                    "https" -> HTTPS_USER_CHOICE
-                    else -> return null
-                }
+    private fun getDefaultBrowserProgId(scheme: String): String? =
+        try {
+            // Built from the scheme rather than matched against two constants: the
+            // key shape is the same for every scheme Windows records here, and the
+            // `else -> return null` that used to sit here reported "nobody owns
+            // this" for any third scheme the type resource might list - which reads
+            // as a fact about the machine rather than a gap in this function.
+            val keyPath = "$URL_ASSOCIATIONS\\$scheme\\UserChoice"
 
             val process = Runtime.getRuntime().exec("""reg query "$keyPath" /v ProgId""")
             val output =
@@ -121,14 +158,20 @@ object WindowsDefaultBrowserHandler {
             logger.warn(LogCategory.BROWSER, "Error querying default browser", mapOf("scheme" to scheme), e)
             null
         }
-    }
 
     /**
      * Register BOSS as a browser candidate in Windows Registry
      *
      * Creates necessary registry keys for Windows to recognize BOSS as a browser
      */
-    private fun registerAsBrowserCandidate(): Boolean {
+
+    /**
+     * Registers BOSS under `StartMenuInternet` so Windows lists it as a browser
+     * at all. `internal` because claiming the `web-links` category from
+     * `Settings > Default Apps` has to do the same thing - the alternative was a
+     * second copy of these registry writes.
+     */
+    internal fun registerAsBrowserCandidate(): Boolean {
         try {
             val appPath = getApplicationPath()
             if (appPath.isNullOrEmpty()) {

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -7,6 +7,7 @@ import ai.rever.boss.components.bars.isBarVisible
 import ai.rever.boss.components.bars.withBarVisible
 import ai.rever.boss.components.dialogs.CLIInstallationDialog
 import ai.rever.boss.components.dialogs.ImportDataDialog
+import ai.rever.boss.components.settings.sidebar.SettingsSection
 import ai.rever.boss.components.window_panel.components.main_window_panels.createBossAppContext
 import ai.rever.boss.components.workspaces.workspaceManager
 import ai.rever.boss.focusmode.FocusModeSettingsManager
@@ -910,6 +911,21 @@ fun ApplicationScope.BossWindow(
                     "Toolbox Setup Wizard...",
                     onClick = {
                         MenuActionsHandler.triggerShowPluginWizard(windowState.id)
+                    },
+                )
+
+                // Settings > Default Apps, named by the enum rather than by a string
+                // literal: `resolveSettingsDeepLink` matches on the enum name, and an
+                // unresolved link is a no-op for an already-open Settings window - so a
+                // rename would leave this item silently doing nothing rather than
+                // failing to compile.
+                Item(
+                    "Set BOSS as Default App...",
+                    onClick = {
+                        MenuActionsHandler.triggerOpenSettings(
+                            windowId = windowState.id,
+                            section = SettingsSection.DEFAULT_APPS.name,
+                        )
                     },
                 )
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/window/BossWindow.kt
@@ -920,7 +920,7 @@ fun ApplicationScope.BossWindow(
                 // rename would leave this item silently doing nothing rather than
                 // failing to compile.
                 Item(
-                    "Set BOSS as Default App...",
+                    "Default Apps...",
                     onClick = {
                         MenuActionsHandler.triggerOpenSettings(
                             windowId = windowState.id,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/windows/SettingsSectionLiteralsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/windows/SettingsSectionLiteralsTest.kt
@@ -1,0 +1,108 @@
+package ai.rever.boss.components.windows
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Asserts every settings-section string written as a **literal** in main source
+ * still names a real [SettingsSection].
+ *
+ * These literals exist because `SettingsSection` lives in desktopMain and their
+ * call sites are commonMain, which cannot see the enum. What makes them worth a
+ * test rather than a comment is how they fail: [resolveSettingsDeepLink] answers
+ * `Unresolved` for a name no section claims, and `Unresolved` is *deliberately* a
+ * no-op for an already-open Settings window - so a renamed section leaves the
+ * menu entry raising the window and doing nothing else, with a `logger.debug`
+ * line as the only record. Nothing crashes and nothing turns red; the entry just
+ * quietly stops working.
+ *
+ * Scanning the source is not a proxy here - the literal in the source **is** the
+ * thing that can drift. A test naming the three current strings would be a fourth
+ * copy of them, and would keep passing after someone edited the real one.
+ *
+ * Callers that *can* see the enum should name it instead (`BossWindow`'s Help
+ * menu does: `SettingsSection.DEFAULT_APPS.name`), which turns the same mistake
+ * into a compile error and contributes nothing for this test to find.
+ */
+class SettingsSectionLiteralsTest {
+    private fun repoRoot(): File =
+        assertNotNull(
+            generateSequence(File("").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+            "could not locate the repository root",
+        )
+
+    /**
+     * Both ways a section is named: the cross-window event, and the state object
+     * the collector calls. Test sources are excluded by the caller - they name
+     * sections deliberately, including strings that must NOT resolve.
+     */
+    private val callPattern = Regex("""(?:triggerOpenSettings|settingsWindow\.open)\(([^)]*)\)""")
+
+    /** A plain string literal. Templates and escapes are not section names. */
+    private val literalPattern = Regex(""""([^"$\\]*)"""")
+
+    /** Section literals in [text], in source order. */
+    private fun sectionLiterals(text: String): List<String> =
+        callPattern
+            .findAll(text)
+            .flatMap { call -> literalPattern.findAll(call.groupValues[1]) }
+            .map { it.groupValues[1] }
+            .toList()
+
+    private fun mainSources(): List<File> =
+        listOf("commonMain", "desktopMain")
+            .map { File(repoRoot(), "composeApp/src/$it") }
+            .flatMap { dir -> dir.walkTopDown().filter { it.isFile && it.extension == "kt" } }
+
+    @Test
+    fun `every section literal in main source names a real section`() {
+        val found = mainSources().flatMap { file -> sectionLiterals(file.readText()).map { file to it } }
+
+        // The scanner finding nothing would pass the assertion below while proving
+        // nothing at all - the failure mode of every source-scanning test.
+        assertTrue(found.isNotEmpty(), "found no section literals at all; the scanner is broken, not the source")
+
+        found.forEach { (file, literal) ->
+            assertTrue(
+                resolveSettingsDeepLink(literal, emptySet()) is SettingsDeepLink.Section,
+                "${file.name} names \"$literal\", which no SettingsSection claims - so that call raises the " +
+                    "Settings window and navigates nowhere. Rename it to a current section, or have the caller " +
+                    "name the enum if it is in desktopMain.",
+            )
+        }
+    }
+
+    @Test
+    fun `the scanner extracts a literal from either call shape and ignores non-literals`() {
+        // Self-check, on a fixture rather than on the tree: a regex that silently
+        // stopped matching would make the test above vacuous, and the assertion
+        // that it found *something* cannot tell "found all of them" from "found one".
+        val fixture =
+            """
+            MenuActionsHandler.triggerOpenSettings(id, "SIDEBAR")
+            state.settingsWindow.open("KEYMAP")
+            MenuActionsHandler.triggerOpenSettings(
+                windowId = windowState.id,
+                section = SettingsSection.DEFAULT_APPS.name,
+            )
+            MenuActionsHandler.triggerOpenSettings(windowId, section)
+            state.settingsWindow.open()
+            """.trimIndent()
+
+        // The enum reference and the forwarded parameter are deliberately absent:
+        // neither can drift into naming a section that does not exist.
+        assertEquals(listOf("SIDEBAR", "KEYMAP"), sectionLiterals(fixture))
+    }
+
+    @Test
+    fun `a section that no longer exists is caught`() {
+        // Reverse-verification: the assertion above only means something if this
+        // is what a stale literal looks like to it.
+        assertTrue(resolveSettingsDeepLink("LLM_PROVIDERS", emptySet()) is SettingsDeepLink.Unresolved)
+        assertTrue(sectionLiterals("""triggerOpenSettings(id, "LLM_PROVIDERS")""") == listOf("LLM_PROVIDERS"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/FileTypeCategoriesTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/filetypes/FileTypeCategoriesTest.kt
@@ -104,6 +104,27 @@ class FileTypeCategoriesTest {
     }
 
     @Test
+    fun `the browser category is schemes with no extensions, which is why a status must read both`() {
+        // The fact that made the Windows status wrong. `WindowsFileTypeHandler`
+        // read only the per-extension `UserChoice` keys, so `web-links` - schemes
+        // and nothing else - reported Other on every machine, including one where
+        // BOSS did hold http and https, and `register` returned early without ever
+        // adding BOSS to the browser list its own settings page sends the user to.
+        //
+        // Pinned here rather than in that handler because the handler shells out to
+        // `reg`, which no mac or Linux runner can answer. If a later change gives
+        // this category an extension or drops its schemes, the reasoning behind
+        // reading both sides changes with it, and this is where that shows up.
+        assertTrue(table.extensionsFor("web-links").isEmpty(), "web-links gained an extension")
+        assertTrue(table.schemesFor("web-links").isNotEmpty(), "web-links lost its schemes")
+
+        // And the converse, which is why the extension side cannot simply be
+        // dropped: web-pages is extensions with no schemes.
+        assertTrue(table.extensionsFor("web-pages").isNotEmpty())
+        assertTrue(table.schemesFor("web-pages").isEmpty())
+    }
+
+    @Test
     fun `every category has Linux MIME types or schemes to claim`() {
         // A category with neither is a row in Settings whose Set button cannot do
         // anything on Linux.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/BrowserHandlerStateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/utils/BrowserHandlerStateTest.kt
@@ -1,0 +1,106 @@
+package ai.rever.boss.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the per-platform identity mapping behind `Settings > Browser`'s status.
+ *
+ * The card used to hold a `Boolean?`, which cannot tell "Safari holds http" from
+ * "a BOSS component holds http" - and the second is the state every install
+ * created before the branded Chromium engine stopped declaring
+ * `CFBundleURLTypes`. Flattened, it said "BOSS is not your default browser" to
+ * users who had set it, while `Settings > Default Apps` reported the same machine
+ * as `OurEngine` and offered a Repair. Two screens, one machine, opposite stories.
+ *
+ * The macOS half needs no mapping test of its own: it reads bundle ids and
+ * `DefaultHandlerState.of` already owns that comparison ([DefaultHandlerStateTest]).
+ * Windows and Linux identify BOSS by a ProgId and a desktop-entry name, so each
+ * has a mapping this pins - extracted from the `reg query` / `xdg-settings` calls
+ * for that reason.
+ */
+class BrowserHandlerStateTest {
+    // ---- Windows ----
+
+    @Test
+    fun `the BOSS ProgId is ours, whatever its case`() {
+        assertEquals(DefaultHandlerState.Ours, WindowsDefaultBrowserHandler.stateForProgId("BOSS"))
+        // The registry preserves the case of whatever wrote the value, so a
+        // case-sensitive comparison would report BOSS as another vendor's browser.
+        assertEquals(DefaultHandlerState.Ours, WindowsDefaultBrowserHandler.stateForProgId("boss"))
+    }
+
+    @Test
+    fun `another browser's ProgId names itself`() {
+        assertEquals(
+            DefaultHandlerState.Other("ChromeHTML"),
+            WindowsDefaultBrowserHandler.stateForProgId("ChromeHTML"),
+        )
+        assertFalse(WindowsDefaultBrowserHandler.stateForProgId("FirefoxURL").isOurs)
+    }
+
+    @Test
+    fun `no recorded choice is not ours`() {
+        assertEquals(DefaultHandlerState.Other(null), WindowsDefaultBrowserHandler.stateForProgId(null))
+    }
+
+    @Test
+    fun `a ProgId that merely starts with BOSS is another application`() {
+        // `BOSS.md` is a real ProgId this repo writes, for the file-type
+        // associations. A `startsWith` comparison anywhere in this chain would
+        // report the markdown association as the browser default.
+        assertEquals(DefaultHandlerState.Other("BOSS.md"), WindowsDefaultBrowserHandler.stateForProgId("BOSS.md"))
+    }
+
+    // ---- Linux ----
+
+    @Test
+    fun `the BOSS desktop entry is ours, whatever its case`() {
+        assertEquals(DefaultHandlerState.Ours, LinuxDefaultBrowserHandler.stateForDesktopEntry("boss.desktop"))
+        assertEquals(DefaultHandlerState.Ours, LinuxDefaultBrowserHandler.stateForDesktopEntry("BOSS.desktop"))
+    }
+
+    @Test
+    fun `another desktop entry names itself, and nothing set is not ours`() {
+        assertEquals(
+            DefaultHandlerState.Other("firefox.desktop"),
+            LinuxDefaultBrowserHandler.stateForDesktopEntry("firefox.desktop"),
+        )
+        assertEquals(DefaultHandlerState.Other(null), LinuxDefaultBrowserHandler.stateForDesktopEntry(null))
+    }
+
+    // ---- the fold both platforms hand their per-scheme answers to ----
+
+    @Test
+    fun `http and https disagreeing is not ours`() {
+        // What the old Windows code said as `http == "BOSS" && https == "BOSS"`.
+        // Rewriting it as a reduce over states must not have loosened it: Launch
+        // Services and the registry store the two schemes separately, and setting
+        // one can succeed while the other fails.
+        val states =
+            listOf(
+                WindowsDefaultBrowserHandler.stateForProgId("BOSS"),
+                WindowsDefaultBrowserHandler.stateForProgId("ChromeHTML"),
+            )
+        val reduced = DefaultHandlerState.reduce(states)
+
+        assertFalse(reduced.isOurs, "one scheme pointing elsewhere still means BOSS is not the browser")
+        assertEquals(DefaultHandlerState.Other("ChromeHTML"), reduced)
+    }
+
+    @Test
+    fun `both schemes pointing at BOSS is ours`() {
+        val reduced =
+            DefaultHandlerState.reduce(
+                listOf(
+                    WindowsDefaultBrowserHandler.stateForProgId("BOSS"),
+                    WindowsDefaultBrowserHandler.stateForProgId("BOSS"),
+                ),
+            )
+
+        assertTrue(reduced.isOurs)
+        assertEquals(DefaultHandlerState.Ours, reduced)
+    }
+}

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -184,7 +184,8 @@ editor can highlight.
 - `DefaultAppsSettings.kt` - Settings > Default Apps
 - `DefaultAppsOffer.desktop.kt` - the one-time first-run offer
 - `DefaultBrowserManager.kt` + `DefaultBrowserSection.kt` - the browser-only
-  facade, still used by Settings > Browser
+  facade behind Settings > Browser. Reads `DefaultHandlerState`, not a boolean,
+  so it cannot tell a user who set BOSS as their browser that they did not
 
 **Platform Behavior**:
 - macOS: `LSSetDefaultRoleHandlerForContentType` / `LSSetDefaultHandlerForURLScheme`

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -162,6 +162,15 @@ CoroutineScope(Dispatchers.IO).launch {
 the file types it opens: markdown, shell scripts, web pages and every language its
 editor can highlight.
 
+**Entry Points**:
+- `Settings > Default Apps` - one row per category, with a Repair action when a
+  BOSS component holds the type
+- `Help > Default Apps...` - the same section, from the menu bar. This is the
+  path `DefaultAppsOffer`'s "it does not ask twice" reasoning assumes exists: the
+  first-run offer persists `promptShown` the moment it appears, so a force quit
+  or a closed window counts as asked and the menu is how that user gets back
+- the one-time first-run offer itself, which never appears twice
+
 **Key Files**:
 - `boss-file-types.json` (`composeApp/src/desktopMain/resources`) - the single
   source of truth: five categories, 83 extensions, the macOS UTIs each claims and


### PR DESCRIPTION
`Settings > Default Apps` shipped in 9.5.2. Nothing in the menus pointed at it, so reaching it meant already knowing the section existed.

Not from zero, to be accurate about the starting point: the first-run offer's own copy names the path in prose, and Settings search indexes the section under `default browser`, `file association`, `open with` and the extensions. Neither is a place someone looks.

The stronger case is what `DefaultAppsOffer`'s KDoc already assumes:

> It does not ask twice. `promptShown` is persisted the moment the dialog appears, not when it is answered - so a crash, a force quit or a window closed with the dialog up all count as asked. Being asked at every launch is worse than never discovering the setting, **and Settings > Default Apps is always there.**

That one-shot design is right, and it rests on a recovery path existing. This is that path.

## The menu item

Help > **Default Apps...**, placed with the two setup wizards:

```
Keyboard Shortcuts
---
Welcome Wizard...
Toolbox Setup Wizard...
Default Apps...                 <- new
---
Import Passwords & Bookmarks...
```

Grouped there deliberately: same kind of action as the wizards (get BOSS set up as the app you actually use), not a reset or a diagnostic like the items below. It names its destination the way the neighbouring "Keyboard Shortcuts" does, rather than reading as an imperative that claims the types on click.

It opens the existing section, so there is no second code path for claiming a type - the per-category rows, "Set all", and the Repair affordance for an engine bundle holding the type are the ones already there.

## Why the section is named by the enum

Every other caller passes a string literal (`"SIDEBAR"`, `"WINDOW_APPEARANCE"`, `"KEYMAP"`) because they live in commonMain and `SettingsSection` is desktopMain. `BossWindow` is desktopMain, so it passes `SettingsSection.DEFAULT_APPS.name`.

That matters because of *how* a wrong name fails. `resolveSettingsDeepLink` answers `Unresolved`, and `Unresolved` is deliberately a no-op for an already-open Settings window - so a renamed section leaves the menu entry raising the window and doing nothing else, with a `logger.debug` line as the only record. Nothing crashes; the entry quietly stops working. Here it is a compile error instead.

## What the other two commits do

**`a511c9d7`** corrects `SidebarSettingsMenuItems`' KDoc, which claimed `SettingsWindow` "falls back to its default section for names it doesn't recognise, so a stale string degrades gracefully". Only a *newly opened* window defaults to FLUCK; an open one is left where the user had it. The comment promised safety on the branch that has none.

**`6d3f413c`** adds the guard that claim implies, which nothing provided: `SettingsSectionLiteralsTest` scans commonMain and desktopMain for literals passed to `triggerOpenSettings` / `settingsWindow.open` and asserts each resolves to a `Section`.

Scanning the source is the instrument, not a proxy: the literal in the source **is** what drifts, and a test naming the three current strings would be a fourth copy of them that keeps passing after someone edits the real one.

- **Reverse-verified**: renaming ChromeBar's literal to `"WINDOW_APPEARANCE_RENAMED"` fails it at the line naming the file and the string.
- **Self-checks the scanner** on a fixture, because "found nothing" would otherwise satisfy the assertion while proving nothing - the standard failure of a source-scanning test.
- Nothing was actually stale: all three resolve today, and no live caller still names the retired `LLM_PROVIDERS` section.

It also documents the entry points in `docs/SUBSYSTEMS.md`, where the Default Apps block listed key files and no way in.

## Deliberately not done

**The item is not gated on `DefaultAppsManager.isSupported()`.** Where Launch Services or `boss-file-types.json` is unavailable, the section explains that in a sentence. A greyed-out or absent menu item replaces the explanation with nothing, which is the worse end state for the user who went looking.

**No test asserts the menu item exists.** A Compose `MenuBar` item cannot be exercised without a real window, and a regex over `BossWindow.kt` would prove the literal is in the file, not that the menu shows it. The hazard that fails *invisibly* - the section name - is handled by the type and by the new test.

## Verification

3117 desktop tests green (3114 + 3 new), `ktlintCheck` and `detekt` clean. Existing coverage for the destination: `SettingsDeepLinkTest` (a built-in section name resolves to that section) and `SettingsWindowStateTest` (`open(section)` bumps `sectionRequest`, so a window already open on another page navigates rather than only raising itself).

## Follow-up, not this PR

`Settings > Browser` still renders `DefaultBrowserSection`, backed by `DefaultBrowserManager.isDefaultBrowser(): Result<Boolean>` - a plain boolean with no `DefaultHandlerState`. So on a machine where the Chromium engine bundle holds http/https it says "BOSS is not your default browser", which is the wrong story to tell somebody who did set it, while `Default Apps` reports `OurEngine` and offers Repair. Pre-existing, but now that Help routes people to the newer section the older one is the more likely thing to contradict it.
