### PR TITLE
Retry a transient magic-link send instead of dead-ending the sign-in

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1031,6 +1031,10 @@ kotlin {
         desktopTest.dependencies {
             implementation(kotlin("test-junit5"))
             implementation(libs.junit.jupiter)
+            // Test-only: supabase-kt's auth exceptions carry the HttpResponse that produced
+            // them, so asserting on what a failed sign-in tells the user means minting a real
+            // response. MockEngine is the supported way to get one without a socket.
+            implementation(libs.ktor.client.mock)
             // Compose UI testing (createComposeRule / onNodeWithText), so renderer
             // behaviour can be asserted against a real composition instead of
             // reasoned about. The API is JUnit 4 only; this module runs on the

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1035,6 +1035,9 @@ kotlin {
             // them, so asserting on what a failed sign-in tells the user means minting a real
             // response. MockEngine is the supported way to get one without a socket.
             implementation(libs.ktor.client.mock)
+            // Test-only: runTest skips the retry backoff in virtual time, so the send loop
+            // can be driven end to end without the test actually waiting 2 seconds.
+            implementation(libs.kotlinx.coroutines.test)
             // Compose UI testing (createComposeRule / onNodeWithText), so renderer
             // behaviour can be asserted against a real composition instead of
             // reasoned about. The API is JUnit 4 only; this module runs on the

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/EmailAuthService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/EmailAuthService.kt
@@ -13,6 +13,7 @@ import io.github.jan.supabase.exceptions.RestException
 import kotlinx.coroutines.delay
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 /**
  * Handles email-based authentication operations
@@ -21,13 +22,30 @@ internal object EmailAuthService {
     private val logger = BossLogger.forComponent("EmailAuthService")
 
     /**
-     * How long to wait between magic-link send attempts, one entry per retry - so two retries,
-     * three attempts in all.
+     * How long to wait between magic-link send attempts, one entry per retry - so one retry, two
+     * attempts in all.
      *
-     * The first wait also clears Supabase's `smtp_max_frequency` (1s), which keeps a retry from
-     * turning a transient failure into a rate-limit failure.
+     * The wait is at least 2s on purpose: it clears Supabase's `smtp_max_frequency` (1s), which
+     * keeps a retry from turning a transient failure into a rate-limit failure.
+     *
+     * Deliberately short. Every attempt asks Supabase to send another email, so the ceiling has to
+     * stay under whatever `rate_limit_email_sent` is set to for the project - a number that lives
+     * in the Supabase dashboard, not in this repo. It reads 2/hour today and is not enforced at
+     * that value (a 29-day log sweep found no `over_email_send_rate_limit` at all, and one hour on
+     * 2026-08-24 carried 7 sends), but the ceiling stays low so this code is correct either way.
      */
-    private val SEND_RETRY_BACKOFF = listOf(2.seconds, 5.seconds)
+    private val SEND_RETRY_BACKOFF = listOf(2.seconds)
+
+    /**
+     * Stop retrying once this much has elapsed, measured from the first attempt.
+     *
+     * The failure worth retrying is fast - Supabase answered the 2026-08-24 one in 6.4s - whereas
+     * a send that burns the full 30s request timeout (`SupabaseConfig`) has already spent longer
+     * than anyone will wait, and a second attempt would only double a spinner that is already too
+     * long. Retrying only the fast failures keeps the worst case near the single-request timeout
+     * it had before this loop existed.
+     */
+    private val SEND_RETRY_BUDGET = 15.seconds
 
     private val SERVER_ERRORS = 500..599
 
@@ -54,6 +72,8 @@ internal object EmailAuthService {
                     Result.failure(error)
                 },
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error(LogCategory.AUTH, "Email verification processing failed", error = e)
             Result.failure(Exception("Failed to process email verification: ${e.message}"))
@@ -63,38 +83,45 @@ internal object EmailAuthService {
      * Send magic link to user's email for passwordless authentication
      * This works for both new signups and existing users (including unconfirmed ones)
      */
-    suspend fun sendMagicLink(email: String): Result<Unit> {
-        logger.info(LogCategory.AUTH, "Sending magic link", mapOf("email" to LogSanitizer.maskEmail(email)))
-        logger.debug(LogCategory.AUTH, "Using Supabase endpoint", mapOf("url" to SupabaseConfig.client.supabaseUrl))
+    suspend fun sendMagicLink(email: String): Result<Unit> = sendMagicLink(email, send = ::requestMagicLink)
 
+    /**
+     * The retry loop, with the send and the clock passed in so it can be driven in a test without a
+     * live Supabase client - and so [SEND_RETRY_BUDGET], which reads wall-clock time, is reachable
+     * from one. Production calls go through [sendMagicLink].
+     */
+    internal suspend fun sendMagicLink(
+        email: String,
+        timeSource: TimeSource = TimeSource.Monotonic,
+        send: suspend (String) -> Unit,
+    ): Result<Unit> {
+        logger.info(LogCategory.AUTH, "Sending magic link", mapOf("email" to LogSanitizer.maskEmail(email)))
+
+        val startedAt = timeSource.markNow()
         var retries = 0
         while (true) {
             try {
-                // signInWith(OTP) handles multiple cases:
-                // 1. New user - creates unconfirmed user and sends signup link
-                // 2. Existing confirmed user - sends login link
-                // 3. Existing unconfirmed user - resends signup/confirmation link
-                SupabaseConfig.client.auth.signInWith(OTP) {
-                    this.email = email
-                    // The createUser flag is true by default, which means:
-                    // - If user doesn't exist, create them (signup)
-                    // - If user exists (confirmed or not), just send the link
-                }
-
+                send(email)
                 logger.info(LogCategory.AUTH, "Magic link sent successfully", mapOf("attempt" to retries + 1))
                 return Result.success(Unit)
             } catch (e: CancellationException) {
-                // Cancellation means the screen went away, not that the send failed. Retrying it
-                // would keep work running after the caller is gone.
+                // Cancellation is the caller walking away, not a send failure. Rethrowing is what
+                // structured concurrency requires; note that CoreLoginViewModel's scope is never
+                // cancelled today, so nothing actually interrupts this loop yet.
                 throw e
             } catch (e: Exception) {
-                val backoff = SEND_RETRY_BACKOFF.getOrNull(retries)?.takeIf { isTransientSendFailure(e) }
+                val elapsed = startedAt.elapsedNow()
+                val backoff =
+                    SEND_RETRY_BACKOFF
+                        .getOrNull(retries)
+                        ?.takeIf { isTransientSendFailure(e) && elapsed < SEND_RETRY_BUDGET }
                 logger.warn(
                     LogCategory.AUTH,
                     "Magic link sending failed",
                     mapOf(
                         "exceptionType" to (e::class.simpleName ?: "unknown"),
                         "attempt" to retries + 1,
+                        "elapsedMs" to elapsed.inWholeMilliseconds,
                         "willRetry" to (backoff != null),
                     ),
                     error = e,
@@ -103,6 +130,21 @@ internal object EmailAuthService {
                 delay(backoff)
                 retries++
             }
+        }
+    }
+
+    /** The real send. signInWith(OTP) handles multiple cases:
+     * 1. New user - creates unconfirmed user and sends signup link
+     * 2. Existing confirmed user - sends login link
+     * 3. Existing unconfirmed user - resends signup/confirmation link
+     */
+    private suspend fun requestMagicLink(email: String) {
+        logger.debug(LogCategory.AUTH, "Using Supabase endpoint", mapOf("url" to SupabaseConfig.client.supabaseUrl))
+        SupabaseConfig.client.auth.signInWith(OTP) {
+            this.email = email
+            // The createUser flag is true by default, which means:
+            // - If user doesn't exist, create them (signup)
+            // - If user exists (confirmed or not), just send the link
         }
     }
 
@@ -115,6 +157,14 @@ internal object EmailAuthService {
      * identical request six minutes later went through untouched. Anything answered with a 4xx -
      * rate limits, validation, disabled signups - is a settled answer, and asking again would only
      * spend more of the sender's hourly email budget.
+     *
+     * [SessionRecoveryPolicy.actionFor] answers the same question for a session refresh and answers
+     * it differently on purpose, so the two are worth reading together. It retries a bare transport
+     * failure; this does not. A refresh is idempotent, so re-asking after a dropped connection
+     * costs nothing, whereas a send that died mid-flight may already have handed the message to
+     * SMTP - retrying it risks a second email, or a second charge against the send budget, to fix a
+     * failure that may not have happened. The practical cost is that a connection reset or an
+     * `HttpRequestTimeoutException` is not a [RestException] and so is *not* retried here.
      */
     internal fun isTransientSendFailure(error: Throwable) = error is RestException && error.statusCode in SERVER_ERRORS
 
@@ -148,7 +198,14 @@ internal object EmailAuthService {
                 "Email sign-in is currently unavailable. Please try again later."
             }
 
-            AuthErrorCode.OverEmailSendRateLimit, AuthErrorCode.OverRequestRateLimit -> {
+            // Split on purpose: `rate_limit_email_sent` is an hourly budget, so "a few minutes" is
+            // wrong advice - and MagicLinkWaitingScreen's resend cooldown tops out at 600s, which
+            // would invite a retry that fails again.
+            AuthErrorCode.OverEmailSendRateLimit -> {
+                "Too many sign-in emails have been sent recently. Please try again in an hour."
+            }
+
+            AuthErrorCode.OverRequestRateLimit -> {
                 "Too many attempts. Please wait a few minutes before trying again."
             }
 
@@ -257,6 +314,9 @@ internal object EmailAuthService {
             logger.info(LogCategory.AUTH, "Magic link verification complete")
 
             Result.success(true)
+        } catch (e: CancellationException) {
+            // Same reason as the send path: cancellation is not a verification failure.
+            throw e
         } catch (e: Exception) {
             logger.warn(
                 LogCategory.AUTH,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/EmailAuthService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/auth/EmailAuthService.kt
@@ -6,13 +6,32 @@ import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
 import io.github.jan.supabase.auth.OtpType
 import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.exception.AuthErrorCode
+import io.github.jan.supabase.auth.exception.AuthRestException
 import io.github.jan.supabase.auth.providers.builtin.OTP
+import io.github.jan.supabase.exceptions.RestException
+import kotlinx.coroutines.delay
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Handles email-based authentication operations
  */
 internal object EmailAuthService {
     private val logger = BossLogger.forComponent("EmailAuthService")
+
+    /**
+     * How long to wait between magic-link send attempts, one entry per retry - so two retries,
+     * three attempts in all.
+     *
+     * The first wait also clears Supabase's `smtp_max_frequency` (1s), which keeps a retry from
+     * turning a transient failure into a rate-limit failure.
+     */
+    private val SEND_RETRY_BACKOFF = listOf(2.seconds, 5.seconds)
+
+    private val SERVER_ERRORS = 500..599
+
+    private const val TRANSIENT_SEND_MESSAGE = "We couldn't send the email just now. Please try again in a minute."
 
     /**
      * Mark email as verified - called when deep link indicates successful verification
@@ -44,46 +63,127 @@ internal object EmailAuthService {
      * Send magic link to user's email for passwordless authentication
      * This works for both new signups and existing users (including unconfirmed ones)
      */
-    suspend fun sendMagicLink(email: String): Result<Unit> =
-        try {
-            logger.info(LogCategory.AUTH, "Sending magic link", mapOf("email" to LogSanitizer.maskEmail(email)))
-            logger.debug(LogCategory.AUTH, "Using Supabase endpoint", mapOf("url" to SupabaseConfig.client.supabaseUrl))
+    suspend fun sendMagicLink(email: String): Result<Unit> {
+        logger.info(LogCategory.AUTH, "Sending magic link", mapOf("email" to LogSanitizer.maskEmail(email)))
+        logger.debug(LogCategory.AUTH, "Using Supabase endpoint", mapOf("url" to SupabaseConfig.client.supabaseUrl))
 
-            // signInWith(OTP) handles multiple cases:
-            // 1. New user - creates unconfirmed user and sends signup link
-            // 2. Existing confirmed user - sends login link
-            // 3. Existing unconfirmed user - resends signup/confirmation link
-            SupabaseConfig.client.auth.signInWith(OTP) {
-                this.email = email
-                // The createUser flag is true by default, which means:
-                // - If user doesn't exist, create them (signup)
-                // - If user exists (confirmed or not), just send the link
+        var retries = 0
+        while (true) {
+            try {
+                // signInWith(OTP) handles multiple cases:
+                // 1. New user - creates unconfirmed user and sends signup link
+                // 2. Existing confirmed user - sends login link
+                // 3. Existing unconfirmed user - resends signup/confirmation link
+                SupabaseConfig.client.auth.signInWith(OTP) {
+                    this.email = email
+                    // The createUser flag is true by default, which means:
+                    // - If user doesn't exist, create them (signup)
+                    // - If user exists (confirmed or not), just send the link
+                }
+
+                logger.info(LogCategory.AUTH, "Magic link sent successfully", mapOf("attempt" to retries + 1))
+                return Result.success(Unit)
+            } catch (e: CancellationException) {
+                // Cancellation means the screen went away, not that the send failed. Retrying it
+                // would keep work running after the caller is gone.
+                throw e
+            } catch (e: Exception) {
+                val backoff = SEND_RETRY_BACKOFF.getOrNull(retries)?.takeIf { isTransientSendFailure(e) }
+                logger.warn(
+                    LogCategory.AUTH,
+                    "Magic link sending failed",
+                    mapOf(
+                        "exceptionType" to (e::class.simpleName ?: "unknown"),
+                        "attempt" to retries + 1,
+                        "willRetry" to (backoff != null),
+                    ),
+                    error = e,
+                )
+                if (backoff == null) return Result.failure(Exception(describeSendFailure(e)))
+                delay(backoff)
+                retries++
+            }
+        }
+    }
+
+    /**
+     * Whether [error] is worth another attempt.
+     *
+     * Supabase hands the message to SMTP inside the `/otp` request and does not retry that hop, so
+     * a mail-provider hiccup comes back as a 500. On 2026-08-24 Gmail answered
+     * `451 4.3.0 Mail server temporarily rejected message` and the sign-in dead-ended, while the
+     * identical request six minutes later went through untouched. Anything answered with a 4xx -
+     * rate limits, validation, disabled signups - is a settled answer, and asking again would only
+     * spend more of the sender's hourly email budget.
+     */
+    internal fun isTransientSendFailure(error: Throwable) = error is RestException && error.statusCode in SERVER_ERRORS
+
+    /**
+     * One sentence about a failed send, for the sign-in screen.
+     *
+     * supabase-kt builds [RestException.message] out of the error code, the request URL and the
+     * whole request header list, and that dump used to be rendered verbatim under the email field.
+     * It still reaches the log with the exception attached; the screen gets prose.
+     */
+    internal fun describeSendFailure(error: Throwable): String {
+        if (isTransientSendFailure(error)) return TRANSIENT_SEND_MESSAGE
+        return when ((error as? AuthRestException)?.errorCode) {
+            AuthErrorCode.UserNotFound -> {
+                "No account found with this email address"
             }
 
-            logger.info(LogCategory.AUTH, "Magic link sent successfully")
-            Result.success(Unit)
-        } catch (e: Exception) {
-            logger.warn(LogCategory.AUTH, "Magic link sending failed", mapOf("exceptionType" to e.javaClass.simpleName), error = e)
+            AuthErrorCode.EmailAddressInvalid -> {
+                "That email address doesn't look valid. Please check it and try again."
+            }
 
-            val errorMessage =
-                when {
-                    e.message?.contains("User not found") == true -> {
-                        "No account found with this email address"
-                    }
+            AuthErrorCode.EmailAddressNotAuthorized -> {
+                "This email address isn't allowed to sign in."
+            }
 
-                    e.message?.contains("cancelled") == true -> {
-                        "Network request cancelled. Please check your internet connection."
-                    }
+            AuthErrorCode.UserBanned -> {
+                "This account has been suspended. Please contact support."
+            }
 
-                    e.message?.contains("Email rate limit exceeded") == true -> {
-                        "Too many attempts. Please wait a few minutes before trying again."
-                    }
+            AuthErrorCode.SignupDisabled, AuthErrorCode.EmailProviderDisabled, AuthErrorCode.OtpDisabled -> {
+                "Email sign-in is currently unavailable. Please try again later."
+            }
 
-                    else -> {
-                        e.message ?: "Failed to send magic link"
-                    }
-                }
-            Result.failure(Exception(errorMessage))
+            AuthErrorCode.OverEmailSendRateLimit, AuthErrorCode.OverRequestRateLimit -> {
+                "Too many attempts. Please wait a few minutes before trying again."
+            }
+
+            else -> {
+                describeUncodedFailure(error, fallback = "Failed to send magic link")
+            }
+        }
+    }
+
+    /**
+     * Wording for failures that carry no [AuthErrorCode] we recognise - an older server build, a
+     * transport error, or a code supabase-kt has not learned yet. Falls back to the server's own
+     * description, which reads fine on its own ("Error sending magic link email"); it is only the
+     * URL and header block bolted onto `message` that does not belong on screen.
+     */
+    private fun describeUncodedFailure(
+        error: Throwable,
+        fallback: String,
+    ): String =
+        when {
+            error.message?.contains("cancelled") == true -> {
+                "Network request cancelled. Please check your internet connection."
+            }
+
+            error.message?.contains("User not found") == true -> {
+                "No account found with this email address"
+            }
+
+            error.message?.contains("Email rate limit exceeded") == true -> {
+                "Too many attempts. Please wait a few minutes before trying again."
+            }
+
+            else -> {
+                (error as? AuthRestException)?.errorDescription?.takeIf { it.isNotBlank() } ?: fallback
+            }
         }
 
     /**
@@ -195,7 +295,7 @@ internal object EmailAuthService {
                     }
 
                     else -> {
-                        e.message ?: "Magic link verification failed"
+                        describeUncodedFailure(e, fallback = "Magic link verification failed")
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/viewmodels/CoreLoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/viewmodels/CoreLoginViewModel.kt
@@ -50,7 +50,10 @@ class CoreLoginViewModel {
                 },
                 onFailure = { error ->
                     logger.warn(LogCategory.AUTH, "Magic link sending failed", error = error)
-                    _errorMessage.value = error.message
+                    // AuthService already turns the failure into one sentence fit for the screen;
+                    // the fallback only covers an exception that carries no message at all, which
+                    // would otherwise leave the form looking like nothing happened.
+                    _errorMessage.value = error.message ?: "Failed to send magic link"
                 },
             )
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/EmailAuthServiceFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/EmailAuthServiceFailureTest.kt
@@ -1,15 +1,6 @@
 package ai.rever.boss.services.auth
 
-import io.github.jan.supabase.auth.exception.AuthRestException
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -53,6 +44,10 @@ class EmailAuthServiceFailureTest {
         assertTrue(raw.contains("Headers:"), "supabase-kt no longer dumps request headers into message")
         assertTrue(raw.contains("URL:"), "supabase-kt no longer dumps the request URL into message")
 
+        // We deliberately keep logging this exception in full. That is only safe while supabase-kt
+        // truncates header values; if it ever stops, the log picks up a live bearer token.
+        assertFalse(raw.contains(TEST_BEARER_TOKEN), "supabase-kt now echoes the bearer token into the message we log")
+
         val shown = EmailAuthService.describeSendFailure(failure)
 
         assertEquals("We couldn't send the email just now. Please try again in a minute.", shown)
@@ -66,7 +61,7 @@ class EmailAuthServiceFailureTest {
         val rateLimited =
             authFailure(HttpStatusCode.TooManyRequests, "over_email_send_rate_limit", "Email rate limit exceeded")
         assertEquals(
-            "Too many attempts. Please wait a few minutes before trying again.",
+            "Too many sign-in emails have been sent recently. Please try again in an hour.",
             EmailAuthService.describeSendFailure(rateLimited),
         )
     }
@@ -81,22 +76,4 @@ class EmailAuthServiceFailureTest {
         assertEquals("Signups are limited to invited addresses", shown)
         assertFalse(shown.contains("Headers:"), "sign-in screen still shows the request dump")
     }
-
-    /** The 2026-08-24 shape: Supabase could not hand the message to SMTP, so it answered 500. */
-    private fun mailSendFailure(): AuthRestException =
-        authFailure(HttpStatusCode.InternalServerError, "unexpected_failure", "Error sending magic link email")
-
-    private fun authFailure(
-        status: HttpStatusCode,
-        code: String,
-        description: String,
-    ): AuthRestException = AuthRestException(code, description, responseWith(status))
-
-    private fun responseWith(status: HttpStatusCode): HttpResponse =
-        runBlocking {
-            HttpClient(MockEngine { respond(content = "", status = status) })
-                .post("https://project.supabase.co/auth/v1/otp") {
-                    header(HttpHeaders.Authorization, "Bearer test-token")
-                }
-        }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/EmailAuthServiceFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/EmailAuthServiceFailureTest.kt
@@ -1,0 +1,102 @@
+package ai.rever.boss.services.auth
+
+import io.github.jan.supabase.auth.exception.AuthRestException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the two decisions that turned one transient mail failure into a dead end on 2026-08-24,
+ * when Supabase's SMTP hop drew a `451 4.3.0 Mail server temporarily rejected message` from Gmail:
+ * whether the send is worth another try, and what the person staring at the sign-in form is told.
+ */
+class EmailAuthServiceFailureTest {
+    @Test
+    fun `a failed mail send is worth another attempt`() {
+        assertTrue(EmailAuthService.isTransientSendFailure(mailSendFailure()))
+    }
+
+    @Test
+    fun `a rate limit is not worth another attempt`() {
+        // Asking again would spend another slice of the sender's hourly email budget and push the
+        // address further from being able to sign in at all.
+        val rateLimited =
+            authFailure(HttpStatusCode.TooManyRequests, "over_email_send_rate_limit", "Email rate limit exceeded")
+        assertFalse(EmailAuthService.isTransientSendFailure(rateLimited))
+    }
+
+    @Test
+    fun `a validation failure is not worth another attempt`() {
+        val invalid =
+            authFailure(HttpStatusCode.BadRequest, "email_address_invalid", "Unable to validate email address")
+        assertFalse(EmailAuthService.isTransientSendFailure(invalid))
+    }
+
+    @Test
+    fun `a failed mail send reads as a sentence, not as supabase-kt's request dump`() {
+        val failure = mailSendFailure()
+
+        // Precondition, so this test cannot quietly pass if supabase-kt stops building its message
+        // this way: `exception.message` really is a multi-line dump of the request we sent, and it
+        // is what the login form used to render verbatim.
+        val raw = requireNotNull(failure.message)
+        assertTrue(raw.contains("Headers:"), "supabase-kt no longer dumps request headers into message")
+        assertTrue(raw.contains("URL:"), "supabase-kt no longer dumps the request URL into message")
+
+        val shown = EmailAuthService.describeSendFailure(failure)
+
+        assertEquals("We couldn't send the email just now. Please try again in a minute.", shown)
+        for (fragment in listOf("URL:", "Headers:", "Http Method:", "Authorization", "unexpected_failure")) {
+            assertFalse(shown.contains(fragment), "sign-in screen still shows `$fragment`")
+        }
+    }
+
+    @Test
+    fun `a rate limit tells the user to wait rather than to retry`() {
+        val rateLimited =
+            authFailure(HttpStatusCode.TooManyRequests, "over_email_send_rate_limit", "Email rate limit exceeded")
+        assertEquals(
+            "Too many attempts. Please wait a few minutes before trying again.",
+            EmailAuthService.describeSendFailure(rateLimited),
+        )
+    }
+
+    @Test
+    fun `an unfamiliar failure keeps the server's own description and drops the dump`() {
+        val unknown =
+            authFailure(HttpStatusCode.BadRequest, "some_code_added_later", "Signups are limited to invited addresses")
+
+        val shown = EmailAuthService.describeSendFailure(unknown)
+
+        assertEquals("Signups are limited to invited addresses", shown)
+        assertFalse(shown.contains("Headers:"), "sign-in screen still shows the request dump")
+    }
+
+    /** The 2026-08-24 shape: Supabase could not hand the message to SMTP, so it answered 500. */
+    private fun mailSendFailure(): AuthRestException =
+        authFailure(HttpStatusCode.InternalServerError, "unexpected_failure", "Error sending magic link email")
+
+    private fun authFailure(
+        status: HttpStatusCode,
+        code: String,
+        description: String,
+    ): AuthRestException = AuthRestException(code, description, responseWith(status))
+
+    private fun responseWith(status: HttpStatusCode): HttpResponse =
+        runBlocking {
+            HttpClient(MockEngine { respond(content = "", status = status) })
+                .post("https://project.supabase.co/auth/v1/otp") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                }
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/EmailAuthServiceRetryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/EmailAuthServiceRetryTest.kt
@@ -1,0 +1,113 @@
+package ai.rever.boss.services.auth
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+/**
+ * Drives the send loop itself. `runTest` skips the backoff in virtual time and [TestTimeSource]
+ * stands in for the wall clock the budget reads, so a test can reach both without waiting.
+ */
+@OptIn(ExperimentalCoroutinesApi::class) // testScheduler.currentTime, to assert the backoff actually waits
+class EmailAuthServiceRetryTest {
+    @Test
+    fun `a transient failure is retried and the second attempt is allowed to succeed`() =
+        runTest {
+            var attempts = 0
+            val result =
+                EmailAuthService.sendMagicLink("someone@example.com", TestTimeSource()) {
+                    attempts++
+                    if (attempts == 1) throw mailSendFailure()
+                }
+
+            assertTrue(result.isSuccess)
+            assertEquals(2, attempts)
+        }
+
+    @Test
+    fun `a transient failure that keeps failing gives up after one retry`() =
+        runTest {
+            var attempts = 0
+            val result =
+                EmailAuthService.sendMagicLink("someone@example.com", TestTimeSource()) {
+                    attempts++
+                    throw mailSendFailure()
+                }
+
+            // Two attempts, not three: every attempt asks Supabase to send another email.
+            assertEquals(2, attempts)
+            assertEquals(
+                "We couldn't send the email just now. Please try again in a minute.",
+                result.exceptionOrNull()?.message,
+            )
+        }
+
+    @Test
+    fun `the retry waits out smtp_max_frequency before asking again`() =
+        runTest {
+            val startedAt = testScheduler.currentTime
+            var attempts = 0
+            EmailAuthService.sendMagicLink("someone@example.com", TestTimeSource()) {
+                attempts++
+                if (attempts == 1) throw mailSendFailure()
+            }
+
+            // Supabase rejects a second send inside smtp_max_frequency (1s) with a rate-limit
+            // error, so a retry that did not wait would replace one failure with a worse one.
+            val waited = testScheduler.currentTime - startedAt
+            assertTrue(waited >= 2_000, "retried after only ${waited}ms")
+        }
+
+    @Test
+    fun `a rate limit is never retried`() =
+        runTest {
+            var attempts = 0
+            val result =
+                EmailAuthService.sendMagicLink("someone@example.com", TestTimeSource()) {
+                    attempts++
+                    throw rateLimited()
+                }
+
+            assertEquals(1, attempts)
+            assertEquals(
+                "Too many sign-in emails have been sent recently. Please try again in an hour.",
+                result.exceptionOrNull()?.message,
+            )
+        }
+
+    @Test
+    fun `a slow failure is not retried, so the wait cannot double`() =
+        runTest {
+            val clock = TestTimeSource()
+            var attempts = 0
+            val result =
+                EmailAuthService.sendMagicLink("someone@example.com", clock) {
+                    attempts++
+                    // A send that burns the 30s request timeout has already outlasted the budget.
+                    clock += 30.seconds
+                    throw mailSendFailure()
+                }
+
+            assertEquals(1, attempts)
+            assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun `cancellation propagates instead of being retried`() =
+        runTest {
+            var attempts = 0
+            assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+                EmailAuthService.sendMagicLink("someone@example.com", TestTimeSource()) {
+                    attempts++
+                    throw kotlin.coroutines.cancellation.CancellationException("screen closed")
+                }
+            }
+
+            assertEquals(1, attempts)
+        }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/SupabaseFailures.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/services/auth/SupabaseFailures.kt
@@ -1,0 +1,44 @@
+package ai.rever.boss.services.auth
+
+import io.github.jan.supabase.auth.exception.AuthRestException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Mints the real supabase-kt exception rather than a stand-in, because the thing under test is how
+ * supabase-kt builds these: the error code, the request URL and the whole header list all end up in
+ * [Throwable.message], and that is what used to reach the sign-in screen.
+ *
+ * The bearer token below is deliberately a recognisable value - see the logging assertion in
+ * [EmailAuthServiceFailureTest].
+ */
+internal const val TEST_BEARER_TOKEN = "test-token-must-never-be-logged"
+
+internal fun authFailure(
+    status: HttpStatusCode,
+    code: String,
+    description: String,
+): AuthRestException = AuthRestException(code, description, responseWith(status))
+
+/** The 2026-08-24 shape: Supabase could not hand the message to SMTP, so it answered 500. */
+internal fun mailSendFailure(): AuthRestException =
+    authFailure(HttpStatusCode.InternalServerError, "unexpected_failure", "Error sending magic link email")
+
+/** The shape that must never be retried: another attempt spends more of the hourly send budget. */
+internal fun rateLimited(): AuthRestException =
+    authFailure(HttpStatusCode.TooManyRequests, "over_email_send_rate_limit", "Email rate limit exceeded")
+
+private fun responseWith(status: HttpStatusCode) =
+    runBlocking {
+        HttpClient(MockEngine { respond(content = "", status = status) }).use { client ->
+            client.post("https://project.supabase.co/auth/v1/otp") {
+                header(HttpHeaders.Authorization, "Bearer $TEST_BEARER_TOKEN")
+            }
+        }
+    }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,6 +148,7 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "k
 ktor-server-tests = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }

--- a/modules/boss-service-auth/build.gradle.kts
+++ b/modules/boss-service-auth/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
     // Testing
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // supabase-kt's auth exceptions carry the HttpResponse that produced them, so asserting on
+    // what a failed sign-in tells the user means minting a real response.
+    testImplementation(libs.ktor.client.mock)
 }
 
 // Application entry point

--- a/modules/boss-service-auth/src/main/kotlin/ai/rever/boss/service/auth/SupabaseAuthClient.kt
+++ b/modules/boss-service-auth/src/main/kotlin/ai/rever/boss/service/auth/SupabaseAuthClient.kt
@@ -2,12 +2,18 @@ package ai.rever.boss.service.auth
 
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.exception.AuthErrorCode
+import io.github.jan.supabase.auth.exception.AuthRestException
 import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.exceptions.RestException
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import org.slf4j.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Wraps the Supabase Kotlin client to provide auth operations for AuthServiceGrpcImpl.
@@ -49,17 +55,87 @@ class SupabaseAuthClient(
      * Sends a magic link to the given email.
      * Returns [AuthResult.MagicLinkSent] immediately — the actual session arrives
      * when the user clicks the link and the deep-link callback updates state.
+     *
+     * Transient failures are retried, and the failure message is prose rather than
+     * supabase-kt's raw dump - see [SEND_RETRY_BACKOFF] and [describeSendFailure].
      */
-    suspend fun sendMagicLink(email: String): AuthResult =
-        try {
-            client.auth.signInWith(OTP) {
-                this.email = email
+    suspend fun sendMagicLink(email: String): AuthResult {
+        var retries = 0
+        while (true) {
+            try {
+                client.auth.signInWith(OTP) {
+                    this.email = email
+                }
+                return AuthResult.MagicLinkSent(email)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val backoff = SEND_RETRY_BACKOFF.getOrNull(retries)?.takeIf { isTransientSendFailure(e) }
+                logger.error(
+                    "Magic link send failed for {} (attempt {}, retrying: {})",
+                    maskEmail(email),
+                    retries + 1,
+                    backoff != null,
+                    e,
+                )
+                if (backoff == null) return AuthResult.Failure(describeSendFailure(e))
+                delay(backoff)
+                retries++
             }
-            AuthResult.MagicLinkSent(email)
-        } catch (e: Exception) {
-            logger.error("Magic link send failed for {}", maskEmail(email), e)
-            AuthResult.Failure(e.message ?: "Magic link failed")
         }
+    }
+
+    /**
+     * Whether [error] is worth another attempt.
+     *
+     * Supabase hands the message to SMTP inside the `/otp` request and does not retry that hop, so
+     * a mail-provider hiccup comes back as a 500 (2026-08-24: Gmail answered
+     * `451 4.3.0 Mail server temporarily rejected message`, and the identical request minutes later
+     * went through). A 4xx is a settled answer and asking again would only spend more of the
+     * sender's hourly email budget.
+     */
+    private fun isTransientSendFailure(error: Throwable) = error is RestException && error.statusCode in SERVER_ERRORS
+
+    /**
+     * One sentence about a failed send, for whoever is looking at the sign-in screen.
+     *
+     * supabase-kt builds [RestException.message] out of the error code, the request URL and the
+     * whole request header list. That dump travels over gRPC as `errorMessage` and lands on screen,
+     * so keep it in the log and hand the caller prose.
+     */
+    private fun describeSendFailure(error: Throwable): String {
+        if (isTransientSendFailure(error)) return TRANSIENT_SEND_MESSAGE
+        return when ((error as? AuthRestException)?.errorCode) {
+            AuthErrorCode.UserNotFound -> {
+                "No account found with this email address"
+            }
+
+            AuthErrorCode.EmailAddressInvalid -> {
+                "That email address doesn't look valid. Please check it and try again."
+            }
+
+            AuthErrorCode.EmailAddressNotAuthorized -> {
+                "This email address isn't allowed to sign in."
+            }
+
+            AuthErrorCode.UserBanned -> {
+                "This account has been suspended. Please contact support."
+            }
+
+            AuthErrorCode.SignupDisabled, AuthErrorCode.EmailProviderDisabled, AuthErrorCode.OtpDisabled -> {
+                "Email sign-in is currently unavailable. Please try again later."
+            }
+
+            AuthErrorCode.OverEmailSendRateLimit, AuthErrorCode.OverRequestRateLimit -> {
+                "Too many attempts. Please wait a few minutes before trying again."
+            }
+
+            // The server's own description ("Error sending magic link email") reads fine alone.
+            else -> {
+                (error as? AuthRestException)?.errorDescription?.takeIf { it.isNotBlank() } ?: "Magic link failed"
+            }
+        }
+    }
 
     /** Signs out and clears the local session. Errors are logged but not re-thrown. */
     suspend fun signOut() {
@@ -109,6 +185,19 @@ class SupabaseAuthClient(
     }
 
     private fun maskEmail(email: String): String = if (email.length > 3) "${email.take(3)}***" else "***"
+
+    private companion object {
+        /**
+         * How long to wait between magic-link send attempts, one entry per retry - so two retries,
+         * three attempts in all. The first wait also clears Supabase's `smtp_max_frequency` (1s),
+         * which keeps a retry from turning a transient failure into a rate-limit failure.
+         */
+        private val SEND_RETRY_BACKOFF = listOf(2.seconds, 5.seconds)
+
+        private val SERVER_ERRORS = 500..599
+
+        private const val TRANSIENT_SEND_MESSAGE = "We couldn't send the email just now. Please try again in a minute."
+    }
 }
 
 sealed class AuthResult {

--- a/modules/boss-service-auth/src/main/kotlin/ai/rever/boss/service/auth/SupabaseAuthClient.kt
+++ b/modules/boss-service-auth/src/main/kotlin/ai/rever/boss/service/auth/SupabaseAuthClient.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.slf4j.LoggerFactory
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 /**
  * Wraps the Supabase Kotlin client to provide auth operations for AuthServiceGrpcImpl.
@@ -46,9 +47,15 @@ class SupabaseAuthClient(
                 this.password = password
             }
             buildSuccessResult(fallbackEmail = email)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error("Email/password sign-in failed for {}", maskEmail(email), e)
-            AuthResult.Failure(e.message ?: "Sign-in failed")
+            // Same dump, same screen: this used to hand `e.message` - error code, request URL and
+            // the whole header list - straight back over gRPC as `errorMessage`.
+            AuthResult.Failure(
+                describeAuthFailure(e, transient = TRANSIENT_SIGN_IN_MESSAGE, fallback = "Sign-in failed"),
+            )
         }
 
     /**
@@ -59,22 +66,37 @@ class SupabaseAuthClient(
      * Transient failures are retried, and the failure message is prose rather than
      * supabase-kt's raw dump - see [SEND_RETRY_BACKOFF] and [describeSendFailure].
      */
-    suspend fun sendMagicLink(email: String): AuthResult {
+    suspend fun sendMagicLink(email: String): AuthResult =
+        sendMagicLink(email, send = { address -> client.auth.signInWith(OTP) { this.email = address } })
+
+    /**
+     * The retry loop, with the send passed in so it can be driven in a test without a live
+     * Supabase client. Production calls go through [sendMagicLink].
+     */
+    internal suspend fun sendMagicLink(
+        email: String,
+        timeSource: TimeSource = TimeSource.Monotonic,
+        send: suspend (String) -> Unit,
+    ): AuthResult {
+        val startedAt = timeSource.markNow()
         var retries = 0
         while (true) {
             try {
-                client.auth.signInWith(OTP) {
-                    this.email = email
-                }
+                send(email)
                 return AuthResult.MagicLinkSent(email)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                val backoff = SEND_RETRY_BACKOFF.getOrNull(retries)?.takeIf { isTransientSendFailure(e) }
+                val elapsed = startedAt.elapsedNow()
+                val backoff =
+                    SEND_RETRY_BACKOFF
+                        .getOrNull(retries)
+                        ?.takeIf { isTransientSendFailure(e) && elapsed < SEND_RETRY_BUDGET }
                 logger.error(
-                    "Magic link send failed for {} (attempt {}, retrying: {})",
+                    "Magic link send failed for {} (attempt {}, {}ms elapsed, retrying: {})",
                     maskEmail(email),
                     retries + 1,
+                    elapsed.inWholeMilliseconds,
                     backoff != null,
                     e,
                 )
@@ -94,7 +116,7 @@ class SupabaseAuthClient(
      * went through). A 4xx is a settled answer and asking again would only spend more of the
      * sender's hourly email budget.
      */
-    private fun isTransientSendFailure(error: Throwable) = error is RestException && error.statusCode in SERVER_ERRORS
+    internal fun isTransientSendFailure(error: Throwable) = error is RestException && error.statusCode in SERVER_ERRORS
 
     /**
      * One sentence about a failed send, for whoever is looking at the sign-in screen.
@@ -103,9 +125,24 @@ class SupabaseAuthClient(
      * whole request header list. That dump travels over gRPC as `errorMessage` and lands on screen,
      * so keep it in the log and hand the caller prose.
      */
-    private fun describeSendFailure(error: Throwable): String {
-        if (isTransientSendFailure(error)) return TRANSIENT_SEND_MESSAGE
+    internal fun describeSendFailure(error: Throwable): String =
+        describeAuthFailure(error, transient = TRANSIENT_SEND_MESSAGE, fallback = "Magic link failed")
+
+    /**
+     * Shared mapping for both sign-in routes. [transient] is what a 5xx becomes, which differs by
+     * route: a failed magic-link send is about the email, a failed password sign-in is not.
+     */
+    internal fun describeAuthFailure(
+        error: Throwable,
+        transient: String,
+        fallback: String,
+    ): String {
+        if (isTransientSendFailure(error)) return transient
         return when ((error as? AuthRestException)?.errorCode) {
+            AuthErrorCode.InvalidCredentials -> {
+                "That email and password don't match."
+            }
+
             AuthErrorCode.UserNotFound -> {
                 "No account found with this email address"
             }
@@ -126,13 +163,18 @@ class SupabaseAuthClient(
                 "Email sign-in is currently unavailable. Please try again later."
             }
 
-            AuthErrorCode.OverEmailSendRateLimit, AuthErrorCode.OverRequestRateLimit -> {
+            // `rate_limit_email_sent` is an hourly budget, so "a few minutes" is wrong advice.
+            AuthErrorCode.OverEmailSendRateLimit -> {
+                "Too many sign-in emails have been sent recently. Please try again in an hour."
+            }
+
+            AuthErrorCode.OverRequestRateLimit -> {
                 "Too many attempts. Please wait a few minutes before trying again."
             }
 
             // The server's own description ("Error sending magic link email") reads fine alone.
             else -> {
-                (error as? AuthRestException)?.errorDescription?.takeIf { it.isNotBlank() } ?: "Magic link failed"
+                (error as? AuthRestException)?.errorDescription?.takeIf { it.isNotBlank() } ?: fallback
             }
         }
     }
@@ -188,15 +230,28 @@ class SupabaseAuthClient(
 
     private companion object {
         /**
-         * How long to wait between magic-link send attempts, one entry per retry - so two retries,
-         * three attempts in all. The first wait also clears Supabase's `smtp_max_frequency` (1s),
-         * which keeps a retry from turning a transient failure into a rate-limit failure.
+         * How long to wait between magic-link send attempts, one entry per retry - so one retry,
+         * two attempts in all. The wait is at least 2s on purpose: it clears Supabase's
+         * `smtp_max_frequency` (1s), which keeps a retry from turning a transient failure into a
+         * rate-limit failure. The ceiling stays low because every attempt asks for another email
+         * and so spends the project's `rate_limit_email_sent` budget, a number that lives in the
+         * Supabase dashboard rather than in this repo.
          */
-        private val SEND_RETRY_BACKOFF = listOf(2.seconds, 5.seconds)
+        private val SEND_RETRY_BACKOFF = listOf(2.seconds)
+
+        /**
+         * Stop retrying once this much has elapsed since the first attempt. The failure worth
+         * retrying is fast; one that burns the full request timeout has already outlasted anyone's
+         * patience, and a second attempt would only double the wait.
+         */
+        private val SEND_RETRY_BUDGET = 15.seconds
 
         private val SERVER_ERRORS = 500..599
 
         private const val TRANSIENT_SEND_MESSAGE = "We couldn't send the email just now. Please try again in a minute."
+
+        private const val TRANSIENT_SIGN_IN_MESSAGE =
+            "We couldn't reach the sign-in service just now. Please try again in a minute."
     }
 }
 

--- a/modules/boss-service-auth/src/test/kotlin/ai/rever/boss/service/auth/SupabaseAuthClientFailureTest.kt
+++ b/modules/boss-service-auth/src/test/kotlin/ai/rever/boss/service/auth/SupabaseAuthClientFailureTest.kt
@@ -1,0 +1,132 @@
+package ai.rever.boss.service.auth
+
+import io.github.jan.supabase.auth.exception.AuthRestException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+/**
+ * The out-of-process twin of composeApp's `EmailAuthServiceFailureTest` / `EmailAuthServiceRetryTest`.
+ *
+ * The retry policy and the message mapping exist twice, character for character, because
+ * `composeApp` cannot depend on this module - `modules/` is excluded from the build on
+ * Windows-ARM64 (settings.gradle.kts), so a shared home is not available. The duplication is
+ * therefore forced, but going untested was not: this module had no `src/test` at all, so the copy
+ * that ships to the microkernel was the copy nothing checked.
+ *
+ * KEEP IN LOCKSTEP with the composeApp tests. Both files assert the same literal strings on
+ * purpose; if you change wording in one, the other's expectations are the checklist.
+ */
+class SupabaseAuthClientFailureTest {
+    private val client = SupabaseAuthClient(supabaseUrl = PROJECT_URL, supabaseAnonKey = "test-anon-key")
+
+    @Test
+    fun `a failed mail send is worth another attempt`() {
+        assertTrue(client.isTransientSendFailure(mailSendFailure()))
+    }
+
+    @Test
+    fun `a rate limit is not worth another attempt`() {
+        assertTrue(!client.isTransientSendFailure(rateLimited()))
+    }
+
+    @Test
+    fun `a failed mail send reads as a sentence, not as supabase-kt's request dump`() {
+        val failure = mailSendFailure()
+        val raw = requireNotNull(failure.message)
+        assertTrue(raw.contains("Headers:"), "supabase-kt no longer dumps request headers into message")
+        assertTrue(!raw.contains(BEARER), "supabase-kt now echoes the bearer token into the message we log")
+
+        val shown = client.describeSendFailure(failure)
+
+        assertEquals("We couldn't send the email just now. Please try again in a minute.", shown)
+        for (fragment in listOf("URL:", "Headers:", "Http Method:", "Authorization", "unexpected_failure")) {
+            assertTrue(!shown.contains(fragment), "sign-in screen still shows `$fragment`")
+        }
+    }
+
+    @Test
+    fun `an hourly email budget is not described as a few minutes`() {
+        assertEquals(
+            "Too many sign-in emails have been sent recently. Please try again in an hour.",
+            client.describeSendFailure(rateLimited()),
+        )
+    }
+
+    @Test
+    fun `a password sign-in failure does not ship the request dump either`() {
+        val shown =
+            client.describeAuthFailure(
+                authFailure(HttpStatusCode.BadRequest, "invalid_credentials", "Invalid login credentials"),
+                transient = "unused",
+                fallback = "Sign-in failed",
+            )
+
+        assertEquals("That email and password don't match.", shown)
+    }
+
+    @Test
+    fun `a transient failure is retried once`() =
+        runTest {
+            var attempts = 0
+            val result =
+                client.sendMagicLink("someone@example.com", TestTimeSource()) {
+                    attempts++
+                    if (attempts == 1) throw mailSendFailure()
+                }
+
+            assertEquals(2, attempts)
+            assertTrue(result is AuthResult.MagicLinkSent)
+        }
+
+    @Test
+    fun `a slow failure is not retried`() =
+        runTest {
+            val clock = TestTimeSource()
+            var attempts = 0
+            client.sendMagicLink("someone@example.com", clock) {
+                attempts++
+                clock += 30.seconds
+                throw mailSendFailure()
+            }
+
+            assertEquals(1, attempts)
+        }
+
+    private fun mailSendFailure() = authFailure(HttpStatusCode.InternalServerError, "unexpected_failure", MAIL_FAILED)
+
+    private fun rateLimited() = authFailure(HttpStatusCode.TooManyRequests, "over_email_send_rate_limit", RATE_LIMITED)
+
+    private fun authFailure(
+        status: HttpStatusCode,
+        code: String,
+        description: String,
+    ) = AuthRestException(code, description, responseWith(status))
+
+    private fun responseWith(status: HttpStatusCode) =
+        runBlocking {
+            HttpClient(MockEngine { respond(content = "", status = status) }).use { http ->
+                http.post("$PROJECT_URL/auth/v1/otp") {
+                    header(HttpHeaders.Authorization, "Bearer $BEARER")
+                }
+            }
+        }
+
+    private companion object {
+        const val BEARER = "test-token-must-never-be-logged"
+        const val PROJECT_URL = "https://project.supabase.co"
+        const val MAIL_FAILED = "Error sending magic link email"
+        const val RATE_LIMITED = "Email rate limit exceeded"
+    }
+}


### PR DESCRIPTION
## What happened

A user hit this on the sign-in screen and reported it; the next attempt worked.

```
unexpected_failure
Error sending magic link email: unexpected_failure
URL: https://ap.../auth/v1/otp
Headers: {Authorization=[Bearer ey... (len=208)], apikey=[ey... (len=208)], ...}
Http Method: POST
```

The GoTrue log for that request:

```
2026-08-24T07:02:31Z  level=error  status=500  path=/otp  error_code=unexpected_failure
error: gomail: could not send email 1: 451 "4.3.0 Mail server temporarily rejected message.
        For more information, go to https://support.google.com/a/answer/3221692 - gsmtp"
request_id: 01a03293-d6d2-76e5-b048-370f262df8ef   duration: 6.46s
```

The project sends through `smtp.gmail.com:587`. Gmail accepted the connection and the auth,
then deferred the message with a transient `451 4.3.0` six seconds in. Supabase hands the
message to SMTP inside the `/otp` request and does not retry that hop, so it became a 500 and
the sign-in dead-ended.

It was not our send volume. The audit log shows this was the first mail-triggering event of the
hour, with none in the hour before.

The account timeline, which is why this reads as transient rather than broken:

| Time (UTC) | Event |
|---|---|
| 07:02:25.391 | `POST /otp`, user record created |
| 07:02:25.408 | auto-confirmed (`mailer_autoconfirm=true`) |
| 07:02:31.5 | Gmail `451 4.3.0` -> 500 `unexpected_failure` |
| 07:08:14.191 | retried by hand, `user_recovery_requested`, 200 |
| 07:08:30.487 | clicked the link, signed in |

Note the signup was left half-finished: the user row existed and was confirmed before the mail
send failed, so a 500 there leaves an account with no way in until someone retries.

### On `rate_limit_email_sent`

An earlier draft of this description said the project's limit "is still 2/hour" without saying
what that measures, which invited the reading that three attempts could not fit inside it. The
sweep contradicts that: over the full 29-day retention window there is **no**
`over_email_send_rate_limit` at all, and the 09:00 hour on 2026-08-24 alone carried 7 sends. So
the configured 2 is not being enforced as two sends per hour for this project.

The retry ceiling is still kept deliberately low, because that number lives in the Supabase
dashboard rather than in this repo and could change without anything here noticing. The coupling
is now written down next to the constant.

## What this changes

Both implementations of the call: the in-process client the app signs in with, and the
out-of-process `boss-service-auth` client behind the microkernel, which had the same two defects
and shipped the raw dump over gRPC as `errorMessage`.

**One retry, bounded by elapsed time.** A 5xx is retried once after 2s, and only while under a
15s budget measured from the first attempt.

- The failure worth retrying is fast - Supabase answered the 2026-08-24 one in 6.4s. A send that
  burns the full 30s request timeout has already outlasted the spinner, and a second attempt
  would only double it. Worst case is ~47s rather than the ~97s a fixed retry count would give,
  and the common case is ~15s.
- The 2s wait clears Supabase's `smtp_max_frequency` (1s), so a retry cannot turn a transient
  failure into a rate-limit failure.
- A 4xx is never retried. Rate limits, validation and disabled signups are settled answers.
- `CancellationException` is rethrown rather than retried, here and on the two verification
  paths. Note this does not yet change behaviour: `CoreLoginViewModel`'s scope is never
  cancelled, so nothing interrupts the loop today. The rethrow is what structured concurrency
  requires and is right ahead of that scope being fixed.

**Scope, stated plainly:** a connection reset or an `HttpRequestTimeoutException` is not a
`RestException` and so is *not* retried. `SessionRecoveryPolicy` (same package) answers the same
question for a session refresh and does retry those, on purpose - a refresh is idempotent, so
re-asking after a dropped connection costs nothing, whereas a send that died mid-flight may
already have reached SMTP. That divergence is now in the KDoc rather than left for a reader to
notice.

**One sentence instead of the dump.** supabase-kt builds `RestException.message` out of the error
code, the request URL and the whole request header list, and that was rendered verbatim under the
email field. It still reaches the log with the exception attached. Unrecognised codes fall back
to the server's own description, which reads fine alone. The 451 case now reads:

> We couldn't send the email just now. Please try again in a minute.

Also folded in: `signInWithEmailPassword` shipped the same dump one function above the fix, so
both routes now share the mapping, parameterised on the 5xx wording. `over_email_send_rate_limit`
no longer says "wait a few minutes" - it is an hourly budget, and `MagicLinkWaitingScreen`'s
resend cooldown tops out at 600s, so the old wording invited a retry that would fail again.

## Tests

There were none over this surface. There are now 19, and `boss-service-auth` gets its first
`src/test` at all - previously the copy that ships to the microkernel was the copy nothing
checked.

The send and the clock are parameters, so `runTest` drives the whole loop in virtual time and
`TestTimeSource` reaches the budget. Mutation results, which are the reason the loop is tested at
all rather than just the mapping:

| Mutation | Tests killed |
|---|---|
| never retry | 3 |
| ignore the elapsed-time budget | 1 (the budget test, exactly) |
| retry every failure, including 4xx | 1 (the rate-limit test, exactly) |
| pre-fix message mapping | 4 |

The mapping is duplicated because `composeApp` cannot depend on `boss-service-auth` (`modules/`
is excluded on Windows-ARM64), so both suites assert the same literal strings and say so in a
header comment. One test pins the property the logging decision rests on: the request we mint
carries a real bearer token, and the raw exception we keep logging must not contain it.

## What this does not fix

Retrying makes the app survive a Gmail deferral; it does not stop them happening. Gmail is not a
transactional relay, and `451 4.3.0`, the 2k/day cap and reputation throttling are expected
behaviour there. Moving to a transactional sender is a Supabase dashboard change, not a code one,
and is the actual fix.
