### PR TITLE
Let one caller own a staged update, not both

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/updater/UpdateManager.kt
@@ -275,17 +275,22 @@ class UpdateManager {
      * The version stays on offer, so the banner can download it again.
      */
     suspend fun discardDownload() {
-        val state = _updateState.value
-        if (state !is UpdateState.ReadyToInstall) return
-        updateService.discardDownload(state.downloadPath)
+        // CLAIM BEFORE DELETING, and give up if the claim is lost. The state move used to
+        // happen AFTER the delete, which is exactly what let an install and a discard both
+        // proceed - see [claimStagedUpdate]. Whoever moves the state out of ReadyToInstall owns
+        // the staged file; the loser touches nothing.
+        //
         // Idle unless there is genuinely a newer version to offer: after discarding a
         // DOWNGRADE, `_updateInfo` holds the older version, and UpdateAvailable would
         // put "Update v9.4.20 available" in the banner.
-        _updateState.value =
-            _updateInfo.value
-                ?.takeIf { it.isNewerVersionAvailable }
-                ?.let { UpdateState.UpdateAvailable(it) }
-                ?: UpdateState.Idle
+        val claimed =
+            _updateState.claimStagedUpdate {
+                _updateInfo.value
+                    ?.takeIf { info -> info.isNewerVersionAvailable }
+                    ?.let { info -> UpdateState.UpdateAvailable(info) }
+                    ?: UpdateState.Idle
+            } ?: return
+        updateService.discardDownload(claimed.downloadPath)
     }
 
     /**
@@ -384,10 +389,29 @@ class UpdateManager {
     /**
      * Install the downloaded update
      */
-    suspend fun installUpdate(downloadPath: String): Boolean =
-        try {
-            _updateState.value = UpdateState.Installing
-
+    suspend fun installUpdate(downloadPath: String): Boolean {
+        // Claim the staged artifact, or do nothing at all.
+        //
+        // Both halves of this matter, and the bug was that neither existed. The state moved to
+        // Installing only once this coroutine had been DISPATCHED, while every caller reaches it
+        // through `launchInBackground` - so between pressing Install and this line running, the
+        // state still read ReadyToInstall and a discard sailed past its own guard, deleted the
+        // artifact, and left this installing a file that was no longer there. The two buttons sit
+        // 8dp apart on the update banner, so "quickly" is one ordinary mis-click.
+        //
+        // A compare-and-set from the exact ReadyToInstall value makes the two mutually exclusive:
+        // whichever lands first wins, and the loser returns without touching the file. It also
+        // makes a second press of Install a no-op rather than a second elevated installer, which
+        // the download center's dialog already got for free by clearing its action on use.
+        if (_updateState.claimStagedUpdate { UpdateState.Installing } == null) {
+            logger.info(
+                LogCategory.SYSTEM,
+                "Ignoring install request - nothing staged, or the staged update was claimed first",
+                mapOf("state" to _updateState.value::class.simpleName.orEmpty()),
+            )
+            return false
+        }
+        return try {
             val outcome = updateService.installUpdate(downloadPath)
             if (outcome.succeeded) {
                 _updateState.value = UpdateState.RestartRequired
@@ -403,6 +427,7 @@ class UpdateManager {
             _updateState.value = UpdateState.Error("Installation failed: ${e.message}")
             false
         }
+    }
 
     /**
      * Get current application version
@@ -474,4 +499,33 @@ sealed class UpdateState {
     data class Error(
         val message: String,
     ) : UpdateState()
+}
+
+/**
+ * Take exclusive ownership of a staged update, moving it to the state [to] describes.
+ *
+ * Returns the [UpdateState.ReadyToInstall] that was claimed, or null when there was nothing
+ * staged or another caller got there first. A null answer means **do not touch the file**.
+ *
+ * This exists because installing and discarding are the same artifact seen two ways, and both
+ * used to check the state and then act, with a gap in between. Every caller reaches them through
+ * `launchInBackground`, so the gap is a real dispatch, not an instruction or two: pressing Install
+ * and then Cancel - two buttons 8dp apart on the update banner - let both pass their checks, and
+ * the discard deleted the artifact while the install was opening it. The user lost the download
+ * AND got an installation failure, which is neither of the two things they asked for.
+ *
+ * A compare-and-set from the exact `ReadyToInstall` value makes them mutually exclusive without a
+ * lock, and the same call makes a second Install press a no-op rather than a second elevated
+ * installer - the download center's dialog already had that, because it clears an action when it
+ * fires; the banner's buttons do not.
+ *
+ * Deliberately takes the destination as a lambda rather than a value: the discard side computes
+ * its next state from `_updateInfo`, and evaluating that eagerly for a claim that then loses would
+ * read state the loser has no business acting on.
+ */
+internal fun MutableStateFlow<UpdateState>.claimStagedUpdate(
+    to: (UpdateState.ReadyToInstall) -> UpdateState,
+): UpdateState.ReadyToInstall? {
+    val ready = value as? UpdateState.ReadyToInstall ?: return null
+    return if (compareAndSet(ready, to(ready))) ready else null
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/StagedUpdateClaimTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/updater/StagedUpdateClaimTest.kt
@@ -1,0 +1,114 @@
+package ai.rever.boss.updater
+
+import ai.rever.boss.utils.Version
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Installing and discarding are the same staged artifact seen two ways, so exactly one of them
+ * may ever win.
+ *
+ * Both used to read the state, then act, with a real coroutine dispatch in between - every caller
+ * goes through `launchInBackground`, and `installUpdate` only moved the state to `Installing` once
+ * it had been dispatched. So Install then Cancel, two buttons 8dp apart on the update banner, let
+ * both pass their guards: the discard deleted the artifact while the install was opening it, and
+ * the user got neither outcome they asked for.
+ *
+ * Tested on the claim rather than through [UpdateManager] on purpose. `UpdateManager` builds its
+ * own `UpdateService`, so a test that drove the real methods would either need a seam that does not
+ * exist or would reach a real installer - and the race is entirely in the compare-and-set, which
+ * this exercises directly and deterministically.
+ */
+class StagedUpdateClaimTest {
+    private fun staged(path: String = "/tmp/BOSS.dmg") = UpdateState.ReadyToInstall(downloadPath = path)
+
+    private fun updateInfo() =
+        UpdateInfo(
+            available = true,
+            currentVersion = Version(major = 9, minor = 5, patch = 2),
+            latestVersion = Version(major = 9, minor = 5, patch = 3),
+            releaseNotes = "",
+            downloadUrl = "https://example.invalid/BOSS.dmg",
+        )
+
+    @Test
+    fun `the winner gets the staged file and the loser is told to leave it alone`() {
+        val state = MutableStateFlow<UpdateState>(staged())
+
+        val install = state.claimStagedUpdate { UpdateState.Installing }
+        val discard = state.claimStagedUpdate { UpdateState.Idle }
+
+        // The claimed value carries the path, so the winner does not have to re-read a state
+        // the loser may already have moved.
+        assertEquals("/tmp/BOSS.dmg", assertNotNull(install).downloadPath)
+        assertNull(discard, "the second caller must be refused - this is the delete that used to happen anyway")
+        assertEquals(UpdateState.Installing, state.value)
+    }
+
+    @Test
+    fun `order does not matter - discard first refuses the install`() {
+        val state = MutableStateFlow<UpdateState>(staged())
+
+        val discard = state.claimStagedUpdate { UpdateState.UpdateAvailable(updateInfo()) }
+        val install = state.claimStagedUpdate { UpdateState.Installing }
+
+        assertNotNull(discard)
+        // The reverse of the case above, and the one the earlier fix attempt still got wrong: an
+        // install that fell back to setting Installing whenever the state was NOT ReadyToInstall
+        // would sail straight past a completed discard and install a deleted file.
+        assertNull(install, "installing after a discard has won means installing a file that is gone")
+    }
+
+    @Test
+    fun `nothing staged means nothing to claim`() {
+        listOf(UpdateState.Idle, UpdateState.Installing, UpdateState.RestartRequired, UpdateState.Downloading(0.5f))
+            .forEach { start ->
+                val state = MutableStateFlow<UpdateState>(start)
+                assertNull(state.claimStagedUpdate { UpdateState.Installing }, "$start is not a staged update")
+                assertEquals(start, state.value, "a refused claim must not move the state")
+            }
+    }
+
+    @Test
+    fun `a second press installs once, not twice`() {
+        val state = MutableStateFlow<UpdateState>(staged())
+
+        // The banner's Install Now is a plain button - unlike the download center's dialog, which
+        // clears its action when it fires. Two quick presses used to mean two elevated installers
+        // for one artifact.
+        val first = state.claimStagedUpdate { UpdateState.Installing }
+        val second = state.claimStagedUpdate { UpdateState.Installing }
+
+        assertNotNull(first)
+        assertNull(second)
+    }
+
+    @Test
+    fun `under real contention exactly one of many claimants wins`() =
+        runBlocking {
+            repeat(200) {
+                val state = MutableStateFlow<UpdateState>(staged())
+                val wins = AtomicInteger()
+
+                // Whether the destination differs or not is irrelevant to the invariant: one
+                // claimant proceeds. `to` is a lambda so it is only evaluated by the winner.
+                val claimants =
+                    (1..8).map { i ->
+                        async {
+                            val target = if (i % 2 == 0) UpdateState.Installing else UpdateState.Idle
+                            if (state.claimStagedUpdate { target } != null) wins.incrementAndGet()
+                        }
+                    }
+                claimants.awaitAll()
+
+                assertEquals(1, wins.get(), "exactly one claimant may own the staged artifact")
+            }
+        }
+}


### PR DESCRIPTION
Installing and discarding are the same staged artifact seen two ways, and nothing stopped both from happening.

Both read the state and then acted, with a **real coroutine dispatch in between**. Every caller reaches them through `launchInBackground`; `installUpdate` moved the state to `Installing` only once it had been dispatched, and `discardDownload` deleted the file *before* moving the state at all:

```kotlin
// installUpdate - state moves only after the dispatch
suspend fun installUpdate(downloadPath: String): Boolean = try {
    _updateState.value = UpdateState.Installing   // <- too late
    ...

// discardDownload - deletes first, moves state after
if (state !is UpdateState.ReadyToInstall) return
updateService.discardDownload(state.downloadPath) // <- gone
_updateState.value = ...
```

So pressing **Install** and then **Cancel** let both pass their guards: the discard deleted the artifact while the install was opening it. The user got neither of the two things they asked for - the download gone *and* an installation failure.

Reachable from the download center's dialog (Install and Cancel side by side on the row) and, once BossConsole#279 lands, from the update banner where the two buttons sit 8dp apart on chrome nobody is studying. Found by review on that PR; the bug predates it and lives in the update state machine, so it is fixed here rather than there.

## The fix

`claimStagedUpdate` compare-and-sets out of the exact `ReadyToInstall` value. Whoever lands first wins; the loser is told to leave the file alone.

```kotlin
internal fun MutableStateFlow<UpdateState>.claimStagedUpdate(
    to: (UpdateState.ReadyToInstall) -> UpdateState,
): UpdateState.ReadyToInstall? {
    val ready = value as? UpdateState.ReadyToInstall ?: return null
    return if (compareAndSet(ready, to(ready))) ready else null
}
```

Both callers go through it, which matters in **both directions** - a narrower patch that only made install claim first would still let an install proceed after a discard had won, installing a file that is no longer there. There is a test for exactly that direction.

`to` is a lambda rather than a value because the discard side computes its next state from `_updateInfo`, and evaluating that for a claim that then loses would read state the loser has no business acting on.

**It closes a second hole for free.** The banner's `Install Now` is a plain button, unlike the download center's, which clears its action when it fires - so two quick presses meant two elevated installers for one artifact. The second is now a no-op.

## Tests

Tested on the claim, not through `UpdateManager`. That class constructs its own `UpdateService`, so driving the real methods would need a seam that does not exist - or would reach a real installer, which is not something a test should do. The race is entirely in the compare-and-set, and this exercises it directly and deterministically.

Five cases: the winner gets the path and the loser is refused; the same with the order reversed; nothing staged means nothing to claim (and a refused claim must not move the state); a second Install press is a no-op; and 200 rounds of eight concurrent claimants asserting exactly one wins each time.

All five confirmed to **fail** against the pre-fix check-then-act shape before being kept.

`ktlintCheck`, `detekt` and the `ai.rever.boss.updater.*` suite pass.

## Scope

Deliberately not included: the `Role.Button`/`onClickLabel` gap and the "two dialogs in one window" issue, both also raised in that review. They are UI-affordance changes that apply equally to the existing bottom-bar item, and neither belongs in a state-machine fix.