### PR TITLE
fix(plugins): prompt for missing dependencies on re-enable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,11 @@ an update-shaped verb (or an intent parameter) on the api rather than a change t
   dependency) and `PluginUpdateBridge` (an update can add a dependency the installed version
   never declared). A **reload** must not report: `resetPluginInstances`, the Toolbox reload and
   the evolver's hot reload all end in a load, and none is a user asking for anything.
+  **Re-enable is a user action in a way a reload is not.** `enablePlugin` and `handleAccessChange`
+  (RBAC un-hide) never go through those three install reporters, and after #178 a required
+  dependency can be removed while its dependent sits disabled. Both paths therefore raise the
+  same prompt via `DynamicPluginManager.onPluginActivated`, wired by `PluginLoaderDelegateSetup`
+  to `MissingDependencyReporter.report`. A redundant enable (already enabled) does not re-offer.
 - **Optional dependencies are reported, flagged, not dropped.** An optional dependency is how a
   plugin says "this feature needs that plugin". Dropping them would leave this reporting
   nothing for the case it was built for.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -214,8 +214,9 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
     }
 
     // A plugin the user just installed declares a dependency that is not present. Only
-    // user-initiated installs report here (see PluginLoaderDelegateImpl), so this cannot
-    // fire during startup restore or the api hot-swap's reload-all.
+    // user-initiated installs and re-activations report here (see PluginLoaderDelegateImpl
+    // and DynamicPluginManager.onPluginActivated), so this cannot fire during startup
+    // restore or the api hot-swap's reload-all.
     LaunchedEffect(windowId) {
         PluginDependencyEventBus.missingDependencies
             .collect { prompt ->

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -1556,7 +1556,13 @@ class DynamicPluginManager(
                         trackingContexts[pluginId]
                             ?: return@withLock Result.failure(Exception("No context for plugin: $pluginId"))
 
-                    wasAlreadyEnabled = _pluginStates.value[pluginId]?.enabled == true
+                    // Keyed off state, not the `enabled` flag: the RBAC hide step in
+                    // handleAccessChange sets state = DISABLED without clearing `enabled`,
+                    // so an enabled-flag check read a hidden plugin as "already running"
+                    // and silenced the #180 prompt for exactly the re-enable case that
+                    // needs it. A redundant enable of a genuinely running plugin (state
+                    // LOADED) still skips, preserving the declined-dependency skip.
+                    wasAlreadyEnabled = _pluginStates.value[pluginId]?.state == PluginState.LOADED
 
                     // Attributed for the duration of register(), so a callback the
                     // plugin wires up and invokes synchronously from here is
@@ -1630,8 +1636,15 @@ class DynamicPluginManager(
             notifyPanelsRefresh(pluginId)
             // Same skip: a redundant enable is not the user re-arming a
             // disabled plugin, so it must not re-offer a dependency they
-            // already declined (#180).
-            notifyPluginActivated(pluginId)
+            // already declined (#180). Gated on canAccess because anything
+            // loaded can reach enablePlugin through the shared API registry:
+            // an install-deps dialog is only actionable for a plugin the user
+            // can see, and one still hidden by RBAC gets its report from
+            // handleAccessChange when access actually arrives.
+            val activatedManifest = _pluginStates.value[pluginId]?.manifest
+            if (activatedManifest != null && canAccess(activatedManifest)) {
+                notifyPluginActivated(pluginId)
+            }
         }
         return result
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -223,6 +223,26 @@ class DynamicPluginManager(
      */
     private val hiddenPlugins = ConcurrentHashMap<String, DynamicPluginInfo>()
 
+    /**
+     * Called after a previously-disabled plugin is actually registered again:
+     * [enablePlugin] (user re-enable) and [handleAccessChange] (RBAC un-hide).
+     *
+     * The desktop layer wires this to `MissingDependencyReporter.report` so a
+     * required dependency that was removed while the plugin sat disabled is
+     * offered the same way an install would (#180). Null in headless/test
+     * contexts.
+     *
+     * Per-manager, not a companion hook: reporting must read *this* window's
+     * `pluginStates`, and a process-wide first-window capture would leave every
+     * other window offering installs into a disposed manager.
+     *
+     * Not invoked from [installPlugin], [reregisterAfterRestart], or any reload:
+     * those either already report through the install paths, or are not a user
+     * asking to activate anything.
+     */
+    @Volatile
+    internal var onPluginActivated: ((PluginManifest) -> Unit)? = null
+
     companion object {
         private val companionLogger = BossLogger.forComponent("DynamicPluginManager")
 
@@ -1606,7 +1626,13 @@ class DynamicPluginManager(
         // Outside the mutex, same as installPlugin. Skipped when the plugin
         // was already enabled: a redundant enable must not discard an open
         // panel's in-memory state (resetComponent loses it by design).
-        if (result.isSuccess && !wasAlreadyEnabled) notifyPanelsRefresh(pluginId)
+        if (result.isSuccess && !wasAlreadyEnabled) {
+            notifyPanelsRefresh(pluginId)
+            // Same skip: a redundant enable is not the user re-arming a
+            // disabled plugin, so it must not re-offer a dependency they
+            // already declined (#180).
+            notifyPluginActivated(pluginId)
+        }
         return result
     }
 
@@ -1726,6 +1752,31 @@ class DynamicPluginManager(
         // watchdog.
         sandboxManager.disablePlugin(pluginId)
         updatePluginState(pluginId, info.copy(state = PluginState.DISABLED, enabled = false))
+    }
+
+    /**
+     * Invoke [onPluginActivated] with [pluginId]'s current manifest; never throws.
+     *
+     * Outside the mutex, same as [notifyPanelsRefresh]. The reporter is
+     * fire-and-forget and only reads `pluginStates`, so it does not need the
+     * lock; holding it would stall enable/RBAC on a dialog that may not exist
+     * yet.
+     */
+    private fun notifyPluginActivated(pluginId: String) {
+        val callback = onPluginActivated ?: return
+        val manifest = _pluginStates.value[pluginId]?.manifest ?: return
+        try {
+            callback(manifest)
+        } catch (t: Throwable) {
+            logger.warn(
+                LogCategory.SYSTEM,
+                "Dependency check after plugin activation failed",
+                mapOf(
+                    "pluginId" to pluginId,
+                    "error" to (t.message ?: t::class.simpleName),
+                ),
+            )
+        }
     }
 
     /** Invoke [pluginPanelsRefresh] with [pluginId]'s currently-registered panels; never throws. */
@@ -2255,6 +2306,7 @@ class DynamicPluginManager(
      * user can now access, and unregisters/hides plugins they can no longer access.
      */
     private suspend fun handleAccessChange() {
+        val reactivated = mutableListOf<String>()
         mutex.withLock {
             // 1. Re-register previously-hidden plugins the user can now access.
             val nowVisible =
@@ -2269,6 +2321,7 @@ class DynamicPluginManager(
                         loadedPlugin.instance.register(trackingContext)
                         updatePluginState(pluginId, info.copy(state = PluginState.LOADED))
                         hiddenPlugins.remove(pluginId)
+                        reactivated += pluginId
                         logger.info(
                             LogCategory.SYSTEM,
                             "Re-registered plugin after access gained",
@@ -2322,6 +2375,9 @@ class DynamicPluginManager(
                 }
             }
         }
+        // Outside the mutex, same as enablePlugin: the reporter only reads
+        // pluginStates and must not stall RBAC behind a dialog.
+        reactivated.forEach(::notifyPluginActivated)
     }
 
     private fun updatePluginState(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -496,7 +496,12 @@ class DynamicPluginManager(
                         // first. This one registers, fixes _pluginStates,
                         // clears the crash registry, enables the sandbox and
                         // refreshes open panels.
-                        manager.enablePlugin(pluginId)
+                        //
+                        // reportMissingDependencies = false: this is crash
+                        // recovery, not the user re-arming a plugin - the
+                        // error-boundary Restart button must not raise a
+                        // store-install dialog mid-recovery.
+                        manager.enablePlugin(pluginId, reportMissingDependencies = false)
                     } else {
                         sandboxManager.restartPlugin(pluginId)
                     }
@@ -1541,9 +1546,16 @@ class DynamicPluginManager(
      * Enable a disabled plugin.
      *
      * @param pluginId The plugin ID
+     * @param reportMissingDependencies When false, skip the missing-dependency report on
+     *   activation. Crash recovery ([Companion.restartOwning]) passes false: a restart is
+     *   recovery, not the user arming a plugin, and the error-boundary Restart button must not
+     *   raise a store-install dialog.
      * @return Result indicating success or failure
      */
-    suspend fun enablePlugin(pluginId: String): Result<Unit> {
+    suspend fun enablePlugin(
+        pluginId: String,
+        reportMissingDependencies: Boolean = true,
+    ): Result<Unit> {
         var wasAlreadyEnabled = false
         val result =
             mutex.withLock {
@@ -1556,13 +1568,15 @@ class DynamicPluginManager(
                         trackingContexts[pluginId]
                             ?: return@withLock Result.failure(Exception("No context for plugin: $pluginId"))
 
-                    // Keyed off state, not the `enabled` flag: the RBAC hide step in
-                    // handleAccessChange sets state = DISABLED without clearing `enabled`,
-                    // so an enabled-flag check read a hidden plugin as "already running"
-                    // and silenced the #180 prompt for exactly the re-enable case that
-                    // needs it. A redundant enable of a genuinely running plugin (state
-                    // LOADED) still skips, preserving the declined-dependency skip.
-                    wasAlreadyEnabled = _pluginStates.value[pluginId]?.state == PluginState.LOADED
+                    // Keyed off the `enabled` flag, same as before this PR: the only case
+                    // where the flag is set while the plugin is not actually running is the
+                    // RBAC hide (state = DISABLED, `enabled` left true) - and that path must
+                    // stay silent here anyway, because the user cannot see the plugin and an
+                    // install-deps dialog is not actionable for them; handleAccessChange
+                    // reports when access actually arrives. The report below is gated on
+                    // canAccess for the same reason, so a state-based key would only unblock
+                    // a branch the gate immediately re-blocks.
+                    wasAlreadyEnabled = _pluginStates.value[pluginId]?.enabled == true
 
                     // Attributed for the duration of register(), so a callback the
                     // plugin wires up and invokes synchronously from here is
@@ -1640,9 +1654,11 @@ class DynamicPluginManager(
             // loaded can reach enablePlugin through the shared API registry:
             // an install-deps dialog is only actionable for a plugin the user
             // can see, and one still hidden by RBAC gets its report from
-            // handleAccessChange when access actually arrives.
+            // handleAccessChange when access actually arrives. Crash recovery
+            // (restartOwning) opts out entirely via reportMissingDependencies:
+            // a restart is recovery, not activation.
             val activatedManifest = _pluginStates.value[pluginId]?.manifest
-            if (activatedManifest != null && canAccess(activatedManifest)) {
+            if (reportMissingDependencies && activatedManifest != null && canAccess(activatedManifest)) {
                 notifyPluginActivated(pluginId)
             }
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/PluginDependencyResolution.kt
@@ -349,9 +349,11 @@ data class MissingDependencyPrompt(
  * UI exists at all - the same reason `TerminalLinkEventBus` exists, though not the same
  * delivery (see [prompts]).
  *
- * **Only user-initiated installs emit here.** Startup restore and the api hot-swap's
- * reload-all both go through `DynamicPluginManager.installPlugin` directly, and a prompt on
- * those paths would be a dialog per plugin on every launch.
+ * **Only user-initiated installs and re-activations emit here.** Startup restore and the api
+ * hot-swap's reload-all both go through `DynamicPluginManager.installPlugin` directly, and a
+ * prompt on those paths would be a dialog per plugin on every launch. Re-activations (enable
+ * after disable, RBAC un-hide) report through the same bus on purpose: the dependency may have
+ * gone missing while the plugin sat disabled (#180).
  *
  * A class with a singleton subclass rather than a bare object, so a test can hold its own bus.
  * The shared buffer otherwise carries prompts between tests, which is the same coupling two

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -51,8 +51,12 @@ actual object PluginLoaderDelegateSetup {
         // come back with no prompt (#180). Per-manager: reporting must read
         // this window's pluginStates, and capturing the first window would
         // leave every other window offering installs into a disposed manager.
+        // Bound once, outside the callback: forManager allocates the states
+        // lambda and the installer, and every activation would pay for a
+        // reporter that never changes for this manager.
+        val missingDependencyReporter = MissingDependencyReporter.forManager(dynamicPluginManager)
         dynamicPluginManager.onPluginActivated = { manifest ->
-            MissingDependencyReporter.forManager(dynamicPluginManager).report(manifest)
+            missingDependencyReporter.report(manifest)
         }
 
         // The home screen's store access: what can be installed, and how. Registered here with

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt
@@ -46,6 +46,15 @@ actual object PluginLoaderDelegateSetup {
         val delegate = PluginLoaderDelegateImpl(dynamicPluginManager)
         context.registerPluginAPI(delegate)
 
+        // Re-enable and RBAC un-hide never go through the install reporters, so
+        // a required dependency removed while the plugin sat disabled used to
+        // come back with no prompt (#180). Per-manager: reporting must read
+        // this window's pluginStates, and capturing the first window would
+        // leave every other window offering installs into a disposed manager.
+        dynamicPluginManager.onPluginActivated = { manifest ->
+            MissingDependencyReporter.forManager(dynamicPluginManager).report(manifest)
+        }
+
         // The home screen's store access: what can be installed, and how. Registered here with
         // the other process-wide wiring rather than from `PluginLoaderDelegateImpl`'s constructor,
         // where a process-global set up as a side effect of constructing an object was easy to

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/MissingDependencyReporter.kt
@@ -17,14 +17,16 @@ import java.io.File
 /**
  * Raises the install-time prompt for dependencies a plugin declares but which are absent.
  *
- * A class, and not the private method it started as, because more than one host path installs
- * on a user's behalf and each of them should report:
+ * A class, and not the private method it started as, because more than one host path
+ * activates a plugin on a user's behalf and each of them should report:
  *
  * - `PluginLoaderDelegateImpl.loadPlugin`, which the plugin-manager's install and update flows
  *   reach directly;
  * - `PluginInstallService`, the first-run wizard - the path where several plugins are chosen at
  *   once, so the one where an unmet dependency is *most* likely;
- * - `PluginUpdateBridge`, where an update can add a dependency the installed version never had.
+ * - `PluginUpdateBridge`, where an update can add a dependency the installed version never had;
+ * - `DynamicPluginManager.enablePlugin` and `handleAccessChange`, via `onPluginActivated` -
+ *   re-enabling a disabled plugin, including one that was hidden for lack of access (#180).
  *
  * What must not report is a **reload**: `resetPluginInstances`, the Toolbox's reload and the
  * evolver's hot reload all end in a load, and none of them is a user asking to install

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnReenableTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnReenableTest.kt
@@ -118,28 +118,42 @@ class DependencyPromptOnReenableTest {
         assertTrue(
             Regex(
                 """if\s*\(\s*result\.isSuccess\s*&&\s*!wasAlreadyEnabled\s*\)\s*\{""" +
-                    """[\s\S]{0,700}?if\s*\(\s*\w+\s*!=\s*null\s*&&\s*canAccess\(\w+\)\s*\)\s*\{""" +
+                    """[\s\S]{0,700}?if\s*\(\s*reportMissingDependencies\s*&&\s*\w+\s*!=\s*null\s*&&""" +
+                    """\s*canAccess\(\w+\)\s*\)\s*\{""" +
                     """\s*notifyPluginActivated\(""",
             ).containsMatchIn(body),
-            "enablePlugin must report missing dependencies when it actually re-enables, gated on canAccess",
+            "enablePlugin must report missing dependencies when it re-enables, " +
+                "gated on canAccess and the explicit opt-out",
         )
     }
 
     @Test
-    fun `the re-enable redundancy check is keyed off plugin state, not the enabled flag`() {
+    fun `the re-enable redundancy check keys off the enabled flag and the canAccess gate covers RBAC`() {
         val body = uncommented(functionBody(managerSource(), "enablePlugin"))
-        // The RBAC hide step sets state = DISABLED without clearing `enabled`,
-        // so an enabled-flag check read a hidden plugin as already running and
-        // silenced the prompt for exactly the re-enable case #180 covers.
+        // Round-2 review decision: keep ONE of the two RBAC guards. The
+        // enabled-flag key stays, same as main: the only enabled-but-not-running
+        // case is the RBAC hide (state = DISABLED, `enabled` left true), and the
+        // canAccess gate on the report blocks exactly that case -
+        // handleAccessChange reports when access actually arrives. Keying off
+        // PluginState.LOADED instead would only unblock a branch the gate
+        // immediately re-blocks: two guards for one net behaviour.
         assertTrue(
             Regex(
-                """wasAlreadyEnabled\s*=\s*_pluginStates\.value\[pluginId\]\?\.state\s*==\s*PluginState\.LOADED""",
+                """wasAlreadyEnabled\s*=\s*_pluginStates\.value\[pluginId\]\?\.enabled\s*==\s*true""",
             ).containsMatchIn(body),
-            "enablePlugin must key the redundancy check off PluginState.LOADED",
+            "enablePlugin must key the redundancy check off the enabled flag",
+        )
+        assertTrue(
+            Regex(
+                """if\s*\(\s*reportMissingDependencies\s*&&\s*\w+\s*!=\s*null\s*&&\s*canAccess\(\w+\)\s*\)""",
+            ).containsMatchIn(body),
+            "the canAccess gate must remain load-bearing on the re-enable report",
         )
         assertFalse(
-            body.contains("?enabled == true"),
-            "enablePlugin must not read the `enabled` flag for the redundancy check",
+            Regex(
+                """wasAlreadyEnabled\s*=\s*_pluginStates\.value\[pluginId\]\?\.state""",
+            ).containsMatchIn(body),
+            "the state-based redundancy key must stay dropped (round-2 review: it double-guards with canAccess)",
         )
     }
 
@@ -173,6 +187,22 @@ class DependencyPromptOnReenableTest {
     }
 
     @Test
+    fun `a crash-recovery restart re-enables without the dependency prompt`() {
+        val body = uncommented(functionBody(managerSource(), "restartOwning"))
+        // restartOwning calls enablePlugin to re-arm the sandbox after a crash.
+        // That is recovery, not the user re-arming a plugin: the error-boundary
+        // Restart button must not raise a store-install dialog mid-recovery
+        // (round-2 review; the old test inspected reregisterAfterRestart, a
+        // different function on the other branch).
+        assertTrue(
+            Regex(
+                """manager\.enablePlugin\s*\(\s*pluginId\s*,\s*reportMissingDependencies\s*=\s*false\s*\)""",
+            ).containsMatchIn(body),
+            "restartOwning must opt out of the re-enable dependency report",
+        )
+    }
+
+    @Test
     fun `installPlugin does not report missing dependencies`() {
         // installPlugin also serves startup restore, bundled load and the api
         // hot-swap reload-all. Reporting here would be one dialog per plugin
@@ -187,13 +217,21 @@ class DependencyPromptOnReenableTest {
     @Test
     fun `the desktop layer wires re-activation to the existing reporter`() {
         val source = uncommented(setupSource())
+        // Round-2 review: bind the reporter once outside the callback - every
+        // activation must not pay for a fresh forManager allocation.
         assertTrue(
             Regex(
-                """onPluginActivated\s*=\s*\{[\s\S]{0,400}?""" +
-                    """MissingDependencyReporter\.forManager\s*\(\s*dynamicPluginManager\s*\)""" +
-                    """[\s\S]{0,200}?\.report\s*\(\s*manifest\s*\)""",
+                """val\s+missingDependencyReporter\s*=\s*MissingDependencyReporter\.forManager""" +
+                    """\s*\(\s*dynamicPluginManager\s*\)""",
             ).containsMatchIn(source),
-            "PluginLoaderDelegateSetup must wire onPluginActivated to MissingDependencyReporter.report",
+            "PluginLoaderDelegateSetup must bind the per-manager reporter once, outside the callback",
+        )
+        assertTrue(
+            Regex(
+                """onPluginActivated\s*=\s*\{\s*manifest\s*->""" +
+                    """\s*missingDependencyReporter\.report\s*\(\s*manifest\s*\)\s*\}""",
+            ).containsMatchIn(source),
+            "onPluginActivated must report via the bound reporter without re-allocating per activation",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnReenableTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnReenableTest.kt
@@ -33,13 +33,19 @@ class DependencyPromptOnReenableTest {
     }
 
     private fun managerSource() =
-        read("composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt")
+        read(
+            "composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt",
+        )
 
     private fun setupSource() =
-        read("composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt")
+        read(
+            "composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt",
+        )
 
     private fun delegateSource() =
-        read("composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt")
+        read(
+            "composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt",
+        )
 
     /**
      * Body of the first `fun <name>(` in [source], brace-matched so a later
@@ -59,7 +65,10 @@ class DependencyPromptOnReenableTest {
         var depth = 0
         for (i in brace until source.length) {
             when (source[i]) {
-                '{' -> depth++
+                '{' -> {
+                    depth++
+                }
+
                 '}' -> {
                     depth--
                     if (depth == 0) return source.substring(brace, i + 1)
@@ -80,7 +89,10 @@ class DependencyPromptOnReenableTest {
         var depth = 0
         for (i in open until body.length) {
             when (body[i]) {
-                '{' -> depth++
+                '{' -> {
+                    depth++
+                }
+
                 '}' -> {
                     depth--
                     if (depth == 0) {
@@ -93,20 +105,41 @@ class DependencyPromptOnReenableTest {
     }
 
     /** Drop `//` comments so a sabotaged call left in a comment cannot pass. */
-    private fun uncommented(kotlin: String): String =
-        kotlin.lineSequence().joinToString("\n") { it.replace(Regex("//.*"), "") }
+    private fun uncommented(code: String) = code.lineSequence().joinToString("\n") { it.replace(Regex("//.*"), "") }
 
     @Test
     fun `re-enabling a disabled plugin reports missing dependencies`() {
         val body = uncommented(functionBody(managerSource(), "enablePlugin"))
         // The same skip notifyPanelsRefresh uses: a redundant enable of an
         // already-running plugin is not the user re-arming a disabled one.
+        // The report itself is gated on canAccess: an install-deps dialog is
+        // only actionable for a plugin the user can see, and one still hidden
+        // by RBAC is reported by handleAccessChange when access arrives.
         assertTrue(
             Regex(
                 """if\s*\(\s*result\.isSuccess\s*&&\s*!wasAlreadyEnabled\s*\)\s*\{""" +
-                    """[\s\S]{0,400}?notifyPluginActivated\(""",
+                    """[\s\S]{0,700}?if\s*\(\s*\w+\s*!=\s*null\s*&&\s*canAccess\(\w+\)\s*\)\s*\{""" +
+                    """\s*notifyPluginActivated\(""",
             ).containsMatchIn(body),
-            "enablePlugin must report missing dependencies when it actually re-enables",
+            "enablePlugin must report missing dependencies when it actually re-enables, gated on canAccess",
+        )
+    }
+
+    @Test
+    fun `the re-enable redundancy check is keyed off plugin state, not the enabled flag`() {
+        val body = uncommented(functionBody(managerSource(), "enablePlugin"))
+        // The RBAC hide step sets state = DISABLED without clearing `enabled`,
+        // so an enabled-flag check read a hidden plugin as already running and
+        // silenced the prompt for exactly the re-enable case #180 covers.
+        assertTrue(
+            Regex(
+                """wasAlreadyEnabled\s*=\s*_pluginStates\.value\[pluginId\]\?\.state\s*==\s*PluginState\.LOADED""",
+            ).containsMatchIn(body),
+            "enablePlugin must key the redundancy check off PluginState.LOADED",
+        )
+        assertFalse(
+            body.contains("?enabled == true"),
+            "enablePlugin must not read the `enabled` flag for the redundancy check",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnReenableTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnReenableTest.kt
@@ -1,0 +1,176 @@
+package ai.rever.boss.plugin
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Re-enabling a disabled plugin must report missing dependencies; reloads must not.
+ *
+ * #180: after #178 a required dependency can be removed while its dependent sits
+ * disabled. `enablePlugin` and `handleAccessChange` used to register with no
+ * `missingFor` check, which is the silent looks-alive-does-nothing state the
+ * reporter exists to prevent.
+ *
+ * A source-level assertion because this seam is unreachable from a unit test:
+ * `DynamicPluginManager` cannot be faked, and `PluginLoaderDelegateImpl` takes a
+ * concrete one. Same approach as `DependencyPromptOnInstallOnlyTest`.
+ */
+class DependencyPromptOnReenableTest {
+    private fun repoRoot(): File =
+        assertNotNull(
+            generateSequence(File("").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+            "could not locate the repository root",
+        )
+
+    private fun read(path: String): String {
+        val file = File(repoRoot(), path)
+        assertTrue(file.isFile, "not found: ${file.absolutePath}")
+        return file.readText()
+    }
+
+    private fun managerSource() =
+        read("composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt")
+
+    private fun setupSource() =
+        read("composeApp/src/desktopMain/kotlin/ai/rever/boss/components/plugin/PluginLoaderDelegateSetup.kt")
+
+    private fun delegateSource() =
+        read("composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt")
+
+    /**
+     * Body of the first `fun <name>(` in [source], brace-matched so a later
+     * sibling of the same name (comments, calls) cannot steal the match.
+     */
+    private fun functionBody(
+        source: String,
+        name: String,
+    ): String {
+        val match =
+            assertNotNull(
+                Regex("""fun\s+$name\s*\(""").find(source),
+                "function $name not found",
+            )
+        val brace = source.indexOf('{', match.range.first)
+        assertTrue(brace >= 0, "function $name has no body")
+        var depth = 0
+        for (i in brace until source.length) {
+            when (source[i]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return source.substring(brace, i + 1)
+                }
+            }
+        }
+        error("unbalanced braces for $name")
+    }
+
+    /** Text of the first `mutex.withLock { ... }` in [body]. */
+    private fun withLockBody(body: String): Pair<String, String> {
+        val match =
+            assertNotNull(
+                Regex("""mutex\.withLock\s*\{""").find(body),
+                "no mutex.withLock in body",
+            )
+        val open = body.indexOf('{', match.range.first)
+        var depth = 0
+        for (i in open until body.length) {
+            when (body[i]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) {
+                        return body.substring(open, i + 1) to body.substring(i + 1)
+                    }
+                }
+            }
+        }
+        error("unbalanced mutex.withLock")
+    }
+
+    /** Drop `//` comments so a sabotaged call left in a comment cannot pass. */
+    private fun uncommented(kotlin: String): String =
+        kotlin.lineSequence().joinToString("\n") { it.replace(Regex("//.*"), "") }
+
+    @Test
+    fun `re-enabling a disabled plugin reports missing dependencies`() {
+        val body = uncommented(functionBody(managerSource(), "enablePlugin"))
+        // The same skip notifyPanelsRefresh uses: a redundant enable of an
+        // already-running plugin is not the user re-arming a disabled one.
+        assertTrue(
+            Regex(
+                """if\s*\(\s*result\.isSuccess\s*&&\s*!wasAlreadyEnabled\s*\)\s*\{""" +
+                    """[\s\S]{0,400}?notifyPluginActivated\(""",
+            ).containsMatchIn(body),
+            "enablePlugin must report missing dependencies when it actually re-enables",
+        )
+    }
+
+    @Test
+    fun `RBAC un-hide reports missing dependencies after a successful re-register`() {
+        val body = uncommented(functionBody(managerSource(), "handleAccessChange"))
+        val (insideLock, afterLock) = withLockBody(body)
+        assertTrue(
+            insideLock.contains("reactivated += pluginId") ||
+                insideLock.contains("reactivated.add(pluginId)"),
+            "handleAccessChange must record plugins it actually re-registered",
+        )
+        assertFalse(
+            insideLock.contains("notifyPluginActivated"),
+            "the report must not run while the mutex is held",
+        )
+        assertTrue(
+            Regex("""reactivated\.forEach\s*\(::notifyPluginActivated\)""")
+                .containsMatchIn(afterLock),
+            "handleAccessChange must report missing dependencies after the mutex releases",
+        )
+    }
+
+    @Test
+    fun `a sandbox restart does not report missing dependencies`() {
+        val body = uncommented(functionBody(managerSource(), "reregisterAfterRestart"))
+        assertFalse(
+            body.contains("notifyPluginActivated"),
+            "reregisterAfterRestart is a reload, and reloads must not prompt",
+        )
+    }
+
+    @Test
+    fun `installPlugin does not report missing dependencies`() {
+        // installPlugin also serves startup restore, bundled load and the api
+        // hot-swap reload-all. Reporting here would be one dialog per plugin
+        // on every launch - the reason the install reporters sit outside it.
+        val body = uncommented(functionBody(managerSource(), "installPlugin"))
+        assertFalse(
+            body.contains("notifyPluginActivated"),
+            "installPlugin must not raise the re-enable dependency prompt",
+        )
+    }
+
+    @Test
+    fun `the desktop layer wires re-activation to the existing reporter`() {
+        val source = uncommented(setupSource())
+        assertTrue(
+            Regex(
+                """onPluginActivated\s*=\s*\{[\s\S]{0,400}?""" +
+                    """MissingDependencyReporter\.forManager\s*\(\s*dynamicPluginManager\s*\)""" +
+                    """[\s\S]{0,200}?\.report\s*\(\s*manifest\s*\)""",
+            ).containsMatchIn(source),
+            "PluginLoaderDelegateSetup must wire onPluginActivated to MissingDependencyReporter.report",
+        )
+    }
+
+    @Test
+    fun `the enable delegate does not report on its own`() {
+        // Reporting here AND via the manager callback would double-prompt.
+        val body = uncommented(functionBody(delegateSource(), "enablePlugin"))
+        assertFalse(
+            body.contains("dependencyReporter") || Regex("""\.report\s*\(""").containsMatchIn(body),
+            "PluginLoaderDelegateImpl.enablePlugin must not report; the manager callback does",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/MissingDependencyReporterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/MissingDependencyReporterTest.kt
@@ -18,10 +18,11 @@ import kotlin.test.assertTrue
 /**
  * What the reporter puts on the bus, with a real bus and no plugin loader.
  *
- * The reporter exists as a class rather than a private method because three host paths install
- * on a user's behalf - the plugin-manager delegate, the first-run wizard and the update bridge -
- * and for a while only the first of them reported. These tests cover the decisions that were
- * previously reachable only by reading `PluginLoaderDelegateImpl`'s source.
+ * The reporter exists as a class rather than a private method because several host paths
+ * activate a plugin on a user's behalf - the plugin-manager delegate, the first-run wizard,
+ * the update bridge, and re-enable / RBAC un-hide via `onPluginActivated` - and for a while
+ * only the first of them reported. These tests cover the decisions that were previously
+ * reachable only by reading `PluginLoaderDelegateImpl`'s source.
  */
 class MissingDependencyReporterTest {
     private fun manifest(


### PR DESCRIPTION
# 📋 Pull Request

## Description

Fixes #180. After #178, a required dependency can be removed while its dependent sits disabled. Re-enabling that plugin (Toolbox, or RBAC un-hide via `handleAccessChange`) registered without consulting `missingFor`, so it came back in the silent looks-alive-does-nothing state `MissingDependencyReporter` exists to prevent.

## 🔄 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change that fixes an issue)

## 📦 Version Impact
- [x] **Patch version** (bug fixes, small improvements) - `x.x.+1`

## ✅ Testing Checklist

### 🧪 **Local Testing**
- [x] I have tested this change locally on my development machine
- [x] All existing tests pass with my changes
- [x] I have added new tests for new functionality (if applicable)
- [x] I have verified the fix/feature works as intended

### 🖥️ **Platform Testing**
- [x] 🐧 **Linux** - Tested and working (unit/source tests; no GUI run)

### 🏗️ **Build Verification**
- [x] Project builds successfully with my changes (`:composeApp:desktopTest` compile + targeted tests)

## 🔍 Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation (if needed)

## 🔗 Related Issues
Fixes #180

## 📝 Additional Context

### 🎯 **Motivation and Context**
`enablePlugin` and `handleAccessChange` never went through the three install reporters (`loadPlugin`, the wizard, `PluginUpdateBridge`). Reloads still must not prompt; re-enable is a user action in a way a reload is not.

### 🧠 **Implementation Details**
- `DynamicPluginManager.onPluginActivated` is a per-manager callback (not a companion hook — reporting must read that window's `pluginStates`).
- Fired after a successful `enablePlugin` of a previously-disabled plugin, and after a successful RBAC re-register in `handleAccessChange`. Skipped on redundant enable, `installPlugin`, and `reregisterAfterRestart`.
- The re-enable report is gated once on `canAccess(manifest)`: a plugin still hidden by RBAC gets its prompt from `handleAccessChange` when access actually arrives, and the redundancy check keeps main's enabled-flag key (review round 2: the state-based key and the gate cancelled out — one guard is enough).
- `restartOwning` (crash recovery) passes `reportMissingDependencies = false` to `enablePlugin`: the error-boundary Restart button must not raise a store-install dialog mid-recovery.
- `PluginLoaderDelegateSetup` binds `MissingDependencyReporter.forManager(...)` once, outside the callback, and wires it to `MissingDependencyReporter.report`.

### ⚠️ **Breaking Changes**
None.

## 👀 Review Focus Areas
- [x] **Logic and Algorithm**: Core functionality and business logic

## Verification

```
./gradlew :composeApp:desktopTest \
  --tests ai.rever.boss.plugin.DependencyPromptOnReenableTest \
  --tests ai.rever.boss.plugin.DependencyPromptOnInstallOnlyTest \
  --tests ai.rever.boss.plugin.MissingDependencyReporterTest
```

`DependencyPromptOnReenableTest`: 8 tests, 0 failures · `DependencyPromptOnInstallOnlyTest`: 3 tests, 0 failures · `MissingDependencyReporterTest`: 8 tests, 0 failures. Same source-level style as `DependencyPromptOnInstallOnlyTest`, because `DynamicPluginManager` cannot be faked.

`./gradlew :composeApp:ktlintCheck :composeApp:detekt` → clean on the pushed head (`0fef1645`, rebased onto current `main`).

Sabotage: dropping the `reportMissingDependencies` opt-out, restoring the state-based redundancy key, or un-hoisting the reporter each fails exactly its pinned test.
