### PR TITLE
IDE features (host): git diff/search providers, diff & composer tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,7 @@ __pycache__/
 # Deliberately UNANCHORED: the LSP writes a bin/ under the repo root AND under each
 # module (modules/*/bin/main/...), so an anchored /bin/ would un-ignore the per-module
 # output and leave a dozen untracked directories in git status.
+# Trade-off: it also swallows any legitimate scripts/bin/ or tools/bin/ added later.
+# Re-include such a directory explicitly with e.g. !scripts/bin/ (after this rule).
 bin/
 .kotlin/

--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,8 @@ __pycache__/
 .worktrees/
 
 # Eclipse/Kotlin-LSP build output. Regenerated on every IDE build; never tracked.
+# Deliberately UNANCHORED: the LSP writes a bin/ under the repo root AND under each
+# module (modules/*/bin/main/...), so an anchored /bin/ would un-ignore the per-module
+# output and leave a dozen untracked directories in git status.
 bin/
 .kotlin/

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ __pycache__/
 # Ignored rather than tracked: what lives here is per-developer and per-task, and a stray
 # entry in `git status` is how a real untracked file gets overlooked.
 .worktrees/
+
+# Eclipse/Kotlin-LSP build output. Regenerated on every IDE build; never tracked.
+bin/
+.kotlin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -593,6 +593,14 @@ restart. There is no Settings row and no per-site exclusion.
   `window.__bossInteractionStarted`. The sanitizers bound what can be *smuggled*
   through; nothing bounds a site lying about its own usage. Treat these as
   indicative, not as measurements, wherever a site has an incentive to lie.
+- **`PluginContext.projectSearchProvider` is the first UNGATED WRITE surface.**
+  Like the event bus it is available to every installed plugin, but where the
+  bus is a read, its `replaceInProject` rewrites file contents anywhere inside
+  the open project (the `project_replace` MCP tool sits behind a
+  `project.replace` permission on the *MCP* side, but the provider itself is
+  ungated). Confinement is to the open project only - `resolveFile` refuses
+  paths outside it, canonical and symlink-checked. A plugin that needs project
+  search should be vetted the same way one that subscribes to the bus is.
 
 ## Two-finger swipe navigation (macOS)
 

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:UnifiedDiffParser.kt$UnifiedDiffParser$internal fun cUnquote(p: String): String</ID>
+    <ID>LongParameterList:HomeToolCatalog.kt$HomeToolCatalog$( tabTypes: List&lt;HomeTabTypeInput&gt;, panels: List&lt;HomePanelInput&gt;, storeCatalogue: List&lt;HomeStorePluginInput&gt;, installedPluginIds: Set&lt;String&gt;, access: RegistryAccess, installedVersionOf: (String) -&gt; String? = { null }, )</ID>
     <ID>LongParameterList:ContentSearchService.kt$EditorBufferBridge$( path: String, startLine: Int, startCol: Int, endLine: Int, endCol: Int, newText: String, expectedVersion: Long, )</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$internal fun resolveFile( rawPath: String, projectPath: String, ): File?</ID>
     <ID>SwallowedException:ContentSearchService.kt$ContentSearchService$e: java.nio.file.AtomicMoveNotSupportedException</ID>
@@ -22,6 +23,7 @@
     <ID>LoopWithTooManyJumpStatements:DesktopGitService.kt$GitService$for</ID>
     <ID>LoopWithTooManyJumpStatements:UnifiedDiffParser.kt$UnifiedDiffParser$for</ID>
     <ID>MaxLineLength:BufferEditRangeTest.kt$BufferEditRangeTest$assertEquals("y", text.substring(offsetOf(lines, r.startLine, r.startCol), offsetOf(lines, r.endLine, r.endCol)))</ID>
+    <ID>MaxLineLength:InstalledPluginVersionDesktop.kt$internal actual fun installedPluginVersionOf(pluginId: String): String?</ID>
     <ID>MaxLineLength:ContentSearchService.kt$ContentSearchService$cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath)</ID>
     <ID>MaxLineLength:EditorAPIAccess.kt$EditorAPIAccess$/** Snapshot of the live buffer for [path], or null when the file has no open buffer (or the plugin predates the method). */</ID>
     <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$DiffLine(DiffLineKind.CONTEXT, text, oldLine = o.takeIf { o &gt; 0 }, newLine = n.takeIf { n &gt; 0 })</ID>
@@ -1209,6 +1211,7 @@
     <ID>ReturnCount:WorkspacePlaceholders.kt$WorkspacePlaceholders$private fun getGitRemoteUrl(projectPath: String): String</ID>
     <ID>SpreadOperator:CrashHandler.kt$CrashHandler$(javaBin, *getRestartArgs())</ID>
     <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, *args.toTypedArray())</ID>
+    <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, *diffArgs.toTypedArray())</ID>
     <ID>SpreadOperator:FilePickerProviderFactory.kt$DesktopFilePickerProvider$( filters.joinToString(", ") { "*.$it" }, *filters.toTypedArray(), )</ID>
     <ID>ThrowsCount:UpdateInstaller.kt$UpdateInstaller$internal fun validateDownloadFile( downloadFile: File, expectedExtension: String, stagingDir: File = defaultStagingDir(), )</ID>
     <ID>ThrowsCount:UpdatePathValidator.kt$UpdatePathValidator$fun validatePath( path: String, description: String, )</ID>
@@ -1866,9 +1869,11 @@
     <ID>PackageNaming:SplitDirectionTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:DiffTabMatch.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:DiffTabMatchTest.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( file: File, projectRoot: String, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, )</ID>
     <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, )</ID>
     <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, )</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInOneFile( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, ): FileReplaceResult</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInOneFile( file: File, projectRoot: String, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -&gt; Boolean, ): FileReplaceResult</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInBuffer( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, ): FileReplaceResult</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -2,6 +2,8 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>CyclomaticComplexMethod:UnifiedDiffParser.kt$UnifiedDiffParser$internal fun cUnquote(p: String): String</ID>
+    <ID>LongParameterList:ContentSearchService.kt$EditorBufferBridge$( path: String, startLine: Int, startCol: Int, endLine: Int, endCol: Int, newText: String, expectedVersion: Long, )</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$internal fun resolveFile( rawPath: String, projectPath: String, ): File?</ID>
     <ID>SwallowedException:ContentSearchService.kt$ContentSearchService$e: java.nio.file.AtomicMoveNotSupportedException</ID>
     <ID>SwallowedException:ResolveFileConfinementTest.kt$ResolveFileConfinementTest$e: Exception</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -1864,5 +1864,11 @@
     <ID>PackageNaming:SplitCreatorMap.kt$package ai.rever.boss.components.window_panel.components.main_window_panels</ID>
     <ID>PackageNaming:SplitCreatorMapTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>PackageNaming:SplitDirectionTest.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:DiffTabMatch.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:DiffTabMatchTest.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, )</ID>
+    <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, )</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInOneFile( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, ): FileReplaceResult</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInBuffer( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, isCancelled: () -> Boolean, ): FileReplaceResult</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -2,6 +2,46 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ComplexCondition:UnifiedDiffParser.kt$UnifiedDiffParser$h != null &amp;&amp; (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ") || line.isEmpty())</ID>
+    <ID>ComplexCondition:WorkspaceExtractor.kt$tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null</ID>
+    <ID>CyclomaticComplexMethod:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>
+    <ID>CyclomaticComplexMethod:UnifiedDiffParser.kt$UnifiedDiffParser$fun parse(input: String): List&lt;GitDiffData&gt;</ID>
+    <ID>CyclomaticComplexMethod:UnifiedDiffParser.kt$UnifiedDiffParser$private fun cUnquote(p: String): String</ID>
+    <ID>CyclomaticComplexMethod:WorkspaceApplier.kt$internal fun createTabFromWorkspaceConfig( tabConfig: TabConfig, resolvedProjectPath: String, splitViewState: SplitViewState, ): TabInfo?</ID>
+    <ID>LongMethod:WorkspaceApplier.kt$internal fun createTabFromWorkspaceConfig( tabConfig: TabConfig, resolvedProjectPath: String, splitViewState: SplitViewState, ): TabInfo?</ID>
+    <ID>LongMethod:WorkspaceExtractor.kt$private fun extractTabConfig( tab: TabInfo, defaultWorkingDirectory: String, ): TabConfig?</ID>
+    <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, )</ID>
+    <ID>LongParameterList:ContentSearchService.kt$ContentSearchService$( projectRoot: String, query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, path: String, // projectRoot is part of the key because a cached FileMatch carries a path // RELATIVE to the root it was found under. The same absolute file walked under // a different root (switching between nested projects) would otherwise get its // old relative path served from cache until its mtime changed, and a // result-click would resolve it against the new root - the wrong file. )</ID>
+    <ID>LongParameterList:EditorAPIAccess.kt$EditorAPIAccess$( path: String, startLine: Int, startCol: Int, endLine: Int, endCol: Int, newText: String, expectedVersion: Long, )</ID>
+    <ID>LoopWithTooManyJumpStatements:ContentSearchService.kt$ContentSearchService$for</ID>
+    <ID>LoopWithTooManyJumpStatements:DesktopGitService.kt$GitService$for</ID>
+    <ID>LoopWithTooManyJumpStatements:UnifiedDiffParser.kt$UnifiedDiffParser$for</ID>
+    <ID>MaxLineLength:BufferEditRangeTest.kt$BufferEditRangeTest$assertEquals("y", text.substring(offsetOf(lines, r.startLine, r.startCol), offsetOf(lines, r.endLine, r.endCol)))</ID>
+    <ID>MaxLineLength:ContentSearchService.kt$ContentSearchService$cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath)</ID>
+    <ID>MaxLineLength:EditorAPIAccess.kt$EditorAPIAccess$/** Snapshot of the live buffer for [path], or null when the file has no open buffer (or the plugin predates the method). */</ID>
+    <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$DiffLine(DiffLineKind.CONTEXT, text, oldLine = o.takeIf { o &gt; 0 }, newLine = n.takeIf { n &gt; 0 })</ID>
+    <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$lines.add(DiffLine(DiffLineKind.ADDED, line.substring(1), oldLine = null, newLine = n.takeIf { n &gt; 0 }))</ID>
+    <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$lines.add(DiffLine(DiffLineKind.REMOVED, line.substring(1), oldLine = o.takeIf { o &gt; 0 }, newLine = null))</ID>
+    <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser$if</ID>
+    <ID>PackageNaming:TabPaths.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>PackageNaming:TabPathsTest.kt$package ai.rever.boss.components.window_panel</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$override suspend fun replaceInProject( query: String, replacement: String, files: List&lt;String&gt;, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, dryRun: Boolean, ): ReplaceSummary</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private fun resolveFile( rawPath: String, projectPath: String, ): File?</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private fun scanText( file: File, text: String, regex: Regex, ): List&lt;FileMatch&gt;?</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInBuffer( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, ): FileReplaceResult</ID>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInOneFile( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, ): FileReplaceResult</ID>
+    <ID>ReturnCount:DesktopGitService.kt$GitService$internal fun isSafeRefName(ref: String): Boolean</ID>
+    <ID>ReturnCount:DesktopGitService.kt$GitService$private fun stagedPathsFor( projectPath: String, filePath: String, ): List&lt;String&gt;</ID>
+    <ID>ReturnCount:UnifiedDiffParser.kt$UnifiedDiffParser$private fun splitSides(s: String): Pair&lt;String, String&gt;?</ID>
+    <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, "restore", "--staged", "--", *paths.toTypedArray())</ID>
+    <ID>SpreadOperator:DesktopGitService.kt$GitService$(projectPath, *args)</ID>
+    <ID>SwallowedException:ContentSearchService.kt$ContentSearchService$e: Exception</ID>
+    <ID>SwallowedException:TabPaths.kt$TabPaths$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ContentSearchService.kt$ContentSearchService$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:TabPaths.kt$TabPaths$e: Exception</ID>
+    <ID>TooManyFunctions:ContentSearchService.kt$ContentSearchService : ProjectSearchProvider</ID>
+    <ID>TooManyFunctions:EditorAPIAccess.kt$EditorAPIAccess</ID>
     <ID>LongParameterList:DownloadCenter.kt$DownloadCenter$( id: String, title: String, kind: TransferKind, detail: String? = null, onCancel: (() -&gt; Unit)? = null, owner: String? = null, )</ID>
     <ID>LongParameterList:StoreVersionInstaller.kt$StoreVersionInstaller$( store: PluginRepository, request: StoreVersionRequest, unload: suspend (String) -&gt; Result&lt;Unit&gt;, load: suspend (String) -&gt; Result&lt;Boolean&gt;, onProgress: ((Float) -&gt; Unit)? = null, onInstalling: (() -&gt; Unit)? = null, )</ID>
     <ID>ComplexCondition:BossAppEventBusEffects.kt$processingState.totalTabs == 0 &amp;&amp; !processingState.isProcessingURLs &amp;&amp; !processingState.isProcessingTerminals &amp;&amp; !processingState.isProcessingFiles &amp;&amp; processingState.isRestorationComplete</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -12,7 +12,6 @@
     <ID>ComplexCondition:WorkspaceExtractor.kt$tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null</ID>
     <ID>CyclomaticComplexMethod:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>
     <ID>CyclomaticComplexMethod:UnifiedDiffParser.kt$UnifiedDiffParser$fun parse(input: String): List&lt;GitDiffData&gt;</ID>
-    <ID>CyclomaticComplexMethod:UnifiedDiffParser.kt$UnifiedDiffParser$private fun cUnquote(p: String): String</ID>
     <ID>CyclomaticComplexMethod:WorkspaceApplier.kt$internal fun createTabFromWorkspaceConfig( tabConfig: TabConfig, resolvedProjectPath: String, splitViewState: SplitViewState, ): TabInfo?</ID>
     <ID>LongMethod:WorkspaceApplier.kt$internal fun createTabFromWorkspaceConfig( tabConfig: TabConfig, resolvedProjectPath: String, splitViewState: SplitViewState, ): TabInfo?</ID>
     <ID>LongMethod:WorkspaceExtractor.kt$private fun extractTabConfig( tab: TabInfo, defaultWorkingDirectory: String, ): TabConfig?</ID>
@@ -33,8 +32,6 @@
     <ID>PackageNaming:TabPathsTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$override suspend fun replaceInProject( query: String, replacement: String, files: List&lt;String&gt;, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, dryRun: Boolean, ): ReplaceSummary</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>
-    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private fun resolveFile( rawPath: String, projectPath: String, ): File?</ID>
-    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private fun scanText( file: File, text: String, regex: Regex, ): List&lt;FileMatch&gt;?</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInBuffer( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, ): FileReplaceResult</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInOneFile( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, ): FileReplaceResult</ID>
     <ID>ReturnCount:DesktopGitService.kt$GitService$internal fun isSafeRefName(ref: String): Boolean</ID>
@@ -1461,7 +1458,7 @@
     <ID>TooManyFunctions:FluckEngine.kt$FluckEngine</ID>
     <ID>TooManyFunctions:FontManager.kt$FontManager</ID>
     <ID>TooManyFunctions:FullscreenBrowserWindow.kt$FullscreenBrowserWindow</ID>
-    <ID>TooManyFunctions:GitDataProviderImpl.kt$GitDataProviderImpl : GitDataProvider</ID>
+    <ID>TooManyFunctions:GitDataProviderImpl.kt$GitDataProviderImpl : GitDataProviderDisposableProvider</ID>
     <ID>TooManyFunctions:GitService.kt$GitService</ID>
     <ID>TooManyFunctions:GitServiceBridge.kt$GitServiceBridge : GitServiceCoroutineImplBase</ID>
     <ID>TooManyFunctions:GlobalSearchDialog.kt$ai.rever.boss.components.dialogs.GlobalSearchDialog.kt</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -7,8 +7,6 @@
     <ID>LongParameterList:ContentSearchService.kt$EditorBufferBridge$( path: String, startLine: Int, startCol: Int, endLine: Int, endCol: Int, newText: String, expectedVersion: Long, )</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$internal fun resolveFile( rawPath: String, projectPath: String, ): File?</ID>
     <ID>SwallowedException:ContentSearchService.kt$ContentSearchService$e: java.nio.file.AtomicMoveNotSupportedException</ID>
-    <ID>SwallowedException:ResolveFileConfinementTest.kt$ResolveFileConfinementTest$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:ResolveFileConfinementTest.kt$ResolveFileConfinementTest$e: Exception</ID>
     <ID>ComplexCondition:UnifiedDiffParser.kt$UnifiedDiffParser$h != null &amp;&amp; (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ") || line.isEmpty())</ID>
     <ID>ComplexCondition:WorkspaceExtractor.kt$tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null</ID>
     <ID>CyclomaticComplexMethod:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>
@@ -26,7 +24,6 @@
     <ID>MaxLineLength:InstalledPluginVersionDesktop.kt$internal actual fun installedPluginVersionOf(pluginId: String): String?</ID>
     <ID>MaxLineLength:ContentSearchService.kt$ContentSearchService$cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath)</ID>
     <ID>MaxLineLength:EditorAPIAccess.kt$EditorAPIAccess$/** Snapshot of the live buffer for [path], or null when the file has no open buffer (or the plugin predates the method). */</ID>
-    <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$DiffLine(DiffLineKind.CONTEXT, text, oldLine = o.takeIf { o &gt; 0 }, newLine = n.takeIf { n &gt; 0 })</ID>
     <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$lines.add(DiffLine(DiffLineKind.ADDED, line.substring(1), oldLine = null, newLine = n.takeIf { n &gt; 0 }))</ID>
     <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser.HunkBuilder$lines.add(DiffLine(DiffLineKind.REMOVED, line.substring(1), oldLine = o.takeIf { o &gt; 0 }, newLine = null))</ID>
     <ID>MaxLineLength:UnifiedDiffParser.kt$UnifiedDiffParser$if</ID>
@@ -34,8 +31,6 @@
     <ID>PackageNaming:TabPathsTest.kt$package ai.rever.boss.components.window_panel</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$override suspend fun replaceInProject( query: String, replacement: String, files: List&lt;String&gt;, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, dryRun: Boolean, ): ReplaceSummary</ID>
     <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>
-    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInBuffer( file: File, text: String, version: Long, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, ): FileReplaceResult</ID>
-    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$private suspend fun replaceInOneFile( file: File, regex: Regex, replacement: String, isRegex: Boolean, dryRun: Boolean, ): FileReplaceResult</ID>
     <ID>ReturnCount:DesktopGitService.kt$GitService$internal fun isSafeRefName(ref: String): Boolean</ID>
     <ID>ReturnCount:DesktopGitService.kt$GitService$private fun stagedPathsFor( projectPath: String, filePath: String, ): List&lt;String&gt;</ID>
     <ID>ReturnCount:UnifiedDiffParser.kt$UnifiedDiffParser$private fun splitSides(s: String): Pair&lt;String, String&gt;?</ID>

--- a/composeApp/detekt-baseline.xml
+++ b/composeApp/detekt-baseline.xml
@@ -2,6 +2,10 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ReturnCount:ContentSearchService.kt$ContentSearchService$internal fun resolveFile( rawPath: String, projectPath: String, ): File?</ID>
+    <ID>SwallowedException:ContentSearchService.kt$ContentSearchService$e: java.nio.file.AtomicMoveNotSupportedException</ID>
+    <ID>SwallowedException:ResolveFileConfinementTest.kt$ResolveFileConfinementTest$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:ResolveFileConfinementTest.kt$ResolveFileConfinementTest$e: Exception</ID>
     <ID>ComplexCondition:UnifiedDiffParser.kt$UnifiedDiffParser$h != null &amp;&amp; (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ") || line.isEmpty())</ID>
     <ID>ComplexCondition:WorkspaceExtractor.kt$tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null</ID>
     <ID>CyclomaticComplexMethod:ContentSearchService.kt$ContentSearchService$override suspend fun searchInProject( query: String, pathPattern: String?, excludePattern: String?, isRegex: Boolean, caseSensitive: Boolean, wholeWord: Boolean, maxResults: Int, ): List&lt;FileMatch&gt;</ID>

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppEventBusEffects.kt
@@ -91,6 +91,15 @@ internal fun BossAppEventBusEffects(state: BossAppState) {
             }.launchIn(this)
     }
 
+    // Listen for diff open events (git data provider's openDiff) - Issue #506 window filter
+    LaunchedEffect(splitViewState, windowId) {
+        FileEventBus.diffOpenEvents
+            .filter { event -> event.sourceWindowId == windowId }
+            .onEach { event ->
+                splitViewState.openDiffTabInActivePanel(event)
+            }.launchIn(this)
+    }
+
     // Listen for terminal open events - now handled by split state
     // Issue #506: Filter by window to prevent terminal opening in all windows
     LaunchedEffect(splitViewState, windowId) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/bars/horizontal/BossTopBar.kt
@@ -477,12 +477,22 @@ fun BossDraggableComponent.BossTopLeftBar(
     val isGitLoading by windowGitState?.isLoading?.collectAsState() ?: remember { mutableStateOf(false) }
     // Git availability is global (system-level) so we still use GitService for this
     val isGitAvailable by GitService.isGitAvailable.collectAsState()
+    // Process-wide: true while ANY git command in ANY window holds (or waits on)
+    // the git lock. The git menu's own actions report through isGitLoading; this
+    // is the signal for when some OTHER slow command freezes every git read.
+    val gitCommandRunning by GitService.gitCommandsRunning.collectAsState()
     var showCreateBranchDialog by remember { mutableStateOf(false) }
     var showCommitDialog by remember { mutableStateOf(false) }
     var gitErrorMessage by remember { mutableStateOf<String?>(null) }
     var gitSuccessMessage by remember { mutableStateOf<String?>(null) }
     var createPRUrl by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
+
+    // Every git verb below runs in THIS window's project, never in the global
+    // currentProjectPath: with two windows on two worktrees the global belongs
+    // to whichever window aligned last, and a Merge pressed here could land in
+    // the other window's tree.
+    val windowProjectPath = selectedProject.path.ifBlank { null }
 
     // Refresh Git state when project changes - uses window-specific state
     // This ensures each window's git UI is independent
@@ -491,7 +501,7 @@ fun BossDraggableComponent.BossTopLeftBar(
             // Refresh git for THIS window only
             GitService.refreshForWindow(selectedProject.path, windowGitState)
             // Also fetch the PR URL and stash list for this window
-            createPRUrl = GitService.getCreatePRUrl()
+            createPRUrl = GitService.getCreatePRUrl(projectPathOverride = windowProjectPath)
             GitService.refreshStashListForWindow(windowGitState)
         } else {
             // Only clear THIS window's git state, not other windows
@@ -513,7 +523,7 @@ fun BossDraggableComponent.BossTopLeftBar(
     // Update PR URL when branch changes
     LaunchedEffect(currentBranch) {
         if (isGitRepo && currentBranch != null) {
-            createPRUrl = GitService.getCreatePRUrl()
+            createPRUrl = GitService.getCreatePRUrl(projectPathOverride = windowProjectPath)
         }
     }
 
@@ -603,18 +613,22 @@ fun BossDraggableComponent.BossTopLeftBar(
                         }
                     },
                     onMerge = { branchName ->
-                        scope.launch { GitService.mergeInTerminal(windowId, branchName) }
+                        scope.launch {
+                            GitService.mergeInTerminal(windowId, branchName, projectPathOverride = windowProjectPath)
+                        }
                     },
                     onRebase = { branchName ->
-                        scope.launch { GitService.rebaseInTerminal(windowId, branchName) }
+                        scope.launch {
+                            GitService.rebaseInTerminal(windowId, branchName, projectPathOverride = windowProjectPath)
+                        }
                     },
                     onCreateBranch = { showCreateBranchDialog = true },
                     onCommit = { showCommitDialog = true },
                     onPull = {
-                        scope.launch { GitService.pullInTerminal(windowId) }
+                        scope.launch { GitService.pullInTerminal(windowId, projectPathOverride = windowProjectPath) }
                     },
                     onPush = {
-                        scope.launch { GitService.pushInTerminal(windowId) }
+                        scope.launch { GitService.pushInTerminal(windowId, projectPathOverride = windowProjectPath) }
                     },
                     onCreatePR =
                         createPRUrl?.let { url ->
@@ -646,12 +660,14 @@ fun BossDraggableComponent.BossTopLeftBar(
                     onRefresh = {
                         scope.launch {
                             GitService.refreshForWindow(selectedProject.path, windowGitState)
-                            createPRUrl = GitService.getCreatePRUrl()
+                            createPRUrl = GitService.getCreatePRUrl(projectPathOverride = windowProjectPath)
                             GitService.refreshStashListForWindow(windowGitState)
                         }
                     },
                 ),
-            hintText = "Git Branch: ${currentBranch ?: "unknown"}",
+            hintText =
+                "Git Branch: ${currentBranch ?: "unknown"}" +
+                    if (gitCommandRunning) " (a git command is running; git updates wait for it)" else "",
         )
     }
 
@@ -689,7 +705,13 @@ fun BossDraggableComponent.BossTopLeftBar(
             onDismiss = { showCreateBranchDialog = false },
             onCreate = { branchName ->
                 scope.launch {
-                    val result = GitService.createBranch(branchName, checkout = true, windowId = windowId)
+                    val result =
+                        GitService.createBranch(
+                            branchName,
+                            checkout = true,
+                            windowId = windowId,
+                            projectPathOverride = windowProjectPath,
+                        )
                     if (result is GitError) {
                         gitErrorMessage = result.message
                     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/FileEventBus.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/events/FileEventBus.kt
@@ -56,6 +56,9 @@ object FileEventBus {
     val fileOpenEvents: SharedFlow<FileOpenEvent>
         get() = delegate.fileOpenEvents
 
+    val diffOpenEvents: SharedFlow<ai.rever.boss.plugin.events.DiffOpenEvent>
+        get() = delegate.diffOpenEvents
+
     suspend fun openFile(
         filePath: String,
         line: Int = 0,
@@ -67,5 +70,21 @@ object FileEventBus {
         val cleanPath = stripFilePrefix(filePath)
         val fileName = cleanPath.substringAfterLast('/').substringAfterLast('\\').ifEmpty { "untitled" }
         ipcBridge?.forward("FileOpenEvent", FileOpenEvent(cleanPath, fileName, line, column, sourceWindowId), sourceWindowId)
+    }
+
+    suspend fun openDiffTab(
+        filePath: String,
+        staged: Boolean,
+        fromRef: String?,
+        toRef: String?,
+        sourceWindowId: String,
+    ) {
+        delegate.openDiffTab(filePath, staged, fromRef, toRef, sourceWindowId)
+        ipcBridge?.forward(
+            "DiffOpenEvent",
+            ai.rever.boss.plugin.events
+                .DiffOpenEvent(filePath, staged, fromRef, toRef, sourceWindowId),
+            sourceWindowId,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeScreen.kt
@@ -170,7 +170,10 @@ private fun JumpBackInSection(
 
 @Composable
 private fun ToolsSection(actions: HomeActions) {
-    val tools = rememberHomeTools()
+    // The retired-plugin floor reads installed.json, which only desktopMain can
+    // reach: the lookup is an expect/actual so commonMain stays platform-agnostic
+    // (the same seam `warmBrowserEngineForTabs` uses).
+    val tools = rememberHomeTools(installedVersionOf = ::installedPluginVersionOf)
     val keymap by KeymapSettingsManager.currentSettings.collectAsState()
     var filter by remember { mutableStateOf(HomeToolFilter.ALL) }
     // Ids currently installing, so a tile shows progress rather than looking unresponsive for the

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeToolCatalog.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/HomeToolCatalog.kt
@@ -114,6 +114,7 @@ object HomeToolCatalog {
         storeCatalogue: List<HomeStorePluginInput>,
         installedPluginIds: Set<String>,
         access: RegistryAccess,
+        installedVersionOf: (String) -> String? = { null },
     ): List<HomeTool> {
         val hostTools = HOST_ACTIONS.map(::hostTool)
 
@@ -170,7 +171,9 @@ object HomeToolCatalog {
                 // Nor a plugin another plugin has taken over. Unlisting the store row is a manual
                 // action outside CI, so until it happens the store still returns it - and a user
                 // could install it, have it swept away at the next launch, and install it again.
-                .filterNot { it.pluginId in RetiredPluginIds.ALL }
+                // The floor is the sweep's own: a fresh install whose replacement predates the
+                // absorbing release would otherwise be offered neither half.
+                .filterNot { RetiredPluginIds.hiddenFromOffers(it.pluginId, installedVersionOf) }
                 .filterNot { it.isService }
                 .filter { it.isCompatible }
                 // A plugin the user has no access to is hidden, not greyed. The host already hides

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/InstalledPluginVersion.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/InstalledPluginVersion.kt
@@ -1,0 +1,11 @@
+package ai.rever.boss.components.home
+
+/**
+ * The INSTALLED version of a plugin from `installed.json`, or null when it has no row.
+ *
+ * expect/actual only because `installed.json` is a desktop concern: the
+ * retired-plugin OFFER filter (commonMain) needs the sweep's floor, which lives
+ * in that table. A host without an install table answers null, and the filter
+ * fails closed - the retired plugin stays OFFERED, the conservative side.
+ */
+internal expect fun installedPluginVersionOf(pluginId: String): String?

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/RememberHomeTools.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/home/RememberHomeTools.kt
@@ -27,7 +27,7 @@ private val logger = BossLogger.forComponent("HomeTools")
  * makes the grid current: install a plugin and its tile appears without a relaunch.
  */
 @Composable
-internal fun rememberHomeTools(): List<HomeTool> {
+internal fun rememberHomeTools(installedVersionOf: (String) -> String? = { null }): List<HomeTool> {
     val tabRegistry = LocalTabRegistry.current
     val panelRegistry = LocalPanelRegistry.current
     val pluginStates by LocalPluginStates.current?.collectAsState()
@@ -112,6 +112,7 @@ internal fun rememberHomeTools(): List<HomeTool> {
             storeCatalogue = discoverable,
             installedPluginIds = installedPluginIds,
             access = access,
+            installedVersionOf = installedVersionOf,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -434,7 +434,27 @@ class DefaultPlugin(
     // use provider-presence to mean "a project is open" - it means "this host
     // implements search". Check projectPath for the other question.
     override val projectSearchProvider: ProjectSearchProvider? by lazy {
-        ContentSearchService { projectPath }
+        ContentSearchService(
+            projectPathProvider = { projectPath },
+            // Bridge over THIS window's registry, not the global EditorAPIAccess, so a
+            // search in this window edits this window's buffers.
+            bufferBridge =
+                object : ai.rever.boss.search.EditorBufferBridge {
+                    private fun provider() = getPluginAPI(ai.rever.boss.plugin.api.EditorTabPluginAPI::class.java)
+
+                    override suspend fun readBuffer(path: String) = provider()?.readBuffer(path)
+
+                    override suspend fun applyEdit(
+                        path: String,
+                        startLine: Int,
+                        startCol: Int,
+                        endLine: Int,
+                        endCol: Int,
+                        newText: String,
+                        expectedVersion: Long,
+                    ) = provider()?.applyEdit(path, startLine, startCol, endLine, endCol, newText, expectedVersion)
+                },
+        )
     }
 
     // Auth data provider for plugins that need authentication state

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -403,21 +403,25 @@ class DefaultPlugin(
     // folded into this same service — see BrowserConfig.profileName/ephemeralProfile/auth.
     override val browserService: BrowserService? = getBrowserServiceInstance(_windowId)
 
-    // Git data provider for plugins that display git information
-    override val gitDataProvider: GitDataProvider? by lazy {
-        if (windowGitState != null) {
-            GitDataProviderImpl(
-                windowGitState,
-                { _windowId },
-                // The window's own selected project: lets the provider bootstrap
-                // windowGitState.projectPath when the project was picked outside
-                // the top bar (e.g. the codebase panel's picker).
-                { windowProjectState?.selectedProject?.value?.path },
-            )
-        } else {
-            null
+    // Git data provider for plugins that display git information.
+    // Named delegate so dispose() can cancel its collectors without forcing the lazy
+    // (see logDataProviderDelegate for the same pattern).
+    private val gitDataProviderDelegate =
+        lazy {
+            if (windowGitState != null) {
+                GitDataProviderImpl(
+                    windowGitState,
+                    { _windowId },
+                    // The window's own selected project: lets the provider bootstrap
+                    // windowGitState.projectPath when the project was picked outside
+                    // the top bar (e.g. the codebase panel's picker).
+                    { windowProjectState?.selectedProject?.value?.path },
+                )
+            } else {
+                null
+            }
         }
-    }
+    override val gitDataProvider: GitDataProvider? by gitDataProviderDelegate
 
     // Window ID for window-scoped operations
     override val windowId: String?
@@ -454,8 +458,48 @@ class DefaultPlugin(
                         expectedVersion: Long,
                     ) = provider()?.applyEdit(path, startLine, startCol, endLine, endCol, newText, expectedVersion)
                 },
+            // The host knows which files have an editor tab open in this window, so the
+            // search asks the bridge about those alone instead of every walked file.
+            openEditorPathsProvider = { openEditorFilePaths() },
         )
     }
+
+    /**
+     * Absolute paths of every file with an editor tab open in THIS window, or null
+     * when the set cannot be trusted - null makes the search fall back to asking the
+     * editor about every file, which is correct, just slower. Untrusted means: no
+     * split view to enumerate, or an editor-typed tab whose class this host cannot
+     * read a path from (a plugin-constructed TabInfo, read by reflection like
+     * [ApiActiveTabsProviderAdapter] does for browser tabs).
+     */
+    private fun openEditorFilePaths(): Set<String>? =
+        runCatching {
+            val panels = splitViewState?.getAllPanels() ?: return@runCatching null
+            val paths = mutableSetOf<String>()
+            for (panel in panels) {
+                for (tab in panel.tabsComponent.tabsState.value.tabs) {
+                    when {
+                        tab is ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo -> {
+                            // A blank path is an unsaved "Untitled" buffer: no file on
+                            // disk can be that tab, so it cannot affect the walk.
+                            if (tab.filePath.isNotBlank()) paths.add(tab.filePath)
+                        }
+
+                        tab.typeId.typeId == "editor" -> {
+                            val p =
+                                runCatching {
+                                    tab.javaClass.getMethod("getFilePath").invoke(tab) as? String
+                                }.getOrNull()
+                            // An editor tab whose path we cannot read means the set is
+                            // incomplete - claiming it complete would skip a live buffer.
+                            if (p.isNullOrBlank()) return@runCatching null
+                            paths.add(p)
+                        }
+                    }
+                }
+            }
+            paths
+        }.getOrNull()
 
     // Auth data provider for plugins that need authentication state
     override val authDataProvider: AuthDataProvider by lazy {
@@ -1050,6 +1094,9 @@ class DefaultPlugin(
         // actually built: see [logDataProviderDelegate].
         if (logDataProviderDelegate.isInitialized()) {
             (logDataProvider as? DisposableProvider)?.dispose()
+        }
+        if (gitDataProviderDelegate.isInitialized()) {
+            (gitDataProvider as? DisposableProvider)?.dispose()
         }
         pluginScope.cancel()
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -437,6 +437,14 @@ class DefaultPlugin(
     // answers with empty results when there is none. A plugin cannot therefore
     // use provider-presence to mean "a project is open" - it means "this host
     // implements search". Check projectPath for the other question.
+    //
+    // UNGATED, deliberately, per the AGENTS.md rule for applicationEventBus
+    // ("gate at install time by choosing which plugins are allowed, not by
+    // trusting the bus") - but this is the first WRITE surface with that
+    // property: any installed plugin can read and rewrite any file inside the
+    // selected project. The corresponding line in the api KDoc (boss-plugin-api
+    // repo) lands with the next api bump; it is stated here now so the host
+    // never ships the surface without the caveat somewhere in-tree.
     override val projectSearchProvider: ProjectSearchProvider? by lazy {
         ContentSearchService(
             projectPathProvider = { projectPath },

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DefaultPlugin.kt
@@ -68,6 +68,7 @@ import ai.rever.boss.plugin.api.PluginSandboxRef
 import ai.rever.boss.plugin.api.PluginStorageFactory
 import ai.rever.boss.plugin.api.PluginStoreApiKeyProvider
 import ai.rever.boss.plugin.api.ProjectData
+import ai.rever.boss.plugin.api.ProjectSearchProvider
 import ai.rever.boss.plugin.api.RoleManagementProvider
 import ai.rever.boss.plugin.api.ScreenCaptureProvider
 import ai.rever.boss.plugin.api.SearchProvider
@@ -94,6 +95,7 @@ import ai.rever.boss.plugin.sandbox.notification.BossPluginNotificationService
 import ai.rever.boss.plugin.sandbox.notification.PluginSandboxNotificationListener
 import ai.rever.boss.plugin.sandbox.notification.PluginToastState
 import ai.rever.boss.plugin.ui.ContextMenuItemData
+import ai.rever.boss.search.ContentSearchService
 import ai.rever.boss.search.SearchRegistryImpl
 import ai.rever.boss.services.auth.AuthDataProviderImpl
 import ai.rever.boss.services.auth.AuthStateManager
@@ -404,7 +406,14 @@ class DefaultPlugin(
     // Git data provider for plugins that display git information
     override val gitDataProvider: GitDataProvider? by lazy {
         if (windowGitState != null) {
-            GitDataProviderImpl(windowGitState) { _windowId }
+            GitDataProviderImpl(
+                windowGitState,
+                { _windowId },
+                // The window's own selected project: lets the provider bootstrap
+                // windowGitState.projectPath when the project was picked outside
+                // the top bar (e.g. the codebase panel's picker).
+                { windowProjectState?.selectedProject?.value?.path },
+            )
         } else {
             null
         }
@@ -417,6 +426,16 @@ class DefaultPlugin(
     // Project path for project-specific operations
     override val projectPath: String?
         get() = windowProjectState?.selectedProject?.value?.path
+
+    // Project-wide content search (boss-plugin-api 1.0.87). Host-side engine.
+    //
+    // NEVER null: the engine exists whether or not a project is selected, and
+    // answers with empty results when there is none. A plugin cannot therefore
+    // use provider-presence to mean "a project is open" - it means "this host
+    // implements search". Check projectPath for the other question.
+    override val projectSearchProvider: ProjectSearchProvider? by lazy {
+        ContentSearchService { projectPath }
+    }
 
     // Auth data provider for plugins that need authentication state
     override val authDataProvider: AuthDataProvider by lazy {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
@@ -20,5 +20,10 @@ package ai.rever.boss.components.plugin
  * without a matching entry here fails rather than quietly staying installable.
  */
 object RetiredPluginIds {
-    val ALL: Set<String> = setOf("ai.rever.boss.plugin.dynamic.usersecretlist")
+    val ALL: Set<String> =
+        setOf(
+            "ai.rever.boss.plugin.dynamic.usersecretlist",
+            "ai.rever.boss.plugin.dynamic.gitstatus",
+            "ai.rever.boss.plugin.dynamic.gitlog",
+        )
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
@@ -19,7 +19,7 @@ import ai.rever.boss.plugin.updater.satisfiesVersionFloor
  * retirement hold regardless of what the store says, which is what stops it being a one-way door
  * in the wrong direction.
  *
- * `RetiredPluginIdsTest` pins this against `RetiredPlugins.ALL` (ids, replacements AND floors),
+ * `RetiredPluginsTest` pins this against `RetiredPlugins.ALL` (ids, replacements AND floors),
  * so a retirement added there without a matching entry here fails rather than quietly staying
  * installable.
  *

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/RetiredPluginIds.kt
@@ -1,5 +1,8 @@
 package ai.rever.boss.components.plugin
 
+import ai.rever.boss.plugin.dependency.SemanticVersion
+import ai.rever.boss.plugin.updater.satisfiesVersionFloor
+
 /**
  * Plugins whose job another plugin has taken over, and which must therefore never be *offered*
  * for install again.
@@ -16,14 +19,74 @@ package ai.rever.boss.components.plugin
  * retirement hold regardless of what the store says, which is what stops it being a one-way door
  * in the wrong direction.
  *
- * `RetiredPluginsTest` pins this against `RetiredPlugins.ALL`, so a retirement added there
- * without a matching entry here fails rather than quietly staying installable.
+ * `RetiredPluginIdsTest` pins this against `RetiredPlugins.ALL` (ids, replacements AND floors),
+ * so a retirement added there without a matching entry here fails rather than quietly staying
+ * installable.
+ *
+ * **The floors are part of the contract, not decoration.** The sweep
+ * (`RetiredPlugins.sweep`) only removes a retired plugin once its replacement is installed at
+ * [Retired.minReplacementVersion] or newer. The OFFER filter below must use the same floor:
+ * hiding a retired plugin unconditionally from a fresh install while the sweep is still floored
+ * leaves that machine with no panel for what the retired one did - exactly the gap between this
+ * host release and the replacement's absorbing release. Hiding only when the sweep would be
+ * able to act closes it regardless of release choreography.
  */
 object RetiredPluginIds {
-    val ALL: Set<String> =
-        setOf(
-            "ai.rever.boss.plugin.dynamic.usersecretlist",
-            "ai.rever.boss.plugin.dynamic.gitstatus",
-            "ai.rever.boss.plugin.dynamic.gitlog",
+    /**
+     * One retired plugin, and the version of its replacement that actually absorbed the work.
+     * Must stay equal to [ai.rever.boss.plugin.RetiredPlugins.Retirement] entry for entry -
+     * `RetiredPluginsTest` checks that.
+     */
+    data class Retired(
+        val pluginId: String,
+        val replacementId: String,
+        val minReplacementVersion: String,
+    )
+
+    val ALL: List<Retired> =
+        listOf(
+            Retired(
+                pluginId = "ai.rever.boss.plugin.dynamic.usersecretlist",
+                replacementId = "ai.rever.boss.plugin.dynamic.secretmanager",
+                minReplacementVersion = "1.2.17",
+            ),
+            Retired(
+                pluginId = "ai.rever.boss.plugin.dynamic.gitstatus",
+                replacementId = "ai.rever.boss.plugin.dynamic.codebase",
+                minReplacementVersion = "1.6.0",
+            ),
+            Retired(
+                pluginId = "ai.rever.boss.plugin.dynamic.gitlog",
+                replacementId = "ai.rever.boss.plugin.dynamic.codebase",
+                minReplacementVersion = "1.6.0",
+            ),
         )
+
+    val ALL_IDS: Set<String> = ALL.map { it.pluginId }.toSet()
+
+    /**
+     * Whether [pluginId] should be hidden from what is offered for install.
+     *
+     * The answer is the sweep's own gate, evaluated against [installedVersionOf]: the retired
+     * plugin disappears from the offer the moment the sweep would be able to remove it, and
+     * stays offered until then - so a fresh install never loses the panel before the
+     * replacement can take over.
+     *
+     * Fails closed like [ai.rever.boss.plugin.RetiredPlugins.replacementIsReady]: the version is
+     * parsed explicitly (not through `satisfiesVersionFloor` alone, which answers true for
+     * anything unparseable), and "replacement not installed or unreadable" keeps the retired
+     * plugin OFFERED - the conservative side, since offering an installable plugin is
+     * recoverable and hiding the only panel for a feature is not.
+     */
+    fun hiddenFromOffers(
+        pluginId: String,
+        installedVersionOf: (String) -> String?,
+    ): Boolean {
+        val retirement = ALL.firstOrNull { it.pluginId == pluginId } ?: return false
+        val version = installedVersionOf(retirement.replacementId)
+        return version != null &&
+            version.isNotBlank() &&
+            SemanticVersion.parse(version) != null &&
+            satisfiesVersionFloor(required = retirement.minReplacementVersion, installed = version)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypePlugins.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypePlugins.kt
@@ -40,6 +40,12 @@ object TabTypePlugins {
         mapOf(
             "fluck" to FLUCK_BROWSER,
             "editor" to EDITOR_TAB,
+            // diff and composer are editor-tab's too: the host opens both (a diff via
+            // GitDataProvider.openDiff, a composer tab), so without these a request with
+            // editor-tab absent fell through to a 15s wait and a silent no-op instead of
+            // the install prompt.
+            "diff" to EDITOR_TAB,
+            "composer" to EDITOR_TAB,
             "terminal" to TERMINAL_TAB,
             "jupyter" to JUPYTER_NOTEBOOK,
         )
@@ -60,6 +66,8 @@ object TabTypePlugins {
         when (typeId.typeId) {
             "fluck" -> "web pages"
             "editor" -> "files in the editor"
+            "diff" -> "git diffs"
+            "composer" -> "the AI composer"
             "terminal" -> "terminals"
             "jupyter" -> "notebooks"
             else -> typeId.typeId

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypePlugins.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TabTypePlugins.kt
@@ -19,9 +19,10 @@ import ai.rever.boss.plugin.api.TabTypeId
  * immediately - the dialog offers to install the wrong plugin - rather than
  * silent.
  *
- * Only the four tab types the host itself opens are listed. A plugin that opens
- * its own tab type does not come through here, because it is loaded by
- * definition.
+ * Only the tab types the host itself opens are listed - six, of which `diff`
+ * and `composer` both resolve to editor-tab (the host opens them, the
+ * plugin renders them). A plugin that opens its own tab type does not come
+ * through here, because it is loaded by definition.
  */
 object TabTypePlugins {
     /** Browser tabs: `fluck-browser`. */

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/TrackingPluginContext.kt
@@ -38,6 +38,7 @@ import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.api.PluginSandboxRef
 import ai.rever.boss.plugin.api.PluginStorageFactory
 import ai.rever.boss.plugin.api.PluginStoreApiKeyProvider
+import ai.rever.boss.plugin.api.ProjectSearchProvider
 import ai.rever.boss.plugin.api.RoleManagementProvider
 import ai.rever.boss.plugin.api.RunConfigurationDataProvider
 import ai.rever.boss.plugin.api.ScreenCaptureProvider
@@ -329,6 +330,7 @@ class TrackingPluginContext(
     override val workspaceDataProvider: WorkspaceDataProvider? get() = delegate.workspaceDataProvider
     override val splitViewOperations: SplitViewOperations? get() = delegate.splitViewOperations
     override val gitDataProvider: GitDataProvider? get() = delegate.gitDataProvider
+    override val projectSearchProvider: ProjectSearchProvider? get() = delegate.projectSearchProvider
     override val fileSystemDataProvider: FileSystemDataProvider? get() = delegate.fileSystemDataProvider
     override val secretDataProvider: SecretDataProvider? get() = delegate.secretDataProvider
     override val llmProvider: LlmProvider? get() = delegate.llmProvider

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/DiffTabMatch.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/DiffTabMatch.kt
@@ -1,0 +1,31 @@
+package ai.rever.boss.components.window_panel
+
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
+
+/**
+ * Whether [tab] is the same diff view as the scope being opened: same file
+ * (via [TabPaths.normalize]), same side of the index, same refs.
+ *
+ * Pure over [DiffTabInfo] so the reuse semantics are pinnable without a UI:
+ * a staged diff and a working-tree diff of one file are different views, and
+ * each gets its own tab, as in VS Code.
+ *
+ * A blank [filePath] with NO refs matches nothing, deliberately:
+ * [TabPaths.normalize] of "" is "", so an unguarded blank query would focus
+ * the first diff tab with an empty file path, whatever its scope. A blank
+ * path WITH a ref is the commit/range-diff scope and matches normally.
+ */
+internal fun diffTabMatches(
+    tab: DiffTabInfo,
+    filePath: String,
+    staged: Boolean,
+    fromRef: String?,
+    toRef: String?,
+): Boolean {
+    if (filePath.isBlank() && fromRef == null && toRef == null) return false
+    val wanted = TabPaths.normalize(filePath)
+    return TabPaths.normalize(tab.filePath) == wanted &&
+        tab.staged == staged &&
+        tab.fromRef == fromRef &&
+        tab.toRef == toRef
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/DiffTabMatch.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/DiffTabMatch.kt
@@ -4,14 +4,14 @@ import ai.rever.boss.plugin.tab.diff.DiffTabInfo
 
 /**
  * Whether [tab] is the same diff view as the scope being opened: same file
- * (via [TabPaths.normalize]), same side of the index, same refs.
+ * (via [TabPaths.pathsMatch]), same side of the index, same refs.
  *
  * Pure over [DiffTabInfo] so the reuse semantics are pinnable without a UI:
  * a staged diff and a working-tree diff of one file are different views, and
  * each gets its own tab, as in VS Code.
  *
  * A blank [filePath] with NO refs matches nothing, deliberately:
- * [TabPaths.normalize] of "" is "", so an unguarded blank query would focus
+ * [TabPaths.pathsMatch] of two blanks is true, so an unguarded blank query would focus
  * the first diff tab with an empty file path, whatever its scope. A blank
  * path WITH a ref is the commit/range-diff scope and matches normally.
  */
@@ -23,8 +23,7 @@ internal fun diffTabMatches(
     toRef: String?,
 ): Boolean {
     if (filePath.isBlank() && fromRef == null && toRef == null) return false
-    val wanted = TabPaths.normalize(filePath)
-    return TabPaths.normalize(tab.filePath) == wanted &&
+    return TabPaths.pathsMatch(tab.filePath, filePath) &&
         tab.staged == staged &&
         tab.fromRef == fromRef &&
         tab.toRef == toRef

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -33,8 +33,11 @@ import ai.rever.boss.plugin.api.TabIcon
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.events.DiffOpenEvent
 import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
 import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
+import ai.rever.boss.plugin.tab.diff.DiffTabType
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
@@ -590,8 +593,12 @@ class SplitViewState(
         }
     }
 
-    private fun findPanelWithNotebookTab(filePath: String): PanelTabMatch? =
-        findPanelWithTabMatching { tab -> tab is JupyterTabInfo && tab.filePath == filePath }
+    private fun findPanelWithNotebookTab(filePath: String): PanelTabMatch? {
+        val wanted = TabPaths.normalize(filePath)
+        return findPanelWithTabMatching { tab ->
+            tab is JupyterTabInfo && TabPaths.normalize(tab.filePath) == wanted
+        }
+    }
 
     /** Find the first panel containing a tab that satisfies [predicate]. */
     private fun findPanelWithTabMatching(predicate: (TabInfo) -> Boolean): PanelTabMatch? {
@@ -648,6 +655,42 @@ class SplitViewState(
                 filePath = filePath,
             )
         activeComponent.addTab(editorTab).takeIf { it >= 0 }?.let {
+            activeComponent.selectTab(it)
+        }
+    }
+
+    /**
+     * Open a git diff in the active panel (from a [DiffOpenEvent], i.e. the
+     * git data provider's `openDiff` or a deep link). The diff tab type is
+     * registered by the editor-tab PLUGIN, not the host, so the gate is real:
+     * with that plugin absent or still starting, [requireTabTypeThen] waits for
+     * the type (or prompts) rather than dropping the open.
+     */
+    fun openDiffTabInActivePanel(event: DiffOpenEvent) {
+        requireTabTypeThen(DiffTabType.typeId, "Opening diff") {
+            openDiffTabNow(event)
+        }
+    }
+
+    private fun openDiffTabNow(event: DiffOpenEvent) {
+        val activeComponent = getActiveTabsComponent() ?: return
+
+        // Reuse an open diff of the same thing, like every other open path.
+        // Without this, clicking a changed file added a tab per click.
+        findPanelWithDiffTab(event)?.let { (panelId, component, tabIndex) ->
+            component.selectTab(tabIndex)
+            setActivePanel(panelId)
+            return
+        }
+
+        val diffTab =
+            DiffTabInfo.create(
+                filePath = event.filePath,
+                staged = event.staged,
+                fromRef = event.fromRef,
+                toRef = event.toRef,
+            )
+        activeComponent.addTab(diffTab).takeIf { it >= 0 }?.let {
             activeComponent.selectTab(it)
         }
     }
@@ -1227,11 +1270,27 @@ class SplitViewState(
     )
 
     /**
-     * Find the panel that contains an editor tab for the given file path.
-     * Unlike findPanelWithFile, this only matches EditorTabInfo (not browser tabs).
+     * An open diff of the same scope: same file, same side of the index, same
+     * refs. A staged diff and a working-tree diff of one file are different
+     * views and each gets its own tab, as in VS Code.
      */
-    private fun findPanelWithEditorTab(filePath: String): PanelTabMatch? =
-        findPanelWithTabMatching { tab -> tab is EditorTabInfo && tab.filePath == filePath }
+    private fun findPanelWithDiffTab(event: DiffOpenEvent): PanelTabMatch? {
+        val wanted = TabPaths.normalize(event.filePath)
+        return findPanelWithTabMatching { tab ->
+            tab is DiffTabInfo &&
+                TabPaths.normalize(tab.filePath) == wanted &&
+                tab.staged == event.staged &&
+                tab.fromRef == event.fromRef &&
+                tab.toRef == event.toRef
+        }
+    }
+
+    private fun findPanelWithEditorTab(filePath: String): PanelTabMatch? {
+        val wanted = TabPaths.normalize(filePath)
+        return findPanelWithTabMatching { tab ->
+            tab is EditorTabInfo && TabPaths.normalize(tab.filePath) == wanted
+        }
+    }
 
     /**
      * Find the panel that contains a tab with the given URL

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -1274,18 +1274,16 @@ class SplitViewState(
      * refs. A staged diff and a working-tree diff of one file are different
      * views and each gets its own tab, as in VS Code.
      */
-    private fun findPanelWithDiffTab(event: DiffOpenEvent): PanelTabMatch? {
-        val wanted = TabPaths.normalize(event.filePath)
-        return findPanelWithTabMatching { tab ->
+    private fun findPanelWithDiffTab(event: DiffOpenEvent): PanelTabMatch? =
+        findPanelWithTabMatching { tab ->
             tab is DiffTabInfo &&
-                TabPaths.normalize(tab.filePath) == wanted &&
-                tab.staged == event.staged &&
-                tab.fromRef == event.fromRef &&
-                tab.toRef == event.toRef
+                diffTabMatches(tab, event.filePath, event.staged, event.fromRef, event.toRef)
         }
-    }
 
     private fun findPanelWithEditorTab(filePath: String): PanelTabMatch? {
+        // A blank path never matches: normalize("") is "", so a blank query
+        // would focus the first Untitled editor tab.
+        if (filePath.isBlank()) return null
         val wanted = TabPaths.normalize(filePath)
         return findPanelWithTabMatching { tab ->
             tab is EditorTabInfo && TabPaths.normalize(tab.filePath) == wanted

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -593,12 +593,10 @@ class SplitViewState(
         }
     }
 
-    private fun findPanelWithNotebookTab(filePath: String): PanelTabMatch? {
-        val wanted = TabPaths.normalize(filePath)
-        return findPanelWithTabMatching { tab ->
-            tab is JupyterTabInfo && TabPaths.normalize(tab.filePath) == wanted
+    private fun findPanelWithNotebookTab(filePath: String): PanelTabMatch? =
+        findPanelWithTabMatching { tab ->
+            tab is JupyterTabInfo && TabPaths.pathsMatch(tab.filePath, filePath)
         }
-    }
 
     /** Find the first panel containing a tab that satisfies [predicate]. */
     private fun findPanelWithTabMatching(predicate: (TabInfo) -> Boolean): PanelTabMatch? {
@@ -1284,9 +1282,10 @@ class SplitViewState(
         // A blank path never matches: normalize("") is "", so a blank query
         // would focus the first Untitled editor tab.
         if (filePath.isBlank()) return null
-        val wanted = TabPaths.normalize(filePath)
+        // pathsMatch keeps the canonicalPath syscalls out of the common case
+        // (identical spellings), paying for them only on a lexical mismatch.
         return findPanelWithTabMatching { tab ->
-            tab is EditorTabInfo && TabPaths.normalize(tab.filePath) == wanted
+            tab is EditorTabInfo && TabPaths.pathsMatch(tab.filePath, filePath)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
@@ -35,14 +35,19 @@ internal object TabPaths {
      *
      * Internal so the two deliberate choices in here are pinnable: backslash is only
      * a separator on Windows, and a leading `//` (UNC host) survives the collapse.
-     * On POSIX [normalize] reaches this only when canonicalPath throws, so the tests
-     * exercise it directly.
+     * On POSIX [normalize] reaches this only when canonicalPath throws, so the
+     * tests exercise it directly. The separator is a parameter so the Windows
+     * branch is testable on the Linux/macOS runners too - with the default it is
+     * unreachable there (`File.separatorChar == '/'`).
      */
-    internal fun lexicalClean(path: String): String {
+    internal fun lexicalClean(
+        path: String,
+        separatorChar: Char = File.separatorChar,
+    ): String {
         // Backslash is a path separator on Windows but a LEGAL filename character on
         // macOS/Linux, so translating it unconditionally turned `a\b.kt` into `a/b.kt`
         // and could canonicalise onto a different real file (focusing the wrong tab).
-        val unified = if (File.separatorChar == '\\') path.replace('\\', '/') else path
+        val unified = if (separatorChar == '\\') path.replace('\\', '/') else path
         // Collapse repeated slashes, but keep a leading "//" - a Windows UNC path
         // (\\server\share) becomes //server/share, and flattening it to /server/share
         // makes two tabs on different servers compare equal.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
@@ -1,0 +1,39 @@
+package ai.rever.boss.components.window_panel
+
+import java.io.File
+
+/**
+ * Path comparison for "is this file already open in a tab?".
+ *
+ * The reuse check was a raw string equality on the tab's stored path, so the
+ * same file opened from two places produced two tabs whenever the two callers
+ * spelled the path differently. They do: the file tree passes the path the
+ * host's scanner produced, while the git provider builds `"$projectPath/$rel"`
+ * - which doubles the separator whenever the project path ends in one, and
+ * never resolves `.`/`..` or a symlinked project root.
+ */
+internal object TabPaths {
+    /**
+     * A canonical form for comparison only - never for display or for opening.
+     *
+     * Falls back to a lexical cleanup when the file cannot be resolved (it may
+     * not exist yet, or be unreadable), so an unresolvable path still compares
+     * consistently with itself.
+     */
+    fun normalize(path: String): String {
+        if (path.isBlank()) return ""
+        val lexical = lexicalClean(path)
+        return try {
+            File(lexical).canonicalPath
+        } catch (e: Exception) {
+            lexical
+        }
+    }
+
+    /** Collapse repeated separators and drop a trailing one. */
+    private fun lexicalClean(path: String): String {
+        val unified = path.replace('\\', '/')
+        val collapsed = unified.replace(Regex("/{2,}"), "/")
+        return if (collapsed.length > 1) collapsed.trimEnd('/') else collapsed
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
@@ -32,7 +32,10 @@ internal object TabPaths {
 
     /** Collapse repeated separators and drop a trailing one. */
     private fun lexicalClean(path: String): String {
-        val unified = path.replace('\\', '/')
+        // Backslash is a path separator on Windows but a LEGAL filename character on
+        // macOS/Linux, so translating it unconditionally turned `a\b.kt` into `a/b.kt`
+        // and could canonicalise onto a different real file (focusing the wrong tab).
+        val unified = if (File.separatorChar == '\\') path.replace('\\', '/') else path
         val collapsed = unified.replace(Regex("/{2,}"), "/")
         return if (collapsed.length > 1) collapsed.trimEnd('/') else collapsed
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
@@ -19,6 +19,11 @@ internal object TabPaths {
      * Falls back to a lexical cleanup when the file cannot be resolved (it may
      * not exist yet, or be unreadable), so an unresolvable path still compares
      * consistently with itself.
+     *
+     * Cost note: [canonicalPath] is a system call per call, and the tab-match
+     * hot path used to pay it for every open event times every open tab.
+     * Callers comparing two paths should prefer [pathsMatch], which only pays
+     * this when the cheap lexical comparison disagrees.
      */
     fun normalize(path: String): String {
         if (path.isBlank()) return ""
@@ -28,6 +33,27 @@ internal object TabPaths {
         } catch (e: Exception) {
             lexical
         }
+    }
+
+    /**
+     * Whether two paths name the same file, without paying for [normalize] when
+     * the lexical forms already agree - which is the common case, since most
+     * openers pass one and the same absolute path. (Lexically equal strings
+     * canonicalise identically, so the fast answer is exact, not a shortcut.)
+     *
+     * Only when the lexical forms DISAGREE does it canonicalise both sides -
+     * the case this exists for: the same file spelled with a doubled
+     * separator is caught lexically, but a symlinked or renamed project root
+     * (`/tmp/proj` vs `/private/tmp/proj`) is caught only on the canonical
+     * form.
+     */
+    fun pathsMatch(
+        a: String,
+        b: String,
+    ): Boolean {
+        if (a.isBlank() || b.isBlank()) return a.isBlank() && b.isBlank()
+        val lexicalMatch = lexicalClean(a) == lexicalClean(b)
+        return lexicalMatch || normalize(a) == normalize(b)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
@@ -36,7 +36,11 @@ internal object TabPaths {
         // macOS/Linux, so translating it unconditionally turned `a\b.kt` into `a/b.kt`
         // and could canonicalise onto a different real file (focusing the wrong tab).
         val unified = if (File.separatorChar == '\\') path.replace('\\', '/') else path
-        val collapsed = unified.replace(Regex("/{2,}"), "/")
+        // Collapse repeated slashes, but keep a leading "//" - a Windows UNC path
+        // (\\server\share) becomes //server/share, and flattening it to /server/share
+        // makes two tabs on different servers compare equal.
+        val uncPrefix = if (unified.startsWith("//")) "/" else ""
+        val collapsed = uncPrefix + unified.replace(Regex("/{2,}"), "/")
         return if (collapsed.length > 1) collapsed.trimEnd('/') else collapsed
     }
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/TabPaths.kt
@@ -30,8 +30,15 @@ internal object TabPaths {
         }
     }
 
-    /** Collapse repeated separators and drop a trailing one. */
-    private fun lexicalClean(path: String): String {
+    /**
+     * Collapse repeated separators and drop a trailing one.
+     *
+     * Internal so the two deliberate choices in here are pinnable: backslash is only
+     * a separator on Windows, and a leading `//` (UNC host) survives the collapse.
+     * On POSIX [normalize] reaches this only when canonicalPath throws, so the tests
+     * exercise it directly.
+     */
+    internal fun lexicalClean(path: String): String {
         // Backslash is a path separator on Windows but a LEGAL filename character on
         // macOS/Linux, so translating it unconditionally turned `a\b.kt` into `a/b.kt`
         // and could canonicalise onto a different real file (focusing the wrong tab).

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
@@ -12,6 +12,10 @@ import ai.rever.boss.plugin.api.TabRegistry
 import ai.rever.boss.plugin.api.TabTypeId
 import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
 import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
+import ai.rever.boss.plugin.tab.composer.ComposerTabInfo
+import ai.rever.boss.plugin.tab.composer.ComposerTabType
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
+import ai.rever.boss.plugin.tab.diff.DiffTabType
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
@@ -214,7 +218,9 @@ private fun tabTypeIdFor(tabConfig: TabConfig): TabTypeId? =
         "browser" -> FluckTabType.typeId
         "terminal" -> TerminalTabType.typeId
         "editor" -> CodeEditorTabType.typeId
+        "diff" -> DiffTabType.typeId
         "jupyter" -> JupyterTabInfo.TYPE_ID
+        "composer" -> ComposerTabType.typeId
         else -> null
     }
 
@@ -421,6 +427,17 @@ internal fun createTabFromWorkspaceConfig(
             createEditorTab(tabConfig, resolvedProjectPath)
         }
 
+        DiffTabType.typeId -> {
+            // Only file diffs are persisted (see WorkspaceExtractor); restore as
+            // a working-tree diff of that file.
+            DiffTabInfo.create(
+                filePath =
+                    tabConfig.filePath?.let {
+                        WorkspacePlaceholders.processPlaceholders(it, resolvedProjectPath, null)
+                    } ?: "",
+            )
+        }
+
         JupyterTabInfo.TYPE_ID -> {
             if (splitViewState.tabRegistry.isRegistered(JupyterTabInfo.TYPE_ID)) {
                 val filePath =
@@ -433,6 +450,19 @@ internal fun createTabFromWorkspaceConfig(
                 // saved): restore the notebook as an editor tab instead of letting addTab
                 // silently drop it — the same isRegistered guard as SplitViewState.openFile.
                 createEditorTab(tabConfig, resolvedProjectPath)
+            }
+        }
+
+        ComposerTabType.typeId -> {
+            // The session id came out of filePath (see WorkspaceExtractor); a
+            // blank one (corrupt layout) yields no tab. The editor-tab plugin's
+            // factory reloads the session from its own storage, or renders an
+            // empty composer when the session is gone.
+            val sessionId = tabConfig.filePath ?: ""
+            if (sessionId.isBlank()) {
+                null
+            } else {
+                ComposerTabInfo.create(sessionId, tabConfig.title)
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplier.kt
@@ -429,13 +429,20 @@ internal fun createTabFromWorkspaceConfig(
 
         DiffTabType.typeId -> {
             // Only file diffs are persisted (see WorkspaceExtractor); restore as
-            // a working-tree diff of that file.
-            DiffTabInfo.create(
-                filePath =
-                    tabConfig.filePath?.let {
-                        WorkspacePlaceholders.processPlaceholders(it, resolvedProjectPath, null)
-                    } ?: "",
-            )
+            // a working-tree diff of that file. A blank filePath (corrupt or
+            // hand-edited layout) yields no tab: a diff tab with no scope can
+            // never show anything, and the composer branch below and the
+            // extractor (which refuses to PERSIST a blank path) already agree
+            // on "no scope, no tab".
+            val processedPath =
+                tabConfig.filePath?.let {
+                    WorkspacePlaceholders.processPlaceholders(it, resolvedProjectPath, null)
+                }
+            if (processedPath.isNullOrBlank()) {
+                null
+            } else {
+                DiffTabInfo.create(filePath = processedPath)
+            }
         }
 
         JupyterTabInfo.TYPE_ID -> {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractor.kt
@@ -5,6 +5,8 @@ import ai.rever.boss.components.window_panel.SplitNode
 import ai.rever.boss.components.window_panel.SplitViewState
 import ai.rever.boss.plugin.api.TabInfo
 import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
+import ai.rever.boss.plugin.tab.composer.ComposerTabInfo
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
 import ai.rever.boss.plugin.workspace.SplitConfig.HorizontalSplit
@@ -132,6 +134,39 @@ private fun extractTabConfig(
             )
         }
 
+        is DiffTabInfo -> {
+            // Only a plain UNSTAGED WORKING-TREE file diff is persisted, because
+            // that is the only scope restore can rebuild: TabConfig has no field
+            // for refs or for `staged`, and DiffTabInfo.create() defaults both.
+            //
+            // The guard used to be `filePath.isBlank()` alone, which let two
+            // scopes through and silently changed their meaning on restart: a
+            // range diff restricted to one file (fromRef+toRef+filePath all set)
+            // and a staged diff both came back as unstaged working-tree diffs of
+            // that path - same tab position, same title, different content.
+            // Dropping the tab is honest; rebuilding it as something else is not.
+            if (tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null) {
+                null
+            } else {
+                TabConfig(
+                    type = "diff",
+                    title = tab.title,
+                    filePath = tab.filePath,
+                )
+            }
+        }
+
+        is ComposerTabInfo -> {
+            // The session id rides in filePath: TabConfig has no generic
+            // extra field, and session ids survive placeholder processing
+            // untouched (they contain no project tokens).
+            TabConfig(
+                type = "composer",
+                title = tab.title,
+                filePath = tab.sessionId,
+            )
+        }
+
         is JupyterTabInfo -> {
             TabConfig(
                 type = "jupyter",
@@ -141,9 +176,20 @@ private fun extractTabConfig(
         }
 
         else -> {
-            TabConfig(
-                type = "unknown",
-                title = tab.title,
-            )
+            // Plugin-constructed composer tabs arrive as the plugin's own
+            // TabInfo class (the api jar filters the host's one out), but they
+            // carry the session id as the tab id, so they persist the same way.
+            if (tab.typeId.typeId == "composer") {
+                TabConfig(
+                    type = "composer",
+                    title = tab.title,
+                    filePath = tab.id,
+                )
+            } else {
+                TabConfig(
+                    type = "unknown",
+                    title = tab.title,
+                )
+            }
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractor.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractor.kt
@@ -96,7 +96,7 @@ private fun extractSplitConfig(
     }
 
 /** The saved form of one open tab, or null for a tab that must not be persisted. */
-private fun extractTabConfig(
+internal fun extractTabConfig(
     tab: TabInfo,
     defaultWorkingDirectory: String,
 ): TabConfig? =
@@ -135,36 +135,11 @@ private fun extractTabConfig(
         }
 
         is DiffTabInfo -> {
-            // Only a plain UNSTAGED WORKING-TREE file diff is persisted, because
-            // that is the only scope restore can rebuild: TabConfig has no field
-            // for refs or for `staged`, and DiffTabInfo.create() defaults both.
-            //
-            // The guard used to be `filePath.isBlank()` alone, which let two
-            // scopes through and silently changed their meaning on restart: a
-            // range diff restricted to one file (fromRef+toRef+filePath all set)
-            // and a staged diff both came back as unstaged working-tree diffs of
-            // that path - same tab position, same title, different content.
-            // Dropping the tab is honest; rebuilding it as something else is not.
-            if (tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null) {
-                null
-            } else {
-                TabConfig(
-                    type = "diff",
-                    title = tab.title,
-                    filePath = tab.filePath,
-                )
-            }
+            extractDiffConfig(tab)
         }
 
         is ComposerTabInfo -> {
-            // The session id rides in filePath: TabConfig has no generic
-            // extra field, and session ids survive placeholder processing
-            // untouched (they contain no project tokens).
-            TabConfig(
-                type = "composer",
-                title = tab.title,
-                filePath = tab.sessionId,
-            )
+            extractComposerConfig(tab)
         }
 
         is JupyterTabInfo -> {
@@ -179,6 +154,14 @@ private fun extractTabConfig(
             // Plugin-constructed composer tabs arrive as the plugin's own
             // TabInfo class (the api jar filters the host's one out), but they
             // carry the session id as the tab id, so they persist the same way.
+            //
+            // There is deliberately NO diff branch here: DiffTabInfo lives in
+            // the same host-only source set, so a plugin cannot construct a
+            // host diff tab, and a custom tab claiming the "diff" type carries
+            // no scope fields (staged/fromRef/toRef) - persisting it would
+            // rebuild it on restore as an unstaged working-tree diff of its
+            // filePath, i.e. silently change its meaning, which the branch
+            // above refuses to do for host-constructed tabs.
             if (tab.typeId.typeId == "composer") {
                 TabConfig(
                     type = "composer",
@@ -193,3 +176,48 @@ private fun extractTabConfig(
             }
         }
     }
+
+/**
+ * The saved form of a host diff tab, or null for a scope restore cannot
+ * rebuild.
+ *
+ * Only a plain UNSTAGED WORKING-TREE file diff is persisted, because that is
+ * the only scope restore can rebuild: TabConfig has no field for refs or for
+ * `staged`, and DiffTabInfo.create() defaults both.
+ *
+ * The guard used to be `filePath.isBlank()` alone, which let two scopes
+ * through and silently changed their meaning on restart: a range diff
+ * restricted to one file (fromRef+toRef+filePath all set) and a staged diff
+ * both came back as unstaged working-tree diffs of that path - same tab
+ * position, same title, different content. Dropping the tab is honest;
+ * rebuilding it as something else is not.
+ */
+private fun extractDiffConfig(tab: DiffTabInfo): TabConfig? {
+    if (tab.filePath.isBlank() || tab.staged || tab.fromRef != null || tab.toRef != null) return null
+    return TabConfig(
+        type = "diff",
+        title = tab.title,
+        filePath = tab.filePath,
+    )
+}
+
+/**
+ * The saved form of a host composer tab, or null for a blank session id.
+ *
+ * The session id rides in filePath: TabConfig has no generic extra field,
+ * and session ids survive placeholder processing untouched (they contain no
+ * project tokens).
+ *
+ * A blank session id is dropped, agreeing with the restore side
+ * (WorkspaceApplier refuses to rebuild one): persisting it would save a tab
+ * that can never come back, and the saved layout would disagree with what
+ * the user sees.
+ */
+private fun extractComposerConfig(tab: ComposerTabInfo): TabConfig? {
+    if (tab.sessionId.isBlank()) return null
+    return TabConfig(
+        type = "composer",
+        title = tab.title,
+        filePath = tab.sessionId,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
 
 /**
@@ -53,6 +55,13 @@ class GitDataProviderImpl(
     // `isGitRepository` cannot carry this: after the first probe a non-repo
     // is also false, which is "known not a repository", not "unknown".
     private var lastProbedPath: String? = null
+
+    // [ensureRepoState] is called from every suspend member, so two of them
+    // can run it at once after a project switch. The check-and-probe is not
+    // atomic without this: both callers would see `lastProbedPath != path`
+    // and both would run the four-command refresh (eight subprocesses behind
+    // the global git lock instead of four, and two racing state writes).
+    private val ensureMutex = Mutex()
 
     // State flows mapped from WindowGitState - initialized with current values
     private val _fileStatus =
@@ -155,6 +164,12 @@ class GitDataProviderImpl(
      */
     private suspend fun ensureRepoState() {
         val state = windowGitState ?: return
+        ensureMutex.withLock {
+            ensureRepoStateLocked(state)
+        }
+    }
+
+    private suspend fun ensureRepoStateLocked(state: WindowGitState) {
         val path = projectPathProvider()
         if (path.isNullOrBlank()) {
             if (state.projectPath.value == null) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -1,8 +1,11 @@
 package ai.rever.boss.git
 
 import ai.rever.boss.components.events.FileEventBus
+import ai.rever.boss.plugin.api.GitBranchRefData
 import ai.rever.boss.plugin.api.GitCommitInfoData
+import ai.rever.boss.plugin.api.GitCommitNodeData
 import ai.rever.boss.plugin.api.GitDataProvider
+import ai.rever.boss.plugin.api.GitDiffData
 import ai.rever.boss.plugin.api.GitFileStatusData
 import ai.rever.boss.plugin.api.GitFileStatusTypeData
 import ai.rever.boss.plugin.api.GitOperationResultData
@@ -10,6 +13,8 @@ import ai.rever.boss.plugin.git.GitCommitInfo
 import ai.rever.boss.plugin.git.GitFileStatus
 import ai.rever.boss.plugin.git.GitFileStatusType
 import ai.rever.boss.plugin.git.GitOperationResult
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.window.WindowGitState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,12 +33,24 @@ import kotlinx.coroutines.launch
  *
  * @param windowGitState The window-specific git state (nullable for flexibility)
  * @param windowIdProvider Provider for the current window ID
+ * @param projectPathProvider Provider for the window's selected project path. The
+ * window-scoped reads (status, log, graph) need [WindowGitState.projectPath],
+ * which the top bar sets when a project is picked there; panels that select a
+ * project on their own (the codebase picker) never go through that path, so
+ * this fills the gap.
  */
 class GitDataProviderImpl(
     private val windowGitState: WindowGitState?,
     private val windowIdProvider: () -> String?,
+    private val projectPathProvider: () -> String? = { null },
 ) : GitDataProvider {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private val logger = BossLogger.forComponent("GitDataProvider")
+
+    // Last path [ensureRepoState] asked [GitService.refreshForWindow] about.
+    // `isGitRepository` cannot carry this: after the first probe a non-repo
+    // is also false, which is "known not a repository", not "unknown".
+    private var lastProbedPath: String? = null
 
     // State flows mapped from WindowGitState - initialized with current values
     private val _fileStatus =
@@ -87,29 +104,133 @@ class GitDataProviderImpl(
     }
 
     override suspend fun refreshStatus() {
+        ensureRepoState()
         GitService.getStatusForWindow(windowGitState)
     }
 
     override suspend fun refreshLog(limit: Int) {
+        ensureRepoState()
         GitService.getLogForWindow(windowGitState, limit)
     }
 
-    override suspend fun stage(filePath: String): GitOperationResultData = GitService.stage(filePath, windowIdProvider()).toData()
+    /**
+     * Bring [WindowGitState] in line with the window's selected project before
+     * every window-scoped read: the right project path, and - once per project -
+     * the repository facts.
+     *
+     * Two separate problems live here.
+     *
+     * The path: window-scoped reads short-circuit to empty without one, so a
+     * project picked outside the top bar (the codebase panel's own picker)
+     * showed an empty git view forever. Filling it only when *unset* was not
+     * enough either, because [GitService.refreshForWindow] also writes it - a
+     * window bootstrapped on a directory that is not a repository kept that
+     * path after the user switched projects. The selected project is the single
+     * authority, so it syncs on change; a blank provider result means "not
+     * resolved yet", not "no project", and is never written.
+     *
+     * The repository facts: `isGitRepository`, the branch name and the branch
+     * lists are only ever written by [GitService.refreshForWindow], and nothing
+     * on the status/log path called it. `getStatusForWindow` updates the file
+     * list alone, so a panel that gates its UI on `isGitRepository` reported
+     * "no repository" for a perfectly good checkout - dirty files and all.
+     *
+     * [GitService.refreshForWindow] costs four extra git invocations (repo
+     * check, branch, local branches, remote branches), so it runs when the
+     * project changed or this path has never been probed - not on every tick
+     * of a panel's status poll. A non-repository leaves `isGitRepository`
+     * false after that first probe; treating the flag as "unknown" would
+     * re-run the four commands on every poll.
+     */
+    private suspend fun ensureRepoState() {
+        val state = windowGitState ?: return
+        val path = projectPathProvider()
+        if (path.isNullOrBlank()) {
+            if (state.projectPath.value == null) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Git window refresh skipped - no project path resolved",
+                    mapOf("windowId" to (windowIdProvider() ?: "none")),
+                )
+            }
+            return
+        }
+        val changed = state.projectPath.value != path
+        if (changed) {
+            logger.debug(
+                LogCategory.SYSTEM,
+                "Git window project path synced to the selected project",
+                mapOf(
+                    "windowId" to (windowIdProvider() ?: "none"),
+                    "from" to (state.projectPath.value ?: "none"),
+                    "to" to path,
+                ),
+            )
+        }
+        // `changed` covers a project switch. `lastProbedPath != path` covers
+        // the case where something wrote [WindowGitState.projectPath] without
+        // ever calling refreshForWindow (the top bar used to be the only
+        // writer; tests still do this). Together they are "unknown"; a
+        // matching path we have already probed is known, repo or not.
+        if (changed || lastProbedPath != path) {
+            GitService.refreshForWindow(path, state)
+            lastProbedPath = path
+        }
+    }
 
-    override suspend fun unstage(filePath: String): GitOperationResultData = GitService.unstage(filePath, windowIdProvider()).toData()
+    // ===== Writes =====
+    //
+    // Every write resolves the repo first, exactly as the reads do. Without it
+    // a write issued before the first read - staging from a freshly opened
+    // panel, say - reached GitService with no project path and came back
+    // "No project selected", so the button did nothing and said nothing useful.
+    // Ordering between a panel's first read and its first write is not
+    // something the panel should have to guarantee.
 
-    override suspend fun stageAll(): GitOperationResultData = GitService.stageAll(windowIdProvider()).toData()
+    override suspend fun commit(message: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.commit(message, windowId = windowIdProvider()).toData()
+    }
 
-    override suspend fun unstageAll(): GitOperationResultData = GitService.unstageAll(windowIdProvider()).toData()
+    override suspend fun stage(filePath: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.stage(filePath, windowIdProvider()).toData()
+    }
 
-    override suspend fun discardChanges(filePath: String): GitOperationResultData =
-        GitService.discardChanges(filePath, windowIdProvider()).toData()
+    override suspend fun unstage(filePath: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.unstage(filePath, windowIdProvider()).toData()
+    }
 
-    override suspend fun cherryPick(commitHash: String): GitOperationResultData = GitService.cherryPick(commitHash).toData()
+    override suspend fun stageAll(): GitOperationResultData {
+        ensureRepoState()
+        return GitService.stageAll(windowIdProvider()).toData()
+    }
 
-    override suspend fun revert(commitHash: String): GitOperationResultData = GitService.revert(commitHash).toData()
+    override suspend fun unstageAll(): GitOperationResultData {
+        ensureRepoState()
+        return GitService.unstageAll(windowIdProvider()).toData()
+    }
 
-    override suspend fun checkout(ref: String): GitOperationResultData = GitService.checkout(ref, windowIdProvider()).toData()
+    override suspend fun discardChanges(filePath: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.discardChanges(filePath, windowIdProvider()).toData()
+    }
+
+    override suspend fun cherryPick(commitHash: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.cherryPick(commitHash).toData()
+    }
+
+    override suspend fun revert(commitHash: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.revert(commitHash).toData()
+    }
+
+    override suspend fun checkout(ref: String): GitOperationResultData {
+        ensureRepoState()
+        return GitService.checkout(ref, windowIdProvider()).toData()
+    }
 
     override fun getCurrentProjectPath(): String? = GitService.getCurrentProjectPath()
 
@@ -117,16 +238,168 @@ class GitDataProviderImpl(
         filePath: String,
         windowId: String,
     ) {
-        val projectPath = getCurrentProjectPath()
-        if (projectPath != null) {
-            val fullPath = "$projectPath/$filePath"
-            scope.launch {
-                FileEventBus.openFile(fullPath, sourceWindowId = windowId)
+        scope.launch {
+            // Resolve the repo first, like every other member: this read the
+            // GLOBAL project path, so "Edit" on a changed file did nothing at
+            // all whenever that path had not been seeded yet.
+            ensureRepoState()
+            // This window's path FIRST, global as fallback - the same ordering every diff
+            // read uses, and for the same reason: the global belongs to whichever window
+            // refreshed last, so once two windows on different projects have settled, this
+            // built the other window's absolute path. A relative path that exists in both
+            // repos opened the wrong file; one that does not opened a dead tab.
+            val projectPath = windowProjectPath() ?: getCurrentProjectPath() ?: projectPathProvider()
+            if (projectPath.isNullOrBlank()) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "Git openFile skipped - no project path resolved",
+                    mapOf("path" to filePath),
+                )
+                return@launch
             }
+            // Trim the separator rather than concatenating blindly: a project
+            // path ending in "/" produced "…//file", which then failed to match
+            // an already-open tab and opened a duplicate.
+            val fullPath =
+                if (filePath.startsWith("/")) filePath else "${projectPath.trimEnd('/')}/$filePath"
+            FileEventBus.openFile(fullPath, sourceWindowId = windowId)
         }
     }
 
+    /**
+     * This window's project path, for the reads that must not use the global.
+     *
+     * `ensureRepoState()` only reseeds the global when THIS window's project
+     * changed, so once two windows have settled nothing re-aligns it - and the
+     * last window to refresh wins. Null falls back to the global, which is the
+     * right answer for a provider with no window.
+     */
+    private fun windowProjectPath(): String? = windowGitState?.projectPath?.value
+
+    // ===== Diff (boss-plugin-api 1.0.87) =====
+
+    override suspend fun diffFile(
+        path: String,
+        staged: Boolean,
+    ): List<GitDiffData> {
+        // Like every other member: these read git's GLOBAL project path, so a
+        // caller that has not triggered a status read first - the diff tab now
+        // loads its own content - got an empty diff and rendered as blank.
+        ensureRepoState()
+        return GitService.getFileDiff(path, staged, windowProjectPath())
+    }
+
+    override suspend fun diffRef(
+        ref: String,
+        path: String?,
+    ): List<GitDiffData> {
+        ensureRepoState()
+        return GitService.getCommitDiff(ref, path, windowProjectPath())
+    }
+
+    override suspend fun diffBetween(
+        from: String,
+        to: String,
+        path: String?,
+    ): List<GitDiffData> {
+        ensureRepoState()
+        return GitService.getRefDiff(from, to, path, windowProjectPath())
+    }
+
+    override suspend fun diffNames(staged: Boolean): List<GitFileStatusData> {
+        ensureRepoState()
+        return GitService.getDiffFileNames(staged, windowProjectPath())
+    }
+
+    override fun openDiff(
+        filePath: String,
+        staged: Boolean,
+        fromRef: String?,
+        toRef: String?,
+        windowId: String,
+    ) {
+        val target = windowId.ifBlank { windowIdProvider().orEmpty() }
+        if (target.isBlank()) {
+            // Consumers filter on exact window-id equality (see BossAppEventBusEffects),
+            // so a blank id matches no window and the click does nothing. Log it rather
+            // than emitting an event nobody can receive - the symptom is otherwise an
+            // invisible dead button.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "openDiff has no window to target; the diff tab cannot be routed",
+                mapOf("filePath" to filePath),
+            )
+            return
+        }
+        scope.launch {
+            // The diff tab resolves its repo from git's project path, so make
+            // sure that is pointing at this window's project before the tab
+            // opens and asks.
+            ensureRepoState()
+            FileEventBus.openDiffTab(filePath, staged, fromRef, toRef, target)
+        }
+    }
+
+    // ===== Graph (boss-plugin-api 1.0.87) =====
+
+    // The log fetch already parses %P (parents) and %D (ref decorations), so
+    // this is a pure mapping - no new git command.
+    override suspend fun logGraph(limit: Int): List<GitCommitNodeData> {
+        ensureRepoState()
+        return GitService.getLogForWindow(windowGitState, limit).map { it.toNodeData() }
+    }
+
+    // ===== Remote + branch-scoped graph (boss-plugin-api 1.0.87) =====
+    //
+    // ensureRepoState() first, like every other member - and then the
+    // WINDOW-scoped GitService entry points rather than pull()/push(), which
+    // resolve their repository from the global `currentProjectPath`. That
+    // global belongs to whichever window refreshed last; pushing the wrong
+    // repository is not a bug worth the convenience.
+
+    override suspend fun fetch(prune: Boolean): GitOperationResultData {
+        ensureRepoState()
+        return GitService.fetchForWindow(windowGitState, prune).toData()
+    }
+
+    override suspend fun pull(): GitOperationResultData {
+        ensureRepoState()
+        return GitService.pullForWindow(windowGitState).toData()
+    }
+
+    override suspend fun push(): GitOperationResultData {
+        ensureRepoState()
+        return GitService.pushForWindow(windowGitState).toData()
+    }
+
+    override suspend fun branches(): List<GitBranchRefData> {
+        ensureRepoState()
+        return GitService.listBranchesForWindow(windowGitState).map {
+            GitBranchRefData(name = it.name, isCurrent = it.isCurrent, isRemote = it.isRemote)
+        }
+    }
+
+    override suspend fun logGraphFor(
+        ref: String?,
+        limit: Int,
+    ): List<GitCommitNodeData> {
+        ensureRepoState()
+        return GitService.getLogForRef(windowGitState, ref, limit).map { it.toNodeData() }
+    }
+
     // ===== Type Conversion Extensions =====
+
+    private fun GitCommitInfo.toNodeData(): GitCommitNodeData =
+        GitCommitNodeData(
+            hash = hash,
+            shortHash = shortHash,
+            subject = subject,
+            author = author,
+            authorEmail = authorEmail,
+            date = date,
+            refs = refs,
+            parents = parentHashes,
+        )
 
     private fun GitFileStatus.toData(): GitFileStatusData =
         GitFileStatusData(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -202,9 +202,16 @@ class GitDataProviderImpl(
         // `changed` covers a project switch. `lastProbedPath != path` covers
         // the case where something wrote [WindowGitState.projectPath] without
         // ever calling refreshForWindow (the top bar used to be the only
-        // writer; tests still do this). Together they are "unknown"; a
-        // matching path we have already probed is known, repo or not.
-        if (changed || lastProbedPath != path) {
+        // writer; tests still do this). `!state.isGitRepository.value` covers
+        // a cached "not a repository" specifically: that fact can change
+        // underneath an open panel (`git init`, or the first probe losing the
+        // race against [DesktopGitService]'s async `_isGitAvailable` check at
+        // app startup) and, unlike a confirmed repo, costs only the one
+        // `isGitRepo` command to keep re-checking - `refreshForWindow` returns
+        // before the four-command branch bundle when it is not a repo. A
+        // confirmed repo still caches (that fact does not spontaneously
+        // reverse), so the steady-state cost this gate exists for is unchanged.
+        if (changed || lastProbedPath != path || !state.isGitRepository.value) {
             GitService.refreshForWindow(path, state)
             lastProbedPath = path
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -167,6 +167,12 @@ class GitDataProviderImpl(
                 ),
             )
         }
+        // Align the global project path unconditionally, so the write verbs
+        // (stage/commit/discard/cherry-pick/revert), which still resolve from it,
+        // operate on THIS window's repo rather than whichever window refreshed last.
+        // It is a bare assignment; the four-command probe below stays gated.
+        GitService.alignCurrentProjectPath(path)
+
         // `changed` covers a project switch. `lastProbedPath != path` covers
         // the case where something wrote [WindowGitState.projectPath] without
         // ever calling refreshForWindow (the top bar used to be the only

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.git
 
 import ai.rever.boss.components.events.FileEventBus
+import ai.rever.boss.components.plugin.providers.DisposableProvider
 import ai.rever.boss.plugin.api.GitBranchRefData
 import ai.rever.boss.plugin.api.GitCommitInfoData
 import ai.rever.boss.plugin.api.GitCommitNodeData
@@ -19,10 +20,9 @@ import ai.rever.boss.window.WindowGitState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -43,7 +43,8 @@ class GitDataProviderImpl(
     private val windowGitState: WindowGitState?,
     private val windowIdProvider: () -> String?,
     private val projectPathProvider: () -> String? = { null },
-) : GitDataProvider {
+) : GitDataProvider,
+    DisposableProvider {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val logger = BossLogger.forComponent("GitDataProvider")
 
@@ -76,6 +77,15 @@ class GitDataProviderImpl(
             windowGitState?.isLoading?.value ?: false,
         )
     override val isLoading: StateFlow<Boolean> = _isLoading
+
+    /**
+     * Cancels the four collectors launched in init. DefaultPlugin is per window and
+     * builds this provider lazily; without this a closed window leaked all four,
+     * each holding its [WindowGitState] alive.
+     */
+    override fun dispose() {
+        scope.cancel()
+    }
 
     init {
         // Collect from WindowGitState and map to plugin API types
@@ -192,50 +202,60 @@ class GitDataProviderImpl(
     // "No project selected", so the button did nothing and said nothing useful.
     // Ordering between a panel's first read and its first write is not
     // something the panel should have to guarantee.
+    //
+    // And every write passes THIS window's path, like the diff reads: aligning
+    // the global in ensureRepoState and then reading it back is two steps, and
+    // another window's align (its status poll runs ensureRepoState too) landing
+    // in between redirected the write - with two worktrees of one repo open, a
+    // Discard ran `git restore` in the other window's tree. The override travels
+    // with the call, so no interleaving can redirect it; null (a provider with
+    // no window state) falls back to the global as before.
 
     override suspend fun commit(message: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.commit(message, windowId = windowIdProvider()).toData()
+        return GitService
+            .commit(message, windowId = windowIdProvider(), projectPathOverride = windowProjectPath())
+            .toData()
     }
 
     override suspend fun stage(filePath: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.stage(filePath, windowIdProvider()).toData()
+        return GitService.stage(filePath, windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun unstage(filePath: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.unstage(filePath, windowIdProvider()).toData()
+        return GitService.unstage(filePath, windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun stageAll(): GitOperationResultData {
         ensureRepoState()
-        return GitService.stageAll(windowIdProvider()).toData()
+        return GitService.stageAll(windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun unstageAll(): GitOperationResultData {
         ensureRepoState()
-        return GitService.unstageAll(windowIdProvider()).toData()
+        return GitService.unstageAll(windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun discardChanges(filePath: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.discardChanges(filePath, windowIdProvider()).toData()
+        return GitService.discardChanges(filePath, windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun cherryPick(commitHash: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.cherryPick(commitHash).toData()
+        return GitService.cherryPick(commitHash, windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun revert(commitHash: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.revert(commitHash).toData()
+        return GitService.revert(commitHash, windowIdProvider(), windowProjectPath()).toData()
     }
 
     override suspend fun checkout(ref: String): GitOperationResultData {
         ensureRepoState()
-        return GitService.checkout(ref, windowIdProvider()).toData()
+        return GitService.checkout(ref, windowIdProvider(), windowProjectPath()).toData()
     }
 
     override fun getCurrentProjectPath(): String? = GitService.getCurrentProjectPath()
@@ -273,12 +293,11 @@ class GitDataProviderImpl(
     }
 
     /**
-     * This window's project path, for the reads that must not use the global.
-     *
-     * `ensureRepoState()` only reseeds the global when THIS window's project
-     * changed, so once two windows have settled nothing re-aligns it - and the
-     * last window to refresh wins. Null falls back to the global, which is the
-     * right answer for a provider with no window.
+     * This window's project path, for the reads AND writes that must not use the
+     * global: the global belongs to whichever window aligned it last, and even with
+     * unconditional alignment another window's align can land between this window's
+     * align and its command. Null falls back to the global, which is the right
+     * answer for a provider with no window.
      */
     private fun windowProjectPath(): String? = windowGitState?.projectPath?.value
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -338,10 +338,10 @@ class GitDataProviderImpl(
 
     override fun openDiff(
         filePath: String,
+        windowId: String,
         staged: Boolean,
         fromRef: String?,
         toRef: String?,
-        windowId: String,
     ) {
         val target = windowId.ifBlank { windowIdProvider().orEmpty() }
         if (target.isBlank()) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitDataProviderImpl.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.io.File
 
 /**
  * Implementation of GitDataProvider that wraps GitService and WindowGitState.
@@ -177,10 +178,10 @@ class GitDataProviderImpl(
                 ),
             )
         }
-        // Align the global project path unconditionally, so the write verbs
-        // (stage/commit/discard/cherry-pick/revert), which still resolve from it,
-        // operate on THIS window's repo rather than whichever window refreshed last.
-        // It is a bare assignment; the four-command probe below stays gated.
+        // Align the global project path unconditionally: it is still read by the
+        // verbs that carry no window override (openFile's fallback,
+        // getCurrentProjectPath's fallback), and it is a bare assignment -
+        // the four-command probe below stays gated.
         GitService.alignCurrentProjectPath(path)
 
         // `changed` covers a project switch. `lastProbedPath != path` covers
@@ -258,7 +259,12 @@ class GitDataProviderImpl(
         return GitService.checkout(ref, windowIdProvider(), windowProjectPath()).toData()
     }
 
-    override fun getCurrentProjectPath(): String? = GitService.getCurrentProjectPath()
+    // This window's path FIRST, the global as fallback: the global belongs to
+    // whichever window aligned it last, and with two windows on different
+    // projects a plugin resolving a relative path (the one this method
+    // exists for) would get the other window's repo. A provider with no
+    // window state has no window path, so the global IS the right answer there.
+    override fun getCurrentProjectPath(): String? = windowProjectPath() ?: GitService.getCurrentProjectPath()
 
     override fun openFile(
         filePath: String,
@@ -286,8 +292,11 @@ class GitDataProviderImpl(
             // Trim the separator rather than concatenating blindly: a project
             // path ending in "/" produced "…//file", which then failed to match
             // an already-open tab and opened a duplicate.
+            // [File.isAbsolute] rather than startsWith("/"): on Windows an
+            // absolute path is `C:\…` and the POSIX test would have glued the
+            // project path onto it.
             val fullPath =
-                if (filePath.startsWith("/")) filePath else "${projectPath.trimEnd('/')}/$filePath"
+                if (File(filePath).isAbsolute) filePath else "${projectPath.trimEnd('/')}/$filePath"
             FileEventBus.openFile(fullPath, sourceWindowId = windowId)
         }
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
@@ -285,9 +285,14 @@ expect object GitService {
      * Get commit log (refreshes the commitLog StateFlow).
      *
      * @param limit Maximum number of commits to retrieve
+     * @param projectPathOverride The repo to read the log from (the caller's window's
+     * project); null falls back to the global current project
      * @return List of commits
      */
-    suspend fun getLog(limit: Int = 100): List<GitCommitInfo>
+    suspend fun getLog(
+        limit: Int = 100,
+        projectPathOverride: String? = null,
+    ): List<GitCommitInfo>
 
     /**
      * Cherry-pick a commit onto the current branch.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
@@ -396,6 +396,21 @@ expect object GitService {
      * @param projectPath The root path of the project
      * @param windowGitState The window-specific git state to update
      */
+
+    /**
+     * Point the global `currentProjectPath` at [projectPath] - a cheap assignment,
+     * no git invocation.
+     *
+     * The write verbs (stage/commit/discard/cherry-pick/revert) still resolve their
+     * repository from the global, and [refreshForWindow] - the only other writer of it -
+     * is gated behind a probe short-circuit, so once two windows on different worktrees
+     * have settled the global belonged to whichever refreshed last. A Discard in the
+     * other window then ran `git restore` in the wrong tree. Aligning here,
+     * unconditionally and before the gated probe, keeps the global tracking the window
+     * whose provider is being used.
+     */
+    fun alignCurrentProjectPath(projectPath: String)
+
     suspend fun refreshForWindow(
         projectPath: String,
         windowGitState: ai.rever.boss.window.WindowGitState?,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
@@ -2,6 +2,8 @@
 
 package ai.rever.boss.git
 
+import ai.rever.boss.plugin.api.GitDiffData
+import ai.rever.boss.plugin.api.GitFileStatusData
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -427,6 +429,55 @@ expect object GitService {
         limit: Int = 100,
     ): List<GitCommitInfo>
 
+    // ===== Window-scoped remote + ref-scoped log (boss-plugin-api 1.0.87) =====
+    //
+    // These take the WINDOW's state rather than reading the global
+    // `currentProjectPath` the way pull()/push() do. The global is written by
+    // whichever window refreshed last, so a two-window session could fetch,
+    // pull or push the wrong repository; a window-scoped path cannot.
+
+    /**
+     * Commit log for an arbitrary [ref] (`git log <ref>`), for the graph's
+     * branch selector.
+     *
+     * Deliberately does NOT write [ai.rever.boss.window.WindowGitState.commitLog]:
+     * that flow is HEAD's history, which the top bar and the git-log panel
+     * read, and filling it with another branch's commits would silently
+     * mis-label them.
+     *
+     * @param ref branch, tag or commit-ish. Blank/null means HEAD.
+     * @return the commits, or an empty list when [ref] resolves to nothing.
+     */
+    suspend fun getLogForRef(
+        windowGitState: ai.rever.boss.window.WindowGitState?,
+        ref: String?,
+        limit: Int = 100,
+    ): List<GitCommitInfo>
+
+    /**
+     * Local + remote-tracking branches of the window's project, read fresh.
+     *
+     * [ai.rever.boss.window.WindowGitState.localBranches] is only written by
+     * [refreshForWindow], which panels call at most once per project, so it
+     * goes stale the moment a branch is created or fetched.
+     */
+    suspend fun listBranchesForWindow(windowGitState: ai.rever.boss.window.WindowGitState?): List<GitBranchInfo>
+
+    /** `git fetch --all [--prune]` in the window's project. */
+    suspend fun fetchForWindow(
+        windowGitState: ai.rever.boss.window.WindowGitState?,
+        prune: Boolean = false,
+    ): GitOperationResult
+
+    /** `git pull` in the window's project. */
+    suspend fun pullForWindow(windowGitState: ai.rever.boss.window.WindowGitState?): GitOperationResult
+
+    /**
+     * `git push -u origin HEAD` in the window's project. Never `--force`:
+     * a force push has no in-app undo and belongs in a terminal.
+     */
+    suspend fun pushForWindow(windowGitState: ai.rever.boss.window.WindowGitState?): GitOperationResult
+
     /**
      * Watch the project's `.git/HEAD` (and refs) for external mutations and
      * refresh [windowGitState] whenever an external `git checkout`,
@@ -446,4 +497,64 @@ expect object GitService {
         projectPath: String,
         windowGitState: ai.rever.boss.window.WindowGitState?,
     )
+
+    // ===== Diff =====
+
+    /**
+     * Unified diff for one file.
+     *
+     * @param filePath Path relative to the project root.
+     * @param staged true = index vs HEAD (staged changes), false = working tree vs index.
+     * @return Parsed diff data for the file, or empty if there is no diff (or git failed).
+     */
+    // Each takes the WINDOW's project path. Reading the global `currentProjectPath`
+    // meant a two-window session could render the OTHER window's diff: the global is
+    // written by whichever window refreshed last, and ensureRepoState only reseeds it
+    // when that window's project CHANGED - so once both windows settle, nothing
+    // re-aligns it before a diff read. Same fix, same reason, as the remote verbs above.
+    // A null path falls back to the global for callers that have no window.
+    suspend fun getFileDiff(
+        filePath: String,
+        staged: Boolean,
+        projectPathOverride: String? = null,
+    ): List<GitDiffData>
+
+    /**
+     * Unified diff of a single commit (against its parent; a root commit diffs
+     * against the empty tree).
+     *
+     * @param commitHash Full or short commit hash.
+     * @param filePath Optional path to restrict the diff to one file.
+     */
+    suspend fun getCommitDiff(
+        commitHash: String,
+        filePath: String? = null,
+        projectPathOverride: String? = null,
+    ): List<GitDiffData>
+
+    /**
+     * Unified diff between two refs.
+     *
+     * @param fromRef Base ref (commit/branch/tag).
+     * @param toRef Target ref (commit/branch/tag).
+     * @param filePath Optional path to restrict the diff to one file.
+     */
+    suspend fun getRefDiff(
+        fromRef: String,
+        toRef: String,
+        filePath: String? = null,
+        projectPathOverride: String? = null,
+    ): List<GitDiffData>
+
+    /**
+     * Name-status listing of the changed files.
+     *
+     * @param staged true = staged (index vs HEAD), false = working tree vs index.
+     * @return One entry per changed file (untracked files are not included -
+     * they have no index or HEAD entry to diff against).
+     */
+    suspend fun getDiffFileNames(
+        staged: Boolean,
+        projectPathOverride: String? = null,
+    ): List<GitFileStatusData>
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
@@ -59,6 +59,16 @@ expect object GitService {
     val isLoading: StateFlow<Boolean>
 
     /**
+     * True while ANY git command is running or queued on the process-wide git
+     * lock - all windows, all repos, including status polls. [isLoading] tracks
+     * one operation's own button state; this is what the user needs when a
+     * DIFFERENT window's slow command (an index write now holds the lock for up
+     * to ten minutes) freezes every git read: "a git command is running",
+     * rather than an unexplained blank.
+     */
+    val gitCommandsRunning: StateFlow<Boolean>
+
+    /**
      * Last error message, if any.
      */
     val lastError: StateFlow<String?>
@@ -102,45 +112,57 @@ expect object GitService {
         branchName: String,
         checkout: Boolean = true,
         windowId: String? = null,
+        projectPathOverride: String? = null,
     ): GitOperationResult
 
     /**
      * Pull changes from remote.
      *
+     * @param projectPathOverride The repo to run in (the caller's window's project).
      * @return Result indicating success or failure
      */
-    suspend fun pull(): GitOperationResult
+    suspend fun pull(projectPathOverride: String? = null): GitOperationResult
 
     /**
      * Push changes to remote.
      *
+     * @param projectPathOverride The repo to run in (the caller's window's project).
      * @return Result indicating success or failure
      */
-    suspend fun push(): GitOperationResult
+    suspend fun push(projectPathOverride: String? = null): GitOperationResult
 
     /**
      * Get the URL for creating a pull request in the browser.
      * Returns the GitHub/GitLab PR creation URL based on the remote origin.
      *
+     * @param projectPathOverride The repo to read the remote from (the caller's window's project).
      * @return The PR creation URL, or null if not a supported remote
      */
-    suspend fun getCreatePRUrl(): String?
+    suspend fun getCreatePRUrl(projectPathOverride: String? = null): String?
 
     /**
      * Merge a branch into the current branch.
      *
      * @param branchName The branch to merge into current
+     * @param projectPathOverride The repo to merge in (the caller's window's project).
      * @return Result indicating success or failure
      */
-    suspend fun merge(branchName: String): GitOperationResult
+    suspend fun merge(
+        branchName: String,
+        projectPathOverride: String? = null,
+    ): GitOperationResult
 
     /**
      * Rebase current branch onto another branch.
      *
      * @param branchName The branch to rebase onto
+     * @param projectPathOverride The repo to rebase in (the caller's window's project).
      * @return Result indicating success or failure
      */
-    suspend fun rebase(branchName: String): GitOperationResult
+    suspend fun rebase(
+        branchName: String,
+        projectPathOverride: String? = null,
+    ): GitOperationResult
 
     /**
      * Clear Git state (when no project is selected).
@@ -157,9 +179,10 @@ expect object GitService {
     /**
      * Get current file status (refreshes the fileStatus StateFlow).
      *
+     * @param projectPathOverride The repo to read (null: the global current project).
      * @return List of files with their status
      */
-    suspend fun getStatus(): List<GitFileStatus>
+    suspend fun getStatus(projectPathOverride: String? = null): List<GitFileStatus>
 
     /**
      * Stage a file for commit.
@@ -349,14 +372,20 @@ expect object GitService {
      *
      * @param windowId The window ID for per-window terminal isolation (Issue #498)
      */
-    suspend fun pullInTerminal(windowId: String)
+    suspend fun pullInTerminal(
+        windowId: String,
+        projectPathOverride: String? = null,
+    )
 
     /**
      * Run git push in the terminal (for real-time output).
      *
      * @param windowId The window ID for per-window terminal isolation (Issue #498)
      */
-    suspend fun pushInTerminal(windowId: String)
+    suspend fun pushInTerminal(
+        windowId: String,
+        projectPathOverride: String? = null,
+    )
 
     /**
      * Run git merge in the terminal (for real-time output).
@@ -367,6 +396,7 @@ expect object GitService {
     suspend fun mergeInTerminal(
         windowId: String,
         branchName: String,
+        projectPathOverride: String? = null,
     )
 
     /**
@@ -378,6 +408,7 @@ expect object GitService {
     suspend fun rebaseInTerminal(
         windowId: String,
         branchName: String,
+        projectPathOverride: String? = null,
     )
 
     /**

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/GitService.kt
@@ -79,11 +79,15 @@ expect object GitService {
      *
      * @param branchName The branch name to checkout
      * @param windowId Optional window ID to update window-specific state after operation
+     * @param projectPathOverride Repository to act on; null falls back to the global
+     *   current project path. Window-scoped callers pass their own (see the write-verbs
+     *   note below) - the global belongs to whichever window aligned it last.
      * @return Result indicating success or failure
      */
     suspend fun checkout(
         branchName: String,
         windowId: String? = null,
+        projectPathOverride: String? = null,
     ): GitOperationResult
 
     /**
@@ -164,9 +168,15 @@ expect object GitService {
      * @param windowId Optional window ID to update window-specific state after operation
      * @return Result indicating success or failure
      */
+    // The write verbs below all take a projectPathOverride: resolving the repo from
+    // the global current project path in a separate step leaves a window where
+    // another window's align lands in between, and the write runs in the wrong
+    // worktree. The override travels with the call, so nothing can redirect it.
+
     suspend fun stage(
         filePath: String,
         windowId: String? = null,
+        projectPathOverride: String? = null,
     ): GitOperationResult
 
     /**
@@ -175,7 +185,10 @@ expect object GitService {
      * @param windowId Optional window ID to update window-specific state after operation
      * @return Result indicating success or failure
      */
-    suspend fun stageAll(windowId: String? = null): GitOperationResult
+    suspend fun stageAll(
+        windowId: String? = null,
+        projectPathOverride: String? = null,
+    ): GitOperationResult
 
     /**
      * Unstage a file.
@@ -187,6 +200,7 @@ expect object GitService {
     suspend fun unstage(
         filePath: String,
         windowId: String? = null,
+        projectPathOverride: String? = null,
     ): GitOperationResult
 
     /**
@@ -195,7 +209,10 @@ expect object GitService {
      * @param windowId Optional window ID to update window-specific state after operation
      * @return Result indicating success or failure
      */
-    suspend fun unstageAll(windowId: String? = null): GitOperationResult
+    suspend fun unstageAll(
+        windowId: String? = null,
+        projectPathOverride: String? = null,
+    ): GitOperationResult
 
     /**
      * Discard changes to a file in the working tree.
@@ -207,6 +224,7 @@ expect object GitService {
     suspend fun discardChanges(
         filePath: String,
         windowId: String? = null,
+        projectPathOverride: String? = null,
     ): GitOperationResult
 
     // ===== Commit =====
@@ -223,6 +241,7 @@ expect object GitService {
         message: String,
         amend: Boolean = false,
         windowId: String? = null,
+        projectPathOverride: String? = null,
     ): GitOperationResult
 
     /**
@@ -251,17 +270,27 @@ expect object GitService {
      * Cherry-pick a commit onto the current branch.
      *
      * @param commitHash The commit hash to cherry-pick
+     * @param windowId Optional window ID to update window-specific state after operation
      * @return Result indicating success or failure
      */
-    suspend fun cherryPick(commitHash: String): GitOperationResult
+    suspend fun cherryPick(
+        commitHash: String,
+        windowId: String? = null,
+        projectPathOverride: String? = null,
+    ): GitOperationResult
 
     /**
      * Revert a commit.
      *
      * @param commitHash The commit hash to revert
+     * @param windowId Optional window ID to update window-specific state after operation
      * @return Result indicating success or failure
      */
-    suspend fun revert(commitHash: String): GitOperationResult
+    suspend fun revert(
+        commitHash: String,
+        windowId: String? = null,
+        projectPathOverride: String? = null,
+    ): GitOperationResult
 
     // ===== Stash =====
 
@@ -401,13 +430,13 @@ expect object GitService {
      * Point the global `currentProjectPath` at [projectPath] - a cheap assignment,
      * no git invocation.
      *
-     * The write verbs (stage/commit/discard/cherry-pick/revert) still resolve their
-     * repository from the global, and [refreshForWindow] - the only other writer of it -
-     * is gated behind a probe short-circuit, so once two windows on different worktrees
-     * have settled the global belonged to whichever refreshed last. A Discard in the
-     * other window then ran `git restore` in the wrong tree. Aligning here,
-     * unconditionally and before the gated probe, keeps the global tracking the window
-     * whose provider is being used.
+     * The window-scoped write verbs no longer depend on this - they carry their own
+     * projectPathOverride, because align-then-write is two steps and another window's
+     * align could land in between. This still matters for everything that reads the
+     * global with no override (merge/rebase/stash, the top-bar actions): once two
+     * windows on different worktrees have settled, the global belonged to whichever
+     * refreshed last. Aligning here, unconditionally and before the gated probe, keeps
+     * the global tracking the window whose provider is being used.
      */
     fun alignCurrentProjectPath(projectPath: String)
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
@@ -1,0 +1,343 @@
+package ai.rever.boss.git
+
+import ai.rever.boss.plugin.api.DiffHunk
+import ai.rever.boss.plugin.api.DiffLine
+import ai.rever.boss.plugin.api.DiffLineKind
+import ai.rever.boss.plugin.api.GitDiffData
+
+/**
+ * Parses `git diff` unified output (one or more files per stream) into [GitDiffData]
+ * values.
+ *
+ * Handles: multiple `diff --git` sections, `rename from`/`rename to`,
+ * `Binary files ... differ`, `@@` headers with optional line counts
+ * (single-line hunks, and `0,0` for created/removed files), the
+ * `\ No newline at end of file` marker, and blank context lines.
+ *
+ * Pure text in, structured data out - no git, no filesystem - so it is unit
+ * tested against captured fixtures in desktopTest.
+ */
+object UnifiedDiffParser {
+    /**
+     * Parse a full unified diff stream. Files come back in input order; a file
+     * section without hunks (e.g. mode-only changes) still appears with empty
+     * hunks.
+     */
+    fun parse(input: String): List<GitDiffData> {
+        // A process's diff ends with "\n", and lineSequence() turns that trailing
+        // terminator into a final "" element. The hunk body accepts "" as a context
+        // line, so that artefact was appended to the last hunk of every real diff -
+        // one phantom blank line numbered past EOF. Fixtures use trimIndent() (no
+        // trailing newline), which is why no test saw it.
+        val rawLines =
+            input.lineSequence().toList().let {
+                if (input.endsWith("\n") && it.isNotEmpty() && it.last().isEmpty()) it.dropLast(1) else it
+            }
+        val files = mutableListOf<FileState>()
+        var current: FileState? = null
+        var hunk: HunkBuilder? = null
+
+        fun closeHunk() {
+            val h = hunk ?: return
+            hunk = null
+            current?.addHunk(h.build())
+        }
+
+        // endExclusive is where THIS file's section stops. Without it every
+        // file's rawUnified ran to the end of the stream, so in a 3-file commit
+        // diff files[0].rawUnified was the entire 3-file patch.
+        fun closeFile(endExclusive: Int) {
+            closeHunk()
+            val f = current ?: return
+            current = null
+            f.rawEnd = endExclusive
+            files.add(f)
+        }
+
+        for (i in rawLines.indices) {
+            val line = rawLines[i]
+            if (line.startsWith("diff --git ")) {
+                closeFile(i)
+                current = FileState(line, rawStart = i)
+                continue
+            }
+            val cur = current ?: continue
+            when {
+                line.startsWith("rename from ") -> {
+                    // Quoted by git under the same rules as the header path.
+                    cur.oldPath = cUnquote(line.removePrefix("rename from "))
+                }
+
+                line.startsWith("rename to ") -> {
+                    cur.path = cUnquote(line.removePrefix("rename to "))
+                }
+
+                line.startsWith("Binary files ") -> {
+                    cur.isBinary = true
+                }
+
+                line.startsWith("@@") -> {
+                    closeHunk()
+                    // `git show <merge>` emits a COMBINED diff: "@@@ -a,b -c,d +e,f @@@"
+                    // with two-column "++"/"+ " prefixes. Feeding that to HunkBuilder
+                    // stripped one "@@", parsed "@ -a,b" as (1,1) and misclassified every
+                    // body line - wrong line numbers, wrong add/remove, no error. There is
+                    // no correct unified reading of it, so the file is reported with NO
+                    // parsed hunks and its rawUnified intact, which is what that field is
+                    // for. hunk stays null, so the body lines below are ignored.
+                    hunk = if (line.startsWith("@@@")) null else HunkBuilder(line)
+                }
+
+                line.startsWith("\\") -> {
+                    // "\ No newline at end of file": a marker, not a diff line.
+                    continue
+                }
+
+                else -> {
+                    val h = hunk
+                    if (h != null && (line.startsWith("+") || line.startsWith("-") || line.startsWith(" ") || line.isEmpty())) {
+                        h.addLine(line)
+                    } else {
+                        // File-level metadata (index/new file mode/old mode/similarity)
+                        // or an unknown line: it ends any open hunk.
+                        closeHunk()
+                    }
+                }
+            }
+        }
+        closeFile(rawLines.size)
+        return files.map { it.build(rawLines) }
+    }
+
+    private class FileState(
+        val headerLine: String,
+        val rawStart: Int,
+    ) {
+        var rawEnd: Int = rawStart
+        var path: String = pathFromHeader(headerLine, newSide = true)
+        var oldPath: String? =
+            pathFromHeader(headerLine, newSide = false).let { if (it == path) null else it }
+        var isBinary = false
+        var additions = 0
+        var deletions = 0
+        val hunks = mutableListOf<DiffHunk>()
+
+        init {
+            require(path.isNotEmpty()) { "Could not read a path from: $headerLine" }
+        }
+
+        fun addHunk(hunk: DiffHunk) {
+            additions += hunk.lines.count { it.kind == DiffLineKind.ADDED }
+            deletions += hunk.lines.count { it.kind == DiffLineKind.REMOVED }
+            hunks.add(hunk)
+        }
+
+        fun build(rawLines: List<String>): GitDiffData =
+            GitDiffData(
+                path = path,
+                oldPath = oldPath,
+                additions = additions,
+                deletions = deletions,
+                isBinary = isBinary,
+                hunks = hunks,
+                rawUnified = rawLines.subList(rawStart, rawEnd.coerceAtLeast(rawStart)).joinToString("\n"),
+            )
+    }
+
+    private class HunkBuilder(
+        header: String,
+    ) {
+        val header: String = header
+        val oldStart: Int
+        val oldLines: Int
+        val newStart: Int
+        val newLines: Int
+
+        private var oldLineNo: Int
+        private var newLineNo: Int
+        private val lines = mutableListOf<DiffLine>()
+
+        init {
+            val body = header.removePrefix("@@").trimEnd('@').trim()
+            // body looks like: "-0,0 +1,5" or "-12 +12,3" or "-12 +12"
+            val parts = body.split(" ").filter { it.isNotEmpty() }
+            val (os, oc) = parseSide(parts.firstOrNull().orEmpty())
+            val (ns, nc) = parseSide(parts.getOrNull(1).orEmpty())
+            oldStart = os
+            oldLines = oc
+            newStart = ns
+            newLines = nc
+            // A side that starts at 0 has no lines on that side to number.
+            oldLineNo = os
+            newLineNo = ns
+        }
+
+        fun addLine(line: String) {
+            when (line.firstOrNull()) {
+                '+' -> {
+                    val n = newLineNo
+                    newLineNo++
+                    lines.add(DiffLine(DiffLineKind.ADDED, line.substring(1), oldLine = null, newLine = n.takeIf { n > 0 }))
+                }
+
+                '-' -> {
+                    val o = oldLineNo
+                    oldLineNo++
+                    lines.add(DiffLine(DiffLineKind.REMOVED, line.substring(1), oldLine = o.takeIf { o > 0 }, newLine = null))
+                }
+
+                else -> {
+                    // Context line (leading space, or a blank line).
+                    val text = if (line.length > 1) line.substring(1) else ""
+                    val o = oldLineNo.also { oldLineNo++ }
+                    val n = newLineNo.also { newLineNo++ }
+                    lines.add(
+                        DiffLine(DiffLineKind.CONTEXT, text, oldLine = o.takeIf { o > 0 }, newLine = n.takeIf { n > 0 }),
+                    )
+                }
+            }
+        }
+
+        fun build(): DiffHunk =
+            DiffHunk(
+                oldStart = oldStart,
+                oldLines = oldLines,
+                newStart = newStart,
+                newLines = newLines,
+                header = header,
+                lines = lines,
+            )
+
+        private fun parseSide(side: String): Pair<Int, Int> {
+            // Drop the side's sign marker: "-12,3" / "+12".
+            val unsigned = side.removePrefix("+").removePrefix("-")
+            val idx = unsigned.indexOf(',')
+            return if (idx < 0) {
+                (unsigned.toIntOrNull() ?: 1) to 1
+            } else {
+                (unsigned.substring(0, idx).toIntOrNull() ?: 1) to (unsigned.substring(idx + 1).toIntOrNull() ?: 0)
+            }
+        }
+    }
+
+    /**
+     * The old- or new-side path from a `diff --git` header.
+     *
+     * git quotes a path containing non-ASCII or special characters and escapes it
+     * C-style, emitting UTF-8 as OCTAL BYTES: `diff --git "a/caf\303\251.txt"
+     * "b/caf\303\251.txt"`. That header contains no ` b/`, so the previous
+     * `lastIndexOf(" b/")` returned -1, the new-side path came back empty, and
+     * FileState's `require(path.isNotEmpty())` threw - one accented or CJK filename
+     * anywhere in a commit aborted the whole diff, uncaught, out through
+     * GitDataProvider into the calling plugin.
+     *
+     * Each side is quoted independently, so both mixed forms are handled.
+     */
+    private fun pathFromHeader(
+        header: String,
+        newSide: Boolean,
+    ): String {
+        val after = header.removePrefix("diff --git ")
+        val (a, b) = splitSides(after) ?: return ""
+        val raw = if (newSide) b else a
+        val prefix = if (newSide) "b/" else "a/"
+        return cUnquote(raw).removePrefix(prefix)
+    }
+
+    /** Splits `a/<old> b/<new>` into its two tokens, either of which may be quoted. */
+    private fun splitSides(s: String): Pair<String, String>? {
+        val t = s.trim()
+        if (t.startsWith("\"")) {
+            val end = closingQuote(t) ?: return null
+            val rest = t.substring(end + 1).trim()
+            if (rest.isEmpty()) return null
+            return t.substring(0, end + 1) to rest
+        }
+        // Unquoted old side: the new side is either ` b/…` or ` "b/…"`.
+        val q = t.indexOf(" \"")
+        if (q >= 0) return t.substring(0, q) to t.substring(q + 1)
+        val idx = t.lastIndexOf(" b/")
+        if (idx < 0) return null
+        return t.substring(0, idx) to t.substring(idx + 1)
+    }
+
+    /** Index of the quote closing the one at position 0, honouring backslash escapes. */
+    private fun closingQuote(s: String): Int? {
+        var i = 1
+        while (i < s.length) {
+            when (s[i]) {
+                '\\' -> i++
+                '"' -> return i
+            }
+            i++
+        }
+        return null
+    }
+
+    /**
+     * Undoes git's C-style quoting, decoding `\ooo` escapes as UTF-8 BYTES.
+     *
+     * Byte-wise, not char-wise: `\303\251` is the two-byte UTF-8 encoding of a
+     * single `é`. Mapping each octal escape to its own Char would produce `Ã©`.
+     * An unquoted token is returned unchanged.
+     */
+    private fun cUnquote(p: String): String {
+        val t = p.trim()
+        if (!t.startsWith("\"") || !t.endsWith("\"") || t.length < 2) return t
+        val body = t.substring(1, t.length - 1)
+        val bytes = ArrayList<Byte>(body.length)
+        var i = 0
+        while (i < body.length) {
+            val c = body[i]
+            if (c != '\\' || i == body.length - 1) {
+                for (b in c.toString().encodeToByteArray()) bytes.add(b)
+                i++
+                continue
+            }
+            val n = body[i + 1]
+            when (n) {
+                'n' -> {
+                    bytes.add('\n'.code.toByte())
+                    i += 2
+                }
+
+                't' -> {
+                    bytes.add('\t'.code.toByte())
+                    i += 2
+                }
+
+                'r' -> {
+                    bytes.add('\r'.code.toByte())
+                    i += 2
+                }
+
+                '"' -> {
+                    bytes.add('"'.code.toByte())
+                    i += 2
+                }
+
+                '\\' -> {
+                    bytes.add('\\'.code.toByte())
+                    i += 2
+                }
+
+                in '0'..'7' -> {
+                    var len = 0
+                    var v = 0
+                    while (len < 3 && i + 1 + len < body.length && body[i + 1 + len] in '0'..'7') {
+                        v = v * 8 + (body[i + 1 + len] - '0')
+                        len++
+                    }
+                    bytes.add((v and 0xFF).toByte())
+                    i += 1 + len
+                }
+
+                else -> {
+                    for (b in n.toString().encodeToByteArray()) bytes.add(b)
+                    i += 2
+                }
+            }
+        }
+        return bytes.toByteArray().decodeToString()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
@@ -281,7 +281,7 @@ object UnifiedDiffParser {
      * single `é`. Mapping each octal escape to its own Char would produce `Ã©`.
      * An unquoted token is returned unchanged.
      */
-    private fun cUnquote(p: String): String {
+    internal fun cUnquote(p: String): String {
         val t = p.trim()
         if (!t.startsWith("\"") || !t.endsWith("\"") || t.length < 2) return t
         val body = t.substring(1, t.length - 1)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
@@ -177,13 +177,17 @@ object UnifiedDiffParser {
                 '+' -> {
                     val n = newLineNo
                     newLineNo++
-                    lines.add(DiffLine(line.substring(1), DiffLineKind.ADDED, oldLine = null, newLine = n.takeIf { n > 0 }))
+                    lines.add(
+                        DiffLine(line.substring(1), DiffLineKind.ADDED, oldLine = null, newLine = n.takeIf { n > 0 }),
+                    )
                 }
 
                 '-' -> {
                     val o = oldLineNo
                     oldLineNo++
-                    lines.add(DiffLine(line.substring(1), DiffLineKind.REMOVED, oldLine = o.takeIf { o > 0 }, newLine = null))
+                    lines.add(
+                        DiffLine(line.substring(1), DiffLineKind.REMOVED, oldLine = o.takeIf { o > 0 }, newLine = null),
+                    )
                 }
 
                 else -> {
@@ -192,7 +196,12 @@ object UnifiedDiffParser {
                     val o = oldLineNo.also { oldLineNo++ }
                     val n = newLineNo.also { newLineNo++ }
                     lines.add(
-                        DiffLine(text, DiffLineKind.CONTEXT, oldLine = o.takeIf { o > 0 }, newLine = n.takeIf { n > 0 }),
+                        DiffLine(
+                            text,
+                            DiffLineKind.CONTEXT,
+                            oldLine = o.takeIf { o > 0 },
+                            newLine = n.takeIf { n > 0 },
+                        ),
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
@@ -253,7 +253,18 @@ object UnifiedDiffParser {
         return cUnquote(raw).removePrefix(prefix)
     }
 
-    /** Splits `a/<old> b/<new>` into its two tokens, either of which may be quoted. */
+    /**
+     * Splits `a/<old> b/<new>` into its two tokens, either of which may be
+     * quoted.
+     *
+     * Known limit, deliberately left: the unquoted fallback is
+     * `lastIndexOf(" b/")`, and git does not quote a path merely for
+     * containing a space - so a directory literally named `b`
+     * (`diff --git a/x b/y b/x b/y`) splits at the wrong point, with no
+     * exception. It cannot be settled from the header alone; the
+     * `--- a/` / `+++ b/` lines just below the header would settle it, and
+     * anyone who needs certainty can parse `git diff --raw -z` instead.
+     */
     private fun splitSides(s: String): Pair<String, String>? {
         val t = s.trim()
         if (t.startsWith("\"")) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/git/UnifiedDiffParser.kt
@@ -177,13 +177,13 @@ object UnifiedDiffParser {
                 '+' -> {
                     val n = newLineNo
                     newLineNo++
-                    lines.add(DiffLine(DiffLineKind.ADDED, line.substring(1), oldLine = null, newLine = n.takeIf { n > 0 }))
+                    lines.add(DiffLine(line.substring(1), DiffLineKind.ADDED, oldLine = null, newLine = n.takeIf { n > 0 }))
                 }
 
                 '-' -> {
                     val o = oldLineNo
                     oldLineNo++
-                    lines.add(DiffLine(DiffLineKind.REMOVED, line.substring(1), oldLine = o.takeIf { o > 0 }, newLine = null))
+                    lines.add(DiffLine(line.substring(1), DiffLineKind.REMOVED, oldLine = o.takeIf { o > 0 }, newLine = null))
                 }
 
                 else -> {
@@ -192,7 +192,7 @@ object UnifiedDiffParser {
                     val o = oldLineNo.also { oldLineNo++ }
                     val n = newLineNo.also { newLineNo++ }
                     lines.add(
-                        DiffLine(DiffLineKind.CONTEXT, text, oldLine = o.takeIf { o > 0 }, newLine = n.takeIf { n > 0 }),
+                        DiffLine(text, DiffLineKind.CONTEXT, oldLine = o.takeIf { o > 0 }, newLine = n.takeIf { n > 0 }),
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/BufferEditRange.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/BufferEditRange.kt
@@ -19,10 +19,6 @@ internal data class BufferEditRange(
 ) {
     companion object {
         /**
-         * @param lines line-start offsets of the text the match came from
-         * @param range the match range, inclusive of its last character
-         */
-        /**
          * The positions for an arbitrary half-open offset span [[start], [endExclusive]).
          *
          * Unlike [of], which takes a match's inclusive range, this maps the two
@@ -41,6 +37,15 @@ internal data class BufferEditRange(
                 endCol = lines.columnOf(endExclusive),
             )
 
+        /**
+         * The positions for a match's INCLUSIVE range (the +1 to an exclusive end is
+         * the whole point - see the class KDoc). No production caller since replace
+         * moved to whole-file diffing, but kept and pinned by [BufferEditRangeTest]:
+         * it is the smallest place that exercises the off-by-one this type exists for.
+         *
+         * @param lines line-start offsets of the text the match came from
+         * @param range the match range, inclusive of its last character
+         */
         fun of(
             lines: LineOffsets,
             range: IntRange,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/BufferEditRange.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/BufferEditRange.kt
@@ -1,0 +1,64 @@
+package ai.rever.boss.search
+
+/**
+ * The 1-based, end-exclusive line/column range an `applyEdit` call needs for a
+ * regex match.
+ *
+ * Its own file, and pure, because getting this wrong silently corrupts text:
+ * `EditorTabPluginAPI.applyEdit` documents 1-based positions and applies
+ * `document.replace(start, end, …)` with an **exclusive** end, while
+ * `MatchResult.range.last` is the **inclusive** index of the match's last
+ * character. Passing `last` straight through replaced one character too few -
+ * replacing `subtract` with `add` produced `addt`.
+ */
+internal data class BufferEditRange(
+    val startLine: Int,
+    val startCol: Int,
+    val endLine: Int,
+    val endCol: Int,
+) {
+    companion object {
+        /**
+         * @param lines line-start offsets of the text the match came from
+         * @param range the match range, inclusive of its last character
+         */
+        /**
+         * The positions for an arbitrary half-open offset span [[start], [endExclusive]).
+         *
+         * Unlike [of], which takes a match's inclusive range, this maps the two
+         * offsets a whole-file diff produces - a single replaced span, which may be a
+         * pure insertion ([start] == [endExclusive]) or a deletion (empty new text).
+         */
+        fun ofSpan(
+            lines: LineOffsets,
+            start: Int,
+            endExclusive: Int,
+        ): BufferEditRange =
+            BufferEditRange(
+                startLine = lines.lineOf(start),
+                startCol = lines.columnOf(start),
+                endLine = lines.lineOf(endExclusive),
+                endCol = lines.columnOf(endExclusive),
+            )
+
+        fun of(
+            lines: LineOffsets,
+            range: IntRange,
+        ): BufferEditRange {
+            val endExclusive = range.last + 1
+            return BufferEditRange(
+                startLine = lines.lineOf(range.first),
+                startCol = lines.columnOf(range.first),
+                endLine = lines.lineOf(endExclusive),
+                endCol = lines.columnOf(endExclusive),
+            )
+        }
+    }
+}
+
+/** 1-based line/column lookup over precomputed line-start offsets. */
+internal interface LineOffsets {
+    fun lineOf(offset: Int): Int
+
+    fun columnOf(offset: Int): Int
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -35,6 +35,13 @@ class ContentSearchService(
     // DefaultPlugin passes a bridge over its OWN (window-scoped) getPluginAPI; the
     // default keeps the old global behaviour for callers and tests that do not care.
     private val bufferBridge: EditorBufferBridge = GlobalEditorBufferBridge,
+    // The files with an editor tab open in this window, or null for "unknown".
+    // A buffer can only exist behind an open tab, so a search consults the bridge
+    // ONLY for these paths - without this it made one bridge call per walked file
+    // (tens of thousands per search on a real repo) to learn "no buffer" for all
+    // but a handful. Null preserves the old ask-for-every-file behaviour, which is
+    // the safe answer whenever the host cannot enumerate the open tabs.
+    private val openEditorPathsProvider: () -> Set<String>? = { null },
 ) : ProjectSearchProvider {
     // Access-ordered and self-evicting: at capacity the ELDEST entry is dropped, not
     // the whole map. The old wholesale clear() meant a project above the cap wiped the
@@ -79,6 +86,8 @@ class ContentSearchService(
         val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return emptyList()
         return withContext(Dispatchers.IO) {
             val results = mutableListOf<FileMatch>()
+            // Snapshotted once per search, not per file - the whole point.
+            val openPaths = openBufferLookupSet(projectPath)
             for (file in walkProjectFiles(projectPath, pathPattern, excludePattern)) {
                 ensureActive()
                 if (results.size >= maxResults) break
@@ -86,8 +95,15 @@ class ContentSearchService(
                 // An open file is searched as the user sees it, not as the disk
                 // has it. Otherwise a replace into a live buffer - or any
                 // unsaved edit - leaves the results tree reporting matches the
-                // editor no longer shows.
-                val buffer = bufferBridge.readBuffer(file.absolutePath)
+                // editor no longer shows. The bridge is only asked for files that
+                // can actually have a buffer (an open editor tab); null means the
+                // open set is unknown and every file is asked, as before.
+                val buffer =
+                    if (openPaths == null || file.absolutePath in openPaths) {
+                        bufferBridge.readBuffer(file.absolutePath)
+                    } else {
+                        null
+                    }
                 val key =
                     cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath) +
                         if (buffer != null) "|buf" else "|disk"
@@ -223,6 +239,34 @@ class ContentSearchService(
 
     /** Canonical path when resolvable, else the absolute one - identity for cycle detection. */
     private fun canonicalOrPath(f: File): String = runCatching { f.canonicalPath }.getOrDefault(f.absolutePath)
+
+    /**
+     * The open-tab paths expanded into every spelling the walk might produce, or null
+     * when the open set is unknown.
+     *
+     * The walk yields paths under the project root AS OPENED, while a tab can hold the
+     * canonical form or vice versa (a project under /tmp is really /private/tmp on
+     * macOS - the same mismatch resolveFile documents). Missing a live buffer here
+     * would silently search stale disk content, so each tab path is added raw,
+     * canonical, and re-expressed under the raw root when the roots differ. O(open
+     * tabs), so the cost is a handful of canonicalise calls per search.
+     */
+    private fun openBufferLookupSet(projectPath: String): Set<String>? {
+        val raw = openEditorPathsProvider() ?: return null
+        val root = File(projectPath).absolutePath.trimEnd(File.separatorChar)
+        val rootCanon = canonicalOrPath(File(projectPath)).trimEnd(File.separatorChar)
+        val out = HashSet<String>(raw.size * 3 + 1)
+        for (p in raw) {
+            val abs = if (File(p).isAbsolute) File(p).path else File(projectPath, p).path
+            out.add(abs)
+            val canon = canonicalOrPath(File(abs))
+            out.add(canon)
+            if (root != rootCanon && canon.startsWith(rootCanon + File.separatorChar)) {
+                out.add(root + canon.removePrefix(rootCanon))
+            }
+        }
+        return out
+    }
 
     private fun cacheKey(
         projectRoot: String,
@@ -506,7 +550,9 @@ class ContentSearchService(
                 java.nio.file.Files
                     .getPosixFilePermissions(file.toPath())
             }.getOrNull()
-        val tmp = File.createTempFile(file.name, ".tmp", file.parentFile)
+        // createTempFile requires a prefix of at least 3 chars; a file named "a" or
+        // "go" otherwise fails its replace with an opaque per-file error.
+        val tmp = File.createTempFile(file.name.padEnd(3, '_'), ".tmp", file.parentFile)
         try {
             tmp.writeText(text)
             java.nio.file.Files.move(

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -29,6 +29,12 @@ import java.io.File
  */
 class ContentSearchService(
     private val projectPathProvider: () -> String?,
+    // How the search reaches the editor's live buffers. Injected, not the global
+    // EditorAPIAccess, because that resolves through a process-wide last-window-wins
+    // DefaultPlugin - so window 1's search would edit buffers in window 2's editor.
+    // DefaultPlugin passes a bridge over its OWN (window-scoped) getPluginAPI; the
+    // default keeps the old global behaviour for callers and tests that do not care.
+    private val bufferBridge: EditorBufferBridge = GlobalEditorBufferBridge,
 ) : ProjectSearchProvider {
     // Access-ordered and self-evicting: at capacity the ELDEST entry is dropped, not
     // the whole map. The old wholesale clear() meant a project above the cap wiped the
@@ -81,7 +87,7 @@ class ContentSearchService(
                 // has it. Otherwise a replace into a live buffer - or any
                 // unsaved edit - leaves the results tree reporting matches the
                 // editor no longer shows.
-                val buffer = EditorAPIAccess.readBuffer(file.absolutePath)
+                val buffer = bufferBridge.readBuffer(file.absolutePath)
                 val key =
                     cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath) +
                         if (buffer != null) "|buf" else "|disk"
@@ -104,6 +110,7 @@ class ContentSearchService(
                             file = file,
                             text = buffer?.content ?: readTextOrNull(file) ?: continue,
                             regex = regex,
+                            projectRoot = File(projectPath),
                         )?.also { found ->
                             // Empty results are not cached: on a large project most files
                             // match nothing, and caching them all filled the map and tripped
@@ -266,7 +273,15 @@ class ContentSearchService(
                 val notSkipped = isRoot || dir.name !in SKIP_DIRECTORIES
                 notSkipped && (isRoot || seen.add(canonicalOrPath(dir)))
             }.filter { it.isFile }
-            .filter { it.length() <= MAX_FILE_SIZE }
+            // Skip symlinked files, so the walk and replaceInProject agree: replace
+            // refuses a path resolving outside the project (resolveFile), and a followed
+            // symlink is exactly such a path. Directory-symlink cycles are handled above.
+            .filterNot {
+                runCatching {
+                    java.nio.file.Files
+                        .isSymbolicLink(it.toPath())
+                }.getOrDefault(false)
+            }.filter { it.length() <= MAX_FILE_SIZE }
             .filter { file ->
                 val rel = file.relativeTo(root).path.replace('\\', '/')
                 val included = globs.isNullOrEmpty() || globs.any { it.matches(rel) }
@@ -321,9 +336,9 @@ class ContentSearchService(
         file: File,
         text: String,
         regex: Regex,
+        projectRoot: File,
     ): List<FileMatch>? {
         return try {
-            val projectRoot = File(projectPathProvider() ?: return null)
             val relative = file.relativeTo(projectRoot).path.replace('\\', '/')
             if ('\u0000' in text) return null
             val lineMap = LineMap(text)
@@ -403,7 +418,7 @@ class ContentSearchService(
 
         return try {
             // Open buffers go through the editor's undoable path.
-            val buffer = EditorAPIAccess.readBuffer(file.absolutePath)
+            val buffer = bufferBridge.readBuffer(file.absolutePath)
             if (buffer != null) {
                 replaceInBuffer(file, buffer.content, buffer.version, regex, replacement, isRegex, dryRun)
             } else {
@@ -457,7 +472,7 @@ class ContentSearchService(
         val range = BufferEditRange.ofSpan(lineMap, span.oldStart, span.oldEndExclusive)
         val newText = outcome.text.substring(span.newStart, span.newEndExclusive)
         val result =
-            EditorAPIAccess.applyEdit(
+            bufferBridge.applyEdit(
                 path = file.absolutePath,
                 startLine = range.startLine,
                 startCol = range.startCol,
@@ -482,6 +497,15 @@ class ContentSearchService(
         file: File,
         text: String,
     ) {
+        // createTempFile is 0600 and ATOMIC_MOVE carries the temp's attributes onto the
+        // destination, so without this an executable script loses +x and a shared file
+        // becomes owner-only. Capture the target's POSIX bits first, reapply after.
+        // Null on a non-POSIX filesystem (the getter throws) - nothing to carry there.
+        val perms =
+            runCatching {
+                java.nio.file.Files
+                    .getPosixFilePermissions(file.toPath())
+            }.getOrNull()
         val tmp = File.createTempFile(file.name, ".tmp", file.parentFile)
         try {
             tmp.writeText(text)
@@ -491,9 +515,21 @@ class ContentSearchService(
                 java.nio.file.StandardCopyOption.REPLACE_EXISTING,
                 java.nio.file.StandardCopyOption.ATOMIC_MOVE,
             )
+            perms?.let {
+                runCatching {
+                    java.nio.file.Files
+                        .setPosixFilePermissions(file.toPath(), it)
+                }
+            }
         } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
             // Rare (a temp on a different filesystem); fall back to a plain replace.
             tmp.copyTo(file, overwrite = true)
+            perms?.let {
+                runCatching {
+                    java.nio.file.Files
+                        .setPosixFilePermissions(file.toPath(), it)
+                }
+            }
             tmp.delete()
         } finally {
             tmp.delete()
@@ -646,4 +682,38 @@ class ContentSearchService(
                 "__pycache__",
             )
     }
+}
+
+/**
+ * How [ContentSearchService] reaches the editor's live buffers. An interface so it is
+ * WINDOW-SCOPED (bound to a specific DefaultPlugin's registry, not the process global)
+ * and fakeable in tests - the replace-into-a-buffer path is otherwise unreachable.
+ */
+interface EditorBufferBridge {
+    suspend fun readBuffer(path: String): ai.rever.boss.plugin.api.BufferSnapshot?
+
+    suspend fun applyEdit(
+        path: String,
+        startLine: Int,
+        startCol: Int,
+        endLine: Int,
+        endCol: Int,
+        newText: String,
+        expectedVersion: Long,
+    ): ai.rever.boss.plugin.api.EditResult?
+}
+
+/** Backs onto the process-global [EditorAPIAccess]; the default, for callers with no window. */
+object GlobalEditorBufferBridge : EditorBufferBridge {
+    override suspend fun readBuffer(path: String) = EditorAPIAccess.readBuffer(path)
+
+    override suspend fun applyEdit(
+        path: String,
+        startLine: Int,
+        startCol: Int,
+        endLine: Int,
+        endCol: Int,
+        newText: String,
+        expectedVersion: Long,
+    ) = EditorAPIAccess.applyEdit(path, startLine, startCol, endLine, endCol, newText, expectedVersion)
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -46,7 +46,10 @@ class ContentSearchService(
     // (tens of thousands per search on a real repo) to learn "no buffer" for all
     // but a handful. Null preserves the old ask-for-every-file behaviour, which is
     // the safe answer whenever the host cannot enumerate the open tabs.
-    private val openEditorPathsProvider: () -> Set<String>? = { null },
+    //
+    // The PROVIDER is nullable too: no provider means no Main hop at all, which
+    // is what unit tests and non-UI hosts (no Compose snapshot to snapshot) get.
+    private val openEditorPathsProvider: (() -> Set<String>?)? = null,
 ) : ProjectSearchProvider {
     private val logger = BossLogger.forComponent("ContentSearchService")
 
@@ -94,13 +97,7 @@ class ContentSearchService(
                     )
                     return emptyList()
                 }
-        // The open-tab set is Compose snapshot state (SplitView's _rootNode).
-        // Snapshot it on Main, where the snapshot lives, BEFORE the scan
-        // drops to IO: a background read can observe a different snapshot
-        // than the UI is showing (docs/THREADING.md is direct about which
-        // dispatcher owns UI state), and the set is computed once per search
-        // anyway. The canonicalise work stays on IO.
-        val rawOpenPaths = withContext(Dispatchers.Main) { openEditorPathsProvider() }
+        val rawOpenPaths = snapshotOpenEditorPaths()
         return withContext(Dispatchers.IO) {
             // The cancellation check the scan hands to the matcher: a caller-
             // supplied pattern can wedge a thread (see [InterruptibleText]), and
@@ -170,6 +167,18 @@ class ContentSearchService(
         }
     }
 
+    /**
+     * Replaces in an EXPLICIT file list - the search-side caps do not apply
+     * here, and that is deliberate: [searchInProject] bounds what the user SEES
+     * ([maxResults], [MAX_MATCHES_PER_FILE]) because a list is a view, while a
+     * half-transformed file is worse than an unhurried one, so
+     * [computeReplaced] applies every match.
+     *
+     * The consequence a consumer has to surface: a file whose matches were
+     * capped at 500 in the search view can have thousands replaced, so the
+     * [ReplaceSummary] counts are NOT the search counts. Never present the
+     * displayed match count as the applied count, or vice versa.
+     */
     override suspend fun replaceInProject(
         query: String,
         replacement: String,
@@ -219,6 +228,25 @@ class ContentSearchService(
         }
     }
 
+    /**
+     * The open-tab set as [Dispatchers.Main] sees it.
+     *
+     * It is Compose snapshot state (SplitView's _rootNode), so it is snapshotted
+     * on Main, where the snapshot lives, BEFORE the scan drops to IO: a
+     * background read can observe a different snapshot than the UI is showing
+     * (docs/THREADING.md is direct about which dispatcher owns UI state), and
+     * the set is computed once per search anyway. The canonicalise work stays
+     * on IO.
+     *
+     * Guarded: the provider is optional, and a caller that supplies none
+     * (unit tests, non-UI hosts) must not pay a hop to Main on every search -
+     * the set is null, so there is nothing to snapshot.
+     */
+    private suspend fun snapshotOpenEditorPaths(): Set<String>? {
+        val provider = openEditorPathsProvider ?: return null
+        return withContext(Dispatchers.Main) { provider() }
+    }
+
     // ===== Internals =====
 
     private fun buildRegex(
@@ -253,6 +281,14 @@ class ContentSearchService(
      *
      * Returns null when the path escapes; callers report that as a per-file error
      * rather than failing the whole batch.
+     *
+     * Known limit: a BROKEN symlink (target absent) does not resolve to a real
+     * path, so it falls back to the canonical check, which passes for a link
+     * inside the project. A write through it would materialise the file at the
+     * target, but creating such a link already requires writing inside the
+     * project, which a plugin holding `project.replace` can do with plain file
+     * I/O anyway - the confinement protects sloppy callers, not adversarial
+     * ones.
      */
     internal fun resolveFile(
         rawPath: String,
@@ -269,7 +305,20 @@ class ContentSearchService(
         val root = runCatching { File(projectPath).canonicalFile }.getOrNull() ?: return null
         val resolvedCanon = runCatching { candidate.canonicalFile }.getOrNull() ?: return null
         val rootPath = root.path.trimEnd(File.separatorChar) + File.separatorChar
-        val inside = resolvedCanon.path == root.path || resolvedCanon.path.startsWith(rootPath)
+        var inside = resolvedCanon.path == root.path || resolvedCanon.path.startsWith(rootPath)
+        // java.io.File's canonical path does NOT follow symlinks on Windows (NIO's
+        // realPath does, on every platform), so a link inside the project pointing
+        // outside passes the canonical check there. When both sides resolve to a
+        // real path, re-verify on those; both are real-pathed so a symlinked or
+        // junctioned project root stays consistent.
+        if (inside) {
+            val rootReal = runCatching { File(projectPath).toPath().toRealPath() }.getOrNull()
+            val candReal = runCatching { candidate.toPath().toRealPath() }.getOrNull()
+            if (rootReal != null && candReal != null) {
+                val realRootPath = rootReal.toString().trimEnd(File.separatorChar) + File.separatorChar
+                inside = candReal == rootReal || candReal.toString().startsWith(realRootPath)
+            }
+        }
         return if (inside) candidate else null
     }
 
@@ -617,6 +666,15 @@ class ContentSearchService(
      * but [replaceInProject] takes an explicit caller-supplied list, and a symlink
      * pointing inside the project passes [resolveFile] - so this is only reachable
      * that way, and a replacement there replaces the link, not its referent.
+     *
+     * The same trade-off is a TOCTOU window, and the two halves of it see
+     * DIFFERENT resolutions: [resolveFile] decides confinement on the canonical
+     * path, then deliberately returns the NON-canonical one (buffer keys match
+     * the tab's raw spelling, so that is the right call), and the write goes to
+     * the non-canonical path. A symlink swapped between check and write is not
+     * caught here; the window is bounded by the write running immediately after
+     * the check in the same call, and the exposure is the explicit-list path
+     * above.
      */
     private fun writeAtomically(
         file: File,

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -53,17 +53,8 @@ class ContentSearchService(
             override fun removeEldestEntry(eldest: Map.Entry<String, CacheEntry>): Boolean = size > MAX_CACHE_ENTRIES
         }
 
-    override suspend fun searchInProject(
-        query: String,
-        pathPattern: String?,
-        isRegex: Boolean,
-        caseSensitive: Boolean,
-        wholeWord: Boolean,
-        maxResults: Int,
-    ): List<FileMatch> = searchInProject(query, pathPattern, null, isRegex, caseSensitive, wholeWord, maxResults)
-
     /**
-     * The one search path; the overload above is this with no exclude.
+     * The one search path.
      *
      * [excludePattern] is applied during the WALK, so [maxResults] caps matches the
      * caller wants rather than matches it is about to discard. Filtering the returned
@@ -156,9 +147,9 @@ class ContentSearchService(
         wholeWord: Boolean,
         dryRun: Boolean,
     ): ReplaceSummary {
-        val projectPath = projectPathProvider() ?: return ReplaceSummary(0, 0, emptyList())
-        if (query.isEmpty() || files.isEmpty()) return ReplaceSummary(0, 0, emptyList())
-        val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return ReplaceSummary(0, 0, emptyList())
+        val projectPath = projectPathProvider() ?: return ReplaceSummary(0, 0, emptyList(), dryRun)
+        if (query.isEmpty() || files.isEmpty()) return ReplaceSummary(0, 0, emptyList(), dryRun)
+        val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return ReplaceSummary(0, 0, emptyList(), dryRun)
 
         return withContext(Dispatchers.IO) {
             var total = 0
@@ -179,7 +170,7 @@ class ContentSearchService(
                 }
                 perFile.add(result)
             }
-            ReplaceSummary(filesReplaced, total, perFile)
+            ReplaceSummary(filesReplaced, total, perFile, dryRun)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.nio.file.Files
 
 /**
  * Host implementation of the plugin-facing [ProjectSearchProvider] (boss-plugin-api 1.0.87):
@@ -93,6 +94,13 @@ class ContentSearchService(
                     )
                     return emptyList()
                 }
+        // The open-tab set is Compose snapshot state (SplitView's _rootNode).
+        // Snapshot it on Main, where the snapshot lives, BEFORE the scan
+        // drops to IO: a background read can observe a different snapshot
+        // than the UI is showing (docs/THREADING.md is direct about which
+        // dispatcher owns UI state), and the set is computed once per search
+        // anyway. The canonicalise work stays on IO.
+        val rawOpenPaths = withContext(Dispatchers.Main) { openEditorPathsProvider() }
         return withContext(Dispatchers.IO) {
             // The cancellation check the scan hands to the matcher: a caller-
             // supplied pattern can wedge a thread (see [InterruptibleText]), and
@@ -101,7 +109,7 @@ class ContentSearchService(
             val isCancelled = { job != null && !job.isActive }
             val results = mutableListOf<FileMatch>()
             // Snapshotted once per search, not per file - the whole point.
-            val openPaths = openBufferLookupSet(projectPath)
+            val openPaths = openBufferLookupSet(projectPath, rawOpenPaths)
             for (file in walkProjectFiles(projectPath, pathPattern, excludePattern)) {
                 ensureActive()
                 if (results.size >= maxResults) break
@@ -118,9 +126,9 @@ class ContentSearchService(
                     } else {
                         null
                     }
-                val key =
-                    cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath) +
-                        if (buffer != null) "|buf" else "|disk"
+                val cacheKeyArg =
+                    cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath)
+                val key = cacheKeyArg + if (buffer != null) "|buf" else "|disk"
                 // The freshness stamp combines BOTH signals for an open file, because
                 // each alone has a blind spot:
                 // - mtime alone misses buffer edits (an unsaved edit does not touch it),
@@ -199,7 +207,7 @@ class ContentSearchService(
                     if (file == null) {
                         FileReplaceResult(rawPath, 0, "outside the project")
                     } else {
-                        replaceInOneFile(file, regex, replacement, isRegex, dryRun, isCancelled)
+                        replaceInOneFile(file, projectPath, regex, replacement, isRegex, dryRun, isCancelled)
                     }
                 if (result.error == null && result.replacements > 0) {
                     total += result.replacements
@@ -279,21 +287,43 @@ class ContentSearchService(
      * canonical, and re-expressed under the raw root when the roots differ. O(open
      * tabs), so the cost is a handful of canonicalise calls per search.
      */
-    private fun openBufferLookupSet(projectPath: String): Set<String>? {
-        val raw = openEditorPathsProvider() ?: return null
-        val root = File(projectPath).absolutePath.trimEnd(File.separatorChar)
+    private fun openBufferLookupSet(
+        projectPath: String,
+        raw: Set<String>?,
+    ): Set<String>? {
+        if (raw == null) return null
+        return raw
+            .map { if (File(it).isAbsolute) File(it) else File(projectPath, it) }
+            .flatMap { bufferPathSpellings(it, projectPath) }
+            .toHashSet()
+    }
+
+    /**
+     * Every spelling a live buffer for [file] can be registered under, given the
+     * project root the walk runs under: the walk's absolute path, the canonical
+     * path, and the canonical path re-expressed under the walk's raw root when
+     * the two differ (a project under /tmp is really /private/tmp on macOS -
+     * the same mismatch [resolveFile] documents).
+     *
+     * Shared by the search side ([openBufferLookupSet], a set over all open tabs)
+     * and the replace side (one file at a time): the tab can hold ANY of the
+     * three spellings, and the replace path used to ask under one only. Missing
+     * the buffer there meant a disk write under the user's open, unsaved tab -
+     * clobbered by the next save.
+     */
+    private fun bufferPathSpellings(
+        file: File,
+        projectPath: String,
+    ): List<String> {
+        val abs = file.absolutePath
+        val canon = canonicalOrPath(file)
+        val out = linkedSetOf(abs, canon)
+        val root = projectPath.trimEnd(File.separatorChar)
         val rootCanon = canonicalOrPath(File(projectPath)).trimEnd(File.separatorChar)
-        val out = HashSet<String>(raw.size * 3 + 1)
-        for (p in raw) {
-            val abs = if (File(p).isAbsolute) File(p).path else File(projectPath, p).path
-            out.add(abs)
-            val canon = canonicalOrPath(File(abs))
-            out.add(canon)
-            if (root != rootCanon && canon.startsWith(rootCanon + File.separatorChar)) {
-                out.add(root + canon.removePrefix(rootCanon))
-            }
+        if (root != rootCanon && canon.startsWith(rootCanon + File.separatorChar)) {
+            out.add(root + canon.removePrefix(rootCanon))
         }
-        return out
+        return out.toList()
     }
 
     private fun cacheKey(
@@ -490,6 +520,7 @@ class ContentSearchService(
 
     private suspend fun replaceInOneFile(
         file: File,
+        projectRoot: String,
         regex: Regex,
         replacement: String,
         isRegex: Boolean,
@@ -500,8 +531,10 @@ class ContentSearchService(
         if (file.length() > MAX_FILE_SIZE) return FileReplaceResult(file.path, 0, "file too large")
 
         return try {
-            // Open buffers go through the editor's undoable path.
-            val buffer = bufferBridge.readBuffer(file.absolutePath)
+            // Open buffers go through the editor's undoable path - under every
+            // spelling the tab may hold the file (see bufferPathSpellings).
+            val buffer =
+                bufferPathSpellings(file, projectRoot).firstNotNullOfOrNull { bufferBridge.readBuffer(it) }
             if (buffer != null) {
                 replaceInBuffer(file, buffer.content, buffer.version, regex, replacement, isRegex, dryRun, isCancelled)
             } else {
@@ -617,14 +650,36 @@ class ContentSearchService(
             }
         } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
             // Rare (a temp on a different filesystem); fall back to a plain replace.
-            tmp.copyTo(file, overwrite = true)
+            // A plain `tmp.copyTo(file, overwrite = true)` would TRUNCATE the target
+            // first - the exact torn state the atomic move exists to prevent, in this
+            // rarer case. So move the target aside, move the temp into place, and
+            // restore the aside if the second move fails. If even the first move
+            // fails (a locked target), FAIL the replace: risking the original
+            // content is worse than one file reported as "replace failed".
+            val aside = File(file.parentFile, file.name + ".aside-" + System.nanoTime())
+            if (!file.renameTo(aside)) {
+                tmp.delete()
+                throw java.io.IOException("Could not move \"$file\" aside for the non-atomic replace")
+            }
+            try {
+                Files.move(tmp.toPath(), file.toPath())
+            } catch (moveFailed: java.io.IOException) {
+                if (!aside.renameTo(file)) {
+                    logger.error(
+                        LogCategory.FILE,
+                        "non-atomic replace failed and the target could not be restored; " +
+                            "the old content is at ${aside.path}",
+                    )
+                }
+                throw moveFailed
+            }
+            aside.delete()
             perms?.let {
                 runCatching {
                     java.nio.file.Files
                         .setPosixFilePermissions(file.toPath(), it)
                 }
             }
-            tmp.delete()
         } finally {
             tmp.delete()
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -1,0 +1,606 @@
+package ai.rever.boss.search
+
+import ai.rever.boss.plugin.api.FileMatch
+import ai.rever.boss.plugin.api.FileReplaceResult
+import ai.rever.boss.plugin.api.ProjectSearchProvider
+import ai.rever.boss.plugin.api.ReplaceSummary
+import ai.rever.boss.services.editor.EditorAPIAccess
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Host implementation of the plugin-facing [ProjectSearchProvider] (boss-plugin-api 1.0.87):
+ * project-wide content search, and replace scoped to an explicit file list.
+ *
+ * Design notes:
+ * - File walking is the same shape as [FileIndexer] (skip VCS/build/VCS-adjacent
+ *   directories), but the scan is on demand: files are read at search time, so a
+ *   fresh checkout needs no reindex. An mtime-keyed result cache makes a repeat
+ *   search with the same query and options cheap.
+ * - Files containing a NUL byte (binary) or larger than [MAX_FILE_SIZE] are
+ *   skipped, so a search over a repo with binaries stays fast and sane.
+ * - `wholeWord` wraps the pattern in `\b...\b`, which for regex queries
+ *   composes with the caller's pattern.
+ * - Replace never touches a file the caller did not name. Open buffers are
+ *   edited through the editor's undoable path (EditorAPIAccess.applyEdit);
+ *   closed files are written to disk directly.
+ */
+class ContentSearchService(
+    private val projectPathProvider: () -> String?,
+) : ProjectSearchProvider {
+    private val cache = HashMap<String, CacheEntry>()
+
+    override suspend fun searchInProject(
+        query: String,
+        pathPattern: String?,
+        isRegex: Boolean,
+        caseSensitive: Boolean,
+        wholeWord: Boolean,
+        maxResults: Int,
+    ): List<FileMatch> = searchInProject(query, pathPattern, null, isRegex, caseSensitive, wholeWord, maxResults)
+
+    /**
+     * The one search path; the overload above is this with no exclude.
+     *
+     * [excludePattern] is applied during the WALK, so [maxResults] caps matches the
+     * caller wants rather than matches it is about to discard. Filtering the returned
+     * list instead - which the codebase panel used to do, with its own copy of the glob
+     * compiler - silently returns fewer results than exist whenever the excluded files
+     * are reached first.
+     */
+    override suspend fun searchInProject(
+        query: String,
+        pathPattern: String?,
+        excludePattern: String?,
+        isRegex: Boolean,
+        caseSensitive: Boolean,
+        wholeWord: Boolean,
+        maxResults: Int,
+    ): List<FileMatch> {
+        val projectPath = projectPathProvider() ?: return emptyList()
+        if (query.isEmpty()) return emptyList()
+
+        val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return emptyList()
+        return withContext(Dispatchers.IO) {
+            val results = mutableListOf<FileMatch>()
+            for (file in walkProjectFiles(projectPath, pathPattern, excludePattern)) {
+                ensureActive()
+                if (results.size >= maxResults) break
+
+                // An open file is searched as the user sees it, not as the disk
+                // has it. Otherwise a replace into a live buffer - or any
+                // unsaved edit - leaves the results tree reporting matches the
+                // editor no longer shows.
+                val buffer = EditorAPIAccess.readBuffer(file.absolutePath)
+                val key =
+                    cacheKey(projectPath, query, pathPattern, excludePattern, isRegex, caseSensitive, wholeWord, file.absolutePath) +
+                        if (buffer != null) "|buf" else "|disk"
+                // The freshness stamp combines BOTH signals for an open file, because
+                // each alone has a blind spot:
+                // - mtime alone misses buffer edits (an unsaved edit does not touch it),
+                //   so the pre-edit matches would be served from cache;
+                // - buffer version alone misses a close-reopen. documentVersion is
+                //   per-document and restarts when a document is created, so closing a
+                //   tab, changing the file on disk and reopening it yields the same key
+                //   AND the same version - and the pre-change matches come back.
+                val stamp =
+                    if (buffer != null) buffer.version * STAMP_MIX + file.lastModified() else file.lastModified()
+                val matches: List<FileMatch> =
+                    synchronized(cache) {
+                        val cached = cache[key]
+                        if (cached != null && cached.stamp == stamp) cached.matches else null
+                    }
+                        ?: scanText(
+                            file = file,
+                            text = buffer?.content ?: readTextOrNull(file) ?: continue,
+                            regex = regex,
+                        )?.also { found ->
+                            synchronized(cache) {
+                                if (cache.size > MAX_CACHE_ENTRIES) cache.clear()
+                                cache[key] = CacheEntry(stamp, found)
+                            }
+                        } ?: continue
+
+                for (match in matches) {
+                    results.add(match)
+                    if (results.size >= maxResults) break
+                }
+            }
+            results.take(maxResults)
+        }
+    }
+
+    override suspend fun replaceInProject(
+        query: String,
+        replacement: String,
+        files: List<String>,
+        isRegex: Boolean,
+        caseSensitive: Boolean,
+        wholeWord: Boolean,
+        dryRun: Boolean,
+    ): ReplaceSummary {
+        val projectPath = projectPathProvider() ?: return ReplaceSummary(0, 0, emptyList())
+        if (query.isEmpty() || files.isEmpty()) return ReplaceSummary(0, 0, emptyList())
+        val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return ReplaceSummary(0, 0, emptyList())
+
+        return withContext(Dispatchers.IO) {
+            var total = 0
+            var filesReplaced = 0
+            val perFile = mutableListOf<FileReplaceResult>()
+            for (rawPath in files) {
+                ensureActive()
+                val file = resolveFile(rawPath, projectPath)
+                val result =
+                    if (file == null) {
+                        FileReplaceResult(rawPath, 0, "outside the project")
+                    } else {
+                        replaceInOneFile(file, regex, replacement, isRegex, dryRun)
+                    }
+                if (result.error == null && result.replacements > 0) {
+                    total += result.replacements
+                    filesReplaced++
+                }
+                perFile.add(result)
+            }
+            ReplaceSummary(filesReplaced, total, perFile)
+        }
+    }
+
+    // ===== Internals =====
+
+    private fun buildRegex(
+        query: String,
+        isRegex: Boolean,
+        caseSensitive: Boolean,
+        wholeWord: Boolean,
+    ): Regex? {
+        val pattern =
+            if (isRegex) {
+                query
+            } else {
+                Regex.escape(query)
+            }
+        val wrapped = if (wholeWord) "\\b(?:$pattern)\\b" else pattern
+        return try {
+            if (caseSensitive) Regex(wrapped) else Regex(wrapped, RegexOption.IGNORE_CASE)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Resolves a caller-supplied path, and refuses anything outside the project.
+     *
+     * Replace is a WRITE reached from the `project_replace` MCP tool, whose permission
+     * is named `project.replace` and whose description says "in an EXPLICIT list of
+     * files". Both imply confinement that absolute paths did not have: a caller holding
+     * that permission could rewrite any file the process can write, `~/.zshrc` included.
+     * Relative traversal (`../../etc`) is covered too, since the check is on the
+     * canonical path.
+     *
+     * Returns null when the path escapes; callers report that as a per-file error
+     * rather than failing the whole batch.
+     */
+    private fun resolveFile(
+        rawPath: String,
+        projectPath: String,
+    ): File? {
+        val f = File(rawPath)
+        val candidate = if (f.isAbsolute) f else File(projectPath, rawPath)
+        // Confinement is decided on the CANONICAL form (so `../` and symlink escapes
+        // are caught), but the NON-canonical candidate is what we return and use. The
+        // editor keys its open buffers by the plain absolute path a tab was opened
+        // with; returning the canonical path here made readBuffer miss the buffer of a
+        // file open under a symlinked checkout (/tmp vs /private/tmp), so replace wrote
+        // to disk under an unsaved buffer and the next save clobbered it.
+        val root = runCatching { File(projectPath).canonicalFile }.getOrNull() ?: return null
+        val resolvedCanon = runCatching { candidate.canonicalFile }.getOrNull() ?: return null
+        val rootPath = root.path.trimEnd(File.separatorChar) + File.separatorChar
+        val inside = resolvedCanon.path == root.path || resolvedCanon.path.startsWith(rootPath)
+        return if (inside) candidate else null
+    }
+
+    /** Canonical path when resolvable, else the absolute one - identity for cycle detection. */
+    private fun canonicalOrPath(f: File): String = runCatching { f.canonicalPath }.getOrDefault(f.absolutePath)
+
+    private fun cacheKey(
+        projectRoot: String,
+        query: String,
+        pathPattern: String?,
+        excludePattern: String?,
+        isRegex: Boolean,
+        caseSensitive: Boolean,
+        wholeWord: Boolean,
+        path: String,
+        // projectRoot is part of the key because a cached FileMatch carries a path
+        // RELATIVE to the root it was found under. The same absolute file walked under
+        // a different root (switching between nested projects) would otherwise get its
+        // old relative path served from cache until its mtime changed, and a
+        // result-click would resolve it against the new root - the wrong file.
+    ): String = "$projectRoot|$query|$pathPattern|$excludePattern|$isRegex|$caseSensitive|$wholeWord|$path"
+
+    private fun walkProjectFiles(
+        projectPath: String,
+        pathPattern: String?,
+        excludePattern: String?,
+    ): Sequence<File> {
+        val root = File(projectPath)
+        // The root's canonical path is IN the set from the start, but the root is still
+        // always entered (the isRoot branch below). Without seeding it, a symlink
+        // `proj/link -> proj` had a canonical path that was not yet "seen", so it was
+        // entered, its children registered their canonicals, and the real subtree was
+        // then skipped as already-seen - matches came back as `link/src/...`.
+        val rootCanon = canonicalOrPath(root)
+        val seen = hashSetOf(rootCanon)
+        val globs = pathPattern?.let { compileIncludeGlobs(it) }
+        // Same compiler for both boxes: include and exclude take identical syntax,
+        // so two implementations would be two sets of edge cases to keep in step.
+        val excludes = excludePattern?.let { compileIncludeGlobs(it) }
+        return root
+            .walkTopDown()
+            // onEnter DESCENDS on true. The predicate has to be "not skipped",
+            // and the root has to pass it: the previous form returned true only
+            // for the skip list, so the walk entered node_modules/.git and
+            // nothing else - including refusing to enter the project root, which
+            // made every search return zero results.
+            .onEnter { dir ->
+                // A directory symlink pointing at an ancestor makes walkTopDown recurse
+                // forever, and ensureActive() only helps if something cancels. A directory
+                // is entered once per canonical path; the root always enters (its canonical
+                // is pre-seeded, so a link back to it is what gets refused).
+                val isRoot = dir.absolutePath == root.absolutePath
+                val notSkipped = isRoot || dir.name !in SKIP_DIRECTORIES
+                notSkipped && (isRoot || seen.add(canonicalOrPath(dir)))
+            }.filter { it.isFile }
+            .filter { it.length() <= MAX_FILE_SIZE }
+            .filter { file ->
+                val rel = file.relativeTo(root).path.replace('\\', '/')
+                val included = globs.isNullOrEmpty() || globs.any { it.matches(rel) }
+                included && excludes?.any { it.matches(rel) } != true
+            }.asSequence()
+    }
+
+    /**
+     * Compile an include pattern the way VS Code's "files to include" box does:
+     * comma-separated alternatives, and a pattern with no path separator
+     * matching at any depth. Matched against the whole relative path, the
+     * "*.kt" a user actually types found only root-level files.
+     *
+     * A literal name yields two patterns - the file itself, and everything
+     * under a folder of that name. Returns null for a blank pattern.
+     */
+    private fun compileIncludeGlobs(pattern: String): List<Regex>? {
+        val parts = pattern.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        if (parts.isEmpty()) return null
+        val expanded = mutableListOf<String>()
+        for (raw in parts) {
+            val p = raw.removePrefix("./").removePrefix("/").removeSuffix("/")
+            if (p.isEmpty()) continue
+            val hasWildcard = p.indexOf('*') >= 0 || p.indexOf('?') >= 0
+            when {
+                p.startsWith(ANY_DEPTH_PREFIX) -> {
+                    expanded.add(p)
+                }
+
+                hasWildcard -> {
+                    expanded.add(ANY_DEPTH_PREFIX + "/" + p)
+                }
+
+                else -> {
+                    expanded.add(ANY_DEPTH_PREFIX + "/" + p)
+                    expanded.add(ANY_DEPTH_PREFIX + "/" + p + "/" + ANY_DEPTH_PREFIX)
+                }
+            }
+        }
+        return expanded.map { globToRegex(it) }
+    }
+
+    /** File contents, or null when it cannot be read (permissions, races). */
+    private fun readTextOrNull(file: File): String? =
+        try {
+            file.readText()
+        } catch (e: Exception) {
+            null
+        }
+
+    private fun scanText(
+        file: File,
+        text: String,
+        regex: Regex,
+    ): List<FileMatch>? {
+        return try {
+            val projectRoot = File(projectPathProvider() ?: return null)
+            val relative = file.relativeTo(projectRoot).path.replace('\\', '/')
+            if ('\u0000' in text) return null
+            val lineMap = LineMap(text)
+            val matches = mutableListOf<FileMatch>()
+            var searchFrom = 0
+            while (searchFrom <= text.length && matches.size < MAX_MATCHES_PER_FILE) {
+                val m = regex.find(text, searchFrom) ?: break
+                matches.add(
+                    FileMatch(
+                        path = relative,
+                        line = lineMap.lineOf(m.range.first),
+                        column = lineMap.columnOf(m.range.first),
+                        matchLength = m.value.length,
+                        contextLine = lineMap.lineText(lineMap.lineOf(m.range.first)),
+                    ),
+                )
+                // A zero-length match (\b, an empty alternation) has
+                // range.last < range.first, so "last + 1" rescanned the same
+                // offset until the per-file cap - 500 hits at one position.
+                searchFrom = maxOf(m.range.last + 1, m.range.first + 1)
+            }
+            matches
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** 1-based line numbers and columns from precomputed line-start offsets. */
+    internal class LineMap(
+        val text: String,
+    ) : LineOffsets {
+        val lineStarts: IntArray
+
+        init {
+            val starts = mutableListOf(0)
+            for (i in text.indices) {
+                if (text[i] == '\n') starts.add(i + 1)
+            }
+            lineStarts = starts.toIntArray()
+        }
+
+        /** 1-based line number containing [offset]. */
+        override fun lineOf(offset: Int): Int {
+            var lo = 0
+            var hi = lineStarts.size - 1
+            while (lo < hi) {
+                val mid = (lo + hi + 1) ushr 1
+                if (lineStarts[mid] <= offset) lo = mid else hi = mid - 1
+            }
+            return lo + 1
+        }
+
+        /** 1-based column of [offset] within its line. */
+        override fun columnOf(offset: Int): Int = offset - lineStarts[lineOf(offset) - 1] + 1
+
+        /**
+         * Full text of 1-based line [line], INCLUDING its trailing newline when it
+         * has one (the last line of a file without a final newline does not).
+         * FileMatch.contextLine carries it through, and the tests pin that.
+         */
+        fun lineText(line: Int): String {
+            val start = lineStarts[line - 1]
+            val end = if (line < lineStarts.size) lineStarts[line] else text.length
+            return text.substring(start, end)
+        }
+    }
+
+    private suspend fun replaceInOneFile(
+        file: File,
+        regex: Regex,
+        replacement: String,
+        isRegex: Boolean,
+        dryRun: Boolean,
+    ): FileReplaceResult {
+        if (!file.isFile) return FileReplaceResult(file.path, 0, "not a file")
+        if (file.length() > MAX_FILE_SIZE) return FileReplaceResult(file.path, 0, "file too large")
+
+        return try {
+            // Open buffers go through the editor's undoable path.
+            val buffer = EditorAPIAccess.readBuffer(file.absolutePath)
+            if (buffer != null) {
+                replaceInBuffer(file, buffer.content, buffer.version, regex, replacement, isRegex, dryRun)
+            } else {
+                // UTF-8 in, UTF-8 out. A file in another single-byte encoding has no NUL
+                // bytes, so it passes the binary check, and round-tripping it through
+                // readText/writeText replaces its undecodable bytes with U+FFFD - a
+                // silent rewrite of bytes the user never asked to touch. Detect that the
+                // decode was lossy and refuse, rather than corrupting the file.
+                val text = file.readText()
+                if ('\u0000' in text) return FileReplaceResult(file.path, 0, "binary file")
+                if ('\uFFFD' in text) return FileReplaceResult(file.path, 0, "not valid UTF-8")
+                val outcome = computeReplaced(text, regex, replacement, isRegex)
+                if (!dryRun && outcome.count > 0) file.writeText(outcome.text)
+                FileReplaceResult(file.path, outcome.count, null)
+            }
+        } catch (e: Exception) {
+            FileReplaceResult(file.path, 0, e.message ?: "replace failed")
+        }
+    }
+
+    /**
+     * Replace in a live buffer as ONE version-guarded, undoable edit.
+     *
+     * The replaced content is computed the same way as the disk path
+     * ([computeReplaced]), then applied as the single span that actually changed
+     * (common prefix and suffix trimmed off). One edit rather than one per match
+     * buys three things at once:
+     * - the replacement string is expanded EXACTLY as on disk - the two paths can
+     *   no longer disagree about whether `$1` is a capture reference or literal text
+     *   (the bug that let the same replace write different bytes depending on whether
+     *   the file happened to be open);
+     * - one `expectedVersion` check covers the whole operation, so a keystroke that
+     *   lands mid-replace rejects it cleanly instead of shifting later edits onto
+     *   stale offsets;
+     * - one undo step, which is what the user means by "undo the replace".
+     */
+    private suspend fun replaceInBuffer(
+        file: File,
+        text: String,
+        version: Long,
+        regex: Regex,
+        replacement: String,
+        isRegex: Boolean,
+        dryRun: Boolean,
+    ): FileReplaceResult {
+        val outcome = computeReplaced(text, regex, replacement, isRegex)
+        if (dryRun || outcome.count == 0) return FileReplaceResult(file.path, outcome.count, null)
+
+        val span = changedSpan(text, outcome.text)
+        val lineMap = LineMap(text)
+        val range = BufferEditRange.ofSpan(lineMap, span.oldStart, span.oldEndExclusive)
+        val newText = outcome.text.substring(span.newStart, span.newEndExclusive)
+        val result =
+            EditorAPIAccess.applyEdit(
+                path = file.absolutePath,
+                startLine = range.startLine,
+                startCol = range.startCol,
+                endLine = range.endLine,
+                endCol = range.endCol,
+                newText = newText,
+                expectedVersion = version,
+            ) ?: return FileReplaceResult(file.path, 0, "editor buffer no longer available")
+        return if (result.applied) {
+            FileReplaceResult(file.path, outcome.count, null)
+        } else {
+            FileReplaceResult(file.path, 0, result.reason ?: "edit rejected")
+        }
+    }
+
+    /** The result of a bounded replace: the new text and how many matches it replaced. */
+    internal data class ReplaceOutcome(
+        val text: String,
+        val count: Int,
+    )
+
+    /**
+     * Replaces up to [MAX_MATCHES_PER_FILE] matches, via Java's reference `Matcher`
+     * expansion - NOT a hand-written one.
+     *
+     * `appendReplacement`/`appendTail` are the exact semantics
+     * [ProjectSearchProvider.replaceInProject]'s KDoc promises: `$1`..`$9` and
+     * `${name}` capture references and `\` escaping for a regex query, and - via
+     * [java.util.regex.Matcher.quoteReplacement] - a truly literal replacement for a
+     * literal query, so a `$` or `\` in the replacement text is not misread as a
+     * group reference. It also advances past zero-width matches on its own, and
+     * throws on a bad group reference exactly as `Regex.replace` does, rather than
+     * silently substituting the empty string. The returned [ReplaceOutcome.count] is
+     * the authority for both the dry-run preview and the applied count, so the two
+     * can never disagree.
+     */
+    internal fun computeReplaced(
+        text: String,
+        regex: Regex,
+        replacement: String,
+        isRegex: Boolean,
+    ): ReplaceOutcome {
+        val matcher = regex.toPattern().matcher(text)
+        val repl =
+            if (isRegex) {
+                replacement
+            } else {
+                java.util.regex.Matcher
+                    .quoteReplacement(replacement)
+            }
+        val sb = StringBuffer(text.length)
+        var count = 0
+        while (count < MAX_MATCHES_PER_FILE && matcher.find()) {
+            matcher.appendReplacement(sb, repl)
+            count++
+        }
+        matcher.appendTail(sb)
+        return ReplaceOutcome(sb.toString(), count)
+    }
+
+    /** The single span that differs between [old] and [new] (common ends trimmed). */
+    internal data class Span(
+        val oldStart: Int,
+        val oldEndExclusive: Int,
+        val newStart: Int,
+        val newEndExclusive: Int,
+    )
+
+    internal fun changedSpan(
+        old: String,
+        new: String,
+    ): Span {
+        val min = minOf(old.length, new.length)
+        var p = 0
+        while (p < min && old[p] == new[p]) p++
+        var s = 0
+        while (s < min - p && old[old.length - 1 - s] == new[new.length - 1 - s]) s++
+        return Span(
+            oldStart = p,
+            oldEndExclusive = old.length - s,
+            newStart = p,
+            newEndExclusive = new.length - s,
+        )
+    }
+
+    /** Glob with `**` path segments and `*`/`?` within a segment. */
+    private fun globToRegex(glob: String): Regex {
+        val sb = StringBuilder()
+        var i = 0
+        while (i < glob.length) {
+            val c = glob[i]
+            when {
+                glob.startsWith("**/", i) -> {
+                    sb.append("(?:[^/]+/)*")
+                    i += 3
+                }
+
+                glob.startsWith("**", i) -> {
+                    sb.append(".*")
+                    i += 2
+                }
+
+                c == '*' -> {
+                    sb.append("[^/]*")
+                    i++
+                }
+
+                c == '?' -> {
+                    sb.append("[^/]")
+                    i++
+                }
+
+                else -> {
+                    sb.append(Regex.escape(c.toString()))
+                    i++
+                }
+            }
+        }
+        return Regex(sb.toString())
+    }
+
+    /**
+     * [stamp] is the file's mtime, mixed with the buffer version when one is open.
+     * See the call site for why neither signal is sufficient alone.
+     */
+    private data class CacheEntry(
+        val stamp: Long,
+        val matches: List<FileMatch>,
+    )
+
+    private companion object {
+        const val MAX_FILE_SIZE: Long = 1_048_576 // 1 MiB
+        const val MAX_MATCHES_PER_FILE = 500
+        const val MAX_CACHE_ENTRIES = 500
+
+        /** Odd multiplier so a buffer-version bump and an mtime change cannot cancel out. */
+        const val STAMP_MIX = 1_000_003L
+
+        /** Recursive-wildcard glob segment; kept out of literals with a slash. */
+        const val ANY_DEPTH_PREFIX = "**"
+
+        val SKIP_DIRECTORIES =
+            setOf(
+                ".git",
+                ".hg",
+                ".svn",
+                "node_modules",
+                ".build",
+                "build",
+                ".gradle",
+                ".idea",
+                "dist",
+                "out",
+                "target",
+                "__pycache__",
+            )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -30,7 +30,15 @@ import java.io.File
 class ContentSearchService(
     private val projectPathProvider: () -> String?,
 ) : ProjectSearchProvider {
-    private val cache = HashMap<String, CacheEntry>()
+    // Access-ordered and self-evicting: at capacity the ELDEST entry is dropped, not
+    // the whole map. The old wholesale clear() meant a project above the cap wiped the
+    // cache on nearly every scanned file, so the repeat search this exists for hit on
+    // nothing. Guarded by `synchronized(cache)` at every access, so a plain
+    // LinkedHashMap (not a concurrent map) is safe.
+    private val cache =
+        object : LinkedHashMap<String, CacheEntry>(16, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<String, CacheEntry>): Boolean = size > MAX_CACHE_ENTRIES
+        }
 
     override suspend fun searchInProject(
         query: String,
@@ -97,9 +105,13 @@ class ContentSearchService(
                             text = buffer?.content ?: readTextOrNull(file) ?: continue,
                             regex = regex,
                         )?.also { found ->
-                            synchronized(cache) {
-                                if (cache.size > MAX_CACHE_ENTRIES) cache.clear()
-                                cache[key] = CacheEntry(stamp, found)
+                            // Empty results are not cached: on a large project most files
+                            // match nothing, and caching them all filled the map and tripped
+                            // the wholesale clear below, so a repeat search - the one this
+                            // cache exists for - hit on nothing. Re-scanning a no-match file
+                            // is cheap; evicting a real hit is not.
+                            if (found.isNotEmpty()) {
+                                synchronized(cache) { cache[key] = CacheEntry(stamp, found) }
                             }
                         } ?: continue
 
@@ -183,7 +195,7 @@ class ContentSearchService(
      * Returns null when the path escapes; callers report that as a per-file error
      * rather than failing the whole batch.
      */
-    private fun resolveFile(
+    internal fun resolveFile(
         rawPath: String,
         projectPath: String,
     ): File? {
@@ -404,7 +416,7 @@ class ContentSearchService(
                 if ('\u0000' in text) return FileReplaceResult(file.path, 0, "binary file")
                 if ('\uFFFD' in text) return FileReplaceResult(file.path, 0, "not valid UTF-8")
                 val outcome = computeReplaced(text, regex, replacement, isRegex)
-                if (!dryRun && outcome.count > 0) file.writeText(outcome.text)
+                if (!dryRun && outcome.count > 0) writeAtomically(file, outcome.text)
                 FileReplaceResult(file.path, outcome.count, null)
             }
         } catch (e: Exception) {
@@ -461,6 +473,33 @@ class ContentSearchService(
         }
     }
 
+    /**
+     * Writes [text] to [file] atomically: a sibling temp file, then an atomic rename.
+     * A crash or I/O error mid-write must not leave a truncated source file with no
+     * backup - the plugin installer promotes its jar the same way, for the same reason.
+     */
+    private fun writeAtomically(
+        file: File,
+        text: String,
+    ) {
+        val tmp = File.createTempFile(file.name, ".tmp", file.parentFile)
+        try {
+            tmp.writeText(text)
+            java.nio.file.Files.move(
+                tmp.toPath(),
+                file.toPath(),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
+            // Rare (a temp on a different filesystem); fall back to a plain replace.
+            tmp.copyTo(file, overwrite = true)
+            tmp.delete()
+        } finally {
+            tmp.delete()
+        }
+    }
+
     /** The result of a bounded replace: the new text and how many matches it replaced. */
     internal data class ReplaceOutcome(
         val text: String,
@@ -468,7 +507,7 @@ class ContentSearchService(
     )
 
     /**
-     * Replaces up to [MAX_MATCHES_PER_FILE] matches, via Java's reference `Matcher`
+     * Replaces EVERY match, via Java's reference `Matcher`
      * expansion - NOT a hand-written one.
      *
      * `appendReplacement`/`appendTail` are the exact semantics
@@ -498,7 +537,11 @@ class ContentSearchService(
             }
         val sb = StringBuffer(text.length)
         var count = 0
-        while (count < MAX_MATCHES_PER_FILE && matcher.find()) {
+        // No match cap here: the file is already bounded to MAX_FILE_SIZE, and a
+        // capped replace leaves the file half-transformed with a success report - worse
+        // than the work of finishing. The loop terminates because a file has finitely
+        // many matches (zero-width matches self-advance via appendReplacement).
+        while (matcher.find()) {
             matcher.appendReplacement(sb, repl)
             count++
         }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -5,7 +5,11 @@ import ai.rever.boss.plugin.api.FileReplaceResult
 import ai.rever.boss.plugin.api.ProjectSearchProvider
 import ai.rever.boss.plugin.api.ReplaceSummary
 import ai.rever.boss.services.editor.EditorAPIAccess
+import ai.rever.boss.utils.logging.BossLogger
+import ai.rever.boss.utils.logging.LogCategory
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -43,6 +47,8 @@ class ContentSearchService(
     // the safe answer whenever the host cannot enumerate the open tabs.
     private val openEditorPathsProvider: () -> Set<String>? = { null },
 ) : ProjectSearchProvider {
+    private val logger = BossLogger.forComponent("ContentSearchService")
+
     // Access-ordered and self-evicting: at capacity the ELDEST entry is dropped, not
     // the whole map. The old wholesale clear() meant a project above the cap wiped the
     // cache on nearly every scanned file, so the repeat search this exists for hit on
@@ -74,8 +80,25 @@ class ContentSearchService(
         val projectPath = projectPathProvider() ?: return emptyList()
         if (query.isEmpty()) return emptyList()
 
-        val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return emptyList()
+        val regex =
+            buildRegex(query, isRegex, caseSensitive, wholeWord)
+                ?: run {
+                    // A pattern the regex compiler rejects is a USER error (a half-typed
+                    // `foo(`), not "no matches" - say so, because the empty list is the
+                    // same shape an honest no-result returns.
+                    logger.warn(
+                        LogCategory.GENERAL,
+                        "search rejected: invalid regex pattern",
+                        mapOf("query" to query.take(120)),
+                    )
+                    return emptyList()
+                }
         return withContext(Dispatchers.IO) {
+            // The cancellation check the scan hands to the matcher: a caller-
+            // supplied pattern can wedge a thread (see [InterruptibleText]), and
+            // `ensureActive()` below only runs between files.
+            val job = coroutineContext[Job]
+            val isCancelled = { job != null && !job.isActive }
             val results = mutableListOf<FileMatch>()
             // Snapshotted once per search, not per file - the whole point.
             val openPaths = openBufferLookupSet(projectPath)
@@ -118,6 +141,7 @@ class ContentSearchService(
                             text = buffer?.content ?: readTextOrNull(file) ?: continue,
                             regex = regex,
                             projectRoot = File(projectPath),
+                            isCancelled = isCancelled,
                         )?.also { found ->
                             // Empty results are not cached: on a large project most files
                             // match nothing, and caching them all filled the map and tripped
@@ -151,9 +175,20 @@ class ContentSearchService(
         if (query.isEmpty() || files.isEmpty()) return ReplaceSummary(0, 0, emptyList(), dryRun)
         val regex =
             buildRegex(query, isRegex, caseSensitive, wholeWord)
-                ?: return ReplaceSummary(0, 0, emptyList(), dryRun)
+                ?: run {
+                    // Same reasoning as searchInProject: a bad pattern is an error the
+                    // caller should see, not a zero-replacement success.
+                    logger.warn(
+                        LogCategory.GENERAL,
+                        "replace rejected: invalid regex pattern",
+                        mapOf("query" to query.take(120)),
+                    )
+                    return ReplaceSummary(0, 0, emptyList(), dryRun)
+                }
 
         return withContext(Dispatchers.IO) {
+            val job = coroutineContext[Job]
+            val isCancelled = { job != null && !job.isActive }
             var total = 0
             var filesReplaced = 0
             val perFile = mutableListOf<FileReplaceResult>()
@@ -164,7 +199,7 @@ class ContentSearchService(
                     if (file == null) {
                         FileReplaceResult(rawPath, 0, "outside the project")
                     } else {
-                        replaceInOneFile(file, regex, replacement, isRegex, dryRun)
+                        replaceInOneFile(file, regex, replacement, isRegex, dryRun, isCancelled)
                     }
                 if (result.error == null && result.replacements > 0) {
                     total += result.replacements
@@ -374,15 +409,20 @@ class ContentSearchService(
         text: String,
         regex: Regex,
         projectRoot: File,
+        isCancelled: () -> Boolean,
     ): List<FileMatch>? {
         return try {
             val relative = file.relativeTo(projectRoot).path.replace('\\', '/')
             if ('\u0000' in text) return null
             val lineMap = LineMap(text)
             val matches = mutableListOf<FileMatch>()
+            // The matcher reads through [InterruptibleText] rather than the raw
+            // string, so a cancel lands inside a wedged pattern instead of at the
+            // next suspension point.
+            val searchable = InterruptibleText(text, isCancelled)
             var searchFrom = 0
             while (searchFrom <= text.length && matches.size < MAX_MATCHES_PER_FILE) {
-                val m = regex.find(text, searchFrom) ?: break
+                val m = regex.find(searchable, searchFrom) ?: break
                 matches.add(
                     FileMatch(
                         path = relative,
@@ -398,6 +438,11 @@ class ContentSearchService(
                 searchFrom = maxOf(m.range.last + 1, m.range.first + 1)
             }
             matches
+        } catch (e: CancellationException) {
+            // A cancel raised inside the matcher is a CANCELLATION of this
+            // search, not a scan error: rethrow so the withContext unwinds
+            // instead of the loop quietly moving on to the next file.
+            throw e
         } catch (e: Exception) {
             null
         }
@@ -449,6 +494,7 @@ class ContentSearchService(
         replacement: String,
         isRegex: Boolean,
         dryRun: Boolean,
+        isCancelled: () -> Boolean,
     ): FileReplaceResult {
         if (!file.isFile) return FileReplaceResult(file.path, 0, "not a file")
         if (file.length() > MAX_FILE_SIZE) return FileReplaceResult(file.path, 0, "file too large")
@@ -457,7 +503,7 @@ class ContentSearchService(
             // Open buffers go through the editor's undoable path.
             val buffer = bufferBridge.readBuffer(file.absolutePath)
             if (buffer != null) {
-                replaceInBuffer(file, buffer.content, buffer.version, regex, replacement, isRegex, dryRun)
+                replaceInBuffer(file, buffer.content, buffer.version, regex, replacement, isRegex, dryRun, isCancelled)
             } else {
                 // UTF-8 in, UTF-8 out. A file in another single-byte encoding has no NUL
                 // bytes, so it passes the binary check, and round-tripping it through
@@ -467,10 +513,12 @@ class ContentSearchService(
                 val text = file.readText()
                 if ('\u0000' in text) return FileReplaceResult(file.path, 0, "binary file")
                 if ('\uFFFD' in text) return FileReplaceResult(file.path, 0, "not valid UTF-8")
-                val outcome = computeReplaced(text, regex, replacement, isRegex)
+                val outcome = computeReplaced(text, regex, replacement, isRegex, isCancelled)
                 if (!dryRun && outcome.count > 0) writeAtomically(file, outcome.text)
                 FileReplaceResult(file.path, outcome.count, null)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             FileReplaceResult(file.path, 0, e.message ?: "replace failed")
         }
@@ -500,8 +548,9 @@ class ContentSearchService(
         replacement: String,
         isRegex: Boolean,
         dryRun: Boolean,
+        isCancelled: () -> Boolean,
     ): FileReplaceResult {
-        val outcome = computeReplaced(text, regex, replacement, isRegex)
+        val outcome = computeReplaced(text, regex, replacement, isRegex, isCancelled)
         if (dryRun || outcome.count == 0) return FileReplaceResult(file.path, outcome.count, null)
 
         val span = changedSpan(text, outcome.text)
@@ -529,6 +578,12 @@ class ContentSearchService(
      * Writes [text] to [file] atomically: a sibling temp file, then an atomic rename.
      * A crash or I/O error mid-write must not leave a truncated source file with no
      * backup - the plugin installer promotes its jar the same way, for the same reason.
+     *
+     * Known: the rename moves a REGULAR file over the target, so a target that is a
+     * symlink becomes a regular file. The project walk filters symlinked files out,
+     * but [replaceInProject] takes an explicit caller-supplied list, and a symlink
+     * pointing inside the project passes [resolveFile] - so this is only reachable
+     * that way, and a replacement there replaces the link, not its referent.
      */
     private fun writeAtomically(
         file: File,
@@ -601,8 +656,12 @@ class ContentSearchService(
         regex: Regex,
         replacement: String,
         isRegex: Boolean,
+        isCancelled: () -> Boolean = { false },
     ): ReplaceOutcome {
-        val matcher = regex.toPattern().matcher(text)
+        // The matcher reads through [InterruptibleText] too: replace is
+        // reachable from a plugin with the same untrusted patterns, and a
+        // wedged file here holds no lock but still parks an IO thread.
+        val matcher = regex.toPattern().matcher(InterruptibleText(text, isCancelled))
         val repl =
             if (isRegex) {
                 replacement
@@ -755,4 +814,48 @@ object GlobalEditorBufferBridge : EditorBufferBridge {
         newText: String,
         expectedVersion: Long,
     ) = EditorAPIAccess.applyEdit(path, startLine, startCol, endLine, endCol, newText, expectedVersion)
+}
+
+/**
+ * A [CharSequence] view of [text] for matcher work that stops the moment
+ * [isCancelled] goes true.
+ *
+ * A caller-supplied pattern is not trusted: `(a+)+$` against a long line is
+ * catastrophic backtracking, and the Java matcher is not interruptible, so
+ * without a check inside the character stream a wedged file pins a
+ * `Dispatchers.IO` thread for as long as the pattern keeps spinning - and
+ * `project_search` is reachable from a plugin, not just the search box.
+ * `ensureActive()` between files cannot reach this: it never suspends.
+ *
+ * The check reads the CALLER's job, not `Thread.interrupted()`: structured
+ * concurrency does not interrupt a thread running a CPU-bound loop, so the
+ * flag would stay clear for the whole wedged run. The matcher re-reads
+ * characters on every backtrack step, so each read is the check, and a
+ * cancel lands mid-pattern rather than at the next suspension point.
+ *
+ * A tripped check throws [CancellationException], so the callers rethrow it
+ * past their `catch (Exception)` - which would otherwise turn the cancel
+ * into a "scan error" and let the loop move on to the next file.
+ */
+internal class InterruptibleText(
+    private val text: String,
+    private val isCancelled: () -> Boolean,
+) : CharSequence {
+    override val length: Int
+        get() = text.length
+
+    override fun get(index: Int): Char {
+        if (isCancelled()) throw CancellationException("search cancelled")
+        return text[index]
+    }
+
+    override fun subSequence(
+        startIndex: Int,
+        endIndex: Int,
+    ): CharSequence {
+        if (isCancelled()) throw CancellationException("search cancelled")
+        return text.subSequence(startIndex, endIndex)
+    }
+
+    override fun toString(): String = text
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/search/ContentSearchService.kt
@@ -149,7 +149,9 @@ class ContentSearchService(
     ): ReplaceSummary {
         val projectPath = projectPathProvider() ?: return ReplaceSummary(0, 0, emptyList(), dryRun)
         if (query.isEmpty() || files.isEmpty()) return ReplaceSummary(0, 0, emptyList(), dryRun)
-        val regex = buildRegex(query, isRegex, caseSensitive, wholeWord) ?: return ReplaceSummary(0, 0, emptyList(), dryRun)
+        val regex =
+            buildRegex(query, isRegex, caseSensitive, wholeWord)
+                ?: return ReplaceSummary(0, 0, emptyList(), dryRun)
 
         return withContext(Dispatchers.IO) {
             var total = 0

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
@@ -1,7 +1,11 @@
 package ai.rever.boss.services.editor
 
 import ai.rever.boss.components.plugin.DefaultPlugin
+import ai.rever.boss.plugin.api.BufferChange
+import ai.rever.boss.plugin.api.BufferSnapshot
+import ai.rever.boss.plugin.api.EditResult
 import ai.rever.boss.plugin.api.EditorTabPluginAPI
+import ai.rever.boss.plugin.api.FocusedDocument
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.Composable
@@ -94,4 +98,40 @@ object EditorAPIAccess {
     fun LspSettingsPanel(modifier: Modifier) {
         getProvider()?.LspSettingsPanel(modifier)
     }
+
+    // ==================== Live buffer model (boss-plugin-api 1.0.87, D3) ====================
+    //
+    // Passthroughs for the editor-tab plugin's buffer API. Each returns the
+    // "plugin predates this method" default (null / false) when the installed
+    // editor-tab plugin does not implement the member, so host callers gate on
+    // null exactly like every other EditorAPIAccess surface.
+
+    /** Snapshot of the live buffer for [path], or null when the file has no open buffer (or the plugin predates the method). */
+    suspend fun readBuffer(path: String): BufferSnapshot? = getProvider()?.readBuffer(path)
+
+    /** Apply an undoable edit to the live buffer; see [EditorTabPluginAPI.applyEdit] for the versioning contract. */
+    suspend fun applyEdit(
+        path: String,
+        startLine: Int,
+        startCol: Int,
+        endLine: Int,
+        endCol: Int,
+        newText: String,
+        expectedVersion: Long,
+    ): EditResult? = getProvider()?.applyEdit(path, startLine, startCol, endLine, endCol, newText, expectedVersion)
+
+    /** Observe changes to the buffer at [path]; null when unsupported. */
+    fun observeChanges(path: String): kotlinx.coroutines.flow.Flow<BufferChange>? = getProvider()?.observeChanges(path)
+
+    /** The focused editor document with its selection, or null. */
+    fun focusedDocument(): FocusedDocument? = getProvider()?.focusedDocument()
+
+    /** Open (or focus) an editor tab for [path], optionally at [line]. */
+    fun openEditor(
+        path: String,
+        line: Int? = null,
+    ): Boolean = getProvider()?.openEditor(path, line) ?: false
+
+    /** Open [path] in a split pane of the current editor tab. */
+    fun openSplit(path: String): Boolean = getProvider()?.openSplit(path) ?: false
 }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/services/editor/EditorAPIAccess.kt
@@ -124,14 +124,14 @@ object EditorAPIAccess {
     fun observeChanges(path: String): kotlinx.coroutines.flow.Flow<BufferChange>? = getProvider()?.observeChanges(path)
 
     /** The focused editor document with its selection, or null. */
-    fun focusedDocument(): FocusedDocument? = getProvider()?.focusedDocument()
+    suspend fun focusedDocument(): FocusedDocument? = getProvider()?.focusedDocument()
 
     /** Open (or focus) an editor tab for [path], optionally at [line]. */
-    fun openEditor(
+    suspend fun openEditor(
         path: String,
         line: Int? = null,
     ): Boolean = getProvider()?.openEditor(path, line) ?: false
 
     /** Open [path] in a split pane of the current editor tab. */
-    fun openSplit(path: String): Boolean = getProvider()?.openSplit(path) ?: false
+    suspend fun openSplit(path: String): Boolean = getProvider()?.openSplit(path) ?: false
 }

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/home/InstalledPluginVersionDesktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/home/InstalledPluginVersionDesktop.kt
@@ -1,0 +1,5 @@
+package ai.rever.boss.components.home
+
+import ai.rever.boss.plugin.PluginPersistence
+
+internal actual fun installedPluginVersionOf(pluginId: String): String? = PluginPersistence.getInstalledPlugin(pluginId)?.installedVersion

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/components/wizard/plugin/PluginListProvider.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.components.wizard.plugin
 
 import ai.rever.boss.components.plugin.RetiredPluginIds
+import ai.rever.boss.plugin.PluginPersistence
 import ai.rever.boss.plugin.PluginStoreSetup
 import ai.rever.boss.plugin.repository.PluginInfo
 import ai.rever.boss.plugin.repository.PluginWithSource
@@ -180,9 +181,17 @@ object PluginListProvider {
                             .filter { it.plugin.pluginId != ai.rever.boss.components.plugin.MicrokernelRuntime.PLUGIN_ID }
                             // Nor a plugin another plugin has taken over: the store keeps
                             // returning it until its row is unlisted by hand, and installing it
-                            // here only gets it swept away at the next launch.
-                            .filter { it.plugin.pluginId !in RetiredPluginIds.ALL }
-                            .map { pws: PluginWithSource ->
+                            // here only gets it swept away at the next launch. The floor is the
+                            // sweep's own (see HomeToolCatalog) - an unconditional hide would
+                            // leave a fresh install with no panel until the replacement ships.
+                            .filter {
+                                !RetiredPluginIds.hiddenFromOffers(
+                                    it.plugin.pluginId,
+                                    installedVersionOf = { id ->
+                                        PluginPersistence.getInstalledPlugin(id)?.installedVersion
+                                    },
+                                )
+                            }.map { pws: PluginWithSource ->
                                 convertToWizardPluginInfo(pws.plugin)
                             }
 

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -1247,7 +1247,11 @@ actual object GitService {
             val parts = raw.split("\t")
             val type = statusTypeFromCode(parts.firstOrNull().orEmpty()) ?: continue
             // Renames/copies carry two columns: STATUS100\told\tnew.
-            val path = parts.getOrNull(if (parts.size > 2) 2 else 1) ?: continue
+            // C-unquote: with core.quotePath on (the default) git wraps a non-ASCII
+            // path in quotes and octal-escapes its bytes, and that token then fails to
+            // resolve when handed back as a pathspec (dead tab / empty diff). The same
+            // decoder the diff header uses fixes it; an unquoted path passes through.
+            val path = UnifiedDiffParser.cUnquote(parts.getOrNull(if (parts.size > 2) 2 else 1) ?: continue)
             list.add(
                 GitFileStatusData(
                     path = path,
@@ -1361,6 +1365,10 @@ actual object GitService {
      * Updates the provided WindowGitState instead of global state.
      * This allows multiple windows to have independent git states.
      */
+    actual fun alignCurrentProjectPath(projectPath: String) {
+        currentProjectPath = projectPath
+    }
+
     actual suspend fun refreshForWindow(
         projectPath: String,
         windowGitState: WindowGitState?,
@@ -1635,6 +1643,16 @@ actual object GitService {
         errReader.join(STREAM_DRAIN_TIMEOUT_SECONDS * 1000)
         val output = synchronized(outBuf) { outBuf.toString() }
         val error = synchronized(errBuf) { errBuf.toString() }
+        if (output.length >= MAX_GIT_OUTPUT_CHARS) {
+            // Not silent: parseDiffSafely will parse the truncated stream into a PARTIAL
+            // diff that looks complete, so at least leave a trail for why a huge diff is
+            // missing its tail.
+            logger.warn(
+                LogCategory.SYSTEM,
+                "git output truncated at the ${MAX_GIT_OUTPUT_CHARS}-char cap; diff may be incomplete",
+                mapOf("args" to args.joinToString(" ")),
+            )
+        }
         if (finished) return GitCommandResult(output, error, process.exitValue())
         logger.warn(
             LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -127,26 +127,32 @@ actual object GitService {
     actual suspend fun checkout(
         branchName: String,
         windowId: String?,
+        projectPathOverride: String?,
     ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             _isLoading.value = true
             try {
-                // For remote branches like "origin/feature", extract just "feature"
-                // Git will automatically set up tracking
+                if (!isSafeRefName(branchName)) {
+                    return@withContext GitError("Refused an unsafe ref: branch")
+                }
+                // A slash does not mean "remote": `feature/x` is a legal LOCAL branch
+                // name, and the branch picker feeds local names through here with their
+                // slashes intact - stripping unconditionally checked out `x` (or failed).
+                // Only when no local branch matches is the name read as remote-tracking
+                // (`origin/feature` -> `feature`, git sets up tracking itself).
+                val isLocalBranch =
+                    runGitCommand(projectPath, "show-ref", "--verify", "--quiet", "refs/heads/$branchName")
+                        .exitCode == 0
                 val localName =
-                    if (branchName.contains("/")) {
+                    if (!isLocalBranch && branchName.contains("/")) {
                         branchName.substringAfter("/")
                     } else {
                         branchName
                     }
-
-                if (!isSafeRefName(localName)) {
-                    return@withContext GitError("Refused an unsafe ref: branch")
-                }
                 // `--` terminates the revision list: without it `checkout <name>`
                 // on a name that is also a path checks OUT THE PATH, discarding
                 // that file's uncommitted changes.
@@ -217,7 +223,10 @@ actual object GitService {
 
             _isLoading.value = true
             try {
-                val result = runGitCommand(projectPath, "pull")
+                // A remote operation: runRemoteGitCommand, not runGitCommand, so a
+                // credential prompt fails immediately instead of blocking for the
+                // whole local timeout while holding gitCommandLock.
+                val result = runRemoteGitCommand(projectPath, "pull")
                 if (result.exitCode == 0) {
                     // Refresh state after pull
                     refresh(projectPath)
@@ -241,8 +250,9 @@ actual object GitService {
 
             _isLoading.value = true
             try {
-                // Use -u to set upstream if not already set
-                val result = runGitCommand(projectPath, "push", "-u", "origin", "HEAD")
+                // Use -u to set upstream if not already set. Remote operation, so it
+                // gets the non-interactive guard and the remote bound (see pull()).
+                val result = runRemoteGitCommand(projectPath, "push", "-u", "origin", "HEAD")
                 if (result.exitCode == 0) {
                     val message =
                         result.output.trim().ifEmpty {
@@ -305,6 +315,12 @@ actual object GitService {
                 currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
+            // The last ref-taking verbs without the guard - which contradicted the
+            // createBranch reasoning ("not currently plugin-reachable is a property
+            // of the callers, not of this function").
+            if (!isSafeRefName(branchName)) {
+                return@withContext GitError("Refused an unsafe ref: branch")
+            }
             _isLoading.value = true
             try {
                 val result = runGitCommand(projectPath, "merge", branchName)
@@ -329,6 +345,10 @@ actual object GitService {
                 currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
+            // See merge(): validated like every other ref-taking command.
+            if (!isSafeRefName(branchName)) {
+                return@withContext GitError("Refused an unsafe ref: branch")
+            }
             _isLoading.value = true
             try {
                 val result = runGitCommand(projectPath, "rebase", branchName)
@@ -497,13 +517,22 @@ actual object GitService {
         java.util.concurrent.locks
             .ReentrantLock()
 
+    // The write verbs take a projectPathOverride for the same reason the diff reads
+    // do: the global currentProjectPath belongs to whichever window ALIGNED last, and
+    // aligning it in a separate step (ensureRepoState) leaves a window in which
+    // another window's align lands between this window's align and its command - so
+    // a discard ran `git restore` in the other window's worktree. The override is
+    // resolved by the caller from ITS window and travels with the call, so no
+    // interleaving can redirect it.
+
     actual suspend fun stage(
         filePath: String,
         windowId: String?,
+        projectPathOverride: String?,
     ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             val result = runGitCommand(projectPath, "add", "--", filePath)
@@ -517,10 +546,13 @@ actual object GitService {
             }
         }
 
-    actual suspend fun stageAll(windowId: String?): GitOperationResult =
+    actual suspend fun stageAll(
+        windowId: String?,
+        projectPathOverride: String?,
+    ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             val result = runGitCommand(projectPath, "add", "-A")
@@ -537,10 +569,11 @@ actual object GitService {
     actual suspend fun unstage(
         filePath: String,
         windowId: String?,
+        projectPathOverride: String?,
     ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             // A staged rename is ONE index entry spanning two paths. Restoring
@@ -590,10 +623,13 @@ actual object GitService {
         }
     }
 
-    actual suspend fun unstageAll(windowId: String?): GitOperationResult =
+    actual suspend fun unstageAll(
+        windowId: String?,
+        projectPathOverride: String?,
+    ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             val result = runGitCommand(projectPath, "restore", "--staged", ".")
@@ -610,10 +646,14 @@ actual object GitService {
     actual suspend fun discardChanges(
         filePath: String,
         windowId: String?,
+        projectPathOverride: String?,
     ): GitOperationResult =
         withContext(Dispatchers.IO) {
+            // Destructive, so the override matters most here: a relative path that
+            // exists in two open worktrees restores in whichever one the global
+            // happened to point at, silently destroying uncommitted work.
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             val result = runGitCommand(projectPath, "restore", "--", filePath)
@@ -633,10 +673,11 @@ actual object GitService {
         message: String,
         amend: Boolean,
         windowId: String?,
+        projectPathOverride: String?,
     ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             _isLoading.value = true
@@ -733,10 +774,14 @@ actual object GitService {
         }
     }
 
-    actual suspend fun cherryPick(commitHash: String): GitOperationResult =
+    actual suspend fun cherryPick(
+        commitHash: String,
+        windowId: String?,
+        projectPathOverride: String?,
+    ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             if (!isSafeRefName(commitHash)) {
@@ -747,6 +792,10 @@ actual object GitService {
                 val result = runGitCommand(projectPath, "cherry-pick", commitHash)
                 if (result.exitCode == 0) {
                     refresh(projectPath)
+                    // The panel that issued the cherry-pick sees its own status and
+                    // log refresh, like every other write - without this it reported
+                    // success while its changes list stayed stale until the next poll.
+                    refreshWindowState(windowId)
                     GitSuccess("Cherry-picked $commitHash")
                 } else {
                     val errorMsg = result.error.ifEmpty { result.output }.trim()
@@ -758,10 +807,14 @@ actual object GitService {
             }
         }
 
-    actual suspend fun revert(commitHash: String): GitOperationResult =
+    actual suspend fun revert(
+        commitHash: String,
+        windowId: String?,
+        projectPathOverride: String?,
+    ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             if (!isSafeRefName(commitHash)) {
@@ -772,6 +825,8 @@ actual object GitService {
                 val result = runGitCommand(projectPath, "revert", "--no-edit", commitHash)
                 if (result.exitCode == 0) {
                     refresh(projectPath)
+                    // See cherryPick: the issuing panel refreshes itself.
+                    refreshWindowState(windowId)
                     GitSuccess("Reverted $commitHash")
                 } else {
                     val errorMsg = result.error.ifEmpty { result.output }.trim()
@@ -955,6 +1010,14 @@ actual object GitService {
         branchName: String,
     ) {
         val projectPath = currentProjectPath ?: return
+        // The branch name is interpolated into a SHELL command string, so this is
+        // shell injection, not just option injection, if an unvalidated name ever
+        // reaches it. Host-UI-only today, with names git itself produced - which is
+        // exactly the property createBranch's guard says not to lean on.
+        if (!isSafeRefName(branchName)) {
+            logger.warn(LogCategory.SYSTEM, "mergeInTerminal refused an unsafe ref", mapOf("branch" to branchName))
+            return
+        }
         GitTerminalEventBus.openGitTerminal(
             command = "git merge $branchName",
             workingDirectory = projectPath,
@@ -968,6 +1031,11 @@ actual object GitService {
         branchName: String,
     ) {
         val projectPath = currentProjectPath ?: return
+        // See mergeInTerminal: the name lands in a shell command string.
+        if (!isSafeRefName(branchName)) {
+            logger.warn(LogCategory.SYSTEM, "rebaseInTerminal refused an unsafe ref", mapOf("branch" to branchName))
+            return
+        }
         GitTerminalEventBus.openGitTerminal(
             command = "git rebase $branchName",
             workingDirectory = projectPath,
@@ -992,10 +1060,16 @@ actual object GitService {
 
     // ===== Private helper functions =====
 
-    private data class GitCommandResult(
+    // Internal (not private) so runProcessBounded's drain/timeout behaviour is
+    // testable - the stderr-flood deadlock it exists to prevent froze the whole app.
+    internal data class GitCommandResult(
         val output: String,
         val error: String,
         val exitCode: Int,
+        // True when stdout hit MAX_GIT_OUTPUT_CHARS and the tail was dropped. The
+        // diff getters refuse a truncated stream: it parses into a PARTIAL diff
+        // that looks complete, which is worse than showing no diff at all.
+        val truncated: Boolean = false,
     )
 
     private fun checkGitAvailable(): Boolean =
@@ -1113,13 +1187,23 @@ actual object GitService {
      * throwing. The parser's `require(path.isNotEmpty())` can still trip on a header
      * shape DIFF_SHAPE_FLAGS does not cover; a blank diff tab is recoverable, an
      * exception propagating into the calling plugin is not.
+     *
+     * A TRUNCATED stream is refused for the same honesty reason: it parses into a
+     * partial diff that looks complete - files silently missing, a hunk cut mid-way -
+     * which reads as "that's the whole change". No diff is a visible failure; a
+     * plausible partial diff is a lie.
      */
-    private fun parseDiffSafely(output: String): List<GitDiffData> =
-        runCatching { UnifiedDiffParser.parse(output) }
+    private fun parseDiffSafely(result: GitCommandResult): List<GitDiffData> {
+        if (result.truncated) {
+            logger.warn(LogCategory.SYSTEM, "diff output truncated at the size cap; showing no diff")
+            return emptyList()
+        }
+        return runCatching { UnifiedDiffParser.parse(result.output) }
             .getOrElse {
                 logger.warn(LogCategory.SYSTEM, "diff parse failed; showing no diff", error = it)
                 emptyList()
             }
+    }
 
     actual suspend fun getFileDiff(
         filePath: String,
@@ -1149,7 +1233,7 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            parseDiffSafely(result.output)
+            parseDiffSafely(result)
         }
 
     actual suspend fun getCommitDiff(
@@ -1184,7 +1268,7 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            parseDiffSafely(result.output)
+            parseDiffSafely(result)
         }
 
     actual suspend fun getRefDiff(
@@ -1217,7 +1301,7 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            parseDiffSafely(result.output)
+            parseDiffSafely(result)
         }
 
     actual suspend fun getDiffFileNames(
@@ -1301,8 +1385,27 @@ actual object GitService {
         // `git add -A` emitting per-file warnings, a chatty hook, a commit waiting
         // on gpg pinentry - froze the status poll, the diff tabs and the top bar
         // in every window, with no timeout to end it.
-        return runProcessBounded(process, LOCAL_GIT_TIMEOUT_SECONDS, args)
+        //
+        // Index-writing commands get a much longer bound: killing `git commit`
+        // mid-run leaves `.git/index.lock` behind and every later git command in
+        // the repo fails until the user deletes it by hand. Pre-commit hooks that
+        // run a formatter or a test subset, and gpg commits waiting on pinentry,
+        // routinely outlive the tight bound that is right for reads.
+        val timeout =
+            if (args.firstOrNull() in INDEX_WRITE_SUBCOMMANDS) {
+                INDEX_WRITE_TIMEOUT_SECONDS
+            } else {
+                LOCAL_GIT_TIMEOUT_SECONDS
+            }
+        return runProcessBounded(process, timeout, args, workingDir)
     }
+
+    /**
+     * Subcommands that take `.git/index.lock` for the duration of the command. A
+     * forcible kill mid-run strands the lock file, so these get the generous bound.
+     */
+    private val INDEX_WRITE_SUBCOMMANDS =
+        setOf("add", "commit", "restore", "checkout", "merge", "rebase", "cherry-pick", "revert", "stash", "mv")
 
     /**
      * Refresh window-specific git state after a write operation.
@@ -1597,7 +1700,7 @@ actual object GitService {
             //    the child fills the stderr pipe buffer (~64KB): it blocks writing
             //    stderr, so it never closes stdout, so we never stop reading. git
             //    fetch writes progress to stderr, so this needed no network fault.
-            runProcessBounded(process, REMOTE_GIT_TIMEOUT_SECONDS, args)
+            runProcessBounded(process, REMOTE_GIT_TIMEOUT_SECONDS, args, workingDir)
         }
 
     /** How long a remote git command may hold the git lock before it is killed. */
@@ -1614,6 +1717,14 @@ actual object GitService {
     private const val LOCAL_GIT_TIMEOUT_SECONDS = 60L
 
     /**
+     * The bound for [INDEX_WRITE_SUBCOMMANDS]. Long, because the failure mode of the
+     * kill is worse than the failure mode of the wait: a killed index write strands
+     * `.git/index.lock`, wedging the repository, while a slow hook merely holds the
+     * lock - annoying, recoverable, and ended by this bound eventually anyway.
+     */
+    private const val INDEX_WRITE_TIMEOUT_SECONDS = 600L
+
+    /**
      * Runs [process] to completion with both pipes drained concurrently and a wall
      * clock bound, returning whatever output was produced either way.
      *
@@ -1625,10 +1736,11 @@ actual object GitService {
      * - kill, then wait for the kill, so the pipes actually close before joining
      *   the readers - otherwise the join just moves the hang one line down.
      */
-    private fun runProcessBounded(
+    internal fun runProcessBounded(
         process: Process,
         timeoutSeconds: Long,
         args: Array<out String>,
+        workingDir: String? = null,
     ): GitCommandResult {
         val outBuf = StringBuilder()
         val errBuf = StringBuilder()
@@ -1643,28 +1755,66 @@ actual object GitService {
         errReader.join(STREAM_DRAIN_TIMEOUT_SECONDS * 1000)
         val output = synchronized(outBuf) { outBuf.toString() }
         val error = synchronized(errBuf) { errBuf.toString() }
-        if (output.length >= MAX_GIT_OUTPUT_CHARS) {
-            // Not silent: parseDiffSafely will parse the truncated stream into a PARTIAL
-            // diff that looks complete, so at least leave a trail for why a huge diff is
-            // missing its tail.
+        val truncated = output.length >= MAX_GIT_OUTPUT_CHARS
+        if (truncated) {
             logger.warn(
                 LogCategory.SYSTEM,
-                "git output truncated at the ${MAX_GIT_OUTPUT_CHARS}-char cap; diff may be incomplete",
+                "git output truncated at the ${MAX_GIT_OUTPUT_CHARS}-char cap",
                 mapOf("args" to args.joinToString(" ")),
             )
         }
-        if (finished) return GitCommandResult(output, error, process.exitValue())
+        if (finished) return GitCommandResult(output, error, process.exitValue(), truncated)
         logger.warn(
             LogCategory.SYSTEM,
             "git command timed out",
             mapOf("args" to args.joinToString(" "), "timeoutSeconds" to timeoutSeconds.toString()),
         )
+        // A kill mid-index-write strands .git/index.lock, and git's later "File
+        // exists" error never says a killed BOSS command left it. Probe and say so.
+        val lockHint =
+            if (workingDir != null && staleIndexLockExists(workingDir)) {
+                " The killed command may have left .git/index.lock behind; " +
+                    "delete that file if git commands keep failing."
+            } else {
+                ""
+            }
         return GitCommandResult(
             output,
-            "Timed out after ${timeoutSeconds}s. Check the remote, your network, or your credentials.",
+            "Timed out after ${timeoutSeconds}s. Check the remote, your network, or your credentials.$lockHint",
             TIMEOUT_EXIT_CODE,
+            truncated,
         )
     }
+
+    /**
+     * Best-effort probe for `.git/index.lock` under [workingDir]. Handles a worktree
+     * checkout too, where `.git` is a FILE containing `gitdir: <path>`.
+     */
+    private fun staleIndexLockExists(workingDir: String): Boolean =
+        runCatching {
+            val dotGit = File(workingDir, ".git")
+            val gitDir =
+                when {
+                    dotGit.isDirectory -> {
+                        dotGit
+                    }
+
+                    dotGit.isFile -> {
+                        dotGit
+                            .readText()
+                            .lineSequence()
+                            .firstOrNull { it.startsWith("gitdir:") }
+                            ?.removePrefix("gitdir:")
+                            ?.trim()
+                            ?.let { p -> if (File(p).isAbsolute) File(p) else File(workingDir, p) }
+                    }
+
+                    else -> {
+                        null
+                    }
+                }
+            gitDir != null && File(gitDir, "index.lock").exists()
+        }.getOrDefault(false)
 
     private const val TIMEOUT_EXIT_CODE = 124
 
@@ -1691,8 +1841,9 @@ actual object GitService {
                         // multi-file commit can be hundreds of MB on stdout; buffering it
                         // all - while holding gitCommandLock - risks an OOM that takes the
                         // app down. Past the cap we keep reading (so the child never blocks
-                        // on a full pipe) but stop appending, and the truncated stream still
-                        // parses into a partial diff rather than crashing.
+                        // on a full pipe) but stop appending; the result is flagged
+                        // truncated and the diff getters refuse it rather than rendering
+                        // a partial diff that looks complete.
                         synchronized(sink) {
                             if (sink.length < MAX_GIT_OUTPUT_CHARS) {
                                 val room = MAX_GIT_OUTPUT_CHARS - sink.length

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.git
 
 import ai.rever.boss.components.events.GitTerminalEventBus
+import ai.rever.boss.plugin.api.GitDiffData
+import ai.rever.boss.plugin.api.GitFileStatusData
+import ai.rever.boss.plugin.api.GitFileStatusTypeData
 import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import ai.rever.boss.utils.logging.LogSanitizer
@@ -21,6 +24,7 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.IOException
 import java.io.InputStreamReader
+import kotlin.concurrent.withLock
 import ai.rever.boss.plugin.git.GitOperationResult.Error as GitError
 import ai.rever.boss.plugin.git.GitOperationResult.Success as GitSuccess
 
@@ -140,7 +144,13 @@ actual object GitService {
                         branchName
                     }
 
-                val result = runGitCommand(projectPath, "checkout", localName)
+                if (!isSafeRefName(localName)) {
+                    return@withContext GitError("Refused an unsafe ref: branch")
+                }
+                // `--` terminates the revision list: without it `checkout <name>`
+                // on a name that is also a path checks OUT THE PATH, discarding
+                // that file's uncommitted changes.
+                val result = runGitCommand(projectPath, "checkout", localName, "--")
                 if (result.exitCode == 0) {
                     // Refresh state after checkout
                     refresh(projectPath)
@@ -165,6 +175,14 @@ actual object GitService {
             val projectPath =
                 currentProjectPath
                     ?: return@withContext GitError("No project selected")
+
+            // Validated like every other ref-taking command. Host-UI-only today, but
+            // "not currently plugin-reachable" is a property of the callers, not of
+            // this function, and the checkout/cherry-pick/revert guards exist exactly
+            // because that property changed once already.
+            if (!isSafeRefName(branchName)) {
+                return@withContext GitError("Refused an unsafe ref: branch")
+            }
 
             _isLoading.value = true
             try {
@@ -459,6 +477,26 @@ actual object GitService {
             else -> null
         }
 
+    /**
+     * Serializes every git invocation from this service.
+     *
+     * git takes `.git/index.lock` for a write and does not queue behind it -
+     * a second concurrent write simply fails, which is how staging several
+     * files at once staged the first and silently dropped the rest.
+     *
+     * The lock sits around the whole command rather than around the writes
+     * alone, because `git status` also takes it: it writes the refreshed stat
+     * cache back to the index. With only the writes guarded, the status read
+     * that every operation performs afterwards still collided with the next
+     * file's `git add`, and a file was lost roughly one run in three.
+     *
+     * These are user-driven, IO-bound commands, so serializing them costs
+     * nothing that matters.
+     */
+    private val gitCommandLock =
+        java.util.concurrent.locks
+            .ReentrantLock()
+
     actual suspend fun stage(
         filePath: String,
         windowId: String?,
@@ -505,7 +543,13 @@ actual object GitService {
                 currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
-            val result = runGitCommand(projectPath, "restore", "--staged", "--", filePath)
+            // A staged rename is ONE index entry spanning two paths. Restoring
+            // only the new path unstages the addition and leaves the deletion
+            // of the old path staged - which is why unstaging `helper2.py` put
+            // `helper.py` back in STAGED. VS Code's git extension passes both
+            // sides for exactly this reason, so pass both here too.
+            val paths = stagedPathsFor(projectPath, filePath)
+            val result = runGitCommand(projectPath, "restore", "--staged", "--", *paths.toTypedArray())
             if (result.exitCode == 0) {
                 getStatus() // Refresh global status
                 refreshWindowState(windowId) // Refresh window-specific status
@@ -515,6 +559,36 @@ actual object GitService {
                 GitError(errorMsg, result.exitCode)
             }
         }
+
+    /**
+     * Every index path that belongs with [filePath].
+     *
+     * For a staged rename that is both sides of the arrow; for anything else
+     * it is just the path itself. Read from the current status rather than
+     * remembered, so it stays correct when the index changed underneath.
+     */
+    private fun stagedPathsFor(
+        projectPath: String,
+        filePath: String,
+    ): List<String> {
+        val status =
+            runCatching {
+                runGitCommand(projectPath, "status", "--porcelain=v1", "--untracked-files=all")
+            }.getOrNull() ?: return listOf(filePath)
+        if (status.exitCode != 0) return listOf(filePath)
+        val entry =
+            status.output
+                .lines()
+                .filter { it.length > 3 }
+                .mapNotNull { parseStatusLine(it) }
+                .firstOrNull { it.path == filePath }
+        val original = entry?.originalPath
+        return if (original.isNullOrBlank() || original == filePath) {
+            listOf(filePath)
+        } else {
+            listOf(filePath, original)
+        }
+    }
 
     actual suspend fun unstageAll(windowId: String?): GitOperationResult =
         withContext(Dispatchers.IO) {
@@ -665,6 +739,9 @@ actual object GitService {
                 currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
+            if (!isSafeRefName(commitHash)) {
+                return@withContext GitError("Refused an unsafe ref: commit")
+            }
             _isLoading.value = true
             try {
                 val result = runGitCommand(projectPath, "cherry-pick", commitHash)
@@ -687,6 +764,9 @@ actual object GitService {
                 currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
+            if (!isSafeRefName(commitHash)) {
+                return@withContext GitError("Refused an unsafe ref: commit")
+            }
             _isLoading.value = true
             try {
                 val result = runGitCommand(projectPath, "revert", "--no-edit", commitHash)
@@ -984,11 +1064,17 @@ actual object GitService {
                 .lines()
                 .filter { it.isNotBlank() }
                 .map { line ->
-                    // The line ends with * if it's the current branch
-                    val isCurrent = line.endsWith("*")
-                    val name = if (isCurrent) line.dropLast(1) else line
+                    // `%(HEAD)` is "*" for the checked-out branch and a SPACE
+                    // for every other one, so the marker has to be trimmed off
+                    // both ways: dropping only the "*" left every non-current
+                    // name with a trailing space ("side "), which is not a ref
+                    // git will resolve - `git log "side "` and `git checkout
+                    // "side "` both fail on it.
+                    val isCurrent = line.trimEnd().endsWith("*")
+                    val name = line.trimEnd().removeSuffix("*").trim()
                     GitBranchInfo(name = name, isCurrent = isCurrent, isRemote = false)
-                }.sortedWith(compareBy({ !it.isCurrent }, { it.name })) // Current branch first
+                }.filter { it.name.isNotEmpty() }
+                .sortedWith(compareBy({ !it.isCurrent }, { it.name })) // Current branch first
         } catch (e: Exception) {
             logger.debug(LogCategory.SYSTEM, "Could not list local branches", mapOf("error" to e.toString()))
             emptyList()
@@ -1011,15 +1097,173 @@ actual object GitService {
                 .filter { it.isNotBlank() }
                 .filter { !it.contains("HEAD") } // Exclude origin/HEAD
                 .map { name ->
-                    GitBranchInfo(name = name, isCurrent = false, isRemote = true)
-                }.sortedBy { it.name }
+                    GitBranchInfo(name = name.trim(), isCurrent = false, isRemote = true)
+                }.filter { it.name.isNotEmpty() }
+                .sortedBy { it.name }
         } catch (e: Exception) {
             logger.debug(LogCategory.SYSTEM, "Could not list remote branches", mapOf("error" to e.toString()))
             emptyList()
         }
     }
 
+    // ===== Diff =====
+
+    actual suspend fun getFileDiff(
+        filePath: String,
+        staged: Boolean,
+        projectPathOverride: String?,
+    ): List<GitDiffData> =
+        withContext(Dispatchers.IO) {
+            val projectPath = projectPathOverride ?: currentProjectPath ?: return@withContext emptyList()
+            // -U with a huge context: a diff tab is a file viewer that marks
+            // changes, not a patch. With git's default 3 lines the file arrives
+            // as disconnected fragments and there is no way to read around a
+            // change. `git diff` clamps the context to the file, so this costs
+            // nothing extra on a small one.
+            val context = "-U$FULL_FILE_CONTEXT"
+            val args =
+                if (staged) {
+                    listOf("diff", context, "--cached", "--", filePath)
+                } else {
+                    listOf("diff", context, "--", filePath)
+                }
+            val result = runGitCommand(projectPath, *args.toTypedArray())
+            if (result.exitCode != 0) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "getFileDiff failed",
+                    mapOf("file" to filePath, "error" to result.error),
+                )
+                return@withContext emptyList()
+            }
+            UnifiedDiffParser.parse(result.output)
+        }
+
+    actual suspend fun getCommitDiff(
+        commitHash: String,
+        filePath: String?,
+        projectPathOverride: String?,
+    ): List<GitDiffData> =
+        withContext(Dispatchers.IO) {
+            val projectPath = projectPathOverride ?: currentProjectPath ?: return@withContext emptyList()
+            // Validated for the same reason as getLogForRef: a ref beginning with
+            // `-` is read by git as an OPTION, and `git diff --output=<path>`
+            // TRUNCATES that path. These endpoints are reachable from the
+            // git_diff_ref / git_diff_between MCP tools, which are declared
+            // readOnly - so an unvalidated ref turns a read-only tool into an
+            // arbitrary file write. `--` terminates the revision list so a ref
+            // can never be taken for a pathspec either.
+            if (!isSafeRefName(commitHash)) {
+                logger.warn(LogCategory.SYSTEM, "getCommitDiff refused an unsafe ref", mapOf("commit" to commitHash))
+                return@withContext emptyList()
+            }
+            // -U matches getFileDiff/getRefDiff: the diff tab is a file viewer, so a
+            // commit-scope tab rendered 3-line fragments while the others showed whole files.
+            val args = mutableListOf("show", "-U$FULL_FILE_CONTEXT", "--format=", "--find-renames", commitHash, "--")
+            if (filePath != null) args += filePath
+            val result = runGitCommand(projectPath, *args.toTypedArray())
+            if (result.exitCode != 0) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "getCommitDiff failed",
+                    mapOf("commit" to commitHash, "error" to result.error),
+                )
+                return@withContext emptyList()
+            }
+            UnifiedDiffParser.parse(result.output)
+        }
+
+    actual suspend fun getRefDiff(
+        fromRef: String,
+        toRef: String,
+        filePath: String?,
+        projectPathOverride: String?,
+    ): List<GitDiffData> =
+        withContext(Dispatchers.IO) {
+            val projectPath = projectPathOverride ?: currentProjectPath ?: return@withContext emptyList()
+            // See getCommitDiff: both refs are validated and the revision list is
+            // terminated, because `git diff --output=<path>` truncates that path.
+            if (!isSafeRefName(fromRef) || !isSafeRefName(toRef)) {
+                logger.warn(
+                    LogCategory.SYSTEM,
+                    "getRefDiff refused an unsafe ref",
+                    mapOf("from" to fromRef, "to" to toRef),
+                )
+                return@withContext emptyList()
+            }
+            val args = mutableListOf("diff", "-U$FULL_FILE_CONTEXT", fromRef, toRef, "--")
+            if (filePath != null) args += filePath
+            val result = runGitCommand(projectPath, *args.toTypedArray())
+            if (result.exitCode != 0) {
+                logger.debug(
+                    LogCategory.SYSTEM,
+                    "getRefDiff failed",
+                    mapOf("from" to fromRef, "to" to toRef, "error" to result.error),
+                )
+                return@withContext emptyList()
+            }
+            UnifiedDiffParser.parse(result.output)
+        }
+
+    actual suspend fun getDiffFileNames(
+        staged: Boolean,
+        projectPathOverride: String?,
+    ): List<GitFileStatusData> =
+        withContext(Dispatchers.IO) {
+            val projectPath = projectPathOverride ?: currentProjectPath ?: return@withContext emptyList()
+            val args =
+                if (staged) {
+                    listOf("diff", "--name-status", "--cached")
+                } else {
+                    listOf("diff", "--name-status")
+                }
+            val result = runGitCommand(projectPath, *args.toTypedArray())
+            if (result.exitCode != 0) return@withContext emptyList()
+            parseNameStatus(result.output, staged)
+        }
+
+    private fun parseNameStatus(
+        output: String,
+        staged: Boolean,
+    ): List<GitFileStatusData> {
+        val list = mutableListOf<GitFileStatusData>()
+        for (raw in output.lines()) {
+            if (raw.isBlank()) continue
+            val parts = raw.split("\t")
+            val type = statusTypeFromCode(parts.firstOrNull().orEmpty()) ?: continue
+            // Renames/copies carry two columns: STATUS100\told\tnew.
+            val path = parts.getOrNull(if (parts.size > 2) 2 else 1) ?: continue
+            list.add(
+                GitFileStatusData(
+                    path = path,
+                    indexStatus = if (staged) type else null,
+                    workTreeStatus = if (staged) null else type,
+                    isStaged = staged,
+                    isUnstaged = !staged,
+                ),
+            )
+        }
+        return list
+    }
+
+    private fun statusTypeFromCode(code: String): GitFileStatusTypeData? =
+        when (code.firstOrNull()) {
+            'M' -> GitFileStatusTypeData.MODIFIED
+            'A' -> GitFileStatusTypeData.ADDED
+            'D' -> GitFileStatusTypeData.DELETED
+            'R' -> GitFileStatusTypeData.RENAMED
+            'C' -> GitFileStatusTypeData.COPIED
+            'T' -> GitFileStatusTypeData.MODIFIED
+            'U' -> GitFileStatusTypeData.UNMERGED
+            else -> null
+        }
+
     private fun runGitCommand(
+        workingDir: String,
+        vararg args: String,
+    ): GitCommandResult = gitCommandLock.withLock { runGitCommandLocked(workingDir, *args) }
+
+    private fun runGitCommandLocked(
         workingDir: String,
         vararg args: String,
     ): GitCommandResult {
@@ -1031,11 +1275,14 @@ actual object GitService {
                     environment().putAll(System.getenv())
                 }.start()
 
-        val output = BufferedReader(InputStreamReader(process.inputStream)).use { it.readText() }
-        val error = BufferedReader(InputStreamReader(process.errorStream)).use { it.readText() }
-        val exitCode = process.waitFor()
-
-        return GitCommandResult(output, error, exitCode)
+        // Drained concurrently and bounded, for the reasons runRemoteGitCommand
+        // spells out. This path had neither, and the index lock made that worse
+        // rather than better: gitCommandLock serialises every git command in the
+        // app, so ONE local command blocked on a full stderr pipe - a big
+        // `git add -A` emitting per-file warnings, a chatty hook, a commit waiting
+        // on gpg pinentry - froze the status poll, the diff tabs and the top bar
+        // in every window, with no timeout to end it.
+        return runProcessBounded(process, LOCAL_GIT_TIMEOUT_SECONDS, args)
     }
 
     /**
@@ -1106,6 +1353,15 @@ actual object GitService {
         if (windowGitState == null) return@withContext
 
         windowGitState.setProjectPath(projectPath)
+        // The file- and ref-scoped diff commands (getFileDiff, getCommitDiff,
+        // getRefDiff) read the GLOBAL currentProjectPath, which only the top
+        // bar's refresh() ever set. For a project picked through a panel it
+        // stayed null, so every diff tab opened on "No changes to show" while
+        // the same panel listed the changes correctly. Seed it from the window
+        // that is asking; null is never the better answer.
+        if (currentProjectPath != projectPath) {
+            currentProjectPath = projectPath
+        }
         windowGitState.setLoading(true)
 
         try {
@@ -1194,7 +1450,14 @@ actual object GitService {
             val projectPath = windowGitState.projectPath.value ?: return@withContext emptyList()
 
             try {
-                val result = runGitCommand(projectPath, "status", "--porcelain=v1")
+                // --untracked-files=all, not git's default: the default
+                // collapses an untracked directory into one `?? dir/` entry, so
+                // a source-control view has a row it cannot expand, stage
+                // individually, or show a diff for. Listing the files is what
+                // every editor's SCM view does. .gitignore still applies, so an
+                // ignored build/ or node_modules/ contributes nothing.
+                val result =
+                    runGitCommand(projectPath, "status", "--porcelain=v1", "--untracked-files=all")
                 if (result.exitCode != 0) {
                     return@withContext emptyList()
                 }
@@ -1240,6 +1503,282 @@ actual object GitService {
             } catch (e: Exception) {
                 logger.warn(LogCategory.SYSTEM, "Error getting log for window", error = e)
                 emptyList()
+            }
+        }
+
+    // ===== Window-scoped remote + ref-scoped log (boss-plugin-api 1.0.87) =====
+
+    /**
+     * A ref safe to hand to `git log` as a positional argument.
+     *
+     * The graph's branch picker feeds this from a list git itself produced, but
+     * the value reaches here through the plugin API, so it is validated at the
+     * boundary rather than trusted: anything starting with `-` would be read as
+     * an OPTION (`--upload-pack=…` and friends), and whitespace or control
+     * characters are not part of any refname git will accept anyway.
+     *
+     * Pure and internal so [ai.rever.boss.git] tests can pin it - a check like
+     * this is exactly the kind that rots silently.
+     */
+    internal fun isSafeRefName(ref: String): Boolean {
+        if (ref.isBlank()) return false
+        if (ref.startsWith("-")) return false
+        if (ref.length > MAX_REF_LENGTH) return false
+        return ref.none { it.isWhitespace() || it.code < 0x20 || it == '\u007F' }
+    }
+
+    private const val MAX_REF_LENGTH = 255
+
+    /**
+     * A git command that talks to a REMOTE: bounded, and never interactive.
+     *
+     * Two properties the ordinary [runGitCommand] does not have, and that
+     * fetch/pull/push are the first callers reachable from a panel to need.
+     *
+     * Non-interactive, because the child process gets no terminal: a
+     * credential prompt would have nothing to read from and would block on
+     * stdin forever. `GIT_TERMINAL_PROMPT=0` (and the empty askpass hooks)
+     * turn that into an immediate authentication failure the panel can show.
+     *
+     * Bounded, because the wait happens while holding [gitCommandLock] - the
+     * lock every git command in the app queues behind. A hung fetch would not
+     * only fail its own button, it would freeze the status poll, the diff
+     * tabs and the top bar for the rest of the session. A killed process
+     * releases the lock; a hung one never does.
+     */
+    private fun runRemoteGitCommand(
+        workingDir: String,
+        vararg args: String,
+    ): GitCommandResult =
+        gitCommandLock.withLock {
+            val process =
+                ProcessBuilder("git", *args)
+                    .directory(File(workingDir))
+                    .apply {
+                        environment().putAll(System.getenv())
+                        // Fail instead of prompting: there is no tty to prompt on.
+                        environment()["GIT_TERMINAL_PROMPT"] = "0"
+                        environment()["GIT_ASKPASS"] = ""
+                        environment()["SSH_ASKPASS"] = ""
+                    }.start()
+
+            // Both pipes are drained on their OWN threads, and the timeout wraps the
+            // whole interaction. Two bugs live in the obvious ordering:
+            //
+            // 1. `readText()` blocks until EOF, i.e. until the child exits. Reading
+            //    before `waitFor` made the timeout unreachable - it could only fire
+            //    after the process had already finished. A fetch hung on an
+            //    unreachable host blocked here forever, holding gitCommandLock, which
+            //    every git command in the app queues behind.
+            // 2. Draining stdout to EOF *before* touching stderr deadlocks whenever
+            //    the child fills the stderr pipe buffer (~64KB): it blocks writing
+            //    stderr, so it never closes stdout, so we never stop reading. git
+            //    fetch writes progress to stderr, so this needed no network fault.
+            runProcessBounded(process, REMOTE_GIT_TIMEOUT_SECONDS, args)
+        }
+
+    /** How long a remote git command may hold the git lock before it is killed. */
+    private const val REMOTE_GIT_TIMEOUT_SECONDS = 120L
+
+    /** How long to wait for a killed child's pipes to close before giving up on its output. */
+    private const val STREAM_DRAIN_TIMEOUT_SECONDS = 5L
+
+    /**
+     * Local git commands are bounded too - generously, since they touch no network,
+     * but a hook or a credential prompt can still wedge one, and it would be holding
+     * [gitCommandLock] while it did.
+     */
+    private const val LOCAL_GIT_TIMEOUT_SECONDS = 60L
+
+    /**
+     * Runs [process] to completion with both pipes drained concurrently and a wall
+     * clock bound, returning whatever output was produced either way.
+     *
+     * The ordering is the whole point, and both callers need it:
+     * - drain BEFORE waiting, on separate threads, or a child that fills one pipe
+     *   blocks writing it, never closes the other, and a sequential reader never
+     *   returns - a deadlock that needs no timeout to be unrecoverable;
+     * - wait with a bound, so a genuinely hung child ends;
+     * - kill, then wait for the kill, so the pipes actually close before joining
+     *   the readers - otherwise the join just moves the hang one line down.
+     */
+    private fun runProcessBounded(
+        process: Process,
+        timeoutSeconds: Long,
+        args: Array<out String>,
+    ): GitCommandResult {
+        val outBuf = StringBuilder()
+        val errBuf = StringBuilder()
+        val outReader = drainAsync(process.inputStream, outBuf)
+        val errReader = drainAsync(process.errorStream, errBuf)
+        val finished = process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)
+        if (!finished) {
+            process.destroyForcibly()
+            process.waitFor(STREAM_DRAIN_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)
+        }
+        outReader.join(STREAM_DRAIN_TIMEOUT_SECONDS * 1000)
+        errReader.join(STREAM_DRAIN_TIMEOUT_SECONDS * 1000)
+        val output = synchronized(outBuf) { outBuf.toString() }
+        val error = synchronized(errBuf) { errBuf.toString() }
+        if (finished) return GitCommandResult(output, error, process.exitValue())
+        logger.warn(
+            LogCategory.SYSTEM,
+            "git command timed out",
+            mapOf("args" to args.joinToString(" "), "timeoutSeconds" to timeoutSeconds.toString()),
+        )
+        return GitCommandResult(
+            output,
+            "Timed out after ${timeoutSeconds}s. Check the remote, your network, or your credentials.",
+            TIMEOUT_EXIT_CODE,
+        )
+    }
+
+    private const val TIMEOUT_EXIT_CODE = 124
+
+    /**
+     * Drains [stream] into [sink] on a daemon thread.
+     *
+     * A thread rather than a coroutine: this is called from inside
+     * `gitCommandLock.withLock`, which is a blocking lock held across the whole
+     * command, so suspending here would park a lock-holding thread. Daemon, so a
+     * reader still blocked on a wedged pipe cannot keep the JVM alive at shutdown.
+     */
+    private fun drainAsync(
+        stream: java.io.InputStream,
+        sink: StringBuilder,
+    ): Thread =
+        Thread {
+            runCatching {
+                BufferedReader(InputStreamReader(stream)).use { reader ->
+                    val buf = CharArray(DRAIN_BUFFER_CHARS)
+                    while (true) {
+                        val n = reader.read(buf)
+                        if (n < 0) break
+                        synchronized(sink) { sink.appendRange(buf, 0, n) }
+                    }
+                }
+            }
+        }.apply {
+            isDaemon = true
+            start()
+        }
+
+    private const val DRAIN_BUFFER_CHARS = 8192
+
+    actual suspend fun getLogForRef(
+        windowGitState: WindowGitState?,
+        ref: String?,
+        limit: Int,
+    ): List<GitCommitInfo> =
+        withContext(Dispatchers.IO) {
+            if (windowGitState == null) return@withContext emptyList()
+            val projectPath = windowGitState.projectPath.value ?: return@withContext emptyList()
+            val target = ref?.trim().orEmpty()
+            if (target.isNotEmpty() && !isSafeRefName(target)) {
+                logger.warn(LogCategory.SYSTEM, "Refusing an unsafe git ref for log", mapOf("ref" to target))
+                return@withContext emptyList()
+            }
+
+            try {
+                val format = "%H%x00%h%x00%an%x00%ae%x00%at%x00%s%x00%P%x00%D"
+                // `--` terminates the revision list, so a ref that survived the
+                // check above still cannot be read as a pathspec or an option.
+                val args =
+                    buildList {
+                        add("log")
+                        add("--format=$format")
+                        add("-n")
+                        add(limit.toString())
+                        if (target.isNotEmpty()) add(target)
+                        add("--")
+                    }
+                val result = runGitCommand(projectPath, *args.toTypedArray())
+                if (result.exitCode != 0) return@withContext emptyList()
+
+                // Deliberately NOT windowGitState.updateCommitLog(...): see the
+                // expect declaration - that flow is HEAD's history.
+                result.output
+                    .lines()
+                    .filter { it.isNotBlank() }
+                    .mapNotNull { parseCommitLine(it) }
+            } catch (e: Exception) {
+                logger.warn(LogCategory.SYSTEM, "Error getting log for ref", error = e)
+                emptyList()
+            }
+        }
+
+    actual suspend fun listBranchesForWindow(windowGitState: WindowGitState?): List<GitBranchInfo> =
+        withContext(Dispatchers.IO) {
+            val projectPath = windowGitState?.projectPath?.value ?: return@withContext emptyList()
+            if (!isGitRepo(projectPath)) return@withContext emptyList()
+            getLocalBranchList(projectPath) + getRemoteBranchList(projectPath)
+        }
+
+    actual suspend fun fetchForWindow(
+        windowGitState: WindowGitState?,
+        prune: Boolean,
+    ): GitOperationResult =
+        withContext(Dispatchers.IO) {
+            val projectPath =
+                windowGitState?.projectPath?.value
+                    ?: return@withContext GitError("No project selected")
+            val args = if (prune) arrayOf("fetch", "--all", "--prune") else arrayOf("fetch", "--all")
+            val result = runRemoteGitCommand(projectPath, *args)
+            if (result.exitCode == 0) {
+                // A fetch moves remote-tracking refs, which is exactly what the
+                // branch list and the graph decorations show.
+                refreshForWindow(projectPath, windowGitState)
+                // git fetch reports on stderr; an empty pair means "nothing new",
+                // which is a result worth saying out loud rather than silence.
+                val message =
+                    result.error
+                        .trim()
+                        .ifEmpty { result.output.trim() }
+                        .ifEmpty { "Already up to date" }
+                GitSuccess(message)
+            } else {
+                val errorMsg = result.error.ifEmpty { result.output }.trim()
+                _lastError.value = errorMsg
+                GitError(errorMsg, result.exitCode)
+            }
+        }
+
+    actual suspend fun pullForWindow(windowGitState: WindowGitState?): GitOperationResult =
+        withContext(Dispatchers.IO) {
+            val projectPath =
+                windowGitState?.projectPath?.value
+                    ?: return@withContext GitError("No project selected")
+            val result = runRemoteGitCommand(projectPath, "pull")
+            if (result.exitCode == 0) {
+                refreshForWindow(projectPath, windowGitState)
+                getStatusForWindow(windowGitState)
+                getLogForWindow(windowGitState)
+                GitSuccess(result.output.trim().ifEmpty { "Pull completed successfully" })
+            } else {
+                val errorMsg = result.error.ifEmpty { result.output }.trim()
+                _lastError.value = errorMsg
+                GitError(errorMsg, result.exitCode)
+            }
+        }
+
+    actual suspend fun pushForWindow(windowGitState: WindowGitState?): GitOperationResult =
+        withContext(Dispatchers.IO) {
+            val projectPath =
+                windowGitState?.projectPath?.value
+                    ?: return@withContext GitError("No project selected")
+            // -u sets upstream on a branch that has none. No --force, ever.
+            val result = runRemoteGitCommand(projectPath, "push", "-u", "origin", "HEAD")
+            if (result.exitCode == 0) {
+                refreshForWindow(projectPath, windowGitState)
+                val message =
+                    result.output.trim().ifEmpty {
+                        result.error.trim().ifEmpty { "Push completed successfully" }
+                    }
+                GitSuccess(message)
+            } else {
+                val errorMsg = result.error.ifEmpty { result.output }.trim()
+                _lastError.value = errorMsg
+                GitError(errorMsg, result.exitCode)
             }
         }
 
@@ -1584,3 +2123,9 @@ actual object GitService {
         }
     }
 }
+
+/**
+ * Context lines requested for a diff that is read as a file rather than as a
+ * patch. Git clamps this to the file's length, so a small file costs nothing.
+ */
+private const val FULL_FILE_CONTEXT = 100_000

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -24,6 +24,9 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.IOException
 import java.io.InputStreamReader
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.withLock
 import ai.rever.boss.plugin.git.GitOperationResult.Error as GitError
 import ai.rever.boss.plugin.git.GitOperationResult.Success as GitSuccess
@@ -71,6 +74,15 @@ actual object GitService {
 
     private var currentProjectPath: String? = null
     private var refreshJob: Job? = null
+
+    // How many git commands are in flight OR waiting on [gitCommandLock], and
+    // the boolean view of it. The lock is process-wide, so a slow index-write
+    // (a commit waiting on gpg pinentry now holds it for up to ten minutes)
+    // freezes every git command in every window; before this the only evidence
+    // was a log line. The UI can say "a git command is running".
+    private val gitCommandDepth = AtomicInteger(0)
+    private val _gitCommandsRunning = MutableStateFlow(false)
+    actual val gitCommandsRunning: StateFlow<Boolean> = _gitCommandsRunning.asStateFlow()
 
     init {
         // Check if git is available on system startup
@@ -176,10 +188,11 @@ actual object GitService {
         branchName: String,
         checkout: Boolean,
         windowId: String?,
+        projectPathOverride: String?,
     ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             // Validated like every other ref-taking command. Host-UI-only today, but
@@ -215,10 +228,10 @@ actual object GitService {
             }
         }
 
-    actual suspend fun pull(): GitOperationResult =
+    actual suspend fun pull(projectPathOverride: String?): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             _isLoading.value = true
@@ -242,10 +255,10 @@ actual object GitService {
             }
         }
 
-    actual suspend fun push(): GitOperationResult =
+    actual suspend fun push(projectPathOverride: String?): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             _isLoading.value = true
@@ -269,9 +282,9 @@ actual object GitService {
             }
         }
 
-    actual suspend fun getCreatePRUrl(): String? =
+    actual suspend fun getCreatePRUrl(projectPathOverride: String?): String? =
         withContext(Dispatchers.IO) {
-            val projectPath = currentProjectPath ?: return@withContext null
+            val projectPath = projectPathOverride ?: currentProjectPath ?: return@withContext null
             val branch = _currentBranch.value ?: return@withContext null
 
             try {
@@ -309,10 +322,13 @@ actual object GitService {
             }
         }
 
-    actual suspend fun merge(branchName: String): GitOperationResult =
+    actual suspend fun merge(
+        branchName: String,
+        projectPathOverride: String?,
+    ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             // The last ref-taking verbs without the guard - which contradicted the
@@ -339,10 +355,13 @@ actual object GitService {
             }
         }
 
-    actual suspend fun rebase(branchName: String): GitOperationResult =
+    actual suspend fun rebase(
+        branchName: String,
+        projectPathOverride: String?,
+    ): GitOperationResult =
         withContext(Dispatchers.IO) {
             val projectPath =
-                currentProjectPath
+                projectPathOverride ?: currentProjectPath
                     ?: return@withContext GitError("No project selected")
 
             // See merge(): validated like every other ref-taking command.
@@ -385,9 +404,9 @@ actual object GitService {
 
     // ===== File Status & Staging Implementation =====
 
-    actual suspend fun getStatus(): List<GitFileStatus> =
+    actual suspend fun getStatus(projectPathOverride: String?): List<GitFileStatus> =
         withContext(Dispatchers.IO) {
-            val projectPath = currentProjectPath ?: return@withContext emptyList()
+            val projectPath = projectPathOverride ?: currentProjectPath ?: return@withContext emptyList()
 
             try {
                 // Use porcelain v1 format for stable parsing
@@ -542,7 +561,7 @@ actual object GitService {
 
             val result = runGitCommand(projectPath, "add", "--", filePath)
             if (result.exitCode == 0) {
-                getStatus() // Refresh global status
+                getStatus(projectPath) // Refresh the repo that was written
                 refreshWindowState(windowId) // Refresh window-specific status
                 GitSuccess("Staged '$filePath'")
             } else {
@@ -562,7 +581,7 @@ actual object GitService {
 
             val result = runGitCommand(projectPath, "add", "-A")
             if (result.exitCode == 0) {
-                getStatus() // Refresh global status
+                getStatus(projectPath) // Refresh the repo that was written
                 refreshWindowState(windowId) // Refresh window-specific status
                 GitSuccess("Staged all changes")
             } else {
@@ -589,7 +608,7 @@ actual object GitService {
             val paths = stagedPathsFor(projectPath, filePath)
             val result = runGitCommand(projectPath, "restore", "--staged", "--", *paths.toTypedArray())
             if (result.exitCode == 0) {
-                getStatus() // Refresh global status
+                getStatus(projectPath) // Refresh the repo that was written
                 refreshWindowState(windowId) // Refresh window-specific status
                 GitSuccess("Unstaged '$filePath'")
             } else {
@@ -990,8 +1009,11 @@ actual object GitService {
 
     // ===== Terminal Integration Implementation =====
 
-    actual suspend fun pullInTerminal(windowId: String) {
-        val projectPath = currentProjectPath ?: return
+    actual suspend fun pullInTerminal(
+        windowId: String,
+        projectPathOverride: String?,
+    ) {
+        val projectPath = projectPathOverride ?: currentProjectPath ?: return
         GitTerminalEventBus.openGitTerminal(
             command = "git pull",
             workingDirectory = projectPath,
@@ -1000,8 +1022,11 @@ actual object GitService {
         )
     }
 
-    actual suspend fun pushInTerminal(windowId: String) {
-        val projectPath = currentProjectPath ?: return
+    actual suspend fun pushInTerminal(
+        windowId: String,
+        projectPathOverride: String?,
+    ) {
+        val projectPath = projectPathOverride ?: currentProjectPath ?: return
         GitTerminalEventBus.openGitTerminal(
             command = "git push -u origin HEAD",
             workingDirectory = projectPath,
@@ -1013,8 +1038,9 @@ actual object GitService {
     actual suspend fun mergeInTerminal(
         windowId: String,
         branchName: String,
+        projectPathOverride: String?,
     ) {
-        val projectPath = currentProjectPath ?: return
+        val projectPath = projectPathOverride ?: currentProjectPath ?: return
         // The branch name lands in a SHELL command string, so this is shell
         // injection, not just option injection, if an unvalidated name ever
         // reaches it. [isSafeRefName] is argv-safety only - git refnames
@@ -1037,8 +1063,9 @@ actual object GitService {
     actual suspend fun rebaseInTerminal(
         windowId: String,
         branchName: String,
+        projectPathOverride: String?,
     ) {
-        val projectPath = currentProjectPath ?: return
+        val projectPath = projectPathOverride ?: currentProjectPath ?: return
         // See mergeInTerminal: the name lands in a shell command string, so
         // isSafeRefName (argv-safety) is not enough on its own - shell-quote it.
         if (!isSafeRefName(branchName)) {
@@ -1204,17 +1231,83 @@ actual object GitService {
      * partial diff that looks complete - files silently missing, a hunk cut mid-way -
      * which reads as "that's the whole change". No diff is a visible failure; a
      * plausible partial diff is a lie.
+     *
+     * "Too large to render" comes back as ONE [GitDiffData] whose [GitDiffData.rawUnified]
+     * is the explanation: the unified view renders that text as-is, so the user sees why
+     * the tab is empty instead of reading blank as "no changes" - the exact ambiguity
+     * the refusal exists to avoid.
      */
-    private fun parseDiffSafely(result: GitCommandResult): List<GitDiffData> {
+    internal fun parseDiffSafely(
+        result: GitCommandResult,
+        label: String,
+    ): List<GitDiffData> {
         if (result.truncated) {
-            logger.warn(LogCategory.SYSTEM, "diff output truncated at the size cap; showing no diff")
-            return emptyList()
+            val capMb = MAX_GIT_OUTPUT_CHARS / (1024 * 1024)
+            logger.warn(
+                LogCategory.SYSTEM,
+                "diff output exceeded the $capMb MB cap; reporting too large to render",
+                mapOf("label" to label),
+            )
+            return listOf(
+                GitDiffData(
+                    path = label,
+                    rawUnified =
+                        "This diff is too large to render (the git output exceeded the $capMb MB cap). " +
+                            "Narrow the diff to fewer files to see the change.",
+                ),
+            )
         }
         return runCatching { UnifiedDiffParser.parse(result.output) }
             .getOrElse {
                 logger.warn(LogCategory.SYSTEM, "diff parse failed; showing no diff", error = it)
                 emptyList()
             }
+    }
+
+    /**
+     * Runs a diff command at [FULL_FILE_CONTEXT], and when the stream blows the output
+     * cap retries once with a small context before falling back to the too-large marker.
+     *
+     * The full context is what makes a diff tab readable (you can read around a change);
+     * its cost is that one huge file, or a big commit, can exceed the cap at full
+     * context. The small-context retry still shows the changes themselves - less to
+     * read around, but not blank - and it is the last stop: if even `-U3` exceeds the
+     * cap, the marker from [parseDiffSafely] is the honest answer.
+     */
+    // Guard clauses per failure mode, each with its own log line; see the same call on
+    // replacementIsReady in RetiredPlugins.kt.
+    @Suppress("ReturnCount")
+    private fun runDiffWithTruncationFallback(
+        label: String,
+        command: (contextFlag: String) -> GitCommandResult,
+    ): List<GitDiffData> {
+        val full = command("-U$FULL_FILE_CONTEXT")
+        if (full.exitCode != 0) {
+            logger.debug(LogCategory.SYSTEM, "diff failed", mapOf("label" to label, "error" to full.error))
+            return emptyList()
+        }
+        // One retry at the small context when the full-context stream blew the output cap.
+        val effective =
+            if (full.truncated) {
+                logger.info(
+                    LogCategory.SYSTEM,
+                    "diff exceeded the output cap at full context; retrying with a small context",
+                    mapOf("label" to label),
+                )
+                val small = command("-U$SMALL_FILE_CONTEXT")
+                if (small.exitCode != 0) {
+                    logger.debug(
+                        LogCategory.SYSTEM,
+                        "diff retry failed",
+                        mapOf("label" to label, "error" to small.error),
+                    )
+                    return emptyList()
+                }
+                small
+            } else {
+                full
+            }
+        return parseDiffSafely(effective, label)
     }
 
     actual suspend fun getFileDiff(
@@ -1229,23 +1322,13 @@ actual object GitService {
             // as disconnected fragments and there is no way to read around a
             // change. `git diff` clamps the context to the file, so this costs
             // nothing extra on a small one.
-            val context = "-U$FULL_FILE_CONTEXT"
-            val args =
-                if (staged) {
-                    listOf("diff") + DIFF_SHAPE_FLAGS + listOf(context, "--cached", "--", filePath)
-                } else {
-                    listOf("diff") + DIFF_SHAPE_FLAGS + listOf(context, "--", filePath)
-                }
-            val result = runGitCommand(projectPath, *args.toTypedArray())
-            if (result.exitCode != 0) {
-                logger.debug(
-                    LogCategory.SYSTEM,
-                    "getFileDiff failed",
-                    mapOf("file" to filePath, "error" to result.error),
-                )
-                return@withContext emptyList()
+            runDiffWithTruncationFallback(filePath) { context ->
+                val diffArgs = (mutableListOf("diff") + DIFF_SHAPE_FLAGS).toMutableList()
+                diffArgs += context
+                if (staged) diffArgs += "--cached"
+                diffArgs += listOf("--", filePath)
+                runGitCommand(projectPath, *diffArgs.toTypedArray())
             }
-            parseDiffSafely(result)
         }
 
     actual suspend fun getCommitDiff(
@@ -1268,19 +1351,12 @@ actual object GitService {
             }
             // -U matches getFileDiff/getRefDiff: the diff tab is a file viewer, so a
             // commit-scope tab rendered 3-line fragments while the others showed whole files.
-            val args = (mutableListOf("show") + DIFF_SHAPE_FLAGS).toMutableList()
-            args += listOf("-U$FULL_FILE_CONTEXT", "--format=", "--find-renames", commitHash, "--")
-            if (filePath != null) args += filePath
-            val result = runGitCommand(projectPath, *args.toTypedArray())
-            if (result.exitCode != 0) {
-                logger.debug(
-                    LogCategory.SYSTEM,
-                    "getCommitDiff failed",
-                    mapOf("commit" to commitHash, "error" to result.error),
-                )
-                return@withContext emptyList()
+            runDiffWithTruncationFallback(filePath ?: commitHash.take(8)) { context ->
+                val diffArgs = (mutableListOf("show") + DIFF_SHAPE_FLAGS).toMutableList()
+                diffArgs += listOf(context, "--format=", "--find-renames", commitHash, "--")
+                if (filePath != null) diffArgs += filePath
+                runGitCommand(projectPath, *diffArgs.toTypedArray())
             }
-            parseDiffSafely(result)
         }
 
     actual suspend fun getRefDiff(
@@ -1301,19 +1377,13 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            val args = (mutableListOf("diff") + DIFF_SHAPE_FLAGS).toMutableList()
-            args += listOf("-U$FULL_FILE_CONTEXT", fromRef, toRef, "--")
-            if (filePath != null) args += filePath
-            val result = runGitCommand(projectPath, *args.toTypedArray())
-            if (result.exitCode != 0) {
-                logger.debug(
-                    LogCategory.SYSTEM,
-                    "getRefDiff failed",
-                    mapOf("from" to fromRef, "to" to toRef, "error" to result.error),
-                )
-                return@withContext emptyList()
+            val label = if (filePath != null) filePath else "$fromRef...$toRef"
+            runDiffWithTruncationFallback(label) { context ->
+                val diffArgs = (mutableListOf("diff") + DIFF_SHAPE_FLAGS).toMutableList()
+                diffArgs += listOf(context, fromRef, toRef, "--")
+                if (filePath != null) diffArgs += filePath
+                runGitCommand(projectPath, *diffArgs.toTypedArray())
             }
-            parseDiffSafely(result)
         }
 
     actual suspend fun getDiffFileNames(
@@ -1373,10 +1443,31 @@ actual object GitService {
             else -> null
         }
 
+    /**
+     * Counts the caller in [gitCommandDepth] for as long as it holds - or is
+     * queued for - [gitCommandLock], so [gitCommandsRunning] is true from the
+     * first command until the last one that queued behind it finishes.
+     */
+    private inline fun <T> withGitCommandSignal(crossinline block: () -> T): T {
+        val entering = gitCommandDepth.incrementAndGet() == 1
+        if (entering) _gitCommandsRunning.value = true
+        try {
+            return block()
+        } finally {
+            val remaining = gitCommandDepth.decrementAndGet()
+            if (remaining == 0) _gitCommandsRunning.value = false
+        }
+    }
+
     private fun runGitCommand(
         workingDir: String,
         vararg args: String,
-    ): GitCommandResult = gitCommandLock.withLock { runGitCommandLocked(workingDir, *args) }
+    ): GitCommandResult =
+        withGitCommandSignal {
+            gitCommandLock.withLock {
+                runGitCommandLocked(workingDir, *args)
+            }
+        }
 
     private fun runGitCommandLocked(
         workingDir: String,
@@ -1720,36 +1811,38 @@ actual object GitService {
         workingDir: String,
         vararg args: String,
     ): GitCommandResult =
-        gitCommandLock.withLock {
-            val process =
-                ProcessBuilder("git", *args)
-                    .directory(File(workingDir))
-                    .apply {
-                        environment().putAll(System.getenv())
-                        // Fail instead of prompting: there is no tty to prompt on.
-                        environment()["GIT_TERMINAL_PROMPT"] = "0"
-                        environment()["GIT_ASKPASS"] = ""
-                        environment()["SSH_ASKPASS"] = ""
-                    }.start()
+        withGitCommandSignal {
+            gitCommandLock.withLock {
+                val process =
+                    ProcessBuilder("git", *args)
+                        .directory(File(workingDir))
+                        .apply {
+                            environment().putAll(System.getenv())
+                            // Fail instead of prompting: there is no tty to prompt on.
+                            environment()["GIT_TERMINAL_PROMPT"] = "0"
+                            environment()["GIT_ASKPASS"] = ""
+                            environment()["SSH_ASKPASS"] = ""
+                        }.start()
 
-            // The child gets no input at all: a helper that READS stdin would
-            // block on the live pipe (see runGitCommandLocked, where the
-            // discard() equivalent was needed for the same reason).
-            process.outputStream.close()
+                // The child gets no input at all: a helper that READS stdin would
+                // block on the live pipe (see runGitCommandLocked, where the
+                // discard() equivalent was needed for the same reason).
+                process.outputStream.close()
 
-            // Both pipes are drained on their OWN threads, and the timeout wraps the
-            // whole interaction. Two bugs live in the obvious ordering:
-            //
-            // 1. `readText()` blocks until EOF, i.e. until the child exits. Reading
-            //    before `waitFor` made the timeout unreachable - it could only fire
-            //    after the process had already finished. A fetch hung on an
-            //    unreachable host blocked here forever, holding gitCommandLock, which
-            //    every git command in the app queues behind.
-            // 2. Draining stdout to EOF *before* touching stderr deadlocks whenever
-            //    the child fills the stderr pipe buffer (~64KB): it blocks writing
-            //    stderr, so it never closes stdout, so we never stop reading. git
-            //    fetch writes progress to stderr, so this needed no network fault.
-            runProcessBounded(process, REMOTE_GIT_TIMEOUT_SECONDS, args, workingDir)
+                // Both pipes are drained on their OWN threads, and the timeout wraps the
+                // whole interaction. Two bugs live in the obvious ordering:
+                //
+                // 1. `readText()` blocks until EOF, i.e. until the child exits. Reading
+                //    before `waitFor` made the timeout unreachable - it could only fire
+                //    after the process had already finished. A fetch hung on an
+                //    unreachable host blocked here forever, holding gitCommandLock, which
+                //    every git command in the app queues behind.
+                // 2. Draining stdout to EOF *before* touching stderr deadlocks whenever
+                //    the child fills the stderr pipe buffer (~64KB): it blocks writing
+                //    stderr, so it never closes stdout, so we never stop reading. git
+                //    fetch writes progress to stderr, so this needed no network fault.
+                runProcessBounded(process, REMOTE_GIT_TIMEOUT_SECONDS, args, workingDir)
+            }
         }
 
     /** How long a remote git command may hold the git lock before it is killed. */
@@ -1793,18 +1886,22 @@ actual object GitService {
     ): GitCommandResult {
         val outBuf = StringBuilder()
         val errBuf = StringBuilder()
-        val outReader = drainAsync(process.inputStream, outBuf)
-        val errReader = drainAsync(process.errorStream, errBuf)
-        val finished = process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)
+        val outDropped = AtomicBoolean(false)
+        val outReader = drainAsync(process.inputStream, outBuf, outDropped)
+        val errReader = drainAsync(process.errorStream, errBuf, outDropped)
+        val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
         if (!finished) {
             process.destroyForcibly()
-            process.waitFor(STREAM_DRAIN_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)
+            process.waitFor(STREAM_DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         }
         outReader.join(STREAM_DRAIN_TIMEOUT_SECONDS * 1000)
         errReader.join(STREAM_DRAIN_TIMEOUT_SECONDS * 1000)
         val output = synchronized(outBuf) { outBuf.toString() }
         val error = synchronized(errBuf) { errBuf.toString() }
-        val truncated = output.length >= MAX_GIT_OUTPUT_CHARS
+        // Set where bytes were actually dropped (drainAsync), not inferred from
+        // the length: output of EXACTLY the cap is complete, and the consequence
+        // of a false positive is refusing the whole diff.
+        val truncated = outDropped.get()
         if (truncated) {
             logger.warn(
                 LogCategory.SYSTEM,
@@ -1878,6 +1975,7 @@ actual object GitService {
     private fun drainAsync(
         stream: java.io.InputStream,
         sink: StringBuilder,
+        dropped: java.util.concurrent.atomic.AtomicBoolean,
     ): Thread =
         Thread {
             runCatching {
@@ -1891,12 +1989,16 @@ actual object GitService {
                         // all - while holding gitCommandLock - risks an OOM that takes the
                         // app down. Past the cap we keep reading (so the child never blocks
                         // on a full pipe) but stop appending; the result is flagged
-                        // truncated and the diff getters refuse it rather than rendering
-                        // a partial diff that looks complete.
+                        // truncated (where the drop happens, not inferred from length)
+                        // and the diff getters refuse it rather than rendering a partial
+                        // diff that looks complete.
                         synchronized(sink) {
                             if (sink.length < MAX_GIT_OUTPUT_CHARS) {
                                 val room = MAX_GIT_OUTPUT_CHARS - sink.length
+                                if (n > room) dropped.set(true)
                                 sink.appendRange(buf, 0, minOf(n, room))
+                            } else {
+                                dropped.set(true)
                             }
                         }
                     }
@@ -2376,6 +2478,9 @@ actual object GitService {
  * patch. Git clamps this to the file's length, so a small file costs nothing.
  */
 private const val FULL_FILE_CONTEXT = 100_000
+
+// The retry context for a diff that blew the output cap at full context.
+private const val SMALL_FILE_CONTEXT = 3
 
 // Pins the diff header shape against a user's personal gitconfig. `diff.noprefix`,
 // `diff.mnemonicPrefix`, `color.diff=always` and `diff.external` all reshape the

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -1108,6 +1108,19 @@ actual object GitService {
 
     // ===== Diff =====
 
+    /**
+     * Parses diff output, degrading an unparseable stream to "no diff" rather than
+     * throwing. The parser's `require(path.isNotEmpty())` can still trip on a header
+     * shape DIFF_SHAPE_FLAGS does not cover; a blank diff tab is recoverable, an
+     * exception propagating into the calling plugin is not.
+     */
+    private fun parseDiffSafely(output: String): List<GitDiffData> =
+        runCatching { UnifiedDiffParser.parse(output) }
+            .getOrElse {
+                logger.warn(LogCategory.SYSTEM, "diff parse failed; showing no diff", error = it)
+                emptyList()
+            }
+
     actual suspend fun getFileDiff(
         filePath: String,
         staged: Boolean,
@@ -1123,9 +1136,9 @@ actual object GitService {
             val context = "-U$FULL_FILE_CONTEXT"
             val args =
                 if (staged) {
-                    listOf("diff", context, "--cached", "--", filePath)
+                    listOf("diff") + DIFF_SHAPE_FLAGS + listOf(context, "--cached", "--", filePath)
                 } else {
-                    listOf("diff", context, "--", filePath)
+                    listOf("diff") + DIFF_SHAPE_FLAGS + listOf(context, "--", filePath)
                 }
             val result = runGitCommand(projectPath, *args.toTypedArray())
             if (result.exitCode != 0) {
@@ -1136,7 +1149,7 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            UnifiedDiffParser.parse(result.output)
+            parseDiffSafely(result.output)
         }
 
     actual suspend fun getCommitDiff(
@@ -1159,7 +1172,8 @@ actual object GitService {
             }
             // -U matches getFileDiff/getRefDiff: the diff tab is a file viewer, so a
             // commit-scope tab rendered 3-line fragments while the others showed whole files.
-            val args = mutableListOf("show", "-U$FULL_FILE_CONTEXT", "--format=", "--find-renames", commitHash, "--")
+            val args = (mutableListOf("show") + DIFF_SHAPE_FLAGS).toMutableList()
+            args += listOf("-U$FULL_FILE_CONTEXT", "--format=", "--find-renames", commitHash, "--")
             if (filePath != null) args += filePath
             val result = runGitCommand(projectPath, *args.toTypedArray())
             if (result.exitCode != 0) {
@@ -1170,7 +1184,7 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            UnifiedDiffParser.parse(result.output)
+            parseDiffSafely(result.output)
         }
 
     actual suspend fun getRefDiff(
@@ -1191,7 +1205,8 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            val args = mutableListOf("diff", "-U$FULL_FILE_CONTEXT", fromRef, toRef, "--")
+            val args = (mutableListOf("diff") + DIFF_SHAPE_FLAGS).toMutableList()
+            args += listOf("-U$FULL_FILE_CONTEXT", fromRef, toRef, "--")
             if (filePath != null) args += filePath
             val result = runGitCommand(projectPath, *args.toTypedArray())
             if (result.exitCode != 0) {
@@ -1202,7 +1217,7 @@ actual object GitService {
                 )
                 return@withContext emptyList()
             }
-            UnifiedDiffParser.parse(result.output)
+            parseDiffSafely(result.output)
         }
 
     actual suspend fun getDiffFileNames(
@@ -1649,7 +1664,7 @@ actual object GitService {
     ): Thread =
         Thread {
             runCatching {
-                BufferedReader(InputStreamReader(stream)).use { reader ->
+                BufferedReader(InputStreamReader(stream, Charsets.UTF_8)).use { reader ->
                     val buf = CharArray(DRAIN_BUFFER_CHARS)
                     while (true) {
                         val n = reader.read(buf)
@@ -2129,3 +2144,10 @@ actual object GitService {
  * patch. Git clamps this to the file's length, so a small file costs nothing.
  */
 private const val FULL_FILE_CONTEXT = 100_000
+
+// Pins the diff header shape against a user's personal gitconfig. `diff.noprefix`,
+// `diff.mnemonicPrefix`, `color.diff=always` and `diff.external` all reshape the
+// `diff --git` header or inject colour, which UnifiedDiffParser cannot read - and a
+// header it cannot read throws out through the provider into the calling plugin.
+// These flags force `a/`..`b/` prefixes, no colour, and git's own diff, regardless.
+private val DIFF_SHAPE_FLAGS = listOf("--no-color", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/")

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.git
 
 import ai.rever.boss.components.events.GitTerminalEventBus
+import ai.rever.boss.components.workspaces.CommandProcessor
 import ai.rever.boss.plugin.api.GitDiffData
 import ai.rever.boss.plugin.api.GitFileStatusData
 import ai.rever.boss.plugin.api.GitFileStatusTypeData
@@ -18,6 +19,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.io.BufferedReader
@@ -27,7 +30,6 @@ import java.io.InputStreamReader
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.concurrent.withLock
 import ai.rever.boss.plugin.git.GitOperationResult.Error as GitError
 import ai.rever.boss.plugin.git.GitOperationResult.Success as GitSuccess
 
@@ -537,9 +539,13 @@ actual object GitService {
      * These are user-driven, IO-bound commands, so serializing them costs
      * nothing that matters.
      */
-    private val gitCommandLock =
-        java.util.concurrent.locks
-            .ReentrantLock()
+    // A coroutines Mutex, not a ReentrantLock: with the index-write bound at
+    // ten minutes, a commit parked on gpg pinentry used to hold a BLOCKING
+    // lock on Dispatchers.IO - parking its own IO thread plus one per queued
+    // caller (64 shared IO threads total, also serving file reads, the
+    // content-search walk, plugin IO). A suspend lock parks no thread; the
+    // waiters wait as coroutines.
+    private val gitCommandLock = kotlinx.coroutines.sync.Mutex()
 
     // The write verbs take a projectPathOverride for the same reason the diff reads
     // do: the global currentProjectPath belongs to whichever window ALIGNED last, and
@@ -624,15 +630,15 @@ actual object GitService {
      * it is just the path itself. Read from the current status rather than
      * remembered, so it stays correct when the index changed underneath.
      */
-    private fun stagedPathsFor(
+    private suspend fun stagedPathsFor(
         projectPath: String,
         filePath: String,
     ): List<String> {
         val status =
             runCatching {
                 runGitCommand(projectPath, "status", "--porcelain=v1", "--untracked-files=all")
-            }.getOrNull() ?: return listOf(filePath)
-        if (status.exitCode != 0) return listOf(filePath)
+            }.getOrNull()
+        if (status == null || status.exitCode != 0) return listOf(filePath)
         val entry =
             status.output
                 .lines()
@@ -658,7 +664,7 @@ actual object GitService {
 
             val result = runGitCommand(projectPath, "restore", "--staged", ".")
             if (result.exitCode == 0) {
-                getStatus() // Refresh global status
+                getStatus(projectPath) // Refresh the repo that was written
                 refreshWindowState(windowId) // Refresh window-specific status
                 GitSuccess("Unstaged all changes")
             } else {
@@ -682,7 +688,7 @@ actual object GitService {
 
             val result = runGitCommand(projectPath, "restore", "--", filePath)
             if (result.exitCode == 0) {
-                getStatus() // Refresh global status
+                getStatus(projectPath) // Refresh the repo that was written
                 refreshWindowState(windowId) // Refresh window-specific status
                 GitSuccess("Discarded changes to '$filePath'")
             } else {
@@ -715,8 +721,8 @@ actual object GitService {
 
                 val result = runGitCommand(projectPath, *args.toTypedArray())
                 if (result.exitCode == 0) {
-                    getStatus() // Refresh global status
-                    getLog() // Refresh global log
+                    getStatus(projectPath) // Refresh the repo that was written
+                    getLog(projectPathOverride = projectPath) // Same repo for the log
                     refreshWindowState(windowId) // Refresh window-specific status and log
                     val action = if (amend) "Amended commit" else "Created commit"
                     GitSuccess(action)
@@ -747,11 +753,30 @@ actual object GitService {
             }
         }
 
+    /**
+     * Whether [filePath] is untracked in [workingDir]: absent from the index
+     * entirely. A tracked file (even a clean or deleted one) has an index entry
+     * and goes through the ordinary diff; only a genuinely untracked file needs
+     * the /dev/null fallback in [getFileDiff].
+     */
+    private suspend fun isUntrackedFile(
+        workingDir: String,
+        filePath: String,
+    ): Boolean {
+        val r = runGitCommand(workingDir, "ls-files", "--", filePath)
+        return r.exitCode == 0 && r.output.isBlank()
+    }
+
     // ===== Commit Log Implementation =====
 
-    actual suspend fun getLog(limit: Int): List<GitCommitInfo> =
+    actual suspend fun getLog(
+        limit: Int,
+        projectPathOverride: String?,
+    ): List<GitCommitInfo> =
         withContext(Dispatchers.IO) {
-            val projectPath = currentProjectPath ?: return@withContext emptyList()
+            val projectPath =
+                projectPathOverride ?: currentProjectPath
+                    ?: return@withContext emptyList()
 
             try {
                 // Format: hash|shorthash|author|email|timestamp|subject|parents|refs
@@ -1053,7 +1078,7 @@ actual object GitService {
             return
         }
         GitTerminalEventBus.openGitTerminal(
-            command = "git merge ${shellQuote(branchName)}",
+            command = "git merge ${CommandProcessor.quotePath(branchName)}",
             workingDirectory = projectPath,
             operationName = "Merge",
             sourceWindowId = windowId,
@@ -1073,7 +1098,7 @@ actual object GitService {
             return
         }
         GitTerminalEventBus.openGitTerminal(
-            command = "git rebase ${shellQuote(branchName)}",
+            command = "git rebase ${CommandProcessor.quotePath(branchName)}",
             workingDirectory = projectPath,
             operationName = "Rebase",
             sourceWindowId = windowId,
@@ -1124,7 +1149,7 @@ actual object GitService {
             false
         }
 
-    private fun isGitRepo(projectPath: String): Boolean =
+    private suspend fun isGitRepo(projectPath: String): Boolean =
         try {
             val result = runGitCommand(projectPath, "rev-parse", "--is-inside-work-tree")
             result.exitCode == 0 && result.output.trim() == "true"
@@ -1137,7 +1162,7 @@ actual object GitService {
             false
         }
 
-    private fun getCurrentBranchName(projectPath: String): String? {
+    private suspend fun getCurrentBranchName(projectPath: String): String? {
         return try {
             // First try to get the branch name
             val result = runGitCommand(projectPath, "rev-parse", "--abbrev-ref", "HEAD")
@@ -1162,7 +1187,7 @@ actual object GitService {
         }
     }
 
-    private fun getLocalBranchList(projectPath: String): List<GitBranchInfo> {
+    private suspend fun getLocalBranchList(projectPath: String): List<GitBranchInfo> {
         return try {
             // Get branches with format that includes current marker
             val result =
@@ -1194,7 +1219,7 @@ actual object GitService {
         }
     }
 
-    private fun getRemoteBranchList(projectPath: String): List<GitBranchInfo> {
+    private suspend fun getRemoteBranchList(projectPath: String): List<GitBranchInfo> {
         return try {
             val result =
                 runGitCommand(
@@ -1277,9 +1302,9 @@ actual object GitService {
     // Guard clauses per failure mode, each with its own log line; see the same call on
     // replacementIsReady in RetiredPlugins.kt.
     @Suppress("ReturnCount")
-    private fun runDiffWithTruncationFallback(
+    private suspend fun runDiffWithTruncationFallback(
         label: String,
-        command: (contextFlag: String) -> GitCommandResult,
+        command: suspend (contextFlag: String) -> GitCommandResult,
     ): List<GitDiffData> {
         val full = command("-U$FULL_FILE_CONTEXT")
         if (full.exitCode != 0) {
@@ -1322,12 +1347,30 @@ actual object GitService {
             // as disconnected fragments and there is no way to read around a
             // change. `git diff` clamps the context to the file, so this costs
             // nothing extra on a small one.
+            //
+            // An untracked file has no index or HEAD entry, so `git diff
+            // [--cached]` emits nothing for it and the tab opens blank - which
+            // reads as "no changes", the exact ambiguity the too-large marker
+            // was added to close through the other door. Diff /dev/null against
+            // the file instead, so its rows arrive all-added like a staged new
+            // file's do.
+            val untracked = isUntrackedFile(projectPath, filePath)
             runDiffWithTruncationFallback(filePath) { context ->
                 val diffArgs = (mutableListOf("diff") + DIFF_SHAPE_FLAGS).toMutableList()
                 diffArgs += context
-                if (staged) diffArgs += "--cached"
-                diffArgs += listOf("--", filePath)
-                runGitCommand(projectPath, *diffArgs.toTypedArray())
+                if (untracked) {
+                    // `--no-index` diffs /dev/null against the file (exit 1 when
+                    // they differ, which they always do), because `git diff --
+                    // <path>` emits nothing for a path git does not track.
+                    diffArgs += listOf("--no-index", "--", "/dev/null", filePath)
+                    val r = runGitCommand(projectPath, *diffArgs.toTypedArray())
+                    // Normalise the exit: an ordinary diff exits 0 either way.
+                    GitCommandResult(r.output, r.error, if (r.exitCode == 1) 0 else r.exitCode, r.truncated)
+                } else {
+                    if (staged) diffArgs += "--cached"
+                    diffArgs += listOf("--", filePath)
+                    runGitCommand(projectPath, *diffArgs.toTypedArray())
+                }
             }
         }
 
@@ -1447,8 +1490,11 @@ actual object GitService {
      * Counts the caller in [gitCommandDepth] for as long as it holds - or is
      * queued for - [gitCommandLock], so [gitCommandsRunning] is true from the
      * first command until the last one that queued behind it finishes.
+     *
+     * A plain suspend function (not inline): the block must be able to wait on
+     * the coroutines Mutex, and an inline non-suspend wrapper would forbid it.
      */
-    private inline fun <T> withGitCommandSignal(crossinline block: () -> T): T {
+    private suspend fun <T> withGitCommandSignal(block: suspend () -> T): T {
         val entering = gitCommandDepth.incrementAndGet() == 1
         if (entering) _gitCommandsRunning.value = true
         try {
@@ -1459,7 +1505,7 @@ actual object GitService {
         }
     }
 
-    private fun runGitCommand(
+    private suspend fun runGitCommand(
         workingDir: String,
         vararg args: String,
     ): GitCommandResult =
@@ -1588,6 +1634,15 @@ actual object GitService {
      */
     actual fun alignCurrentProjectPath(projectPath: String) {
         currentProjectPath = projectPath
+    }
+
+    /**
+     * Test-only inverse of [alignCurrentProjectPath], which can only point, never
+     * unpoint: a test that steers the global at a temp repo must be able to put
+     * "no project" back, or a later test in the same JVM reads a deleted dir.
+     */
+    internal fun clearCurrentProjectPathForTests() {
+        currentProjectPath = null
     }
 
     actual suspend fun refreshForWindow(
@@ -1767,7 +1822,7 @@ actual object GitService {
      * This is ARGV safety, not shell safety: git refnames legally contain `;`,
      * `|`, `&`, `$` and backtick, all of which pass. The two callers that build
      * a shell command string ([mergeInTerminal], [rebaseInTerminal]) therefore
-     * also pass the value through [shellQuote].
+     * also pass the value through [CommandProcessor.quotePath].
      */
     internal fun isSafeRefName(ref: String): Boolean {
         if (ref.isBlank()) return false
@@ -1779,16 +1834,17 @@ actual object GitService {
     private const val MAX_REF_LENGTH = 255
 
     /**
-     * Single-quotes a value for interpolation into a POSIX shell command
-     * string: `'` becomes `'\''` (end the quote, a literal quote, resume it).
-     *
-     * [mergeInTerminal] and [rebaseInTerminal] build their command this way,
+     * [mergeInTerminal] and [rebaseInTerminal] build their command string through
+     * [CommandProcessor.quotePath] (the repo's one definition of shell quoting),
      * because `git check-ref-format --branch` accepts names carrying `;`, `|`,
      * `&`, `$` and backtick, and those are live shell metacharacters in a
-     * command string. The result is what a user sees typed in the terminal
-     * pane, so the quoting is deliberate and visible, not hidden.
+     * command string. The platform decision is the processor's: POSIX
+     * close-escape-reopen on Unix, doubled quotes under Windows PowerShell -
+     * a local POSIX-only copy of the quoting used to hand the PowerShell
+     * dance to the Windows terminal, and a branch name with an apostrophe
+     * produced a broken command there. The result is what a user sees typed
+     * in the terminal pane, so the quoting is deliberate and visible, not hidden.
      */
-    internal fun shellQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"
 
     /**
      * A git command that talks to a REMOTE: bounded, and never interactive.
@@ -1807,7 +1863,7 @@ actual object GitService {
      * tabs and the top bar for the rest of the session. A killed process
      * releases the lock; a hung one never does.
      */
-    private fun runRemoteGitCommand(
+    private suspend fun runRemoteGitCommand(
         workingDir: String,
         vararg args: String,
     ): GitCommandResult =
@@ -1883,12 +1939,17 @@ actual object GitService {
         timeoutSeconds: Long,
         args: Array<out String>,
         workingDir: String? = null,
+        capChars: Int = MAX_GIT_OUTPUT_CHARS,
     ): GitCommandResult {
         val outBuf = StringBuilder()
         val errBuf = StringBuilder()
         val outDropped = AtomicBoolean(false)
-        val outReader = drainAsync(process.inputStream, outBuf, outDropped)
-        val errReader = drainAsync(process.errorStream, errBuf, outDropped)
+        // stderr gets its own flag: [truncated] is what parseDiffSafely refuses on,
+        // and a stderr flood must not mark a perfectly complete stdout truncated
+        // (nothing reads a stderr "truncated" bit, so the drop is silent).
+        val errDropped = AtomicBoolean(false)
+        val outReader = drainAsync(process.inputStream, outBuf, outDropped, capChars)
+        val errReader = drainAsync(process.errorStream, errBuf, errDropped, capChars)
         val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
         if (!finished) {
             process.destroyForcibly()
@@ -1905,7 +1966,7 @@ actual object GitService {
         if (truncated) {
             logger.warn(
                 LogCategory.SYSTEM,
-                "git output truncated at the ${MAX_GIT_OUTPUT_CHARS}-char cap",
+                "git output truncated at the $capChars-char cap",
                 mapOf("args" to args.joinToString(" ")),
             )
         }
@@ -1917,8 +1978,15 @@ actual object GitService {
         )
         // A kill mid-index-write strands .git/index.lock, and git's later "File
         // exists" error never says a killed BOSS command left it. Probe and say so.
+        // Gated on the subcommand: a timed-out `git diff` / `log` / `status`
+        // never takes the lock, and telling the user to delete a lock some OTHER
+        // process legitimately holds is advice to break a live repo.
         val lockHint =
-            if (workingDir != null && staleIndexLockExists(workingDir)) {
+            if (
+                args.firstOrNull() in INDEX_WRITE_SUBCOMMANDS &&
+                workingDir != null &&
+                staleIndexLockExists(workingDir)
+            ) {
                 " The killed command may have left .git/index.lock behind; " +
                     "delete that file if git commands keep failing."
             } else {
@@ -1976,6 +2044,7 @@ actual object GitService {
         stream: java.io.InputStream,
         sink: StringBuilder,
         dropped: java.util.concurrent.atomic.AtomicBoolean,
+        capChars: Int = MAX_GIT_OUTPUT_CHARS,
     ): Thread =
         Thread {
             runCatching {
@@ -1992,9 +2061,17 @@ actual object GitService {
                         // truncated (where the drop happens, not inferred from length)
                         // and the diff getters refuse it rather than rendering a partial
                         // diff that looks complete.
+                        //
+                        // The cap is PER SINK, in CHARS: a UTF-8 byte stream decodes to at
+                        // most as many chars, so the real ceiling is 32M chars per stream
+                        // (~64 MB of UTF-8) and up to ~128 MB per command with both
+                        // streams at the cap - all held in memory while the
+                        // process-wide lock is held. The number is a bound, not a budget:
+                        // it must stay far below what the heap can absorb, and it is not
+                        // a byte count despite the "MB" framing below.
                         synchronized(sink) {
-                            if (sink.length < MAX_GIT_OUTPUT_CHARS) {
-                                val room = MAX_GIT_OUTPUT_CHARS - sink.length
+                            if (sink.length < capChars) {
+                                val room = capChars - sink.length
                                 if (n > room) dropped.set(true)
                                 sink.appendRange(buf, 0, minOf(n, room))
                             } else {
@@ -2011,7 +2088,13 @@ actual object GitService {
 
     private const val DRAIN_BUFFER_CHARS = 8192
 
-    /** ~32 MB ceiling on one git command's captured output; see drainAsync. */
+    /**
+     * Ceiling PER SINK, counted in CHARS, applied to stdout and stderr independently:
+     * a UTF-8 byte stream decodes to at most as many chars, so the real ceiling is
+     * ~64 MB per stream and ~128 MB per command with both at the cap, held in memory
+     * while the process-wide lock is held. It is a bound against OOM, not a byte
+     * budget; see [drainAsync].
+     */
     private const val MAX_GIT_OUTPUT_CHARS = 32 * 1024 * 1024
 
     actual suspend fun getLogForRef(

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -1669,7 +1669,18 @@ actual object GitService {
                     while (true) {
                         val n = reader.read(buf)
                         if (n < 0) break
-                        synchronized(sink) { sink.appendRange(buf, 0, n) }
+                        // Bounded memory. A whole-file-context (-U100000) diff of a large
+                        // multi-file commit can be hundreds of MB on stdout; buffering it
+                        // all - while holding gitCommandLock - risks an OOM that takes the
+                        // app down. Past the cap we keep reading (so the child never blocks
+                        // on a full pipe) but stop appending, and the truncated stream still
+                        // parses into a partial diff rather than crashing.
+                        synchronized(sink) {
+                            if (sink.length < MAX_GIT_OUTPUT_CHARS) {
+                                val room = MAX_GIT_OUTPUT_CHARS - sink.length
+                                sink.appendRange(buf, 0, minOf(n, room))
+                            }
+                        }
                     }
                 }
             }
@@ -1679,6 +1690,9 @@ actual object GitService {
         }
 
     private const val DRAIN_BUFFER_CHARS = 8192
+
+    /** ~32 MB ceiling on one git command's captured output; see drainAsync. */
+    private const val MAX_GIT_OUTPUT_CHARS = 32 * 1024 * 1024
 
     actual suspend fun getLogForRef(
         windowGitState: WindowGitState?,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/git/DesktopGitService.kt
@@ -450,13 +450,18 @@ actual object GitService {
         val workTreeChar = line[1]
         val pathPart = line.substring(3)
 
-        // Handle rename/copy with arrow
+        // Handle rename/copy with arrow. C-unquote afterwards (not before): with
+        // core.quotePath on (the default) git wraps a non-ASCII path in quotes
+        // and octal-escapes its bytes, and that token then fails to resolve
+        // when the panel hands it back as a pathspec (stage/discard/diffFile).
+        // Same decoder parseNameStatus uses - without it the two parsers
+        // report two spellings for the same file.
         val (path, originalPath) =
             if (pathPart.contains(" -> ")) {
                 val parts = pathPart.split(" -> ")
-                parts[1] to parts[0]
+                UnifiedDiffParser.cUnquote(parts[1]) to UnifiedDiffParser.cUnquote(parts[0])
             } else {
-                pathPart to null
+                UnifiedDiffParser.cUnquote(pathPart) to null
             }
 
         val indexStatus = parseStatusChar(indexChar)
@@ -1010,16 +1015,19 @@ actual object GitService {
         branchName: String,
     ) {
         val projectPath = currentProjectPath ?: return
-        // The branch name is interpolated into a SHELL command string, so this is
-        // shell injection, not just option injection, if an unvalidated name ever
-        // reaches it. Host-UI-only today, with names git itself produced - which is
-        // exactly the property createBranch's guard says not to lean on.
+        // The branch name lands in a SHELL command string, so this is shell
+        // injection, not just option injection, if an unvalidated name ever
+        // reaches it. [isSafeRefName] is argv-safety only - git refnames
+        // legally contain `;`, `|`, `&`, `$` and backtick - so the value is
+        // shell-quoted as well. Host-UI-only today, with names git itself
+        // produced - which is exactly the property createBranch's guard says
+        // not to lean on.
         if (!isSafeRefName(branchName)) {
             logger.warn(LogCategory.SYSTEM, "mergeInTerminal refused an unsafe ref", mapOf("branch" to branchName))
             return
         }
         GitTerminalEventBus.openGitTerminal(
-            command = "git merge $branchName",
+            command = "git merge ${shellQuote(branchName)}",
             workingDirectory = projectPath,
             operationName = "Merge",
             sourceWindowId = windowId,
@@ -1031,13 +1039,14 @@ actual object GitService {
         branchName: String,
     ) {
         val projectPath = currentProjectPath ?: return
-        // See mergeInTerminal: the name lands in a shell command string.
+        // See mergeInTerminal: the name lands in a shell command string, so
+        // isSafeRefName (argv-safety) is not enough on its own - shell-quote it.
         if (!isSafeRefName(branchName)) {
             logger.warn(LogCategory.SYSTEM, "rebaseInTerminal refused an unsafe ref", mapOf("branch" to branchName))
             return
         }
         GitTerminalEventBus.openGitTerminal(
-            command = "git rebase $branchName",
+            command = "git rebase ${shellQuote(branchName)}",
             workingDirectory = projectPath,
             operationName = "Rebase",
             sourceWindowId = windowId,
@@ -1049,6 +1058,9 @@ actual object GitService {
         vararg args: String,
     ) {
         val projectPath = currentProjectPath ?: return
+        // Every argument is interpolated VERBATIM into a shell command string.
+        // There is no in-repo caller today; a future one must pass literal,
+        // trusted arguments only - or shell-quote them, as mergeInTerminal does.
         val command = "git ${args.joinToString(" ")}"
         GitTerminalEventBus.openGitTerminal(
             command = command,
@@ -1376,7 +1388,22 @@ actual object GitService {
                 .apply {
                     // Inherit parent process environment for SSH/git credentials
                     environment().putAll(System.getenv())
+                    // Never interactive on this path: a credential prompt or a
+                    // hook reading stdin would otherwise hold gitCommandLock for
+                    // the whole bound. Same guard runRemoteGitCommand applies.
+                    environment()["GIT_TERMINAL_PROMPT"] = "0"
+                    // `--` blocks option injection, not pathspec magic: without
+                    // this a plugin-passed `:/` reaches `git restore -- :/`,
+                    // which discards the entire worktree. Every pathspec this
+                    // file passes is already a literal path, so nothing
+                    // regresses.
+                    environment()["GIT_LITERAL_PATHSPECS"] = "1"
                 }.start()
+        // The child gets no input at all: with a live stdin pipe, a hook or
+        // credential helper that READS it (rather than prompting on a tty)
+        // would block until the timeout while holding gitCommandLock.
+        // (Redirect.discard() does this, but is Java 9+ - this target is 8.)
+        process.outputStream.close()
 
         // Drained concurrently and bounded, for the reasons runRemoteGitCommand
         // spells out. This path had neither, and the index lock made that worse
@@ -1645,6 +1672,11 @@ actual object GitService {
      *
      * Pure and internal so [ai.rever.boss.git] tests can pin it - a check like
      * this is exactly the kind that rots silently.
+     *
+     * This is ARGV safety, not shell safety: git refnames legally contain `;`,
+     * `|`, `&`, `$` and backtick, all of which pass. The two callers that build
+     * a shell command string ([mergeInTerminal], [rebaseInTerminal]) therefore
+     * also pass the value through [shellQuote].
      */
     internal fun isSafeRefName(ref: String): Boolean {
         if (ref.isBlank()) return false
@@ -1654,6 +1686,18 @@ actual object GitService {
     }
 
     private const val MAX_REF_LENGTH = 255
+
+    /**
+     * Single-quotes a value for interpolation into a POSIX shell command
+     * string: `'` becomes `'\''` (end the quote, a literal quote, resume it).
+     *
+     * [mergeInTerminal] and [rebaseInTerminal] build their command this way,
+     * because `git check-ref-format --branch` accepts names carrying `;`, `|`,
+     * `&`, `$` and backtick, and those are live shell metacharacters in a
+     * command string. The result is what a user sees typed in the terminal
+     * pane, so the quoting is deliberate and visible, not hidden.
+     */
+    internal fun shellQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"
 
     /**
      * A git command that talks to a REMOTE: bounded, and never interactive.
@@ -1687,6 +1731,11 @@ actual object GitService {
                         environment()["GIT_ASKPASS"] = ""
                         environment()["SSH_ASKPASS"] = ""
                     }.start()
+
+            // The child gets no input at all: a helper that READS stdin would
+            // block on the live pipe (see runGitCommandLocked, where the
+            // discard() equivalent was needed for the same reason).
+            process.outputStream.close()
 
             // Both pipes are drained on their OWN threads, and the timeout wraps the
             // whole interaction. Two bugs live in the obvious ordering:

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/IpcEventBridgeImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/kernel/IpcEventBridgeImpl.kt
@@ -35,9 +35,14 @@ class IpcEventBridgeImpl(
                     .encodeToString(kotlinx.serialization.serializer(payload.javaClass), payload)
                     .toByteArray(Charsets.UTF_8)
             } catch (e: Exception) {
-                // Fall back to toString() if serialization fails — for debugging
-                logger.debug(
-                    "Payload serialization failed for event {} - forwarding toString(): {}",
+                // Fall back to toString() if serialization fails - for debugging.
+                // Warn, not debug: an un-serializable payload (a new event type
+                // that forgot its @Serializable, the case DiffOpenEvent still is)
+                // is otherwise a SILENT cross-process data loss - the subscriber
+                // gets a toString() blob it cannot decode, and at the default log
+                // level nobody ever sees that it happened.
+                logger.warn(
+                    "Payload serialization failed for event {} - forwarding toString() instead of structured JSON: {}",
                     eventType,
                     e.toString(),
                 )

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/RetiredPlugins.kt
@@ -59,6 +59,30 @@ object RetiredPlugins {
                 replacementDisplayName = "Secret Manager",
                 minReplacementVersion = "1.2.17",
             ),
+            // The codebase panel grew a FILES/SEARCH/GIT tab row (IDE batch P7):
+            // global search/replace, the changes accordion, the commit graph and
+            // the git_* / project_* MCP tools all live there now. 1.6.0 is the
+            // release that absorbed both - lower would sweep the old plugins
+            // while their tools and UI are still only in them.
+            //
+            // Search & Replace is deliberately NOT here. It was written during this
+            // batch and superseded by the SEARCH tab before it was ever published,
+            // so it is installed on no machine: a retirement entry would be a sweep
+            // that can never match, carrying a version floor nobody has to maintain.
+            Retirement(
+                pluginId = "ai.rever.boss.plugin.dynamic.gitstatus",
+                displayName = "Git Status (Dynamic)",
+                replacementId = "ai.rever.boss.plugin.dynamic.codebase",
+                replacementDisplayName = "Codebase (Dynamic)",
+                minReplacementVersion = "1.6.0",
+            ),
+            Retirement(
+                pluginId = "ai.rever.boss.plugin.dynamic.gitlog",
+                displayName = "Git Log (Dynamic)",
+                replacementId = "ai.rever.boss.plugin.dynamic.codebase",
+                replacementDisplayName = "Codebase (Dynamic)",
+                minReplacementVersion = "1.6.0",
+            ),
         )
 
     /**

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/HomeToolCatalogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/home/HomeToolCatalogTest.kt
@@ -61,6 +61,7 @@ class HomeToolCatalogTest {
         store: List<HomeStorePluginInput> = emptyList(),
         installed: Set<String> = emptySet(),
         access: RegistryAccess = admin,
+        versions: Map<String, String> = emptyMap(),
     ) = HomeToolCatalog
         .build(
             tabTypes = tabTypes,
@@ -68,6 +69,7 @@ class HomeToolCatalogTest {
             storeCatalogue = store,
             installedPluginIds = installed,
             access = access,
+            installedVersionOf = { versions[it] },
         )
         // The host actions are always present and tested separately below; every case here is
         // about what plugins and the store contribute.
@@ -197,18 +199,46 @@ class HomeToolCatalogTest {
     }
 
     @Test
-    fun `a retired plugin is never offered`() {
+    fun `a retired plugin is not offered once its replacement is new enough`() {
         // Unlisting the store row is a manual action outside CI, so until it happens the store
         // keeps returning the plugin - and a user could install it, have the startup sweep remove
         // it, and install it again indefinitely. The filter is what makes the retirement hold
-        // regardless of what the store says.
-        val tools = build(store = RetiredPluginIds.ALL.map { storeRow(it) })
+        // regardless of what the store says - and only once the sweep itself would be able to
+        // act (the replacement at its absorbing release or newer).
+        val versions =
+            RetiredPluginIds
+                .ALL
+                .associate { it.replacementId to it.minReplacementVersion }
+        val tools = build(store = RetiredPluginIds.ALL_IDS.map { storeRow(it) }, versions = versions)
 
         assertTrue(
             tools.isEmpty(),
             "a retired plugin reached a tile: installing it only gets it swept away at the " +
                 "next launch",
         )
+    }
+
+    @Test
+    fun `a retired plugin is still offered while its replacement predates the floor`() {
+        // The floor is the sweep's own: between this host release and the replacement's
+        // absorbing release a fresh install has only the retired plugin, so hiding it
+        // unconditionally would leave the machine with no panel at all. An OLD replacement
+        // (installed but below the floor) must therefore NOT hide the retired one.
+        val oldVersion = "0.0.1"
+        val tools =
+            build(
+                store = RetiredPluginIds.ALL_IDS.map { storeRow(it) },
+                versions = RetiredPluginIds.ALL.associate { it.replacementId to oldVersion },
+            )
+        assertEquals(
+            RetiredPluginIds.ALL_IDS.size,
+            tools.size,
+            "the retired plugin was hidden while the sweep is floored out: a fresh install would have no panel",
+        )
+        // ... and a missing replacement is the same answer - offered, because the sweep cannot
+        // act either.
+        val noneInstalled = build(store = RetiredPluginIds.ALL_IDS.map { storeRow(it) })
+        assertEquals(RetiredPluginIds.ALL_IDS.size, noneInstalled.size)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/TabTypePluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/plugin/TabTypePluginsTest.kt
@@ -2,6 +2,8 @@ package ai.rever.boss.components.plugin
 
 import ai.rever.boss.plugin.api.TabTypeId
 import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
+import ai.rever.boss.plugin.tab.composer.ComposerTabType
+import ai.rever.boss.plugin.tab.diff.DiffTabType
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabType
@@ -21,6 +23,10 @@ class TabTypePluginsTest {
         // offered for it and the tab is dropped silently again.
         assertEquals(TabTypePlugins.FLUCK_BROWSER, TabTypePlugins.pluginFor(FluckTabType.typeId))
         assertEquals(TabTypePlugins.EDITOR_TAB, TabTypePlugins.pluginFor(CodeEditorTabType.typeId))
+        // diff and composer are editor-tab's too, and the host opens both - without
+        // them a diff-open with editor-tab absent hangs 15s and silently drops.
+        assertEquals(TabTypePlugins.EDITOR_TAB, TabTypePlugins.pluginFor(DiffTabType.typeId))
+        assertEquals(TabTypePlugins.EDITOR_TAB, TabTypePlugins.pluginFor(ComposerTabType.typeId))
         assertEquals(TabTypePlugins.TERMINAL_TAB, TabTypePlugins.pluginFor(TerminalTabType.typeId))
         assertEquals(TabTypePlugins.JUPYTER_NOTEBOOK, TabTypePlugins.pluginFor(JupyterTabInfo.TYPE_ID))
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/DiffTabMatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/DiffTabMatchTest.kt
@@ -1,0 +1,83 @@
+package ai.rever.boss.components.window_panel
+
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The diff-tab reuse semantics, pinned without a UI: [diffTabMatches] is the
+ * predicate `findPanelWithDiffTab` runs over the tab list, and a wrong answer
+ * either duplicates a tab the user can see or - worse - focuses a DIFFERENT
+ * view than the one asked for (a staged diff is not a working-tree diff).
+ */
+class DiffTabMatchTest {
+    @Test
+    fun `a working-tree file diff matches its own scope`() {
+        val tab = DiffTabInfo.create(filePath = "a/b.kt")
+        assertTrue(diffTabMatches(tab, "a/b.kt", staged = false, fromRef = null, toRef = null))
+    }
+
+    @Test
+    fun `the same file spelled differently matches`() {
+        val tab = DiffTabInfo.create(filePath = "a/b.kt")
+        assertTrue(diffTabMatches(tab, "a//b.kt", staged = false, fromRef = null, toRef = null))
+    }
+
+    @Test
+    fun `a staged diff is a different view from a working-tree diff`() {
+        val workingTree = DiffTabInfo.create(filePath = "a/b.kt", staged = false)
+        val staged = DiffTabInfo.create(filePath = "a/b.kt", staged = true)
+
+        assertFalse(diffTabMatches(workingTree, "a/b.kt", staged = true, fromRef = null, toRef = null))
+        assertFalse(diffTabMatches(staged, "a/b.kt", staged = false, fromRef = null, toRef = null))
+        assertTrue(diffTabMatches(staged, "a/b.kt", staged = true, fromRef = null, toRef = null))
+    }
+
+    @Test
+    fun `a commit diff restricted to a file is not the file diff`() {
+        val commit = DiffTabInfo.create(filePath = "a/b.kt", fromRef = "abc123")
+        val fileDiff = DiffTabInfo.create(filePath = "a/b.kt")
+
+        assertFalse(diffTabMatches(fileDiff, "a/b.kt", staged = false, fromRef = "abc123", toRef = null))
+        assertFalse(diffTabMatches(commit, "a/b.kt", staged = false, fromRef = null, toRef = null))
+        assertTrue(diffTabMatches(commit, "a/b.kt", staged = false, fromRef = "abc123", toRef = null))
+    }
+
+    @Test
+    fun `a ref-range diff matches only its exact refs`() {
+        val range = DiffTabInfo.create(filePath = "", fromRef = "a1", toRef = "b2")
+
+        assertFalse(diffTabMatches(range, "", staged = false, fromRef = "a1", toRef = null))
+        assertFalse(diffTabMatches(range, "", staged = false, fromRef = "a1", toRef = "c3"))
+        assertTrue(diffTabMatches(range, "", staged = false, fromRef = "a1", toRef = "b2"))
+    }
+
+    @Test
+    fun `a blank query path with no refs never matches`() {
+        // normalize("") is "", so without the blank guard a blank, refless
+        // query would focus the first diff tab whose filePath is also blank
+        // - whatever its actual scope.
+        val fileDiff = DiffTabInfo.create(filePath = "")
+
+        assertFalse(diffTabMatches(fileDiff, "", staged = false, fromRef = null, toRef = null))
+        assertFalse(diffTabMatches(fileDiff, "   ", staged = false, fromRef = null, toRef = null))
+    }
+
+    @Test
+    fun `a blank path with refs is the range-diff scope and matches its own tab`() {
+        // A commit/range diff of the whole tree carries a blank filePath - that
+        // scope must still reuse its tab, or every second click opens a
+        // duplicate.
+        val range = DiffTabInfo.create(filePath = "", fromRef = "a1", toRef = "b2")
+        assertTrue(diffTabMatches(range, "", staged = false, fromRef = "a1", toRef = "b2"))
+        assertFalse(diffTabMatches(range, "", staged = false, fromRef = "a1", toRef = null))
+    }
+
+    @Test
+    fun `different files never match`() {
+        val tab = DiffTabInfo.create(filePath = "a/b.kt")
+        assertFalse(diffTabMatches(tab, "a/c.kt", staged = false, fromRef = null, toRef = null))
+        assertFalse(diffTabMatches(tab, "other/b.kt", staged = false, fromRef = null, toRef = null))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabPathsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabPathsTest.kt
@@ -1,0 +1,78 @@
+package ai.rever.boss.components.window_panel
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Path comparison for tab reuse.
+ *
+ * Clicking a file that is already open must focus that tab. It opened a second
+ * one instead because the check was raw string equality and the two callers
+ * spell the same path differently.
+ */
+class TabPathsTest {
+    @Test
+    fun `a doubled separator compares equal to a single one`(
+        @TempDir dir: File,
+    ) {
+        val file = File(dir, "a.kt").also { it.writeText("x") }
+        // What the git provider produced from a project path ending in "/".
+        assertEquals(
+            TabPaths.normalize(file.absolutePath),
+            TabPaths.normalize("${dir.absolutePath}//a.kt"),
+        )
+    }
+
+    @Test
+    fun `a dot segment resolves to the same file`(
+        @TempDir dir: File,
+    ) {
+        File(dir, "sub").mkdirs()
+        val file = File(dir, "sub/a.kt").also { it.writeText("x") }
+        assertEquals(
+            TabPaths.normalize(file.absolutePath),
+            TabPaths.normalize("${dir.absolutePath}/sub/./a.kt"),
+        )
+        assertEquals(
+            TabPaths.normalize(file.absolutePath),
+            TabPaths.normalize("${dir.absolutePath}/sub/../sub/a.kt"),
+        )
+    }
+
+    @Test
+    fun `a trailing separator does not change the identity`(
+        @TempDir dir: File,
+    ) {
+        assertEquals(TabPaths.normalize(dir.absolutePath), TabPaths.normalize("${dir.absolutePath}/"))
+    }
+
+    @Test
+    fun `different files stay different`(
+        @TempDir dir: File,
+    ) {
+        File(dir, "a.kt").writeText("x")
+        File(dir, "b.kt").writeText("y")
+        assertNotEquals(
+            TabPaths.normalize("${dir.absolutePath}/a.kt"),
+            TabPaths.normalize("${dir.absolutePath}/b.kt"),
+        )
+    }
+
+    @Test
+    fun `an unresolvable path still compares consistently with itself`() {
+        // The file need not exist - a tab can outlive its file.
+        assertEquals(
+            TabPaths.normalize("/nope/does/not/exist.kt"),
+            TabPaths.normalize("/nope/does//not/exist.kt"),
+        )
+    }
+
+    @Test
+    fun `a blank path is blank, not the working directory`() {
+        assertEquals("", TabPaths.normalize(""))
+        assertEquals("", TabPaths.normalize("   "))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabPathsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabPathsTest.kt
@@ -75,4 +75,24 @@ class TabPathsTest {
         assertEquals("", TabPaths.normalize(""))
         assertEquals("", TabPaths.normalize("   "))
     }
+
+    @Test
+    fun `a backslash is a filename character on POSIX, not a separator`() {
+        // Translating it unconditionally turned `a\bak.kt` into `a/bak.kt`, which can
+        // canonicalise onto a DIFFERENT real file and focus the wrong tab.
+        if (File.separatorChar == '\\') return // on Windows the translation is correct
+        assertNotEquals(
+            TabPaths.normalize("/x/a\\bak.kt"),
+            TabPaths.normalize("/x/a/bak.kt"),
+        )
+    }
+
+    @Test
+    fun `lexical cleanup keeps a UNC host prefix while collapsing inner separators`() {
+        // //server/share must not flatten to /server/share - two tabs on different
+        // servers would compare equal. Exercised directly: on POSIX normalize() only
+        // reaches the lexical path when canonicalPath throws.
+        assertEquals("//server/share/x", TabPaths.lexicalClean("//server/share//x"))
+        assertNotEquals(TabPaths.lexicalClean("//server/share"), TabPaths.lexicalClean("/server/share"))
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabPathsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/window_panel/TabPathsTest.kt
@@ -95,4 +95,21 @@ class TabPathsTest {
         assertEquals("//server/share/x", TabPaths.lexicalClean("//server/share//x"))
         assertNotEquals(TabPaths.lexicalClean("//server/share"), TabPaths.lexicalClean("/server/share"))
     }
+
+    @Test
+    fun `on the windows branch a backslash is a separator and a UNC path keeps its host`() {
+        // The separator is passed explicitly: on the Linux/macOS runners the
+        // default ('/') makes this branch unreachable.
+        assertEquals("/server/share/x", TabPaths.lexicalClean("\\server/share/x", '\\'))
+        assertEquals("//server/share/x", TabPaths.lexicalClean("\\\\server\\share\\x", '\\'))
+        assertNotEquals(
+            TabPaths.lexicalClean("\\\\server\\share", '\\'),
+            TabPaths.lexicalClean("\\server\\share", '\\'),
+        )
+    }
+
+    @Test
+    fun `on the posix branch a backslash stays a filename character`() {
+        assertEquals("/x/a\\bak.kt", TabPaths.lexicalClean("/x/a\\bak.kt", '/'))
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplierRestoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceApplierRestoreTest.kt
@@ -1,0 +1,133 @@
+package ai.rever.boss.components.workspaces
+
+import ai.rever.boss.components.plugin.TabUpdateRegistry
+import ai.rever.boss.components.window_panel.SplitViewState
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabRegistry
+import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
+import ai.rever.boss.plugin.tab.composer.ComposerTabInfo
+import ai.rever.boss.plugin.tab.composer.ComposerTabType
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
+import ai.rever.boss.plugin.tab.diff.DiffTabType
+import ai.rever.boss.plugin.workspace.TabConfig
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the RESTORE side of the layout round trip: [createTabFromWorkspaceConfig]
+ * over a saved [TabConfig] tree.
+ *
+ * [WorkspaceExtractorTest] covers the extract side; this test exists because
+ * the two sides are separate decisions and used to disagree. A blank diff
+ * path used to restore as a diff tab that can never show anything, while the
+ * composer branch refused a blank session id and the extractor refused to
+ * persist a blank path - three answers to "no scope". All three must agree
+ * on "no scope, no tab".
+ */
+class WorkspaceApplierRestoreTest {
+    private val tabRegistry =
+        TabRegistry().apply {
+            listOf(CodeEditorTabType, DiffTabType, ComposerTabType).forEach { type ->
+                registerTabType(type) { _, _ -> throw UnsupportedOperationException("not used by restore") }
+            }
+        }
+
+    @AfterTest
+    fun tearDown() {
+        TabUpdateRegistry.clear()
+    }
+
+    private fun restore(tabConfig: TabConfig): TabInfo? =
+        createTabFromWorkspaceConfig(
+            tabConfig = tabConfig,
+            resolvedProjectPath = "/tmp/proj",
+            splitViewState = SplitViewState(tabRegistry, windowId = "restore-test"),
+        )
+
+    // ==================== diff tabs ====================
+
+    @Test
+    fun `a saved file diff restores as a working tree diff of that file`() {
+        val tab =
+            restore(
+                TabConfig(
+                    type = "diff",
+                    title = "main.kt",
+                    filePath = "src/main.kt",
+                ),
+            )
+
+        val diff = assertIs<DiffTabInfo>(tab)
+        assertEquals("src/main.kt", diff.filePath)
+        assertTrue(
+            !diff.staged,
+            "the extractor only persists working-tree diffs, so restore must not invent staged ones",
+        )
+        assertNull(diff.fromRef)
+        assertNull(diff.toRef)
+    }
+
+    @Test
+    fun `a blank diff path restores no tab`() {
+        // A corrupt or hand-edited layout: no scope, no tab. Agreeing with the
+        // composer branch (blank session id) and the extractor (refuses to
+        // persist a blank path) is the contract this test exists for.
+        val tab =
+            restore(
+                TabConfig(
+                    type = "diff",
+                    title = "Diff",
+                    filePath = "",
+                ),
+            )
+        assertNull(tab, "a diff tab with no scope can never show anything; it must not be restored")
+    }
+
+    @Test
+    fun `a null diff path restores no tab`() {
+        val tab = restore(TabConfig(type = "diff", title = "Diff"))
+        assertNull(tab)
+    }
+
+    // ==================== composer tabs ====================
+
+    @Test
+    fun `a saved composer tab restores with its session id`() {
+        val tab =
+            restore(
+                TabConfig(
+                    type = "composer",
+                    title = "Composer",
+                    filePath = "session-abc123",
+                ),
+            )
+
+        val composer = assertIs<ComposerTabInfo>(tab)
+        assertEquals("session-abc123", composer.sessionId)
+    }
+
+    @Test
+    fun `a blank composer session id restores no tab`() {
+        // The branch the diff one used to disagree with; the round trip only
+        // holds if both sides drop the scopeless tab.
+        val tab =
+            restore(
+                TabConfig(
+                    type = "composer",
+                    title = "Composer",
+                    filePath = "",
+                ),
+            )
+        assertNull(tab, "a composer tab with no session id cannot reload a session")
+    }
+
+    @Test
+    fun `an unknown tab type restores nothing rather than crashing the layout`() {
+        val tab = restore(TabConfig(type = "mystery", title = "?"))
+        assertNull(tab)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractorTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/workspaces/WorkspaceExtractorTest.kt
@@ -14,6 +14,10 @@ import ai.rever.boss.plugin.api.TabTypeId
 import ai.rever.boss.plugin.api.TabTypeInfo
 import ai.rever.boss.plugin.tab.codeeditor.CodeEditorTabType
 import ai.rever.boss.plugin.tab.codeeditor.EditorTabInfo
+import ai.rever.boss.plugin.tab.composer.ComposerTabInfo
+import ai.rever.boss.plugin.tab.composer.ComposerTabType
+import ai.rever.boss.plugin.tab.diff.DiffTabInfo
+import ai.rever.boss.plugin.tab.diff.DiffTabType
 import ai.rever.boss.plugin.tab.fluck.FluckTabType
 import ai.rever.boss.plugin.tab.jupyter.JupyterTabInfo
 import ai.rever.boss.plugin.tab.terminal.TerminalTabInfo
@@ -82,10 +86,18 @@ class WorkspaceExtractorTest {
 
     private val tabRegistry =
         TabRegistry().apply {
-            listOf(TerminalTabType, CodeEditorTabType, FluckTabType, JupyterStubType, CustomTabType, PanelHostTabType)
-                .forEach { type ->
-                    registerTabType(type) { config, ctx -> StubTabComponent(ctx, config, type) }
-                }
+            listOf(
+                TerminalTabType,
+                CodeEditorTabType,
+                FluckTabType,
+                JupyterStubType,
+                CustomTabType,
+                PanelHostTabType,
+                DiffTabType,
+                ComposerTabType,
+            ).forEach { type ->
+                registerTabType(type) { config, ctx -> StubTabComponent(ctx, config, type) }
+            }
         }
 
     private fun newSplitViewState() = SplitViewState(tabRegistry, windowId = "test-window")
@@ -275,6 +287,39 @@ class WorkspaceExtractorTest {
 
         val layout = assertIs<SinglePanel>(extract(state).layout)
         assertEquals(listOf("terminal" to "Term", "editor" to "App.kt"), layout.panel.tabs.map { it.type to it.title })
+    }
+
+    /**
+     * A diff scope the saved form cannot rebuild must be DROPPED, not persisted:
+     * `TabConfig` has no field for refs or for `staged`, so restoring any of these
+     * as an unstaged working-tree diff of the same path would keep the tab position
+     * and title while silently changing the content. Dropping the tab is honest.
+     */
+    @Test
+    fun `only a plain working-tree file diff persists among diff scopes`() {
+        val state = newSplitViewState()
+        val component = state.getPanel("main")!!.tabsComponent
+        component.addTab(DiffTabInfo.create(filePath = "a/b.kt"))
+        component.addTab(DiffTabInfo.create(filePath = "a/b.kt", staged = true))
+        component.addTab(DiffTabInfo.create(filePath = "", fromRef = "abc123"))
+        component.addTab(DiffTabInfo.create(filePath = "a/b.kt", fromRef = "a1", toRef = "b2"))
+        component.addTab(DiffTabInfo.create(filePath = "c/d.kt", staged = true))
+
+        val layout = assertIs<SinglePanel>(extract(state).layout)
+        assertEquals(listOf("diff" to "a/b.kt"), layout.panel.tabs.map { it.type to it.filePath })
+    }
+
+    @Test
+    fun `composer tabs persist their session id, blank sessions are dropped`() {
+        val state = newSplitViewState()
+        val component = state.getPanel("main")!!.tabsComponent
+        component.addTab(ComposerTabInfo.create("sess-1"))
+        component.addTab(ComposerTabInfo.create(""))
+
+        val layout = assertIs<SinglePanel>(extract(state).layout)
+        // The blank-session tab must not persist: the restore side refuses to
+        // rebuild one, so saving it would store a tab that can never come back.
+        assertEquals(listOf("composer" to "sess-1"), layout.panel.tabs.map { it.type to it.filePath })
     }
 
     // ==================== workspace metadata ====================

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
@@ -1,5 +1,6 @@
 package ai.rever.boss.git
 
+import ai.rever.boss.components.workspaces.CommandProcessor
 import ai.rever.boss.plugin.api.GitOperationResultData
 import ai.rever.boss.window.WindowGitState
 import kotlinx.coroutines.test.runTest
@@ -442,7 +443,7 @@ class GitDataProviderImplTest {
             assertTrue(GitService.isSafeRefName(name), "expected $name to pass the argv guard")
             if (!java.io.File("/bin/sh").exists()) continue // POSIX-shell round trip only
             val process =
-                ProcessBuilder("/bin/sh", "-c", "printf '%s' ${GitService.shellQuote(name)}")
+                ProcessBuilder("/bin/sh", "-c", "printf '%s' ${CommandProcessor.quotePath(name)}")
                     .redirectErrorStream(true)
                     .start()
             val out = process.inputStream.bufferedReader().readText()

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
@@ -119,7 +119,7 @@ class GitDataProviderImplTest {
         }
 
     @Test
-    fun refreshStatusDoesNotReProbeAKnownNonRepository() =
+    fun refreshStatusReProbesAKnownNonRepositoryUntilItBecomesOne() =
         runTest {
             val plain =
                 java.nio.file.Files
@@ -132,15 +132,22 @@ class GitDataProviderImplTest {
             assertFalse(state.isGitRepository.value)
             assertEquals(plain.absolutePath, state.projectPath.value)
 
-            // Turning the directory into a repository after the first probe is
-            // how we tell a skip from a re-run: refreshForWindow would see the
-            // new checkout and flip the flag. A status poll must not.
+            // A cached "not a repository" is not the same fact as a cached
+            // "is a repository": `git init`, or a panel's first probe simply
+            // losing a startup race, can both turn a real non-repo into a
+            // real repo underneath an already-open panel. Unlike the
+            // confirmed-repo case (which cannot spontaneously reverse), this
+            // costs only the one `isGitRepo` command per re-check - the
+            // four-command branch bundle still never runs until it is true -
+            // so the panel's own Refresh (or the next status poll) must pick
+            // it up rather than being stuck showing "not a Git repository"
+            // for the rest of the session.
             ProcessBuilder("git", "init", "-q", plain.absolutePath).start().waitFor()
             provider.refreshStatus()
 
-            assertFalse(
+            assertTrue(
                 state.isGitRepository.value,
-                "a known non-repository must not be re-probed on every status poll",
+                "a directory that became a repository must be re-probed and reported as one",
             )
             plain.deleteRecursively()
         }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
@@ -1,0 +1,431 @@
+package ai.rever.boss.git
+
+import ai.rever.boss.plugin.api.GitOperationResultData
+import ai.rever.boss.window.WindowGitState
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Window-scoped git reads short-circuit to empty when
+ * WindowGitState.projectPath is unset. The top bar was the only place that
+ * used to set it, so a project picked through a panel's own picker (the
+ * codebase panel) saw an empty git view forever. GitDataProviderImpl now
+ * bootstraps the path from the window's selected project; these tests pin
+ * that bootstrap.
+ */
+class GitDataProviderImplTest {
+    private val temp = File(System.getProperty("java.io.tmpdir"), "boss-git-provider-${hashCode()}")
+
+    @AfterTest
+    fun cleanup() {
+        temp.deleteRecursively()
+    }
+
+    private fun git(vararg args: String) {
+        val process = ProcessBuilder(listOf("git", "-C", temp.absolutePath) + args).start()
+        process.waitFor()
+        assertEquals(0, process.exitValue(), process.errorStream.bufferedReader().readText())
+    }
+
+    /** A real, dirty repository: one commit, then a work-tree change. */
+    private fun dirtyRepo(): File {
+        temp.mkdirs()
+        git("init", "-q")
+        git("config", "user.email", "test@boss.local")
+        git("config", "user.name", "Test")
+        File(temp, "f.txt").writeText("one\n")
+        git("add", "f.txt")
+        git("commit", "-q", "-m", "init")
+        File(temp, "f.txt").appendText("two\n")
+        return temp
+    }
+
+    @Test
+    fun refreshStatusBootstrapsMissingProjectPathFromWindowProject() =
+        runTest {
+            val repo = dirtyRepo()
+            val state = WindowGitState("test-window")
+            assertNull(state.projectPath.value)
+
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+            provider.refreshStatus()
+
+            assertEquals(repo.absolutePath, state.projectPath.value)
+            assertTrue(
+                state.fileStatus.value.isNotEmpty(),
+                "the status read must actually run for the bootstrapped path",
+            )
+        }
+
+    @Test
+    fun refreshStatusReportsARealCheckoutAsARepository() =
+        runTest {
+            val repo = dirtyRepo()
+            val state = WindowGitState("test-window")
+            assertFalse(state.isGitRepository.value)
+
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+            provider.refreshStatus()
+
+            // Only GitService.refreshForWindow writes these; nothing on the
+            // status/log path used to call it, so a panel gating its UI on
+            // isGitRepository showed "no repository" for a valid checkout.
+            assertTrue(state.isGitRepository.value, "a checkout with commits must report as a repository")
+            assertNotNull(state.currentBranch.value, "the branch name must be resolved too")
+            assertTrue(state.fileStatus.value.isNotEmpty(), "and the file status must still be read")
+        }
+
+    @Test
+    fun refreshStatusAlignsGitsProjectPathSoFileDiffsResolve() =
+        runTest {
+            val repo = dirtyRepo()
+            val state = WindowGitState("test-window")
+
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+            provider.refreshStatus()
+
+            // getFileDiff / getCommitDiff / getRefDiff read git's global project
+            // path, which only the top bar used to set. Left null, every diff tab
+            // opened on "No changes to show" while the panel listed the changes.
+            assertEquals(repo.absolutePath, GitService.getCurrentProjectPath())
+            assertTrue(
+                GitService.getFileDiff("f.txt", staged = false).isNotEmpty(),
+                "a dirty tracked file must produce a diff once the path resolves",
+            )
+        }
+
+    @Test
+    fun refreshStatusReportsANonRepositoryAsSuch() =
+        runTest {
+            val plain =
+                java.nio.file.Files
+                    .createTempDirectory("not-a-repo")
+                    .toFile()
+            val state = WindowGitState("test-window")
+
+            val provider = GitDataProviderImpl(state, { "test-window" }) { plain.absolutePath }
+            provider.refreshStatus()
+
+            assertFalse(state.isGitRepository.value)
+            plain.deleteRecursively()
+        }
+
+    @Test
+    fun refreshStatusDoesNotReProbeAKnownNonRepository() =
+        runTest {
+            val plain =
+                java.nio.file.Files
+                    .createTempDirectory("not-a-repo")
+                    .toFile()
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }) { plain.absolutePath }
+
+            provider.refreshStatus()
+            assertFalse(state.isGitRepository.value)
+            assertEquals(plain.absolutePath, state.projectPath.value)
+
+            // Turning the directory into a repository after the first probe is
+            // how we tell a skip from a re-run: refreshForWindow would see the
+            // new checkout and flip the flag. A status poll must not.
+            ProcessBuilder("git", "init", "-q", plain.absolutePath).start().waitFor()
+            provider.refreshStatus()
+
+            assertFalse(
+                state.isGitRepository.value,
+                "a known non-repository must not be re-probed on every status poll",
+            )
+            plain.deleteRecursively()
+        }
+
+    @Test
+    fun refreshStatusStillProbesWhenThePathWasSetWithoutARefresh() =
+        runTest {
+            val repo = dirtyRepo()
+            val state = WindowGitState("test-window")
+            // Same path as the selected project, written without refreshForWindow.
+            // Gating only on projectPath equality would skip the first probe and
+            // leave isGitRepository false for a real checkout.
+            state.setProjectPath(repo.absolutePath)
+            assertFalse(state.isGitRepository.value)
+
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+            provider.refreshStatus()
+
+            assertTrue(
+                state.isGitRepository.value,
+                "a path written without a probe is still unknown and must be probed",
+            )
+        }
+
+    @Test
+    fun refreshStatusFollowsTheSelectedProjectWhenItChanges() =
+        runTest {
+            val repo = dirtyRepo()
+            val state = WindowGitState("test-window")
+            // A window bootstrapped on something that is not a repository - e.g. a
+            // folder holding several sibling repos. Keeping that path once it was
+            // set left every git view reporting "no repository" after the user
+            // switched to a project that has one.
+            state.setProjectPath("/definitely/not/a/repo")
+
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+            provider.refreshStatus()
+
+            assertEquals(repo.absolutePath, state.projectPath.value)
+            assertTrue(
+                state.fileStatus.value.isNotEmpty(),
+                "the status read must run against the newly selected project",
+            )
+        }
+
+    @Test
+    fun refreshStatusKeepsAnExistingPathWhenNothingResolves() =
+        runTest {
+            dirtyRepo()
+            val state = WindowGitState("test-window")
+            state.setProjectPath("/some/path")
+
+            // A blank provider result means "not resolved yet", not "no project".
+            val provider = GitDataProviderImpl(state, { "test-window" }) { null }
+            provider.refreshStatus()
+
+            assertEquals("/some/path", state.projectPath.value)
+        }
+
+    @Test
+    fun refreshStatusWithNoResolvablePathStaysNull() =
+        runTest {
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }, { null })
+
+            provider.refreshStatus()
+
+            assertNull(state.projectPath.value)
+        }
+
+    // ===== boss-plugin-api 1.0.87: branches + ref-scoped graph =====
+
+    /** [dirtyRepo] plus a second branch with a commit of its own. */
+    private fun branchedRepo(): File {
+        val repo = dirtyRepo()
+        git("checkout", "-q", "-b", "side")
+        File(repo, "side.txt").writeText("side\n")
+        git("add", "side.txt")
+        git("commit", "-q", "-m", "side commit")
+        git("checkout", "-q", "-")
+        return repo
+    }
+
+    @Test
+    fun branchesListsEveryLocalBranchAndMarksTheCurrentOne() =
+        runTest {
+            val repo = branchedRepo()
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+
+            val branches = provider.branches()
+
+            // `%(HEAD)` emits a SPACE for a non-current branch, and the parser used
+            // to drop only the "*" - so every branch but the checked-out one came
+            // back as "side ", a name neither `git log` nor `git checkout` resolves.
+            assertTrue(branches.any { it.name == "side" }, "the side branch must be listed: $branches")
+            assertTrue(branches.none { it.name != it.name.trim() }, "no name carries the marker column: $branches")
+            assertEquals(
+                1,
+                branches.count { it.isCurrent },
+                "exactly one branch is checked out: $branches",
+            )
+            assertFalse(
+                branches.first { it.isCurrent }.name == "side",
+                "the repo was switched back off side before listing",
+            )
+        }
+
+    @Test
+    fun logGraphForAnotherBranchShowsThatBranchesTipNotHeads() =
+        runTest {
+            val repo = branchedRepo()
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+
+            val head = provider.logGraph(50)
+            val side = provider.logGraphFor("side", 50)
+
+            assertEquals("init", head.first().subject, "HEAD has only the initial commit")
+            assertEquals("side commit", side.first().subject, "side's tip is its own commit")
+            assertTrue(side.size > head.size, "side is one commit ahead: $side vs $head")
+        }
+
+    @Test
+    fun logGraphForDoesNotOverwriteTheWindowsHeadCommitLog() =
+        runTest {
+            val repo = branchedRepo()
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+
+            provider.logGraph(50)
+            val headLog = state.commitLog.value.map { it.subject }
+            provider.logGraphFor("side", 50)
+
+            // WindowGitState.commitLog is HEAD's history - the top bar and the
+            // git-log panel read it. Filling it with another branch's commits
+            // would silently mis-label them.
+            assertEquals(headLog, state.commitLog.value.map { it.subject })
+        }
+
+    @Test
+    fun logGraphForABlankRefFallsBackToHead() =
+        runTest {
+            val repo = branchedRepo()
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+
+            assertEquals(
+                provider.logGraph(50).map { it.hash },
+                provider.logGraphFor(null, 50).map { it.hash },
+            )
+        }
+
+    @Test
+    fun logGraphForRefusesRefsThatWouldReadAsGitOptions() =
+        runTest {
+            val repo = branchedRepo()
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }) { repo.absolutePath }
+
+            // The picker only ever feeds names git produced, but the value crosses
+            // the plugin API boundary, so it is validated rather than trusted.
+            assertTrue(provider.logGraphFor("--upload-pack=touch /tmp/pwn", 50).isEmpty())
+            assertTrue(provider.logGraphFor("-n1", 50).isEmpty())
+        }
+
+    // ===== boss-plugin-api 1.0.87: the remote verbs, against a real remote =====
+
+    /**
+     * [dirtyRepo] wired to a bare repository standing in for `origin`.
+     *
+     * A local bare repo is a real remote as far as git is concerned - the same
+     * refspec plumbing, the same fast-forward rules - and it exercises
+     * fetch/pull/push end to end without a network or credentials.
+     */
+    private fun repoWithRemote(): Pair<File, File> {
+        val repo = dirtyRepo()
+        val bare =
+            java.nio.file.Files
+                .createTempDirectory("boss-git-origin")
+                .toFile()
+        ProcessBuilder("git", "init", "-q", "--bare", bare.absolutePath).start().waitFor()
+        git("remote", "add", "origin", bare.absolutePath)
+        return repo to bare
+    }
+
+    private fun provider(repo: File): Pair<GitDataProviderImpl, WindowGitState> {
+        val state = WindowGitState("test-window")
+        return GitDataProviderImpl(state, { "test-window" }, { repo.absolutePath }) to state
+    }
+
+    @Test
+    fun pushPublishesTheCurrentBranchToTheRemote() =
+        runTest {
+            val (repo, bare) = repoWithRemote()
+            val (provider, _) = provider(repo)
+
+            val result = provider.push()
+
+            assertTrue(result is GitOperationResultData.Success, "push said: $result")
+            // The bare repo now has the commit - proof the push actually landed
+            // rather than the exit code merely being zero.
+            val branches =
+                ProcessBuilder("git", "-C", bare.absolutePath, "branch", "--format=%(refname:short)")
+                    .start()
+                    .inputStream
+                    .bufferedReader()
+                    .readText()
+            assertTrue(branches.isNotBlank(), "the remote has no branches after a successful push")
+            bare.deleteRecursively()
+        }
+
+    @Test
+    fun fetchThenPullBringsTheRemoteCommitDown() =
+        runTest {
+            val (repo, bare) = repoWithRemote()
+            val (provider, state) = provider(repo)
+            assertTrue(provider.push() is GitOperationResultData.Success)
+
+            // A second clone commits and pushes, so the first repo is genuinely behind.
+            val other =
+                java.nio.file.Files
+                    .createTempDirectory("boss-git-other")
+                    .toFile()
+
+            fun other(vararg args: String) {
+                ProcessBuilder(listOf("git", "-C", other.absolutePath) + args).start().waitFor()
+            }
+            ProcessBuilder("git", "clone", "-q", bare.absolutePath, other.absolutePath).start().waitFor()
+            other("config", "user.email", "other@boss.local")
+            other("config", "user.name", "Other")
+            File(other, "remote.txt").writeText("from the other clone\n")
+            other("add", "remote.txt")
+            other("commit", "-q", "-m", "remote commit")
+            other("push", "-q")
+
+            val fetched = provider.fetch()
+            assertTrue(fetched is GitOperationResultData.Success, "fetch said: $fetched")
+            // The fetch moved the remote-tracking ref, which is what the graph's
+            // decorations and the branch picker read.
+            assertTrue(
+                provider.branches().any { it.isRemote },
+                "no remote-tracking branch after a fetch: ${provider.branches()}",
+            )
+
+            val pulled = provider.pull()
+            assertTrue(pulled is GitOperationResultData.Success, "pull said: $pulled")
+            assertTrue(File(repo, "remote.txt").isFile, "pull did not bring the other clone's file down")
+            assertEquals(
+                "remote commit",
+                state.commitLog.value
+                    .firstOrNull()
+                    ?.subject,
+                "pull must leave the window's HEAD log current",
+            )
+
+            other.deleteRecursively()
+            bare.deleteRecursively()
+        }
+
+    @Test
+    fun theRemoteVerbsReportNoProjectRatherThanActingOnTheWrongOne() =
+        runTest {
+            // Window-scoped by construction: no window path means no repository to
+            // act on, never "whichever repo some other window refreshed last".
+            val state = WindowGitState("test-window")
+            val provider = GitDataProviderImpl(state, { "test-window" }, { null })
+
+            assertTrue(provider.fetch() is GitOperationResultData.Error)
+            assertTrue(provider.pull() is GitOperationResultData.Error)
+            assertTrue(provider.push() is GitOperationResultData.Error)
+        }
+
+    @Test
+    fun safeRefNameAcceptsRealRefsAndRejectsOptionsAndControlCharacters() {
+        assertTrue(GitService.isSafeRefName("main"))
+        assertTrue(GitService.isSafeRefName("feat/ide-tab-completion"))
+        assertTrue(GitService.isSafeRefName("origin/release-9.5"))
+        assertTrue(GitService.isSafeRefName("v1.0.90"))
+
+        assertFalse(GitService.isSafeRefName(""))
+        assertFalse(GitService.isSafeRefName("   "))
+        assertFalse(GitService.isSafeRefName("--upload-pack=sh"))
+        assertFalse(GitService.isSafeRefName("-n1"))
+        assertFalse(GitService.isSafeRefName("has space"))
+        assertFalse(GitService.isSafeRefName("has\nnewline"))
+        assertFalse(GitService.isSafeRefName("a".repeat(256)))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDataProviderImplTest.kt
@@ -428,4 +428,26 @@ class GitDataProviderImplTest {
         assertFalse(GitService.isSafeRefName("has\nnewline"))
         assertFalse(GitService.isSafeRefName("a".repeat(256)))
     }
+
+    @Test
+    fun shellMetacharactersPassTheArgvGuardSoTheTerminalVerbsQuoteThem() {
+        // All of these are names `git check-ref-format --branch` accepts
+        // (no whitespace, no leading dash, no control chars), so the argv
+        // guard passes them - which is exactly why mergeInTerminal /
+        // rebaseInTerminal cannot lean on it: in a shell command string
+        // they are live metacharacters. The quote round-trip pins the fix.
+        val names =
+            listOf("main;reboot", "x`id`", "y$(id)", "z&whoami", "a'b|sh")
+        for (name in names) {
+            assertTrue(GitService.isSafeRefName(name), "expected $name to pass the argv guard")
+            if (!java.io.File("/bin/sh").exists()) continue // POSIX-shell round trip only
+            val process =
+                ProcessBuilder("/bin/sh", "-c", "printf '%s' ${GitService.shellQuote(name)}")
+                    .redirectErrorStream(true)
+                    .start()
+            val out = process.inputStream.bufferedReader().readText()
+            assertTrue(process.waitFor() == 0, "shell rejected the quoting for $name")
+            assertEquals(name, out, "shell round trip for $name")
+        }
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDiffTruncationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitDiffTruncationTest.kt
@@ -1,0 +1,84 @@
+package ai.rever.boss.git
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The diff getters' refusal of a truncated stream, and the too-large marker
+ * that replaces the blank tab.
+ *
+ * A truncated `git diff` parses into a PARTIAL diff that looks complete -
+ * files silently missing, a hunk cut mid-way - which reads as "that's the
+ * whole change". The refusal is therefore a user-visible behaviour: the tab
+ * must say WHY it is empty, and a diff that still exceeds the cap after the
+ * small-context retry must not be indistinguishable from "no changes".
+ */
+class GitDiffTruncationTest {
+    @Test
+    fun `a truncated diff is refused with an in-band explanation, not a blank`() {
+        val result =
+            GitService.GitCommandResult(
+                output = "diff --git a/huge.txt b/huge.txt\n--- a/huge.txt\n+++ b/huge.txt\n",
+                error = "",
+                exitCode = 0,
+                truncated = true,
+            )
+
+        val diffs = GitService.parseDiffSafely(result, "huge.txt")
+
+        // One marker entry, not an empty list: an empty list is "no changes",
+        // which is the lie the refusal exists to prevent.
+        assertEquals(1, diffs.size, "a truncated stream must not parse into a partial diff")
+        val marker = diffs.single()
+        assertEquals("huge.txt", marker.path)
+        assertTrue(
+            marker.rawUnified.contains("too large to render"),
+            "the marker must carry the user-visible reason: ${marker.rawUnified}",
+        )
+        assertTrue(marker.hunks.isEmpty(), "a refusal must not carry parsed hunks")
+    }
+
+    @Test
+    fun `an untruncated diff parses normally`() {
+        val result =
+            GitService.GitCommandResult(
+                output =
+                    "diff --git a/x.txt b/x.txt\n" +
+                        "index 1111111..2222222 100644\n" +
+                        "--- a/x.txt\n" +
+                        "+++ b/x.txt\n" +
+                        "@@ -1 +1 @@\n" +
+                        "-old\n" +
+                        "+new\n",
+                error = "",
+                exitCode = 0,
+                truncated = false,
+            )
+
+        val diffs = GitService.parseDiffSafely(result, "x.txt")
+
+        assertEquals(1, diffs.size)
+        assertEquals("x.txt", diffs.single().path)
+        assertTrue(diffs.single().rawUnified.isNotEmpty())
+        assertFalse(diffs.single().rawUnified.contains("too large to render"))
+    }
+
+    @Test
+    fun `a parse failure on an untruncated stream degrades to no diff, not an exception`() {
+        // A header shape the shape flags do not cover reaches the parser's
+        // require(path.isNotEmpty()); the caller sees "no diff", never a throw.
+        val result =
+            GitService.GitCommandResult(
+                output = "not a diff at all",
+                error = "",
+                exitCode = 0,
+                truncated = false,
+            )
+
+        val diffs = GitService.parseDiffSafely(result, "odd.txt")
+
+        assertTrue(diffs.isEmpty())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitPorcelainParserTest.kt
@@ -257,13 +257,34 @@ class GitPorcelainParserTest {
     }
 
     @Test
-    fun `C-quoted path is passed through verbatim, not unquoted`() {
-        // Documents the parser's contract: with core.quotePath=true git C-quotes
-        // special paths (e.g. "a\"b.txt"); the parser performs no unquoting and the
-        // quoted token flows through as the path (display-level limitation).
+    fun `C-quoted path with an escaped quote is unquoted`() {
+        // core.quotePath=true (the default) C-quotes a path with a literal quote
+        // in it: "a\"b.txt". The parser undoes that, because the panel hands
+        // the result straight back to git as a pathspec - the quoted token would
+        // match no file.
         val status = GitService.parseStatusLine("M  \"a\\\"b.txt\"")
         assertNotNull(status)
-        assertEquals("\"a\\\"b.txt\"", status.path)
+        assertEquals("a\"b.txt", status.path)
+    }
+
+    @Test
+    fun `C-quoted octal-escaped UTF-8 path round-trips to the real filename`() {
+        // The status -> stage/discard/diffFile round trip: git emits the octal
+        // byte form for é under core.quotePath, and the parsed path must come
+        // back as the file ACTUALLY is named, or the pathspec matches nothing.
+        // \303\251 is the two-byte UTF-8 encoding of é.
+        val status = GitService.parseStatusLine(" M \"docs/caf\\303\\251.txt\"")
+        assertNotNull(status)
+        assertEquals("docs/café.txt", status.path)
+    }
+
+    @Test
+    fun `C-quoted rename unquotes both sides`() {
+        val status = GitService.parseStatusLine("R  \"old/a\\303\\251.txt\" -> \"new/b\\303\\251.txt\"")
+        assertNotNull(status)
+        assertEquals("new/bé.txt", status.path)
+        assertEquals("old/aé.txt", status.originalPath)
+        assertEquals(GitFileStatusType.RENAMED, status.indexStatus)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProcessBoundedTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProcessBoundedTest.kt
@@ -1,0 +1,79 @@
+package ai.rever.boss.git
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The subprocess harness under every git command in the app.
+ *
+ * [GitService.runProcessBounded] exists to survive exactly two situations, and
+ * both once froze the whole app because the caller holds the process-wide
+ * gitCommandLock: a child that fills one pipe while the reader drains the other
+ * sequentially (deadlock, no timeout can help), and a child that never exits
+ * (the wait must be bounded and the kill must actually end it). Pinned with a
+ * real child process; skipped on Windows, where the shell used to fake the
+ * child does not exist.
+ */
+class GitProcessBoundedTest {
+    private fun onWindows() = System.getProperty("os.name").startsWith("Windows")
+
+    @Test
+    fun `a child flooding stderr past the pipe buffer cannot deadlock the drain`() {
+        if (onWindows()) return
+        // ~1.6 MB of stderr - far past the ~64KB pipe buffer that blocks the
+        // child once nothing drains it. A sequential read of stdout-to-EOF
+        // never returns here, because the child never exits.
+        val process =
+            ProcessBuilder(
+                "/bin/sh",
+                "-c",
+                "i=0; while [ \$i -lt 40000 ]; do " +
+                    "echo 0123456789012345678901234567890123456789 1>&2; i=\$((i+1)); done; echo done-out",
+            ).start()
+
+        val result = GitService.runProcessBounded(process, 60L, arrayOf("test-flood"))
+
+        assertEquals(0, result.exitCode, "child failed: ${result.error.take(200)}")
+        assertTrue("done-out" in result.output, "stdout was lost while stderr flooded")
+        assertTrue(result.error.length > 1_000_000, "stderr was not drained: ${result.error.length} chars")
+    }
+
+    @Test
+    fun `a hung child is killed at the bound instead of holding the lock forever`() {
+        if (onWindows()) return
+        val process = ProcessBuilder("/bin/sh", "-c", "sleep 60").start()
+        val startedAt = System.currentTimeMillis()
+
+        val result = GitService.runProcessBounded(process, 1L, arrayOf("test-hang"))
+
+        val elapsedMs = System.currentTimeMillis() - startedAt
+        assertEquals(124, result.exitCode, "a timeout must be reported as the timeout exit code")
+        assertTrue(result.error.startsWith("Timed out"), "error should say it timed out: ${result.error}")
+        // 1s bound + 5s drain grace, with slack for a loaded CI worker.
+        assertTrue(elapsedMs < 30_000, "the kill did not end the wait: ${elapsedMs}ms")
+        assertTrue(!process.isAlive, "the child must actually be dead")
+    }
+
+    @Test
+    fun `a timeout in a repo with a stranded index lock says so`(
+        @TempDir tmp: File,
+    ) {
+        if (onWindows()) return
+        // The reason index-writing commands get the long bound: a kill mid-write
+        // strands .git/index.lock and git's later "File exists" error never
+        // explains it. When the lock is there after a kill, the error must.
+        File(tmp, ".git").mkdirs()
+        File(tmp, ".git/index.lock").writeText("")
+        val process = ProcessBuilder("/bin/sh", "-c", "sleep 60").start()
+
+        val result = GitService.runProcessBounded(process, 1L, arrayOf("test-lock"), tmp.absolutePath)
+
+        assertTrue(
+            "index.lock" in result.error,
+            "the timeout error should mention the stranded lock: ${result.error}",
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProcessBoundedTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProcessBoundedTest.kt
@@ -58,7 +58,37 @@ class GitProcessBoundedTest {
     }
 
     @Test
-    fun `a timeout in a repo with a stranded index lock says so`(
+    fun `a stderr flood past the cap does not mark a complete stdout truncated`() {
+        if (onWindows()) return
+        // [truncated] is what parseDiffSafely refuses on, so the flag must mean
+        // "bytes were dropped from THIS stream". With one shared flag a stderr
+        // flood refused a perfectly complete diff as "too large to render".
+        // capChars=10_000 makes the overflow cheap to produce; the production
+        // call sites keep the 32M-char default.
+        val process =
+            ProcessBuilder(
+                "/bin/sh",
+                "-c",
+                "i=0; while [ \$i -lt 3000 ]; do " +
+                    "echo 0123456789012345678901234567890123456789 1>&2; i=\$((i+1)); done; echo done-out",
+            ).start()
+
+        val result = GitService.runProcessBounded(process, 60L, arrayOf("test-flood"), null, capChars = 10_000)
+
+        assertEquals(0, result.exitCode, "child failed: ${result.error.take(200)}")
+        assertTrue(result.output.trim() == "done-out", "the small stdout must arrive complete: '${result.output}'")
+        // errDropped has no field on the result (nothing reads it); the
+        // observable half of the wiring is that the stderr BUFFER keeps the
+        // first capChars - 3000 x 40 = 120k, well past the 10k cap.
+        assertTrue(result.error.length >= 10_000, "stderr was not drained: ${result.error.length} chars")
+        assertTrue(
+            !result.truncated,
+            "a stderr overflow must not set the stdout truncation flag",
+        )
+    }
+
+    @Test
+    fun `a timeout of an index-write in a repo with a stranded index lock says so`(
         @TempDir tmp: File,
     ) {
         if (onWindows()) return
@@ -69,11 +99,32 @@ class GitProcessBoundedTest {
         File(tmp, ".git/index.lock").writeText("")
         val process = ProcessBuilder("/bin/sh", "-c", "sleep 60").start()
 
-        val result = GitService.runProcessBounded(process, 1L, arrayOf("test-lock"), tmp.absolutePath)
+        // "commit" is in INDEX_WRITE_SUBCOMMANDS, the gate the hint sits behind.
+        val result = GitService.runProcessBounded(process, 1L, arrayOf("commit"), tmp.absolutePath)
 
         assertTrue(
             "index.lock" in result.error,
             "the timeout error should mention the stranded lock: ${result.error}",
+        )
+    }
+
+    @Test
+    fun `a timeout of a read-only command does not blame the index lock`(
+        @TempDir tmp: File,
+    ) {
+        if (onWindows()) return
+        // A lock that some OTHER process legitimately holds, with a command that
+        // never takes one: the old code told the user to delete it, which is
+        // advice to break a live repo. The hint must stay silent.
+        File(tmp, ".git").mkdirs()
+        File(tmp, ".git/index.lock").writeText("")
+        val process = ProcessBuilder("/bin/sh", "-c", "sleep 60").start()
+
+        val result = GitService.runProcessBounded(process, 1L, arrayOf("diff"), tmp.absolutePath)
+
+        assertTrue(
+            "index.lock" !in result.error,
+            "a non-index-write timeout must not advise deleting the lock: ${result.error}",
         )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProviderWritesToRepoTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProviderWritesToRepoTest.kt
@@ -251,6 +251,81 @@ class GitProviderWritesToRepoTest {
     }
 
     @Test
+    fun checkoutOfASlashedLocalBranchChecksOutThatBranchNotItsLastSegment(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        val base = git(dir, "rev-parse", "--abbrev-ref", "HEAD").trim()
+        git(dir, "branch", "feature/x")
+        // A branch named like the stripped segment makes the old DWIM SUCCEED on
+        // the wrong branch rather than fail loudly - the worst variant.
+        git(dir, "branch", "x")
+
+        val result = provider(dir).checkout("feature/x")
+
+        assertTrue(result is GitOperationResultData.Success, "checkout reported $result")
+        assertEquals(
+            "feature/x",
+            git(dir, "rev-parse", "--abbrev-ref", "HEAD").trim(),
+            "the slashed LOCAL branch name was mangled (base was $base)",
+        )
+    }
+
+    @Test
+    fun aRemoteStyleNameStillDwimsToItsLocalTrackingBranch(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        // Simulate a remote-tracking ref without a network: clone into a second
+        // worktree-free local clone whose origin is the first repo.
+        val cloneDir = File(tmp, "clone").apply { mkdirs() }
+        git(dir, "branch", "side")
+        git(cloneDir.parentFile, "clone", "-q", dir.absolutePath, cloneDir.absolutePath)
+        git(cloneDir, "config", "user.email", "t@example.com")
+        git(cloneDir, "config", "user.name", "Test")
+
+        val result = provider(cloneDir).checkout("origin/side")
+
+        assertTrue(result is GitOperationResultData.Success, "checkout reported $result")
+        assertEquals(
+            "side",
+            git(cloneDir, "rev-parse", "--abbrev-ref", "HEAD").trim(),
+            "origin/side should create and check out the local tracking branch",
+        )
+    }
+
+    @Test
+    fun aWriteHonoursItsProjectPathOverrideEvenWhenTheGlobalPointsAtAnotherRepo(
+        @TempDir tmpA: File,
+        @TempDir tmpB: File,
+    ) = runTest {
+        // The round-4 review scenario: window B's align lands between window A's
+        // align and A's command, so a global-resolved `git restore` runs in B's
+        // tree. The override travels with the call, so the interleaving cannot
+        // redirect it - pinned here by pointing the global at the WRONG repo.
+        val repoA = repo(tmpA)
+        val repoB = repo(tmpB)
+        File(repoA, "tracked.txt").writeText("A-dirty\n")
+        File(repoB, "tracked.txt").writeText("B-dirty\n")
+        GitService.alignCurrentProjectPath(repoB.absolutePath)
+
+        val result =
+            GitService.discardChanges(
+                "tracked.txt",
+                windowId = null,
+                projectPathOverride = repoA.absolutePath,
+            )
+
+        assertTrue(result is ai.rever.boss.plugin.git.GitOperationResult.Success, "discard reported $result")
+        assertEquals("one\n", File(repoA, "tracked.txt").readText(), "the override's repo was not restored")
+        assertEquals(
+            "B-dirty\n",
+            File(repoB, "tracked.txt").readText(),
+            "the discard leaked into the repo the GLOBAL pointed at",
+        )
+    }
+
+    @Test
     fun statusReportsUntrackedFilesIndividuallyNotAsADirectory(
         @TempDir tmp: File,
     ) = runTest {

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProviderWritesToRepoTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProviderWritesToRepoTest.kt
@@ -1,0 +1,272 @@
+package ai.rever.boss.git
+
+import ai.rever.boss.plugin.api.GitOperationResultData
+import ai.rever.boss.window.WindowGitState
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Every write the codebase panel's GIT tab can perform, checked against real
+ * `git` output rather than against the provider's own state.
+ *
+ * The panel drives `GitDataProvider`; if a button updates the UI but not the
+ * index, nothing in the provider's flows would reveal it. These tests shell
+ * out to git afterwards and read the porcelain status, so a UI-only mutation
+ * fails here.
+ */
+class GitProviderWritesToRepoTest {
+    private fun git(
+        dir: File,
+        vararg args: String,
+    ): String {
+        val p = ProcessBuilder(listOf("git", *args)).directory(dir).redirectErrorStream(true).start()
+        val out = p.inputStream.bufferedReader().readText()
+        p.waitFor()
+        return out
+    }
+
+    private fun repo(dir: File): File {
+        git(dir, "init", "-q")
+        git(dir, "config", "user.email", "t@example.com")
+        git(dir, "config", "user.name", "Test")
+        git(dir, "config", "commit.gpgsign", "false")
+        File(dir, "tracked.txt").writeText("one\n")
+        File(dir, "other.txt").writeText("a\n")
+        git(dir, "add", ".")
+        git(dir, "commit", "-q", "-m", "init")
+        return dir
+    }
+
+    private fun provider(dir: File): GitDataProviderImpl {
+        val state = WindowGitState("w")
+        return GitDataProviderImpl(state, { "w" }) { dir.absolutePath }
+    }
+
+    /** Porcelain status of one path, e.g. " M", "M ", "??", or "" when clean. */
+    private fun statusOf(
+        dir: File,
+        path: String,
+    ): String =
+        git(dir, "status", "--porcelain=v1", "--untracked-files=all")
+            .lines()
+            .firstOrNull { it.length > 3 && it.substring(3).trim() == path }
+            ?.take(2)
+            ?: ""
+
+    @Test
+    fun stageMovesTheChangeIntoTheRealIndex(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        assertEquals(" M", statusOf(dir, "tracked.txt"), "precondition: unstaged modification")
+
+        val result = provider(dir).stage("tracked.txt")
+
+        assertTrue(result is GitOperationResultData.Success, "stage reported $result")
+        assertEquals("M ", statusOf(dir, "tracked.txt"), "the index was not updated")
+    }
+
+    @Test
+    fun unstageTakesItBackOutOfTheRealIndex(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        git(dir, "add", "tracked.txt")
+        assertEquals("M ", statusOf(dir, "tracked.txt"))
+
+        provider(dir).unstage("tracked.txt")
+
+        assertEquals(" M", statusOf(dir, "tracked.txt"))
+    }
+
+    @Test
+    fun discardRestoresTheFileOnDisk(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        val file = File(dir, "tracked.txt")
+        file.writeText("two\n")
+
+        provider(dir).discardChanges("tracked.txt")
+
+        assertEquals("one\n", file.readText(), "the working tree was not restored")
+        assertEquals("", statusOf(dir, "tracked.txt"))
+    }
+
+    @Test
+    fun stageAllAndUnstageAllCoverEveryChange(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        File(dir, "other.txt").writeText("b\n")
+        val p = provider(dir)
+
+        p.stageAll()
+        assertEquals("M ", statusOf(dir, "tracked.txt"))
+        assertEquals("M ", statusOf(dir, "other.txt"))
+
+        p.unstageAll()
+        assertEquals(" M", statusOf(dir, "tracked.txt"))
+        assertEquals(" M", statusOf(dir, "other.txt"))
+    }
+
+    @Test
+    fun commitCreatesARealCommitContainingTheStagedChange(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        git(dir, "add", "tracked.txt")
+
+        val result = provider(dir).commit("panel commit")
+
+        assertTrue(result is GitOperationResultData.Success, "commit reported $result")
+        assertTrue(
+            git(dir, "log", "-1", "--pretty=%s").trim() == "panel commit",
+            "HEAD subject is ${git(dir, "log", "-1", "--pretty=%s").trim()}",
+        )
+        assertEquals("", statusOf(dir, "tracked.txt"), "the commit left the change uncommitted")
+    }
+
+    @Test
+    fun anUntrackedFileCanBeStaged(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "new.txt").writeText("fresh\n")
+        assertEquals("??", statusOf(dir, "new.txt"))
+
+        provider(dir).stage("new.txt")
+
+        assertEquals("A ", statusOf(dir, "new.txt"))
+    }
+
+    @Test
+    fun unstagingARenameRestoresBothSidesOfIt(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        git(dir, "mv", "tracked.txt", "renamed.txt")
+        // git reports this as one index entry: "R  tracked.txt -> renamed.txt"
+        assertTrue(
+            git(dir, "status", "--porcelain=v1").contains("tracked.txt -> renamed.txt"),
+            "precondition: a staged rename",
+        )
+
+        provider(dir).unstage("renamed.txt")
+
+        // Restoring only the new path leaves the deletion of the old one
+        // staged, which surfaced as the ORIGINAL file reappearing under
+        // STAGED after unstaging the renamed one.
+        val status = git(dir, "status", "--porcelain=v1", "--untracked-files=all")
+        assertTrue(
+            status.lines().none { it.startsWith("D ") },
+            "the deletion of the old path is still staged:\n$status",
+        )
+        assertTrue(
+            status.lines().any { it.trim().startsWith("??") && it.contains("renamed.txt") },
+            "the renamed file should be untracked after a full unstage:\n$status",
+        )
+    }
+
+    @Test
+    fun unstagingAPlainModificationStillTouchesOnlyThatPath(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        File(dir, "other.txt").writeText("b\n")
+        git(dir, "add", ".")
+
+        provider(dir).unstage("tracked.txt")
+
+        assertEquals(" M", statusOf(dir, "tracked.txt"))
+        assertEquals("M ", statusOf(dir, "other.txt"), "unstaging one file must not touch another")
+    }
+
+    @Test
+    fun stageAllIsGitAddDashA_soItAlsoStagesUntrackedFiles(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        File(dir, "brand-new.txt").writeText("new\n")
+
+        provider(dir).stageAll()
+
+        // Pinned because it is easy to assume otherwise: this is `git add -A`.
+        // The panel's CHANGES group therefore stages its own files one by one
+        // rather than calling this, so the button beside an UNTRACKED group
+        // does not quietly sweep that group in too.
+        assertEquals("M ", statusOf(dir, "tracked.txt"))
+        assertEquals("A ", statusOf(dir, "brand-new.txt"))
+    }
+
+    @Test
+    fun discardRestoresFromTheIndexAndLeavesUntrackedFilesAlone(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "tracked.txt").writeText("two\n")
+        val untracked = File(dir, "fresh.txt").also { it.writeText("x\n") }
+
+        val p = provider(dir)
+        p.discardChanges("tracked.txt")
+        p.discardChanges("fresh.txt")
+
+        assertEquals("one\n", File(dir, "tracked.txt").readText())
+        // `git restore` does not delete untracked files. VS Code offers a
+        // separate delete for those, which is why the panel does not put a
+        // discard action on an untracked row at all.
+        assertTrue(untracked.exists(), "discard must not silently delete an untracked file")
+    }
+
+    @Test
+    fun concurrentStagesAllLandRatherThanLosingToTheIndexLock(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        val names = (1..8).map { "f$it.txt" }
+        names.forEach { File(dir, it).writeText("x\n") }
+        val p = provider(dir)
+
+        // git holds .git/index.lock for a write and a second concurrent write
+        // FAILS rather than queueing, so firing one `git add` per file at once
+        // staged the first and silently dropped the rest.
+        kotlinx.coroutines.coroutineScope {
+            val jobs = names.map { name -> async { p.stage(name) } }
+            jobs.forEach { it.await() }
+        }
+
+        val missed = names.filter { statusOf(dir, it) != "A " }
+        assertTrue(missed.isEmpty(), "these never made it into the index: $missed")
+    }
+
+    @Test
+    fun statusReportsUntrackedFilesIndividuallyNotAsADirectory(
+        @TempDir tmp: File,
+    ) = runTest {
+        val dir = repo(tmp)
+        File(dir, "nested/deep").mkdirs()
+        File(dir, "nested/deep/a.txt").writeText("x\n")
+        File(dir, "nested/b.txt").writeText("y\n")
+        val state = WindowGitState("w")
+        val p = GitDataProviderImpl(state, { "w" }) { dir.absolutePath }
+
+        p.refreshStatus()
+
+        val paths = state.fileStatus.value.map { it.path }
+        // git's default collapses this to a single "nested/" row, which the
+        // panel cannot expand, stage individually, or diff.
+        assertTrue("nested/deep/a.txt" in paths, "untracked files not listed individually: $paths")
+        assertTrue("nested/b.txt" in paths, "untracked files not listed individually: $paths")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProviderWritesToRepoTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/GitProviderWritesToRepoTest.kt
@@ -1,6 +1,7 @@
 package ai.rever.boss.git
 
 import ai.rever.boss.plugin.api.GitOperationResultData
+import ai.rever.boss.plugin.git.GitOperationResult
 import ai.rever.boss.window.WindowGitState
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
@@ -35,6 +36,10 @@ class GitProviderWritesToRepoTest {
         git(dir, "config", "user.email", "t@example.com")
         git(dir, "config", "user.name", "Test")
         git(dir, "config", "commit.gpgsign", "false")
+        // Windows CI runners default core.autocrlf=true, which would restore a
+        // committed "one\n" as "one\r\n" and fail every content assertion
+        // below for the wrong reason. Pin LF on this platform too.
+        git(dir, "config", "core.autocrlf", "false")
         File(dir, "tracked.txt").writeText("one\n")
         File(dir, "other.txt").writeText("a\n")
         git(dir, "add", ".")
@@ -303,25 +308,235 @@ class GitProviderWritesToRepoTest {
         // align and A's command, so a global-resolved `git restore` runs in B's
         // tree. The override travels with the call, so the interleaving cannot
         // redirect it - pinned here by pointing the global at the WRONG repo.
-        val repoA = repo(tmpA)
-        val repoB = repo(tmpB)
-        File(repoA, "tracked.txt").writeText("A-dirty\n")
-        File(repoB, "tracked.txt").writeText("B-dirty\n")
-        GitService.alignCurrentProjectPath(repoB.absolutePath)
+        val globalBefore = GitService.getCurrentProjectPath()
+        try {
+            val repoA = repo(tmpA)
+            val repoB = repo(tmpB)
+            File(repoA, "tracked.txt").writeText("A-dirty\n")
+            File(repoB, "tracked.txt").writeText("B-dirty\n")
+            GitService.alignCurrentProjectPath(repoB.absolutePath)
 
-        val result =
-            GitService.discardChanges(
-                "tracked.txt",
-                windowId = null,
-                projectPathOverride = repoA.absolutePath,
+            val result =
+                GitService.discardChanges(
+                    "tracked.txt",
+                    windowId = null,
+                    projectPathOverride = repoA.absolutePath,
+                )
+
+            assertTrue(result is ai.rever.boss.plugin.git.GitOperationResult.Success, "discard reported $result")
+            assertEquals("one\n", File(repoA, "tracked.txt").readText(), "the override's repo was not restored")
+            assertEquals(
+                "B-dirty\n",
+                File(repoB, "tracked.txt").readText(),
+                "the discard leaked into the repo the GLOBAL pointed at",
+            )
+        } finally {
+            // This test steers the GitService singleton; a later test (or this
+            // one under parallel execution) must not inherit a global pointing
+            // at a deleted @TempDir.
+            if (globalBefore == null) {
+                GitService.clearCurrentProjectPathForTests()
+            } else {
+                GitService.alignCurrentProjectPath(globalBefore)
+            }
+        }
+    }
+
+    @Test
+    fun unstageAllRefreshesTheStatusOfTheRepoThatWasWrittenNotTheGlobal(
+        @TempDir tmpA: File,
+        @TempDir tmpB: File,
+    ) = runTest {
+        // Finding 1 of the round-9 review: the verb's post-write refresh used
+        // the NO-ARG getStatus(), which resolves the GLOBAL project - so with
+        // two windows the write landed in A but the refresh ran in B, the repo
+        // nobody asked about. Both repos dirty in a distinguishable way; the
+        // global points at B.
+        val globalBefore = GitService.getCurrentProjectPath()
+        try {
+            val repoA = repo(tmpA)
+            val repoB = repo(tmpB)
+            File(repoA, "tracked.txt").writeText("A-two\n")
+            git(repoA, "add", "tracked.txt") // A: staged
+            File(repoB, "tracked.txt").writeText("B-two\n")
+            git(repoB, "add", "tracked.txt") // B: staged
+            GitService.alignCurrentProjectPath(repoB.absolutePath)
+            GitService.getStatus() // prime the global flow from B
+            assertTrue(
+                GitService.fileStatus.value
+                    .first { it.path == "tracked.txt" }
+                    .isStaged,
+                "precondition: the global flow holds B's staged change",
             )
 
-        assertTrue(result is ai.rever.boss.plugin.git.GitOperationResult.Success, "discard reported $result")
-        assertEquals("one\n", File(repoA, "tracked.txt").readText(), "the override's repo was not restored")
-        assertEquals(
-            "B-dirty\n",
-            File(repoB, "tracked.txt").readText(),
-            "the discard leaked into the repo the GLOBAL pointed at",
+            provider(repoA).unstageAll()
+
+            val globalEntry = GitService.fileStatus.value.first { it.path == "tracked.txt" }
+            assertTrue(
+                globalEntry.isUnstaged && !globalEntry.isStaged,
+                "the refresh ran in the global's repo (B), not the written one (A): " +
+                    "A's entry is ${globalEntry.isStaged}-staged, " +
+                    "and B's index was left staged: ${git(repoB, "status", "--porcelain=v1", "--", "tracked.txt")}",
+            )
+        } finally {
+            if (globalBefore == null) {
+                GitService.clearCurrentProjectPathForTests()
+            } else {
+                GitService.alignCurrentProjectPath(globalBefore)
+            }
+        }
+    }
+
+    @Test
+    fun discardChangesRefreshesTheStatusOfTheRepoThatWasWrittenNotTheGlobal(
+        @TempDir tmpA: File,
+        @TempDir tmpB: File,
+    ) = runTest {
+        // Same finding, same shape: after discarding in A the global flow must
+        // hold A's (now clean) status, not B's still-dirty one.
+        val globalBefore = GitService.getCurrentProjectPath()
+        try {
+            val repoA = repo(tmpA)
+            val repoB = repo(tmpB)
+            File(repoA, "tracked.txt").writeText("A-two\n") // A: unstaged change
+            File(repoB, "tracked.txt").writeText("B-two\n")
+            git(repoB, "add", "tracked.txt") // B: staged
+            GitService.alignCurrentProjectPath(repoB.absolutePath)
+            GitService.getStatus() // prime the global flow from B
+            assertTrue(GitService.fileStatus.value.any { it.path == "tracked.txt" })
+
+            provider(repoA).discardChanges("tracked.txt")
+
+            assertTrue(
+                GitService.fileStatus.value.none { it.path == "tracked.txt" },
+                "the refresh must come from A (clean after discard), not B (still dirty): " +
+                    "${GitService.fileStatus.value.map { it.path to (it.isStaged || it.isUnstaged) }}",
+            )
+        } finally {
+            if (globalBefore == null) {
+                GitService.clearCurrentProjectPathForTests()
+            } else {
+                GitService.alignCurrentProjectPath(globalBefore)
+            }
+        }
+    }
+
+    @Test
+    fun commitRefreshesTheLogOfTheRepoThatWasWrittenNotTheGlobal(
+        @TempDir tmpA: File,
+        @TempDir tmpB: File,
+    ) = runTest {
+        // Same finding for commit's getLog(): the global log flow must end on
+        // A's new commit, not on B's marker commit.
+        val globalBefore = GitService.getCurrentProjectPath()
+        try {
+            val repoA = repo(tmpA)
+            val repoB = repo(tmpB)
+            File(repoA, "tracked.txt").writeText("A-two\n")
+            git(repoA, "add", "tracked.txt")
+            git(repoB, "commit", "-q", "--allow-empty", "-m", "B-marker")
+            GitService.alignCurrentProjectPath(repoB.absolutePath)
+            GitService.getLog() // prime the global log flow from B
+            assertEquals(
+                "B-marker",
+                GitService.commitLog.value
+                    .first()
+                    .subject,
+            )
+
+            provider(repoA).commit("A-panel-commit")
+
+            assertEquals(
+                "A-panel-commit",
+                GitService.commitLog.value
+                    .first()
+                    .subject,
+                "the log refresh ran in the global's repo (B), not the committed one (A)",
+            )
+        } finally {
+            if (globalBefore == null) {
+                GitService.clearCurrentProjectPathForTests()
+            } else {
+                GitService.alignCurrentProjectPath(globalBefore)
+            }
+        }
+    }
+
+    @Test
+    fun anUnsafeRefIsRefusedByEveryRefTakingVerb(
+        @TempDir tmp: File,
+    ) = runTest {
+        // The guard is `isSafeRefName` in each verb, and each verb is its own
+        // copy of that line - so each verb is pinned against the name that
+        // would do the most damage if its copy were "simplified" away:
+        // `main;reboot` is shell metacharacters in the terminal-verbs' command
+        // string, and `-o/evil` is an OPTION to git in the argv verbs.
+        val dir = repo(tmp)
+        val baseBranch = git(dir, "rev-parse", "--abbrev-ref", "HEAD").trim()
+        val globalBefore = GitService.getCurrentProjectPath()
+        try {
+            val p = provider(dir)
+            // Option-shaped names are the argv danger: without the guard they
+            // would land as OPTIONS (checkout --force, branch --force ...),
+            // and git happily accepts them - a silent behaviour change, not
+            // an error. `main;reboot` is the SHELL danger and is only illegal
+            // for the terminal verbs: as a single argv element it is a legal
+            // git refname, so the argv verbs may accept it.
+            for (name in listOf("-o/evil", "--force", "-b")) {
+                val checkout = p.checkout(name)
+                assertTrue(checkout !is GitOperationResultData.Success, "checkout accepted $name")
+                val created = GitService.createBranch(name, checkout = false, projectPathOverride = dir.absolutePath)
+                assertTrue(created !is GitOperationResult.Success, "createBranch accepted $name")
+                val merged = GitService.merge(name, projectPathOverride = dir.absolutePath)
+                assertTrue(merged !is GitOperationResult.Success, "merge accepted $name")
+                val rebased = GitService.rebase(name, projectPathOverride = dir.absolutePath)
+                assertTrue(rebased !is GitOperationResult.Success, "rebase accepted $name")
+            }
+            // And nothing was created or checked out: the branch list is unchanged.
+            assertEquals(
+                git(dir, "branch", "--format=%(refname:short)"),
+                "$baseBranch\n",
+                "an unsafe ref must not leave a branch behind",
+            )
+        } finally {
+            if (globalBefore == null) {
+                GitService.clearCurrentProjectPathForTests()
+            } else {
+                GitService.alignCurrentProjectPath(globalBefore)
+            }
+        }
+    }
+
+    @Test
+    fun anUntrackedFileGetsAnAllAddedDiffNotABlankTab(
+        @TempDir tmp: File,
+    ) = runTest {
+        // The status panel lists untracked files individually
+        // (statusReportsUntrackedFilesIndividuallyNotAsADirectory), but the old
+        // getFileDiff ran `git diff -- <path>`, which emits nothing for a path
+        // git does not track - the diff tab opened blank, reading as "no
+        // changes". The fix diffs /dev/null against the file, so its rows
+        // arrive all-added, like a staged new file's do.
+        val dir = repo(tmp)
+        File(dir, "fresh.txt").writeText("hello\nworld\n")
+        val p = provider(dir)
+
+        val diff = p.diffFile("fresh.txt", staged = false)
+
+        assertTrue(diff.isNotEmpty(), "an untracked file must produce a diff: $diff")
+        val lines =
+            diff
+                .flatMap { it.hunks }
+                .flatMap { it.lines }
+                .map { it.kind }
+        assertTrue(lines.isNotEmpty(), "the diff has no lines")
+        assertTrue(lines.all { it == ai.rever.boss.plugin.api.DiffLineKind.ADDED }, "every line must be added: $lines")
+        assertTrue(diff.any { it.path == "fresh.txt" }, "the diff must be keyed on the file: $diff")
+        // A clean TRACKED file must still show no diff - the blank there means
+        // "no changes" and is correct.
+        assertTrue(
+            p.diffFile("tracked.txt", staged = false).isEmpty(),
+            "a clean tracked file must still diff empty",
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/UnifiedDiffParserTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/git/UnifiedDiffParserTest.kt
@@ -1,0 +1,267 @@
+package ai.rever.boss.git
+
+import ai.rever.boss.plugin.api.DiffLineKind
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Fixture-driven tests for [UnifiedDiffParser]. The fixtures are hand-written
+ * captures of real `git diff` output shapes (multi-file, rename, binary,
+ * created file, missing hunk counts, no-newline marker).
+ */
+class UnifiedDiffParserTest {
+    private val singleFileFixture =
+        """
+        diff --git a/src/A.kt b/src/A.kt
+        index 1111111..2222222 100644
+        --- a/src/A.kt
+        +++ b/src/A.kt
+        @@ -10,7 +10,8 @@ class A {
+             val x = 1
+        -val y = 2
+        +val y = 3
+        +val z = 4
+             fun f() {}
+
+        -    val w = 9
+        +    val w = 10
+             fun g() {}
+        """.trimIndent()
+
+    @Test
+    fun `single file parses path counts and hunk line numbers`() {
+        val files = UnifiedDiffParser.parse(singleFileFixture)
+        assertEquals(1, files.size)
+        val file = files.single()
+        assertEquals("src/A.kt", file.path)
+        assertNull(file.oldPath)
+        assertFalse(file.isBinary)
+        assertEquals(3, file.additions)
+        assertEquals(2, file.deletions)
+        assertEquals(1, file.hunks.size)
+
+        val hunk = file.hunks.single()
+        assertEquals(10, hunk.oldStart)
+        assertEquals(7, hunk.oldLines)
+        assertEquals(10, hunk.newStart)
+        assertEquals(8, hunk.newLines)
+        assertEquals(9, hunk.lines.size)
+
+        // First context line keeps both line numbers.
+        val first = hunk.lines.first()
+        assertEquals(DiffLineKind.CONTEXT, first.kind)
+        assertEquals(10, first.oldLine)
+        assertEquals(10, first.newLine)
+
+        val removed = hunk.lines.first { it.kind == DiffLineKind.REMOVED }
+        assertEquals("val y = 2", removed.text)
+        assertEquals(11, removed.oldLine)
+        assertNull(removed.newLine)
+
+        val added = hunk.lines.first { it.kind == DiffLineKind.ADDED }
+        assertEquals("val y = 3", added.text)
+        assertEquals(11, added.newLine)
+        assertNull(added.oldLine)
+
+        // Last context line: old 15 / new 16.
+        val last = hunk.lines.last()
+        assertEquals(15, last.oldLine)
+        assertEquals(16, last.newLine)
+    }
+
+    @Test
+    fun `blank context line is kept with both line numbers`() {
+        val hunk =
+            UnifiedDiffParser
+                .parse(singleFileFixture)
+                .single()
+                .hunks
+                .single()
+        val blank = hunk.lines.first { it.text.isEmpty() }
+        assertEquals(DiffLineKind.CONTEXT, blank.kind)
+        assertEquals(13, blank.oldLine)
+        assertEquals(14, blank.newLine)
+    }
+
+    @Test
+    fun `multi file stream parses both files in order`() {
+        val input =
+            singleFileFixture +
+                "\n" +
+                """
+                diff --git a/notes.txt b/notes.txt
+                index 3333333..4444444 100644
+                --- a/notes.txt
+                +++ b/notes.txt
+                @@ -1,2 +1,2 @@
+                 keep
+                -drop
+                +take
+                """.trimIndent()
+        val files = UnifiedDiffParser.parse(input)
+        assertEquals(2, files.size)
+        assertEquals("src/A.kt", files[0].path)
+        assertEquals("notes.txt", files[1].path)
+        assertEquals(1, files[1].additions)
+        assertEquals(1, files[1].deletions)
+    }
+
+    @Test
+    fun `rename is captured with old and new path and no hunks`() {
+        val input =
+            """
+            diff --git a/old.txt b/new.txt
+            rename from old.txt
+            rename to new.txt
+            """.trimIndent()
+        val file = UnifiedDiffParser.parse(input).single()
+        assertEquals("new.txt", file.path)
+        assertEquals("old.txt", file.oldPath)
+        assertTrue(file.hunks.isEmpty())
+    }
+
+    @Test
+    fun `binary file is flagged without hunks`() {
+        val input =
+            """
+            diff --git a/img.png b/img.png
+            index 5555555..6666666 100644
+            Binary files a/img.png and b/img.png differ
+            """.trimIndent()
+        val file = UnifiedDiffParser.parse(input).single()
+        assertEquals("img.png", file.path)
+        assertTrue(file.isBinary)
+        assertTrue(file.hunks.isEmpty())
+        assertEquals(0, file.additions)
+        assertEquals(0, file.deletions)
+    }
+
+    @Test
+    fun `header without explicit old count defaults to one line`() {
+        val input =
+            """
+            diff --git a/b.txt b/b.txt
+            index 7777777..8888888 100644
+            --- a/b.txt
+            +++ b/b.txt
+            @@ -12 +12,2 @@
+            -old12
+            +new12
+            """.trimIndent()
+        val hunk =
+            UnifiedDiffParser
+                .parse(input)
+                .single()
+                .hunks
+                .single()
+        assertEquals(12, hunk.oldStart)
+        assertEquals(1, hunk.oldLines)
+        assertEquals(12, hunk.newStart)
+        assertEquals(2, hunk.newLines)
+        assertEquals(2, hunk.lines.size)
+        assertEquals(12, hunk.lines.first().oldLine)
+        assertEquals(12, hunk.lines.last().newLine)
+    }
+
+    @Test
+    fun `created file numbers lines from one and skips the no-newline marker`() {
+        val input =
+            """
+            diff --git a/c.txt b/c.txt
+            new file mode 100644
+            index 0000000..9999999
+            --- /dev/null
+            +++ b/c.txt
+            @@ -0,0 +1,3 @@
+            +line1
+            +line2
+            +line3
+            \ No newline at end of file
+            """.trimIndent()
+        val file = UnifiedDiffParser.parse(input).single()
+        assertEquals("c.txt", file.path)
+        assertEquals(3, file.additions)
+        assertEquals(0, file.deletions)
+        val lines = file.hunks.single().lines
+        assertEquals(3, lines.size)
+        assertEquals(listOf(1, 2, 3), lines.map { it.newLine })
+        assertTrue(lines.all { it.kind == DiffLineKind.ADDED })
+    }
+
+    @Test
+    fun `empty input yields no files`() {
+        assertTrue(UnifiedDiffParser.parse("").isEmpty())
+        assertTrue(UnifiedDiffParser.parse("\n\n").isEmpty())
+    }
+
+    @Test
+    fun `raw unified text is preserved per file`() {
+        val files = UnifiedDiffParser.parse(singleFileFixture)
+        val raw = files.single().rawUnified
+        assertTrue(raw.startsWith("diff --git a/src/A.kt b/src/A.kt"))
+        assertTrue(raw.contains("@@ -10,7 +10,8 @@"))
+        assertTrue(raw.contains("+val z = 4"))
+    }
+
+    // ---- regressions found in independent review ----
+
+    @Test
+    fun `a quoted non-ascii path is decoded as utf-8, not per-escape chars`() {
+        // Real `git diff` output with core.quotepath on (the default).
+        val input =
+            "diff --git \"a/caf\\303\\251.txt\" \"b/caf\\303\\251.txt\"\n" +
+                "index ce01362..5ea2ed4 100644\n" +
+                "--- \"a/caf\\303\\251.txt\"\n" +
+                "+++ \"b/caf\\303\\251.txt\"\n" +
+                "@@ -1 +1 @@\n" +
+                "-hello\n" +
+                "+changed\n"
+        val file = UnifiedDiffParser.parse(input).single()
+        assertEquals("café.txt", file.path)
+    }
+
+    @Test
+    fun `a quoted path does not throw`() {
+        val input = "diff --git \"a/\\346\\227\\245.kt\" \"b/\\346\\227\\245.kt\"\n@@ -1 +1 @@\n-a\n+b\n"
+        assertEquals(1, UnifiedDiffParser.parse(input).size)
+    }
+
+    @Test
+    fun `rawUnified stops at the file boundary`() {
+        val input =
+            "diff --git a/one.kt b/one.kt\n@@ -1 +1 @@\n-a\n+b\n" +
+                "diff --git a/two.kt b/two.kt\n@@ -1 +1 @@\n-c\n+d\n"
+        val files = UnifiedDiffParser.parse(input)
+        assertEquals(2, files.size)
+        assertTrue(files[0].rawUnified.contains("one.kt"), files[0].rawUnified)
+        assertTrue(!files[0].rawUnified.contains("two.kt"), "file 0 leaked file 1: ${files[0].rawUnified}")
+    }
+
+    @Test
+    fun `a trailing newline does not append a phantom context line`() {
+        // Process output always ends with a newline; fixtures using trimIndent() do not.
+        val input = "diff --git a/a.kt b/a.kt\n@@ -1,2 +1,2 @@\n one\n-two\n+three\n"
+        val hunk =
+            UnifiedDiffParser
+                .parse(input)
+                .single()
+                .hunks
+                .single()
+        assertEquals(3, hunk.lines.size, hunk.lines.map { it.text }.toString())
+    }
+
+    @Test
+    fun `a merge commit's combined diff yields no hunks rather than wrong ones`() {
+        val input =
+            "diff --cc merged.kt\n" +
+                "index 1111111,2222222..3333333\n" +
+                "@@@ -1,2 -1,2 +1,3 @@@\n" +
+                "++both\n" +
+                "+ ours\n"
+        val files = UnifiedDiffParser.parse("diff --git a/merged.kt b/merged.kt\n" + input.substringAfter("\n"))
+        assertTrue(files.single().hunks.isEmpty(), "combined diff was parsed as unified: ${files.single().hunks}")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
@@ -297,23 +297,26 @@ class RetiredPluginsTest {
     }
 
     @Test
-    fun `the shipped retirement names the plugin the wizard no longer installs`() {
-        // Pins the pair rather than the mechanism: PluginListProvider dropped
-        // `usersecretlist` and put `secretmanager` among the defaults in the same change, and
-        // a retirement pointing somewhere else would silently uninstall the wrong plugin.
-        val shipped = RetiredPlugins.ALL.single()
-        assertEquals("ai.rever.boss.plugin.dynamic.usersecretlist", shipped.pluginId)
-        assertEquals("ai.rever.boss.plugin.dynamic.secretmanager", shipped.replacementId)
-        assertTrue(
-            shipped.pluginId !in
-                ai.rever.boss.components.wizard.plugin.PluginListProvider.DEFAULT_PLUGIN_IDS,
-            "the wizard still installs a plugin this sweep uninstalls at the next launch",
-        )
-        assertTrue(
-            shipped.replacementId in
-                ai.rever.boss.components.wizard.plugin.PluginListProvider.DEFAULT_PLUGIN_IDS,
-            "nothing takes the retired plugin's place in a fresh install",
-        )
+    fun `every shipped retirement names plugins the wizard will not and does install`() {
+        // Pins the pairs rather than the mechanism: when a plugin is retired, the wizard
+        // stops offering it and offers its replacement in the same change, and a retirement
+        // pointing somewhere else would silently uninstall the wrong plugin.
+        assertTrue(RetiredPlugins.ALL.isNotEmpty(), "no shipped retirements to pin")
+        RetiredPlugins.ALL.forEach { retirement ->
+            assertTrue(
+                retirement.pluginId !in
+                    ai.rever.boss.components.wizard.plugin.PluginListProvider.DEFAULT_PLUGIN_IDS,
+                "the wizard still installs a plugin this sweep uninstalls at the next launch: " + retirement.pluginId,
+            )
+            assertTrue(
+                retirement.replacementId in
+                    ai.rever.boss.components.wizard.plugin.PluginListProvider.DEFAULT_PLUGIN_IDS,
+                "nothing takes the retired plugin's place in a fresh install: " + retirement.replacementId,
+            )
+        }
+        // The original pair that motivated the pin.
+        val mySecrets = RetiredPlugins.ALL.first { it.pluginId == "ai.rever.boss.plugin.dynamic.usersecretlist" }
+        assertEquals("ai.rever.boss.plugin.dynamic.secretmanager", mySecrets.replacementId)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/RetiredPluginsTest.kt
@@ -2,6 +2,7 @@ package ai.rever.boss.plugin
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -325,9 +326,46 @@ class RetiredPluginsTest {
         // RetiredPluginIds (commonMain) is what the wizard and the home grid refuse to offer. A
         // retirement added to one and not the other leaves the plugin installable, swept away at
         // the next launch, and installable again - which is the loop the filter exists to stop.
-        assertEquals(
-            RetiredPlugins.ALL.map { it.pluginId }.toSet(),
-            ai.rever.boss.components.plugin.RetiredPluginIds.ALL,
+        //
+        // The FLOORS are pinned too: the offer filter hides a retired plugin only from the
+        // moment the sweep would be able to remove it. A floor that drifts between the two
+        // lists re-opens either the install-then-sweep loop (filter too eager) or a fresh
+        // install with no panel at all (filter too lazy).
+        val sweepRetirements =
+            RetiredPlugins.ALL
+                .map { (it.pluginId) to (it.replacementId) to (it.minReplacementVersion) }
+                .toSet()
+        val offerRetirements =
+            ai.rever.boss.components.plugin.RetiredPluginIds
+                .ALL
+                .map { (it.pluginId) to (it.replacementId) to (it.minReplacementVersion) }
+                .toSet()
+        assertEquals(sweepRetirements, offerRetirements)
+    }
+
+    @Test
+    fun `the offer filter uses the sweep floor and fails closed`() {
+        // The gap this floor closes: a fresh install between this host release and the
+        // replacement's absorbing release must STILL be offered the retired plugin, because
+        // the sweep cannot act and hiding the offer would leave no panel.
+        val gitStatus = "ai.rever.boss.plugin.dynamic.gitstatus"
+        val codebase = "ai.rever.boss.plugin.dynamic.codebase"
+        val hide = { version: String? ->
+            ai.rever.boss.components.plugin.RetiredPluginIds.hiddenFromOffers(gitStatus) { id ->
+                if (id == codebase) version else null
+            }
+        }
+        assertTrue(hide("1.6.0"), "the floor version itself must hide the retired plugin")
+        assertTrue(hide("2.0.0"), "a newer replacement must hide the retired plugin")
+        assertFalse(hide("1.5.9"), "a replacement below the floor must NOT hide it")
+        assertFalse(hide(null), "no replacement installed must NOT hide it")
+        assertFalse(hide(""), "a blank version must NOT hide it")
+        assertFalse(hide("dev"), "an unparseable version must NOT hide it (fails closed like the sweep)")
+        assertFalse(hide("-"), "a trailing '-' version must NOT hide it (satisfiesVersionFloor alone would not)")
+        // An id that is not retired is never hidden by this filter.
+        assertFalse(
+            ai.rever.boss.components.plugin.RetiredPluginIds
+                .hiddenFromOffers("ai.rever.boss.plugin.dynamic.codebase") { "1.6.0" },
         )
     }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/BufferEditRangeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/BufferEditRangeTest.kt
@@ -1,0 +1,93 @@
+package ai.rever.boss.search
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * The range handed to `applyEdit` for a live-buffer replace.
+ *
+ * The regression this pins is a silent text corruption: `applyEdit`'s end
+ * position is exclusive, `MatchResult.range.last` is inclusive, and passing
+ * one as the other replaced every match one character short - replacing
+ * `subtract` with `add` produced `addt`.
+ */
+class BufferEditRangeTest {
+    private fun rangeOf(
+        text: String,
+        needle: String,
+    ): BufferEditRange {
+        val m = Regex(Regex.escape(needle)).find(text)!!
+        return BufferEditRange.of(ContentSearchService.LineMap(text), m.range)
+    }
+
+    @Test
+    fun `the end column is one past the match, not on its last character`() {
+        // "subtract" occupies columns 1..8, so the exclusive end is column 9.
+        val r = rangeOf("subtract\n", "subtract")
+        assertEquals(1, r.startLine)
+        assertEquals(1, r.startCol)
+        assertEquals(1, r.endLine)
+        assertEquals(9, r.endCol, "an inclusive end here leaves the match's last character behind")
+    }
+
+    @Test
+    fun `the replaced span covers the whole match`() {
+        val text = "val x = subtract(a, b)\n"
+        val r = rangeOf(text, "subtract")
+        // Simulate what applyEdit does with these positions.
+        val lines = ContentSearchService.LineMap(text)
+        val start = offsetOf(lines, r.startLine, r.startCol)
+        val end = offsetOf(lines, r.endLine, r.endCol)
+        assertEquals("subtract", text.substring(start, end))
+        assertEquals("val x = add(a, b)\n", text.replaceRange(start, end, "add"))
+    }
+
+    @Test
+    fun `a match on a later line reports that line`() {
+        val text = "first\nsecond subtract here\n"
+        val r = rangeOf(text, "subtract")
+        assertEquals(2, r.startLine)
+        assertEquals(8, r.startCol)
+        assertEquals(2, r.endLine)
+        assertEquals(16, r.endCol)
+    }
+
+    @Test
+    fun `a single-character match spans one column`() {
+        val r = rangeOf("abc", "b")
+        assertEquals(2, r.startCol)
+        assertEquals(3, r.endCol)
+    }
+
+    @Test
+    fun `a match ending at the very end of the text does not overrun`() {
+        val text = "xy"
+        val r = rangeOf(text, "y")
+        assertEquals(1, r.endLine)
+        assertEquals(3, r.endCol)
+        val lines = ContentSearchService.LineMap(text)
+        assertEquals("y", text.substring(offsetOf(lines, r.startLine, r.startCol), offsetOf(lines, r.endLine, r.endCol)))
+    }
+
+    @Test
+    fun `a match ending exactly at a newline stays on its own line`() {
+        val text = "ab\ncd"
+        val r = rangeOf(text, "ab")
+        assertEquals(1, r.endLine, "the exclusive end must not roll onto the next line")
+        assertEquals(3, r.endCol)
+    }
+
+    /** The inverse of LineMap, mirroring applyEdit's positionToOffset(line-1, col-1). */
+    private fun offsetOf(
+        lines: ContentSearchService.LineMap,
+        line: Int,
+        col: Int,
+    ): Int {
+        var seen = 0
+        lines.text.lines().forEachIndexed { index, text ->
+            if (index + 1 == line) return seen + (col - 1)
+            seen += text.length + 1
+        }
+        return seen
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
@@ -34,7 +34,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         tree(dir)
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val hits = service.searchInProject(query = "needle")
 
@@ -48,7 +48,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         tree(dir)
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val paths = service.searchInProject(query = "needle").map { it.path }
 
@@ -61,7 +61,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         tree(dir)
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         // What a user actually types in "files to include". Matched against the
         // whole relative path, `*.kt` used to find only root-level files.
@@ -75,7 +75,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         tree(dir)
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val paths =
             service
@@ -91,7 +91,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         tree(dir)
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val paths = service.searchInProject(query = "needle", pathPattern = "src").map { it.path }.toSet()
 
@@ -124,7 +124,7 @@ class ContentSearchServiceTest {
         exclude: String?,
     ): Set<String> =
         runBlocking {
-            ContentSearchService { dir.absolutePath }
+            ContentSearchService(projectPathProvider = { dir.absolutePath })
                 .searchInProject(
                     query = "needle",
                     pathPattern = null,
@@ -209,7 +209,7 @@ class ContentSearchServiceTest {
 
         val paths =
             runBlocking {
-                ContentSearchService { dir.absolutePath }
+                ContentSearchService(projectPathProvider = { dir.absolutePath })
                     .searchInProject(
                         query = "needle",
                         pathPattern = null,
@@ -231,7 +231,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         File(dir, "a.txt").writeText("first\n  needle\n")
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val hit = service.searchInProject(query = "needle").single()
 
@@ -246,7 +246,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         File(dir, "a.txt").writeText("ab\n")
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         // `x*` matches empty at every offset. Advancing by `range.last + 1`
         // never moved past a zero-length match, so this used to return the
@@ -266,7 +266,7 @@ class ContentSearchServiceTest {
         // a zero-length match, so this grew a list until the app stopped
         // responding. It has to come back bounded.
         val summary =
-            ContentSearchService { dir.absolutePath }.replaceInProject(
+            ContentSearchService(projectPathProvider = { dir.absolutePath }).replaceInProject(
                 query = "x*",
                 replacement = "-",
                 files = listOf("a.txt"),
@@ -281,7 +281,7 @@ class ContentSearchServiceTest {
     fun `a per-file replace failure is reported, not swallowed`(
         @TempDir dir: File,
     ) = runBlocking {
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         // A path that is not a file: the summary has to carry the reason so a
         // caller can say why nothing changed.
@@ -308,7 +308,7 @@ class ContentSearchServiceTest {
         a.writeText("val needle = 1\nval other = needle\n")
         val b = File(dir, "B.kt")
         b.writeText("// needle\n")
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         // 1. Exactly what the SEARCH tab does: scan, then feed the result
         //    paths (project-relative, as reported) into a dry run.
@@ -346,7 +346,7 @@ class ContentSearchServiceTest {
     ) = runBlocking {
         val f = File(dir, "a.kt")
         f.writeText("fun oldName(x: Int)\n")
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val applied =
             service.replaceInProject(
@@ -367,7 +367,7 @@ class ContentSearchServiceTest {
     ) = runBlocking {
         val file = File(dir, "a.txt")
         file.writeText("needle needle\n")
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val summary =
             service.replaceInProject(
@@ -391,7 +391,7 @@ class ContentSearchServiceTest {
         // landed after the second match, whose lookahead reads past it, so re-matching
         // the truncated prefix found only the first.
         val f = File(dir, "a.txt").apply { writeText("ab ab") }
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         val summary =
             service.replaceInProject(
@@ -411,7 +411,7 @@ class ContentSearchServiceTest {
         @TempDir dir: File,
     ) = runBlocking {
         val f = File(dir, "b.txt").apply { writeText("foo=1\nbar=2\n") }
-        val service = ContentSearchService { dir.absolutePath }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
 
         service.replaceInProject(
             query = "(\\w+)=(\\d)",

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
@@ -1,6 +1,10 @@
 package ai.rever.boss.search
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -545,5 +549,45 @@ class ContentSearchServiceTest {
         val paths = service.searchInProject(query = "unsavedNeedle").map { it.path }
 
         assertEquals(listOf("top.kt"), paths, "the live buffer's content was not searched")
+    }
+
+    @Test
+    fun `a cancelling caller unwinds a catastrophic-backtracking regex instead of pinning the thread`(
+        @TempDir dir: File,
+    ) {
+        // The security control this class exists for: [InterruptibleText] re-checks
+        // the CALLER'S job on every character read, so `(a+)+$` against a long line
+        // - catastrophic backtracking in the non-interruptible Java matcher - must
+        // unwind on cancel rather than pinning a Dispatchers.IO thread (and with it
+        // every git/search behind the shared pools). Pinned the same way the
+        // isSafeRefName guard is pinned: a check that rots silently is worse than
+        // none, and only a test can prove it still trips.
+        // The trailing 'b' is what makes it catastrophic: the run of 'a's matches,
+        // the '$' then fails at the 'b', and the matcher backtracks exponentially.
+        // A pure 'a' line would simply match at the end and finish in milliseconds,
+        // proving nothing.
+        runBlocking {
+            File(dir, "long.kt").writeText("a".repeat(40_000) + "b\n")
+            val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
+
+            val finished: Boolean? =
+                withTimeoutOrNull(20_000L) {
+                    val job: Job =
+                        launch(Dispatchers.IO) {
+                            service.searchInProject(query = "(a+)+\$", isRegex = true)
+                        }
+                    // Let the matcher start spinning before the cancel lands.
+                    kotlinx.coroutines.delay(1_000)
+                    job.cancel()
+                    job.join()
+                    true
+                }
+
+            assertTrue(
+                finished == true,
+                "the cancel did not unwind the wedged matcher within 20s - the check inside the " +
+                    "character stream has stopped working",
+            )
+        }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
@@ -1,0 +1,426 @@
+package ai.rever.boss.search
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The find-in-files engine behind the codebase panel's SEARCH tab and the
+ * `project_search` MCP tool.
+ *
+ * The first two tests pin the walk itself, which had an inverted `onEnter`
+ * predicate: `walkTopDown().onEnter { … }` descends on **true**, and the
+ * predicate returned true only for the skip list - so the walk entered
+ * `node_modules` and `.git`, refused to enter the project root, and every
+ * search in the app returned zero results.
+ */
+class ContentSearchServiceTest {
+    private fun tree(root: File) {
+        File(root, "top.kt").writeText("val needle = 1\n")
+        File(root, "src/main").mkdirs()
+        File(root, "src/main/Deep.kt").writeText("// needle here\nfun f() {}\n")
+        File(root, "src/main/Other.java").writeText("// needle in java\n")
+        File(root, "node_modules/pkg").mkdirs()
+        File(root, "node_modules/pkg/index.js").writeText("needle in a dependency\n")
+        File(root, "build").mkdirs()
+        File(root, "build/gen.kt").writeText("needle in generated output\n")
+    }
+
+    @Test
+    fun `finds matches at the project root and at depth`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        val service = ContentSearchService { dir.absolutePath }
+
+        val hits = service.searchInProject(query = "needle")
+
+        val paths = hits.map { it.path }.toSet()
+        assertTrue("top.kt" in paths, "root-level file not scanned: $paths")
+        assertTrue("src/main/Deep.kt" in paths, "nested file not scanned: $paths")
+    }
+
+    @Test
+    fun `skips the ignored directories`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        val service = ContentSearchService { dir.absolutePath }
+
+        val paths = service.searchInProject(query = "needle").map { it.path }
+
+        assertTrue(paths.none { it.startsWith("node_modules/") }, "walked node_modules: $paths")
+        assertTrue(paths.none { it.startsWith("build/") }, "walked build: $paths")
+    }
+
+    @Test
+    fun `a bare extension glob matches at any depth`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        val service = ContentSearchService { dir.absolutePath }
+
+        // What a user actually types in "files to include". Matched against the
+        // whole relative path, `*.kt` used to find only root-level files.
+        val paths = service.searchInProject(query = "needle", pathPattern = "*.kt").map { it.path }.toSet()
+
+        assertEquals(setOf("top.kt", "src/main/Deep.kt"), paths)
+    }
+
+    @Test
+    fun `a comma separated include list matches any alternative`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        val service = ContentSearchService { dir.absolutePath }
+
+        val paths =
+            service
+                .searchInProject(query = "needle", pathPattern = "*.java, *.kt")
+                .map { it.path }
+                .toSet()
+
+        assertEquals(setOf("top.kt", "src/main/Deep.kt", "src/main/Other.java"), paths)
+    }
+
+    @Test
+    fun `a directory include matches everything under it`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        val service = ContentSearchService { dir.absolutePath }
+
+        val paths = service.searchInProject(query = "needle", pathPattern = "src").map { it.path }.toSet()
+
+        assertEquals(setOf("src/main/Deep.kt", "src/main/Other.java"), paths)
+    }
+
+    // ---- exclude globs (moved here from the codebase plugin's PathGlob) ------
+    //
+    // These lived in the plugin, over its own copy of the glob compiler, filtering
+    // the list the engine returned. That made the cap apply BEFORE the exclude, so
+    // excluding a busy directory returned fewer results than existed. The exclude
+    // now runs in the walk, and these cases moved with it.
+
+    /** A tree the SKIP_DIRECTORIES list does not already hide, so excludes are what filters. */
+    private fun excludeTree(root: File) {
+        File(root, "src/main").mkdirs()
+        File(root, "src/main/Main.kt").writeText("needle\n")
+        File(root, "src/main/deep/More.kt").apply { parentFile.mkdirs() }.writeText("needle\n")
+        File(root, "web/static").mkdirs()
+        File(root, "web/static/app.min.js").writeText("needle\n")
+        File(root, "web/static/app.js").writeText("needle\n")
+        File(root, "module/gen").mkdirs()
+        File(root, "module/gen/Out.kt").writeText("needle\n")
+        File(root, "notsrc").mkdirs()
+        File(root, "notsrc/Main.kt").writeText("needle\n")
+    }
+
+    private fun search(
+        dir: File,
+        exclude: String?,
+    ): Set<String> =
+        runBlocking {
+            ContentSearchService { dir.absolutePath }
+                .searchInProject(
+                    query = "needle",
+                    pathPattern = null,
+                    excludePattern = exclude,
+                    isRegex = false,
+                    caseSensitive = false,
+                    wholeWord = false,
+                    maxResults = 200,
+                ).map { it.path }
+                .toSet()
+        }
+
+    @Test
+    fun `a blank exclude excludes nothing`(
+        @TempDir dir: File,
+    ) {
+        excludeTree(dir)
+        assertEquals(search(dir, null), search(dir, ""))
+    }
+
+    @Test
+    fun `an extension exclude applies at any depth`(
+        @TempDir dir: File,
+    ) {
+        excludeTree(dir)
+        val paths = search(dir, "*.min.js")
+        assertTrue("web/static/app.min.js" !in paths, paths.toString())
+        assertTrue("web/static/app.js" in paths, paths.toString())
+    }
+
+    @Test
+    fun `a bare folder name excludes everything under it, at any depth`(
+        @TempDir dir: File,
+    ) {
+        excludeTree(dir)
+        val paths = search(dir, "gen")
+        assertTrue("module/gen/Out.kt" !in paths, paths.toString())
+        assertTrue("src/main/Main.kt" in paths, paths.toString())
+    }
+
+    @Test
+    fun `comma separated excludes are alternatives`(
+        @TempDir dir: File,
+    ) {
+        excludeTree(dir)
+        val paths = search(dir, "gen, *.min.js")
+        assertTrue("module/gen/Out.kt" !in paths, paths.toString())
+        assertTrue("web/static/app.min.js" !in paths, paths.toString())
+        assertTrue("src/main/Main.kt" in paths, paths.toString())
+    }
+
+    @Test
+    fun `a single-segment wildcard does not cross a separator`(
+        @TempDir dir: File,
+    ) {
+        excludeTree(dir)
+        val paths = search(dir, "src/*.kt")
+        assertTrue("src/main/deep/More.kt" in paths, paths.toString())
+    }
+
+    @Test
+    fun `an exclude is anchored, not a substring test`(
+        @TempDir dir: File,
+    ) {
+        excludeTree(dir)
+        val paths = search(dir, "src")
+        assertTrue("src/main/Main.kt" !in paths, paths.toString())
+        assertTrue("notsrc/Main.kt" in paths, "'src' must not exclude 'notsrc': $paths")
+    }
+
+    @Test
+    fun `the exclude runs inside the walk, so the cap is not spent on excluded files`(
+        @TempDir dir: File,
+    ) {
+        // The bug this whole change exists for. 30 files in noise/, 3 in keep/,
+        // cap of 5: filtering AFTER the cap can return 0, because the cap is
+        // reached before a single keep/ file is scanned.
+        File(dir, "noise").mkdirs()
+        repeat(30) { File(dir, "noise/n$it.kt").writeText("needle\n") }
+        File(dir, "keep").mkdirs()
+        repeat(3) { File(dir, "keep/k$it.kt").writeText("needle\n") }
+
+        val paths =
+            runBlocking {
+                ContentSearchService { dir.absolutePath }
+                    .searchInProject(
+                        query = "needle",
+                        pathPattern = null,
+                        excludePattern = "noise",
+                        isRegex = false,
+                        caseSensitive = false,
+                        wholeWord = false,
+                        maxResults = 5,
+                    ).map { it.path }
+                    .toSet()
+            }
+
+        assertEquals(3, paths.size, "the cap was spent on excluded files: $paths")
+        assertTrue(paths.all { it.startsWith("keep/") }, paths.toString())
+    }
+
+    @Test
+    fun `line and column are 1-based and point at the match`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        File(dir, "a.txt").writeText("first\n  needle\n")
+        val service = ContentSearchService { dir.absolutePath }
+
+        val hit = service.searchInProject(query = "needle").single()
+
+        assertEquals(2, hit.line)
+        assertEquals(3, hit.column)
+        assertEquals("needle".length, hit.matchLength)
+        assertEquals("  needle\n", hit.contextLine)
+    }
+
+    @Test
+    fun `a zero-length regex match does not rescan the same offset`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        File(dir, "a.txt").writeText("ab\n")
+        val service = ContentSearchService { dir.absolutePath }
+
+        // `x*` matches empty at every offset. Advancing by `range.last + 1`
+        // never moved past a zero-length match, so this used to return the
+        // per-file cap (500) of identical positions.
+        val hits = service.searchInProject(query = "x*", isRegex = true)
+
+        assertTrue(hits.size <= 4, "zero-length match looped: ${hits.size} hits")
+    }
+
+    @Test
+    fun `a zero-length regex replace terminates instead of hanging`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        File(dir, "a.txt").writeText("abc\n")
+
+        // The buffer path built its match list with no cap and no advance past
+        // a zero-length match, so this grew a list until the app stopped
+        // responding. It has to come back bounded.
+        val summary =
+            ContentSearchService { dir.absolutePath }.replaceInProject(
+                query = "x*",
+                replacement = "-",
+                files = listOf("a.txt"),
+                isRegex = true,
+                dryRun = true,
+            )
+
+        assertTrue(summary.totalReplacements <= 500, "unbounded match list: ${summary.totalReplacements}")
+    }
+
+    @Test
+    fun `a per-file replace failure is reported, not swallowed`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val service = ContentSearchService { dir.absolutePath }
+
+        // A path that is not a file: the summary has to carry the reason so a
+        // caller can say why nothing changed.
+        val summary =
+            service.replaceInProject(
+                query = "needle",
+                replacement = "pin",
+                files = listOf("does-not-exist.txt"),
+                dryRun = false,
+            )
+
+        assertEquals(0, summary.totalReplacements)
+        assertTrue(
+            summary.files.any { !it.error.isNullOrBlank() },
+            "no per-file error reported: ${summary.files}",
+        )
+    }
+
+    @Test
+    fun `the search-then-replace flow the panel performs actually writes`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val a = File(dir, "src/A.kt").also { it.parentFile.mkdirs() }
+        a.writeText("val needle = 1\nval other = needle\n")
+        val b = File(dir, "B.kt")
+        b.writeText("// needle\n")
+        val service = ContentSearchService { dir.absolutePath }
+
+        // 1. Exactly what the SEARCH tab does: scan, then feed the result
+        //    paths (project-relative, as reported) into a dry run.
+        val hits = service.searchInProject(query = "needle")
+        val paths = hits.map { it.path }.distinct()
+        assertTrue(paths.isNotEmpty(), "no hits to replace")
+
+        val preview =
+            service.replaceInProject(
+                query = "needle",
+                replacement = "pin",
+                files = paths,
+                dryRun = true,
+            )
+        assertEquals(3, preview.totalReplacements, "dry run miscounted: ${preview.files}")
+        assertTrue(preview.files.isNotEmpty(), "dry run reported no per-file rows to apply")
+
+        // 2. Then applies using the paths the preview reported back.
+        val applied =
+            service.replaceInProject(
+                query = "needle",
+                replacement = "pin",
+                files = preview.files.map { it.path },
+                dryRun = false,
+            )
+
+        assertEquals(3, applied.totalReplacements, "apply reported nothing: ${applied.files}")
+        assertEquals("val pin = 1\nval other = pin\n", a.readText())
+        assertEquals("// pin\n", b.readText())
+    }
+
+    @Test
+    fun `a regex replace supports capture-group references`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val f = File(dir, "a.kt")
+        f.writeText("fun oldName(x: Int)\n")
+        val service = ContentSearchService { dir.absolutePath }
+
+        val applied =
+            service.replaceInProject(
+                query = "fun (\\w+)\\(",
+                replacement = "fun new_$1(",
+                files = listOf("a.kt"),
+                isRegex = true,
+                dryRun = false,
+            )
+
+        assertEquals(1, applied.totalReplacements, "regex replace failed: ${applied.files}")
+        assertEquals("fun new_oldName(x: Int)\n", f.readText())
+    }
+
+    @Test
+    fun `dry run replace counts without writing`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val file = File(dir, "a.txt")
+        file.writeText("needle needle\n")
+        val service = ContentSearchService { dir.absolutePath }
+
+        val summary =
+            service.replaceInProject(
+                query = "needle",
+                replacement = "pin",
+                files = listOf("a.txt"),
+                dryRun = true,
+            )
+
+        assertEquals(2, summary.totalReplacements)
+        assertEquals("needle needle\n", file.readText())
+    }
+
+    // ---- round-2 regressions ----
+
+    @Test
+    fun `a lookahead regex replaces every counted match and reports the truth`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        // The cut-and-replace implementation reported 2 and wrote 1 here: the cut
+        // landed after the second match, whose lookahead reads past it, so re-matching
+        // the truncated prefix found only the first.
+        val f = File(dir, "a.txt").apply { writeText("ab ab") }
+        val service = ContentSearchService { dir.absolutePath }
+
+        val summary =
+            service.replaceInProject(
+                query = "a(?=b)",
+                replacement = "X",
+                files = listOf(f.absolutePath),
+                isRegex = true,
+                dryRun = false,
+            )
+
+        assertEquals("Xb Xb", f.readText())
+        assertEquals(2, summary.totalReplacements)
+    }
+
+    @Test
+    fun `capture group references survive the disk replace path`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val f = File(dir, "b.txt").apply { writeText("foo=1\nbar=2\n") }
+        val service = ContentSearchService { dir.absolutePath }
+
+        service.replaceInProject(
+            query = "(\\w+)=(\\d)",
+            replacement = "$2:$1",
+            files = listOf(f.absolutePath),
+            isRegex = true,
+            dryRun = false,
+        )
+
+        assertEquals("1:foo\n2:bar\n", f.readText())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ContentSearchServiceTest.kt
@@ -423,4 +423,127 @@ class ContentSearchServiceTest {
 
         assertEquals("1:foo\n2:bar\n", f.readText())
     }
+
+    // ---- round-4 regressions ----
+
+    @Test
+    fun `replacing in an executable script keeps its executable bit`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        // writeAtomically lands a fresh temp file on the target's inode, and
+        // createTempFile is owner-only 0600 - so a replace in a git hook or a
+        // build script silently cleared +x until the perms were carried across.
+        val script = File(dir, "hook.sh").apply { writeText("#!/bin/sh\necho needle\n") }
+        if (!script.setExecutable(true)) return@runBlocking // non-POSIX filesystem: nothing to pin
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
+
+        service.replaceInProject(
+            query = "needle",
+            replacement = "pin",
+            files = listOf("hook.sh"),
+            dryRun = false,
+        )
+
+        assertEquals("#!/bin/sh\necho pin\n", script.readText())
+        assertTrue(script.canExecute(), "the replace dropped the executable bit")
+    }
+
+    @Test
+    fun `a file with a name shorter than three chars can still be replaced`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        // createTempFile throws "Prefix string too short" for a prefix under 3
+        // chars, which surfaced as an opaque per-file failure for a file named "a".
+        val f = File(dir, "a").apply { writeText("needle\n") }
+        val service = ContentSearchService(projectPathProvider = { dir.absolutePath })
+
+        val summary =
+            service.replaceInProject(
+                query = "needle",
+                replacement = "pin",
+                files = listOf("a"),
+                dryRun = false,
+            )
+
+        assertEquals(1, summary.totalReplacements, "replace failed: ${summary.files}")
+        assertEquals("pin\n", f.readText())
+    }
+
+    @Test
+    fun `an authoritative empty open-tab set skips the buffer bridge entirely`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        var bridgeCalls = 0
+        val countingBridge =
+            object : EditorBufferBridge {
+                override suspend fun readBuffer(path: String): ai.rever.boss.plugin.api.BufferSnapshot? {
+                    bridgeCalls++
+                    return null
+                }
+
+                override suspend fun applyEdit(
+                    path: String,
+                    startLine: Int,
+                    startCol: Int,
+                    endLine: Int,
+                    endCol: Int,
+                    newText: String,
+                    expectedVersion: Long,
+                ): ai.rever.boss.plugin.api.EditResult? = null
+            }
+        val service =
+            ContentSearchService(
+                projectPathProvider = { dir.absolutePath },
+                bufferBridge = countingBridge,
+                openEditorPathsProvider = { emptySet() },
+            )
+
+        val hits = service.searchInProject(query = "needle")
+
+        assertTrue(hits.isNotEmpty(), "the search itself must still work")
+        assertEquals(0, bridgeCalls, "no editor tab is open, so the bridge must not be asked per file")
+    }
+
+    @Test
+    fun `an open tab's buffer still overlays the disk when the open set is provided`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        tree(dir)
+        val open = File(dir, "top.kt").absolutePath
+        val bridge =
+            object : EditorBufferBridge {
+                override suspend fun readBuffer(path: String): ai.rever.boss.plugin.api.BufferSnapshot? =
+                    if (path == open) {
+                        ai.rever.boss.plugin.api.BufferSnapshot(
+                            path = path,
+                            content = "val unsavedNeedle = 2\n",
+                            version = 1L,
+                            isModified = true,
+                        )
+                    } else {
+                        null
+                    }
+
+                override suspend fun applyEdit(
+                    path: String,
+                    startLine: Int,
+                    startCol: Int,
+                    endLine: Int,
+                    endCol: Int,
+                    newText: String,
+                    expectedVersion: Long,
+                ): ai.rever.boss.plugin.api.EditResult? = null
+            }
+        val service =
+            ContentSearchService(
+                projectPathProvider = { dir.absolutePath },
+                bufferBridge = bridge,
+                openEditorPathsProvider = { setOf(open) },
+            )
+
+        val paths = service.searchInProject(query = "unsavedNeedle").map { it.path }
+
+        assertEquals(listOf("top.kt"), paths, "the live buffer's content was not searched")
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ReplaceExpansionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ReplaceExpansionTest.kt
@@ -1,0 +1,54 @@
+package ai.rever.boss.search
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * The replacement-expansion contract, pinned on the shared function BOTH the disk and
+ * buffer paths call. The bug this guards against: a literal query with a `$` in its
+ * replacement was expanded as a capture reference ("$40 off" → "0 off"), and the two
+ * paths disagreed about whether `$1` was literal or a group.
+ */
+class ReplaceExpansionTest {
+    private val svc = ContentSearchService { null }
+
+    private fun run(
+        text: String,
+        pattern: String,
+        repl: String,
+        isRegex: Boolean,
+    ) = svc.computeReplaced(text, Regex(pattern), repl, isRegex)
+
+    @Test
+    fun `a literal query keeps a dollar-digit in the replacement literal`() {
+        val out = run("PRICE", "PRICE", "$40 off", isRegex = false)
+        assertEquals("$40 off", out.text)
+        assertEquals(1, out.count)
+    }
+
+    @Test
+    fun `a literal query keeps backslashes`() {
+        assertEquals("C:\\temp", run("x", "x", "C:\\temp", isRegex = false).text)
+    }
+
+    @Test
+    fun `a regex query expands capture references`() {
+        val out = run("fun foo(", "fun (\\w+)\\(", "fun new_$1(", isRegex = true)
+        assertEquals("fun new_foo(", out.text)
+    }
+
+    @Test
+    fun `a lookahead regex advances past every match`() {
+        val out = run("ab ab", "a(?=b)", "X", isRegex = true)
+        assertEquals("Xb Xb", out.text)
+        assertEquals(2, out.count)
+    }
+
+    @Test
+    fun `the changed span is the minimal edit`() {
+        val span = svc.changedSpan("hello world", "hello brave world")
+        assertEquals("hello ".length, span.oldStart)
+        assertEquals("hello ".length, span.oldEndExclusive) // pure insertion
+        assertEquals("hello brave ".length, span.newEndExclusive)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ReplaceExpansionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ReplaceExpansionTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
  * paths disagreed about whether `$1` was literal or a group.
  */
 class ReplaceExpansionTest {
-    private val svc = ContentSearchService { null }
+    private val svc = ContentSearchService(projectPathProvider = { null })
 
     private fun run(
         text: String,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ReplaceInBufferTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ReplaceInBufferTest.kt
@@ -1,0 +1,117 @@
+package ai.rever.boss.search
+
+import ai.rever.boss.plugin.api.BufferSnapshot
+import ai.rever.boss.plugin.api.EditResult
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+
+/**
+ * The open-buffer replace path end to end: replaceInBuffer -> changedSpan ->
+ * BufferEditRange.ofSpan -> one version-guarded applyEdit. Previously unreachable in a
+ * test because the editor was a process-global singleton; the EditorBufferBridge seam
+ * makes it fakeable. This is the most delicate arithmetic in the change.
+ */
+class ReplaceInBufferTest {
+    /** A one-file in-memory editor buffer that honours the version guard. */
+    private class FakeBuffer(
+        var content: String,
+    ) : EditorBufferBridge {
+        var version = 7L // arbitrary non-zero, to prove the guard is exercised
+        var reportedVersion: Long? = null // when set, readBuffer lies (buffer moved since)
+
+        override suspend fun readBuffer(path: String) =
+            BufferSnapshot(path = path, content = content, version = reportedVersion ?: version, isModified = false)
+
+        override suspend fun applyEdit(
+            path: String,
+            startLine: Int,
+            startCol: Int,
+            endLine: Int,
+            endCol: Int,
+            newText: String,
+            expectedVersion: Long,
+        ): EditResult {
+            if (expectedVersion != version) {
+                return EditResult(applied = false, reason = "stale")
+            }
+            val start = offset(startLine, startCol)
+            val end = offset(endLine, endCol)
+            content = content.substring(0, start) + newText + content.substring(end)
+            version++
+            return EditResult(applied = true, newVersion = version)
+        }
+
+        // 1-based line, 1-based col -> absolute offset
+        private fun offset(
+            line: Int,
+            col: Int,
+        ): Int {
+            var off = 0
+            var l = 1
+            while (l < line) {
+                off = content.indexOf('\n', off) + 1
+                l++
+            }
+            return off + (col - 1)
+        }
+    }
+
+    private fun serviceOver(
+        buffer: FakeBuffer,
+        root: String,
+    ) = ContentSearchService(projectPathProvider = { root }, bufferBridge = buffer)
+
+    @Test
+    fun `replace edits the open buffer, not disk, and expands captures`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val f = File(dir, "a.kt").apply { writeText("val OLD = 1\nval OLD = 2\n") }
+        val buffer = FakeBuffer("val OLD = 1\nval OLD = 2\n")
+        val svc = serviceOver(buffer, dir.absolutePath)
+
+        val summary =
+            svc.replaceInProject(
+                query = "OLD",
+                replacement = "NEW",
+                files = listOf(f.absolutePath),
+                isRegex = false,
+                dryRun = false,
+            )
+
+        assertEquals(2, summary.totalReplacements)
+        assertEquals("val NEW = 1\nval NEW = 2\n", buffer.content)
+        // Disk is untouched: the file was open, so the edit went to the buffer.
+        assertEquals("val OLD = 1\nval OLD = 2\n", f.readText())
+    }
+
+    @Test
+    fun `a stale buffer version aborts without touching the buffer`(
+        @TempDir dir: File,
+    ) = runBlocking {
+        val f = File(dir, "b.kt").apply { writeText("OLD OLD\n") }
+        // readBuffer reports v7, but the buffer has really moved to v8 (a keystroke since
+        // the snapshot). applyEdit(expectedVersion = 7) must see the mismatch and refuse.
+        val buffer =
+            FakeBuffer("OLD OLD\n").apply {
+                version = 8
+                reportedVersion = 7
+            }
+        val svc = serviceOver(buffer, dir.absolutePath)
+
+        val summary =
+            svc.replaceInProject(
+                query = "OLD",
+                replacement = "X",
+                files = listOf(f.absolutePath),
+                isRegex = false,
+                dryRun = false,
+            )
+
+        assertEquals("OLD OLD\n", buffer.content, "a stale edit must not be applied")
+        assertEquals(0, summary.totalReplacements)
+        assertEquals("stale", summary.files.single().error)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ResolveFileConfinementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ResolveFileConfinementTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * resolveFile is the control that stops project_replace rewriting a file outside the
@@ -59,12 +60,24 @@ class ResolveFileConfinementTest {
     ) {
         val target = File(other, "outside.txt").apply { writeText("x") }
         val link = File(dir, "link.txt")
+        // Catch the SPECIFIC failures that mean "no symlink support" (the
+        // Windows filesystem case this test skips for): the JDK throws
+        // UnsupportedOperationException on an unsupported filesystem and a
+        // FileSystemException when the create itself fails. A bare
+        // `catch (e: Exception)` swallowed every error, including a link that
+        // failed to be created for a different reason - in which case the
+        // assertNull below would have "passed" without testing anything.
         try {
             java.nio.file.Files
                 .createSymbolicLink(link.toPath(), target.toPath())
-        } catch (e: Exception) {
-            return // filesystem without symlink support; skip
+        } catch (e: UnsupportedOperationException) {
+            org.junit.jupiter.api.Assumptions
+                .abort("no symlink support: ${e.message}")
+        } catch (e: java.nio.file.FileSystemException) {
+            org.junit.jupiter.api.Assumptions
+                .abort("symlink creation refused: ${e.message}")
         }
+        assertTrue(link.exists(), "precondition: the symlink was created")
         assertNull(svc.resolveFile("link.txt", dir.absolutePath))
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ResolveFileConfinementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ResolveFileConfinementTest.kt
@@ -1,0 +1,70 @@
+package ai.rever.boss.search
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * resolveFile is the control that stops project_replace rewriting a file outside the
+ * project (e.g. ~/.zshrc). Its KDoc says so; these pin it, since a confinement check
+ * that silently rots is worse than none.
+ */
+class ResolveFileConfinementTest {
+    private val svc = ContentSearchService { null }
+
+    @Test
+    fun `a relative path inside the project resolves`(
+        @TempDir dir: File,
+    ) {
+        File(dir, "src").mkdirs()
+        val f = File(dir, "src/A.kt").apply { writeText("x") }
+        val resolved = svc.resolveFile("src/A.kt", dir.absolutePath)
+        assertEquals(f.canonicalFile, resolved?.canonicalFile)
+    }
+
+    @Test
+    fun `an absolute path outside the project is refused`(
+        @TempDir dir: File,
+        @TempDir other: File,
+    ) {
+        val outside = File(other, "secret.txt").apply { writeText("x") }
+        assertNull(svc.resolveFile(outside.absolutePath, dir.absolutePath))
+    }
+
+    @Test
+    fun `a dotdot traversal escaping the project is refused`(
+        @TempDir dir: File,
+    ) {
+        val victim = File(dir.parentFile, "victim.txt").apply { writeText("x") }
+        assertNull(svc.resolveFile("../${victim.name}", dir.absolutePath))
+    }
+
+    @Test
+    fun `a sibling project sharing a name prefix is refused`(
+        @TempDir parent: File,
+    ) {
+        // /parent/proj must not admit /parent/proj-other/x
+        val proj = File(parent, "proj").apply { mkdirs() }
+        val other = File(parent, "proj-other").apply { mkdirs() }
+        val f = File(other, "x.kt").apply { writeText("x") }
+        assertNull(svc.resolveFile(f.absolutePath, proj.absolutePath))
+    }
+
+    @Test
+    fun `a symlink escaping the project is refused`(
+        @TempDir dir: File,
+        @TempDir other: File,
+    ) {
+        val target = File(other, "outside.txt").apply { writeText("x") }
+        val link = File(dir, "link.txt")
+        try {
+            java.nio.file.Files
+                .createSymbolicLink(link.toPath(), target.toPath())
+        } catch (e: Exception) {
+            return // filesystem without symlink support; skip
+        }
+        assertNull(svc.resolveFile("link.txt", dir.absolutePath))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ResolveFileConfinementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/search/ResolveFileConfinementTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertNull
  * that silently rots is worse than none.
  */
 class ResolveFileConfinementTest {
-    private val svc = ContentSearchService { null }
+    private val svc = ContentSearchService(projectPathProvider = { null })
 
     @Test
     fun `a relative path inside the project resolves`(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,7 +125,25 @@ intellij-platform = "243.21565.199"
 #
 # Superset of 1.0.84: both additions are new declarations with a null default on PluginContext,
 # so nothing a host module or an installed plugin resolves has been withdrawn.
-boss-plugin-api = "1.0.85"
+#
+# 1.0.87 adds the IDE-features batch, as ONE release: GitDataProvider diff members
+# (diffFile/diffRef/diffBetween/diffNames/openDiff + GitDiffData/DiffHunk/DiffLine),
+# the graph members (logGraph/logGraphFor/branches + GitCommitNodeData/GitBranchRefData),
+# the remote actions (fetch/pull/push), the EditorTabPluginAPI buffer section
+# (readBuffer/applyEdit/observeChanges/focusedDocument/openEditor/openSplit),
+# ProjectSearchProvider + PluginContext.projectSearchProvider, DiffTabConfig (so the
+# diff renderer can live in editor-tab, where BossEditor is), the deprecated no-op
+# legacy EditorContentProvider methods, and AiRequest.modelOverride (body-level getter
+# over extras, no constructor change). All additive with default bodies.
+#
+# The surface was developed across four working versions (.87/.88/.89/.90) and
+# collapsed back to a single release before publishing, per the plan's R8 rule - one
+# release means one number for every consumer to pin and no manifest drift.
+#
+# The host implements the new members in this branch: UnifiedDiffParser + git diff
+# plumbing, HunkApplier, the diff/composer tab types, the editor buffer API, and
+# ContentSearchService. Same forced order as above: api first, then this.
+boss-plugin-api = "1.0.87"
 
 [libraries]
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,7 +141,7 @@ intellij-platform = "243.21565.199"
 # release means one number for every consumer to pin and no manifest drift.
 #
 # The host implements the new members in this branch: UnifiedDiffParser + git diff
-# plumbing, HunkApplier, the diff/composer tab types, the editor buffer API, and
+# plumbing, the diff/composer tab types, the editor buffer API, and
 # ContentSearchService. Same forced order as above: api first, then this.
 boss-plugin-api = "1.0.87"
 

--- a/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/composer/ComposerTabInfo.kt
+++ b/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/composer/ComposerTabInfo.kt
@@ -1,0 +1,52 @@
+package ai.rever.boss.plugin.tab.composer
+
+import ai.rever.boss.plugin.api.TabIcon
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabTypeId
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SmartToy
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Tab info for an AI Composer tab.
+ *
+ * The composer session's state (messages, proposals) lives in the editor-tab
+ * plugin's plugin storage, keyed by [sessionId]. Only the id is persisted in
+ * the workspace so a restored tab can reload its session; when the plugin (and
+ * its store) is absent the host DROPS this tab and restores the rest of the
+ * layout - `addTab` refuses a type with no registered factory. The layout
+ * survives; the tab does not.
+ *
+ * @param id Unique identifier for this tab instance
+ * @param title Display title (the task, truncated)
+ * @param icon Tab icon vector
+ * @param tabIcon Tab icon wrapper
+ * @param sessionId Opaque session id the editor-tab plugin resolves against its storage
+ */
+data class ComposerTabInfo(
+    override val id: String,
+    override val typeId: TabTypeId = ComposerTabType.typeId,
+    override val title: String,
+    override val icon: ImageVector = Icons.Outlined.SmartToy,
+    override val tabIcon: TabIcon? = null,
+    val sessionId: String = "",
+) : TabInfo {
+    companion object {
+        /**
+         * Build a composer tab for the given session. [title] defaults to the generic name.
+         *
+         * The tab id IS the session id: the plugin side cannot see this class
+         * (the api jar filters it out) and reads the id through the plain
+         * TabInfo interface to resolve its session.
+         */
+        fun create(
+            sessionId: String,
+            title: String = "Composer",
+        ): ComposerTabInfo =
+            ComposerTabInfo(
+                id = sessionId,
+                title = title,
+                sessionId = sessionId,
+            )
+    }
+}

--- a/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/composer/ComposerTabType.kt
+++ b/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/composer/ComposerTabType.kt
@@ -1,0 +1,22 @@
+package ai.rever.boss.plugin.tab.composer
+
+import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.api.TabTypeInfo
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SmartToy
+
+/**
+ * Composer tab type (host-provided type, plugin-provided UI).
+ *
+ * The AI composer tab is rendered by the editor-tab plugin (it owns the
+ * buffers the composer edits and the diff machinery for the review), but the
+ * tab TYPE and its persistable [ComposerTabInfo] live here so workspace
+ * restore can rebuild the tab without the plugin's classes: the host persists
+ * the session id, waits for the plugin to register its factory, and drops the
+ * tab gracefully when the plugin is absent.
+ */
+object ComposerTabType : TabTypeInfo {
+    override val typeId = TabTypeId("composer")
+    override val displayName = "Composer"
+    override val icon = Icons.Outlined.SmartToy
+}

--- a/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/diff/DiffTabInfo.kt
+++ b/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/diff/DiffTabInfo.kt
@@ -1,0 +1,98 @@
+package ai.rever.boss.plugin.tab.diff
+
+import ai.rever.boss.plugin.api.TabIcon
+import ai.rever.boss.plugin.api.TabInfo
+import ai.rever.boss.plugin.api.TabTypeId
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Difference
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlin.random.Random
+
+/**
+ * Tab info for a git diff tab.
+ *
+ * Exactly one scope applies, mirroring `GitDataProvider`'s diff methods:
+ * - working/staged file diff: [filePath] set, refs null
+ * - single commit diff: [fromRef] set ([filePath] optionally restricts it)
+ * - ref range diff: [fromRef] and [toRef] set ([filePath] optional)
+ *
+ * @param id Unique identifier for this tab instance
+ * @param title Display title (file name, short hash, or a ref range)
+ * @param icon Tab icon vector
+ * @param tabIcon Tab icon wrapper
+ * @param filePath File path relative to the project root ("" for commit/range diffs)
+ * @param staged true = staged (index vs HEAD), false = working tree vs index
+ * @param fromRef Base ref for commit/range diffs
+ * @param toRef Target ref for range diffs
+ */
+data class DiffTabInfo(
+    override val id: String,
+    override val typeId: TabTypeId = DiffTabType.typeId,
+    override val title: String,
+    override val icon: ImageVector = Icons.Outlined.Difference,
+    override val tabIcon: TabIcon? = null,
+    override val filePath: String = "",
+    override val staged: Boolean = false,
+    override val fromRef: String? = null,
+    override val toRef: String? = null,
+    // DiffTabConfig is the read side of this config, on the plugin api surface:
+    // it is what lets the renderer live in the editor-tab plugin (where the
+    // lexer, language servers and overview ruler are) instead of the host.
+) : TabInfo,
+    ai.rever.boss.plugin.api.DiffTabConfig {
+    companion object {
+        fun newId(): String = "diff-${Random.nextLong()}"
+
+        /**
+         * Build a diff tab for the given scope. The title is derived from the
+         * scope: file name for file diffs, short hash for commit diffs,
+         * "from...to" (truncated) for range diffs.
+         */
+        fun create(
+            filePath: String,
+            staged: Boolean = false,
+            fromRef: String? = null,
+            toRef: String? = null,
+        ): DiffTabInfo {
+            val title =
+                when {
+                    fromRef != null && toRef != null -> {
+                        rangeTitle(fromRef, toRef)
+                    }
+
+                    fromRef != null -> {
+                        shortRef(fromRef)
+                    }
+
+                    filePath.isNotBlank() -> {
+                        filePath.substringAfterLast('/').ifEmpty { "Diff" }
+                    }
+
+                    else -> {
+                        "Diff"
+                    }
+                }
+            return DiffTabInfo(
+                id = newId(),
+                title = title,
+                filePath = filePath,
+                staged = staged,
+                fromRef = fromRef,
+                toRef = toRef,
+            )
+        }
+
+        private fun shortRef(ref: String): String {
+            val trimmed = ref.trim()
+            return if (trimmed.length > 12) trimmed.take(8) + "…" else trimmed
+        }
+
+        private fun rangeTitle(
+            from: String,
+            to: String,
+        ): String {
+            val t = "${shortRef(from)}...${shortRef(to)}"
+            return if (t.length > 40) t.take(39) + "…" else t
+        }
+    }
+}

--- a/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/diff/DiffTabType.kt
+++ b/plugin-platform/plugin-api-core/src/commonMain/kotlin/ai/rever/boss/plugin/tab/diff/DiffTabType.kt
@@ -1,0 +1,21 @@
+package ai.rever.boss.plugin.tab.diff
+
+import ai.rever.boss.plugin.api.TabTypeId
+import ai.rever.boss.plugin.api.TabTypeInfo
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Difference
+
+/**
+ * Git Diff tab type (host-provided).
+ *
+ * The diff tab is opened by the host itself: the git data provider's
+ * `openDiff` (which plugins call) emits an event the host consumes, and
+ * workspace restore rebuilds it. Plugins never construct a [DiffTabInfo]
+ * directly, so this type stays host-internal - the plugin-facing surface is
+ * `GitDataProvider.openDiff`.
+ */
+object DiffTabType : TabTypeInfo {
+    override val typeId = TabTypeId("diff")
+    override val displayName = "Diff"
+    override val icon = Icons.Outlined.Difference
+}

--- a/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
+++ b/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
@@ -323,7 +323,8 @@ object FileEventBus {
      * @param staged true = staged (index vs HEAD), false = working tree vs index
      * @param fromRef Base ref for commit/range diffs
      * @param toRef Target ref for range diffs
-     * @param sourceWindowId The window to open the tab in ("" = current window)
+     * @param sourceWindowId The window to open the tab in. Required: consumers filter
+     *   on exact equality, so a blank id matches no window (the caller refuses it).
      */
     suspend fun openDiffTab(
         filePath: String,

--- a/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
+++ b/plugin-platform/plugin-events/src/commonMain/kotlin/ai/rever/boss/plugin/events/FileEventBus.kt
@@ -26,6 +26,30 @@ data class FileOpenEvent(
 )
 
 /**
+ * Event emitted when a git diff should be opened in a dedicated diff tab.
+ *
+ * Exactly one of the three scopes applies:
+ * - working/staged file: [filePath] set, [fromRef]/[toRef] null
+ * - single commit: [filePath] blank, [fromRef] set, [toRef] null
+ * - ref range: [fromRef] and [toRef] both set ([filePath] optional)
+ *
+ * @property filePath File path relative to the project root ("" for commit/range diffs)
+ * @property staged true = staged (index vs HEAD), false = working tree vs index
+ * @property fromRef Base ref for commit/range diffs
+ * @property toRef Target ref for range diffs
+ * @property sourceWindowId The window that initiated this event (required for
+ *   multi-window support, as on [FileOpenEvent]). Consumers filter on exact
+ *   equality, so a blank id routes to NO window - it does not mean "current".
+ */
+data class DiffOpenEvent(
+    val filePath: String,
+    val staged: Boolean,
+    val fromRef: String?,
+    val toRef: String?,
+    val sourceWindowId: String,
+)
+
+/**
  * Callback interface for file open tracking.
  * Implement this to track file opens (e.g., recent files tracking).
  */
@@ -238,6 +262,13 @@ object FileEventBus {
         )
     val fileOpenEvents: SharedFlow<FileOpenEvent> = _fileOpenEvents.asSharedFlow()
 
+    private val _diffOpenEvents =
+        MutableSharedFlow<DiffOpenEvent>(
+            replay = 0, // Don't replay past events to new subscribers (new windows)
+            extraBufferCapacity = 10,
+        )
+    val diffOpenEvents: SharedFlow<DiffOpenEvent> = _diffOpenEvents.asSharedFlow()
+
     // Callback for file tracking (e.g., recent files)
     private var fileOpenCallback: FileOpenCallback? = null
 
@@ -283,5 +314,34 @@ object FileEventBus {
             ),
         )
         _fileOpenEvents.emit(FileOpenEvent(cleanPath, fileName, line, column, sourceWindowId))
+    }
+
+    /**
+     * Opens a git diff in a dedicated diff tab.
+     *
+     * @param filePath File path relative to the project root ("" for commit/range diffs)
+     * @param staged true = staged (index vs HEAD), false = working tree vs index
+     * @param fromRef Base ref for commit/range diffs
+     * @param toRef Target ref for range diffs
+     * @param sourceWindowId The window to open the tab in ("" = current window)
+     */
+    suspend fun openDiffTab(
+        filePath: String,
+        staged: Boolean,
+        fromRef: String?,
+        toRef: String?,
+        sourceWindowId: String,
+    ) {
+        logger.debug(
+            LogCategory.FILE,
+            "Opening diff tab",
+            mapOf(
+                "path" to filePath,
+                "from" to fromRef,
+                "to" to toRef,
+                "window" to sourceWindowId,
+            ),
+        )
+        _diffOpenEvents.emit(DiffOpenEvent(filePath, staged, fromRef, toRef, sourceWindowId))
     }
 }

--- a/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
+++ b/plugin-platform/plugin-sandbox/src/desktopMain/kotlin/ai/rever/boss/plugin/sandbox/context/SandboxedPluginContext.kt
@@ -34,6 +34,7 @@ import ai.rever.boss.plugin.api.PluginManifest
 import ai.rever.boss.plugin.api.PluginSandboxRef
 import ai.rever.boss.plugin.api.PluginStorageFactory
 import ai.rever.boss.plugin.api.PluginStoreApiKeyProvider
+import ai.rever.boss.plugin.api.ProjectSearchProvider
 import ai.rever.boss.plugin.api.RoleManagementProvider
 import ai.rever.boss.plugin.api.RunConfigurationDataProvider
 import ai.rever.boss.plugin.api.ScreenCaptureProvider
@@ -117,6 +118,9 @@ class SandboxedPluginContext(
 
     override val gitDataProvider: GitDataProvider?
         get() = delegate.gitDataProvider
+
+    override val projectSearchProvider: ProjectSearchProvider?
+        get() = delegate.projectSearchProvider
 
     override val fileSystemDataProvider: FileSystemDataProvider?
         get() = delegate.fileSystemDataProvider


### PR DESCRIPTION
## What this is

The **host half** of the IDE-features batch — the provider implementations and host plumbing that make BOSS more Cursor-like. Sandboxed / out-of-process plugins (editor-tab, codebase, git-status, git-log) consume this surface through **boss-plugin-api 1.0.87**.

**Draft, and the plugin repos land separately.** This PR is BossConsole only; editor-tab, codebase, git-status, git-log, and the api release each get their own PR, reviewed repo-by-repo. CI here is red until `boss-plugin-api` 1.0.87 is published (this PR bumps the pin to it).

## What's in it

**Git diff plumbing**  -  `GitService`/`DesktopGitService` gain per-file, commit, and ref-range diffs plus window-scoped fetch/pull/push and ref-scoped log; `UnifiedDiffParser` turns git output into `GitDiffData`; `GitDataProviderImpl` implements the 1.0.87 provider and resolves the **window's** project path for both the reads and the writes (two-window correctness).

**Project search / replace**  -  `ContentSearchService` behind `ProjectSearchProvider`: exclusion inside the walk, project confinement on replace, one shared `computeReplaced` (Java `Matcher.appendReplacement`) driving both the disk and open-buffer paths so literal-vs-regex expansion can't diverge. Buffer replace is a single version-guarded, undoable edit. The buffer bridge is only asked about files with an open editor tab in the searching window.

**Tabs & events** — `DiffTabInfo`/`DiffTabType` and `ComposerTabInfo`/`ComposerTabType` in `plugin-api-core` with safe workspace persistence; `DiffOpenEvent` on `FileEventBus`, window-filtered.

**Security & robustness**  -  every plugin-reachable git ref is validated and revision lists are `--`-terminated (closes an arbitrary-file-write via `git diff --output=` reachable from read-only MCP tools); `runProcessBounded` drains both pipes on daemon threads before a bounded wait (no deadlock, no app-wide lock freeze); index-writing git subcommands get a generous bound and a stranded-`index.lock` hint on a timeout kill; truncated git output is flagged and the diff getters refuse a partial stream.

## How it was reviewed

Five rounds of independent adversarial review (each a fresh agent, no shared context). The git-argument, subprocess, diff-parser, and search/replace-engine code was re-verified as correct in every round. The final round's data-loss findings - a wrong-worktree write race, a checkout that mangled slashed local branch names, a 60s kill that could wedge `.git/index.lock`, and legacy `pull()`/`push()` on the interactive path - are all fixed in `99e27867`, together with the round's smaller items. **The one outstanding blocker the reviews found - a buffer refcount asymmetry - is in the editor-tab plugin, not the host, and lands with that repo's PR.**

## Testing

`:composeApp:desktopTest` - **3312 tests, 0 failures**. ktlint and detekt clean.

## Not in this PR

**Tracked for the plugin PRs**
- editor-tab buffer acquire/release refcount fix (final-review blocker, plugin-side)
- editor-tab: merge commits render as an empty diff tab until the renderer falls back to `rawUnified` for combined diffs
- codebase `plugin.json` version bump so the retirement floor (≥1.6.0) actually fires
- the coordinated `boss-plugin-api` 1.0.87 release

**Release ordering**
The `RetiredPluginIds` filter (wizard + home tool grid) hides git-status/git-log unconditionally from this host build on, while the retirement sweep stays floored at codebase ≥1.6.0. Between this host release and the codebase 1.6.0 release, a fresh install loses those two panels with no replacement - this host build must ship with (or after) the codebase 1.6.0 release, or the filter gets the same floor.

**Host follow-ups, deliberately deferred**
- `@Serializable` for `DiffOpenEvent`/`FileOpenEvent` (the cross-process forward currently ships `toString()` bytes; inherited from the older event, and the fix touches the api module mid-release - one small PR for the pair)
- `gitCommandLock` re-keyed by repo root (and/or a coroutine mutex) - a focused change; the index-safety argument needs care
- an `openBufferPaths()` member on the editor API; the host enumerates its own open editor tabs meanwhile, which is correct and bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)