### PR TITLE
fix: two-finger swipe committed mid-gesture instead of on release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,21 @@ vertical measured as a path length and horizontal as net displacement. Chrome's 
 are fractions of the trackpad from `NSTouch.normalizedPosition`, which a page cannot see, so those
 carry over as the same fractions of the commit distance.
 
+**It commits on release, not on crossing the commit distance.** AWT does not surface NSEvent's
+scroll phases, so "the fingers lifted" is inferred from `GESTURE_GAP_MS` (120ms) of quiet, and the
+gesture is decided there - against the LAST horizontal position, so easing back below the line
+cancels. That makes `GESTURE_GAP_MS` do three jobs at once: segmenting one gesture from the next,
+setting a floor on commit latency, and (as the minimum possible gap between two gesture ends)
+bounding `SWIPE_NAV_DEBOUNCE_MS` from above. Raising or lowering it touches all three.
+
+**Momentum phase is the open question.** A `CGEvent` tap on this hardware (measured 2026-09-02)
+shows macOS emitting momentum-phase scroll for 180-870ms after the fingers lift, carrying
+325-2500px of horizontal travel. Whether Chromium forwards those to the renderer as `wheel` events
+is NOT confirmed: if it does, each one re-arms the end-of-gesture timer and a flick commits at
+end-of-momentum instead of at release. Synthetic phase-tagged events cannot answer it - `CGEventPost`
+from another process never reaches the layered native browser surface, and does not even enter the
+session event stream - so it needs one real flick against a recording `wheel` listener.
+
 **Off switch**: `Settings > Browser > Trackpad`, stored in `~/.boss/swipe-nav.json`, or
 `BOSS_BROWSER_SWIPE_NAV=false` (also `0` / `no` / `off`). The environment wins, and the Settings row
 says so. The setting is published as a **system property** because the browser plugin draws the home

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,20 +607,43 @@ vertical measured as a path length and horizontal as net displacement. Chrome's 
 are fractions of the trackpad from `NSTouch.normalizedPosition`, which a page cannot see, so those
 carry over as the same fractions of the commit distance.
 
-**It commits on release, not on crossing the commit distance.** AWT does not surface NSEvent's
-scroll phases, so "the fingers lifted" is inferred from `GESTURE_GAP_MS` (120ms) of quiet, and the
-gesture is decided there - against the LAST horizontal position, so easing back below the line
-cancels. That makes `GESTURE_GAP_MS` do three jobs at once: segmenting one gesture from the next,
-setting a floor on commit latency, and (as the minimum possible gap between two gesture ends)
-bounding `SWIPE_NAV_DEBOUNCE_MS` from above. Raising or lowering it touches all three.
+**It commits at the end of the gesture, not on crossing the commit distance** - and "end of
+gesture" is literally `GESTURE_GAP_MS` (120ms) with no wheel event, because AWT does not surface
+NSEvent's scroll phases and a time gap is the only segmentation signal there is. So it is not
+release: holding past the line and simply STOPPING, fingers still down, commits after 120ms too.
+The window in which reversing still cancels is 120ms of continuous motion, not "until you lift".
+The decision reads the LAST horizontal position, so easing back below the line cancels.
 
-**Momentum phase is the open question.** A `CGEvent` tap on this hardware (measured 2026-09-02)
-shows macOS emitting momentum-phase scroll for 180-870ms after the fingers lift, carrying
-325-2500px of horizontal travel. Whether Chromium forwards those to the renderer as `wheel` events
-is NOT confirmed: if it does, each one re-arms the end-of-gesture timer and a flick commits at
-end-of-momentum instead of at release. Synthetic phase-tagged events cannot answer it - `CGEventPost`
-from another process never reaches the layered native browser surface, and does not even enter the
-session event stream - so it needs one real flick against a recording `wheel` listener.
+That makes `GESTURE_GAP_MS` do three jobs at once: segmenting one gesture from the next, setting a
+floor on commit latency, and (as the minimum possible gap between two gesture ends) bounding
+`SWIPE_NAV_DEBOUNCE_MS` from above. Raising or lowering it touches all three, and
+`BrowserSwipeNavTest` reads it out of the script so the third one fails loudly.
+
+**Past the commit distance, vertical drift stops cancelling** (`reachedCommit`). Vertical is a path
+length and only ever grows, so every event after the crossing was one more chance to cancel a swipe
+the user had already completed. Before the line the three tiers apply unchanged; after it, only
+easing back or reversing can still cancel. Native swipe-back behaves the same way.
+
+**Two host-side windows, for two different things** (`BrowserSwipeNavBridge.kt`).
+`SWIPE_NAV_DEBOUNCE_MS` (32ms, any direction) catches a double-dispatch bug in the bridge.
+`SWIPE_NAV_REPEAT_MS` (400ms, same direction only) is the paused-drag guard: a slow drag that
+hesitates past `GESTURE_GAP_MS` with the fingers down is two gestures to the script and would
+navigate back twice. That guard cannot live in the page - the first commit navigates the tab and
+the script's state dies with the document. The cost is that two intentional same-direction swipes
+under 400ms apart become one; that is the deliberate trade, because a dropped swipe is retryable
+and an extra step back may not be, since the forward entry need not survive a redirect. A reversal
+is never held for the repeat window.
+
+**Momentum phase costs latency and nothing else.** A `CGEvent` tap on this hardware (measured
+2026-09-02) shows macOS emitting momentum-phase scroll for 180-870ms after the fingers lift,
+carrying 325-2500px of horizontal travel. Whether Chromium forwards those to the renderer as
+`wheel` events is NOT confirmed: if it does, each one re-arms the end-of-gesture timer and a flick
+commits at end-of-momentum instead of at release. It cannot change the ANSWER - a tail runs the
+flick's own direction, so it can neither reverse nor ease back, and `reachedCommit` is what closed
+the remaining path, a tail's `deltaY` tripping the vertical tiers. Synthetic phase-tagged events
+cannot settle the forwarding question - `CGEventPost` from another process never reaches the
+layered native browser surface, and does not even enter the session event stream - so it needs one
+real flick against a recording `wheel` listener.
 
 **Off switch**: `Settings > Browser > Trackpad`, stored in `~/.boss/swipe-nav.json`, or
 `BOSS_BROWSER_SWIPE_NAV=false` (also `0` / `no` / `off`). The environment wins, and the Settings row

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserHandleImpl.kt
@@ -306,11 +306,11 @@ internal class BrowserHandleImpl(
             windowId = { currentWindowId },
         )
 
-    // When the last two-finger swipe navigated, for [shouldAcceptSwipeNav]. A handle-level field
-    // rather than the `lastNavigationTime` the aux mouse buttons use, because that one is a
-    // `remember` slot inside Content() and this arrives from a JxBrowser thread with no
-    // composition in sight.
-    @Volatile private var lastSwipeNavAt = 0L
+    // How close together two two-finger swipes may navigate. A handle-level object rather than the
+    // `lastNavigationTime` the aux mouse buttons use, because that one is a `remember` slot inside
+    // Content() and this arrives from a JxBrowser thread with no composition in sight. It survives
+    // the navigation it just caused, which the page-side script cannot - see [SwipeNavGate].
+    private val swipeNavGate = SwipeNavGate()
 
     /** Receives committed two-finger swipes from the page. See [BrowserSwipeNavScript]. */
     private val swipeNavBridge = BrowserSwipeNavBridge(onNavigate = ::onSwipeNavigate)
@@ -1905,9 +1905,7 @@ internal class BrowserHandleImpl(
      * renderer it will not block, and `goBack()` is a round trip into the browser.
      */
     private fun onSwipeNavigate(direction: SwipeNavDirection) {
-        val now = System.currentTimeMillis()
-        if (!isValid || !shouldAcceptSwipeNav(now, lastSwipeNavAt)) return
-        lastSwipeNavAt = now
+        if (!isValid || !swipeNavGate.accept(direction)) return
         pageInjectScope.launch(pageInjectDispatcher) {
             when (direction) {
                 SwipeNavDirection.BACK -> goBack()

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt
@@ -95,10 +95,23 @@ internal fun parseSwipeNavDirection(raw: String?): SwipeNavDirection? =
 /**
  * Whether a swipe arriving at [nowMs] should navigate, given when the last one did.
  *
- * The debounce is longer than the 100ms the aux mouse buttons use. A button click is a discrete
- * act; a swipe is a continuous one that a trackpad can re-trigger from the tail of the same finger
- * movement, and going back two pages when the user meant one is not obviously recoverable - the
- * forward entry may not survive the intervening page's redirect.
+ * **The rationale this originally shipped with no longer applies, and the value changed with
+ * it.** `swipe-nav.js` used to call [navigate] the instant a gesture crossed the commit
+ * distance, mid-swipe - so the tail of ONE continuous finger movement really could look like a
+ * second gesture and re-fire. Since `swipe-nav.js`'s `decide()` (boss-plugin-fluck-browser#36)
+ * now calls this at most once per gesture END, that case is structurally impossible: there is
+ * nothing left in the page's own state machine that can produce two calls for one swipe.
+ *
+ * What is left to guard against is narrower - a genuine double-fire *bug* in this bridge or its
+ * caller, not a real second gesture - and the value was still tuned for the old case. Two
+ * distinct 90px swipes, timed as a deliberate long hold followed by a quick flick, can now land
+ * as little as roughly `GESTURE_GAP_MS` (120ms, `swipe-nav.js`) plus the second gesture's own
+ * duration apart - a fast trackpad flick clears the script's `MIN_EVENTS` in well under 100ms -
+ * so the old 400ms window silently dropped a legitimate second swipe the user could see they had
+ * just made. 100ms sits below `GESTURE_GAP_MS` itself (400ms did not), which is a hard floor on
+ * every real gesture's END regardless of how short the gesture that produced it was - so this
+ * can never reject a genuinely separate swipe - while still exceeding a same-tick or same-frame
+ * double-dispatch, which is the actual failure shape a bridge-level bug would take.
  *
  * Pure, so the window is pinned by a test rather than by trying to swipe twice quickly by hand.
  */
@@ -107,4 +120,4 @@ internal fun shouldAcceptSwipeNav(
     lastNavigationMs: Long,
 ): Boolean = nowMs - lastNavigationMs > SWIPE_NAV_DEBOUNCE_MS
 
-internal const val SWIPE_NAV_DEBOUNCE_MS = 400L
+internal const val SWIPE_NAV_DEBOUNCE_MS = 100L

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt
@@ -95,23 +95,23 @@ internal fun parseSwipeNavDirection(raw: String?): SwipeNavDirection? =
 /**
  * Whether a swipe arriving at [nowMs] should navigate, given when the last one did.
  *
- * **The rationale this originally shipped with no longer applies, and the value changed with
- * it.** `swipe-nav.js` used to call [navigate] the instant a gesture crossed the commit
- * distance, mid-swipe - so the tail of ONE continuous finger movement really could look like a
- * second gesture and re-fire. Since `swipe-nav.js`'s `decide()` (boss-plugin-fluck-browser#36)
- * now calls this at most once per gesture END, that case is structurally impossible: there is
- * nothing left in the page's own state machine that can produce two calls for one swipe.
+ * The window is here for a double-fire *bug* in this bridge or its caller, and not for a real
+ * second gesture. The page cannot produce one: `swipe-nav.js`'s `decide()` calls this at most
+ * once per gesture END, and two gesture ends are always at least the script's own
+ * `GESTURE_GAP_MS` apart, because that quiet gap IS how the script tells one gesture from the
+ * next.
  *
- * What is left to guard against is narrower - a genuine double-fire *bug* in this bridge or its
- * caller, not a real second gesture - and the value was still tuned for the old case. Two
- * distinct 90px swipes, timed as a deliberate long hold followed by a quick flick, can now land
- * as little as roughly `GESTURE_GAP_MS` (120ms, `swipe-nav.js`) plus the second gesture's own
- * duration apart - a fast trackpad flick clears the script's `MIN_EVENTS` in well under 100ms -
- * so the old 400ms window silently dropped a legitimate second swipe the user could see they had
- * just made. 100ms sits below `GESTURE_GAP_MS` itself (400ms did not), which is a hard floor on
- * every real gesture's END regardless of how short the gesture that produced it was - so this
- * can never reject a genuinely separate swipe - while still exceeding a same-tick or same-frame
- * double-dispatch, which is the actual failure shape a bridge-level bug would take.
+ * So the value belongs strictly BELOW that floor, and above a same-tick or same-frame
+ * double-dispatch, which is the shape a bridge-level bug takes. Above the floor it starts
+ * rejecting real swipes: two distinct 90px gestures timed as a deliberate long hold followed by
+ * a quick flick land about `GESTURE_GAP_MS` plus the flick's own duration apart, and a flick
+ * clears the script's `MIN_EVENTS` in well under 100ms. `BrowserSwipeNavTest` pins both ends
+ * against the script's constant rather than against a number restated here.
+ *
+ * It incidentally rate-limits a hostile page looping `window.__bossSwipeNav.navigate()`, at
+ * roughly 10 calls a second. That is not a boundary and is not sized as one - what holds is the
+ * class KDoc's reasoning, that the page can already loop on `history.back()` with no bridge at
+ * all.
  *
  * Pure, so the window is pinned by a test rather than by trying to swipe twice quickly by hand.
  */

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.utils.logging.BossLogger
 import ai.rever.boss.utils.logging.LogCategory
 import com.teamdev.jxbrowser.js.JsAccessible
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /** Which way a committed swipe was going. */
 internal enum class SwipeNavDirection { BACK, FORWARD }
@@ -92,32 +93,92 @@ internal fun parseSwipeNavDirection(raw: String?): SwipeNavDirection? =
         else -> null
     }
 
+/** A swipe that navigated: when, and which way. */
+internal data class SwipeNavCommit(
+    val atMs: Long,
+    val direction: SwipeNavDirection,
+)
+
 /**
- * Whether a swipe arriving at [nowMs] should navigate, given when the last one did.
+ * Whether a swipe arriving at [nowMs] should navigate, given the one that last did.
  *
- * The window is here for a double-fire *bug* in this bridge or its caller, and not for a real
- * second gesture. The page cannot produce one: `swipe-nav.js`'s `decide()` calls this at most
- * once per gesture END, and two gesture ends are always at least the script's own
- * `GESTURE_GAP_MS` apart, because that quiet gap IS how the script tells one gesture from the
- * next.
+ * Two windows, because two different things are being refused.
  *
- * So the value belongs strictly BELOW that floor, and above a same-tick or same-frame
- * double-dispatch, which is the shape a bridge-level bug takes. Above the floor it starts
- * rejecting real swipes: two distinct 90px gestures timed as a deliberate long hold followed by
- * a quick flick land about `GESTURE_GAP_MS` plus the flick's own duration apart, and a flick
- * clears the script's `MIN_EVENTS` in well under 100ms. `BrowserSwipeNavTest` pins both ends
- * against the script's constant rather than against a number restated here.
+ * [SWIPE_NAV_DEBOUNCE_MS] catches a double-fire *bug* in this bridge or its caller, in either
+ * direction. The page cannot produce a real second gesture that fast: `swipe-nav.js`'s `decide()`
+ * calls this at most once per gesture END, and two gesture ends are always at least the script's
+ * own `GESTURE_GAP_MS` apart, because that quiet gap IS how the script tells one gesture from the
+ * next. So the value belongs strictly below that floor and above a same-frame double-dispatch,
+ * with enough headroom that host-side clock jitter cannot eat the difference.
  *
- * It incidentally rate-limits a hostile page looping `window.__bossSwipeNav.navigate()`, at
- * roughly 10 calls a second. That is not a boundary and is not sized as one - what holds is the
- * class KDoc's reasoning, that the page can already loop on `history.back()` with no bridge at
- * all.
+ * [SWIPE_NAV_REPEAT_MS] refuses a SAME-DIRECTION repeat, and it is the one guard against a paused
+ * drag. The script segments gestures on 120ms of quiet, and 120ms of quiet with the fingers still
+ * down is byte-identical to a lift: a slow deliberate drag that hesitates mid-swipe is two
+ * gestures to the script and would navigate back twice. That guard cannot live in the page,
+ * because the commit navigates the tab and the script's state dies with the document - the second
+ * half of the drag lands in a freshly loaded script that has never heard of the first.
  *
- * Pure, so the window is pinned by a test rather than by trying to swipe twice quickly by hand.
+ * The trade is deliberate and it is not symmetric. Two intentional same-direction swipes less
+ * than [SWIPE_NAV_REPEAT_MS] apart are dropped, and the user swipes again. An unwanted extra step
+ * back may not be undoable at all, because the forward entry does not have to survive the
+ * intervening page's redirect. Dropping the recoverable one is the cheaper mistake.
+ *
+ * A REVERSAL is never held for the repeat window - only for the debounce. Swiping forward straight
+ * after a back is how someone undoes a navigation they did not mean, and a momentum tail cannot
+ * produce one (it runs the flick's own direction), so there is nothing to protect against there.
+ *
+ * The window incidentally rate-limits a hostile page looping `window.__bossSwipeNav.navigate()`,
+ * at roughly 30 calls a second. That is not a boundary and is not sized as one - what holds is the
+ * class KDoc's reasoning, that the page can already loop on `history.back()` with no bridge at all.
+ *
+ * Pure, so both windows are pinned by tests rather than by trying to swipe twice quickly by hand.
  */
 internal fun shouldAcceptSwipeNav(
     nowMs: Long,
-    lastNavigationMs: Long,
-): Boolean = nowMs - lastNavigationMs > SWIPE_NAV_DEBOUNCE_MS
+    previous: SwipeNavCommit?,
+    direction: SwipeNavDirection,
+): Boolean {
+    if (previous == null) return true
+    // The repeat window is the larger of the two - pinned in BrowserSwipeNavTest against the
+    // script's own gesture gap, which sits between them - so a same-direction swipe clearing it has
+    // cleared the debounce as well, and one window per case is the whole rule.
+    val window = if (direction == previous.direction) SWIPE_NAV_REPEAT_MS else SWIPE_NAV_DEBOUNCE_MS
+    return nowMs - previous.atMs > window
+}
 
-internal const val SWIPE_NAV_DEBOUNCE_MS = 100L
+/**
+ * Holds the last committed swipe for [shouldAcceptSwipeNav].
+ *
+ * The check and the record have to happen together. Two calls that genuinely raced would both read
+ * the same `previous`, both pass, and both navigate - `@Volatile` on a plain field gives visibility
+ * and not atomicity, so it would not have closed that. Today only one JxBrowser JS thread can get
+ * here (the script is injected into `mainFrame()` alone), which makes this cheap insurance rather
+ * than a fix for an observed race.
+ *
+ * The clock is [System.nanoTime] and not wall time on purpose: both windows are elapsed-time
+ * questions, and an NTP step backwards on a wall clock would refuse every swipe until real time
+ * caught up.
+ */
+internal class SwipeNavGate(
+    private val nowMs: () -> Long = { System.nanoTime() / NANOS_PER_MS },
+) {
+    private val lastCommit = AtomicReference<SwipeNavCommit?>(null)
+
+    /** True exactly once per accepted swipe; the loser of a race gets false. */
+    fun accept(direction: SwipeNavDirection): Boolean {
+        val now = nowMs()
+        val previous = lastCommit.get()
+        if (!shouldAcceptSwipeNav(now, previous, direction)) return false
+        return lastCommit.compareAndSet(previous, SwipeNavCommit(now, direction))
+    }
+
+    private companion object {
+        const val NANOS_PER_MS = 1_000_000L
+    }
+}
+
+/** Any direction, for a double-dispatch bug. Two frames, well clear of the script's 120ms floor. */
+internal const val SWIPE_NAV_DEBOUNCE_MS = 32L
+
+/** Same direction, for a drag that hesitated past the script's gesture gap. */
+internal const val SWIPE_NAV_REPEAT_MS = 400L

--- a/composeApp/src/desktopMain/resources/browser/swipe-nav.js
+++ b/composeApp/src/desktopMain/resources/browser/swipe-nav.js
@@ -67,8 +67,6 @@
     // Set once the gesture has been ruled out; stays set until the gesture ends, so a
     // rejected swipe cannot become an accepted one halfway through.
     var rejected = false;
-    // Set once the navigation has fired, so one continuous swipe navigates exactly once.
-    var committed = false;
     var direction = 0;
     // Ends the gesture when the fingers lift.
     //
@@ -289,7 +287,6 @@
         verticalPath = 0;
         eventCount = 0;
         rejected = false;
-        committed = false;
         direction = 0;
     }
 
@@ -313,22 +310,48 @@
         }
     }
 
+    // The one place "reached the commit distance" becomes an actual navigation.
+    //
+    // Called only when the gesture ENDS - the endTimer firing, which is the only signal a
+    // lifted finger gives us at all, since AWT does not surface NSEvent's scroll phases. Never
+    // called mid-swipe: reaching COMMIT_PX used to navigate on the spot, in the same wheel
+    // event that crossed it, which is boss-plugin-fluck-browser#36 - a swipe that brushed the
+    // threshold committed with the fingers still down, no way to see it coming and no way to
+    // back out. Read here, this is the same question a native trackpad swipe-back answers only
+    // on release: was the LAST position past the line, not "was any position ever past it".
+    //
+    // Rechecked against the live accumulators rather than a cached progress, so easing back
+    // below COMMIT_PX before release - same direction the whole time, no reversal - cancels
+    // exactly like letting go early on a real trackpad. A genuine reversal never reaches here at
+    // all: it flips `direction` inside onWheel and calls abandon() immediately, which is the
+    // existing, separate cancel-by-reversing path this does not duplicate.
+    function decide() {
+        if (rejected || direction === 0) {
+            return;
+        }
+        if (Math.abs(accumX) / COMMIT_PX >= 1) {
+            navigate(direction);
+        }
+    }
+
     function onWheel(event) {
         var now = Date.now();
         if (now - lastEventAt > GESTURE_GAP_MS) {
             reset();
         }
         lastEventAt = now;
-        // Kept armed for as long as events keep arriving; fires once they stop.
+        // Kept armed for as long as events keep arriving; fires once they stop - the moment
+        // this decides whether the gesture navigates, then resets to neutral either way.
         if (endTimer) {
             w.clearTimeout(endTimer);
         }
         endTimer = w.setTimeout(function () {
             endTimer = 0;
+            decide();
             reset();
         }, GESTURE_GAP_MS);
 
-        if (committed || rejected || switchedOff()) {
+        if (rejected || switchedOff()) {
             return;
         }
         // Line and page modes come from sources that are never a trackpad.
@@ -386,20 +409,20 @@
             return;
         }
 
+        // Progress is tracked all the way through the gesture now, never gated on whether it
+        // has reached the commit distance yet - see decide() for why crossing COMMIT_PX no
+        // longer does anything here beyond what trackAffordance already draws.
         var progress = Math.abs(accumX) / COMMIT_PX;
         showAffordance(direction);
         trackAffordance(direction, progress);
-
-        if (progress >= 1) {
-            committed = true;
-            hideAffordance(direction);
-            navigate(direction);
-        }
     }
 
     // Capture-phase and passive: the gesture only commits when nothing was going to scroll,
     // so there is never anything to preventDefault, and passive keeps this off Chromium's
     // scroll-blocking path.
     w.addEventListener('wheel', onWheel, { capture: true, passive: true });
+    // pagehide is NOT routed through decide() - the page is already unloading, so navigating
+    // it anywhere is moot at best; this only tears down the affordance so nothing outlives the
+    // document it was drawn into.
     w.addEventListener('pagehide', reset, { capture: true });
 })();

--- a/composeApp/src/desktopMain/resources/browser/swipe-nav.js
+++ b/composeApp/src/desktopMain/resources/browser/swipe-nav.js
@@ -274,9 +274,18 @@
 
     // ---- gesture ----------------------------------------------------------------------
 
-    // End of gesture: everything goes back to neutral. Only ever called on a gap in the
-    // wheel stream or on pagehide - never to abandon a gesture in flight, because clearing
-    // `rejected` mid-gesture would let a swipe this code already ruled out come back.
+    // End of gesture: everything goes back to neutral. Never to abandon a gesture in flight -
+    // clearing `rejected` mid-gesture would let a swipe this code already ruled out come back.
+    //
+    // Three call sites, and only one of them decides first: the endTimer callback calls decide()
+    // immediately before this; the gap check at the top of onWheel (a NEXT event arriving after
+    // GESTURE_GAP_MS of quiet) and pagehide call this alone. The gap check dropping a decision in
+    // practice would need a wheel event to land between the timer firing and this running - the
+    // timer is scheduled at exactly GESTURE_GAP_MS and the gap check fires only strictly after,
+    // so the timer task is queued first on a JS event loop with no true concurrency. That is an
+    // argument from task ordering, not a guarantee against every future change, and a decision
+    // dropped there would be a silently lost navigation. pagehide deliberately does NOT decide -
+    // see decide()'s KDoc for why navigating a page that is already unloading is moot.
     function reset() {
         if (endTimer) {
             w.clearTimeout(endTimer);
@@ -325,11 +334,33 @@
     // exactly like letting go early on a real trackpad. A genuine reversal never reaches here at
     // all: it flips `direction` inside onWheel and calls abandon() immediately, which is the
     // existing, separate cancel-by-reversing path this does not duplicate.
+    //
+    // Both extra guards below matter specifically BECAUSE this runs from a timer, not from
+    // onWheel: onWheel's own early returns (the eventCount gate, switchedOff()) stop updating
+    // state the moment they fire, but the timer that calls this keeps firing regardless of how
+    // onWheel's LAST call actually ended - a second review round caught both as real:
+    //
+    // - eventCount < MIN_EVENTS: onWheel never even reaches COMMIT_PX/showAffordance below that
+    //   count, but accumX and direction are still live by then. Two shift-modified mouse-wheel
+    //   notches (or two big trackpad deltas) can each land under MAX_STEP_PX - so neither is
+    //   caught by the wheel-shape guard - and together clear COMMIT_PX before a third event ever
+    //   arrives. Without this, that pair navigates on the timer with no affordance ever shown.
+    // - switchedOff(): the setting can flip WHILE a gesture is in flight - the file's own comment
+    //   above says the detector "stops here rather than staying live until the next navigation",
+    //   which this timer path is the one way to violate silently otherwise.
+    //
+    // Not verified against macOS momentum-phase scroll events specifically: if Chromium delivers
+    // those as further `wheel` events after the fingers lift, they would keep re-arming endTimer
+    // through onWheel and this would not run - and therefore not navigate - until the momentum
+    // scroll itself dies down, not at the moment of release. Same direction throughout a momentum
+    // tail, so it could not flip a commit into a cancel, but it could add real, unmeasured latency
+    // to a fast flick. Flagged rather than assumed away, since the whole design rests on the
+    // timer standing in for "the fingers lifted."
     function decide() {
-        if (rejected || direction === 0) {
+        if (rejected || direction === 0 || eventCount < MIN_EVENTS || switchedOff()) {
             return;
         }
-        if (Math.abs(accumX) / COMMIT_PX >= 1) {
+        if (Math.abs(accumX) >= COMMIT_PX) {
             navigate(direction);
         }
     }

--- a/composeApp/src/desktopMain/resources/browser/swipe-nav.js
+++ b/composeApp/src/desktopMain/resources/browser/swipe-nav.js
@@ -277,15 +277,15 @@
     // End of gesture: everything goes back to neutral. Never to abandon a gesture in flight -
     // clearing `rejected` mid-gesture would let a swipe this code already ruled out come back.
     //
-    // Three call sites, and only one of them decides first: the endTimer callback calls decide()
-    // immediately before this; the gap check at the top of onWheel (a NEXT event arriving after
-    // GESTURE_GAP_MS of quiet) and pagehide call this alone. The gap check dropping a decision in
-    // practice would need a wheel event to land between the timer firing and this running - the
-    // timer is scheduled at exactly GESTURE_GAP_MS and the gap check fires only strictly after,
-    // so the timer task is queued first on a JS event loop with no true concurrency. That is an
-    // argument from task ordering, not a guarantee against every future change, and a decision
-    // dropped there would be a silently lost navigation. pagehide deliberately does NOT decide -
-    // see decide()'s KDoc for why navigating a page that is already unloading is moot.
+    // Both signals that a gesture ended call decide() immediately before this: the endTimer
+    // callback, and the gap check at the top of onWheel (a NEXT event arriving after
+    // GESTURE_GAP_MS of quiet). Whichever of the two gets there first, the other's decide() is a
+    // no-op, because this already put `direction` and `accumX` back to zero. Neither may be the
+    // only decider: Chromium dispatches input on a higher-priority task queue than timers, so a
+    // wheel event can run ahead of an already-due timer task, and a completed gesture that got
+    // reset without deciding is a navigation the user made and silently did not get.
+    //
+    // pagehide is the one reset() that deliberately does NOT decide - see decide().
     function reset() {
         if (endTimer) {
             w.clearTimeout(endTimer);
@@ -321,43 +321,42 @@
 
     // The one place "reached the commit distance" becomes an actual navigation.
     //
-    // Called only when the gesture ENDS - the endTimer firing, which is the only signal a
-    // lifted finger gives us at all, since AWT does not surface NSEvent's scroll phases. Never
-    // called mid-swipe: reaching COMMIT_PX used to navigate on the spot, in the same wheel
-    // event that crossed it, which is boss-plugin-fluck-browser#36 - a swipe that brushed the
-    // threshold committed with the fingers still down, no way to see it coming and no way to
-    // back out. Read here, this is the same question a native trackpad swipe-back answers only
-    // on release: was the LAST position past the line, not "was any position ever past it".
+    // Called only when the gesture ENDS, never mid-swipe. That is the same question a native
+    // trackpad swipe-back answers on release: was the LAST position past the line, not "was any
+    // position ever past it". Reaching COMMIT_PX used to navigate on the spot, in the same wheel
+    // event that crossed it (boss-plugin-fluck-browser#36) - fingers still down, no chance to see
+    // it coming and no way to back out.
     //
-    // Rechecked against the live accumulators rather than a cached progress, so easing back
-    // below COMMIT_PX before release - same direction the whole time, no reversal - cancels
-    // exactly like letting go early on a real trackpad. A genuine reversal never reaches here at
-    // all: it flips `direction` inside onWheel and calls abandon() immediately, which is the
-    // existing, separate cancel-by-reversing path this does not duplicate.
+    // Read against the live accumulators rather than a cached progress, so easing back below
+    // COMMIT_PX before release - same direction the whole time, no reversal - cancels exactly like
+    // letting go early on a real trackpad. A genuine reversal never reaches here at all: it flips
+    // `direction` inside onWheel and abandons there, which is the separate, pre-existing
+    // cancel-by-reversing path this does not duplicate.
     //
-    // Both extra guards below matter specifically BECAUSE this runs from a timer, not from
-    // onWheel: onWheel's own early returns (the eventCount gate, switchedOff()) stop updating
-    // state the moment they fire, but the timer that calls this keeps firing regardless of how
-    // onWheel's LAST call actually ended - a second review round caught both as real:
+    // Both guards past `rejected` matter specifically BECAUSE this runs at gesture end and not
+    // from onWheel: onWheel's early returns stop updating state the moment they fire, but the
+    // gesture still ends, and this still runs on whatever the last onWheel call left behind.
     //
-    // - eventCount < MIN_EVENTS: onWheel never even reaches COMMIT_PX/showAffordance below that
-    //   count, but accumX and direction are still live by then. Two shift-modified mouse-wheel
-    //   notches (or two big trackpad deltas) can each land under MAX_STEP_PX - so neither is
-    //   caught by the wheel-shape guard - and together clear COMMIT_PX before a third event ever
-    //   arrives. Without this, that pair navigates on the timer with no affordance ever shown.
-    // - switchedOff(): the setting can flip WHILE a gesture is in flight - the file's own comment
-    //   above says the detector "stops here rather than staying live until the next navigation",
-    //   which this timer path is the one way to violate silently otherwise.
+    // - eventCount < MIN_EVENTS: below that count onWheel draws no affordance, yet accumX and
+    //   direction are already live. Two shift-modified mouse-wheel notches (or two big trackpad
+    //   deltas) can each land under MAX_STEP_PX - so neither trips the wheel-shape guard alone -
+    //   and together clear COMMIT_PX before a third event ever arrives. Without this, that pair
+    //   navigates with no chevron ever drawn.
+    // - available(direction): asked again here rather than reusing the answer latched in onWheel,
+    //   because the host can push new state during the gesture and throughout the GESTURE_GAP_MS
+    //   after it. It subsumes switchedOff() - the setting can flip mid-gesture, and the comment on
+    //   switchedOff() promises the detector stops when it does - and additionally fails closed if
+    //   the direction lost its history entry, or if state went away entirely.
     //
-    // Not verified against macOS momentum-phase scroll events specifically: if Chromium delivers
-    // those as further `wheel` events after the fingers lift, they would keep re-arming endTimer
-    // through onWheel and this would not run - and therefore not navigate - until the momentum
-    // scroll itself dies down, not at the moment of release. Same direction throughout a momentum
-    // tail, so it could not flip a commit into a cancel, but it could add real, unmeasured latency
-    // to a fast flick. Flagged rather than assumed away, since the whole design rests on the
-    // timer standing in for "the fingers lifted."
+    // MOMENTUM is the open question in this design, and the numbers behind it are in AGENTS.md:
+    // macOS emits momentum-phase scroll for 180-870ms after the fingers lift, measured on this
+    // hardware. Whether Chromium forwards those to the renderer as `wheel` events is not yet
+    // confirmed. If it does, each one re-arms endTimer through onWheel and a flick commits at
+    // end-of-momentum rather than at release. That cannot turn a commit into a cancel, since a
+    // momentum tail runs the flick's own direction; it is latency, on the gesture that should
+    // feel fastest.
     function decide() {
-        if (rejected || direction === 0 || eventCount < MIN_EVENTS || switchedOff()) {
+        if (rejected || direction === 0 || eventCount < MIN_EVENTS || !available(direction)) {
             return;
         }
         if (Math.abs(accumX) >= COMMIT_PX) {
@@ -368,11 +367,19 @@
     function onWheel(event) {
         var now = Date.now();
         if (now - lastEventAt > GESTURE_GAP_MS) {
+            // This much quiet means the PREVIOUS gesture ended, and this event belongs to a new
+            // one - so the old gesture gets decided here, not silently discarded. See reset().
+            decide();
             reset();
         }
         lastEventAt = now;
-        // Kept armed for as long as events keep arriving; fires once they stop - the moment
-        // this decides whether the gesture navigates, then resets to neutral either way.
+        // Kept armed for as long as events keep arriving; fires once they stop - the other of the
+        // two places a gesture is decided and then reset to neutral either way.
+        //
+        // Armed before the early returns below on purpose: a gesture that is rejected or switched
+        // off partway still has to end, and this timer is the only thing that ends one. The cost
+        // is a clearTimeout/setTimeout pair on every wheel event, even with the gesture switched
+        // off, on the hottest path in a browser.
         if (endTimer) {
             w.clearTimeout(endTimer);
         }

--- a/composeApp/src/desktopMain/resources/browser/swipe-nav.js
+++ b/composeApp/src/desktopMain/resources/browser/swipe-nav.js
@@ -68,6 +68,16 @@
     // rejected swipe cannot become an accepted one halfway through.
     var rejected = false;
     var direction = 0;
+    // Latched the first time this gesture is past COMMIT_PX with enough events to be real.
+    //
+    // From that point the vertical tiers stop being asked. Vertical is a PATH LENGTH, so it only
+    // ever grows, and every event after the crossing is one more chance for it to cancel a swipe
+    // the user already completed - including events the user did not make. macOS momentum-phase
+    // scroll carries 325-2500px of travel (AGENTS.md), and a tail with even a little dy in it
+    // clears CANCEL_VERTICAL_HIGH on its own. Past the line only the horizontal position decides:
+    // easing back below COMMIT_PX, or reversing outright. That is also what a native swipe-back
+    // does - once you are past the threshold, wobble no longer counts against you.
+    var reachedCommit = false;
     // Ends the gesture when the fingers lift.
     //
     // The gap check at the top of onWheel cannot do this on its own: it only runs when a NEXT
@@ -297,6 +307,7 @@
         eventCount = 0;
         rejected = false;
         direction = 0;
+        reachedCommit = false;
     }
 
     // Rule the current gesture out, keeping the accumulators so nothing restarts until the
@@ -348,13 +359,16 @@
     //   switchedOff() promises the detector stops when it does - and additionally fails closed if
     //   the direction lost its history entry, or if state went away entirely.
     //
-    // MOMENTUM is the open question in this design, and the numbers behind it are in AGENTS.md:
-    // macOS emits momentum-phase scroll for 180-870ms after the fingers lift, measured on this
-    // hardware. Whether Chromium forwards those to the renderer as `wheel` events is not yet
-    // confirmed. If it does, each one re-arms endTimer through onWheel and a flick commits at
-    // end-of-momentum rather than at release. That cannot turn a commit into a cancel, since a
-    // momentum tail runs the flick's own direction; it is latency, on the gesture that should
-    // feel fastest.
+    // MOMENTUM costs latency here and nothing else, which is what reachedCommit is for. The
+    // numbers are in AGENTS.md: macOS emits momentum-phase scroll for 180-870ms after the fingers
+    // lift, carrying 325-2500px, measured on this hardware. Whether Chromium forwards those to the
+    // renderer as `wheel` events is not confirmed and cannot be settled with synthetic events. If
+    // it does, each one re-arms endTimer through onWheel and a flick commits at end-of-momentum
+    // rather than at release.
+    //
+    // It cannot change the ANSWER, only when it arrives: a momentum tail runs the flick's own
+    // direction, so it cannot reverse or ease back, and past COMMIT_PX the vertical tiers - the
+    // one path by which a tail's dy could have cancelled a completed swipe - are no longer asked.
     function decide() {
         if (rejected || direction === 0 || eventCount < MIN_EVENTS || !available(direction)) {
             return;
@@ -418,11 +432,13 @@
         eventCount++;
         accumX += dx;
 
-        // Chrome's three tiers, in its order.
+        // Chrome's three tiers, in its order. Asked only until the gesture is past the commit
+        // distance - see reachedCommit.
         var xDelta = Math.abs(accumX);
-        if (verticalPath > CANCEL_STRONG_RATIO * xDelta ||
-            (verticalPath * CANCEL_MIXED_RATIO > xDelta && verticalPath > CANCEL_VERTICAL_LOW) ||
-            verticalPath > CANCEL_VERTICAL_HIGH) {
+        if (!reachedCommit &&
+            (verticalPath > CANCEL_STRONG_RATIO * xDelta ||
+                (verticalPath * CANCEL_MIXED_RATIO > xDelta && verticalPath > CANCEL_VERTICAL_LOW) ||
+                verticalPath > CANCEL_VERTICAL_HIGH)) {
             abandon();
             return;
         }
@@ -446,11 +462,18 @@
         if (eventCount < MIN_EVENTS) {
             return;
         }
+        // Latched here rather than the moment xDelta crosses, so it means the same thing decide()
+        // does: past the line AND enough events to be a trackpad at all. Latching earlier would
+        // let the two-big-deltas pair decide() rejects switch the vertical tiers off on its way
+        // through.
+        if (xDelta >= COMMIT_PX) {
+            reachedCommit = true;
+        }
 
         // Progress is tracked all the way through the gesture now, never gated on whether it
         // has reached the commit distance yet - see decide() for why crossing COMMIT_PX no
         // longer does anything here beyond what trackAffordance already draws.
-        var progress = Math.abs(accumX) / COMMIT_PX;
+        var progress = xDelta / COMMIT_PX;
         showAffordance(direction);
         trackAffordance(direction, progress);
     }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavTest.kt
@@ -111,12 +111,14 @@ class BrowserSwipeNavTest {
     }
 
     /**
-     * Longer than the 100ms the aux mouse buttons use, and deliberately so: a click is discrete,
-     * a swipe is one continuous finger movement whose tail can look like a second gesture.
+     * The window's only remaining job (see [shouldAcceptSwipeNav]'s KDoc for why) is catching a
+     * genuine double-fire bug, not a real second gesture - so it must sit comfortably BELOW the
+     * structural floor between two real gestures, not above some other feature's window. 120 is
+     * `swipe-nav.js`'s own GESTURE_GAP_MS - the minimum possible gap between two gesture ends.
      */
     @Test
-    fun `the window is longer than the mouse-button one`() {
-        assertTrue(SWIPE_NAV_DEBOUNCE_MS > 100)
+    fun `the window sits below the structural floor between two real gestures`() {
+        assertTrue(SWIPE_NAV_DEBOUNCE_MS < 120, "must not be able to reject a genuinely separate swipe")
     }
 
     // --- What the host pushes into the page --------------------------------------------------

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavTest.kt
@@ -1,6 +1,9 @@
 package ai.rever.boss.plugin.browser
 
 import ai.rever.boss.config.parseSwipeNavEnabled
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -97,32 +100,65 @@ class BrowserSwipeNavTest {
 
     @Test
     fun `the first swipe of the session navigates`() {
-        assertTrue(shouldAcceptSwipeNav(nowMs = 1_000, lastNavigationMs = 0))
+        assertTrue(shouldAcceptSwipeNav(nowMs = 1_000, previous = null, direction = SwipeNavDirection.BACK))
     }
 
     @Test
-    fun `a second swipe inside the window is refused`() {
-        assertFalse(shouldAcceptSwipeNav(nowMs = 1_000 + SWIPE_NAV_DEBOUNCE_MS, lastNavigationMs = 1_000))
-        assertFalse(shouldAcceptSwipeNav(nowMs = 1_000 + SWIPE_NAV_DEBOUNCE_MS / 2, lastNavigationMs = 1_000))
-    }
-
-    @Test
-    fun `and accepted once the window has passed`() {
-        assertTrue(shouldAcceptSwipeNav(nowMs = 1_001 + SWIPE_NAV_DEBOUNCE_MS, lastNavigationMs = 1_000))
+    fun `a second swipe inside the debounce is refused whichever way it goes`() {
+        for (direction in SwipeNavDirection.entries) {
+            assertFalse(
+                shouldAcceptSwipeNav(1_000 + SWIPE_NAV_DEBOUNCE_MS, back(1_000), direction),
+                direction.name,
+            )
+            assertFalse(
+                shouldAcceptSwipeNav(1_000 + SWIPE_NAV_DEBOUNCE_MS / 2, back(1_000), direction),
+                direction.name,
+            )
+        }
     }
 
     /**
-     * The window's job (see [shouldAcceptSwipeNav]'s KDoc for why) is catching a genuine
-     * double-fire bug and not a real second gesture, so it is bounded at both ends: below
-     * `swipe-nav.js`'s own `GESTURE_GAP_MS`, the minimum possible gap between two gesture ends,
-     * and at or above one frame, which is the shape a bridge-level double-dispatch takes.
-     *
-     * The upper bound is read OUT of the script rather than restated here. The whole argument is
-     * a cross-language coupling to a constant in another file, and hard-coded, lowering
-     * `GESTURE_GAP_MS` would leave this green while quietly falsifying its own reasoning.
+     * The reversal is how someone undoes a navigation they did not mean, so it waits out the
+     * double-dispatch window and nothing more.
      */
     @Test
-    fun `the window sits between a double-dispatch and the floor between two real gestures`() {
+    fun `a reversal is held only for the debounce`() {
+        assertTrue(
+            shouldAcceptSwipeNav(1_001 + SWIPE_NAV_DEBOUNCE_MS, back(1_000), SwipeNavDirection.FORWARD),
+        )
+    }
+
+    /**
+     * The paused-drag case, and the reason [SWIPE_NAV_REPEAT_MS] exists: `swipe-nav.js` segments
+     * gestures on `GESTURE_GAP_MS` of quiet, which a drag that hesitates mid-swipe produces with
+     * the fingers still down. `scripts/test/test-swipe-nav.js` pins that the script really does
+     * emit two commits there - it has no way not to - so this is where the second one dies.
+     */
+    @Test
+    fun `a same-direction repeat inside the repeat window is refused`() {
+        assertFalse(shouldAcceptSwipeNav(1_000 + GESTURE_GAP_MS_FLOOR, back(1_000), SwipeNavDirection.BACK))
+        assertFalse(shouldAcceptSwipeNav(1_000 + SWIPE_NAV_REPEAT_MS, back(1_000), SwipeNavDirection.BACK))
+    }
+
+    @Test
+    fun `and accepted once the repeat window has passed`() {
+        assertTrue(shouldAcceptSwipeNav(1_001 + SWIPE_NAV_REPEAT_MS, back(1_000), SwipeNavDirection.BACK))
+    }
+
+    /**
+     * Both windows are bounded against `swipe-nav.js`'s own `GESTURE_GAP_MS`, read OUT of the
+     * script rather than restated here. The whole argument is a cross-language coupling to a
+     * constant in another file: hard-coded, changing the gap would leave this green while quietly
+     * falsifying its own reasoning.
+     *
+     * The debounce sits strictly below the gap - that is the minimum possible distance between two
+     * gesture ends, so anything at or above it starts refusing real swipes - and at or above one
+     * frame, which is the shape a bridge-level double-dispatch takes. The repeat window sits
+     * strictly above it, because a hesitation the script mistook for a lift is by definition longer
+     * than the gap.
+     */
+    @Test
+    fun `both windows are bounded against the script's gesture gap`() {
         val match = GESTURE_GAP_MS_IN_SCRIPT.find(BrowserSwipeNavScript.source)
         assertNotNull(match, "GESTURE_GAP_MS not found in swipe-nav.js")
         val gapMs = match.groupValues[1].toLong()
@@ -135,6 +171,67 @@ class BrowserSwipeNavTest {
             SWIPE_NAV_DEBOUNCE_MS >= ONE_FRAME_MS,
             "$SWIPE_NAV_DEBOUNCE_MS must still cover a same-frame double-dispatch",
         )
+        assertTrue(
+            SWIPE_NAV_REPEAT_MS > gapMs,
+            "$SWIPE_NAV_REPEAT_MS must exceed the script's ${gapMs}ms gesture gap, or it guards " +
+                "nothing the script did not already merge",
+        )
+        // The value the other tests use for "one gesture gap later" has to be the real one.
+        assertEquals(gapMs, GESTURE_GAP_MS_FLOOR)
+    }
+
+    // --- The gate that holds that state ------------------------------------------------------
+
+    @Test
+    fun `the gate records a commit and refuses the repeat that follows it`() {
+        var now = 1_000L
+        val gate = SwipeNavGate(nowMs = { now })
+        assertTrue(gate.accept(SwipeNavDirection.BACK))
+        now += GESTURE_GAP_MS_FLOOR
+        assertFalse(gate.accept(SwipeNavDirection.BACK), "the second half of a paused drag")
+        now += SWIPE_NAV_REPEAT_MS
+        assertTrue(gate.accept(SwipeNavDirection.BACK), "a deliberate second swipe later on")
+    }
+
+    /**
+     * A refused swipe must not push the window forward. Otherwise a page calling the bridge in a
+     * loop would hold the window open indefinitely and a real swipe after it would be refused too.
+     */
+    @Test
+    fun `a refused swipe does not restart the window`() {
+        var now = 1_000L
+        val gate = SwipeNavGate(nowMs = { now })
+        assertTrue(gate.accept(SwipeNavDirection.BACK))
+        for (step in 1..10) {
+            now = 1_000L + step
+            assertFalse(gate.accept(SwipeNavDirection.BACK))
+        }
+        now = 1_001L + SWIPE_NAV_REPEAT_MS
+        assertTrue(gate.accept(SwipeNavDirection.BACK))
+    }
+
+    /**
+     * The check and the record are one compare-and-set, so of two callers reading the same state
+     * exactly one wins. `@Volatile` on a plain field gave visibility and not atomicity: both would
+     * have passed the check and both would have navigated.
+     */
+    @Test
+    fun `only one of two racing swipes is accepted`() {
+        val gate = SwipeNavGate(nowMs = { 1_000L })
+        val threads = 8
+        val start = CountDownLatch(1)
+        val accepted = AtomicInteger(0)
+        val done = CountDownLatch(threads)
+        repeat(threads) {
+            Thread {
+                start.await()
+                if (gate.accept(SwipeNavDirection.BACK)) accepted.incrementAndGet()
+                done.countDown()
+            }.start()
+        }
+        start.countDown()
+        assertTrue(done.await(10, TimeUnit.SECONDS), "racing threads never finished")
+        assertEquals(1, accepted.get(), "exactly one swipe may win the race")
     }
 
     // --- What the host pushes into the page --------------------------------------------------
@@ -168,7 +265,16 @@ class BrowserSwipeNavTest {
     }
 
     private companion object {
-        val GESTURE_GAP_MS_IN_SCRIPT = Regex("""var GESTURE_GAP_MS = (\d+)""")
+        // Anchored to the start of a line and tolerant of spacing, so a commented-out declaration
+        // is not what gets read. It still fails loudly rather than wrongly if the shape changes:
+        // no match is an assertion failure, not a silently skipped bound.
+        val GESTURE_GAP_MS_IN_SCRIPT = Regex("""^\s*var GESTURE_GAP_MS\s*=\s*(\d+)""", RegexOption.MULTILINE)
         const val ONE_FRAME_MS = 16L
+
+        // Kept honest against the script by `both windows are bounded against the script's gesture
+        // gap`, so the cases below can say "one gesture gap later" without re-parsing the source.
+        const val GESTURE_GAP_MS_FLOOR = 120L
+
+        fun back(atMs: Long) = SwipeNavCommit(atMs, SwipeNavDirection.BACK)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavTest.kt
@@ -4,6 +4,7 @@ import ai.rever.boss.config.parseSwipeNavEnabled
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -102,7 +103,7 @@ class BrowserSwipeNavTest {
     @Test
     fun `a second swipe inside the window is refused`() {
         assertFalse(shouldAcceptSwipeNav(nowMs = 1_000 + SWIPE_NAV_DEBOUNCE_MS, lastNavigationMs = 1_000))
-        assertFalse(shouldAcceptSwipeNav(nowMs = 1_100, lastNavigationMs = 1_000))
+        assertFalse(shouldAcceptSwipeNav(nowMs = 1_000 + SWIPE_NAV_DEBOUNCE_MS / 2, lastNavigationMs = 1_000))
     }
 
     @Test
@@ -111,14 +112,29 @@ class BrowserSwipeNavTest {
     }
 
     /**
-     * The window's only remaining job (see [shouldAcceptSwipeNav]'s KDoc for why) is catching a
-     * genuine double-fire bug, not a real second gesture - so it must sit comfortably BELOW the
-     * structural floor between two real gestures, not above some other feature's window. 120 is
-     * `swipe-nav.js`'s own GESTURE_GAP_MS - the minimum possible gap between two gesture ends.
+     * The window's job (see [shouldAcceptSwipeNav]'s KDoc for why) is catching a genuine
+     * double-fire bug and not a real second gesture, so it is bounded at both ends: below
+     * `swipe-nav.js`'s own `GESTURE_GAP_MS`, the minimum possible gap between two gesture ends,
+     * and at or above one frame, which is the shape a bridge-level double-dispatch takes.
+     *
+     * The upper bound is read OUT of the script rather than restated here. The whole argument is
+     * a cross-language coupling to a constant in another file, and hard-coded, lowering
+     * `GESTURE_GAP_MS` would leave this green while quietly falsifying its own reasoning.
      */
     @Test
-    fun `the window sits below the structural floor between two real gestures`() {
-        assertTrue(SWIPE_NAV_DEBOUNCE_MS < 120, "must not be able to reject a genuinely separate swipe")
+    fun `the window sits between a double-dispatch and the floor between two real gestures`() {
+        val match = GESTURE_GAP_MS_IN_SCRIPT.find(BrowserSwipeNavScript.source)
+        assertNotNull(match, "GESTURE_GAP_MS not found in swipe-nav.js")
+        val gapMs = match.groupValues[1].toLong()
+        assertTrue(
+            SWIPE_NAV_DEBOUNCE_MS < gapMs,
+            "$SWIPE_NAV_DEBOUNCE_MS must stay under the script's ${gapMs}ms gesture gap, or it can " +
+                "reject a genuinely separate swipe",
+        )
+        assertTrue(
+            SWIPE_NAV_DEBOUNCE_MS >= ONE_FRAME_MS,
+            "$SWIPE_NAV_DEBOUNCE_MS must still cover a same-frame double-dispatch",
+        )
     }
 
     // --- What the host pushes into the page --------------------------------------------------
@@ -149,5 +165,10 @@ class BrowserSwipeNavTest {
             source.contains(BrowserSwipeNavScript.STATE_PROPERTY),
             "the packaged script does not name ${BrowserSwipeNavScript.STATE_PROPERTY}",
         )
+    }
+
+    private companion object {
+        val GESTURE_GAP_MS_IN_SCRIPT = Regex("""var GESTURE_GAP_MS = (\d+)""")
+        const val ONE_FRAME_MS = 16L
     }
 }

--- a/scripts/test/test-swipe-nav.js
+++ b/scripts/test/test-swipe-nav.js
@@ -208,6 +208,17 @@ function newPage(js, options = {}) {
       clockMs += ms;
       fireDue();
     },
+    // Move the clock WITHOUT running anything that came due. Models the one ordering the script
+    // cannot control: Chromium dispatches input on a higher-priority task queue than timers, so a
+    // wheel event can run while the end-of-gesture timer is due but has not fired yet.
+    jump: (ms) => {
+      clockMs += ms;
+    },
+    // Replace the state object the host pushes, mid-gesture. Assigning a whole new value (or
+    // taking it away) is what the host actually does; mutating the existing one is a separate case.
+    setState: (value) => {
+      sandbox.window[hostProps.state] = value;
+    },
     // Let every pending timer run, however far in the future. What a lifted finger and a
     // finished exit animation look like from the script's side.
     settle: () => {
@@ -347,16 +358,69 @@ console.log('\nrelease, not the threshold, is what commits');
   check('and no affordance was ever shown for it', p.liveOverlays() === 0, p.liveOverlays());
 }
 {
-  // The setting can flip WHILE a gesture is in flight. switchedOff() is checked inside onWheel
-  // already, so this specifically exercises decide() on the timer path, after the last onWheel
-  // call already latched a direction and distance. `state` is passed by reference and mutated
-  // directly - the same object the host pushes the flag onto in production.
+  // The setting can flip WHILE a gesture is in flight. onWheel checks it already, so this
+  // specifically exercises decide() at gesture end, after the last onWheel call latched a
+  // direction and a distance. `state` is passed by reference and mutated directly - the same
+  // object the host pushes the flag onto in production.
   const state = { back: true, forward: true };
   const p = newPage(js, { state });
   p.swipe(12, -10);
   state.enabled = false;
   p.settle();
   eq('switching the gesture off mid-swipe stops it committing on release too', p.navigated, []);
+}
+{
+  // decide() asks available() rather than switchedOff(), which also fails closed on state going
+  // away entirely - the host replacing the object, not mutating it.
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.setState(null);
+  p.settle();
+  eq('state disappearing mid-swipe stops it committing too', p.navigated, []);
+}
+{
+  // A direction that lost its history entry mid-gesture. onWheel latched `available` at the first
+  // event on purpose (see chainCanScroll's note on latching); decide() re-asks at the end, which
+  // is the conservative half of that pair.
+  const state = { back: true, forward: true };
+  const p = newPage(js, { state });
+  p.swipe(12, -10);
+  state.back = false;
+  p.settle();
+  eq('a direction that stopped being navigable mid-swipe does not commit', p.navigated, []);
+}
+{
+  // The gap check at the top of onWheel is the OTHER end-of-gesture signal, and it must decide
+  // too. Here the timer is due but has not run and a new gesture's first event beats it - the
+  // ordering Chromium's higher-priority input queue makes possible. Without decide() there, a
+  // gesture the user completed past the commit distance navigates nowhere, silently.
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.jump(GAP_MS + 1);
+  p.wheel(-10, 0);
+  eq('a finished gesture still commits when the next event beats its timer', p.navigated, ['back']);
+  p.settle();
+  eq('and the timer firing afterwards does not commit it twice', p.navigated, ['back']);
+}
+{
+  // Removing `committed` means the gesture keeps being evaluated after crossing COMMIT_PX, where
+  // it used to stop listening entirely. Reversing past the line therefore cancels now - the
+  // interesting half of the reversal guard, and consistent with reading the LAST position.
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.swipe(20, 10);
+  p.settle();
+  eq('reversing after crossing the commit distance cancels', p.navigated, []);
+}
+{
+  // Same consequence through the vertical rule: verticalPath keeps accumulating past the line, so
+  // a slow swipe that wobbles in its tail cancels. Deliberate, and the answer Chrome gives too -
+  // vertical is a path length, so it only ever counts against you.
+  const p = newPage(js);
+  p.swipe(10, -10);
+  for (let i = 0; i < 12; i++) p.wheel(-1, i % 2 === 0 ? 9 : -9);
+  p.settle();
+  eq('vertical drift after crossing the commit distance cancels', p.navigated, []);
 }
 
 console.log('\ngestures that must not navigate');

--- a/scripts/test/test-swipe-nav.js
+++ b/scripts/test/test-swipe-nav.js
@@ -334,6 +334,30 @@ console.log('\nrelease, not the threshold, is what commits');
   p.pagehide();
   eq('the page going away mid-swipe is not routed through a commit', p.navigated, []);
 }
+{
+  // A second review round caught this: decide() runs from the endTimer regardless of how few
+  // events the gesture had, so without its own MIN_EVENTS check, two deltas of 50px each - each
+  // one under MAX_STEP_PX, so neither is caught by the wheel-shape guard on its own - total
+  // 100px, clear COMMIT_PX (90), and never reach the eventCount that would have shown any
+  // affordance at all. That must not navigate.
+  const p = newPage(js);
+  p.swipe(2, -50);
+  p.settle();
+  eq('two events under MIN_EVENTS must not navigate however far they travel', p.navigated, []);
+  check('and no affordance was ever shown for it', p.liveOverlays() === 0, p.liveOverlays());
+}
+{
+  // The setting can flip WHILE a gesture is in flight. switchedOff() is checked inside onWheel
+  // already, so this specifically exercises decide() on the timer path, after the last onWheel
+  // call already latched a direction and distance. `state` is passed by reference and mutated
+  // directly - the same object the host pushes the flag onto in production.
+  const state = { back: true, forward: true };
+  const p = newPage(js, { state });
+  p.swipe(12, -10);
+  state.enabled = false;
+  p.settle();
+  eq('switching the gesture off mid-swipe stops it committing on release too', p.navigated, []);
+}
 
 console.log('\ngestures that must not navigate');
 {

--- a/scripts/test/test-swipe-nav.js
+++ b/scripts/test/test-swipe-nav.js
@@ -25,6 +25,10 @@ const scriptKt = path.join(
   repoRoot,
   'composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavScript.kt',
 );
+const bridgeKt = path.join(
+  repoRoot,
+  'composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/browser/BrowserSwipeNavBridge.kt',
+);
 
 let failures = 0;
 function check(name, cond, detail) {
@@ -34,6 +38,12 @@ function check(name, cond, detail) {
     failures++;
     console.log(`  FAIL ${name}${detail === undefined ? '' : ` -> ${detail}`}`);
   }
+}
+/** Smallest distance between consecutive commits; Infinity when there are fewer than two. */
+function minGap(times) {
+  let smallest = Infinity;
+  for (let i = 1; i < times.length; i++) smallest = Math.min(smallest, times[i] - times[i - 1]);
+  return smallest;
 }
 function eq(name, actual, expected) {
   check(
@@ -54,12 +64,27 @@ function hostProperties() {
   return { bridge: grab('BRIDGE_PROPERTY'), state: grab('STATE_PROPERTY') };
 }
 
+/**
+ * The host's same-direction repeat window, read from the Kotlin.
+ *
+ * The paused-drag case below is the one place these two files make a claim about each other: the
+ * script emits two commits and the host is what collapses them. Restating 400 here would let the
+ * two drift apart with both suites green.
+ */
+function hostRepeatMs() {
+  const src = fs.readFileSync(bridgeKt, 'utf8');
+  const m = /^internal const val SWIPE_NAV_REPEAT_MS = (\d+)L/m.exec(src);
+  if (!m) throw new Error('SWIPE_NAV_REPEAT_MS not found in BrowserSwipeNavBridge.kt');
+  return Number(m[1]);
+}
+
 // ---------------------------------------------------------------------------
 // Fake DOM: only what the detector touches, so an added DOM read fails loudly.
 // ---------------------------------------------------------------------------
 function newPage(js, options = {}) {
   const listeners = {};
   const navigated = [];
+  const navigatedAt = [];
   const registrations = [];
   let clockMs = 1000;
   let preventedDefaults = 0;
@@ -168,7 +193,14 @@ function newPage(js, options = {}) {
   };
   sandbox.window.top = options.subframe ? {} : sandbox.window;
   sandbox.document = sandbox.window.document;
-  sandbox.window[hostProps.bridge] = { navigate: (d) => navigated.push(d) };
+  // The clock is recorded alongside the direction: the host's SWIPE_NAV_DEBOUNCE_MS rests on
+  // "two commits are never closer than GESTURE_GAP_MS", and that claim lives in this script.
+  sandbox.window[hostProps.bridge] = {
+    navigate: (d) => {
+      navigated.push(d);
+      navigatedAt.push(clockMs);
+    },
+  };
   if (options.state !== null) {
     sandbox.window[hostProps.state] = options.state || { back: true, forward: true };
   }
@@ -195,6 +227,7 @@ function newPage(js, options = {}) {
     element,
     body,
     navigated,
+    navigatedAt,
     registrations,
     wheel,
     wheelRaw: (event) => (listeners.wheel || []).forEach((f) => f(event)),
@@ -252,6 +285,7 @@ function newPage(js, options = {}) {
 
 // ---------------------------------------------------------------------------
 const hostProps = hostProperties();
+const REPEAT_MS = hostRepeatMs();
 const js = fs.readFileSync(scriptJs, 'utf8');
 const constant = (name) => Number(new RegExp(`var ${name} = (\\d+)`).exec(js)[1]);
 const COMMIT_PX = constant('COMMIT_PX');
@@ -260,7 +294,8 @@ const MIN_EVENTS = constant('MIN_EVENTS');
 const MAX_STEP_PX = constant('MAX_STEP_PX');
 console.log(
   `detector: COMMIT_PX=${COMMIT_PX} GESTURE_GAP_MS=${GAP_MS} MIN_EVENTS=${MIN_EVENTS} ` +
-    `MAX_STEP_PX=${MAX_STEP_PX}; host: ${hostProps.bridge} / ${hostProps.state}`,
+    `MAX_STEP_PX=${MAX_STEP_PX}; host: ${hostProps.bridge} / ${hostProps.state}, ` +
+    `SWIPE_NAV_REPEAT_MS=${REPEAT_MS}`,
 );
 
 console.log('\nwiring');
@@ -310,15 +345,52 @@ console.log('\na real swipe');
   p.settle();
   eq('two swipes across a gap navigate twice', p.navigated, ['back', 'back']);
 }
+{
+  // The floor the host's SWIPE_NAV_DEBOUNCE_MS is derived from, proved rather than asserted in
+  // prose: whatever the ordering of timers and events, two commits are never closer together than
+  // GESTURE_GAP_MS, because that gap IS how one gesture is told from the next. If a future change
+  // to decide()'s call sites falsifies that, the debounce's whole justification goes with it.
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.advance(GAP_MS + 40);
+  p.swipe(12, -10);
+  p.advance(GAP_MS + 40);
+  p.swipe(12, 10);
+  p.settle();
+  eq('three gestures navigate three times', p.navigated, ['back', 'back', 'forward']);
+  check(
+    'and no two commits are closer than the gesture gap',
+    minGap(p.navigatedAt) >= GAP_MS,
+    `${JSON.stringify(p.navigatedAt)} min gap ${minGap(p.navigatedAt)}, want >= ${GAP_MS}`,
+  );
+}
+{
+  // A slow deliberate drag that HESITATES mid-swipe. 120ms of quiet with the fingers still down is
+  // byte-identical to a lift, so this is two gestures here and there is no signal that would make
+  // it one. What is pinned is that the script really does emit two commits: the guard against it
+  // is SWIPE_NAV_REPEAT_MS in BrowserSwipeNavBridge.kt, which has to live host-side because this
+  // script's state dies with the document the first commit navigates away from.
+  const p = newPage(js);
+  p.swipe(9, -10);
+  p.advance(GAP_MS + 1);
+  p.swipe(9, -10);
+  p.settle();
+  eq('a drag paused past the gesture gap is two gestures to the script', p.navigated, ['back', 'back']);
+  check(
+    'and the two are close enough for the host repeat window to catch',
+    minGap(p.navigatedAt) <= REPEAT_MS,
+    `${JSON.stringify(p.navigatedAt)} min gap ${minGap(p.navigatedAt)}, want <= ${REPEAT_MS}`,
+  );
+}
 
-console.log('\nrelease, not the threshold, is what commits');
+console.log('\nthe end of the gesture, not the threshold, is what commits');
 {
   // The bug this whole change fixes (boss-plugin-fluck-browser#36): crossing COMMIT_PX used to
   // navigate on the spot, in the same wheel event, fingers still down. Held right at the commit
   // distance with no further events, it must not navigate until the gesture actually ends.
   const p = newPage(js);
   p.swipe(9, -10);
-  eq('holding at the commit distance does not navigate yet', p.navigated, []);
+  eq('holding at the commit distance does not navigate on the crossing event', p.navigated, []);
   check('the affordance is still up, filled in', p.visibleOverlays() === 1, p.visibleOverlays());
   p.settle();
   eq('and only fires once the gesture ends', p.navigated, ['back']);
@@ -413,14 +485,51 @@ console.log('\nrelease, not the threshold, is what commits');
   eq('reversing after crossing the commit distance cancels', p.navigated, []);
 }
 {
-  // Same consequence through the vertical rule: verticalPath keeps accumulating past the line, so
-  // a slow swipe that wobbles in its tail cancels. Deliberate, and the answer Chrome gives too -
-  // vertical is a path length, so it only ever counts against you.
+  // The vertical rule is the opposite call, and it is `reachedCommit`. verticalPath only ever
+  // grows, so once the gesture is past the line every further event is another chance to cancel a
+  // swipe the user already completed - including events the user did not make, since a momentum
+  // tail carries 325-2500px (AGENTS.md) and any dy in it clears CANCEL_VERTICAL_HIGH outright.
+  // Past the line only the horizontal position decides, which is what a native swipe-back does.
   const p = newPage(js);
   p.swipe(10, -10);
   for (let i = 0; i < 12; i++) p.wheel(-1, i % 2 === 0 ? 9 : -9);
   p.settle();
-  eq('vertical drift after crossing the commit distance cancels', p.navigated, []);
+  eq('vertical drift after crossing the commit distance no longer cancels', p.navigated, ['back']);
+}
+{
+  // The same rule BEFORE the line still cancels, which is the half that must not be lost: this is
+  // one event short of COMMIT_PX when the wobble starts.
+  const p = newPage(js);
+  p.swipe(8, -10);
+  for (let i = 0; i < 12; i++) p.wheel(-1, i % 2 === 0 ? 9 : -9);
+  p.settle();
+  eq('vertical drift before the commit distance still cancels', p.navigated, []);
+}
+{
+  // The closest this harness gets to the momentum shape, sized to the top of the range measured in
+  // AGENTS.md: 2400px of same-direction travel after the gesture is past the line, with a little
+  // over 10% of it as vertical path. That clears CANCEL_VERTICAL_HIGH (270px) on its own - which
+  // is exactly how a tail the user never made could have cancelled a swipe they had completed.
+  // It must still commit, exactly once: late rather than lost is the whole claim decide() makes.
+  const p = newPage(js);
+  p.swipe(10, -10);
+  for (let i = 0; i < 60; i++) p.wheel(-40, i % 2 === 0 ? 5 : -5);
+  p.settle();
+  eq('a long same-direction tail past the line still commits once', p.navigated, ['back']);
+}
+{
+  // reachedCommit is latched only once the gesture also has MIN_EVENTS, so the two-big-deltas pair
+  // decide() refuses on its own cannot switch the vertical tiers off on its way past the line.
+  // Two 50px notches clear COMMIT_PX at eventCount 2; then real vertical scrolling (which
+  // accumulates verticalPath without running the tiers, since those events carry no dx); then one
+  // stray horizontal event, which is the tiers' single chance to see the whole shape. It has to
+  // still be taken, or the pair has bought itself immunity it never earned.
+  const p = newPage(js);
+  p.swipe(2, -50);
+  p.swipe(8, 0, 40);
+  p.wheel(-1, 0);
+  p.settle();
+  eq('two big deltas past the line do not switch the vertical tiers off', p.navigated, []);
 }
 
 console.log('\ngestures that must not navigate');

--- a/scripts/test/test-swipe-nav.js
+++ b/scripts/test/test-swipe-nav.js
@@ -274,19 +274,21 @@ console.log('\na real swipe');
 {
   const p = newPage(js);
   p.swipe(12, -10);
-  eq('goes back once', p.navigated, ['back']);
   p.settle();
+  eq('goes back once', p.navigated, ['back']);
   check('leaves nothing showing', p.visibleOverlays() === 0, p.visibleOverlays());
   check('never calls preventDefault', p.preventedDefaults() === 0, p.preventedDefaults());
 }
 {
   const p = newPage(js);
   p.swipe(12, 10);
+  p.settle();
   eq('the other direction goes forward', p.navigated, ['forward']);
 }
 {
   const p = newPage(js);
   p.swipe(24, -10);
+  p.settle();
   eq('one continuous swipe navigates exactly once', p.navigated, ['back']);
 }
 {
@@ -294,7 +296,43 @@ console.log('\na real swipe');
   p.swipe(12, -10);
   p.advance(GAP_MS + 80);
   p.swipe(12, -10);
+  p.settle();
   eq('two swipes across a gap navigate twice', p.navigated, ['back', 'back']);
+}
+
+console.log('\nrelease, not the threshold, is what commits');
+{
+  // The bug this whole change fixes (boss-plugin-fluck-browser#36): crossing COMMIT_PX used to
+  // navigate on the spot, in the same wheel event, fingers still down. Held right at the commit
+  // distance with no further events, it must not navigate until the gesture actually ends.
+  const p = newPage(js);
+  p.swipe(9, -10);
+  eq('holding at the commit distance does not navigate yet', p.navigated, []);
+  check('the affordance is still up, filled in', p.visibleOverlays() === 1, p.visibleOverlays());
+  p.settle();
+  eq('and only fires once the gesture ends', p.navigated, ['back']);
+}
+{
+  // Same direction throughout - accumX never crosses back through zero, so this is NOT the
+  // reversal guard below, just letting go before release while short of the line again.
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.swipe(4, 10);
+  p.settle();
+  eq('easing back below the commit distance before release does not navigate', p.navigated, []);
+}
+{
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.swipe(1, -10);
+  p.settle();
+  eq('holding past the commit distance through release still navigates', p.navigated, ['back']);
+}
+{
+  const p = newPage(js);
+  p.swipe(12, -10);
+  p.pagehide();
+  eq('the page going away mid-swipe is not routed through a commit', p.navigated, []);
 }
 
 console.log('\ngestures that must not navigate');
@@ -310,6 +348,7 @@ console.log('\ngestures that must not navigate');
   const p = newPage(js);
   const carousel = p.element({ scrollWidth: 1200, clientWidth: 400, scrollLeft: 300, overflowX: 'auto' });
   p.swipe(12, -10, 0, carousel);
+  p.settle();
   eq('over something that can still scroll that way', p.navigated, []);
 }
 {
@@ -317,35 +356,41 @@ console.log('\ngestures that must not navigate');
   // Same element, already scrolled hard against the edge the swipe is pushing toward.
   const carousel = p.element({ scrollWidth: 1200, clientWidth: 400, scrollLeft: 0, overflowX: 'auto' });
   p.swipe(12, -10, 0, carousel);
+  p.settle();
   eq('but does navigate once that element is at its edge', p.navigated, ['back']);
 }
 {
   const p = newPage(js);
   const styled = p.element({ scrollWidth: 1200, clientWidth: 400, scrollLeft: 300, overflowX: 'hidden' });
   p.swipe(12, -10, 0, styled);
+  p.settle();
   eq('overflow:hidden is not a scroll chain', p.navigated, ['back']);
 }
 {
   const p = newPage(js);
   p.swipe(3, -MAX_STEP_PX);
+  p.settle();
   eq('a discrete mouse wheel, however far it travels', p.navigated, []);
 }
 {
   const p = newPage(js);
   p.wheelRaw({ deltaMode: 1, deltaX: -40, deltaY: 0, target: p.body, composedPath: () => [p.body] });
   p.swipe(12, -10);
+  p.settle();
   eq('anything that is not pixel-mode', p.navigated, []);
 }
 {
   // Diagonal: vertical travel outruns the floor immediately.
   const p = newPage(js);
   p.swipe(12, -10, -40);
+  p.settle();
   eq('a diagonal drag', p.navigated, []);
 }
 {
   const p = newPage(js);
   p.swipe(5, 0, -50);
   p.swipe(12, -10);
+  p.settle();
   eq('a vertical scroll that curls into a horizontal one', p.navigated, []);
 }
 {
@@ -355,17 +400,20 @@ console.log('\ngestures that must not navigate');
   // the guard is there or not.
   p.swipe(5, -10);
   p.swipe(15, 10);
+  p.settle();
   eq('a swipe reversed halfway', p.navigated, []);
 }
 {
   const p = newPage(js, { state: { back: false, forward: true } });
   p.swipe(12, -10);
+  p.settle();
   eq('a direction with no history entry', p.navigated, []);
   check('and shows no affordance for it', p.visibleOverlays() === 0, p.visibleOverlays());
 }
 {
   const p = newPage(js, { state: null });
   p.swipe(12, -10);
+  p.settle();
   eq('before the host has said what is navigable', p.navigated, []);
 }
 {
@@ -379,18 +427,21 @@ console.log("\nChrome's cancellation tiers (history_swiper.mm)");
   // it, and this is the shape of an ordinary slightly-sloped swipe.
   const p = newPage(js);
   p.swipe(14, -10, 6);
+  p.settle();
   eq('a swipe with honest slope is taken', p.navigated, ['back']);
 }
 {
   // Rule 1: yDelta > 2 * xDelta.
   const p = newPage(js);
   p.swipe(14, -10, -25);
+  p.settle();
   eq('strongly vertical is refused', p.navigated, []);
 }
 {
   // Rule 2: yDelta * 1.3 > xDelta, once vertical passes the low threshold. 8*1.3 = 10.4 > 10.
   const p = newPage(js);
   p.swipe(14, -10, 8);
+  p.settle();
   eq('vertical past about three quarters of horizontal is refused', p.navigated, []);
 }
 {
@@ -403,6 +454,7 @@ console.log("\nChrome's cancellation tiers (history_swiper.mm)");
   // the navigation threshold. It is a backstop for a gesture that wanders without committing.
   const p = newPage(js);
   for (let i = 0; i < 20; i++) p.wheel(-10, i % 2 === 0 ? 8 : -8);
+  p.settle();
   eq('vertical wobble that nets to zero is still refused', p.navigated, []);
 }
 {
@@ -410,6 +462,7 @@ console.log("\nChrome's cancellation tiers (history_swiper.mm)");
   // bug this asymmetry prevents.
   const p = newPage(js);
   p.swipe(14, -10, 0);
+  p.settle();
   eq('and a clean swipe still is not', p.navigated, ['back']);
 }
 
@@ -417,6 +470,7 @@ console.log('\nswitching it off while a page is open');
 {
   const p = newPage(js, { state: { enabled: false, back: true, forward: true } });
   p.swipe(12, -10);
+  p.settle();
   eq('a page told the gesture is off does nothing', p.navigated, []);
   check('and draws no chevron', p.visibleOverlays() === 0, p.visibleOverlays());
 }
@@ -425,6 +479,7 @@ console.log('\nswitching it off while a page is open');
   // has a state with no `enabled` key at all. Absent must mean on, not off.
   const p = newPage(js, { state: { back: true, forward: true } });
   p.swipe(12, -10);
+  p.settle();
   eq('a state without the flag still works', p.navigated, ['back']);
 }
 
@@ -437,6 +492,7 @@ console.log('\nthe root scroller');
     root: { scrollWidth: 4000, clientWidth: 800, scrollLeft: 0, overflowX: 'hidden' },
   });
   p.swipe(12, 10);
+  p.settle();
   eq('a root that cannot scroll does not block the swipe', p.navigated, ['forward']);
 }
 {
@@ -446,6 +502,7 @@ console.log('\nthe root scroller');
     root: { scrollWidth: 4000, clientWidth: 800, scrollLeft: 500, overflowX: 'visible' },
   });
   p.swipe(12, -10);
+  p.settle();
   eq('a root that can still scroll keeps the gesture', p.navigated, []);
 }
 
@@ -456,11 +513,13 @@ console.log('\na fast flick');
   const p = newPage(js);
   p.swipe(3, -8);
   p.swipe(6, -MAX_STEP_PX - 10, 0, undefined, 1_003);
+  p.settle();
   eq('a flick that accelerates still commits', p.navigated, ['back']);
 }
 {
   const p = newPage(js);
   p.swipe(4, -MAX_STEP_PX - 10);
+  p.settle();
   eq('but wheel-shaped from the first event is still refused', p.navigated, []);
 }
 
@@ -505,6 +564,7 @@ console.log('\nthe affordance');
 {
   const p = newPage(js, { noBody: true });
   p.swipe(12, -10);
+  p.settle();
   eq('a document with no body still navigates', p.navigated, ['back']);
 }
 


### PR DESCRIPTION
Fixes #296. Also fixes boss-plugin-fluck-browser#36, where the same report was moved (this is host code, not plugin code, so the fix belongs here).

## The bug

A two-finger trackpad swipe navigated back/forward the instant it crossed the 90px commit distance, fingers still down - no hold, no chance to see it coming, no way to cancel by reversing after crossing the line. The chevron affordance and reversal-cancel logic already existed; the missing piece was that `onWheel` called `navigate()` itself the moment `progress >= 1`, in the same event that crossed the threshold, rather than waiting for the gesture to actually end.

## The fix

The decision moved to end-of-gesture. `onWheel` now only tracks progress; a new `decide()` re-checks the live `accumX` against `COMMIT_PX` and is the only place `navigate()` is called. It runs from both signals that a gesture ended - the `GESTURE_GAP_MS` timer, and the gap check at the top of `onWheel` when a next event arrives after that much quiet. Whichever gets there first, the other is a no-op, because `reset()` has already zeroed `direction` and `accumX`.

- Hold past the commit distance through release -> still navigates
- Ease back below it before release (same direction, no reversal) -> cancels
- Reverse *after* crossing the line -> cancels, where `committed` used to swallow it
- `pagehide` still resets state but is deliberately not routed through `decide()`

`decide()` guards on `eventCount >= MIN_EVENTS` and re-asks `available(direction)`. Both matter only because it runs at gesture end rather than from `onWheel`: two shift-modified mouse-wheel notches under `MAX_STEP_PX` each can clear 90px before a third event arrives and would otherwise navigate with no chevron ever drawn, and the host can push new state (including the setting being switched off) during the gesture and throughout the `GESTURE_GAP_MS` after it.

**"End of gesture" is 120ms of no movement, not release.** AWT does not surface NSEvent's scroll phases, so a time gap is the only segmentation signal there is. Holding past the line and simply stopping, fingers still down, commits too - the window in which reversing still cancels is 120ms of *continuous motion*. Stated plainly in `AGENTS.md` rather than left reading as though lifting is the trigger.

## Past the commit distance, vertical drift no longer cancels

`reachedCommit` latches once the gesture is past `COMMIT_PX` with at least `MIN_EVENTS`, and from there the three vertical tiers stop being asked. Vertical is a **path length** - it only ever grows - so before this, every event after the crossing was one more chance to cancel a swipe the user had already completed, including events the user never made: a momentum tail carries 325-2500px (measured, below), and a tail with even ~11% vertical content clears the absolute `CANCEL_VERTICAL_HIGH` on its own. Before the line the tiers apply unchanged; after it, only easing back below `COMMIT_PX` or reversing outright can still cancel. That is also what a native swipe-back does.

This is what makes the momentum question a latency question and nothing more.

## Two host-side windows

`SWIPE_NAV_DEBOUNCE_MS` **drops from 400ms to 32ms** and `SWIPE_NAV_REPEAT_MS` (400ms) is new. They refuse two different things:

- **32ms, any direction** - a double-dispatch *bug* in the bridge or its caller. The page cannot produce a real second gesture that fast, since two `decide()` calls are always at least `GESTURE_GAP_MS` apart. Sized well under that floor so host-side clock jitter cannot eat the margin, and at or above one frame.
- **400ms, same direction only** - the paused drag. 120ms of quiet with the fingers still down is byte-identical to a lift, so a slow deliberate drag that hesitates mid-swipe is two gestures to the script and navigated back twice. That guard **cannot** live in the page: the first commit navigates the tab and the script's state dies with the document, so the second half of the drag lands in a freshly loaded script that has never heard of the first.

The trade is deliberate and it is not symmetric: two intentional same-direction swipes under 400ms apart become one, and the user swipes again; an unwanted extra step back may not be undoable at all, because the forward entry need not survive the intervening page's redirect. A reversal is never held for the repeat window - swiping forward straight after a back is how someone undoes a navigation they did not mean.

Both live in `SwipeNavGate`, where the check and the record are one `compareAndSet` on a monotonic clock. `@Volatile` gave visibility, not atomicity, and wall time would have refused every swipe after an NTP step backwards.

## Commit latency

A `CGEvent` tap on this hardware shows macOS emitting momentum-phase scroll for **180-870ms** after the fingers lift, carrying 325-2500px of horizontal travel. Whether Chromium forwards those to the renderer as `wheel` events is still unconfirmed - if it does, each one re-arms the end-of-gesture timer and a flick commits at end-of-momentum instead of at release. With `reachedCommit` that can only move *when* the answer arrives, never what it is: a tail runs the flick's own direction, so it can neither reverse nor ease back, and the vertical path was the one route by which it could have cancelled a completed swipe. Synthetic phase-tagged events cannot settle the forwarding question: `CGEventPost` from another process never reaches the layered native browser surface and does not even enter the session event stream, so it needs one real flick against a recording `wheel` listener. Both the numbers and the gap are recorded in `AGENTS.md`.

Unconditionally, `GESTURE_GAP_MS` is now a 120ms floor on every navigation, and it does three jobs where it did one: segmentation, commit latency, and the ceiling on `SWIPE_NAV_DEBOUNCE_MS`. That coupling is documented in `AGENTS.md`.

## Testing

`node scripts/test/test-swipe-nav.js` - hold-then-release commits, ease-back cancels, `pagehide` never commits, two events under `MIN_EVENTS` never commit (and draw no affordance), switched-off / state-gone / direction-no-longer-available mid-gesture all cancel, the gap check commits a finished gesture whose timer has not run yet without double-firing, and reversal past the commit line cancels. New this round: commits now carry a timestamp, so **"two commits are never closer than `GESTURE_GAP_MS`"** - the entire justification for the debounce - is proved by a three-gesture run rather than asserted in prose; the paused drag pins that the script really does emit two commits; a momentum-shaped tail sized to the top of the measured range (2400px of same-direction travel with 300px of vertical path) still commits exactly once; vertical drift *before* the line still cancels and *after* it no longer does; and the two-big-deltas pair cannot buy itself immunity from the tiers on its way past the line.

`BrowserSwipeNavTest` reads `GESTURE_GAP_MS` out of `BrowserSwipeNavScript.source` and bounds both windows against it - the debounce strictly below and at or above one frame, the repeat window strictly above. The regex is line-anchored so a commented-out declaration is not what gets read. `test-swipe-nav.js` reads `SWIPE_NAV_REPEAT_MS` out of the Kotlin the same way, so the one claim these two files make about each other cannot drift with both suites green. `SwipeNavGate` is tested directly, including eight threads racing on one accepted swipe.

Mutation-verified, eight ways: dropping the `reachedCommit` guard on the tiers fails 2 checks; latching it before the `MIN_EVENTS` return fails 1; reinstating the inline mid-gesture `navigate()` fails 28, including the min-gap floor; `SWIPE_NAV_DEBOUNCE_MS = 0L` fails the Kotlin bound; `SWIPE_NAV_REPEAT_MS = 100L` fails 3 Kotlin checks and the JS paused-drag claim; `GESTURE_GAP_MS = 80` in the JS fails the Kotlin bound; a non-atomic `SwipeNavGate` fails the race test.

`node scripts/test/test-swipe-nav.js`, `./gradlew :composeApp:desktopTest --tests "*BrowserSwipeNav*"`, and `./gradlew ktlintCheck detekt` all pass.
