### PR TITLE
fix: stop the crash dialog's primary button being squeezed at min width

### DIFF
--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -564,122 +565,126 @@ internal fun CrashReportDialog(
                 Spacer(modifier = Modifier.height(16.dp))
             }
 
-            // Action buttons
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                // Clean & Restart button. Gated on the disposition as well as the
-                // callback: the caller already passes null for a recoverable crash,
-                // but that left the invariant - "wiping the install is never offered
-                // as the answer to one plugin misbehaving" - resting entirely on a
-                // call site with no test, and a test here could only assert it
-                // vacuously. Now it holds however this is called.
-                if (onCleanAndRestart != null && recoverablePluginId == null) {
-                    Button(
-                        onClick = onCleanAndRestart,
-                        enabled = !isSubmitting,
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                backgroundColor = BossTheme.colors.alert,
-                                contentColor = BossTheme.colors.onSignal,
-                                disabledBackgroundColor = BossTheme.colors.raised,
-                                disabledContentColor = BossTheme.colors.textMuted,
-                            ),
-                        shape = RoundedCornerShape(6.dp),
-                    ) {
-                        Text("Clean Data & Restart")
-                    }
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-
-                // Dismiss button. For a recoverable crash this is the *recovery* action rather
-                // than a decline, so it reads as one and is given the foreground colour - the
-                // user who wants their session back must not have to guess that the greyed-out
-                // "Don't Send" is the button that keeps it.
-                TextButton(
-                    onClick = onDismiss,
-                    enabled = !isSubmitting,
-                    colors =
-                        ButtonDefaults.textButtonColors(
-                            contentColor =
-                                if (recoverablePluginId != null) {
-                                    BossTheme.colors.textPrimary
-                                } else {
-                                    BossTheme.colors.textSecondary
-                                },
-                        ),
-                ) {
-                    Text(dismissLabel)
-                }
-
-                Spacer(modifier = Modifier.width(12.dp))
-
-                // Report Issue button
-                Button(
-                    onClick = {
-                        isSubmitting = true
-                        onSubmittingChanged(true)
-                        coroutineScope.launch {
-                            // try/finally, and the finally is load-bearing now.
-                            // isSubmitting gates all three exits, and the window is
-                            // DO_NOTHING_ON_CLOSE, so a submit that threw anywhere -
-                            // updateReportWithUserInput, or the plumbing around
-                            // submitCrashReport that sits outside its own inner
-                            // catch - used to leave the flag set forever and the
-                            // crash dialog with no way out but killing the process,
-                            // on a machine already in a bad state. Before this
-                            // change the close box always worked, so the same throw
-                            // was survivable.
-                            // Exception, not a narrower type: the point is that
-                            // NOTHING escapes and leaves isSubmitting stuck, and the
-                            // paths involved reach the network, the filesystem and a
-                            // config loader.
-                            @Suppress("TooGenericExceptionCaught")
-                            val submitted =
-                                try {
-                                    submitReport(
-                                        userNotes = userNotes.takeIf { it.isNotBlank() },
-                                        includeLogs = includeLogs,
-                                    ).also { submitResult = it }
-                                } catch (e: Exception) {
-                                    submitResult =
-                                        CrashReportService.SubmitResult.Error(
-                                            "Failed to submit crash report: ${e.message ?: e.javaClass.simpleName}",
-                                        )
-                                    null
-                                } finally {
-                                    isSubmitting = false
-                                    onSubmittingChanged(false)
-                                }
-
-                            // If successful, call onSubmit after a brief delay
-                            if (submitted is CrashReportService.SubmitResult.Success) {
-                                kotlinx.coroutines.delay(SUBMIT_CONFIRMATION_MILLIS)
-                                onSubmit(userNotes.takeIf { it.isNotBlank() }, includeLogs)
-                            }
+            // Action buttons. Extracted per-button so the same three can be laid out either
+            // side by side or stacked — see the BoxWithConstraints below.
+            //
+            // Bound to a local val (rather than checking `onCleanAndRestart != null` at each of
+            // the two call sites below) precisely so it *is* the non-null reference the compiler
+            // can smart-cast from — the two-branch layout needs it twice, and re-deriving the
+            // condition from the parameter wouldn't carry that smart cast across either branch.
+            val cleanAndRestart = onCleanAndRestart.takeIf { recoverablePluginId == null }
+            val reportIssueEnabled = !isSubmitting && submitResult !is CrashReportService.SubmitResult.Success
+            val onReportIssueClick: () -> Unit = {
+                isSubmitting = true
+                onSubmittingChanged(true)
+                coroutineScope.launch {
+                    // try/finally, and the finally is load-bearing now.
+                    // isSubmitting gates all three exits, and the window is
+                    // DO_NOTHING_ON_CLOSE, so a submit that threw anywhere -
+                    // updateReportWithUserInput, or the plumbing around
+                    // submitCrashReport that sits outside its own inner
+                    // catch - used to leave the flag set forever and the
+                    // crash dialog with no way out but killing the process,
+                    // on a machine already in a bad state. Before this
+                    // change the close box always worked, so the same throw
+                    // was survivable.
+                    // Exception, not a narrower type: the point is that
+                    // NOTHING escapes and leaves isSubmitting stuck, and the
+                    // paths involved reach the network, the filesystem and a
+                    // config loader.
+                    @Suppress("TooGenericExceptionCaught")
+                    val submitted =
+                        try {
+                            submitReport(
+                                userNotes = userNotes.takeIf { it.isNotBlank() },
+                                includeLogs = includeLogs,
+                            ).also { submitResult = it }
+                        } catch (e: Exception) {
+                            submitResult =
+                                CrashReportService.SubmitResult.Error(
+                                    "Failed to submit crash report: ${e.message ?: e.javaClass.simpleName}",
+                                )
+                            null
+                        } finally {
+                            isSubmitting = false
+                            onSubmittingChanged(false)
                         }
-                    },
-                    enabled = !isSubmitting && submitResult !is CrashReportService.SubmitResult.Success,
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            backgroundColor = BossTheme.colors.signal,
-                            contentColor = BossTheme.colors.onSignal,
-                            disabledBackgroundColor = BossTheme.colors.raised,
-                            disabledContentColor = BossTheme.colors.textMuted,
-                        ),
-                    shape = RoundedCornerShape(6.dp),
-                ) {
-                    if (isSubmitting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            color = BossTheme.colors.textPrimary,
-                            strokeWidth = 2.dp,
+
+                    // If successful, call onSubmit after a brief delay
+                    if (submitted is CrashReportService.SubmitResult.Success) {
+                        kotlinx.coroutines.delay(SUBMIT_CONFIRMATION_MILLIS)
+                        onSubmit(userNotes.takeIf { it.isNotBlank() }, includeLogs)
+                    }
+                }
+            }
+
+            // Below FooterActionsInlineMinWidth the three buttons don't fit on one row at the
+            // crash window's 450dp minimum. Compose's Row then squeezes the space it can't
+            // reclaim elsewhere into the *last* child rather than overflowing, which shreds the
+            // primary button's label ("Report Issue" / "Submitting...") across several lines
+            // instead of the row simply running wide (#104). Below the breakpoint, stack the
+            // same three buttons full-width instead.
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                if (showsInlineFooterActions(maxWidth)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        // Clean & Restart button. Gated on the disposition as well as the
+                        // callback: the caller already passes null for a recoverable crash,
+                        // but that left the invariant - "wiping the install is never offered
+                        // as the answer to one plugin misbehaving" - resting entirely on a
+                        // call site with no test, and a test here could only assert it
+                        // vacuously. Now it holds however this is called.
+                        if (cleanAndRestart != null) {
+                            CleanAndRestartButton(onClick = cleanAndRestart, enabled = !isSubmitting)
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+
+                        // Dismiss button. For a recoverable crash this is the *recovery* action
+                        // rather than a decline, so it reads as one and is given the foreground
+                        // colour - the user who wants their session back must not have to guess
+                        // that the greyed-out "Don't Send" is the button that keeps it.
+                        DismissActionButton(
+                            label = dismissLabel,
+                            onClick = onDismiss,
+                            enabled = !isSubmitting,
+                            isPrimary = recoverablePluginId != null,
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text("Submitting...")
-                    } else {
-                        Text("Report Issue")
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        ReportIssueButton(
+                            isSubmitting = isSubmitting,
+                            enabled = reportIssueEnabled,
+                            onClick = onReportIssueClick,
+                        )
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        if (cleanAndRestart != null) {
+                            CleanAndRestartButton(
+                                onClick = cleanAndRestart,
+                                enabled = !isSubmitting,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                        DismissActionButton(
+                            label = dismissLabel,
+                            onClick = onDismiss,
+                            enabled = !isSubmitting,
+                            isPrimary = recoverablePluginId != null,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        ReportIssueButton(
+                            isSubmitting = isSubmitting,
+                            enabled = reportIssueEnabled,
+                            onClick = onReportIssueClick,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
                     }
                 }
             }
@@ -774,3 +779,100 @@ internal const val TRACE_SCROLLBAR_TAG = "crash-dialog-trace-scrollbar"
  * composition of any content, however short.
  */
 private fun ScrollState.isClipping(): Boolean = maxValue in 1 until Int.MAX_VALUE
+
+/**
+ * Width below which the footer's three buttons ("Clean Data & Restart", the dismiss button,
+ * "Report Issue"/"Submitting...") stop fitting on one row and stack instead.
+ *
+ * Measured (#104): at the crash window's 450dp minimum, available content width is ~386-402dp,
+ * while the three buttons together want "Clean Data & Restart" (198dp) + the dismiss button
+ * (104dp) + a 12dp spacer + "[spinner] Submitting..." (~145dp) ≈ 459dp. Below that, Compose's Row
+ * squeezes the space it can't reclaim elsewhere into the *last* child instead of overflowing,
+ * which shreds the primary button's label rather than the row running wide. This constant sits
+ * above that 459dp figure, with headroom for the worst-case ("Submitting...") label.
+ *
+ * A named constant with a pure predicate ([showsInlineFooterActions]) rather than an inline
+ * comparison, so the breakpoint is pinned by a test with no display — the shape
+ * `HomeHeader.showsInlineSearch` already established for the same reason.
+ */
+internal val FooterActionsInlineMinWidth: Dp = 480.dp
+
+internal fun showsInlineFooterActions(availableWidth: Dp): Boolean = availableWidth >= FooterActionsInlineMinWidth
+
+@Composable
+private fun CleanAndRestartButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        colors =
+            ButtonDefaults.buttonColors(
+                backgroundColor = BossTheme.colors.alert,
+                contentColor = BossTheme.colors.onSignal,
+                disabledBackgroundColor = BossTheme.colors.raised,
+                disabledContentColor = BossTheme.colors.textMuted,
+            ),
+        shape = RoundedCornerShape(6.dp),
+        modifier = modifier,
+    ) {
+        Text("Clean Data & Restart")
+    }
+}
+
+@Composable
+private fun DismissActionButton(
+    label: String,
+    onClick: () -> Unit,
+    enabled: Boolean,
+    isPrimary: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onClick,
+        enabled = enabled,
+        colors =
+            ButtonDefaults.textButtonColors(
+                contentColor = if (isPrimary) BossTheme.colors.textPrimary else BossTheme.colors.textSecondary,
+            ),
+        modifier = modifier,
+    ) {
+        Text(label)
+    }
+}
+
+@Composable
+private fun ReportIssueButton(
+    isSubmitting: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        colors =
+            ButtonDefaults.buttonColors(
+                backgroundColor = BossTheme.colors.signal,
+                contentColor = BossTheme.colors.onSignal,
+                disabledBackgroundColor = BossTheme.colors.raised,
+                disabledContentColor = BossTheme.colors.textMuted,
+            ),
+        shape = RoundedCornerShape(6.dp),
+        modifier = modifier,
+    ) {
+        if (isSubmitting) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = BossTheme.colors.textPrimary,
+                strokeWidth = 2.dp,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Submitting...")
+        } else {
+            Text("Report Issue")
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/crash/CrashReportDialog.kt
@@ -238,7 +238,10 @@ internal fun CrashReportDialog(
             // instead of pushing the action buttons past the bottom of the window.
             // `fill = false` keeps the cap from becoming a floor: when the content is short the
             // body stays short and the footer sits right below it, as it did before the cap.
-            Box(modifier = Modifier.weight(1f, fill = false).fillMaxWidth()) {
+            BoxWithConstraints(modifier = Modifier.weight(1f, fill = false).fillMaxWidth()) {
+                // A stacked footer leaves less room for the body. Keep the nested trace viewport
+                // within half of that space so surrounding report content remains reachable.
+                val tracePaneMaxHeight = minOf(TRACE_PANE_MAX_HEIGHT, maxHeight / 2)
                 Column(
                     modifier = Modifier.fillMaxWidth().verticalScroll(bodyScrollState),
                 ) {
@@ -344,7 +347,7 @@ internal fun CrashReportDialog(
                                             modifier =
                                                 Modifier
                                                     .fillMaxWidth()
-                                                    .heightIn(max = TRACE_PANE_MAX_HEIGHT)
+                                                    .heightIn(max = tracePaneMaxHeight)
                                                     .testTag(TRACE_PANE_TAG)
                                                     .background(
                                                         BossTheme.colors.panel,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashDialogFooterActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashDialogFooterActionsTest.kt
@@ -1,0 +1,44 @@
+package ai.rever.boss.crash
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [showsInlineFooterActions] as a pure function, pinned without a display — the shape
+ * `HomeHeader.showsInlineSearch` and `HomeLayoutTest` already established for a reflow decision
+ * that would otherwise be a bare `if` buried inside a composable.
+ *
+ * What this protects is #104: at the crash window's 450dp minimum, the three footer buttons
+ * don't fit on one row, and a Row over-subscribed like that squeezes the shortfall into its last
+ * child instead of overflowing — shredding "Report Issue" / "Submitting..." across several lines
+ * rather than the row simply running wide.
+ */
+class CrashDialogFooterActionsTest {
+    @Test
+    fun `the crash window's minimum content width does not fit the buttons inline`() {
+        // ~386-402dp is the measured available content width at the 450dp frame minimum (#104).
+        assertFalse(showsInlineFooterActions(386.dp))
+        assertFalse(showsInlineFooterActions(402.dp))
+    }
+
+    @Test
+    fun `a width one pixel short of the breakpoint stacks`() {
+        assertFalse(showsInlineFooterActions(FooterActionsInlineMinWidth - 1.dp))
+    }
+
+    @Test
+    fun `the breakpoint itself and anything wider goes inline`() {
+        assertTrue(showsInlineFooterActions(FooterActionsInlineMinWidth))
+        assertTrue(showsInlineFooterActions(700.dp))
+    }
+
+    @Test
+    fun `the preferred crash window's content width fits the buttons inline`() {
+        // CrashHandler.CONTENT_PREFERRED_WIDTH is 550dp; minus the ~48dp of outer content
+        // padding (#104's own measurement), that's the available width the footer actually
+        // sees — where it has shipped fine. This reflow must not change that default case.
+        assertTrue(showsInlineFooterActions(CrashHandler.CONTENT_PREFERRED_WIDTH.dp - 48.dp))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
@@ -415,6 +415,31 @@ class CrashReportDialogLayoutTest {
     }
 
     @Test
+    fun theReportIssueButtonIsNotSqueezedAtTheMinimumWindowWidth() {
+        // #104: at the crash window's 450dp minimum, three buttons side by side used to
+        // over-subscribe the row, and Compose squeezed the shortfall into the *last* child
+        // instead of overflowing - down to ~88dp, well under either label's natural width. The
+        // fix stacks all three full-width below FooterActionsInlineMinWidth instead, so the
+        // primary button's width should now equal its stacked siblings', not be squeezed
+        // relative to them.
+        setDialogAtMinimumWindowSize()
+
+        val reportIssueWidth = rule.onNodeWithText("Report Issue").getUnclippedBoundsInRoot().width
+        val dismissWidth = rule.onNodeWithText("Don't Send").getUnclippedBoundsInRoot().width
+
+        assertTrue(
+            reportIssueWidth.value > 200f,
+            "\"Report Issue\" measured ${reportIssueWidth.value}dp wide - " +
+                "the pre-#104 squeeze produced ~88dp",
+        )
+        assertTrue(
+            abs(reportIssueWidth.value - dismissWidth.value) <= 1f,
+            "stacked buttons should be full-width siblings, not independently sized: " +
+                "\"Report Issue\" ${reportIssueWidth.value}dp vs \"Don't Send\" ${dismissWidth.value}dp",
+        )
+    }
+
+    @Test
     fun aBlankFailureMessageRendersThePlaceholderNotAnEmptyCard() {
         // Unreachable today (every Error interpolates a prefix), but it is the one behaviour the
         // sanitizer swap changed beyond redaction: maskUriParams answered "[empty]" for blank input,

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/crash/CrashReportDialogLayoutTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
 import org.junit.Rule
 import org.junit.Test
 import kotlin.math.abs


### PR DESCRIPTION
Fixes #104.

At the crash window's 450dp minimum width, the three footer buttons don't fit on one row, and Compose's `Row` squeezes the shortfall into the *last* child instead of overflowing — shredding "Report Issue" onto two lines idle, and "Submitting..." onto four lines while submitting.

Extracted the three buttons into their own composables and laid them out in a `BoxWithConstraints`: side by side above a measured breakpoint, stacked full-width below it — same width-breakpoint pattern already used elsewhere in this codebase (`HomeHeader`, `AuthScaffold`, `BossDialog`). Added a pure test for the breakpoint and a layout test confirming the primary button isn't narrower than its stacked siblings at the minimum size.

Tested by resizing the crash dialog to 450dp width on `main` vs. this branch. Screenshots to follow.

Before : 
<img width="962" height="1060" alt="BOSS - Crash Report" src="https://github.com/user-attachments/assets/2b7fe932-0303-49e9-8463-976764b2a510" />

after :
<img width="992" height="1056" alt="BOSS - Crash Report" src="https://github.com/user-attachments/assets/815d6d0d-f17b-48ce-9e2a-81f3c803f126" />


### Maintainer follow-up and attribution

Original responsive footer implementation and added tests: **Shwetas Dhake (@shwetd19)**. Original commits and authorship are preserved.

Maintainer follow-up caps the nested stack-trace pane at the smaller of 200dp and half the available body height. This prevents the taller stacked footer from leaving a trace pane larger than the report viewport. The existing failing regression test remains unchanged. This correction is recorded separately from the original hackathon contribution.

The branch includes the merged #303 scrollbar styling. Validation covers 23 focused footer, crash-dialog layout and recovery tests, plus ktlint and detekt. Independent subagent review found no blocking issue in the adaptive height change.
