### PR TITLE
fix(panels): give each panel its own lifecycle so doOnDestroy actually fires

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppStartupEffects.kt
@@ -440,6 +440,11 @@ internal fun BossAppStartupEffects(state: BossAppState) {
             // handle is released by rememberBossAppState, which also acquired it,
             // and app-level teardown is UpdateCoordinator.shutdown() in main.kt.
 
+            // Destroy every open panel's lifecycle so their doOnDestroy callbacks fire
+            // on window close — mirrors BossTabsComponent.disposeAllTabsBlocking for tabs
+            // (issue #213: panel doOnDestroy was dead code before this).
+            state.panelComponentStore.disposeAll()
+
             // Unregister this window's state from the global registries
             SplitViewStateRegistry.unregister(windowId)
             PanelComponentStoreRegistry.unregister(windowId)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/registery/PanelComponentStore.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/registery/PanelComponentStore.kt
@@ -6,6 +6,10 @@ import ai.rever.boss.utils.logging.LogCategory
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.destroy
+import com.arkivanov.essenty.lifecycle.resume
 
 class PanelComponentStore(
     private val rootContext: ComponentContext,
@@ -15,6 +19,18 @@ class PanelComponentStore(
 
     // Map of active components by panel ID
     val activeComponents: SnapshotStateMap<PanelId, PanelComponentWithUI> = mutableStateMapOf()
+
+    // Per-panel lifecycle registries. Each panel component gets its own ComponentContext whose
+    // lifecycle is destroyed when the panel is closed or reset, so components that clean up in
+    // lifecycle.doOnDestroy (e.g. plugin panels disposing CoroutineScopes, stopping poll loops)
+    // actually get destroyed. Previously all panel components shared the window's root context,
+    // whose LifecycleRegistry is never destroyed — closing a panel leaked every resource the
+    // component registered in doOnDestroy (issue #213).
+    //
+    // Mirrors BossTabsComponent.tabLifecycles for tabs. Plain map on purpose: all panel
+    // mutations happen on the UI thread (see PanelComponentStoreRegistry KDoc), matching
+    // Essenty's lifecycle threading expectations.
+    private val panelLifecycles = mutableMapOf<PanelId, LifecycleRegistry>()
 
     // Get or create a component for a panel
     fun getOrCreateComponent(panelId: PanelId): PanelComponentWithUI? {
@@ -28,10 +44,20 @@ class PanelComponentStore(
         // Return existing component if available
         activeComponents[panelId]?.let { return it }
 
-        // Create new component
-        val component = registry.createComponent(panelId, rootContext) ?: return null
+        // Create a per-panel lifecycle so doOnDestroy callbacks actually fire on close/reset.
+        val panelLifecycle = LifecycleRegistry()
+        val panelContext = DefaultComponentContext(panelLifecycle)
+
+        // Create new component with its own context (not the shared root)
+        val component = registry.createComponent(panelId, panelContext) ?: return null
+
+        // Drive the lifecycle to RESUMED: subscribers added in the component's init get
+        // their up-callbacks replayed, and destroy() from CREATED would otherwise be a
+        // silent no-op (Essenty only fires onDestroy from CREATED or above).
+        panelLifecycle.resume()
 
         // Store and return
+        panelLifecycles[panelId] = panelLifecycle
         activeComponents[panelId] = component
         return component
     }
@@ -39,6 +65,11 @@ class PanelComponentStore(
     // Remove a component when panel is closed
     fun removeComponent(panelId: PanelId) {
         activeComponents.remove(panelId)
+        // Destroy the panel's own lifecycle so components that clean up in
+        // lifecycle.doOnDestroy (plugin panels disposing scopes, stopping pollers)
+        // release their resources — without this a closed panel's callbacks are
+        // dead code and every close/reopen stacks another set of invisible workers.
+        panelLifecycles.remove(panelId)?.destroy()
     }
 
     /**
@@ -46,10 +77,11 @@ class PanelComponentStore(
      *
      * This method implements the "component recreation" reset strategy:
      * 1. Call onBeforeReset() on the current component for cleanup
-     * 2. Remove component from activeComponents (triggers Decompose disposal)
-     * 3. Create a fresh component instance
-     * 4. Call onInitialized() on the new component
-     * 5. Store and activate the new component
+     * 2. Destroy the outgoing component's per-panel lifecycle (fires its doOnDestroy)
+     * 3. Remove component from activeComponents
+     * 4. Create a fresh component instance with a new per-panel lifecycle
+     * 5. Call onInitialized() on the new component
+     * 6. Store and activate the new component
      *
      * This ensures the panel starts with completely fresh state,
      * as if it were just opened for the first time.
@@ -79,21 +111,40 @@ class PanelComponentStore(
             logger.warn(LogCategory.UI, "onBeforeReset failed during panel reset (continuing)", mapOf("panelId" to panelId.panelId), t)
         }
 
-        // Remove from active components (triggers Decompose disposal)
+        // Destroy the outgoing panel's lifecycle so its doOnDestroy callbacks fire.
+        // Done after onBeforeReset so the existing hook keeps its current meaning and
+        // ordering (onBeforeReset = "save state before I go away", doOnDestroy =
+        // "release resources now that I'm gone"). Isolated: a throwing doOnDestroy
+        // subscriber must not prevent the reset from continuing.
+        try {
+            panelLifecycles.remove(panelId)?.destroy()
+        } catch (t: Throwable) {
+            logger.warn(LogCategory.UI, "lifecycle destroy failed during panel reset (continuing)", mapOf("panelId" to panelId.panelId), t)
+        }
+
+        // Remove from active components
         activeComponents.remove(panelId)
 
         try {
+            // Create a fresh per-panel lifecycle for the new component
+            val panelLifecycle = LifecycleRegistry()
+            val panelContext = DefaultComponentContext(panelLifecycle)
+
             // Create new component instance
-            val newComponent = registry.createComponent(panelId, rootContext)
+            val newComponent = registry.createComponent(panelId, panelContext)
             if (newComponent == null) {
                 logger.warn(LogCategory.UI, "Failed to create new component", mapOf("panelId" to panelId.panelId))
                 return false
             }
 
+            // Drive the lifecycle to RESUMED (same contract as getOrCreateComponent)
+            panelLifecycle.resume()
+
             // Call initialization hook
             newComponent.onInitialized()
 
             // Store and activate new component
+            panelLifecycles[panelId] = panelLifecycle
             activeComponents[panelId] = newComponent
 
             logger.info(LogCategory.UI, "Successfully reset panel", mapOf("panelId" to panelId.panelId))
@@ -102,5 +153,16 @@ class PanelComponentStore(
             logger.error(LogCategory.UI, "Error resetting panel", mapOf("panelId" to panelId.panelId), error = t)
             return false
         }
+    }
+
+    /**
+     * Destroy all panel lifecycles in this store. Called on window close so every
+     * open panel's doOnDestroy callbacks fire — mirrors
+     * BossTabsComponent.disposeAllTabsBlocking for tabs.
+     */
+    fun disposeAll() {
+        panelLifecycles.values.toList().forEach { it.destroy() }
+        panelLifecycles.clear()
+        activeComponents.clear()
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/registery/PanelComponentStoreResetTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/components/registery/PanelComponentStoreResetTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.doOnDestroy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -210,4 +211,113 @@ class PanelComponentStoreResetTest {
         }
         assertFalse(PanelComponentStoreRegistry.getAllStores().contains(storeA))
     }
+
+    // --- Issue #213: per-panel lifecycle tests ---
+    // Panels used to share the window's root ComponentContext, whose lifecycle is never
+    // destroyed. Every doOnDestroy a panel registered was dead code. These tests pin the fix:
+    // each panel gets its own LifecycleRegistry, destroyed on close/reset/disposeAll.
+
+    @Test
+    fun `removeComponent fires doOnDestroy on the closed panel's lifecycle`() {
+        val registry = PanelRegistry()
+        val id = PanelId("lifecycle-close", 1)
+        var destroyCalled = false
+        registry.registerPanel(panelInfo(id)) { ctx, info ->
+            object : PanelComponentWithUI, ComponentContext by ctx {
+                init { lifecycle.doOnDestroy { destroyCalled = true } }
+
+                @Composable
+                override fun Content() {}
+            }
+        }
+        val store = PanelComponentStore(newContext(), registry)
+        store.getOrCreateComponent(id)
+
+        store.removeComponent(id)
+
+        assertTrue(destroyCalled, "doOnDestroy must fire when a panel is closed (issue #213)")
+    }
+
+    @Test
+    fun `resetComponent fires doOnDestroy on the outgoing component's lifecycle`() {
+        val registry = PanelRegistry()
+        val id = PanelId("lifecycle-reset", 1)
+        var destroyCalled = false
+        registerFactory(registry, id, generation = 1)
+        val store = PanelComponentStore(newContext(), registry)
+        val component = store.getOrCreateComponent(id)!!
+        component.lifecycle.doOnDestroy { destroyCalled = true }
+
+        assertTrue(store.resetComponent(id))
+
+        assertTrue(destroyCalled, "doOnDestroy must fire on the outgoing component during reset (issue #213)")
+    }
+
+    @Test
+    fun `disposeAll fires doOnDestroy on every open panel`() {
+        val registry = PanelRegistry()
+        val idA = PanelId("lifecycle-all-a", 1)
+        val idB = PanelId("lifecycle-all-b", 2)
+        var destroyA = false
+        var destroyB = false
+        registry.registerPanel(panelInfo(idA)) { ctx, info ->
+            object : PanelComponentWithUI, ComponentContext by ctx {
+                init { lifecycle.doOnDestroy { destroyA = true } }
+
+                @Composable
+                override fun Content() {}
+            }
+        }
+        registry.registerPanel(panelInfo(idB)) { ctx, info ->
+            object : PanelComponentWithUI, ComponentContext by ctx {
+                init { lifecycle.doOnDestroy { destroyB = true } }
+
+                @Composable
+                override fun Content() {}
+            }
+        }
+        val store = PanelComponentStore(newContext(), registry)
+        store.getOrCreateComponent(idA)
+        store.getOrCreateComponent(idB)
+
+        store.disposeAll()
+
+        assertTrue(destroyA, "disposeAll must fire doOnDestroy on panel A (window close)")
+        assertTrue(destroyB, "disposeAll must fire doOnDestroy on panel B (window close)")
+        assertTrue(store.activeComponents.isEmpty())
+    }
+
+    @Test
+    fun `closing one panel does not fire doOnDestroy on another`() {
+        val registry = PanelRegistry()
+        val idA = PanelId("lifecycle-iso-a", 1)
+        val idB = PanelId("lifecycle-iso-b", 2)
+        var destroyA = false
+        var destroyB = false
+        registry.registerPanel(panelInfo(idA)) { ctx, info ->
+            object : PanelComponentWithUI, ComponentContext by ctx {
+                init { lifecycle.doOnDestroy { destroyA = true } }
+
+                @Composable
+                override fun Content() {}
+            }
+        }
+        registry.registerPanel(panelInfo(idB)) { ctx, info ->
+            object : PanelComponentWithUI, ComponentContext by ctx {
+                init { lifecycle.doOnDestroy { destroyB = true } }
+
+                @Composable
+                override fun Content() {}
+            }
+        }
+        val store = PanelComponentStore(newContext(), registry)
+        store.getOrCreateComponent(idA)
+        store.getOrCreateComponent(idB)
+
+        store.removeComponent(idA)
+
+        assertTrue(destroyA, "the closed panel's doOnDestroy must fire")
+        assertFalse(destroyB, "a sibling panel's lifecycle must be unaffected")
+    }
+
 }


### PR DESCRIPTION
Fixes #213

## Problem

Every panel component received the window's root `ComponentContext` (`createBossAppContext`), whose `LifecycleRegistry` is never destroyed. So every `lifecycle.doOnDestroy { ... }` a panel plugin registered was dead code: closing or resetting a panel leaked every resource the component released in that callback — per-panel CoroutineScopes, poll loops, subscriptions. Tabs already had the fix (`tabLifecycles` in `BossTabsComponent`); panels never got the same treatment.

## The fix

Mirrors the tab pattern into `PanelComponentStore`, exactly as the issue suggests:

- A `LifecycleRegistry` per `PanelId`, handed to `createComponent` wrapped in a `DefaultComponentContext` instead of the shared root context, and resumed on creation (destroy() from CREATED would otherwise be a silent no-op — Essenty only fires onDestroy from CREATED or above).
- `removeComponent` destroys the panel's lifecycle, so `doOnDestroy` fires on close.
- `resetComponent` destroys the outgoing lifecycle **after** `onBeforeReset` (the existing hook keeps its meaning and ordering), isolated in try/catch so a throwing subscriber cannot block the reset, then builds a fresh lifecycle for the new component.
- New `disposeAll()`, called from `BossAppStartupEffects` on window close, so open panels' callbacks fire there too (mirrors `disposeAllTabsBlocking` for tabs).
- The false comment ("triggers Decompose disposal") is replaced with what actually happens.

## Tests

Four new tests in `PanelComponentStoreResetTest`: close fires `doOnDestroy`; reset fires it on the outgoing component; `disposeAll` fires it on every open panel; closing one panel leaves a sibling untouched.
