### PR TITLE
fix(plugins): report unmet dependencies when a disabled plugin is re-enabled

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt
@@ -132,6 +132,27 @@ class DynamicPluginManager(
     private val mutex = Mutex()
 
     /**
+     * Raised after a re-activation path re-registers a plugin whose manifest may declare
+     * dependencies that are no longer present (issue #180).
+     *
+     * The dependency check runs at install and never again, but a required dependency can be
+     * removed while its dependent sits DISABLED - the unload veto only covers LOADED dependents,
+     * which is what #178's isDisabled exemption opened. Re-enabling such a plugin registers it
+     * against a provider that is not there: the silent looks-alive-does-nothing state
+     * MissingDependencyReporter exists to prevent. Re-enabling and RBAC access regain are user
+     * actions, so - unlike a reload - they report.
+     *
+     * A function property rather than a constructor parameter because the thing that answers it,
+     * MissingDependencyReporter, lives in desktopMain while this manager is commonMain - the same
+     * source-set split `MissingDependencyInstaller` crosses by injection. PluginLoaderDelegateImpl
+     * binds it to the reporter's `report`, which computes the missing set with the real
+     * jar-existence predicate and raises the same prompt the install paths raise. Null in tests
+     * and wherever no reporter is wired; the notifier is an announcement, never a veto - a
+     * re-enable succeeds even when it fires.
+     */
+    var dependencyMissingNotifier: ((PluginManifest) -> Unit)? = null
+
+    /**
      * The underlying plugin loader.
      */
     private val pluginLoader =
@@ -1606,7 +1627,15 @@ class DynamicPluginManager(
         // Outside the mutex, same as installPlugin. Skipped when the plugin
         // was already enabled: a redundant enable must not discard an open
         // panel's in-memory state (resetComponent loses it by design).
-        if (result.isSuccess && !wasAlreadyEnabled) notifyPanelsRefresh(pluginId)
+        if (result.isSuccess && !wasAlreadyEnabled) {
+            notifyPanelsRefresh(pluginId)
+            // Issue #180: the dependency check ran at install and never again, but the
+            // dependency can have been removed while this plugin sat disabled. Announce it
+            // so the existing prompt can offer the install; the enable itself stands.
+            _pluginStates.value[pluginId]?.manifest?.let { manifest ->
+                dependencyMissingNotifier?.invoke(manifest)
+            }
+        }
         return result
     }
 
@@ -2276,6 +2305,12 @@ class DynamicPluginManager(
                                 "pluginId" to pluginId,
                             ),
                         )
+                        // Issue #180: same re-activation gap as enablePlugin - the plugin sat
+                        // unregistered while hidden, its dependency may have been removed in
+                        // that window, and registering against an absent provider is the silent
+                        // looks-alive-does-nothing state. Regained access is user-visible, so
+                        // report like an install would; the re-register itself stands.
+                        dependencyMissingNotifier?.invoke(info.manifest)
                     } catch (e: Throwable) {
                         logger.error(
                             LogCategory.SYSTEM,

--- a/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
+++ b/composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt
@@ -70,6 +70,17 @@ class PluginLoaderDelegateImpl(
      */
     private val dependencyReporter = MissingDependencyReporter.forManager(dynamicPluginManager)
 
+    init {
+        // Issue #180: the manager's re-activation paths - enablePlugin and the RBAC
+        // access-regain loop in handleAccessChange - re-register a plugin without consulting
+        // its manifest, and a dependency removed while the plugin sat disabled leaves it in
+        // the silent looks-alive-does-nothing state. The manager is commonMain and the
+        // reporter desktopMain, so the manager exposes a notifier hook and this delegate
+        // binds it to the same reporter the install paths use - one reporter, one definition
+        // of "installed", one prompt shape.
+        dynamicPluginManager.dependencyMissingNotifier = dependencyReporter::report
+    }
+
     /**
      * Report the plugin's unmet dependencies (unless this is a reload) and describe it for the
      * caller.

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/plugin/DependencyPromptOnInstallOnlyTest.kt
@@ -18,18 +18,28 @@ import kotlin.test.assertTrue
  * Same approach as `WindowsArm64SourceIsolationTest`, for the same reason - a mistake no
  * behavioural test can see should still fail a PR. Everything else about the prompt now has real
  * tests (`MissingDependencyReporterTest`, `PluginDependencyResolutionTest`), so this file is
- * deliberately down to the one property that cannot have one.
+ * down to the properties that cannot have one: the install-only rule above, and the two
+ * re-activation paths that must report again since #180 (a dependency removed while its
+ * dependent sat disabled leaves a re-enabled plugin registering against a provider that is
+ * not there - re-enabling is a user action, so it reports).
  */
 class DependencyPromptOnInstallOnlyTest {
+    private fun repoRoot(): File =
+        assertNotNull(
+            generateSequence(File("").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
+            "could not locate the repository root",
+        )
+
     private fun source(): String {
-        val root =
-            assertNotNull(
-                generateSequence(File("").absoluteFile) { it.parentFile }
-                    .firstOrNull { File(it, "composeApp/build.gradle.kts").isFile },
-                "could not locate the repository root",
-            )
-        val file = File(root, "composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt")
+        val file = File(repoRoot(), "composeApp/src/desktopMain/kotlin/ai/rever/boss/plugin/PluginLoaderDelegateImpl.kt")
         assertTrue(file.isFile, "PluginLoaderDelegateImpl.kt not found at ${file.absolutePath}")
+        return file.readText()
+    }
+
+    private fun managerSource(): String {
+        val file = File(repoRoot(), "composeApp/src/commonMain/kotlin/ai/rever/boss/components/plugin/DynamicPluginManager.kt")
+        assertTrue(file.isFile, "DynamicPluginManager.kt not found at ${file.absolutePath}")
         return file.readText()
     }
 
@@ -70,6 +80,41 @@ class DependencyPromptOnInstallOnlyTest {
         assertTrue(
             Regex("""if\s*\(\s*reportDependencies\b[\s\S]{0,400}?\.report\(""").containsMatchIn(source()),
             "the load path must consult reportDependencies before reporting",
+        )
+    }
+
+    @Test
+    fun `the delegate binds the manager's re-activation notifier to the reporter`() {
+        // The manager is commonMain and the reporter desktopMain, so the notifier reaches the
+        // prompt only if this binding exists. Asserting the property, not the formatting.
+        assertTrue(
+            Regex("""dependencyMissingNotifier\s*=\s*dependencyReporter\.report""").containsMatchIn(source()),
+            "PluginLoaderDelegateImpl must bind dependencyMissingNotifier to the reporter (issue #180)",
+        )
+    }
+
+    @Test
+    fun `re-enabling a disabled plugin reports its unmet dependencies`() {
+        // A genuine re-enable (not a redundant one) is a user action, so after the panels
+        // refresh it must announce the manifest to the notifier.
+        assertTrue(
+            Regex(
+                """if\s*\(\s*result\.isSuccess\s*&&\s*!wasAlreadyEnabled\s*\)\s*\{[\s\S]{0,600}?""" +
+                    """dependencyMissingNotifier\?\.invoke\(""",
+            ).containsMatchIn(managerSource()),
+            "enablePlugin must report unmet dependencies on a genuine re-enable (issue #180)",
+        )
+    }
+
+    @Test
+    fun `regaining RBAC access reports unmet dependencies`() {
+        // Anchor on the log line the success path writes, so the assertion stays tied to the
+        // re-register that succeeded rather than to an arbitrary point in the loop.
+        assertTrue(
+            Regex(
+                """Re-registered plugin after access gained[\s\S]{0,600}?dependencyMissingNotifier\?\.invoke\(""",
+            ).containsMatchIn(managerSource()),
+            "handleAccessChange must report unmet dependencies when a hidden plugin becomes visible (issue #180)",
         )
     }
 }


### PR DESCRIPTION
Fixes #180

## Problem

The dependency check runs at install and never again. But a required dependency can be removed while its dependent sits DISABLED — the unload veto only covers LOADED dependents (the #178 `isDisabled` exemption). Both re-activation paths then register the plugin against a provider that is not there — `DynamicPluginManager.enablePlugin` and the access-regain loop in `handleAccessChange` go straight to `instance.register(trackingContext)` — landing in the silent looks-alive-does-nothing state `MissingDependencyReporter` exists to prevent.

## The fix

The issue's suggested shape, adapted to the source-set boundary: the reporter is desktopMain, the manager commonMain, so the manager exposes a `dependencyMissingNotifier: ((PluginManifest) -> Unit)?` hook — the same injection pattern `MissingDependencyInstaller` already crosses — and `PluginLoaderDelegateImpl` binds it to the same `MissingDependencyReporter` the install paths use (one reporter, one definition of "installed", one prompt shape).

- `enablePlugin`: on a genuine re-enable (`!wasAlreadyEnabled`), outside the mutex, announces the plugin's manifest after `notifyPanelsRefresh`.
- `handleAccessChange`: after a successful re-register on access regained, announces `info.manifest`.
- The notifier is an announcement, never a veto: a re-enable succeeds even when it fires, matching `report()`'s fire-and-forget contract. A redundant enable does not report.
- Reload paths still never report — unchanged, as the existing rule requires.

## Tests

Extended `DependencyPromptOnInstallOnlyTest` (this seam is unreachable from a unit test — the manager cannot be faked — which is why that file exists): the delegate binding exists, `enablePlugin` announces on a genuine re-enable, and the access-regain loop announces after a successful re-register.
