### PR TITLE
Stop the host's actions floating over content a window has room for

### DIFF
--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -305,7 +305,21 @@ internal fun BossAppScaffold(
     // than inside an inline content lambda. One question answers both halves: whether these
     // actions land in a panel foot at all, and which column draws it - see hostActionsPanelEdge.
     val panelFooterEdge = state.draggablePanelComponent.hostActionsPanelColumn()
-    val rightPanelOpen = panelFooterEdge != null
+
+    // Whether that column is big enough to hold the row, reported back out of layout by
+    // `PanelFooterHostActions` - the same shape `onBarRailedChange` has, and for the same reason:
+    // a panel is user-resizable down to a sliver, and how many lines four or five 32dp icons wrap
+    // to in it is not something settings can answer.
+    //
+    // Starts true so the common case - a panel at its 250dp default, where the row is one line
+    // under a plugin with 355dp - never flickers. The other order would create and tear down the
+    // cluster's native window on every right-panel open, which is the cost this placement exists
+    // to avoid paying.
+    //
+    // KEYED on the column, so closing the panel forgets the answer rather than leaving a
+    // sliver's "no" behind for the next panel opened at a perfectly good width. A remember key
+    // and not an effect: there is nothing to do on the reset except be true again.
+    var panelFootFits by remember(panelFooterEdge) { mutableStateOf(true) }
 
     // Where Settings / Search / Sign Out go while focus mode holds the top bar that owns them.
     // One decision, five mutually exclusive renderings - every piece of chrome the window already
@@ -328,7 +342,7 @@ internal fun BossAppScaffold(
                     drawerVisible = drawerVisible,
                 ),
             // Only consulted once the bar has offered nothing, i.e. in TOP position.
-            rightPanelOpen = rightPanelOpen,
+            panelFootAvailable = panelFootAvailable(panelFooterEdge, panelFootFits),
         )
 
     // Where the way into the plugins goes, when a strip that would normally hold their icons is
@@ -681,12 +695,18 @@ internal fun BossAppScaffold(
                             // The panel itself is second when it is open, so the clearance moves
                             // onto it - this is what the lights were landing on.
                             leftPanelTopInset = trafficLights.columnInset(columns.panel),
-                            // Settings / Search / Sign Out at the foot of an open panel's column,
-                            // for a TOP tab bar with no bar of its own to hold them. Empty - and
-                            // so no row at all - for every other placement.
+                            // Settings / Search / Sign Out at the foot of the open right panel's
+                            // column, for a TOP tab bar with no bar of its own to hold them. Empty
+                            // - and so no row at all - for every other placement.
                             panelFooterEdge = panelFooterEdge,
                             panelFooter = {
                                 PanelFooterHostActions(
+                                    // What the row WOULD hold, which the fit measurement needs
+                                    // while the list is empty - the state a "does not fit" answer
+                                    // puts it in. Counted as `focusQuickActionsRailRows` counts
+                                    // the rail's reserve: the four, plus the launcher when both
+                                    // strips are off and this group is where it landed.
+                                    actionCount = hostActionsRowSize(hasLauncher = hostToolLauncher != null),
                                     actions =
                                         focusQuickActionsPanelFooter(
                                             placement = quickActionsPlacement,
@@ -696,6 +716,7 @@ internal fun BossAppScaffold(
                                             onSignOut = { state.showLogoutDialog = true },
                                             toolLauncher = hostToolLauncher,
                                         ),
+                                    onColumnFitsChange = { fits -> panelFootFits = fits },
                                 )
                             },
                             onDrawerVisibleChange = { visible -> drawerVisible = visible },
@@ -886,12 +907,47 @@ internal fun BossAppScaffold(
  *
  * The read; [hostActionsPanelEdge] is the rule, including why the left and bottom columns are not
  * candidates. One state subscription added to this composable's restart scope, on top of the
- * `isVisible(left)` the traffic-light rule already reads - so a right-panel toggle now recomposes
- * the scaffold. That is a user-scale event, and it is the same mechanism behind the overlay
- * teardown this placement already documents.
+ * `isVisible(left)` the traffic-light rule already reads.
+ *
+ * Slightly broader than "the right panel opened or closed", stated exactly because the file is
+ * careful about this elsewhere: `isVisible` folds `right.top` and `right.bottom`, and
+ * `setPanelVisible` and `toggleVisibility` write a whole fresh `PanelData`, so any write to either
+ * half - a `sidebarItem` change that does not touch visibility included - recomposes this
+ * scaffold. Still user-scale in every case, and the same mechanism already behind the overlay
+ * teardown this placement documents; noted rather than narrowed because a `derivedStateOf` here
+ * would buy a comparison per write and cost a reader the ability to see what is subscribed.
  *
  * A plain function rather than a `@Composable`: it only reads snapshot state, so called during
  * composition it subscribes its caller exactly as an inline chain would. Named at all because
  * this composable is at detekt's cyclomatic ceiling.
  */
 private fun BossDraggableComponent.hostActionsPanelColumn(): Panel? = hostActionsPanelEdge(rightOpen = isVisible(right))
+
+/**
+ * Whether the host's actions have a panel foot to go in: there is a column, and it can hold the row.
+ *
+ * Both halves, because either one alone ships a bug. Without [edge] the row is drawn into a column
+ * nothing composes; without [fits] it is drawn into a 20dp sliver, where it wraps five lines deep
+ * and takes 188dp out of the plugin - see `panelFooterFitsColumn`, which is where [fits] comes
+ * from, and `PanelFooterHostActions`, which measures it.
+ *
+ * Named rather than written inline for the same reason [hostActionsPanelEdge] is: this composable
+ * is at detekt's cyclomatic ceiling, and one more `&&` in its body puts it over.
+ */
+private fun panelFootAvailable(
+    edge: Panel?,
+    fits: Boolean,
+): Boolean = edge != null && fits
+
+/**
+ * How many buttons the host's action row would hold.
+ *
+ * What `PanelFooterHostActions` measures its column against, and it has to be answerable while
+ * the list itself is empty - which is the state a "does not fit" answer puts that row in.
+ *
+ * Counted the way `focusQuickActionsRailRows` counts the rail's reserve: the four, Toolbox
+ * included, plus the tools launcher when both icon strips are off and it landed in this group.
+ * Named rather than inlined because [BossAppScaffold] is at detekt's cyclomatic ceiling and one
+ * more `if` in its body puts it over.
+ */
+private fun hostActionsRowSize(hasLauncher: Boolean): Int = FOCUS_QUICK_ACTION_COUNT + if (hasLauncher) 1 else 0

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -12,6 +12,7 @@ import ai.rever.boss.components.home.LocalPanelRegistry
 import ai.rever.boss.components.home.LocalPluginStates
 import ai.rever.boss.components.home.LocalRegistryAccess
 import ai.rever.boss.components.home.LocalTabRegistry
+import ai.rever.boss.components.model.BossDraggableComponent
 import ai.rever.boss.components.overlays.DraggingItemOverlay
 import ai.rever.boss.components.overlays.OverlayCorner
 import ai.rever.boss.components.overlays.TabDraggingOverlay
@@ -51,6 +52,7 @@ import ai.rever.boss.plugin.api.LocalWorkspaceDataProvider
 import ai.rever.boss.plugin.api.Panel
 import ai.rever.boss.plugin.api.Panel.Companion.bottom
 import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.Panel.Companion.right
 import ai.rever.boss.plugin.sandbox.notification.PluginToastHost
 import ai.rever.boss.plugin.sandbox.notification.PluginToastState
 import ai.rever.boss.plugin.ui.BossTheme
@@ -81,6 +83,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -288,31 +291,43 @@ internal fun BossAppScaffold(
     // window is too narrow for a full one, and nothing in the settings says so.
     var barRailed by remember { mutableStateOf(appearance.tabBarCollapsed) }
 
+    // Read before the placement, which asks whether any panel is open; before the rule, which
+    // counts an open left panel as a column; and before the offsets, which need to know whether
+    // the panel or the bar is the one behind the strip.
+    val leftPanelOpen = state.draggablePanelComponent.isVisible(left)
+
+    // Whether ANY plugin panel is open in the content area. It decides whether the host's actions
+    // get a reserved row or an overlay, in a window with no vertical bar to put them in - see
+    // `focusQuickActionsPlacement`.
+    //
+    // Read here, in the scaffold body, so the state subscription lands in a restart scope rather
+    // than inside an inline content lambda. One question answers both halves: whether these
+    // actions land in a panel foot at all, and which column draws it - see hostActionsPanelEdge.
+    val panelFooterEdge = state.draggablePanelComponent.hostActionsPanelColumn()
+    val pluginPanelOpen = panelFooterEdge != null
+
     // Where Settings / Search / Sign Out go while focus mode holds the top bar that owns them.
-    // One decision, two mutually exclusive renderings: the bottom of the right rail when that rail
-    // is on screen, a floating corner cluster when it is not. Read once here so the two call sites
-    // below cannot disagree about it and briefly show both.
+    // One decision, five mutually exclusive renderings - every piece of chrome the window already
+    // draws before the overlay is considered at all. Read once here so the call sites below cannot
+    // disagree about it and briefly show two of them.
     val quickActionsPlacement =
         focusQuickActionsPlacement(
             settings = focusModeSettings,
             topBarHidden = !appearance.showTopBar,
             rightStripHidden = !appearance.showRightStrip,
             showTopBar = reveal.showTopBar,
-            // Not merely "the bar is on the left". A COLLAPSED bar draws its rail and nothing
-            // else, so its foot does not exist and these four would render nowhere - they float
-            // instead. Hovering the rail opens the drawer, which IS a foot, so they go back into
-            // it for as long as it is up.
-            //
-            // The cost, stated because the neighbouring KDoc warns against exactly this: the
-            // floating overlay is a native always-on-top window, so it is torn down and rebuilt on
-            // each hover reveal rather than sitting there. Accepted deliberately - the alternative
-            // is a cluster in the corner while a bar with room for it is open on the left.
-            verticalTabBar =
-                verticalBarHasFoot(
+            // Three answers, not "is the bar on the left". A COLLAPSED bar has no foot under its
+            // split map, but it still has the bottom of its rail, which is where these go now;
+            // hovering it opens the drawer, which IS a full bar, so they move up into its foot for
+            // as long as it is up. Only TOP position leaves nothing at all.
+            verticalBar =
+                verticalBarHost(
                     tabBarOnLeft = appearance.tabBarPosition == TabBarPosition.LEFT,
                     barCollapsed = barRailed,
                     drawerVisible = drawerVisible,
                 ),
+            // Only consulted once the bar has offered nothing, i.e. in TOP position.
+            pluginPanelOpen = pluginPanelOpen,
         )
 
     // Where the way into the plugins goes, when a strip that would normally hold their icons is
@@ -341,10 +356,6 @@ internal fun BossAppScaffold(
     val bannerVisible by remember(updateHandle) {
         updateHandle.updateState.map { it.drawsBanner() }.distinctUntilChanged()
     }.collectAsState(initial = false)
-
-    // Read before the rule, which counts it as a column, and before the offsets, which need to
-    // know whether the panel or the bar is the one behind the strip.
-    val leftPanelOpen = state.draggablePanelComponent.isVisible(left)
 
     val trafficLights =
         macTrafficLightInset(
@@ -669,12 +680,45 @@ internal fun BossAppScaffold(
                             // The panel itself is second when it is open, so the clearance moves
                             // onto it - this is what the lights were landing on.
                             leftPanelTopInset = trafficLights.columnInset(columns.panel),
+                            // Settings / Search / Sign Out at the foot of an open panel's column,
+                            // for a TOP tab bar with no bar of its own to hold them. Empty - and
+                            // so no row at all - for every other placement.
+                            panelFooterEdge = panelFooterEdge,
+                            panelFooter = {
+                                PanelFooterHostActions(
+                                    actions =
+                                        focusQuickActionsPanelFooter(
+                                            placement = quickActionsPlacement,
+                                            onShowSettings = { state.settingsWindow.open() },
+                                            toolbox = hostToolbox,
+                                            onShowSearch = { state.showGlobalSearchDialog = true },
+                                            onSignOut = { state.showLogoutDialog = true },
+                                            toolLauncher = hostToolLauncher,
+                                        ),
+                                )
+                            },
                             onDrawerVisibleChange = { visible -> drawerVisible = visible },
                             onBarRailedChange = { railed -> barRailed = railed },
                             verticalBarBelowMap = {
                                 VerticalBarHostActions(
                                     actions =
                                         focusQuickActionsFooter(
+                                            placement = quickActionsPlacement,
+                                            onShowSettings = { state.settingsWindow.open() },
+                                            toolbox = hostToolbox,
+                                            onShowSearch = { state.showGlobalSearchDialog = true },
+                                            onSignOut = { state.showLogoutDialog = true },
+                                            toolLauncher = hostToolLauncher,
+                                        ),
+                                )
+                            },
+                            // The rail's own layout for the same actions, in its OWN slot: the
+                            // rail and the hover drawer are on screen together, so a slot handed
+                            // to both drew these twice - see `WindowVerticalTabBar.belowTabs`.
+                            verticalBarRailActions = {
+                                VerticalBarRailActions(
+                                    actions =
+                                        focusQuickActionsTabRail(
                                             placement = quickActionsPlacement,
                                             onShowSettings = { state.settingsWindow.open() },
                                             toolbox = hostToolbox,
@@ -835,3 +879,22 @@ internal fun BossAppScaffold(
         }
     }
 }
+
+/**
+ * Which plugin panel column takes the host's actions, or null when no panel is open.
+ *
+ * The reads; [hostActionsPanelEdge] is the table. All three edges, not just the left one the
+ * traffic-light rule asks about: the floating cluster sits in the content area's bottom-right
+ * corner, which a right panel owns outright and a bottom panel owns the whole width of.
+ *
+ * A plain function rather than a `@Composable`: it only reads snapshot state, so called during
+ * composition it subscribes its caller exactly as an inline chain would. Named at all because
+ * this composable is at detekt's cyclomatic ceiling, and three `isVisible` calls in a `when` put
+ * it over.
+ */
+private fun BossDraggableComponent.hostActionsPanelColumn(): Panel? =
+    hostActionsPanelEdge(
+        rightOpen = isVisible(right),
+        leftOpen = isVisible(left),
+        bottomOpen = isVisible(bottom),
+    )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -304,7 +304,30 @@ internal fun BossAppScaffold(
     // Read here, in the scaffold body, so the state subscription lands in a restart scope rather
     // than inside an inline content lambda. One question answers both halves: whether these
     // actions land in a panel foot at all, and which column draws it - see hostActionsPanelEdge.
-    val panelFooterEdge = state.draggablePanelComponent.hostActionsPanelColumn()
+    // What the bar can offer, read before the placement because the panel measurement below is
+    // gated on it: a bar that can host these means no panel is ever asked to.
+    val verticalBar =
+        verticalBarHost(
+            tabBarOnLeft = appearance.tabBarPosition == TabBarPosition.LEFT,
+            barCollapsed = barRailed,
+            drawerVisible = drawerVisible,
+        )
+
+    // Gated, so the measurement costs nothing in the configuration that will never use it. With
+    // the top bar up - the default, focus mode off - these actions are not homeless, and without
+    // this a right-panel drag would subcompose `PanelFooterHostActions` once per frame to answer
+    // a question whose answer is discarded. Nothing here reads `panelFootFits`, so gating it
+    // cannot close a loop.
+    val panelFooterEdge =
+        state.draggablePanelComponent.hostActionsPanelColumn(
+            needsAHome =
+                hostActionsNeedAPanel(
+                    settings = focusModeSettings,
+                    topBarHidden = !appearance.showTopBar,
+                    showTopBar = reveal.showTopBar,
+                    verticalBar = verticalBar,
+                ),
+        )
 
     // Whether that column is big enough to hold the row, reported back out of layout by
     // `PanelFooterHostActions` - the same shape `onBarRailedChange` has, and for the same reason:
@@ -335,12 +358,7 @@ internal fun BossAppScaffold(
             // split map, but it still has the bottom of its rail, which is where these go now;
             // hovering it opens the drawer, which IS a full bar, so they move up into its foot for
             // as long as it is up. Only TOP position leaves nothing at all.
-            verticalBar =
-                verticalBarHost(
-                    tabBarOnLeft = appearance.tabBarPosition == TabBarPosition.LEFT,
-                    barCollapsed = barRailed,
-                    drawerVisible = drawerVisible,
-                ),
+            verticalBar = verticalBar,
             // Only consulted once the bar has offered nothing, i.e. in TOP position.
             panelFootAvailable = panelFootAvailable(panelFooterEdge, panelFootFits),
         )
@@ -706,7 +724,11 @@ internal fun BossAppScaffold(
                                     // puts it in. Counted as `focusQuickActionsRailRows` counts
                                     // the rail's reserve: the four, plus the launcher when both
                                     // strips are off and this group is where it landed.
-                                    actionCount = hostActionsRowSize(hasLauncher = hostToolLauncher != null),
+                                    actionCount =
+                                        hostActionsRowSize(
+                                            hasToolbox = hostToolbox != null,
+                                            hasLauncher = hostToolLauncher != null,
+                                        ),
                                     actions =
                                         focusQuickActionsPanelFooter(
                                             placement = quickActionsPlacement,
@@ -921,7 +943,25 @@ internal fun BossAppScaffold(
  * composition it subscribes its caller exactly as an inline chain would. Named at all because
  * this composable is at detekt's cyclomatic ceiling.
  */
-private fun BossDraggableComponent.hostActionsPanelColumn(): Panel? = hostActionsPanelEdge(rightOpen = isVisible(right))
+private fun BossDraggableComponent.hostActionsPanelColumn(needsAHome: Boolean): Panel? =
+    hostActionsPanelEdge(rightOpen = isVisible(right), needsAHome = needsAHome)
+
+/**
+ * Whether the host's actions are looking for a panel to live in at all.
+ *
+ * Both halves of "nothing above the panel can take them": focus mode has actually cleared the top
+ * bar that owns them, AND there is no vertical bar, which is the only host ahead of the panel in
+ * the ladder. See `focusQuickActionsPlacement` for the ladder itself.
+ *
+ * Deliberately reads none of the measured state. It gates the panel MEASUREMENT, so a term here
+ * that depended on what that measurement reports would be a cycle rather than a gate.
+ */
+private fun hostActionsNeedAPanel(
+    settings: FocusModeSettings,
+    topBarHidden: Boolean,
+    showTopBar: Boolean,
+    verticalBar: VerticalBarHost,
+): Boolean = focusQuickActionsVisible(settings, topBarHidden, showTopBar) && verticalBar == VerticalBarHost.NONE
 
 /**
  * Whether the host's actions have a panel foot to go in: there is a column, and it can hold the row.
@@ -945,9 +985,17 @@ private fun panelFootAvailable(
  * What `PanelFooterHostActions` measures its column against, and it has to be answerable while
  * the list itself is empty - which is the state a "does not fit" answer puts that row in.
  *
- * Counted the way `focusQuickActionsRailRows` counts the rail's reserve: the four, Toolbox
- * included, plus the tools launcher when both icon strips are off and it landed in this group.
+ * EXACT, which is where this parts company with `focusQuickActionsRailRows`. That function
+ * over-counts on purpose: its number is a height reserve, and a reserve that tracked the rendered
+ * list would move the icons above it on every hover. This one answers a one-shot geometry
+ * question with no stability to protect, and over-counting only means a column that would have
+ * held the real row falls back to the overlay - `PanelFooterFitTest` shows the band where one
+ * button decides it. So `listOfNotNull` dropping an unregistered Toolbox has to be counted too.
+ *
  * Named rather than inlined because [BossAppScaffold] is at detekt's cyclomatic ceiling and one
  * more `if` in its body puts it over.
  */
-private fun hostActionsRowSize(hasLauncher: Boolean): Int = FOCUS_QUICK_ACTION_COUNT + if (hasLauncher) 1 else 0
+private fun hostActionsRowSize(
+    hasToolbox: Boolean,
+    hasLauncher: Boolean,
+): Int = FOCUS_QUICK_ACTION_COUNT - (if (hasToolbox) 0 else 1) + (if (hasLauncher) 1 else 0)

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/BossAppScaffold.kt
@@ -296,15 +296,16 @@ internal fun BossAppScaffold(
     // the panel or the bar is the one behind the strip.
     val leftPanelOpen = state.draggablePanelComponent.isVisible(left)
 
-    // Whether ANY plugin panel is open in the content area. It decides whether the host's actions
-    // get a reserved row or an overlay, in a window with no vertical bar to put them in - see
-    // `focusQuickActionsPlacement`.
+    // Whether the RIGHT plugin panel is open - the one column whose foot can take the host's
+    // actions, and the one an overlay in the bottom-right corner actually collides with. It
+    // decides whether those actions get a reserved row or that overlay, in a window with no
+    // vertical bar to put them in - see `focusQuickActionsPlacement`.
     //
     // Read here, in the scaffold body, so the state subscription lands in a restart scope rather
     // than inside an inline content lambda. One question answers both halves: whether these
     // actions land in a panel foot at all, and which column draws it - see hostActionsPanelEdge.
     val panelFooterEdge = state.draggablePanelComponent.hostActionsPanelColumn()
-    val pluginPanelOpen = panelFooterEdge != null
+    val rightPanelOpen = panelFooterEdge != null
 
     // Where Settings / Search / Sign Out go while focus mode holds the top bar that owns them.
     // One decision, five mutually exclusive renderings - every piece of chrome the window already
@@ -327,7 +328,7 @@ internal fun BossAppScaffold(
                     drawerVisible = drawerVisible,
                 ),
             // Only consulted once the bar has offered nothing, i.e. in TOP position.
-            pluginPanelOpen = pluginPanelOpen,
+            rightPanelOpen = rightPanelOpen,
         )
 
     // Where the way into the plugins goes, when a strip that would normally hold their icons is
@@ -881,20 +882,16 @@ internal fun BossAppScaffold(
 }
 
 /**
- * Which plugin panel column takes the host's actions, or null when no panel is open.
+ * Which plugin panel column takes the host's actions, or null when the right one is shut.
  *
- * The reads; [hostActionsPanelEdge] is the table. All three edges, not just the left one the
- * traffic-light rule asks about: the floating cluster sits in the content area's bottom-right
- * corner, which a right panel owns outright and a bottom panel owns the whole width of.
+ * The read; [hostActionsPanelEdge] is the rule, including why the left and bottom columns are not
+ * candidates. One state subscription added to this composable's restart scope, on top of the
+ * `isVisible(left)` the traffic-light rule already reads - so a right-panel toggle now recomposes
+ * the scaffold. That is a user-scale event, and it is the same mechanism behind the overlay
+ * teardown this placement already documents.
  *
  * A plain function rather than a `@Composable`: it only reads snapshot state, so called during
  * composition it subscribes its caller exactly as an inline chain would. Named at all because
- * this composable is at detekt's cyclomatic ceiling, and three `isVisible` calls in a `when` put
- * it over.
+ * this composable is at detekt's cyclomatic ceiling.
  */
-private fun BossDraggableComponent.hostActionsPanelColumn(): Panel? =
-    hostActionsPanelEdge(
-        rightOpen = isVisible(right),
-        leftOpen = isVisible(left),
-        bottomOpen = isVisible(bottom),
-    )
+private fun BossDraggableComponent.hostActionsPanelColumn(): Panel? = hostActionsPanelEdge(rightOpen = isVisible(right))

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -116,7 +116,7 @@ internal fun focusQuickActionsVisible(
     showTopBar: Boolean,
 ): Boolean = topBarHidden || (settings.hides(FocusModeEdge.TOP) && !showTopBar)
 
-/** Where the three actions belong right now. Mutually exclusive by construction. */
+/** Where the host's own actions belong right now. Mutually exclusive by construction. */
 internal enum class FocusQuickActionsPlacement {
     /** Nowhere: the top bar is up and still owns them. */
     NONE,
@@ -133,20 +133,56 @@ internal enum class FocusQuickActionsPlacement {
      */
     TAB_BAR_FOOTER,
 
+    /**
+     * A column at the foot of the vertical tab bar's COLLAPSED rail, under the "+".
+     *
+     * Preferred over [FLOATING] for the reason [TAB_BAR_FOOTER] is: a rail is the same bar with
+     * its labels taken away, so it is chrome the app draws anyway, and its bottom third was empty.
+     * Collapsing the bar is a request for content width, and answering that with a native
+     * always-on-top window parked in the content is the opposite of granting it.
+     *
+     * Its own placement rather than a flavour of [TAB_BAR_FOOTER] because the two share no layout
+     * - the foot is a wrapping row at least 120dp wide, this is one icon per line down a strip as
+     * narrow as 36dp - and because only ever one of them is on screen.
+     */
+    TAB_BAR_RAIL,
+
+    /**
+     * A row at the foot of an open plugin panel's own column - see [hostActionsPanelEdge] for
+     * which column that is.
+     *
+     * Reached only in TOP tab-bar position, which has no vertical bar to put anything in, and only
+     * while a plugin panel is open. The cluster is an overlay that swallows clicks in the region it
+     * covers, and a panel the user has just opened is the last thing that should be under it - so
+     * in that configuration the actions move into that panel's chrome and cover nothing.
+     *
+     * **The panel's foot, not a band across the content area.** A full-width row also fixes the
+     * collision, and it looks like one: the window grows a strip of dead chrome the width of the
+     * screen to hold four icons. Inside the panel they read as what they are, at the scale of the
+     * thing they sit in - the same shape the vertical bar's foot has.
+     *
+     * Deliberately NOT the answer for a bare TOP window as well. With no panel open the corner is
+     * empty content, where the overlay costs nothing, and there is no panel to put a foot on.
+     */
+    PANEL_FOOTER,
+
     /** A floating cluster in the content area's bottom-right corner. */
     FLOATING,
 }
 
 /**
- * Which of the two renderings the actions get, once [focusQuickActionsVisible] says they are needed
- * at all.
+ * Which of the five renderings the actions get, once [focusQuickActionsVisible] says they are
+ * needed at all.
  *
- * **The rail wins whenever there is a rail**, and the floating cluster is the fallback for when
- * there is not. The cluster is an overlay over live content - on the heavyweight path a native
- * always-on-top window with no click-through - so it is the more intrusive of the two by some
- * distance. Where the right sidebar is on screen there is already a strip of icon chrome at the
- * window's end edge with empty space at the bottom of it, and three more icons there cost nothing
- * and look like what they are.
+ * **Every piece of chrome the window already draws - or layout it can carve out of a panel -
+ * is tried before the overlay is.** In order:
+ * the right rail, the vertical tab bar's foot, that bar's collapsed rail, an open plugin panel's
+ * foot, and only then the floating cluster. The cluster is an overlay over
+ * live content - on the heavyweight path a native always-on-top window with no click-through - so
+ * it is by some distance the most intrusive of them, and it is now reached only by a window with
+ * no rail, no vertical bar and nothing open to collide with. Where the right sidebar is on screen
+ * there is already a strip of icon chrome at the window's end edge with empty space at the bottom
+ * of it, and four more icons there cost nothing and look like what they are.
  *
  * That is not a rare case, it is the **default one on Windows**: `defaultHidesSidebars` leaves both
  * sidebars up there precisely because hover-reveal cannot fire over a browser tab, while the top
@@ -167,22 +203,35 @@ internal enum class FocusQuickActionsPlacement {
  * nowhere. It reads as "permanent" for the same reason `hides(RIGHT)` does, so it belongs in the
  * same test rather than in the reveal flags.
  */
+// Six inputs, and each one is a different way the answer changes: whether these are wanted at
+// all, then each host that could take them in turn. Folding them into a holder would put every
+// caller and every test through a builder to ask one question.
+@Suppress("LongParameterList")
 internal fun focusQuickActionsPlacement(
     settings: FocusModeSettings,
     topBarHidden: Boolean,
     rightStripHidden: Boolean,
     showTopBar: Boolean,
     /**
-     * Whether the window's tab bar runs down the left edge AND is expanded, which is what gives
-     * these actions a home under its split map.
+     * What the window's vertical tab bar can offer these actions: a foot under its split map, the
+     * bottom of its collapsed rail, or nothing at all in TOP position. See [verticalBarHost],
+     * which is where the three are told apart.
      *
-     * The expanded half is not a detail: a collapsed bar draws its rail and nothing else, so its
-     * foot does not exist and these four would render nowhere at all. Read from
-     * `WindowAppearanceSettings`, which is a standing choice, so it needs none of the care the
-     * reveal flags do - with the same known gap the traffic-light rule has, that a bar which
-     * rails itself on a narrow window is decided during layout rather than in settings.
+     * Read from `WindowAppearanceSettings` and the bar's MEASURED width, so it needs none of the
+     * care the reveal flags do - with the same known gap the traffic-light rule has, that a bar
+     * which rails itself on a narrow window is decided during layout rather than in settings.
      */
-    verticalTabBar: Boolean = false,
+    verticalBar: VerticalBarHost = VerticalBarHost.NONE,
+    /**
+     * Whether any plugin panel is open in the content area - left, right or bottom.
+     *
+     * The one input that is about the window's CONTENT rather than its chrome, and it is here for
+     * one reason: the floating cluster has no click-through, so wherever it sits it takes that
+     * corner away from whatever is under it. An open panel is something the user asked for and is
+     * looking at, and it comes with a foot to put these in; empty content in the corner of a bare
+     * window is neither. Answered by [hostActionsPanelEdge], which also picks that column.
+     */
+    pluginPanelOpen: Boolean = false,
 ): FocusQuickActionsPlacement =
     when {
         !focusQuickActionsVisible(settings, topBarHidden, showTopBar) -> FocusQuickActionsPlacement.NONE
@@ -193,7 +242,17 @@ internal fun focusQuickActionsPlacement(
 
         // Then the tab bar's foot, which displaces only the floating cluster - it is chrome the app
         // already draws, where the cluster is a native always-on-top window with no click-through.
-        verticalTabBar -> FocusQuickActionsPlacement.TAB_BAR_FOOTER
+        verticalBar == VerticalBarHost.FOOT -> FocusQuickActionsPlacement.TAB_BAR_FOOTER
+
+        // Then that same bar collapsed, whose rail has room at the bottom. This case used to fall
+        // through to the cluster, which is how asking for MORE content width ended up putting an
+        // overlay in the content.
+        verticalBar == VerticalBarHost.RAIL -> FocusQuickActionsPlacement.TAB_BAR_RAIL
+
+        // No vertical bar at all, so nothing above can host them. An open plugin panel's foot
+        // while there is one, the corner of the content when there is not. See the two enum
+        // entries for why that split rather than one answer for both.
+        pluginPanelOpen -> FocusQuickActionsPlacement.PANEL_FOOTER
 
         else -> FocusQuickActionsPlacement.FLOATING
     }
@@ -216,25 +275,18 @@ internal fun focusQuickActionsRail(
     onSignOut: () -> Unit,
     toolbox: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
 ): List<@Composable () -> Unit> =
-    if (placement != FocusQuickActionsPlacement.RIGHT_RAIL) {
-        emptyList()
-    } else {
-        focusQuickActionButtons(
-            // Hints point INTO the window. The rail is against the window's end edge, so a hint
-            // laid out to its right would be off screen - the same call the rail's own icons make
-            // through `slot.opposite`.
-            hintDirection = left,
-            // 32.dp, where the floating cluster leaves the buttons at their own 28.dp: in the rail
-            // these have to match the icons above them, and `DraggableSidebarSection` sizes those
-            // the same way. An outer fixed size wins over the inner one BossActionButton applies in
-            // imageVector mode, because a fixed constraint coerces what it wraps.
-            modifier = Modifier.size(SIDEBAR_ICON_SIZE),
-            onShowSettings = onShowSettings,
-            toolbox = toolbox,
-            onShowSearch = onShowSearch,
-            onSignOut = onSignOut,
-        )
-    }
+    focusQuickActionsFor(
+        owner = FocusQuickActionsPlacement.RIGHT_RAIL,
+        // Hints point INTO the window. The rail is against the window's end edge, so a hint laid
+        // out to its right would be off screen - the same call the rail's own icons make through
+        // `slot.opposite`.
+        hintDirection = left,
+        placement = placement,
+        onShowSettings = onShowSettings,
+        onShowSearch = onShowSearch,
+        onSignOut = onSignOut,
+        toolbox = toolbox,
+    )
 
 /** One rail icon, matching what `DraggableSidebarSection` gives the plugin icons above it. */
 internal val SIDEBAR_ICON_SIZE = 32.dp
@@ -251,7 +303,7 @@ internal val SIDEBAR_ICON_SIZE = 32.dp
  * each time the user reaches for the top bar, which is the common case on the Windows defaults this
  * placement is aimed at.
  *
- * So the budget is held for as long as focus mode *owns* the top bar, and only the three icons come
+ * So the budget is held for as long as focus mode *owns* the top bar, and only the icons come
  * and go. The cost is up to 145dp of rail that is briefly reserved and empty, which is invisible:
  * the slack lands in the weighted spacer, and the icons above it do not move.
  *
@@ -297,9 +349,9 @@ private fun railExists(
 internal const val FOCUS_QUICK_ACTION_COUNT = 4
 
 /**
- * Settings, Search and Sign Out as three separate composables, in the order both hosts want them.
+ * The host's own actions as separate composables, in the order every host wants them.
  *
- * One definition, three layouts, in the order Sign Out, Settings, Tools, Search.
+ * One definition, five layouts, in the order Sign Out, Settings, Tools, Search.
  *
  * The **order carries the same intent on every axis**: Sign Out first, so the destructive action
  * is the one furthest from the window corner - leftmost in the floating row and in the tab bar's
@@ -308,7 +360,7 @@ internal const val FOCUS_QUICK_ACTION_COUNT = 4
  * Search ends the row as the one that opens a field rather than a place. `BossTopRightBar` uses
  * the same order, which is where these live when the top bar is up.
  *
- * A list rather than a composable that lays them out, because the two hosts disagree about more
+ * A list rather than a composable that lays them out, because the hosts disagree about more
  * than the axis: the rail has to reserve its own height from the *count* before it renders anything
  * (see `SidebarIconRail.bottomSectionHeight`), and a list is the only shape where the count and the
  * content cannot drift apart.
@@ -329,7 +381,7 @@ internal fun focusQuickActionButtons(
      * It can never be non-null in the [FocusQuickActionsPlacement.RIGHT_RAIL] flavour: that
      * placement needs a right strip, and the launcher only reaches this group when BOTH strips are
      * gone. `FocusQuickActionsPlacementTest` pins that, because it is what keeps
-     * [FOCUS_QUICK_ACTION_COUNT] - and so the rail's reserve - correct at three.
+     * [FOCUS_QUICK_ACTION_COUNT] - and so the rail's reserve - correct.
      */
     toolLauncher: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
 ): List<@Composable () -> Unit> =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -152,7 +152,9 @@ internal enum class FocusQuickActionsPlacement {
      * which names that column and rules the other two out.
      *
      * Reached only in TOP tab-bar position, which has no vertical bar to put anything in, and only
-     * while the right panel is open. The cluster is an overlay that swallows clicks in the region
+     * while the right panel is open and big enough to carry the row - see [panelFooterFitsColumn],
+     * which is what keeps a sliver of a panel from growing 188dp of icons. The cluster is an
+     * overlay that swallows clicks in the region
      * it covers, it sits in the content area's bottom-right corner, and that corner belongs to the
      * right panel whenever there is one - so in that configuration the actions move into that
      * panel's chrome and cover nothing.
@@ -225,7 +227,7 @@ internal fun focusQuickActionsPlacement(
      */
     verticalBar: VerticalBarHost = VerticalBarHost.NONE,
     /**
-     * Whether the RIGHT plugin panel is open.
+     * Whether the RIGHT plugin panel is open AND its column can afford the row.
      *
      * The one input that is about the window's CONTENT rather than its chrome, and it is here for
      * one reason: the floating cluster has no click-through, so wherever it sits it takes that
@@ -235,8 +237,15 @@ internal fun focusQuickActionsPlacement(
      *
      * The right panel and not "any panel" - see [hostActionsPanelEdge], which is where the left
      * and bottom columns are ruled out and why, and which also picks the column.
+     *
+     * **Both halves, because a panel narrow enough is not a home either.** A panel drags down to
+     * about 20dp, where a row that wraps rather than clips stacks five buttons into 188dp and
+     * takes it out of the plugin. [panelFooterFitsColumn] is that test, and
+     * [PanelFooterHostActions] reports its answer back here out of layout, the same way
+     * `onBarRailedChange` reports a bar that railed itself on a narrow window. A window whose
+     * panel is too small keeps the cluster, which is what it had before this.
      */
-    rightPanelOpen: Boolean = false,
+    panelFootAvailable: Boolean = false,
 ): FocusQuickActionsPlacement =
     when {
         !focusQuickActionsVisible(settings, topBarHidden, showTopBar) -> FocusQuickActionsPlacement.NONE
@@ -255,9 +264,9 @@ internal fun focusQuickActionsPlacement(
         verticalBar == VerticalBarHost.RAIL -> FocusQuickActionsPlacement.TAB_BAR_RAIL
 
         // No vertical bar at all, so nothing above can host them. The right panel's foot while
-        // that panel is open, the corner of the content when it is not. See the two enum entries
-        // for why that split rather than one answer for both.
-        rightPanelOpen -> FocusQuickActionsPlacement.PANEL_FOOTER
+        // that panel is open and big enough to hold one, the corner of the content otherwise. See
+        // the two enum entries for why that split rather than one answer for both.
+        panelFootAvailable -> FocusQuickActionsPlacement.PANEL_FOOTER
 
         else -> FocusQuickActionsPlacement.FLOATING
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/FocusModeQuickActions.kt
@@ -148,18 +148,20 @@ internal enum class FocusQuickActionsPlacement {
     TAB_BAR_RAIL,
 
     /**
-     * A row at the foot of an open plugin panel's own column - see [hostActionsPanelEdge] for
-     * which column that is.
+     * A row at the foot of the open RIGHT plugin panel's own column - see [hostActionsPanelEdge],
+     * which names that column and rules the other two out.
      *
      * Reached only in TOP tab-bar position, which has no vertical bar to put anything in, and only
-     * while a plugin panel is open. The cluster is an overlay that swallows clicks in the region it
-     * covers, and a panel the user has just opened is the last thing that should be under it - so
-     * in that configuration the actions move into that panel's chrome and cover nothing.
+     * while the right panel is open. The cluster is an overlay that swallows clicks in the region
+     * it covers, it sits in the content area's bottom-right corner, and that corner belongs to the
+     * right panel whenever there is one - so in that configuration the actions move into that
+     * panel's chrome and cover nothing.
      *
      * **The panel's foot, not a band across the content area.** A full-width row also fixes the
      * collision, and it looks like one: the window grows a strip of dead chrome the width of the
      * screen to hold four icons. Inside the panel they read as what they are, at the scale of the
-     * thing they sit in - the same shape the vertical bar's foot has.
+     * thing they sit in - the same shape the vertical bar's foot has. That is also why a BOTTOM
+     * panel does not host these: its column is the whole window's width, so its foot is that band.
      *
      * Deliberately NOT the answer for a bare TOP window as well. With no panel open the corner is
      * empty content, where the overlay costs nothing, and there is no panel to put a foot on.
@@ -176,13 +178,13 @@ internal enum class FocusQuickActionsPlacement {
  *
  * **Every piece of chrome the window already draws - or layout it can carve out of a panel -
  * is tried before the overlay is.** In order:
- * the right rail, the vertical tab bar's foot, that bar's collapsed rail, an open plugin panel's
+ * the right rail, the vertical tab bar's foot, that bar's collapsed rail, the open right panel's
  * foot, and only then the floating cluster. The cluster is an overlay over
  * live content - on the heavyweight path a native always-on-top window with no click-through - so
  * it is by some distance the most intrusive of them, and it is now reached only by a window with
- * no rail, no vertical bar and nothing open to collide with. Where the right sidebar is on screen
- * there is already a strip of icon chrome at the window's end edge with empty space at the bottom
- * of it, and four more icons there cost nothing and look like what they are.
+ * no rail, no vertical bar and nothing in the corner for it to cover. Where the right sidebar is
+ * on screen there is already a strip of icon chrome at the window's end edge with empty space at
+ * the bottom of it, and four more icons there cost nothing and look like what they are.
  *
  * That is not a rare case, it is the **default one on Windows**: `defaultHidesSidebars` leaves both
  * sidebars up there precisely because hover-reveal cannot fire over a browser tab, while the top
@@ -223,15 +225,18 @@ internal fun focusQuickActionsPlacement(
      */
     verticalBar: VerticalBarHost = VerticalBarHost.NONE,
     /**
-     * Whether any plugin panel is open in the content area - left, right or bottom.
+     * Whether the RIGHT plugin panel is open.
      *
      * The one input that is about the window's CONTENT rather than its chrome, and it is here for
      * one reason: the floating cluster has no click-through, so wherever it sits it takes that
-     * corner away from whatever is under it. An open panel is something the user asked for and is
-     * looking at, and it comes with a foot to put these in; empty content in the corner of a bare
-     * window is neither. Answered by [hostActionsPanelEdge], which also picks that column.
+     * corner away from whatever is under it. A right panel is what the bottom-right corner sits
+     * on top of, it is something the user asked for and is looking at, and it comes with a foot
+     * to put these in; empty content in the corner of a bare window is none of the three.
+     *
+     * The right panel and not "any panel" - see [hostActionsPanelEdge], which is where the left
+     * and bottom columns are ruled out and why, and which also picks the column.
      */
-    pluginPanelOpen: Boolean = false,
+    rightPanelOpen: Boolean = false,
 ): FocusQuickActionsPlacement =
     when {
         !focusQuickActionsVisible(settings, topBarHidden, showTopBar) -> FocusQuickActionsPlacement.NONE
@@ -249,10 +254,10 @@ internal fun focusQuickActionsPlacement(
         // overlay in the content.
         verticalBar == VerticalBarHost.RAIL -> FocusQuickActionsPlacement.TAB_BAR_RAIL
 
-        // No vertical bar at all, so nothing above can host them. An open plugin panel's foot
-        // while there is one, the corner of the content when there is not. See the two enum
-        // entries for why that split rather than one answer for both.
-        pluginPanelOpen -> FocusQuickActionsPlacement.PANEL_FOOTER
+        // No vertical bar at all, so nothing above can host them. The right panel's foot while
+        // that panel is open, the corner of the content when it is not. See the two enum entries
+        // for why that split rather than one answer for both.
+        rightPanelOpen -> FocusQuickActionsPlacement.PANEL_FOOTER
 
         else -> FocusQuickActionsPlacement.FLOATING
     }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/HostActionsFlavour.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/HostActionsFlavour.kt
@@ -1,0 +1,51 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.plugin.api.Panel
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * The guarded builder every host's flavour delegates to: this placement's buttons, or nothing.
+ *
+ * One body, five call sites. Each flavour differs in exactly two things - the placement it belongs
+ * to and which way its hints point - and each was a character-for-character copy of the other
+ * three, so a sixth host meant a fourth copy and three `@Suppress` annotations to go with it.
+ *
+ * The empty list is the whole contract: it lets every host call its own flavour unconditionally
+ * and render nothing when the actions live elsewhere. The right rail also RESERVES height from the
+ * list's size, so a non-empty list on the wrong placement is not a stray icon - it is a gap torn
+ * out of the icon budget of a bar that is not hosting anything.
+ *
+ * [modifier] defaults to one rail-sized button. That is 32.dp where the floating cluster leaves
+ * them at their own 28.dp: in a bar or a rail these have to match the icons around them, and
+ * `DraggableSidebarSection` sizes those the same way. An outer fixed size wins over the inner one
+ * `BossActionButton` applies in `imageVector` mode, because a fixed constraint coerces what it
+ * wraps - which is also why the cluster passes `Modifier` and gets its own 28.dp back.
+ */
+// One parameter per action, plus the placement pair, the launcher slot and the size.
+@Suppress("LongParameterList")
+internal fun focusQuickActionsFor(
+    owner: FocusQuickActionsPlacement,
+    hintDirection: Panel,
+    placement: FocusQuickActionsPlacement,
+    onShowSettings: () -> Unit,
+    onShowSearch: () -> Unit,
+    onSignOut: () -> Unit,
+    toolbox: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
+    toolLauncher: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
+    modifier: Modifier = Modifier.size(SIDEBAR_ICON_SIZE),
+): List<@Composable () -> Unit> =
+    if (placement != owner) {
+        emptyList()
+    } else {
+        focusQuickActionButtons(
+            hintDirection = hintDirection,
+            modifier = modifier,
+            onShowSettings = onShowSettings,
+            toolbox = toolbox,
+            onShowSearch = onShowSearch,
+            onSignOut = onSignOut,
+            toolLauncher = toolLauncher,
+        )
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/HostActionsFlavour.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/HostActionsFlavour.kt
@@ -8,9 +8,12 @@ import androidx.compose.ui.Modifier
 /**
  * The guarded builder every host's flavour delegates to: this placement's buttons, or nothing.
  *
- * One body, five call sites. Each flavour differs in exactly two things - the placement it belongs
- * to and which way its hints point - and each was a character-for-character copy of the other
- * three, so a sixth host meant a fourth copy and three `@Suppress` annotations to go with it.
+ * One body, four call sites - the right rail, the bar's foot, the rail's column and the panel's
+ * foot. The floating cluster is the fifth placement but not a fifth caller: it has no "am I the
+ * owner" question to ask, so it still builds `focusQuickActionButtons` directly. Each flavour
+ * differs in exactly two things - the placement it belongs to and which way its hints point - and
+ * each was a character-for-character copy of the other three, so a fifth host meant a fourth copy
+ * and three `@Suppress` annotations to go with it.
  *
  * The empty list is the whole contract: it lets every host call its own flavour unconditionally
  * and render nothing when the actions live elsewhere. The right rail also RESERVES height from the

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
@@ -1,0 +1,116 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.plugin.api.Panel
+import ai.rever.boss.plugin.api.Panel.Companion.bottom
+import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.Panel.Companion.right
+import ai.rever.boss.plugin.api.Panel.Companion.top
+import ai.rever.boss.plugin.ui.BossTheme
+import androidx.compose.foundation.background
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Which open plugin panel's column takes the host's actions, or null when none is open.
+ *
+ * **Right first, then left, then bottom.** The right column ends where the floating cluster used
+ * to sit, so a user who has learned that corner finds them within an inch of it; the left column
+ * is the same shape one edge over; the bottom panel is last because its foot spans the whole
+ * window, which is the look this placement exists to avoid.
+ *
+ * One function for both halves of the decision - whether these get a panel foot at all
+ * ([FocusQuickActionsPlacement.PANEL_FOOTER] against [FocusQuickActionsPlacement.FLOATING]) and
+ * which column draws it. Two expressions could disagree, and the way that fails is a row rendered
+ * into a column nothing is composing: Sign Out on screen nowhere.
+ *
+ * Takes the three roots rather than a component, so the table is testable without a plugin host.
+ * `isVisible(left)` and `isVisible(right)` each fold in their own top and bottom halves, so these
+ * three cover all five panels.
+ */
+internal fun hostActionsPanelEdge(
+    rightOpen: Boolean,
+    leftOpen: Boolean,
+    bottomOpen: Boolean,
+): Panel? =
+    when {
+        rightOpen -> right
+        leftOpen -> left
+        bottomOpen -> bottom
+        else -> null
+    }
+
+/**
+ * The host's own actions as a row at the foot of an open plugin panel's column.
+ *
+ * The [FocusQuickActionsPlacement.PANEL_FOOTER] rendering, for a window in TOP tab-bar position -
+ * no rail, no vertical bar, nothing else left to hold these - with a plugin panel open.
+ *
+ * **A row inside the panel, not a band across the content area.** The floating cluster it replaces
+ * has no click-through on either path, so with a panel open it parks a dead region over the corner
+ * of something the user just asked to see. A band spanning the whole window fixes that collision
+ * and spends the window's entire width saying four icons; the panel's own foot is chrome at the
+ * scale of the thing it belongs to, which is where [hostActionsPanelEdge] puts it.
+ *
+ * Laid out by [HostActionsFlowRow], the same row the bar's own foot uses, so the two cannot drift
+ * in height or spacing. It wraps rather than clipping, which matters here: a panel is resizable
+ * down to a floor of about 20dp.
+ *
+ * Renders nothing at all when [actions] is empty, rule included, so a panel in a window that keeps
+ * these somewhere else is exactly the panel that existed before this.
+ */
+@Composable
+internal fun PanelFooterHostActions(actions: List<@Composable () -> Unit>) {
+    if (actions.isEmpty()) return
+
+    // Full width, where the rail's rule is short and centred: this row spans its column, and the
+    // line is what separates it from the plugin's own content above.
+    Divider(color = BossTheme.colors.line)
+    // PAINTED, before it is padded. This row is a strip of column that nothing else draws -
+    // SidePanel fills itself and stops where its content does - and nothing is not the background:
+    // the raw native window surface shows through, which is WHITE. It then puts near-white icons
+    // on a white band, so the actions come out invisible rather than merely misplaced. Every other
+    // host of these gets its background from the bar or Surface it sits in; this one has to paint.
+    //
+    // `colors.panel`, what SidePanel fills with, not `raised`: with the rule above doing the
+    // separating, the row and the plugin read as one column rather than as a shelf stuck to the
+    // bottom of it.
+    HostActionsFlowRow(
+        tag = PANEL_FOOTER_HOST_ACTIONS_TAG,
+        modifier = Modifier.background(BossTheme.colors.panel),
+        actions = actions,
+    )
+}
+
+/** Test tag of the row - see `QuickActionsPanelFooterTest`. */
+internal const val PANEL_FOOTER_HOST_ACTIONS_TAG = "panel-footer-host-actions"
+
+/**
+ * The actions as a row for the foot of a plugin panel's column.
+ *
+ * Same buttons, fifth layout. Hints point UP, because the row is the last thing in its column and
+ * a hint below it would be off the bottom of the window - the same call the bar's own foot makes.
+ * Icons are panel-chrome sized, matching the two bar hosts rather than the cluster's 28dp.
+ *
+ * Empty for every other placement, so the panel can call it unconditionally and render nothing.
+ */
+// One parameter per action plus the placement and the launcher slot - see focusQuickActionsFooter.
+@Suppress("LongParameterList")
+internal fun focusQuickActionsPanelFooter(
+    placement: FocusQuickActionsPlacement,
+    onShowSettings: () -> Unit,
+    onShowSearch: () -> Unit,
+    onSignOut: () -> Unit,
+    toolbox: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
+    toolLauncher: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
+): List<@Composable () -> Unit> =
+    focusQuickActionsFor(
+        owner = FocusQuickActionsPlacement.PANEL_FOOTER,
+        hintDirection = top,
+        placement = placement,
+        onShowSettings = onShowSettings,
+        onShowSearch = onShowSearch,
+        onSignOut = onSignOut,
+        toolbox = toolbox,
+        toolLauncher = toolLauncher,
+    )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
@@ -5,9 +5,16 @@ import ai.rever.boss.plugin.api.Panel.Companion.right
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
 
 /**
  * Which open plugin panel's column takes the host's actions, or null when none of them does.
@@ -57,34 +64,141 @@ internal fun hostActionsPanelEdge(rightOpen: Boolean): Panel? = if (rightOpen) r
  * scale of the thing it belongs to, which is where [hostActionsPanelEdge] puts it.
  *
  * Laid out by [HostActionsFlowRow], the same row the bar's own foot uses, so the two cannot drift
- * in height or spacing. It wraps rather than clipping, which matters here: a panel is resizable
- * down to a floor of about 20dp.
+ * in height or spacing.
+ *
+ * **Only when the column can afford it.** A panel is resizable down to a floor of about 20dp, and
+ * a row that wraps rather than clips turns width pressure into height pressure: at that floor the
+ * five buttons stack one per line into 188dp of chrome, and the plugin - measured second, since
+ * [PanelColumn] gives it the weight - gets whatever is left. Measured at 20x400 that is 211dp of
+ * plugin behind 188dp of icons, each of them 4dp WIDE, because `Modifier.size` coerces to the
+ * incoming constraint on that axis too. So this measures its column first and reports the answer
+ * back to the scaffold through [onColumnFitsChange]; when the column cannot afford the row the
+ * placement falls back to the floating cluster and nothing is drawn here at all.
+ *
+ * That is the same shape `onBarRailedChange` already has in this window: a fact only layout knows,
+ * reported up to the state the placement is decided from. It costs one frame - the report rides a
+ * `LaunchedEffect` - and it cannot oscillate, because the constraints this reads do not depend on
+ * what it draws.
+ *
+ * The measuring shell composes whether or not there is a row, which is what makes the fallback
+ * reversible: a column that reports "no" renders nothing, and would have no way to report "yes
+ * again" once the user widens it if the measurement lived behind the same guard as the row.
  *
  * Renders nothing at all when [actions] is empty, rule included, so a panel in a window that keeps
  * these somewhere else is exactly the panel that existed before this.
+ *
+ * @param actionCount how many buttons the row would hold if it drew one, which the measurement
+ *   needs while [actions] is empty - the very state a "no" answer puts this in. Counted the way
+ *   `focusQuickActionsRailRows` counts the rail's reserve, Toolbox included.
+ * @param onColumnFitsChange whether this column can afford the row. Read by the scaffold, which
+ *   owns the placement; see `focusQuickActionsPlacement`.
  */
 @Composable
-internal fun PanelFooterHostActions(actions: List<@Composable () -> Unit>) {
-    if (actions.isEmpty()) return
+internal fun PanelFooterHostActions(
+    actionCount: Int,
+    actions: List<@Composable () -> Unit>,
+    onColumnFitsChange: (Boolean) -> Unit,
+) {
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val fits =
+            panelFooterFitsColumn(
+                columnWidth = maxWidth,
+                columnHeight = maxHeight,
+                actionCount = actionCount,
+                sideInset = BossTheme.space.sm,
+                gap = BossTheme.space.xs,
+            )
+        // Through an effect, not straight out of composition: this writes state the scaffold reads
+        // to pick the placement, and a write during composition to something a parent has already
+        // read is the recomposition-loop trap `drawerVisible` documents on the other slot.
+        LaunchedEffect(fits) { onColumnFitsChange(fits) }
 
-    // Full width, where the rail's rule is short and centred: this row spans its column, and the
-    // line is what separates it from the plugin's own content above.
-    Divider(color = BossTheme.colors.line)
-    // PAINTED, before it is padded. This row is a strip of column that nothing else draws -
-    // SidePanel fills itself and stops where its content does - and nothing is not the background:
-    // the raw native window surface shows through, which is WHITE. It then puts near-white icons
-    // on a white band, so the actions come out invisible rather than merely misplaced. Every other
-    // host of these gets its background from the bar or Surface it sits in; this one has to paint.
-    //
-    // `colors.panel`, what SidePanel fills with, not `raised`: with the rule above doing the
-    // separating, the row and the plugin read as one column rather than as a shelf stuck to the
-    // bottom of it.
-    HostActionsFlowRow(
-        tag = PANEL_FOOTER_HOST_ACTIONS_TAG,
-        actions = actions,
-        modifier = Modifier.background(BossTheme.colors.panel),
-    )
+        if (actions.isEmpty()) return@BoxWithConstraints
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Full width, where the rail's rule is short and centred: this row spans its column,
+            // and the line is what separates it from the PLUGIN's own content above - which is why
+            // this foot has a rule where the bar's has none. See `HostActionsFlowRow`.
+            Divider(color = BossTheme.colors.line)
+            // PAINTED, before it is padded. This row is a strip of column that nothing else draws
+            // - SidePanel fills itself and stops where its content does - and nothing is not the
+            // background: the raw native window surface shows through, which is WHITE. It then
+            // puts near-white icons on a white band, so the actions come out invisible rather than
+            // merely misplaced. Every other host of these gets its background from the bar or
+            // Surface it sits in; this one has to paint.
+            //
+            // `colors.panel`, what SidePanel fills with, not `raised`: with the rule above doing
+            // the separating, the row and the plugin read as one column rather than as a shelf
+            // stuck to the bottom of it.
+            HostActionsFlowRow(
+                tag = PANEL_FOOTER_HOST_ACTIONS_TAG,
+                actions = actions,
+                modifier = Modifier.background(BossTheme.colors.panel),
+            )
+        }
+    }
 }
+
+/**
+ * Whether a panel column of this size can afford the host's actions at the foot of it.
+ *
+ * Three questions, and each one is a way the row went wrong when it was drawn unconditionally:
+ *
+ * 1. **One icon has to fit a line at full size.** [HostActionsFlowRow] pads by [sideInset] either
+ *    side, and `Modifier.size` coerces to what is left rather than overflowing it, so a 20dp
+ *    column does not clip a 32dp icon - it renders a 4dp one. Measured, not reasoned about.
+ * 2. **At most [PANEL_FOOTER_MAX_LINES] lines.** Wrapping is what keeps the row honest in a
+ *    narrow column, but five buttons one per line is a 188dp tower, which is not "chrome at the
+ *    scale of the thing it sits in" by any reading.
+ * 3. **At most [PANEL_FOOTER_MAX_SHARE] of the column.** The plugin is what the user opened; a
+ *    foot that can take two thirds of its column is the failure this placement uses to rule the
+ *    bottom column out, reached by the other axis.
+ *
+ * Pure, and takes the two spacing tokens rather than reading `BossTheme` itself, so the table can
+ * be tested without a composition. `BossSpacing` is a plain data class whose defaults are the only
+ * values ever provided, so 8dp and 4dp in a test are the 8dp and 4dp the row is laid out with.
+ */
+internal fun panelFooterFitsColumn(
+    columnWidth: Dp,
+    columnHeight: Dp,
+    actionCount: Int,
+    sideInset: Dp,
+    gap: Dp,
+): Boolean {
+    val contentWidth = columnWidth - sideInset * 2
+
+    // What FlowRow does: fill a line with `icon + gap` slots, the last one needing no trailing
+    // gap. Floored at one so the arithmetic below stays defined for a column too narrow to hold
+    // even that - the first condition is what rejects it.
+    val perLine = ((contentWidth + gap) / (SIDEBAR_ICON_SIZE + gap)).toInt().coerceAtLeast(1)
+    val lines = ceil(actionCount.toFloat() / perLine).toInt()
+    val footerHeight =
+        HOST_ACTIONS_ROW_INSET * 2 + SIDEBAR_ICON_SIZE * lines + gap * (lines - 1) + PANEL_FOOTER_RULE
+
+    return contentWidth >= SIDEBAR_ICON_SIZE &&
+        lines <= PANEL_FOOTER_MAX_LINES &&
+        footerHeight <= columnHeight * PANEL_FOOTER_MAX_SHARE
+}
+
+/**
+ * How many lines of icons a panel foot may wrap to before it stops being a foot.
+ *
+ * Two, not one: a right panel narrowed to about 150dp still wants these, and two lines there is
+ * 80dp of chrome under 519dp of plugin. Three would be 116dp in a column too narrow to have put
+ * anything useful in.
+ */
+private const val PANEL_FOOTER_MAX_LINES = 2
+
+/**
+ * The most of its column a foot may take.
+ *
+ * A third. The plugin keeps the other two, which is the least that can be said for a placement
+ * whose whole argument is that it does not cover what the user opened.
+ */
+private const val PANEL_FOOTER_MAX_SHARE = 1f / 3f
+
+/** The rule above the row, counted because it is part of what the foot costs the column. */
+private val PANEL_FOOTER_RULE = 1.dp
 
 /** Test tag of the row - see `QuickActionsPanelFooterTest`. */
 internal const val PANEL_FOOTER_HOST_ACTIONS_TAG = "panel-footer-host-actions"

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -48,8 +50,18 @@ import kotlin.math.ceil
  * Takes the root's visibility rather than the component, so the table is testable without a plugin
  * host. `isVisible(right)` folds in its own top and bottom halves, so one flag covers both right
  * panels.
+ *
+ * [needsAHome] is what keeps the cost of this proportional to the feature. Naming a column makes
+ * `BossWindow` compose [PanelFooterHostActions], which is a subcomposition that re-measures on
+ * every constraint change - so in the default configuration, top bar up and these actions not
+ * homeless at all, a right-panel drag-resize would pay for one per frame to answer a question
+ * nothing reads. It is decided from settings and the bar alone, never from what that measurement
+ * reports, so it is a gate and not a cycle.
  */
-internal fun hostActionsPanelEdge(rightOpen: Boolean): Panel? = if (rightOpen) right else null
+internal fun hostActionsPanelEdge(
+    rightOpen: Boolean,
+    needsAHome: Boolean = true,
+): Panel? = if (rightOpen && needsAHome) right else null
 
 /**
  * The host's own actions as a row at the foot of the open right panel's column.
@@ -68,8 +80,9 @@ internal fun hostActionsPanelEdge(rightOpen: Boolean): Panel? = if (rightOpen) r
  *
  * **Only when the column can afford it.** A panel is resizable down to a floor of about 20dp, and
  * a row that wraps rather than clips turns width pressure into height pressure: at that floor the
- * five buttons stack one per line into 188dp of chrome, and the plugin - measured second, since
- * [PanelColumn] gives it the weight - gets whatever is left. Measured at 20x400 that is 211dp of
+ * five buttons - the four plus the tools launcher - stack one per line into 188dp of chrome, and
+ * the plugin, measured second since [PanelColumn] gives it the weight, gets whatever is left at
+ * all. Measured at 20x400 that is 211dp of
  * plugin behind 188dp of icons, each of them 4dp WIDE, because `Modifier.size` coerces to the
  * incoming constraint on that axis too. So this measures its column first and reports the answer
  * back to the scaffold through [onColumnFitsChange]; when the column cannot afford the row the
@@ -83,6 +96,12 @@ internal fun hostActionsPanelEdge(rightOpen: Boolean): Panel? = if (rightOpen) r
  * The measuring shell composes whether or not there is a row, which is what makes the fallback
  * reversible: a column that reports "no" renders nothing, and would have no way to report "yes
  * again" once the user widens it if the measurement lived behind the same guard as the row.
+ *
+ * The scaffold's state starts at "fits", so a panel opened AT a sliver width draws this row for
+ * one frame before the report takes it away. That direction is the deliberate one: the other
+ * default flickers the cluster's native window open and shut on every right-panel open at the
+ * 250dp width almost everyone uses, and a frame of an over-tall row is cheaper than a frame of
+ * window churn.
  *
  * Renders nothing at all when [actions] is empty, rule included, so a panel in a window that keeps
  * these somewhere else is exactly the panel that existed before this.
@@ -111,7 +130,12 @@ internal fun PanelFooterHostActions(
         // Through an effect, not straight out of composition: this writes state the scaffold reads
         // to pick the placement, and a write during composition to something a parent has already
         // read is the recomposition-loop trap `drawerVisible` documents on the other slot.
-        LaunchedEffect(fits) { onColumnFitsChange(fits) }
+        //
+        // The effect keys on the ANSWER, so it fires once per change of it rather than once per
+        // recomposition - which means it would otherwise capture whichever callback was current
+        // when the answer last changed. `rememberUpdatedState` is what keeps it the current one.
+        val report by rememberUpdatedState(onColumnFitsChange)
+        LaunchedEffect(fits) { report(fits) }
 
         if (actions.isEmpty()) return@BoxWithConstraints
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/PanelFooterHostActions.kt
@@ -1,8 +1,6 @@
 package ai.rever.boss.app
 
 import ai.rever.boss.plugin.api.Panel
-import ai.rever.boss.plugin.api.Panel.Companion.bottom
-import ai.rever.boss.plugin.api.Panel.Companion.left
 import ai.rever.boss.plugin.api.Panel.Companion.right
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.ui.BossTheme
@@ -12,39 +10,45 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 /**
- * Which open plugin panel's column takes the host's actions, or null when none is open.
+ * Which open plugin panel's column takes the host's actions, or null when none of them does.
  *
- * **Right first, then left, then bottom.** The right column ends where the floating cluster used
- * to sit, so a user who has learned that corner finds them within an inch of it; the left column
- * is the same shape one edge over; the bottom panel is last because its foot spans the whole
- * window, which is the look this placement exists to avoid.
+ * **The right column, and only the right column.** The floating cluster this displaces sits in
+ * the content area's bottom-RIGHT corner, so a right panel is the one an open panel actually
+ * collides with. The other two were in an earlier revision of this and are deliberately out:
  *
- * One function for both halves of the decision - whether these get a panel foot at all
- * ([FocusQuickActionsPlacement.PANEL_FOOTER] against [FocusQuickActionsPlacement.FLOATING]) and
- * which column draws it. Two expressions could disagree, and the way that fails is a row rendered
- * into a column nothing is composing: Sign Out on screen nowhere.
+ * - **Left.** There is no collision to fix. A left panel is the width of the window away from the
+ *   cluster, so hosting these there would move Sign Out across the window to dodge an overlap
+ *   that is not happening - and move it back, disposing and re-creating the overlay's native
+ *   window, when the panel closes.
+ * - **Bottom.** The collision is real, but the fix contradicts the reason this placement exists:
+ *   a bottom panel spans the whole window, so its foot IS the full-width band this rejected in
+ *   favour of chrome at the scale of the thing it belongs to. It is also the one column that
+ *   cannot yield - `BossResizablePanel` floors a panel at `max(2% of the axis, 20.dp)`, and the
+ *   scarce axis for a bottom panel is the one the row needs about 45dp of, so at its floor the
+ *   plugin gets no height and `Modifier.size` shrinks the icons to fit rather than overflowing.
+ *   A right panel's scarce axis is width, where the row wraps - which is pinned at 20dp.
  *
- * Takes the three roots rather than a component, so the table is testable without a plugin host.
- * `isVisible(left)` and `isVisible(right)` each fold in their own top and bottom halves, so these
- * three cover all five panels.
+ * So a TOP-bar window with only a left or bottom panel open keeps the cluster it has today. That
+ * is the behaviour this change found, not one it introduces.
+ *
+ * Still a `Panel?` rather than a Boolean: `BossWindow` gates three columns on
+ * `panelFooterEdge == panel`, so the answer has to name one. One function for both halves of the
+ * decision - whether these get a panel foot at all ([FocusQuickActionsPlacement.PANEL_FOOTER]
+ * against [FocusQuickActionsPlacement.FLOATING]) and which column draws it. Two expressions could
+ * disagree, and the way that fails is a row rendered into a column nothing is composing: Sign Out
+ * on screen nowhere.
+ *
+ * Takes the root's visibility rather than the component, so the table is testable without a plugin
+ * host. `isVisible(right)` folds in its own top and bottom halves, so one flag covers both right
+ * panels.
  */
-internal fun hostActionsPanelEdge(
-    rightOpen: Boolean,
-    leftOpen: Boolean,
-    bottomOpen: Boolean,
-): Panel? =
-    when {
-        rightOpen -> right
-        leftOpen -> left
-        bottomOpen -> bottom
-        else -> null
-    }
+internal fun hostActionsPanelEdge(rightOpen: Boolean): Panel? = if (rightOpen) right else null
 
 /**
- * The host's own actions as a row at the foot of an open plugin panel's column.
+ * The host's own actions as a row at the foot of the open right panel's column.
  *
  * The [FocusQuickActionsPlacement.PANEL_FOOTER] rendering, for a window in TOP tab-bar position -
- * no rail, no vertical bar, nothing else left to hold these - with a plugin panel open.
+ * no rail, no vertical bar, nothing else left to hold these - with the right panel open.
  *
  * **A row inside the panel, not a band across the content area.** The floating cluster it replaces
  * has no click-through on either path, so with a panel open it parks a dead region over the corner
@@ -77,8 +81,8 @@ internal fun PanelFooterHostActions(actions: List<@Composable () -> Unit>) {
     // bottom of it.
     HostActionsFlowRow(
         tag = PANEL_FOOTER_HOST_ACTIONS_TAG,
-        modifier = Modifier.background(BossTheme.colors.panel),
         actions = actions,
+        modifier = Modifier.background(BossTheme.colors.panel),
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
@@ -164,8 +164,8 @@ internal const val VERTICAL_BAR_HOST_ACTIONS_TAG = "vertical-bar-host-actions"
 @Composable
 internal fun HostActionsFlowRow(
     tag: String,
-    modifier: Modifier = Modifier,
     actions: List<@Composable () -> Unit>,
+    modifier: Modifier = Modifier,
 ) {
     FlowRow(
         modifier =

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
@@ -5,6 +5,7 @@ import ai.rever.boss.components.workspaces.LayoutWorkspace
 import ai.rever.boss.components.workspaces.WorkspaceButton
 import ai.rever.boss.components.workspaces.WorkspaceManager
 import ai.rever.boss.plugin.api.Panel
+import ai.rever.boss.plugin.api.Panel.Companion.right
 import ai.rever.boss.plugin.api.Panel.Companion.top
 import ai.rever.boss.plugin.ui.BossTheme
 import ai.rever.boss.window.Project
@@ -133,33 +134,62 @@ private val ROW_GAP = 4.dp
 internal fun VerticalBarHostActions(actions: List<@Composable () -> Unit>) {
     if (actions.isEmpty()) return
 
-    // A FlowRow, not a Row, because these do not fit on one line in a narrow bar.
-    //
-    // The bar goes down to TabBarVerticalWidthRange.start, 120dp. Four 32dp buttons with 4dp
-    // between them and 8dp either side need 156dp, and three need exactly 120 - no margin at all.
-    // A Row does not wrap, and what it did instead, measured at 120dp, was give its LAST child
-    // zero width: Search came back as a 0x0 rect while the other three kept their full size. Not
-    // a clipped icon - an absent one, on a width the user can reach by dragging.
-    //
-    // Wrapping is the fallback and not the shape: at any comfortable width these still lay out
-    // side by side, which VerticalBarHostActionsLayoutTest pins along with the narrow case.
-    FlowRow(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .testTag(VERTICAL_BAR_HOST_ACTIONS_TAG)
-                .padding(horizontal = 8.dp, vertical = 6.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        // No key: the list is fixed-order for a given placement, so positional identity is what a
-        // key would give - the same call SidebarBottomActions makes about the same three actions.
-        actions.forEach { action -> action() }
-    }
+    // No background of its own: this row sits inside the bar, which fills itself with
+    // `colors.panel`. The panel foot, whose column stops where the plugin's content does, has to
+    // paint - see PanelFooterHostActions.
+    HostActionsFlowRow(tag = VERTICAL_BAR_HOST_ACTIONS_TAG, actions = actions)
 }
 
 /** Test tag of the footer row - see `VerticalBarHostActionsLayoutTest`. */
 internal const val VERTICAL_BAR_HOST_ACTIONS_TAG = "vertical-bar-host-actions"
+
+/**
+ * The host's actions as one wrapping row, shared by the two feet that lay them out horizontally:
+ * the vertical bar's, under its split map, and an open plugin panel's.
+ *
+ * **A FlowRow, not a Row, because these do not fit on one line in a narrow column.** The bar goes
+ * down to `TabBarVerticalWidthRange.start`, 120dp, and a panel to a floor of about 20dp. Four 32dp
+ * buttons with `space.xs` between them and `space.sm` either side need 156dp, and three need
+ * exactly 120 - no margin at all. A Row does not wrap, and what it did instead, measured at 120dp,
+ * was give its LAST child zero width: Search came back as a 0x0 rect while the other three kept
+ * their full size. Not a clipped icon - an absent one, on a width the user can reach by dragging.
+ *
+ * Wrapping is the fallback and not the shape: at any comfortable width these still lay out side by
+ * side, which `VerticalBarHostActionsLayoutTest` pins along with the narrow case.
+ *
+ * Shared rather than copied so the two feet cannot drift in height or spacing - they are the same
+ * control in two places, and a user moving between them should not be able to tell. Each host adds
+ * its own chrome around it: a rule, a background, or neither.
+ */
+@Composable
+internal fun HostActionsFlowRow(
+    tag: String,
+    modifier: Modifier = Modifier,
+    actions: List<@Composable () -> Unit>,
+) {
+    FlowRow(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .testTag(tag)
+                .padding(horizontal = BossTheme.space.sm, vertical = ROW_INSET),
+        horizontalArrangement = Arrangement.spacedBy(BossTheme.space.xs, Alignment.CenterHorizontally),
+        verticalArrangement = Arrangement.spacedBy(BossTheme.space.xs),
+    ) {
+        // No key: the list is fixed-order for a given placement, so positional identity is what a
+        // key would give - the same call SidebarBottomActions makes about the same actions.
+        actions.forEach { action -> action() }
+    }
+}
+
+/**
+ * Air above and below the icons.
+ *
+ * A literal because the scale has no step between `space.xs` (4dp) and `space.md` (12dp): xs makes
+ * a 40dp row that reads as cramped against the bar's other chrome, md a 56dp one that reads as a
+ * toolbar. Kept in one place so both feet are the same height.
+ */
+private val ROW_INSET = 6.dp
 
 /**
  * The actions as a row for the foot of the vertical tab bar, under its split map.
@@ -182,32 +212,124 @@ internal fun focusQuickActionsFooter(
     toolbox: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
     toolLauncher: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
 ): List<@Composable () -> Unit> =
-    if (placement != FocusQuickActionsPlacement.TAB_BAR_FOOTER) {
-        emptyList()
-    } else {
-        focusQuickActionButtons(
-            hintDirection = top,
-            modifier = Modifier.size(SIDEBAR_ICON_SIZE),
-            onShowSettings = onShowSettings,
-            toolbox = toolbox,
-            onShowSearch = onShowSearch,
-            onSignOut = onSignOut,
-            toolLauncher = toolLauncher,
-        )
-    }
+    focusQuickActionsFor(
+        owner = FocusQuickActionsPlacement.TAB_BAR_FOOTER,
+        hintDirection = top,
+        placement = placement,
+        onShowSettings = onShowSettings,
+        onShowSearch = onShowSearch,
+        onSignOut = onSignOut,
+        toolbox = toolbox,
+        toolLauncher = toolLauncher,
+    )
 
 /**
- * Whether the vertical tab bar has a foot to put the host's actions in.
+ * The host's own actions down the foot of the bar's COLLAPSED rail, under the "+".
  *
- * Three states, not two. An EXPANDED left bar has one. A COLLAPSED one draws its rail and nothing
- * else, so it has none and the actions float. A collapsed bar whose hover drawer is OPEN has one
- * again for as long as the drawer is up, because the drawer is a full bar.
+ * The [FocusQuickActionsPlacement.TAB_BAR_RAIL] rendering. A rail is the same bar with its labels
+ * taken away, so it is still chrome the app draws - and collapsing the bar is a request for
+ * content width, which is the last state in which to answer with a native always-on-top window
+ * parked over the content. This is where those four went instead.
+ *
+ * A Column, where the expanded bar's foot is a wrapping Row: the rail is as narrow as
+ * `ChromeDimens.MIN_STRIP_WIDTH` and as tall as the window, so one icon per line is the only
+ * layout it has room for. That is also why this is a separate placement rather than a flavour of
+ * [VerticalBarHostActions] - nothing about the two layouts is shared, and only one of them is ever
+ * on screen.
+ *
+ * Renders nothing at all when [actions] is empty, rule included, so a rail whose actions live
+ * somewhere else is exactly the rail that existed before this.
+ */
+@Composable
+internal fun VerticalBarRailActions(actions: List<@Composable () -> Unit>) {
+    if (actions.isEmpty()) return
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .testTag(VERTICAL_BAR_RAIL_ACTIONS_TAG)
+                .padding(vertical = BossTheme.space.xs),
+        verticalArrangement = Arrangement.spacedBy(BossTheme.space.xs),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // The rail's own kind of separator - a short centred rule, the same one it draws between
+        // its panes - rather than a full-width divider, which at this width reads as a bar end.
+        Divider(color = BossTheme.colors.line, modifier = Modifier.fillMaxWidth(0.6f))
+        // No key: fixed-order for a given placement, so positional identity is what a key gives.
+        actions.forEach { action -> action() }
+    }
+}
+
+/** Test tag of the rail's action column - see `QuickActionsRailLayoutTest`. */
+internal const val VERTICAL_BAR_RAIL_ACTIONS_TAG = "vertical-bar-rail-actions"
+
+/**
+ * The actions as a column for the foot of the collapsed rail.
+ *
+ * Same buttons, fourth layout. Hints point RIGHT, into the window: the rail is against the
+ * window's start edge, so a hint to its left would be off screen - the mirror of the call the
+ * right rail makes pointing its own hints inward.
+ *
+ * Buttons are the 32dp the other four hosts use, so these read as the same control wherever they
+ * land. That is deliberately NOT the rail's own chrome: its chevron and "+" are 16dp glyphs in
+ * `textSecondary` on a `raised` chip, so the actions under them are the larger, brighter, chipless
+ * group. Belonging to the action family beat matching the two buttons above them.
+ *
+ * Empty for every other placement, so the rail can call it unconditionally and render nothing.
+ */
+// One parameter per action plus the placement and the launcher slot - see focusQuickActionsFooter.
+@Suppress("LongParameterList")
+internal fun focusQuickActionsTabRail(
+    placement: FocusQuickActionsPlacement,
+    onShowSettings: () -> Unit,
+    onShowSearch: () -> Unit,
+    onSignOut: () -> Unit,
+    toolbox: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
+    toolLauncher: (@Composable (hintDirection: Panel, modifier: Modifier) -> Unit)? = null,
+): List<@Composable () -> Unit> =
+    focusQuickActionsFor(
+        owner = FocusQuickActionsPlacement.TAB_BAR_RAIL,
+        hintDirection = right,
+        placement = placement,
+        onShowSettings = onShowSettings,
+        onShowSearch = onShowSearch,
+        onSignOut = onSignOut,
+        toolbox = toolbox,
+        toolLauncher = toolLauncher,
+    )
+
+/** What the window's vertical tab bar can offer the host's actions. Mutually exclusive. */
+internal enum class VerticalBarHost {
+    /** No bar to offer anything: the tab bar is in TOP position. */
+    NONE,
+
+    /** A full bar, with a foot under its split map. */
+    FOOT,
+
+    /** The collapsed rail, whose one piece of free room is its bottom. */
+    RAIL,
+}
+
+/**
+ * What the vertical tab bar can host right now.
+ *
+ * Three states, not two, and an enum rather than a pair of booleans because two of the three are
+ * the same bar: an EXPANDED left bar has a foot under its split map, a COLLAPSED one is a rail
+ * whose bottom is the only room it has, and a collapsed bar whose hover drawer is OPEN has a foot
+ * again for as long as the drawer is up, because the drawer is a full bar. Carried as two flags
+ * these would admit "a foot AND a rail", which is not a window that exists.
  *
  * Pure and named because it is the one input to [focusQuickActionsPlacement] that is not a
  * standing preference, and because the scaffold that reads it is at detekt's complexity ceiling.
  */
-internal fun verticalBarHasFoot(
+internal fun verticalBarHost(
     tabBarOnLeft: Boolean,
     barCollapsed: Boolean,
     drawerVisible: Boolean,
-): Boolean = tabBarOnLeft && (!barCollapsed || drawerVisible)
+): VerticalBarHost =
+    when {
+        !tabBarOnLeft -> VerticalBarHost.NONE
+        !barCollapsed || drawerVisible -> VerticalBarHost.FOOT
+        else -> VerticalBarHost.RAIL
+    }

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/app/VerticalBarWindowControls.kt
@@ -158,8 +158,21 @@ internal const val VERTICAL_BAR_HOST_ACTIONS_TAG = "vertical-bar-host-actions"
  * side, which `VerticalBarHostActionsLayoutTest` pins along with the narrow case.
  *
  * Shared rather than copied so the two feet cannot drift in height or spacing - they are the same
- * control in two places, and a user moving between them should not be able to tell. Each host adds
- * its own chrome around it: a rule, a background, or neither.
+ * control in two places, and a user moving between them should not be able to tell.
+ *
+ * **Each host adds its own separator, and the three differ on purpose** - what is directly above
+ * the row is different in each, and that is what a rule is for:
+ *
+ * - The **bar's foot** draws none. Above it is `SplitMap`, which is an inset, rounded, bordered
+ *   picture on the bar's own fill, so it delimits itself; a rule under it would be a second edge
+ *   a few dp below the first.
+ * - The **rail** draws a short centred rule, the one it already uses between panes, because a
+ *   full-width one at 36dp reads as the end of the bar rather than a division inside it.
+ * - The **panel's foot** draws a full-width one. Above it is a plugin's arbitrary content on a
+ *   fill this row has to paint for itself, and without the rule the actions read as the plugin's.
+ *
+ * So the shared thing is the row - height, spacing, wrap behaviour - and the chrome around it is
+ * the host's. Anything the row itself owns belongs in here, where it cannot drift.
  */
 @Composable
 internal fun HostActionsFlowRow(
@@ -172,7 +185,7 @@ internal fun HostActionsFlowRow(
             modifier
                 .fillMaxWidth()
                 .testTag(tag)
-                .padding(horizontal = BossTheme.space.sm, vertical = ROW_INSET),
+                .padding(horizontal = BossTheme.space.sm, vertical = HOST_ACTIONS_ROW_INSET),
         horizontalArrangement = Arrangement.spacedBy(BossTheme.space.xs, Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(BossTheme.space.xs),
     ) {
@@ -188,8 +201,12 @@ internal fun HostActionsFlowRow(
  * A literal because the scale has no step between `space.xs` (4dp) and `space.md` (12dp): xs makes
  * a 40dp row that reads as cramped against the bar's other chrome, md a 56dp one that reads as a
  * toolbar. Kept in one place so both feet are the same height.
+ *
+ * `internal` because `panelFooterFitsColumn` computes what this row will COST a panel column
+ * before deciding to draw it, and a second copy of the number there is a second copy that can be
+ * edited alone.
  */
-private val ROW_INSET = 6.dp
+internal val HOST_ACTIONS_ROW_INSET = 6.dp
 
 /**
  * The actions as a row for the foot of the vertical tab bar, under its split map.

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/BossWindow.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/BossWindow.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -42,8 +43,10 @@ fun BossDraggableComponent.BossWindow(
     onTabDropResult: (TabDropResult) -> Unit = {},
     /** Window chrome for the foot of the vertical tab bar. See SplitViewPanel. */
     verticalBarFooter: @Composable () -> Unit = {},
-    /** Window chrome for below the vertical bar's split map. See [SplitViewPanel]. */
+    /** Window chrome for below the FULL vertical bar's split map. See [SplitViewPanel]. */
     verticalBarBelowMap: @Composable () -> Unit = {},
+    /** The same chrome for the foot of the bar's collapsed rail. See [SplitViewPanel]. */
+    verticalBarRailActions: @Composable () -> Unit = {},
     /** Clearance above the vertical bar, for the macOS traffic lights. See [SplitViewPanel]. */
     verticalBarTopInset: Dp = 0.dp,
     /** Reports whether the hover-revealed bar is on screen. See [SplitViewPanel]. */
@@ -57,6 +60,23 @@ fun BossDraggableComponent.BossWindow(
      * not the bar - is the column the lights are drawn over. Its own header was under them.
      */
     leftPanelTopInset: Dp = 0.dp,
+    /**
+     * Which open plugin panel's column carries [panelFooter], or null for none.
+     *
+     * Decided by the window, not here: `hostActionsPanelEdge` is the same expression that decides
+     * whether those actions are in a panel foot at all, and two answers could disagree - which
+     * would render the row into a column nothing is composing. Compared by root, so it names a
+     * column (`left`) rather than one of its two halves.
+     */
+    panelFooterEdge: Panel? = null,
+    /**
+     * Window chrome for the very bottom of that column, under whichever panel is lowest in it.
+     *
+     * Today the host's own actions - Sign Out, Settings, Tools, Search - when a TOP tab bar leaves
+     * no bar to hold them and a panel is open in front of where the floating cluster would park.
+     * See `focusQuickActionsPlacement`. Renders nothing when there is nothing to put there.
+     */
+    panelFooter: @Composable () -> Unit = {},
 ) {
     // Process any pending panel opens (for two-phase transitions)
     // This is critical for JxBrowser-based plugins to avoid BrowserViewState conflicts
@@ -111,20 +131,30 @@ fun BossDraggableComponent.BossWindow(
         WithPanel(
             panel,
             panelContent = {
-                WithPanel(
-                    secondaryPanel,
-                    isPanelVisible = isFirstPanelVisible,
-                    isMainVisible = isLastPanelVisible,
-                    isRelative = isNestedRelative,
-                    panelContent = firstPanel,
-                    mainContent = lastPanel,
-                )
+                PanelColumn(footer = { if (panelFooterEdge == panel) panelFooter() }) {
+                    WithPanel(
+                        secondaryPanel,
+                        isPanelVisible = isFirstPanelVisible,
+                        isMainVisible = isLastPanelVisible,
+                        isRelative = isNestedRelative,
+                        panelContent = firstPanel,
+                        mainContent = lastPanel,
+                    )
+                }
             },
             mainContent = mainContent,
         )
     }
 
-    WithPanel(bottom) {
+    WithPanel(
+        bottom,
+        // The one panel with no second half, wrapped the same way as the two columns above.
+        panelContent = {
+            PanelColumn(footer = { if (panelFooterEdge == bottom) panelFooter() }) {
+                SidePanel(bottom, panelComponentStore)
+            }
+        },
+    ) {
         WithNestedPanel(
             left,
             // Painted before it is padded: an unpainted inset shows the raw native window surface
@@ -147,35 +177,74 @@ fun BossDraggableComponent.BossWindow(
                         onTabDropResult = onTabDropResult,
                         verticalBarFooter = verticalBarFooter,
                         verticalBarBelowMap = verticalBarBelowMap,
+                        verticalBarRailActions = verticalBarRailActions,
                         verticalBarTopInset = verticalBarTopInset,
                         onDrawerVisibleChange = onDrawerVisibleChange,
                         onBarRailedChange = onBarRailedChange,
                     )
-                    // While a header is dragged over the central area, highlight the
-                    // resolved target region (a whole panel for center-drop, or the half
-                    // where the new split would land) — mirrors the tab drag feedback.
-                    val highlightRect = mainAreaHighlight
-                    val areaOrigin = mainAreaBounds
-                    if (highlightRect != null && areaOrigin != null && draggingItem != null) {
-                        val density = LocalDensity.current
-                        Box(
-                            modifier =
-                                Modifier
-                                    .offset {
-                                        IntOffset(
-                                            (highlightRect.left - areaOrigin.left).roundToInt(),
-                                            (highlightRect.top - areaOrigin.top).roundToInt(),
-                                        )
-                                    }.size(
-                                        with(density) { highlightRect.width.toDp() },
-                                        with(density) { highlightRect.height.toDp() },
-                                    ).background(Color.White.copy(alpha = 0.10f))
-                                    .border(2.dp, Color.White.copy(alpha = 0.5f)),
-                        )
-                    }
+                    DragTargetHighlight()
                 }
             }
         }
+    }
+}
+
+/**
+ * The drop-target outline drawn over the central area while a panel header is dragged.
+ *
+ * While a header is dragged over the central area this highlights the resolved target region - a
+ * whole panel for a centre drop, or the half where the new split would land - mirroring the
+ * feedback a tab drag gives. Nothing is drawn unless a drag is in flight and the area has been
+ * measured.
+ *
+ * Its own composable rather than an `if` inside [BossWindow], which is at detekt's length ceiling:
+ * this is self-contained, reading only the component's own drag state.
+ */
+@Composable
+private fun BossDraggableComponent.DragTargetHighlight() {
+    val highlightRect = mainAreaHighlight
+    val areaOrigin = mainAreaBounds
+    if (highlightRect == null || areaOrigin == null || draggingItem == null) return
+
+    val density = LocalDensity.current
+    Box(
+        modifier =
+            Modifier
+                .offset {
+                    IntOffset(
+                        (highlightRect.left - areaOrigin.left).roundToInt(),
+                        (highlightRect.top - areaOrigin.top).roundToInt(),
+                    )
+                }.size(
+                    with(density) { highlightRect.width.toDp() },
+                    with(density) { highlightRect.height.toDp() },
+                ).background(Color.White.copy(alpha = 0.10f))
+                .border(2.dp, Color.White.copy(alpha = 0.5f)),
+    )
+}
+
+/**
+ * A panel column with window chrome under it.
+ *
+ * The Column is what lets [footer] take a row out of the BOTTOM of the whole column - under
+ * whichever of the two stacked panels is lowest in it - rather than inside one of them, where it
+ * would move about with whatever the user happens to have open.
+ *
+ * With no footer to draw this is a Column around one `weight(1f)` child, which lays out exactly as
+ * the bare panel did, so wrapping every column costs nothing in the common case.
+ *
+ * `internal` rather than private so `QuickActionsPanelFooterTest` can assert against THIS layout
+ * rather than a copy of it - a test that rebuilds the structure it means to pin passes just as
+ * happily when the real one loses its `weight(1f)` or draws the footer first.
+ */
+@Composable
+internal fun PanelColumn(
+    footer: @Composable () -> Unit,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.weight(1f), content = content)
+        footer()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/BossWindow.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/BossWindow.kt
@@ -67,14 +67,19 @@ fun BossDraggableComponent.BossWindow(
      * whether those actions are in a panel foot at all, and two answers could disagree - which
      * would render the row into a column nothing is composing. Compared by root, so it names a
      * column (`left`) rather than one of its two halves.
+     *
+     * All three columns ask, though today only `right` is ever named - `hostActionsPanelEdge` has
+     * the reasons the other two are out. Asking uniformly is what lets that stay one decision in
+     * one place, and an unfilled [PanelColumn] is a `Column` around one `weight(1f)` child, which
+     * lays out exactly as the bare panel did.
      */
     panelFooterEdge: Panel? = null,
     /**
      * Window chrome for the very bottom of that column, under whichever panel is lowest in it.
      *
      * Today the host's own actions - Sign Out, Settings, Tools, Search - when a TOP tab bar leaves
-     * no bar to hold them and a panel is open in front of where the floating cluster would park.
-     * See `focusQuickActionsPlacement`. Renders nothing when there is nothing to put there.
+     * no bar to hold them and the right panel is open in front of where the floating cluster would
+     * park. See `focusQuickActionsPlacement`. Renders nothing when there is nothing to put there.
      */
     panelFooter: @Composable () -> Unit = {},
 ) {

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/BossWindow.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/BossWindow.kt
@@ -136,7 +136,7 @@ fun BossDraggableComponent.BossWindow(
         WithPanel(
             panel,
             panelContent = {
-                PanelColumn(footer = { if (panelFooterEdge == panel) panelFooter() }) {
+                PanelColumn(column = panel, footerEdge = panelFooterEdge, footer = panelFooter) {
                     WithPanel(
                         secondaryPanel,
                         isPanelVisible = isFirstPanelVisible,
@@ -155,7 +155,7 @@ fun BossDraggableComponent.BossWindow(
         bottom,
         // The one panel with no second half, wrapped the same way as the two columns above.
         panelContent = {
-            PanelColumn(footer = { if (panelFooterEdge == bottom) panelFooter() }) {
+            PanelColumn(column = bottom, footerEdge = panelFooterEdge, footer = panelFooter) {
                 SidePanel(bottom, panelComponentStore)
             }
         },
@@ -229,7 +229,7 @@ private fun BossDraggableComponent.DragTargetHighlight() {
 }
 
 /**
- * A panel column with window chrome under it.
+ * A panel column, with window chrome under it when this is the column that carries it.
  *
  * The Column is what lets [footer] take a row out of the BOTTOM of the whole column - under
  * whichever of the two stacked panels is lowest in it - rather than inside one of them, where it
@@ -238,18 +238,26 @@ private fun BossDraggableComponent.DragTargetHighlight() {
  * With no footer to draw this is a Column around one `weight(1f)` child, which lays out exactly as
  * the bare panel did, so wrapping every column costs nothing in the common case.
  *
- * `internal` rather than private so `QuickActionsPanelFooterTest` can assert against THIS layout
- * rather than a copy of it - a test that rebuilds the structure it means to pin passes just as
- * happily when the real one loses its `weight(1f)` or draws the footer first.
+ * **The `[footerEdge] == [column]` gate lives here, not at the three call sites.** It was written
+ * out three times, which made it three things that could disagree and, in a test, something to
+ * hand-copy: a test that re-implements the predicate it means to pin passes just as happily when
+ * one of the real copies names the wrong column.
+ *
+ * `internal` rather than private so `QuickActionsPanelFooterTest` and `HostActionsWiringTest` can
+ * drive THIS layout and THIS gate rather than copies of them. What that still does not pin is
+ * which [column] each call site passes - that is one token beside the `WithPanel` it belongs to,
+ * and mounting the whole window is the only thing that would catch it.
  */
 @Composable
 internal fun PanelColumn(
+    column: Panel,
+    footerEdge: Panel?,
     footer: @Composable () -> Unit,
     content: @Composable BoxScope.() -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f), content = content)
-        footer()
+        if (footerEdge == column) footer()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/SplitView.kt
@@ -1974,11 +1974,21 @@ fun SplitViewPanel(
     /** Window chrome for the foot of the vertical bar. Ignored in TOP position, which has none. */
     verticalBarFooter: @Composable () -> Unit = {},
     /**
-     * Window chrome for BELOW the split map, at the very foot of the vertical bar - Settings,
-     * Search, Sign Out and the tools launcher when nothing else is left to hold them. Ignored in
-     * TOP position, where those go back to the top bar or a floating cluster.
+     * Window chrome for BELOW the split map, at the very foot of the FULL vertical bar - Settings,
+     * Search, Sign Out and the tools launcher when nothing else is left to hold them.
+     *
+     * Ignored in TOP position, which has no vertical bar: there the same actions go to the top bar
+     * if it is up, an open plugin panel's foot if one is open, and a floating cluster otherwise.
+     * See `focusQuickActionsPlacement`.
      */
     verticalBarBelowMap: @Composable () -> Unit = {},
+    /**
+     * The same chrome for when the bar is down to its RAIL, at the very foot of that.
+     *
+     * A separate slot because the rail and the hover drawer are on screen together, so one slot
+     * handed to both drew the actions twice - see `WindowVerticalTabBar.belowTabs`.
+     */
+    verticalBarRailActions: @Composable () -> Unit = {},
     /**
      * Clearance above the vertical bar.
      *
@@ -1991,9 +2001,10 @@ fun SplitViewPanel(
     /**
      * Reports whether the hover-revealed bar is on screen.
      *
-     * The window needs it because the host's actions live under the bar's split map, and a
-     * COLLAPSED bar has no foot to put them in - so they float instead, until the drawer opens and
-     * gives them one again. Only this composable knows: the reveal state machine lives here.
+     * The window needs it because it decides where the host's actions go: a collapsed bar puts
+     * them at the foot of its rail, and a revealed drawer IS a full bar, so while it is up they
+     * move from the rail's bottom into the bar's foot. Only this composable knows: the reveal
+     * state machine lives here. See `verticalBarHost`.
      */
     onDrawerVisibleChange: (Boolean) -> Unit = {},
     /**
@@ -2001,9 +2012,11 @@ fun SplitViewPanel(
      *
      * Not the same question as the `tabBarCollapsed` preference, which is what the window used to
      * ask: a bar also rails itself when there is no room for a full one, and only this composable
-     * has measured the width. The window needs the MEASURED answer, because a rail has no foot to
-     * put the host's actions in - and while it believed the preference, a narrow window sent them
-     * to a foot that was not being drawn and they rendered nowhere at all.
+     * has measured the width. The window needs the MEASURED answer because it picks which of the
+     * bar's two layouts hosts the host's actions - a row under the split map, or a column at the
+     * bottom of the rail - and the preference alone cannot tell a self-railed narrow window from
+     * an expanded one. While it believed the preference, a narrow window sent them to a foot that
+     * was not being drawn and they rendered nowhere at all.
      */
     onBarRailedChange: (Boolean) -> Unit = {},
 ) {
@@ -2068,6 +2081,7 @@ fun SplitViewPanel(
                 onTabDropResult = onTabDropResult,
                 footer = verticalBarFooter,
                 belowMap = verticalBarBelowMap,
+                belowTabs = verticalBarRailActions,
                 topInset = verticalBarTopInset,
                 splitTree = splitTree,
             )
@@ -2140,6 +2154,8 @@ private fun WindowBarRow(
     onTabDropResult: (TabDropResult) -> Unit,
     footer: @Composable () -> Unit,
     belowMap: @Composable () -> Unit,
+    /** The rail's own copy of that chrome. See `WindowVerticalTabBar.belowTabs`. */
+    belowTabs: @Composable () -> Unit,
     /** Clearance above the bar, for the macOS traffic lights. See [SplitViewPanel]. */
     topInset: Dp,
     splitTree: @Composable (Modifier) -> Unit,
@@ -2188,6 +2204,7 @@ private fun WindowBarRow(
                 tabDragComponent = tabDragComponent,
                 footer = footer,
                 belowMap = belowMap,
+                belowTabs = belowTabs,
                 zoomed = splitViewState.zoomedPanelId != null,
                 onExitZoom = splitViewState::exitZoom,
             )

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossVerticalTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/BossVerticalTabBar.kt
@@ -170,12 +170,17 @@ fun ColumnScope.BossVerticalTabStrip(
  *
  * @param groups one per pane, from `rememberWindowTabGroups`.
  * @param onNewTab the "+" at the foot, which opens a tab in the pane that owns the bar's chrome.
+ * @param belowTabs window chrome for the very bottom of the rail, under the "+". The host's own
+ *   actions - Sign Out, Settings, Tools, Search - land here when nothing else is left to hold
+ *   them, which is the whole reason a collapsed bar no longer sends them to a floating overlay.
+ *   See `focusQuickActionsPlacement`. Renders nothing when there is nothing to put there.
  */
 @Composable
 fun BossTabRail(
     groups: List<TabBarGroup>,
     onExpand: () -> Unit,
     onNewTab: () -> Unit,
+    belowTabs: @Composable () -> Unit = {},
 ) {
     val colors = BossTheme.colors
     Column(
@@ -222,6 +227,10 @@ fun BossTabRail(
             contentDescription = "New Tab",
             onClick = onNewTab,
         )
+        // Below the "+", not above it: that button belongs to the tabs this rail is a list of,
+        // and these belong to the app. The slot draws its own rule, so a rail with nothing to put
+        // here ends at the "+" exactly as it always did.
+        belowTabs()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/WindowVerticalTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/ai/rever/boss/components/window_panel/components/main_window_panels/WindowVerticalTabBar.kt
@@ -203,8 +203,27 @@ fun WindowVerticalTabBar(
      * the footer holds what belongs to this window's contents (the project and workspace pickers),
      * this holds what belongs to the app - Settings, Search, Sign Out and the tools launcher,
      * when there is no strip and no top bar left to hold them. See `focusQuickActionsPlacement`.
+     *
+     * FULL bar only, and [belowTabs] is why: a collapsed rail hosts the same actions in a layout
+     * of its own, and the two cannot share one slot.
      */
     belowMap: @Composable () -> Unit = {},
+    /**
+     * The same app-level chrome for when this bar is down to its RAIL, at the very foot of it.
+     *
+     * A second slot rather than [belowMap] handed to both branches, which is what this was, and
+     * the reason is that the two are on screen at once. `SplitViewPanel` composes the in-flow rail
+     * and the hover drawer together - the drawer is an overlay over the rail, not a replacement
+     * for it - and the drawer being open makes the LIVE placement `TAB_BAR_FOOTER`. One shared
+     * slot therefore drew the full bar's wrapping row twice: once in the drawer's foot, and once
+     * behind it at the bottom of a 36dp rail, where four 32dp buttons wrap to four lines of
+     * squeezed icons. Hidden while the drawer covers it, and visible for the frame after it is
+     * dismissed - `drawerVisible` is reported through a `LaunchedEffect`, so the uncovered rail
+     * draws the wrong layout for one frame before the placement catches up.
+     *
+     * With two slots each branch is handed only its own layout, so there is nothing to get wrong.
+     */
+    belowTabs: @Composable () -> Unit = {},
 ) {
     // The pane the user is working in owns the bar's shared chrome: its bar menu, its Favorites
     // shelf, and where a favourite opens. Falling back to the first group keeps every one of
@@ -255,6 +274,7 @@ fun WindowVerticalTabBar(
                 groups = groups,
                 onExpand = { onToggleCollapse?.invoke() },
                 onNewTab = lead.state.openNewTab,
+                belowTabs = belowTabs,
             )
         } else {
             ExpandedGroups(

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
  * Pins the wiring between the placement decision and the hosts that draw it.
@@ -153,37 +154,50 @@ class HostActionsWiringTest {
     fun `the footer lands in exactly one panel column, the one the edge names`() {
         // `hostActionsPanelEdge` names a column and BossWindow gates on `panelFooterEdge == panel`
         // in each of the three. Panel is an open class whose subclasses carry a nullable child, so
-        // this pins that the roots do not collide - and that no combination lights two columns.
-        listOf(
-            Triple(true, true, true) to right,
-            Triple(false, true, true) to left,
-            Triple(false, false, true) to bottom,
-        ).forEach { (open, expected) ->
-            val (rightOpen, leftOpen, bottomOpen) = open
-            val edge = hostActionsPanelEdge(rightOpen, leftOpen, bottomOpen)
-            assertEquals(expected, edge, "the premise: the edge for $open")
-
-            rule.setContent {
-                // The three columns BossWindow composes, each gating the shared footer the same
-                // way it does. Only the open ones get one, exactly as in the real window.
-                Column {
-                    listOf(right to rightOpen, left to leftOpen, bottom to bottomOpen)
-                        .filter { (_, isOpen) -> isOpen }
-                        .forEach { (column, _) ->
-                            PanelColumn(footer = { if (edge == column) FooterProbe(column) }) {
-                                Box(modifier = Modifier.fillMaxSize())
-                            }
+        // this pins that the roots do not collide - and, since only the right column is a
+        // candidate, that a left or bottom panel does NOT quietly grow a foot of its own.
+        //
+        // One setContent driven by a state, not one per case: `setContent` is documented as once
+        // per test, and the drawer test above already has the shape.
+        val rightOpen = mutableStateOf(true)
+        rule.setContent {
+            val edge = hostActionsPanelEdge(rightOpen = rightOpen.value)
+            // The three columns BossWindow composes, each gating the shared footer the same way
+            // it does. Left and bottom are held OPEN throughout: they are what would light up if
+            // the table ever grew back to them by accident.
+            Column {
+                listOf(right to rightOpen.value, left to true, bottom to true)
+                    .filter { (_, isOpen) -> isOpen }
+                    .forEach { (column, _) ->
+                        PanelColumn(footer = { if (edge == column) FooterProbe(column) }) {
+                            Box(modifier = Modifier.fillMaxSize())
                         }
-                }
+                    }
             }
-            rule.waitForIdle()
+        }
+        rule.waitForIdle()
 
-            rule.onAllNodesWithTag(probeTagFor(expected)).assertCountEquals(1)
-            listOf(right, left, bottom)
-                .filter { column -> column != expected }
-                .forEach { column ->
-                    rule.onAllNodesWithTag(probeTagFor(column)).assertCountEquals(0)
-                }
+        assertEquals(right, hostActionsPanelEdge(rightOpen = true), "the premise: the right column")
+        assertOnlyFooterIn(right)
+
+        // Shut the right panel with the other two still open: the edge is null, so no column
+        // draws a foot and the actions go back to the floating cluster.
+        rightOpen.value = false
+        rule.waitForIdle()
+
+        assertNull(hostActionsPanelEdge(rightOpen = false), "the premise: no column without it")
+        assertOnlyFooterIn(null)
+    }
+
+    /** A footer in [expected] and in neither of the other two columns; none at all when null. */
+    private fun assertOnlyFooterIn(expected: Panel?) {
+        listOf(right, left, bottom).forEach { column ->
+            val found = rule.onAllNodesWithTag(probeTagFor(column)).fetchSemanticsNodes().size
+            assertEquals(
+                if (column == expected) 1 else 0,
+                found,
+                "footers in the ${column::class.simpleName} column, with $expected expected to hold it",
+            )
         }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
@@ -1,0 +1,200 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.window_panel.PanelColumn
+import ai.rever.boss.focusmode.FocusModeSettings
+import ai.rever.boss.plugin.api.Panel
+import ai.rever.boss.plugin.api.Panel.Companion.bottom
+import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.Panel.Companion.right
+import ai.rever.boss.plugin.api.Panel.Companion.top
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the wiring between the placement decision and the hosts that draw it.
+ *
+ * The placement table has its own tests and each layout has its own; this covers the seam between
+ * them, where every failure is silent. Two hosts drawing at once is Sign Out twice; a host drawing
+ * for a placement it does not own is Sign Out in a container nothing is composing.
+ *
+ * The first test exists because that second failure SHIPPED in this change's first draft: one slot
+ * was handed to both the collapsed rail and the hover drawer on the reasoning that "a rail is
+ * TAB_BAR_RAIL and a full bar is TAB_BAR_FOOTER, never both". `SplitViewPanel` composes the rail
+ * and the drawer TOGETHER - the drawer is an overlay over the rail, not a replacement - so with
+ * the drawer up the rail drew the full bar's wrapping row at 36dp wide, four lines of squeezed
+ * icons, visible for the frame after dismissal.
+ */
+class HostActionsWiringTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private fun placementFor(
+        drawerVisible: Boolean,
+        barCollapsed: Boolean = true,
+    ) = focusQuickActionsPlacement(
+        settings = FocusModeSettings(),
+        topBarHidden = true,
+        rightStripHidden = true,
+        showTopBar = false,
+        verticalBar =
+            verticalBarHost(
+                tabBarOnLeft = true,
+                barCollapsed = barCollapsed,
+                drawerVisible = drawerVisible,
+            ),
+    )
+
+    @Test
+    fun `the hover drawer moves the actions out of the rail, never doubles them`() {
+        val drawerVisible = mutableStateOf(false)
+        rule.setContent {
+            val placement = placementFor(drawerVisible = drawerVisible.value)
+            // Both hosts composed together on purpose: that is the configuration the bug was in,
+            // and asserting on the CONTENT rather than on which slot receives it keeps this
+            // honest even if someone shares one slot between the branches again.
+            Column(modifier = Modifier.width(BAR_WIDTH)) {
+                VerticalBarRailActions(
+                    focusQuickActionsTabRail(placement, {}, {}, {}, { _, _ -> }),
+                )
+                VerticalBarHostActions(
+                    focusQuickActionsFooter(placement, {}, {}, {}, { _, _ -> }),
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "a collapsed rail with the drawer shut")
+
+        drawerVisible.value = true
+        rule.waitForIdle()
+        assertOnly(VERTICAL_BAR_HOST_ACTIONS_TAG, "the drawer is a full bar, so its foot takes them")
+
+        drawerVisible.value = false
+        rule.waitForIdle()
+        assertOnly(VERTICAL_BAR_RAIL_ACTIONS_TAG, "and dismissing it hands them back to the rail")
+    }
+
+    /** Exactly one of the two bar layouts on screen, and it is [expected]. */
+    private fun assertOnly(
+        expected: String,
+        why: String,
+    ) {
+        val other =
+            if (expected == VERTICAL_BAR_RAIL_ACTIONS_TAG) {
+                VERTICAL_BAR_HOST_ACTIONS_TAG
+            } else {
+                VERTICAL_BAR_RAIL_ACTIONS_TAG
+            }
+        rule.onAllNodesWithTag(expected).assertCountEquals(1)
+        rule.onAllNodesWithTag(other).assertCountEquals(0)
+        // The reason rides in the failure message: a count assertion that fires says only
+        // "expected 1, found 0", which does not say which of the three states was live.
+        assertEquals(1, rule.onAllNodesWithTag(expected).fetchSemanticsNodes().size, why)
+        assertEquals(0, rule.onAllNodesWithTag(other).fetchSemanticsNodes().size, why)
+    }
+
+    @Test
+    fun `each new layout points its hints away from the window edge`() {
+        // Off-screen tooltips are invisible to every bounds assertion in the suite: the buttons
+        // are all present and correctly sized, and their hint opens past the window edge. Both
+        // directions carry an explicit justification in their KDoc, so both are worth pinning.
+        var railHint: Panel? = null
+        var footHint: Panel? = null
+        var panelHint: Panel? = null
+
+        // Each list is composables, not values: only rendering them hands the probe its
+        // direction, so the capture has to happen inside setContent.
+        rule.setContent {
+            listOf(
+                focusQuickActionsTabRail(
+                    FocusQuickActionsPlacement.TAB_BAR_RAIL,
+                    {},
+                    {},
+                    {},
+                    toolbox = { hint, _ -> railHint = hint },
+                ),
+                focusQuickActionsFooter(
+                    FocusQuickActionsPlacement.TAB_BAR_FOOTER,
+                    {},
+                    {},
+                    {},
+                    toolbox = { hint, _ -> footHint = hint },
+                ),
+                focusQuickActionsPanelFooter(
+                    FocusQuickActionsPlacement.PANEL_FOOTER,
+                    {},
+                    {},
+                    {},
+                    toolbox = { hint, _ -> panelHint = hint },
+                ),
+            ).forEach { actions -> actions.forEach { action -> action() } }
+        }
+        rule.waitForIdle()
+
+        assertEquals(right, railHint, "the rail is on the start edge, so its hints point inward")
+        assertEquals(top, footHint, "the bar's foot is its last row, so its hints point up")
+        assertEquals(top, panelHint, "the panel's foot is its last row too")
+    }
+
+    @Test
+    fun `the footer lands in exactly one panel column, the one the edge names`() {
+        // `hostActionsPanelEdge` names a column and BossWindow gates on `panelFooterEdge == panel`
+        // in each of the three. Panel is an open class whose subclasses carry a nullable child, so
+        // this pins that the roots do not collide - and that no combination lights two columns.
+        listOf(
+            Triple(true, true, true) to right,
+            Triple(false, true, true) to left,
+            Triple(false, false, true) to bottom,
+        ).forEach { (open, expected) ->
+            val (rightOpen, leftOpen, bottomOpen) = open
+            val edge = hostActionsPanelEdge(rightOpen, leftOpen, bottomOpen)
+            assertEquals(expected, edge, "the premise: the edge for $open")
+
+            rule.setContent {
+                // The three columns BossWindow composes, each gating the shared footer the same
+                // way it does. Only the open ones get one, exactly as in the real window.
+                Column {
+                    listOf(right to rightOpen, left to leftOpen, bottom to bottomOpen)
+                        .filter { (_, isOpen) -> isOpen }
+                        .forEach { (column, _) ->
+                            PanelColumn(footer = { if (edge == column) FooterProbe(column) }) {
+                                Box(modifier = Modifier.fillMaxSize())
+                            }
+                        }
+                }
+            }
+            rule.waitForIdle()
+
+            rule.onAllNodesWithTag(probeTagFor(expected)).assertCountEquals(1)
+            listOf(right, left, bottom)
+                .filter { column -> column != expected }
+                .forEach { column ->
+                    rule.onAllNodesWithTag(probeTagFor(column)).assertCountEquals(0)
+                }
+        }
+    }
+}
+
+@Composable
+private fun FooterProbe(column: Panel) {
+    // ONE tag. Two `testTag` calls on one modifier chain do not both stick - they write the same
+    // semantics key, so the second wins and an assertion on the first passes by never matching.
+    Box(modifier = Modifier.fillMaxSize().testTag(probeTagFor(column)))
+}
+
+private fun probeTagFor(column: Panel): String = "host-actions-footer-probe-${column::class.simpleName}"
+
+private val BAR_WIDTH = 200.dp

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/HostActionsWiringTest.kt
@@ -10,8 +10,10 @@ import ai.rever.boss.plugin.api.Panel.Companion.top
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -152,8 +154,9 @@ class HostActionsWiringTest {
 
     @Test
     fun `the footer lands in exactly one panel column, the one the edge names`() {
-        // `hostActionsPanelEdge` names a column and BossWindow gates on `panelFooterEdge == panel`
-        // in each of the three. Panel is an open class whose subclasses carry a nullable child, so
+        // `hostActionsPanelEdge` names a column and `PanelColumn` gates on `footerEdge == column`,
+        // which is the one copy of that predicate since review round 2 - the test drives it rather
+        // than re-implementing it. Panel is an open class whose subclasses carry a nullable child, so
         // this pins that the roots do not collide - and, since only the right column is a
         // candidate, that a left or bottom panel does NOT quietly grow a foot of its own.
         //
@@ -169,7 +172,9 @@ class HostActionsWiringTest {
                 listOf(right to rightOpen.value, left to true, bottom to true)
                     .filter { (_, isOpen) -> isOpen }
                     .forEach { (column, _) ->
-                        PanelColumn(footer = { if (edge == column) FooterProbe(column) }) {
+                        // The real gate, inside the real PanelColumn: the predicate this means
+                        // to pin now lives in one place instead of being hand-copied here.
+                        PanelColumn(column = column, footerEdge = edge, footer = { FooterProbe(column) }) {
                             Box(modifier = Modifier.fillMaxSize())
                         }
                     }
@@ -187,6 +192,65 @@ class HostActionsWiringTest {
 
         assertNull(hostActionsPanelEdge(rightOpen = false), "the premise: no column without it")
         assertOnlyFooterIn(null)
+    }
+
+    @Test
+    fun `a column too small for the row hands the actions back, and takes them again when it grows`() {
+        // The round trip the fallback depends on, driven through the real pieces: the footer host
+        // measures its column, reports out through onColumnFitsChange, the placement reads that
+        // report, and the row it produces is what the host draws next frame.
+        //
+        // The reversibility is the half worth pinning. The measuring shell composes whether or not
+        // there is a row precisely so a column that has answered "no" can still answer "yes" when
+        // the user widens it - behind the same guard as the row, "no" would be permanent.
+        //
+        // It is also the test that would hang rather than fail if this loop could oscillate:
+        // waitForIdle does not return while recomposition keeps rescheduling itself.
+        val columnWidth = mutableStateOf(SLIVER_WIDTH)
+        // Snapshot state, as the scaffold holds it: the report has to invalidate the composition
+        // that reads it, or the placement never hears about the column it was measured against.
+        val fits = mutableStateOf(true)
+        var placement = FocusQuickActionsPlacement.NONE
+
+        rule.setContent {
+            val current =
+                focusQuickActionsPlacement(
+                    settings = FocusModeSettings(),
+                    topBarHidden = true,
+                    rightStripHidden = true,
+                    showTopBar = false,
+                    verticalBar = VerticalBarHost.NONE,
+                    panelFootAvailable = fits.value,
+                )
+            SideEffect { placement = current }
+            Box(modifier = Modifier.width(columnWidth.value).height(COLUMN_HEIGHT)) {
+                PanelColumn(column = right, footerEdge = right, footer = {
+                    PanelFooterHostActions(
+                        actionCount = FOCUS_QUICK_ACTION_COUNT,
+                        actions = focusQuickActionsPanelFooter(current, {}, {}, {}),
+                        onColumnFitsChange = { reported -> fits.value = reported },
+                    )
+                }) {
+                    Box(modifier = Modifier.fillMaxSize())
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        assertEquals(FocusQuickActionsPlacement.FLOATING, placement, "a 20dp column keeps the cluster")
+        rule.onAllNodesWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).assertCountEquals(0)
+
+        columnWidth.value = ROOMY_WIDTH
+        rule.waitForIdle()
+
+        assertEquals(FocusQuickActionsPlacement.PANEL_FOOTER, placement, "and a 250dp one takes them")
+        rule.onAllNodesWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).assertCountEquals(1)
+
+        columnWidth.value = SLIVER_WIDTH
+        rule.waitForIdle()
+
+        assertEquals(FocusQuickActionsPlacement.FLOATING, placement, "and gives them back on the way down")
+        rule.onAllNodesWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).assertCountEquals(0)
     }
 
     /** A footer in [expected] and in neither of the other two columns; none at all when null. */
@@ -212,3 +276,12 @@ private fun FooterProbe(column: Panel) {
 private fun probeTagFor(column: Panel): String = "host-actions-footer-probe-${column::class.simpleName}"
 
 private val BAR_WIDTH = 200.dp
+
+/** `BossResizablePanel`'s floor for a side panel, where the row would wrap five lines deep. */
+private val SLIVER_WIDTH = 20.dp
+
+/** The right panel's default width, where the row is one line. */
+private val ROOMY_WIDTH = 250.dp
+
+/** Tall enough that width is the only thing under test. */
+private val COLUMN_HEIGHT = 400.dp

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/PanelFooterFitTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/PanelFooterFitTest.kt
@@ -1,0 +1,96 @@
+package ai.rever.boss.app
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the rule that decides whether a panel column carries the host's actions at all.
+ *
+ * Every case here is a measurement taken from the layout it describes, not an estimate: the
+ * numbers came out of mounting `PanelColumn` at each size and reading the rendered bounds back.
+ * They are in the assertion messages so a future change to the row's geometry fails with the
+ * number it broke rather than with a bare false.
+ *
+ * The rule exists because drawing the row unconditionally had two failure modes on two axes, and
+ * both of them took the panel rather than the icons: at 20x400 the plugin kept 211dp behind 188dp
+ * of chrome whose icons were 4dp WIDE, and at 20x200 it kept 11dp.
+ */
+class PanelFooterFitTest {
+    private fun fits(
+        width: Int,
+        height: Int,
+        count: Int = EVERY_ACTION,
+    ) = panelFooterFitsColumn(
+        columnWidth = width.dp,
+        columnHeight = height.dp,
+        actionCount = count,
+        sideInset = SM,
+        gap = XS,
+    )
+
+    @Test
+    fun `the default panel hosts them on one line`() {
+        // 250x400 measured: a 44dp row under 355dp of plugin. This is the case the placement is
+        // aimed at, and it must never be the one the rule rejects.
+        assertTrue(fits(250, 400), "the 250dp default is where this placement lives")
+    }
+
+    @Test
+    fun `a narrowed panel still hosts them on two lines`() {
+        // 150x600 measured: an 80dp row under 519dp of plugin. Wrapping is the point of using a
+        // FlowRow, so the rule has to allow the wrap it was chosen for.
+        assertTrue(fits(150, 600), "two lines is chrome, not a tower")
+        assertTrue(fits(120, 600), "120dp is three per line, the floor of the two-line band")
+    }
+
+    @Test
+    fun `a sliver does not, because the icons would be slivers too`() {
+        // 20x400 measured: icons 4dp wide. `Modifier.size` coerces to the incoming constraint on
+        // the width axis as well, so a column narrower than one icon plus its inset renders
+        // shrunken buttons rather than clipped ones - invisible in a different way.
+        assertFalse(fits(20, 400), "a 20dp column renders 4dp icons")
+        assertFalse(fits(47, 400), "one 32dp icon plus 8dp either side is 48dp, so 47 is out")
+        assertTrue(fits(48, 400, count = 1), "and 48dp is in, for a row that only needs one line")
+    }
+
+    @Test
+    fun `a column that would need three lines does not`() {
+        // 60x300 measured: a 188dp row under 111dp of plugin, with every icon at its full 32dp.
+        // Nothing is squeezed here - the row simply took two thirds of the column, which is the
+        // failure the bottom column was ruled out for, reached on the other axis.
+        assertFalse(fits(60, 300), "five buttons one per line is 188dp of chrome")
+        assertFalse(fits(100, 600), "100dp is two per line, so five buttons need three lines")
+    }
+
+    @Test
+    fun `a short column does not, however wide it is`() {
+        // The height half of the rule. A 45dp row in a 100dp column is nearly half of it.
+        assertFalse(fits(250, 100), "one line is 45dp, which is not a third of 100dp")
+        assertTrue(fits(250, 135), "45dp is exactly a third of 135dp")
+        assertFalse(fits(150, 200), "two lines is 81dp, over a third of 200dp")
+    }
+
+    @Test
+    fun `the launcher can be what tips a column over`() {
+        // The count is not a constant: with both icon strips off the tools launcher joins this
+        // group, which is why `PanelFooterHostActions` is told the count rather than the list.
+        assertTrue(fits(120, 600, count = FOCUS_QUICK_ACTION_COUNT), "four buttons fit two lines at 120dp")
+        assertTrue(fits(120, 600, count = EVERY_ACTION), "and so do five, three per line")
+        assertEquals(
+            false,
+            fits(88, 600, count = EVERY_ACTION),
+            "at 88dp two per line, five buttons need three lines where four need two",
+        )
+        assertTrue(fits(88, 600, count = FOCUS_QUICK_ACTION_COUNT), "the same column, one button fewer")
+    }
+}
+
+/** Every button the row can hold: the four, plus the tools launcher with both strips off. */
+private const val EVERY_ACTION = FOCUS_QUICK_ACTION_COUNT + 1
+
+/** `BossSpacing`'s defaults, which are the only values ever provided - see BossTheme.kt. */
+private val SM = 8.dp
+private val XS = 4.dp

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
@@ -22,14 +22,14 @@ class QuickActionsFooterPlacementTest {
     private fun placement(
         rightStripHidden: Boolean,
         verticalBar: VerticalBarHost,
-        rightPanelOpen: Boolean = false,
+        panelFootAvailable: Boolean = false,
     ) = focusQuickActionsPlacement(
         settings = focusOff,
         topBarHidden = true,
         rightStripHidden = rightStripHidden,
         showTopBar = false,
         verticalBar = verticalBar,
-        rightPanelOpen = rightPanelOpen,
+        panelFootAvailable = panelFootAvailable,
     )
 
     @Test
@@ -66,11 +66,11 @@ class QuickActionsFooterPlacementTest {
         // while a bar - full or railed - can hold these itself.
         assertEquals(
             FocusQuickActionsPlacement.TAB_BAR_RAIL,
-            placement(rightStripHidden = true, verticalBar = VerticalBarHost.RAIL, rightPanelOpen = true),
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.RAIL, panelFootAvailable = true),
         )
         assertEquals(
             FocusQuickActionsPlacement.TAB_BAR_FOOTER,
-            placement(rightStripHidden = true, verticalBar = VerticalBarHost.FOOT, rightPanelOpen = true),
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.FOOT, panelFootAvailable = true),
         )
     }
 
@@ -88,7 +88,7 @@ class QuickActionsFooterPlacementTest {
         // With the right panel open, the same window reserves a row instead of covering it.
         assertEquals(
             FocusQuickActionsPlacement.PANEL_FOOTER,
-            placement(rightStripHidden = true, verticalBar = tabsOnTop, rightPanelOpen = true),
+            placement(rightStripHidden = true, verticalBar = tabsOnTop, panelFootAvailable = true),
         )
 
         // A collapsed bar on the left reaches its own rail by the other route.
@@ -116,7 +116,7 @@ class QuickActionsFooterPlacementTest {
                 rightStripHidden = true,
                 showTopBar = true,
                 verticalBar = VerticalBarHost.FOOT,
-                rightPanelOpen = true,
+                panelFootAvailable = true,
             ),
             "the top bar owns these whenever it is on screen",
         )
@@ -216,7 +216,7 @@ class QuickActionsFooterPlacementTest {
                     placement(
                         rightStripHidden = true,
                         verticalBar = bar,
-                        rightPanelOpen = open,
+                        panelFootAvailable = open,
                     ) == FocusQuickActionsPlacement.FLOATING
                 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
@@ -3,18 +3,17 @@ package ai.rever.boss.app
 import ai.rever.boss.focusmode.FocusModeSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
- * Pins the precedence between the three renderings of Settings / Search / Sign Out.
+ * Pins the precedence between the five renderings of Settings / Search / Sign Out.
  *
- * The order is rail, then the tab bar's footer, then the floating cluster, and each step is a
- * choice rather than an accident. The floating cluster is a native always-on-top window with no
- * click-through, so it is the most intrusive of the three and goes last; the rail was already
- * preferred over it and stays preferred; the tab bar's foot is chrome the app draws anyway.
+ * The order is the right rail, the tab bar's foot, that bar's collapsed rail, a reserved row at
+ * the foot of the content area, and only then the floating cluster - and each step is a choice
+ * rather than an accident. The cluster is a native always-on-top window with no click-through, so
+ * it is the most intrusive of the five and goes last; every one before it is chrome the app draws
+ * anyway, or layout it can carve out.
  *
- * Getting this backwards does not crash - it puts a dead click region over the content area in a
+ * Getting this backwards does not crash - it puts a dead click region over the content area of a
  * window that had a perfectly good place to put four icons.
  */
 class QuickActionsFooterPlacementTest {
@@ -22,20 +21,22 @@ class QuickActionsFooterPlacementTest {
 
     private fun placement(
         rightStripHidden: Boolean,
-        verticalTabBar: Boolean,
+        verticalBar: VerticalBarHost,
+        pluginPanelOpen: Boolean = false,
     ) = focusQuickActionsPlacement(
         settings = focusOff,
         topBarHidden = true,
         rightStripHidden = rightStripHidden,
         showTopBar = false,
-        verticalTabBar = verticalTabBar,
+        verticalBar = verticalBar,
+        pluginPanelOpen = pluginPanelOpen,
     )
 
     @Test
     fun `the rail still wins when there is a rail`() {
         assertEquals(
             FocusQuickActionsPlacement.RIGHT_RAIL,
-            placement(rightStripHidden = false, verticalTabBar = true),
+            placement(rightStripHidden = false, verticalBar = VerticalBarHost.FOOT),
             "the vertical tab bar displaces the floating cluster, not the rail",
         )
     }
@@ -44,51 +45,69 @@ class QuickActionsFooterPlacementTest {
     fun `the tab bar's foot takes the floating cluster's place`() {
         assertEquals(
             FocusQuickActionsPlacement.TAB_BAR_FOOTER,
-            placement(rightStripHidden = true, verticalTabBar = true),
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.FOOT),
         )
     }
 
     @Test
-    fun `a collapsed bar floats them, because its foot does not exist`() {
-        // The caller passes verticalTabBar = false for a collapsed bar. Pinned here as the
-        // contract rather than left to the scaffold, because the failure is silent: the four
-        // actions simply render nowhere.
+    fun `a collapsed bar puts them at the foot of its rail, not in the corner`() {
+        // The rail has no foot under a split map, but it does have a bottom, and it is still the
+        // bar. Collapsing it is a request for content width; answering that with a native overlay
+        // parked in the content is the opposite of granting it.
         assertEquals(
-            FocusQuickActionsPlacement.FLOATING,
-            placement(rightStripHidden = true, verticalTabBar = false),
+            FocusQuickActionsPlacement.TAB_BAR_RAIL,
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.RAIL),
         )
     }
 
     @Test
-    fun `a bar that is not on the left has no foot either`() {
-        // Was a character-for-character copy of the test above, so the case its name described -
-        // no vertical bar AT ALL, as against a collapsed one - went untested while looking covered.
-        //
-        // Asked through verticalBarHasFoot rather than by passing `false` again, because that is
-        // the composition the scaffold performs and the only way the two cases differ.
-        val tabsOnTop = verticalBarHasFoot(tabBarOnLeft = false, barCollapsed = false, drawerVisible = false)
+    fun `a collapsed bar keeps the rail even with a plugin panel open`() {
+        // The panel only decides between its own foot and the overlay, and neither is reached
+        // while a bar - full or railed - can hold these itself.
+        assertEquals(
+            FocusQuickActionsPlacement.TAB_BAR_RAIL,
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.RAIL, pluginPanelOpen = true),
+        )
+        assertEquals(
+            FocusQuickActionsPlacement.TAB_BAR_FOOTER,
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.FOOT, pluginPanelOpen = true),
+        )
+    }
+
+    @Test
+    fun `a bar that is not on the left hosts nothing at all`() {
+        // Asked through verticalBarHost rather than by naming NONE again, because that is the
+        // composition the scaffold performs and the only way these cases differ.
+        val tabsOnTop = verticalBarHost(tabBarOnLeft = false, barCollapsed = false, drawerVisible = false)
+        assertEquals(VerticalBarHost.NONE, tabsOnTop)
         assertEquals(
             FocusQuickActionsPlacement.FLOATING,
-            placement(rightStripHidden = true, verticalTabBar = tabsOnTop),
+            placement(rightStripHidden = true, verticalBar = tabsOnTop),
         )
 
-        // And the collapsed-bar case reaches the same answer by the other route.
-        val collapsedOnLeft = verticalBarHasFoot(tabBarOnLeft = true, barCollapsed = true, drawerVisible = false)
+        // With a plugin panel open, the same window reserves a row instead of covering it.
         assertEquals(
-            FocusQuickActionsPlacement.FLOATING,
-            placement(rightStripHidden = true, verticalTabBar = collapsedOnLeft),
+            FocusQuickActionsPlacement.PANEL_FOOTER,
+            placement(rightStripHidden = true, verticalBar = tabsOnTop, pluginPanelOpen = true),
+        )
+
+        // A collapsed bar on the left reaches its own rail by the other route.
+        val collapsedOnLeft = verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = false)
+        assertEquals(
+            FocusQuickActionsPlacement.TAB_BAR_RAIL,
+            placement(rightStripHidden = true, verticalBar = collapsedOnLeft),
         )
 
         // The drawer is the third state: a collapsed bar with it open HAS a foot again.
-        val drawerOpen = verticalBarHasFoot(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true)
+        val drawerOpen = verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true)
         assertEquals(
             FocusQuickActionsPlacement.TAB_BAR_FOOTER,
-            placement(rightStripHidden = true, verticalTabBar = drawerOpen),
+            placement(rightStripHidden = true, verticalBar = drawerOpen),
         )
     }
 
     @Test
-    fun `the top bar being up still beats all three`() {
+    fun `the top bar being up still beats all of them`() {
         assertEquals(
             FocusQuickActionsPlacement.NONE,
             focusQuickActionsPlacement(
@@ -96,44 +115,73 @@ class QuickActionsFooterPlacementTest {
                 topBarHidden = false,
                 rightStripHidden = true,
                 showTopBar = true,
-                verticalTabBar = true,
+                verticalBar = VerticalBarHost.FOOT,
+                pluginPanelOpen = true,
             ),
-            "the top bar owns these three whenever it is on screen",
+            "the top bar owns these whenever it is on screen",
         )
     }
 
     @Test
-    fun `the footer list is empty for every other placement`() {
-        // What lets the bar call it unconditionally and render nothing.
-        FocusQuickActionsPlacement.entries
-            .filter { it != FocusQuickActionsPlacement.TAB_BAR_FOOTER }
-            .forEach { placement ->
-                assertTrue(
-                    focusQuickActionsFooter(placement, {}, {}, {}, { _, _ -> }).isEmpty(),
-                    "$placement should contribute no footer actions",
-                )
-            }
-        assertEquals(
-            FOCUS_QUICK_ACTION_COUNT,
-            focusQuickActionsFooter(FocusQuickActionsPlacement.TAB_BAR_FOOTER, {}, {}, {}, { _, _ -> }).size,
-        )
-    }
-
-    @Test
-    fun `the launcher adds a fourth action without disturbing the reserve`() {
-        // The rail's reserve is FOCUS_QUICK_ACTION_COUNT rows, and it stays at three because the
-        // launcher can never join the rail flavour - see ToolLauncherPlacementTest.
-        val withLauncher =
-            focusQuickActionsFooter(
-                FocusQuickActionsPlacement.TAB_BAR_FOOTER,
-                {},
-                {},
-                {},
-                toolbox = { _, _ -> },
-                toolLauncher = { _, _ -> },
+    fun `each layout is empty for every placement but its own`() {
+        // What lets all four hosts call their builder unconditionally and render nothing. A
+        // non-empty list on the wrong placement is not a stray icon: the right rail reserves
+        // height from its list's SIZE, and two hosts drawing at once is Sign Out twice.
+        val builders =
+            mapOf(
+                FocusQuickActionsPlacement.RIGHT_RAIL to
+                    { p: FocusQuickActionsPlacement -> focusQuickActionsRail(p, {}, {}, {}, { _, _ -> }) },
+                FocusQuickActionsPlacement.TAB_BAR_FOOTER to
+                    { p: FocusQuickActionsPlacement -> focusQuickActionsFooter(p, {}, {}, {}, { _, _ -> }) },
+                FocusQuickActionsPlacement.TAB_BAR_RAIL to
+                    { p: FocusQuickActionsPlacement -> focusQuickActionsTabRail(p, {}, {}, {}, { _, _ -> }) },
+                FocusQuickActionsPlacement.PANEL_FOOTER to
+                    { p: FocusQuickActionsPlacement -> focusQuickActionsPanelFooter(p, {}, {}, {}, { _, _ -> }) },
             )
 
-        assertEquals(FOCUS_QUICK_ACTION_COUNT + 1, withLauncher.size)
+        builders.forEach { (owner, build) ->
+            FocusQuickActionsPlacement.entries.forEach { placement ->
+                val expected = if (placement == owner) FOCUS_QUICK_ACTION_COUNT else 0
+                assertEquals(
+                    expected,
+                    build(placement).size,
+                    "the $owner layout for placement $placement",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the launcher adds one more action to each layout without disturbing the reserve`() {
+        // The rail's reserve is FOCUS_QUICK_ACTION_COUNT rows, and it stays at four because the
+        // launcher can never join the right-rail flavour - see ToolLauncherPlacementTest.
+        val hosts =
+            listOf(
+                FocusQuickActionsPlacement.TAB_BAR_FOOTER to
+                    { p: FocusQuickActionsPlacement ->
+                        focusQuickActionsFooter(p, {}, {}, {}, toolbox = { _, _ -> }, toolLauncher = { _, _ -> })
+                    },
+                FocusQuickActionsPlacement.TAB_BAR_RAIL to
+                    { p: FocusQuickActionsPlacement ->
+                        focusQuickActionsTabRail(p, {}, {}, {}, toolbox = { _, _ -> }, toolLauncher = { _, _ -> })
+                    },
+                FocusQuickActionsPlacement.PANEL_FOOTER to
+                    { p: FocusQuickActionsPlacement ->
+                        focusQuickActionsPanelFooter(
+                            p,
+                            {},
+                            {},
+                            {},
+                            toolbox = { _, _ -> },
+                            toolLauncher = { _, _ -> },
+                        )
+                    },
+            )
+
+        hosts.forEach { (placement, build) ->
+            assertEquals(FOCUS_QUICK_ACTION_COUNT + 1, build(placement).size, "with the launcher, $placement")
+        }
+
         val rail = focusQuickActionsRail(FocusQuickActionsPlacement.RIGHT_RAIL, {}, {}, {}, { _, _ -> })
         assertEquals(FOCUS_QUICK_ACTION_COUNT, rail.size)
     }
@@ -151,40 +199,71 @@ class QuickActionsFooterPlacementTest {
                 topBarHidden = true,
                 rightStripHidden = false,
                 showTopBar = false,
-                verticalTabBar = true,
+                verticalBar = VerticalBarHost.FOOT,
             ),
         )
+    }
+
+    @Test
+    fun `the overlay is the only placement that draws over content`() {
+        // The whole point of the two additions, stated as one assertion: of the configurations a
+        // window with the top bar off can be in, the only one that ends up with an overlay is the
+        // one with no bar to host these and nothing open for it to cover.
+        val overlaid =
+            VerticalBarHost.entries
+                .flatMap { bar -> listOf(false, true).map { open -> bar to open } }
+                .filter { (bar, open) ->
+                    placement(
+                        rightStripHidden = true,
+                        verticalBar = bar,
+                        pluginPanelOpen = open,
+                    ) == FocusQuickActionsPlacement.FLOATING
+                }
+
+        assertEquals(listOf(VerticalBarHost.NONE to false), overlaid)
     }
 }
 
 /**
- * Pins the three states of "does the vertical bar have a foot to put the host's actions in".
+ * Pins the three states of "what can the vertical bar host".
  *
  * Two of them look the same from the settings alone - a collapsed bar with the drawer open and one
  * with it shut differ only in a transient flag - and getting it wrong is silent either way: the
  * actions render twice, or nowhere.
  */
-class VerticalBarFootTest {
+class VerticalBarHostTest {
     @Test
     fun `an expanded left bar has a foot`() {
-        assertTrue(verticalBarHasFoot(tabBarOnLeft = true, barCollapsed = false, drawerVisible = false))
+        assertEquals(
+            VerticalBarHost.FOOT,
+            verticalBarHost(tabBarOnLeft = true, barCollapsed = false, drawerVisible = false),
+        )
     }
 
     @Test
-    fun `a collapsed bar has none, so they float`() {
-        // It draws its rail and nothing else - there is no foot to render into.
-        assertFalse(verticalBarHasFoot(tabBarOnLeft = true, barCollapsed = true, drawerVisible = false))
+    fun `a collapsed bar offers its rail`() {
+        // It draws its rail and nothing else, and the bottom of that rail is what it has room for.
+        assertEquals(
+            VerticalBarHost.RAIL,
+            verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = false),
+        )
     }
 
     @Test
-    fun `a collapsed bar with the drawer open has one again`() {
+    fun `a collapsed bar with the drawer open has a foot again`() {
         // The drawer is a full bar, split map and all, for as long as it is up.
-        assertTrue(verticalBarHasFoot(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true))
+        assertEquals(
+            VerticalBarHost.FOOT,
+            verticalBarHost(tabBarOnLeft = true, barCollapsed = true, drawerVisible = true),
+        )
     }
 
     @Test
-    fun `a top tab bar never has one, drawer or not`() {
+    fun `a top tab bar hosts nothing, drawer or not`() {
         // There is no vertical bar at all in TOP position, so no drawer can give it a foot.
-        assertFalse(verticalBarHasFoot(tabBarOnLeft = false, barCollapsed = false, drawerVisible = true))
+        assertEquals(
+            VerticalBarHost.NONE,
+            verticalBarHost(tabBarOnLeft = false, barCollapsed = false, drawerVisible = true),
+        )
     }
 }

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsFooterPlacementTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
  * Pins the precedence between the five renderings of Settings / Search / Sign Out.
  *
  * The order is the right rail, the tab bar's foot, that bar's collapsed rail, a reserved row at
- * the foot of the content area, and only then the floating cluster - and each step is a choice
+ * the foot of the open right panel, and only then the floating cluster - and each step is a choice
  * rather than an accident. The cluster is a native always-on-top window with no click-through, so
  * it is the most intrusive of the five and goes last; every one before it is chrome the app draws
  * anyway, or layout it can carve out.
@@ -22,14 +22,14 @@ class QuickActionsFooterPlacementTest {
     private fun placement(
         rightStripHidden: Boolean,
         verticalBar: VerticalBarHost,
-        pluginPanelOpen: Boolean = false,
+        rightPanelOpen: Boolean = false,
     ) = focusQuickActionsPlacement(
         settings = focusOff,
         topBarHidden = true,
         rightStripHidden = rightStripHidden,
         showTopBar = false,
         verticalBar = verticalBar,
-        pluginPanelOpen = pluginPanelOpen,
+        rightPanelOpen = rightPanelOpen,
     )
 
     @Test
@@ -61,16 +61,16 @@ class QuickActionsFooterPlacementTest {
     }
 
     @Test
-    fun `a collapsed bar keeps the rail even with a plugin panel open`() {
+    fun `a collapsed bar keeps the rail even with the right panel open`() {
         // The panel only decides between its own foot and the overlay, and neither is reached
         // while a bar - full or railed - can hold these itself.
         assertEquals(
             FocusQuickActionsPlacement.TAB_BAR_RAIL,
-            placement(rightStripHidden = true, verticalBar = VerticalBarHost.RAIL, pluginPanelOpen = true),
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.RAIL, rightPanelOpen = true),
         )
         assertEquals(
             FocusQuickActionsPlacement.TAB_BAR_FOOTER,
-            placement(rightStripHidden = true, verticalBar = VerticalBarHost.FOOT, pluginPanelOpen = true),
+            placement(rightStripHidden = true, verticalBar = VerticalBarHost.FOOT, rightPanelOpen = true),
         )
     }
 
@@ -85,10 +85,10 @@ class QuickActionsFooterPlacementTest {
             placement(rightStripHidden = true, verticalBar = tabsOnTop),
         )
 
-        // With a plugin panel open, the same window reserves a row instead of covering it.
+        // With the right panel open, the same window reserves a row instead of covering it.
         assertEquals(
             FocusQuickActionsPlacement.PANEL_FOOTER,
-            placement(rightStripHidden = true, verticalBar = tabsOnTop, pluginPanelOpen = true),
+            placement(rightStripHidden = true, verticalBar = tabsOnTop, rightPanelOpen = true),
         )
 
         // A collapsed bar on the left reaches its own rail by the other route.
@@ -116,7 +116,7 @@ class QuickActionsFooterPlacementTest {
                 rightStripHidden = true,
                 showTopBar = true,
                 verticalBar = VerticalBarHost.FOOT,
-                pluginPanelOpen = true,
+                rightPanelOpen = true,
             ),
             "the top bar owns these whenever it is on screen",
         )
@@ -216,7 +216,7 @@ class QuickActionsFooterPlacementTest {
                     placement(
                         rightStripHidden = true,
                         verticalBar = bar,
-                        pluginPanelOpen = open,
+                        rightPanelOpen = open,
                     ) == FocusQuickActionsPlacement.FLOATING
                 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
@@ -5,10 +5,9 @@ import ai.rever.boss.components.buttons.ToolboxButton
 import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.components.window_panel.PanelColumn
 import ai.rever.boss.plugin.api.Panel
-import ai.rever.boss.plugin.api.Panel.Companion.bottom
-import ai.rever.boss.plugin.api.Panel.Companion.left
 import ai.rever.boss.plugin.api.Panel.Companion.right
 import ai.rever.boss.plugin.api.SidebarItem
+import ai.rever.boss.plugin.ui.BossTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -19,8 +18,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -194,6 +196,51 @@ class QuickActionsPanelFooterTest {
     }
 
     @Test
+    fun `the row paints its own background`() {
+        // The one regression in this placement that no bounds assertion can see: the row is a
+        // strip of column nothing else draws - SidePanel fills itself and stops where its content
+        // does - and nothing is not the background. The raw native window surface shows through,
+        // which is WHITE, and these are near-white icons.
+        //
+        // So this reads a PIXEL. Compose's semantics tree carries no colour, and every other test
+        // in this file passes just as happily against an unpainted row.
+        var expected: Color? = null
+        rule.setContent {
+            expected = BossTheme.colors.panel
+            Box(modifier = Modifier.width(PANEL_WIDTH).height(400.dp).testTag(COLUMN_TAG)) {
+                PanelColumn(
+                    footer = {
+                        PanelFooterHostActions(
+                            actions =
+                                focusQuickActionsPanelFooter(
+                                    placement = FocusQuickActionsPlacement.PANEL_FOOTER,
+                                    onShowSettings = {},
+                                    onShowSearch = {},
+                                    onSignOut = {},
+                                ),
+                        )
+                    },
+                ) {
+                    Box(modifier = Modifier.fillMaxSize().testTag(PLUGIN_TAG))
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        val row = rule.onNodeWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).captureToImage().toPixelMap()
+        // Two pixels in from the row's start edge, halfway down it. The buttons are centred in a
+        // 250dp column and take about 140dp of it, so this lands on background and not on a glyph
+        // - and the row is a flat fill, so there is nothing to antialias against.
+        val painted = row[2, row.height / 2]
+
+        assertEquals(
+            expected,
+            painted,
+            "the row came back $painted, not the panel fill - an unpainted strip shows the white window surface",
+        )
+    }
+
+    @Test
     fun `any other placement leaves the panel exactly as it was`() {
         // The zero-cost half of the design: a window with nothing open gets the overlay, and no
         // panel anywhere should quietly grow a row of chrome in the meantime.
@@ -213,26 +260,23 @@ class QuickActionsPanelFooterTest {
  *
  * One function for both, because two expressions could disagree - and the way that fails is the
  * row rendered into a column nothing is composing: Sign Out on screen nowhere.
+ *
+ * The left and bottom columns are the interesting half now: both were candidates in an earlier
+ * revision, and both were dropped on purpose - left because the cluster is nowhere near it, bottom
+ * because its foot is the full-window band this placement exists to avoid AND because it is the
+ * one column with no axis that can yield at its floor. A test rather than a comment, so growing
+ * the table back is a decision someone makes rather than one that lands quietly.
  */
 class HostActionsPanelEdgeTest {
     @Test
-    fun `the right column wins, being where the cluster sat`() {
-        assertEquals(right, hostActionsPanelEdge(rightOpen = true, leftOpen = true, bottomOpen = true))
+    fun `the right column takes them, being the one the cluster sat on`() {
+        assertEquals(right, hostActionsPanelEdge(rightOpen = true))
     }
 
     @Test
-    fun `then the left column`() {
-        assertEquals(left, hostActionsPanelEdge(rightOpen = false, leftOpen = true, bottomOpen = true))
-    }
-
-    @Test
-    fun `the bottom panel is last, since its foot is the whole window's width`() {
-        assertEquals(bottom, hostActionsPanelEdge(rightOpen = false, leftOpen = false, bottomOpen = true))
-    }
-
-    @Test
-    fun `nothing open means no column, which is what sends them back to the corner`() {
-        assertNull(hostActionsPanelEdge(rightOpen = false, leftOpen = false, bottomOpen = false))
+    fun `a shut right panel means no column, which is what sends them back to the corner`() {
+        // Whatever else is open. A left or bottom panel does not host these - see the KDoc.
+        assertNull(hostActionsPanelEdge(rightOpen = false))
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
@@ -1,0 +1,244 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.buttons.ToolLauncherButton
+import ai.rever.boss.components.buttons.ToolboxButton
+import ai.rever.boss.components.plugin.PanelIds
+import ai.rever.boss.components.window_panel.PanelColumn
+import ai.rever.boss.plugin.api.Panel
+import ai.rever.boss.plugin.api.Panel.Companion.bottom
+import ai.rever.boss.plugin.api.Panel.Companion.left
+import ai.rever.boss.plugin.api.Panel.Companion.right
+import ai.rever.boss.plugin.api.SidebarItem
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Extension
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the two claims [PanelFooterHostActions] makes that the floating cluster could not: that it
+ * takes a row out of the panel's column rather than drawing over it, and that the row is the
+ * PANEL's width rather than the window's.
+ *
+ * The second is not cosmetic bookkeeping - it was the first version of this placement. A band
+ * across the whole content area also stops the cluster covering an open panel, and it looks like
+ * what it is: a strip of dead chrome the width of the screen holding four icons.
+ */
+class QuickActionsPanelFooterTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    /**
+     * The panel column, mounted through the REAL [PanelColumn] rather than a copy of its layout.
+     *
+     * That is what makes the carve-out assertions below mean anything: a test that rebuilds the
+     * structure it means to pin passes just as happily when the production wrapper loses its
+     * `weight(1f)` or draws the footer above the content.
+     */
+    private fun mountPanelColumn(
+        placement: FocusQuickActionsPlacement,
+        width: Dp = PANEL_WIDTH,
+        everyButton: Boolean = false,
+    ) {
+        rule.setContent {
+            val toolbox: (@Composable (Panel, Modifier) -> Unit)? =
+                if (!everyButton) {
+                    null
+                } else {
+                    { hint, mod ->
+                        ToolboxButton(item = toolboxItem(), onClick = {}, hintDirection = hint, modifier = mod)
+                    }
+                }
+            val launcher: (@Composable (Panel, Modifier) -> Unit)? =
+                if (!everyButton) {
+                    null
+                } else {
+                    { hint, mod -> ToolLauncherButton(onClick = {}, hintDirection = hint, modifier = mod) }
+                }
+            // clipToBounds mirrors the panel, which is what turns an overflow into a vanished
+            // button rather than one drawn outside its column.
+            Box(
+                modifier =
+                    Modifier
+                        .width(width)
+                        .height(400.dp)
+                        .clipToBounds()
+                        .testTag(COLUMN_TAG),
+            ) {
+                PanelColumn(
+                    footer = {
+                        PanelFooterHostActions(
+                            actions =
+                                focusQuickActionsPanelFooter(
+                                    placement = placement,
+                                    onShowSettings = {},
+                                    onShowSearch = {},
+                                    onSignOut = {},
+                                    toolbox = toolbox,
+                                    toolLauncher = launcher,
+                                ),
+                        )
+                    },
+                ) {
+                    // Stands in for SidePanel: the plugin's own content, which is what the
+                    // cluster used to be drawn over.
+                    Box(modifier = Modifier.fillMaxSize().testTag(PLUGIN_TAG))
+                }
+            }
+        }
+        rule.waitForIdle()
+    }
+
+    private fun toolboxItem() =
+        SidebarItem(
+            pluginContentId = PanelIds.PLUGIN_MANAGER,
+            icon = Icons.Outlined.Extension,
+            label = "Toolbox",
+        )
+
+    private fun bounds(tag: String): Rect = rule.onNodeWithTag(tag).fetchSemanticsNode().boundsInRoot
+
+    @Test
+    fun `the row is carved out of the panel, not drawn over it`() {
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER)
+
+        val plugin = bounds(PLUGIN_TAG)
+        val row = bounds(PANEL_FOOTER_HOST_ACTIONS_TAG)
+
+        assertTrue(row.height > 0f, "the row reserved no height at all")
+        assertTrue(
+            plugin.bottom <= row.top,
+            "the plugin ends at ${plugin.bottom} but the row starts at ${row.top} - they overlap",
+        )
+        assertEquals(
+            bounds(COLUMN_TAG).bottom,
+            row.bottom,
+            "the row belongs at the very bottom of the column",
+        )
+    }
+
+    @Test
+    fun `the row is the panel's width, not the window's`() {
+        // The whole point of moving it here from a content-area band. Asserted against the
+        // column it was given rather than a number, so a different panel width still pins it.
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER)
+
+        val column = bounds(COLUMN_TAG)
+        val row = bounds(PANEL_FOOTER_HOST_ACTIONS_TAG)
+
+        assertEquals(column.left, row.left, "the row starts where its column does")
+        assertEquals(column.right, row.right, "and ends where its column does")
+    }
+
+    @Test
+    fun `every button sits inside the row it reserved`() {
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER)
+
+        val row = bounds(PANEL_FOOTER_HOST_ACTIONS_TAG)
+        val expected = with(rule.density) { SIDEBAR_ICON_SIZE.toPx() }
+
+        // The Toolbox slot is null here, so it draws no icon of its own - see
+        // HostActionsContentTest, which mounts the real button.
+        listOf("Sign Out", "Settings", "Search").forEach { label ->
+            val icon = rule.onNodeWithContentDescription(label).fetchSemanticsNode().boundsInRoot
+            assertEquals(expected, icon.width, "$label is ${icon.width}px wide, expected $expected")
+            assertTrue(
+                icon.top >= row.top && icon.bottom <= row.bottom,
+                "$label spans ${icon.top}..${icon.bottom}, outside the row's ${row.top}..${row.bottom}",
+            )
+            assertTrue(
+                icon.left >= row.left && icon.right <= row.right,
+                "$label spans ${icon.left}..${icon.right}, outside the row's ${row.left}..${row.right}",
+            )
+        }
+    }
+
+    @Test
+    fun `every action survives a panel dragged to its floor`() {
+        // BossResizablePanel floors a side panel at max(2% of the window, 20dp) - narrower than
+        // ONE 32dp icon. The row wraps rather than clipping, and that claim is only worth making
+        // if it holds at the narrowest width a drag can reach, carrying the widest content it
+        // ever has: five buttons, which is a TOP tab bar with both icon strips switched off.
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER, width = FLOOR_WIDTH, everyButton = true)
+
+        val column = bounds(COLUMN_TAG)
+        val expected = with(rule.density) { SIDEBAR_ICON_SIZE.toPx() }
+        listOf("Sign Out", "Settings", "Toolbox", "Tools", "Search").forEach { label ->
+            val icon = rule.onNodeWithContentDescription(label).fetchSemanticsNode().boundsInRoot
+            // SIZE, not just bounds: a row that cannot fit its children hands the last one a 0x0
+            // rect at the origin, which sits inside every bounds check ever written.
+            assertEquals(expected, icon.height, "$label is ${icon.height}px tall, expected $expected")
+            assertTrue(
+                icon.top >= column.top && icon.bottom <= column.bottom,
+                "$label spans ${icon.top}..${icon.bottom}, outside the column's ${column.top}..${column.bottom}",
+            )
+        }
+    }
+
+    @Test
+    fun `any other placement leaves the panel exactly as it was`() {
+        // The zero-cost half of the design: a window with nothing open gets the overlay, and no
+        // panel anywhere should quietly grow a row of chrome in the meantime.
+        mountPanelColumn(FocusQuickActionsPlacement.FLOATING)
+
+        rule.onAllNodesWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).assertCountEquals(0)
+        assertEquals(
+            bounds(COLUMN_TAG).height,
+            bounds(PLUGIN_TAG).height,
+            "the plugin must still fill the whole column",
+        )
+    }
+}
+
+/**
+ * Pins which column hosts the row, which is also the answer to "is there a panel foot at all".
+ *
+ * One function for both, because two expressions could disagree - and the way that fails is the
+ * row rendered into a column nothing is composing: Sign Out on screen nowhere.
+ */
+class HostActionsPanelEdgeTest {
+    @Test
+    fun `the right column wins, being where the cluster sat`() {
+        assertEquals(right, hostActionsPanelEdge(rightOpen = true, leftOpen = true, bottomOpen = true))
+    }
+
+    @Test
+    fun `then the left column`() {
+        assertEquals(left, hostActionsPanelEdge(rightOpen = false, leftOpen = true, bottomOpen = true))
+    }
+
+    @Test
+    fun `the bottom panel is last, since its foot is the whole window's width`() {
+        assertEquals(bottom, hostActionsPanelEdge(rightOpen = false, leftOpen = false, bottomOpen = true))
+    }
+
+    @Test
+    fun `nothing open means no column, which is what sends them back to the corner`() {
+        assertNull(hostActionsPanelEdge(rightOpen = false, leftOpen = false, bottomOpen = false))
+    }
+}
+
+private val PANEL_WIDTH = 250.dp
+
+/** `BossResizablePanel`'s floor for a side panel - narrower than one 32dp icon. */
+private val FLOOR_WIDTH = 20.dp
+private const val COLUMN_TAG = "panel-footer-test-column"
+private const val PLUGIN_TAG = "panel-footer-test-plugin"

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertCountEquals
@@ -300,14 +301,20 @@ class QuickActionsPanelFooterTest {
         rule.waitForIdle()
 
         val row = rule.onNodeWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).captureToImage().toPixelMap()
-        // Two pixels in from the row's start edge, halfway down it. The buttons are centred in a
-        // 250dp column and take about 140dp of it, so this lands on background and not on a glyph
-        // - and the row is a flat fill, so there is nothing to antialias against.
-        val painted = row[2, row.height / 2]
+        // 2dp in from the row's start edge, halfway down it - converted through the test density
+        // rather than passed as a raw pixel index, because the captured image scales with it and
+        // an implicit 1x assumption has no business in the one test whose point is to be exact.
+        // The buttons are centred in a 250dp column and take about 140dp of it, so this lands on
+        // background and not on a glyph, and the fill is flat, so there is nothing to antialias.
+        val inset = with(rule.density) { 2.dp.roundToPx() }
+        val painted = row[inset, row.height / 2]
 
+        // Compared as ARGB, not as Color: a Color carries its colour space, and toPixelMap hands
+        // back whatever space the captured bitmap is in. Comparing the values themselves keeps a
+        // difference nobody can see from failing the test.
         assertEquals(
-            expected,
-            painted,
+            expected.toArgb(),
+            painted.toArgb(),
             "the row came back $painted, not the panel fill - an unpainted strip shows the white window surface",
         )
     }
@@ -349,6 +356,15 @@ class HostActionsPanelEdgeTest {
     fun `a shut right panel means no column, which is what sends them back to the corner`() {
         // Whatever else is open. A left or bottom panel does not host these - see the KDoc.
         assertNull(hostActionsPanelEdge(rightOpen = false))
+    }
+
+    @Test
+    fun `actions that are not homeless name no column at all`() {
+        // The gate that keeps the measurement's cost proportional to the feature: naming a column
+        // is what makes BossWindow compose the subcomposition that measures it, so a window whose
+        // top bar still owns these must not name one however many panels are open.
+        assertNull(hostActionsPanelEdge(rightOpen = true, needsAHome = false))
+        assertEquals(right, hostActionsPanelEdge(rightOpen = true, needsAHome = true))
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsPanelFooterTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Rect
@@ -48,16 +49,21 @@ class QuickActionsPanelFooterTest {
     @get:Rule
     val rule = createComposeRule()
 
+    /** The last answer [PanelFooterHostActions] reported about the column it was mounted in. */
+    private var reportedFits: Boolean? = null
+
     /**
      * The panel column, mounted through the REAL [PanelColumn] rather than a copy of its layout.
      *
      * That is what makes the carve-out assertions below mean anything: a test that rebuilds the
      * structure it means to pin passes just as happily when the production wrapper loses its
-     * `weight(1f)` or draws the footer above the content.
+     * `weight(1f)`, draws the footer above the content, or re-implements the gate that decides
+     * which column gets one.
      */
     private fun mountPanelColumn(
         placement: FocusQuickActionsPlacement,
         width: Dp = PANEL_WIDTH,
+        height: Dp = PANEL_HEIGHT,
         everyButton: Boolean = false,
     ) {
         rule.setContent {
@@ -81,13 +87,16 @@ class QuickActionsPanelFooterTest {
                 modifier =
                     Modifier
                         .width(width)
-                        .height(400.dp)
+                        .height(height)
                         .clipToBounds()
                         .testTag(COLUMN_TAG),
             ) {
                 PanelColumn(
+                    column = right,
+                    footerEdge = right,
                     footer = {
                         PanelFooterHostActions(
+                            actionCount = if (everyButton) EVERY_BUTTON else FOCUS_QUICK_ACTION_COUNT,
                             actions =
                                 focusQuickActionsPanelFooter(
                                     placement = placement,
@@ -97,6 +106,7 @@ class QuickActionsPanelFooterTest {
                                     toolbox = toolbox,
                                     toolLauncher = launcher,
                                 ),
+                            onColumnFitsChange = { fits -> reportedFits = fits },
                         )
                     },
                 ) {
@@ -174,25 +184,77 @@ class QuickActionsPanelFooterTest {
     }
 
     @Test
-    fun `every action survives a panel dragged to its floor`() {
-        // BossResizablePanel floors a side panel at max(2% of the window, 20dp) - narrower than
-        // ONE 32dp icon. The row wraps rather than clipping, and that claim is only worth making
-        // if it holds at the narrowest width a drag can reach, carrying the widest content it
-        // ever has: five buttons, which is a TOP tab bar with both icon strips switched off.
-        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER, width = FLOOR_WIDTH, everyButton = true)
+    fun `every action survives the narrowest column that still hosts them`() {
+        // The row wraps rather than clipping, and that claim is only worth making at the
+        // narrowest width it is ever asked to hold - carrying the widest content it ever has:
+        // five buttons, which is a TOP tab bar with both icon strips switched off.
+        //
+        // WRAP_WIDTH is two lines, the most `panelFooterFitsColumn` allows. Below it the column
+        // stops hosting these at all rather than growing a tower of them - the test below.
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER, width = WRAP_WIDTH, everyButton = true)
 
         val column = bounds(COLUMN_TAG)
+        val row = bounds(PANEL_FOOTER_HOST_ACTIONS_TAG)
         val expected = with(rule.density) { SIDEBAR_ICON_SIZE.toPx() }
         listOf("Sign Out", "Settings", "Toolbox", "Tools", "Search").forEach { label ->
             val icon = rule.onNodeWithContentDescription(label).fetchSemanticsNode().boundsInRoot
-            // SIZE, not just bounds: a row that cannot fit its children hands the last one a 0x0
-            // rect at the origin, which sits inside every bounds check ever written.
+            // BOTH axes. A row that cannot fit its children hands the last one a 0x0 rect at the
+            // origin, and a column narrower than an icon renders a 4dp-WIDE one - `Modifier.size`
+            // coerces to the incoming constraint rather than overflowing it. Height alone passed
+            // while the icons were slivers.
             assertEquals(expected, icon.height, "$label is ${icon.height}px tall, expected $expected")
+            assertEquals(expected, icon.width, "$label is ${icon.width}px wide, expected $expected")
             assertTrue(
                 icon.top >= column.top && icon.bottom <= column.bottom,
                 "$label spans ${icon.top}..${icon.bottom}, outside the column's ${column.top}..${column.bottom}",
             )
         }
+
+        // And the plugin still has the column. This is the assertion the old floor test was
+        // missing: the icons surviving is only good news if they did not take the panel to do it.
+        val plugin = bounds(PLUGIN_TAG)
+        assertTrue(
+            plugin.height > row.height * 2,
+            "the plugin kept ${plugin.height} against ${row.height} of chrome - the foot is eating its column",
+        )
+    }
+
+    @Test
+    fun `a column too small for the row reports it and draws nothing`() {
+        // The failure this reports out of layout to avoid. At the panel's 20dp floor the row
+        // wraps to five lines - measured at 188dp, with 4dp-wide icons - and `PanelColumn` gives
+        // the footer its height before the plugin, so the plugin gets what is left.
+        //
+        // The report is what makes the fallback work: the scaffold hands the actions back to the
+        // floating cluster, which is what this configuration had before this change.
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER, width = FLOOR_WIDTH, everyButton = true)
+
+        assertEquals(false, reportedFits, "a 20dp column must report that it cannot host the row")
+
+        // Still no row of its own, because the placement is what decides that and it has not been
+        // told yet - so the guard has to be the report, not a half-drawn footer.
+        assertEquals(
+            false,
+            panelFooterFitsColumn(FLOOR_WIDTH, PANEL_HEIGHT, EVERY_BUTTON, SPACE_SM, SPACE_XS),
+            "the rule itself, so the report and the table cannot drift",
+        )
+    }
+
+    @Test
+    fun `a short column hands them back even at a comfortable width`() {
+        // The other axis. A 250dp panel in a 100dp-tall content area fits the row on one line and
+        // still should not spend nearly half its height on it.
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER, height = SHORT_COLUMN)
+
+        assertEquals(false, reportedFits, "a 100dp column must report that it cannot host the row")
+    }
+
+    @Test
+    fun `a default panel hosts them and says so`() {
+        mountPanelColumn(FocusQuickActionsPlacement.PANEL_FOOTER)
+
+        assertEquals(true, reportedFits, "a 250x400 column is where this placement is aimed")
+        rule.onAllNodesWithTag(PANEL_FOOTER_HOST_ACTIONS_TAG).assertCountEquals(1)
     }
 
     @Test
@@ -204,13 +266,22 @@ class QuickActionsPanelFooterTest {
         //
         // So this reads a PIXEL. Compose's semantics tree carries no colour, and every other test
         // in this file passes just as happily against an unpainted row.
-        var expected: Color? = null
+        //
+        // Compared against the TOKEN rather than a hardcoded value: `BossColors` comes through a
+        // CompositionLocal, so the expectation has to be read from the same place the fill is.
+        var expected = Color.Unspecified
         rule.setContent {
-            expected = BossTheme.colors.panel
-            Box(modifier = Modifier.width(PANEL_WIDTH).height(400.dp).testTag(COLUMN_TAG)) {
+            // Published through SideEffect, which is what that hook is for: a plain assignment in
+            // the composable body is a write to captured state that every recomposition repeats.
+            val panel = BossTheme.colors.panel
+            SideEffect { expected = panel }
+            Box(modifier = Modifier.width(PANEL_WIDTH).height(PANEL_HEIGHT).testTag(COLUMN_TAG)) {
                 PanelColumn(
+                    column = right,
+                    footerEdge = right,
                     footer = {
                         PanelFooterHostActions(
+                            actionCount = FOCUS_QUICK_ACTION_COUNT,
                             actions =
                                 focusQuickActionsPanelFooter(
                                     placement = FocusQuickActionsPlacement.PANEL_FOOTER,
@@ -218,6 +289,7 @@ class QuickActionsPanelFooterTest {
                                     onShowSearch = {},
                                     onSignOut = {},
                                 ),
+                            onColumnFitsChange = {},
                         )
                     },
                 ) {
@@ -281,6 +353,27 @@ class HostActionsPanelEdgeTest {
 }
 
 private val PANEL_WIDTH = 250.dp
+
+/** A content area tall enough that height is never the binding constraint. */
+private val PANEL_HEIGHT = 400.dp
+
+/**
+ * The narrowest column that still carries the row: two lines of five buttons.
+ *
+ * `panelFooterFitsColumn` allows two, so three per line is the floor - 3 * 32dp + 2 * 4dp of gap
+ * plus 8dp either side is 120dp, which is also where the vertical bar's own foot bottoms out.
+ */
+private val WRAP_WIDTH = 120.dp
+
+/** Every button the row can hold: the four, plus the tools launcher with both strips off. */
+private const val EVERY_BUTTON = FOCUS_QUICK_ACTION_COUNT + 1
+
+/** A content area too short to spend a third of on four icons. */
+private val SHORT_COLUMN = 100.dp
+
+/** `BossSpacing`'s defaults, which are the only values ever provided - see BossTheme.kt. */
+private val SPACE_SM = 8.dp
+private val SPACE_XS = 4.dp
 
 /** `BossResizablePanel`'s floor for a side panel - narrower than one 32dp icon. */
 private val FLOOR_WIDTH = 20.dp

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
@@ -2,12 +2,17 @@ package ai.rever.boss.app
 
 import ai.rever.boss.components.buttons.TOOL_LAUNCHER_TAG
 import ai.rever.boss.components.buttons.ToolLauncherButton
+import ai.rever.boss.components.buttons.ToolboxButton
+import ai.rever.boss.components.plugin.PanelIds
 import ai.rever.boss.layout.ChromeDimens
+import ai.rever.boss.plugin.api.SidebarItem
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Rect
@@ -64,6 +69,13 @@ class QuickActionsRailLayoutTest {
         }
         rule.waitForIdle()
     }
+
+    private fun toolboxItem() =
+        SidebarItem(
+            pluginContentId = PanelIds.PLUGIN_MANAGER,
+            icon = Icons.Outlined.Extension,
+            label = "Toolbox",
+        )
 
     private fun railBounds(): Rect = rule.onNodeWithTag(RAIL_TAG).fetchSemanticsNode().boundsInRoot
 
@@ -143,8 +155,16 @@ class QuickActionsRailLayoutTest {
                         onShowSettings = {},
                         onShowSearch = {},
                         onSignOut = {},
+                        // The REAL Toolbox button, not a second launcher. A copy of the slot
+                        // below it mounts two nodes carrying "Tools" and TOOL_LAUNCHER_TAG, and
+                        // leaves the one button this slot exists to cover untested in a rail.
                         toolbox = { hintDirection, modifier ->
-                            ToolLauncherButton(onClick = {}, hintDirection = hintDirection, modifier = modifier)
+                            ToolboxButton(
+                                item = toolboxItem(),
+                                onClick = {},
+                                hintDirection = hintDirection,
+                                modifier = modifier,
+                            )
                         },
                         toolLauncher = { hintDirection, modifier ->
                             ToolLauncherButton(onClick = {}, hintDirection = hintDirection, modifier = modifier)
@@ -157,7 +177,10 @@ class QuickActionsRailLayoutTest {
 
         val rail = railBounds()
         val expected = with(rule.density) { SIDEBAR_ICON_SIZE.toPx() }
-        listOf("Sign Out", "Settings", "Search").forEach { label ->
+        // All five, Toolbox and Tools included: they are the two that only appear in this
+        // configuration, and a list that names only the other three is a list that would pass
+        // with either of them missing.
+        listOf("Sign Out", "Settings", "Toolbox", "Tools", "Search").forEach { label ->
             val icon = iconBounds(label)
             assertEquals(expected, icon.height, "$label is ${icon.height}px tall, expected $expected")
             assertTrue(icon.bottom <= rail.bottom, "$label ends at ${icon.bottom}, past the rail's ${rail.bottom}")

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
@@ -1,0 +1,199 @@
+package ai.rever.boss.app
+
+import ai.rever.boss.components.buttons.TOOL_LAUNCHER_TAG
+import ai.rever.boss.components.buttons.ToolLauncherButton
+import ai.rever.boss.layout.ChromeDimens
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins that the host's actions fit the COLLAPSED rail, which is the narrowest thing that has ever
+ * had to hold them.
+ *
+ * The rail is [ChromeDimens.MIN_STRIP_WIDTH] at the tightest density - 36dp for a 32dp button, so
+ * there is 2dp either side and no room for a second column. The expanded bar's foot learned this
+ * the hard way (see `VerticalBarHostActionsLayoutTest`): a `Row` that cannot fit its children does
+ * not clip them, it hands the last one ZERO width, which renders as an action that is simply not
+ * there. So these assertions check each icon's SIZE and not merely that it sits between the rail's
+ * edges - a zero-width rect at the origin passes every bounds check ever written.
+ */
+class QuickActionsRailLayoutTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private fun mountRail() {
+        val actions =
+            focusQuickActionsTabRail(
+                placement = FocusQuickActionsPlacement.TAB_BAR_RAIL,
+                onShowSettings = {},
+                onShowSearch = {},
+                onSignOut = {},
+                toolLauncher = { hintDirection, modifier ->
+                    ToolLauncherButton(onClick = {}, hintDirection = hintDirection, modifier = modifier)
+                },
+            )
+        rule.setContent {
+            // clipToBounds mirrors the rail, which is what turns an overflow into a vanished
+            // button rather than one drawn outside its column.
+            Column(
+                modifier =
+                    Modifier
+                        .width(ChromeDimens.MIN_STRIP_WIDTH)
+                        .clipToBounds()
+                        .testTag(RAIL_TAG),
+            ) {
+                VerticalBarRailActions(actions)
+            }
+        }
+        rule.waitForIdle()
+    }
+
+    private fun railBounds(): Rect = rule.onNodeWithTag(RAIL_TAG).fetchSemanticsNode().boundsInRoot
+
+    private fun iconBounds(contentDescription: String): Rect =
+        rule.onNodeWithContentDescription(contentDescription).fetchSemanticsNode().boundsInRoot
+
+    /** Present at its full size AND within the rail's edges. Either alone passes the bug. */
+    private fun assertShown(contentDescription: String) {
+        val rail = railBounds()
+        val icon = iconBounds(contentDescription)
+        val expected = with(rule.density) { SIDEBAR_ICON_SIZE.toPx() }
+
+        assertEquals(expected, icon.width, "$contentDescription is ${icon.width}px wide, expected $expected")
+        assertEquals(expected, icon.height, "$contentDescription is ${icon.height}px tall, expected $expected")
+        assertTrue(
+            icon.left >= rail.left && icon.right <= rail.right,
+            "$contentDescription spans ${icon.left}..${icon.right}, outside the rail's ${rail.left}..${rail.right}",
+        )
+    }
+
+    @Test
+    fun `every action fits the narrowest rail`() {
+        mountRail()
+
+        assertShown("Sign Out")
+        assertShown("Settings")
+        assertShown("Tools")
+        assertShown("Search")
+
+        // By tag as well as by label, for the same reason the bar's own test does it: a tag
+        // nothing reads is a tag that can be renamed without a failure.
+        val launcher = rule.onNodeWithTag(TOOL_LAUNCHER_TAG).fetchSemanticsNode().boundsInRoot
+        assertEquals(
+            with(rule.density) { SIDEBAR_ICON_SIZE.toPx() },
+            launcher.width,
+            "the launcher's own tag must find it at full size",
+        )
+    }
+
+    @Test
+    fun `they stack one per line, in the order the other hosts use`() {
+        // A column, not a wrapping row: at 36dp there is room for exactly one, and the order is
+        // Sign Out first so the destructive action is furthest from the window corner.
+        mountRail()
+
+        val signOut = iconBounds("Sign Out")
+        val settings = iconBounds("Settings")
+        val search = iconBounds("Search")
+
+        assertTrue(signOut.bottom <= settings.top, "Sign Out ($signOut) must sit above Settings ($settings)")
+        assertTrue(settings.bottom <= search.top, "Settings ($settings) must sit above Search ($search)")
+    }
+
+    @Test
+    fun `every action survives a short rail`() {
+        // The rail's SCARCE dimension once four or five stacked 32dp icons are added to it is
+        // height, not width - and this column is the LAST thing in it, under a chevron, two
+        // rules, the scrolling tab list and the "+". A Column that cannot fit its children gives
+        // the last ones zero height, which is the same failure the bar's foot had on the other
+        // axis: not a clipped icon, an absent one.
+        //
+        // The tab list stands in for BossTabRail's own weight(1f) scroll region, which is what is
+        // supposed to yield first.
+        rule.setContent {
+            Column(
+                modifier =
+                    Modifier
+                        .width(ChromeDimens.MIN_STRIP_WIDTH)
+                        .height(SHORT_RAIL_HEIGHT)
+                        .clipToBounds()
+                        .testTag(RAIL_TAG),
+            ) {
+                Box(modifier = Modifier.fillMaxWidth().weight(1f))
+                VerticalBarRailActions(
+                    focusQuickActionsTabRail(
+                        placement = FocusQuickActionsPlacement.TAB_BAR_RAIL,
+                        onShowSettings = {},
+                        onShowSearch = {},
+                        onSignOut = {},
+                        toolbox = { hintDirection, modifier ->
+                            ToolLauncherButton(onClick = {}, hintDirection = hintDirection, modifier = modifier)
+                        },
+                        toolLauncher = { hintDirection, modifier ->
+                            ToolLauncherButton(onClick = {}, hintDirection = hintDirection, modifier = modifier)
+                        },
+                    ),
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        val rail = railBounds()
+        val expected = with(rule.density) { SIDEBAR_ICON_SIZE.toPx() }
+        listOf("Sign Out", "Settings", "Search").forEach { label ->
+            val icon = iconBounds(label)
+            assertEquals(expected, icon.height, "$label is ${icon.height}px tall, expected $expected")
+            assertTrue(icon.bottom <= rail.bottom, "$label ends at ${icon.bottom}, past the rail's ${rail.bottom}")
+        }
+    }
+
+    @Test
+    fun `an empty list draws nothing, rule included`() {
+        // What lets the rail hand this slot every placement's list: a rail whose actions live in
+        // the top bar has to be exactly the rail that existed before this.
+        rule.setContent {
+            Column(modifier = Modifier.width(ChromeDimens.MIN_STRIP_WIDTH).testTag(RAIL_TAG)) {
+                VerticalBarRailActions(
+                    focusQuickActionsTabRail(
+                        placement = FocusQuickActionsPlacement.TAB_BAR_FOOTER,
+                        onShowSettings = {},
+                        onShowSearch = {},
+                        onSignOut = {},
+                    ),
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        rule.onAllNodesWithTag(VERTICAL_BAR_RAIL_ACTIONS_TAG).assertCountEquals(0)
+        assertEquals(0f, railBounds().height, "the empty slot must take no height at all")
+    }
+}
+
+private const val RAIL_TAG = "quick-actions-rail-layout-test-rail"
+
+/**
+ * A rail with less height than its content wants.
+ *
+ * Five 32dp icons with `space.xs` between them plus the rule is about 180dp, and the rail's own
+ * chrome (chevron, two rules, the "+") is another 90dp - so this is short enough that something
+ * has to give, and the scrolling tab list is what should.
+ */
+private val SHORT_RAIL_HEIGHT = 200.dp

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
@@ -8,6 +8,7 @@ import ai.rever.boss.layout.ChromeDimens
 import ai.rever.boss.plugin.api.SidebarItem
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
@@ -130,25 +131,28 @@ class QuickActionsRailLayoutTest {
     }
 
     @Test
-    fun `every action survives a short rail`() {
+    fun `every action survives the shortest rail the window can make`() {
         // The rail's SCARCE dimension once four or five stacked 32dp icons are added to it is
         // height, not width - and this column is the LAST thing in it, under a chevron, two
-        // rules, the scrolling tab list and the "+". A Column that cannot fit its children gives
-        // the last ones zero height, which is the same failure the bar's foot had on the other
-        // axis: not a clipped icon, an absent one.
+        // rules, the scrolling tab list and the "+". A Column measures its unweighted children in
+        // order and gives the last ones nothing when it runs out, so these are the first casualty,
+        // not the last: the same failure the bar's foot had on the other axis, an absent icon
+        // rather than a clipped one.
         //
-        // The tab list stands in for BossTabRail's own weight(1f) scroll region, which is what is
-        // supposed to yield first.
+        // The stand-in carries `RAIL_FIXED_CHROME`, which is BossTabRail's real fixed budget added
+        // up rather than estimated, and a weighted Box for the tab list - the one thing in that
+        // bar with `weight(1f)`, and so the only thing that can yield. That is a real trade this
+        // change makes and not a free win: the rail's own list of tabs is what pays for these.
         rule.setContent {
             Column(
                 modifier =
                     Modifier
                         .width(ChromeDimens.MIN_STRIP_WIDTH)
                         .height(SHORT_RAIL_HEIGHT)
-                        .clipToBounds()
                         .testTag(RAIL_TAG),
             ) {
-                Box(modifier = Modifier.fillMaxWidth().weight(1f))
+                Spacer(modifier = Modifier.height(RAIL_FIXED_CHROME))
+                Box(modifier = Modifier.fillMaxWidth().weight(1f).testTag(TAB_LIST_TAG))
                 VerticalBarRailActions(
                     focusQuickActionsTabRail(
                         placement = FocusQuickActionsPlacement.TAB_BAR_RAIL,
@@ -185,6 +189,15 @@ class QuickActionsRailLayoutTest {
             assertEquals(expected, icon.height, "$label is ${icon.height}px tall, expected $expected")
             assertTrue(icon.bottom <= rail.bottom, "$label ends at ${icon.bottom}, past the rail's ${rail.bottom}")
         }
+
+        // And the tab list is what gave way, which is the claim rather than a side effect. No
+        // clipToBounds here: BossTabRail has none either, so overflow in the real rail SPILLS,
+        // and a harness that clipped would be describing a bar that does not exist.
+        val tabList = rule.onNodeWithTag(TAB_LIST_TAG).fetchSemanticsNode().boundsInRoot
+        assertTrue(
+            tabList.height >= 0f && tabList.top >= rail.top,
+            "the tab list should have absorbed the squeeze, not overflowed the rail",
+        )
     }
 
     @Test
@@ -213,10 +226,27 @@ class QuickActionsRailLayoutTest {
 private const val RAIL_TAG = "quick-actions-rail-layout-test-rail"
 
 /**
- * A rail with less height than its content wants.
+ * `BossTabRail`'s fixed budget, everything in it that is not the weighted tab list.
  *
- * Five 32dp icons with `space.xs` between them plus the rule is about 180dp, and the rail's own
- * chrome (chevron, two rules, the "+") is another 90dp - so this is short enough that something
- * has to give, and the scrolling tab list is what should.
+ * 4 + 4 (the Column's vertical padding), 32 (the chevron), 4, 1 (rule), 6, then below the list
+ * 6, 1 (rule), 4, 32 (the "+"). Added up rather than estimated, because the point of putting it
+ * in the harness is that the harness stops being more generous than the bar.
  */
-private val SHORT_RAIL_HEIGHT = 200.dp
+private val RAIL_FIXED_CHROME = 94.dp
+
+/**
+ * The shortest rail this window can produce, near enough.
+ *
+ * The rail is as tall as the content area. `DisplayUtils.calculateMainWindowSize` floors a new
+ * main window at 600dp of height, and 300 is half of that - well under anything the app opens
+ * itself, and still 17dp clear of the 283dp that [RAIL_FIXED_CHROME] plus five actions costs.
+ *
+ * Deliberately NOT a height where the actions lose: below about 283dp they do, because they are
+ * measured last. That is a real edge and it is reachable by dragging a window very short; it is
+ * out of this PR because fixing it means giving the rail a scroll or a drop rule of its own, and
+ * the number is written down here so the next person has it.
+ */
+private val SHORT_RAIL_HEIGHT = 300.dp
+
+/** The rail's scrolling tab list, the one thing in it that can yield. */
+private const val TAB_LIST_TAG = "quick-actions-rail-layout-test-tab-list"

--- a/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
+++ b/composeApp/src/desktopTest/kotlin/ai/rever/boss/app/QuickActionsRailLayoutTest.kt
@@ -242,9 +242,10 @@ private val RAIL_FIXED_CHROME = 94.dp
  * itself, and still 17dp clear of the 283dp that [RAIL_FIXED_CHROME] plus five actions costs.
  *
  * Deliberately NOT a height where the actions lose: below about 283dp they do, because they are
- * measured last. That is a real edge and it is reachable by dragging a window very short; it is
- * out of this PR because fixing it means giving the rail a scroll or a drop rule of its own, and
- * the number is written down here so the next person has it.
+ * measured last, and they vanish rather than clip. That is a real edge, reachable by dragging a
+ * window short - the 600dp floor in `DisplayUtils.calculateMainWindowSize` is an initial size and
+ * not a constraint. Tracked in issue #320, with the numbers and the shape of the fix; the panel
+ * foot's `panelFooterFitsColumn` + `onColumnFitsChange` is the machinery it should reuse.
  */
 private val SHORT_RAIL_HEIGHT = 300.dp
 


### PR DESCRIPTION
## What

Sign Out, Settings, Toolbox, Tools and Search live in the top bar, which is off by default. With it gone they fall back through whichever host can take them, and the last resort is a floating cluster: a native always-on-top window with no click-through, so wherever it lands it takes that corner away from whatever is underneath.

Two configurations reached that overlay while the window had somewhere better to put them.

**A collapsed vertical tab bar now hosts them at the foot of its rail.** Collapsing the bar is a request for content width; answering it with an overlay parked in the content was the opposite of granting it. The rail is the same bar with its labels taken away, and its bottom third was empty.

**A TOP tab bar with the RIGHT plugin panel open now hosts them at the foot of that panel's column, when that column can afford the row.** The cluster parks in the content area's bottom-right corner, which is the right panel's outright whenever there is one - so it covered the one thing the user just asked to see. A bare TOP window still gets the cluster: the corner is empty content there, and a reserved row would cost every such window height to solve a collision that is not happening. So does a panel narrowed to a sliver - see "The foot yields to the plugin".

Placement order is now: right rail, tab bar foot, **collapsed rail**, **open right panel's foot**, floating cluster.

## Notable in the diff

- `verticalBarHasFoot` (Boolean) becomes `verticalBarHost` returning `NONE / FOOT / RAIL`, so "a foot AND a rail" stops being a state the types admit.
- `hostActionsPanelEdge` answers both halves of the panel question - whether there is a foot at all, and which column draws it - because two expressions could disagree, and that failure renders Sign Out into a container nothing composes.
- Both new hosts are chrome-scale, not window-scale. An earlier revision of the panel case put a band across the whole content area: it fixes the collision and spends the window's entire width saying four icons.
- Four copies of the guarded per-placement builder fold into one `focusQuickActionsFor`. The floating cluster is the fifth placement but not a fifth caller - it has no "am I the owner" question to ask.
- The `footerEdge == column` gate lives in `PanelColumn`, one copy for the three columns that ask.
- `PanelColumn` and `DragTargetHighlight` are extracted so `BossWindow` stays under detekt's length ceiling. `DragTargetHighlight` is the same code and the same conditions, moved.

## Why only the right column

Left and bottom were both in an earlier revision of this and were taken out in review:

- **Left.** No collision to fix. A left panel is the width of the window away from the corner the cluster sits in, so hosting these there moved Sign Out across the window to dodge an overlap that is not happening - and moved it back, disposing and re-creating the overlay's native window, when the panel closed.
- **Bottom.** The collision is real, but a bottom panel spans the whole window, so its foot **is** the full-width band this placement rejected. It is also the one column with no axis that can yield: `BossResizablePanel` floors a panel at `max(2% of the axis, 20.dp)`, and for a bottom panel the scarce axis is the one the row needs about 45dp of - at its floor the plugin gets no height and `Modifier.size` shrinks the icons rather than overflowing. A right panel's scarce axis is width, where the row wraps, which is pinned at 20dp.

A TOP-bar window with only a left or bottom panel open therefore keeps the cluster it has today. That is behaviour this change found, not behaviour it introduces.

## The foot yields to the plugin, not the other way round

`PanelColumn` measures the footer before the plugin, and `HostActionsFlowRow` wraps - which is what makes the row survive a narrow column on the width axis, and what turns width pressure into height pressure. Measured, by mounting the column and reading the bounds back:

| column | row | plugin | icon |
|---|---|---|---|
| 250x400 | 44dp | 355dp | 32x32 |
| 150x600 | 80dp | 519dp | 32x32 |
| 60x300 | 188dp | 111dp | 32x32 |
| 20x400 | 188dp | 211dp | **4x32** |
| 20x200 | 188dp | **11dp** | 4x32 |

Two failures on two axes: the plugin loses its column, and below one icon's width the icons themselves come out as 4dp slivers, because `Modifier.size` coerces to the incoming constraint rather than overflowing it.

So `panelFooterFitsColumn` gates the placement: one icon has to fit a line at full size, the row may wrap to at most two lines, and it may take at most a third of the column. `PanelFooterHostActions` measures its column and reports the answer out to the scaffold, which hands the actions back to the floating cluster when the answer is no - the same shape `onBarRailedChange` already has for a bar that rails itself on a width settings cannot see.

It is reversible, because the measuring shell composes whether or not there is a row: behind the same guard as the row, a "no" would be permanent. It cannot oscillate, because the constraints it reads do not depend on what it draws. `HostActionsWiringTest` drives the whole trip - sliver, cluster, widen, foot, narrow, cluster - which is also the test that would hang rather than fail if that were untrue.

## Three bugs found in review, all fixed here

1. **The rail and the hover-reveal drawer are composed together**, so handing one slot to both drew the full bar's wrapping row twice: once in the drawer's foot, once behind it at 36dp as four lines of squeezed icons, visible for the frame after dismissal (`drawerVisible` is reported through a `LaunchedEffect`). The rail has its own slot now, and `HostActionsWiringTest` drives the transition.
2. **The panel foot painted no background.** Nothing else draws that strip - `SidePanel` fills itself and stops where its content does - and nothing is not the background: the raw native window surface shows through, which is white, with near-white icons on it. Now `BossTheme.colors.panel`, the token `SidePanel` uses. Pinned by a pixel read since round 1.
3. **The rail layout test mounted the wrong button.** Its toolbox slot held a second `ToolLauncherButton`, so two nodes shared "Tools" and `TOOL_LAUNCHER_TAG` and the real Toolbox button was never mounted in a rail at all. Real `ToolboxButton` now, and the assertion names all five.

## Tests

The placement files are green and so are detekt and ktlintCheck, verified on a clean worktree off `main`, not only on the branch this was written on. The full desktop suite is 3376 tests, 0 failures.

New coverage: the fit rule as a table, with the measured numbers in its assertion messages, and the fallback driven end to end through the real pieces; the placement table over the two added values; both new layouts at their narrowest (a 20dp panel, a 36dp rail) and the rail at a constrained height, asserting icon SIZE rather than bounds because a row that cannot fit its children hands the last one a 0x0 rect at the origin; the drawer transition asserting exactly one layout on screen; hint directions, which decide whether a tooltip opens off the window edge; the footer landing in exactly one panel column, with the left and bottom columns held open throughout so neither can quietly grow a foot; and the painted background, read as a pixel through `captureToImage().toPixelMap()` - verified failing with the `background()` removed. That is the first use of the capture API in this repo.

## Known and deliberately not in this PR

- The drag drop-target outline is hardcoded white (`Color.White` at 10% fill / 50% border) and is effectively invisible on Blueprint Light, the Windows default theme. Pre-existing, and only in this diff because the extraction moved it. Follow-up PR.
- The rail's host actions are 32dp/20dp glyphs in `textPrimary`, matching the other four hosts rather than the rail's own 16dp `textSecondary` chevron and "+". Deliberate, and the KDoc now says so instead of claiming a match that does not exist.
- Opening or closing the right plugin panel in a TOP-bar window disposes and re-creates the floating overlay's native window, because the placement flips. Accepted: it is the same cost the file already documents for hover reveals.
- A bottom panel open under a TOP tab bar still gets the cluster over its corner. See "Why only the right column" - fixing it well means a footer-aware floor on `BossResizablePanel`, which is a change to shared resize code and not this PR's.
- The collapsed rail does not yield the way the panel now does. Its height is the window's, not a user-draggable sliver: 94dp of the rail's own fixed chrome plus five actions is 283dp, against a 600dp floor for a new main window. Reachable by dragging a window very short, at which point the actions are measured last and lose. The number is written down beside `QuickActionsRailLayoutTest`; a fix means giving the rail a scroll or a drop rule of its own.

## Testing done

Manual on a dev build: rail collapsed and expanded, hover drawer in and out, auto-railed narrow window, panel open on each edge, two panels stacked in one column, and panel close returning to the cluster. The white-band bug above was caught this way, not by tests - though it now has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
